### PR TITLE
sweepers: Create AWS SDK version-specific skip error handlers for sweepers

### DIFF
--- a/internal/service/accessanalyzer/sweep.go
+++ b/internal/service/accessanalyzer/sweep.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/accessanalyzer"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
 )
 
 func init() {
@@ -37,7 +38,7 @@ func sweepAnalyzers(region string) error {
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
-		if sweep.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) {
 			log.Printf("[WARN] Skipping IAM Access Analyzer Analyzer sweep for %s: %s", region, err)
 			return nil
 		}

--- a/internal/service/acm/sweep.go
+++ b/internal/service/acm/sweep.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/acm"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
 )
 
 func init() {
@@ -54,7 +55,7 @@ func sweepCertificates(region string) error {
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
-		if sweep.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) {
 			log.Printf("[WARN] Skipping ACM Certificate sweep for %s: %s", region, err)
 			return nil
 		}

--- a/internal/service/acmpca/sweep.go
+++ b/internal/service/acmpca/sweep.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv1"
 )
 
 func init() {
@@ -72,7 +73,7 @@ func sweepCertificateAuthorities(region string) error {
 		errs = multierror.Append(errs, fmt.Errorf("sweeping ACM PCA Certificate Authorities for %s: %w", region, err))
 	}
 
-	if sweep.SkipSweepError(errs.ErrorOrNil()) {
+	if awsv1.SkipSweepError(errs.ErrorOrNil()) {
 		log.Printf("[WARN] Skipping ACM PCA Certificate Authorities sweep for %s: %s", region, errs)
 		return nil
 	}

--- a/internal/service/auditmanager/sweep.go
+++ b/internal/service/auditmanager/sweep.go
@@ -14,9 +14,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/auditmanager"
 	"github.com/aws/aws-sdk-go-v2/service/auditmanager/types"
-	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/framework"
 )
 
@@ -70,19 +70,18 @@ func sweepAssessments(region string) error {
 	ctx := sweep.Context(region)
 	client, err := sweep.SharedRegionalSweepClient(ctx, region)
 	if err != nil {
-		fmt.Errorf("error getting client: %s", err)
+		return fmt.Errorf("error getting client: %s", err)
 	}
 
 	conn := client.AuditManagerClient(ctx)
 	sweepResources := make([]sweep.Sweepable, 0)
 	in := &auditmanager.ListAssessmentsInput{}
-	var errs *multierror.Error
 
 	pages := auditmanager.NewListAssessmentsPaginator(conn, in)
 
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-		if sweep.SkipSweepError(err) || isCompleteSetupError(err) {
+		if awsv2.SkipSweepError(err) || isCompleteSetupError(err) {
 			log.Printf("[WARN] Skipping AuditManager Assessments sweep for %s: %s", region, err)
 			return nil
 		}
@@ -101,33 +100,28 @@ func sweepAssessments(region string) error {
 	}
 
 	if err := sweep.SweepOrchestrator(ctx, sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error sweeping AuditManager Assessments for %s: %w", region, err))
-	}
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping AuditManager Assessments sweep for %s: %s", region, errs)
-		return nil
+		return fmt.Errorf("error sweeping AuditManager Assessments for %s: %w", region, err)
 	}
 
-	return errs.ErrorOrNil()
+	return nil
 }
 
 func sweepAssessmentDelegations(region string) error {
 	ctx := sweep.Context(region)
 	client, err := sweep.SharedRegionalSweepClient(ctx, region)
 	if err != nil {
-		fmt.Errorf("error getting client: %s", err)
+		return fmt.Errorf("error getting client: %s", err)
 	}
 
 	conn := client.AuditManagerClient(ctx)
 	sweepResources := make([]sweep.Sweepable, 0)
 	in := &auditmanager.GetDelegationsInput{}
-	var errs *multierror.Error
 
 	pages := auditmanager.NewGetDelegationsPaginator(conn, in)
 
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-		if sweep.SkipSweepError(err) || isCompleteSetupError(err) {
+		if awsv2.SkipSweepError(err) || isCompleteSetupError(err) {
 			log.Printf("[WARN] Skipping AuditManager Assesment Delegations sweep for %s: %s", region, err)
 			return nil
 		}
@@ -145,33 +139,28 @@ func sweepAssessmentDelegations(region string) error {
 	}
 
 	if err := sweep.SweepOrchestrator(ctx, sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error sweeping AuditManager Assessment Delegations for %s: %w", region, err))
-	}
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping AuditManager Assessment Delegations sweep for %s: %s", region, errs)
-		return nil
+		return fmt.Errorf("error sweeping AuditManager Assessment Delegations for %s: %w", region, err)
 	}
 
-	return errs.ErrorOrNil()
+	return nil
 }
 
 func sweepAssessmentReports(region string) error {
 	ctx := sweep.Context(region)
 	client, err := sweep.SharedRegionalSweepClient(ctx, region)
 	if err != nil {
-		fmt.Errorf("error getting client: %s", err)
+		return fmt.Errorf("error getting client: %s", err)
 	}
 
 	conn := client.AuditManagerClient(ctx)
 	sweepResources := make([]sweep.Sweepable, 0)
 	in := &auditmanager.ListAssessmentReportsInput{}
-	var errs *multierror.Error
 
 	pages := auditmanager.NewListAssessmentReportsPaginator(conn, in)
 
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-		if sweep.SkipSweepError(err) || isCompleteSetupError(err) {
+		if awsv2.SkipSweepError(err) || isCompleteSetupError(err) {
 			log.Printf("[WARN] Skipping AuditManager Assesment Reports sweep for %s: %s", region, err)
 			return nil
 		}
@@ -191,33 +180,28 @@ func sweepAssessmentReports(region string) error {
 	}
 
 	if err := sweep.SweepOrchestrator(ctx, sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error sweeping AuditManager Assessment Reports for %s: %w", region, err))
-	}
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping AuditManager Assessment Reports sweep for %s: %s", region, errs)
-		return nil
+		return fmt.Errorf("error sweeping AuditManager Assessment Reports for %s: %w", region, err)
 	}
 
-	return errs.ErrorOrNil()
+	return nil
 }
 
 func sweepControls(region string) error {
 	ctx := sweep.Context(region)
 	client, err := sweep.SharedRegionalSweepClient(ctx, region)
 	if err != nil {
-		fmt.Errorf("error getting client: %s", err)
+		return fmt.Errorf("error getting client: %s", err)
 	}
 
 	conn := client.AuditManagerClient(ctx)
 	sweepResources := make([]sweep.Sweepable, 0)
 	in := &auditmanager.ListControlsInput{ControlType: types.ControlTypeCustom}
-	var errs *multierror.Error
 
 	pages := auditmanager.NewListControlsPaginator(conn, in)
 
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-		if sweep.SkipSweepError(err) || isCompleteSetupError(err) {
+		if awsv2.SkipSweepError(err) || isCompleteSetupError(err) {
 			log.Printf("[WARN] Skipping AuditManager Controls sweep for %s: %s", region, err)
 			return nil
 		}
@@ -236,33 +220,28 @@ func sweepControls(region string) error {
 	}
 
 	if err := sweep.SweepOrchestrator(ctx, sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error sweeping AuditManager Controls for %s: %w", region, err))
-	}
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping AuditManager Controls sweep for %s: %s", region, errs)
-		return nil
+		return fmt.Errorf("error sweeping AuditManager Controls for %s: %w", region, err)
 	}
 
-	return errs.ErrorOrNil()
+	return nil
 }
 
 func sweepFrameworks(region string) error {
 	ctx := sweep.Context(region)
 	client, err := sweep.SharedRegionalSweepClient(ctx, region)
 	if err != nil {
-		fmt.Errorf("error getting client: %s", err)
+		return fmt.Errorf("error getting client: %s", err)
 	}
 
 	conn := client.AuditManagerClient(ctx)
 	sweepResources := make([]sweep.Sweepable, 0)
 	in := &auditmanager.ListAssessmentFrameworksInput{FrameworkType: types.FrameworkTypeCustom}
-	var errs *multierror.Error
 
 	pages := auditmanager.NewListAssessmentFrameworksPaginator(conn, in)
 
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-		if sweep.SkipSweepError(err) || isCompleteSetupError(err) {
+		if awsv2.SkipSweepError(err) || isCompleteSetupError(err) {
 			log.Printf("[WARN] Skipping AuditManager Frameworks sweep for %s: %s", region, err)
 			return nil
 		}
@@ -281,33 +260,28 @@ func sweepFrameworks(region string) error {
 	}
 
 	if err := sweep.SweepOrchestrator(ctx, sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error sweeping AuditManager Frameworks for %s: %w", region, err))
-	}
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping AuditManager Frameworks sweep for %s: %s", region, errs)
-		return nil
+		return fmt.Errorf("error sweeping AuditManager Frameworks for %s: %w", region, err)
 	}
 
-	return errs.ErrorOrNil()
+	return nil
 }
 
 func sweepFrameworkShares(region string) error {
 	ctx := sweep.Context(region)
 	client, err := sweep.SharedRegionalSweepClient(ctx, region)
 	if err != nil {
-		fmt.Errorf("error getting client: %s", err)
+		return fmt.Errorf("error getting client: %s", err)
 	}
 
 	conn := client.AuditManagerClient(ctx)
 	sweepResources := make([]sweep.Sweepable, 0)
 	in := &auditmanager.ListAssessmentFrameworkShareRequestsInput{RequestType: types.ShareRequestTypeSent}
-	var errs *multierror.Error
 
 	pages := auditmanager.NewListAssessmentFrameworkShareRequestsPaginator(conn, in)
 
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-		if sweep.SkipSweepError(err) || isCompleteSetupError(err) {
+		if awsv2.SkipSweepError(err) || isCompleteSetupError(err) {
 			log.Printf("[WARN] Skipping AuditManager Framework Shares sweep for %s: %s", region, err)
 			return nil
 		}
@@ -326,12 +300,8 @@ func sweepFrameworkShares(region string) error {
 	}
 
 	if err := sweep.SweepOrchestrator(ctx, sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error sweeping AuditManager Framework Shares for %s: %w", region, err))
-	}
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping AuditManager Framework Shares sweep for %s: %s", region, errs)
-		return nil
+		return fmt.Errorf("error sweeping AuditManager Framework Shares for %s: %w", region, err)
 	}
 
-	return errs.ErrorOrNil()
+	return nil
 }

--- a/internal/service/ec2/sweep.go
+++ b/internal/service/ec2/sweep.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
@@ -2628,7 +2627,7 @@ func sweepInstanceConnectEndpoints(region string) error {
 			}
 
 			sweepResources = append(sweepResources, framework.NewSweepResource(newResourceInstanceConnectEndpoint, client,
-				framework.NewAttribute("id", aws_sdkv2.ToString(v.InstanceConnectEndpointId)),
+				framework.NewAttribute("id", aws.StringValue(v.InstanceConnectEndpointId)),
 			))
 		}
 

--- a/internal/service/glacier/sweep.go
+++ b/internal/service/glacier/sweep.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/glacier"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
 )
 
 func init() {
@@ -37,7 +38,7 @@ func sweepVaults(region string) error {
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
-		if sweep.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) {
 			log.Printf("[WARN] Skipping Glacier Vault sweep for %s: %s", region, err)
 			return nil
 		}

--- a/internal/service/internetmonitor/sweep.go
+++ b/internal/service/internetmonitor/sweep.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/internetmonitor"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
 )
 
 func init() {
@@ -37,7 +38,7 @@ func sweepMonitors(region string) error {
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
-		if sweep.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) {
 			log.Printf("[WARN] Skipping Internet Monitor Monitor sweep for %s: %s", region, err)
 			return nil
 		}

--- a/internal/service/kendra/sweep.go
+++ b/internal/service/kendra/sweep.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
 )
 
 func init() {
@@ -41,7 +42,7 @@ func sweepIndex(region string) error {
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
-		if sweep.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) {
 			log.Printf("[WARN] Skipping Kendra Indices sweep for %s: %s", region, err)
 			return errs.ErrorOrNil()
 		}

--- a/internal/service/keyspaces/sweep.go
+++ b/internal/service/keyspaces/sweep.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/keyspaces"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
 )
 
 func init() {
@@ -38,7 +39,7 @@ func sweepKeyspaces(region string) error { // nosemgrep:ci.keyspaces-in-func-nam
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
-		if sweep.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) {
 			log.Printf("[WARN] Skipping Keyspaces Keyspace sweep for %s: %s", region, err)
 			return nil
 		}

--- a/internal/service/lightsail/sweep.go
+++ b/internal/service/lightsail/sweep.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
 )
 
 func init() {
@@ -43,12 +44,11 @@ func sweepContainerServices(region string) error {
 	conn := client.LightsailClient(ctx)
 
 	input := &lightsail.GetContainerServicesInput{}
-	var sweeperErrs *multierror.Error
 	sweepResources := make([]sweep.Sweepable, 0)
 
 	output, err := conn.GetContainerServices(ctx, input)
 
-	if sweep.SkipSweepError(err) {
+	if awsv2.SkipSweepError(err) {
 		log.Printf("[WARN] Skipping Lightsail Container Service sweep for %s: %s", region, err)
 		return nil
 	}
@@ -65,20 +65,11 @@ func sweepContainerServices(region string) error {
 		sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 	}
 
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping Lightsail Container Services sweep for %s: %s", region, err)
-		return sweeperErrs.ErrorOrNil()
-	}
-
-	if err != nil {
-		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing Lightsail Container Services  for %s: %w", region, err))
-	}
-
 	if err := sweep.SweepOrchestrator(ctx, sweepResources); err != nil {
-		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error sweeping Lightsail Container Services for %s: %w", region, err))
+		return fmt.Errorf("error sweeping Lightsail Container Services for %s: %w", region, err)
 	}
 
-	return sweeperErrs.ErrorOrNil()
+	return nil
 }
 
 func sweepInstances(region string) error {
@@ -95,7 +86,7 @@ func sweepInstances(region string) error {
 	for {
 		output, err := conn.GetInstances(ctx, input)
 
-		if sweep.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) {
 			log.Printf("[WARN] Skipping Lightsail Instance sweep for %s: %s", region, err)
 			return nil
 		}
@@ -143,7 +134,7 @@ func sweepStaticIPs(region string) error {
 	for {
 		output, err := conn.GetStaticIps(ctx, input)
 		if err != nil {
-			if sweep.SkipSweepError(err) {
+			if awsv2.SkipSweepError(err) {
 				log.Printf("[WARN] Skipping Lightsail Static IP sweep for %s: %s", region, err)
 				return nil
 			}

--- a/internal/service/medialive/sweep.go
+++ b/internal/service/medialive/sweep.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/medialive"
-	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
 )
 
 func init() {
@@ -46,20 +46,19 @@ func sweepChannels(region string) error {
 	ctx := sweep.Context(region)
 	client, err := sweep.SharedRegionalSweepClient(ctx, region)
 	if err != nil {
-		fmt.Errorf("error getting client: %s", err)
+		return fmt.Errorf("error getting client: %s", err)
 	}
 
 	conn := client.MediaLiveClient(ctx)
 	sweepResources := make([]sweep.Sweepable, 0)
 	in := &medialive.ListChannelsInput{}
-	var errs *multierror.Error
 
 	pages := medialive.NewListChannelsPaginator(conn, in)
 
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
-		if sweep.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) {
 			log.Println("[WARN] Skipping MediaLive Channels sweep for %s: %s", region, err)
 			return nil
 		}
@@ -81,35 +80,29 @@ func sweepChannels(region string) error {
 	}
 
 	if err := sweep.SweepOrchestrator(ctx, sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error sweeping MediaLive Channels for %s: %w", region, err))
+		return fmt.Errorf("error sweeping MediaLive Channels for %s: %w", region, err)
 	}
 
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping MediaLive Channels sweep for %s: %s", region, errs)
-		return nil
-	}
-
-	return errs.ErrorOrNil()
+	return nil
 }
 
 func sweepInputs(region string) error {
 	ctx := sweep.Context(region)
 	client, err := sweep.SharedRegionalSweepClient(ctx, region)
 	if err != nil {
-		fmt.Errorf("error getting client: %s", err)
+		return fmt.Errorf("error getting client: %s", err)
 	}
 
 	conn := client.MediaLiveClient(ctx)
 	sweepResources := make([]sweep.Sweepable, 0)
 	in := &medialive.ListInputsInput{}
-	var errs *multierror.Error
 
 	pages := medialive.NewListInputsPaginator(conn, in)
 
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
-		if sweep.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) {
 			log.Println("[WARN] Skipping MediaLive Inputs sweep for %s: %s", region, err)
 			return nil
 		}
@@ -131,35 +124,29 @@ func sweepInputs(region string) error {
 	}
 
 	if err := sweep.SweepOrchestrator(ctx, sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error sweeping MediaLive Inputs for %s: %w", region, err))
+		return fmt.Errorf("error sweeping MediaLive Inputs for %s: %w", region, err)
 	}
 
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping MediaLive Inputs sweep for %s: %s", region, errs)
-		return nil
-	}
-
-	return errs.ErrorOrNil()
+	return nil
 }
 
 func sweepInputSecurityGroups(region string) error {
 	ctx := sweep.Context(region)
 	client, err := sweep.SharedRegionalSweepClient(ctx, region)
 	if err != nil {
-		fmt.Errorf("error getting client: %s", err)
+		return fmt.Errorf("error getting client: %s", err)
 	}
 
 	conn := client.MediaLiveClient(ctx)
 	sweepResources := make([]sweep.Sweepable, 0)
 	in := &medialive.ListInputSecurityGroupsInput{}
-	var errs *multierror.Error
 
 	pages := medialive.NewListInputSecurityGroupsPaginator(conn, in)
 
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
-		if sweep.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) {
 			log.Println("[WARN] Skipping MediaLive Input Security Groups sweep for %s: %s", region, err)
 			return nil
 		}
@@ -181,35 +168,29 @@ func sweepInputSecurityGroups(region string) error {
 	}
 
 	if err := sweep.SweepOrchestrator(ctx, sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error sweeping MediaLive Input Security Groups for %s: %w", region, err))
+		return fmt.Errorf("error sweeping MediaLive Input Security Groups for %s: %w", region, err)
 	}
 
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping MediaLive Input Security Groups sweep for %s: %s", region, errs)
-		return nil
-	}
-
-	return errs.ErrorOrNil()
+	return nil
 }
 
 func sweepMultiplexes(region string) error {
 	ctx := sweep.Context(region)
 	client, err := sweep.SharedRegionalSweepClient(ctx, region)
 	if err != nil {
-		fmt.Errorf("error getting client: %s", err)
+		return fmt.Errorf("error getting client: %s", err)
 	}
 
 	conn := client.MediaLiveClient(ctx)
 	sweepResources := make([]sweep.Sweepable, 0)
 	in := &medialive.ListMultiplexesInput{}
-	var errs *multierror.Error
 
 	pages := medialive.NewListMultiplexesPaginator(conn, in)
 
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
-		if sweep.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) {
 			log.Println("[WARN] Skipping MediaLive Multiplexes sweep for %s: %s", region, err)
 			return nil
 		}
@@ -231,13 +212,8 @@ func sweepMultiplexes(region string) error {
 	}
 
 	if err := sweep.SweepOrchestrator(ctx, sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error sweeping MediaLive Multiplexes for %s: %w", region, err))
+		return fmt.Errorf("error sweeping MediaLive Multiplexes for %s: %w", region, err)
 	}
 
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping MediaLive Multiplexes sweep for %s: %s", region, errs)
-		return nil
-	}
-
-	return errs.ErrorOrNil()
+	return nil
 }

--- a/internal/service/opensearchserverless/sweep.go
+++ b/internal/service/opensearchserverless/sweep.go
@@ -13,9 +13,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/opensearchserverless"
 	"github.com/aws/aws-sdk-go-v2/service/opensearchserverless/types"
-	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/framework"
 )
 
@@ -52,7 +52,6 @@ func sweepAccessPolicies(region string) error {
 
 	conn := client.OpenSearchServerlessClient(ctx)
 	sweepResources := make([]sweep.Sweepable, 0)
-	var errs *multierror.Error
 	input := &opensearchserverless.ListAccessPoliciesInput{
 		Type: types.AccessPolicyTypeData,
 	}
@@ -61,7 +60,7 @@ func sweepAccessPolicies(region string) error {
 
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-		if sweep.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) {
 			log.Printf("[WARN] Skipping OpenSearch Serverless Access Policies sweep for %s: %s", region, err)
 			return nil
 		}
@@ -82,14 +81,10 @@ func sweepAccessPolicies(region string) error {
 	}
 
 	if err := sweep.SweepOrchestrator(ctx, sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error sweeping OpenSearch Serverless Access Policies for %s: %w", region, err))
-	}
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping OpenSearch Serverless Access Policies sweep for %s: %s", region, errs)
-		return nil
+		return fmt.Errorf("error sweeping OpenSearch Serverless Access Policies for %s: %w", region, err)
 	}
 
-	return errs.ErrorOrNil()
+	return nil
 }
 
 func sweepCollections(region string) error {
@@ -102,14 +97,13 @@ func sweepCollections(region string) error {
 
 	conn := client.OpenSearchServerlessClient(ctx)
 	sweepResources := make([]sweep.Sweepable, 0)
-	var errs *multierror.Error
 	input := &opensearchserverless.ListCollectionsInput{}
 
 	pages := opensearchserverless.NewListCollectionsPaginator(conn, input)
 
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-		if sweep.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) {
 			log.Printf("[WARN] Skipping OpenSearch Serverless Collections sweep for %s: %s", region, err)
 			return nil
 		}
@@ -128,14 +122,10 @@ func sweepCollections(region string) error {
 	}
 
 	if err := sweep.SweepOrchestrator(ctx, sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error sweeping OpenSearch Serverless Collections for %s: %w", region, err))
-	}
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping OpenSearch Serverless Collections sweep for %s: %s", region, errs)
-		return nil
+		return fmt.Errorf("error sweeping OpenSearch Serverless Collections for %s: %w", region, err)
 	}
 
-	return errs.ErrorOrNil()
+	return nil
 }
 
 func sweepSecurityConfigs(region string) error {
@@ -148,7 +138,6 @@ func sweepSecurityConfigs(region string) error {
 
 	conn := client.OpenSearchServerlessClient(ctx)
 	sweepResources := make([]sweep.Sweepable, 0)
-	var errs *multierror.Error
 
 	input := &opensearchserverless.ListSecurityConfigsInput{
 		Type: types.SecurityConfigTypeSaml,
@@ -157,7 +146,7 @@ func sweepSecurityConfigs(region string) error {
 
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-		if sweep.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) {
 			log.Printf("[WARN] Skipping OpenSearch Serverless Security Configs sweep for %s: %s", region, err)
 			return nil
 		}
@@ -176,14 +165,10 @@ func sweepSecurityConfigs(region string) error {
 	}
 
 	if err := sweep.SweepOrchestrator(ctx, sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error sweeping OpenSearch Serverless Security Configs for %s: %w", region, err))
-	}
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping OpenSearch Serverless Security Configs sweep for %s: %s", region, errs)
-		return nil
+		return fmt.Errorf("error sweeping OpenSearch Serverless Security Configs for %s: %w", region, err)
 	}
 
-	return errs.ErrorOrNil()
+	return nil
 }
 
 func sweepSecurityPolicies(region string) error {
@@ -196,7 +181,6 @@ func sweepSecurityPolicies(region string) error {
 
 	conn := client.OpenSearchServerlessClient(ctx)
 	sweepResources := make([]sweep.Sweepable, 0)
-	var errs *multierror.Error
 
 	inputEncryption := &opensearchserverless.ListSecurityPoliciesInput{
 		Type: types.SecurityPolicyTypeEncryption,
@@ -205,7 +189,7 @@ func sweepSecurityPolicies(region string) error {
 
 	for pagesEncryption.HasMorePages() {
 		page, err := pagesEncryption.NextPage(ctx)
-		if sweep.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) {
 			log.Printf("[WARN] Skipping OpenSearch Serverless Security Policies sweep for %s: %s", region, err)
 			return nil
 		}
@@ -232,7 +216,7 @@ func sweepSecurityPolicies(region string) error {
 
 	for pagesNetwork.HasMorePages() {
 		page, err := pagesNetwork.NextPage(ctx)
-		if sweep.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) {
 			log.Printf("[WARN] Skipping OpenSearch Serverless Security Policies sweep for %s: %s", region, err)
 			return nil
 		}
@@ -253,14 +237,10 @@ func sweepSecurityPolicies(region string) error {
 	}
 
 	if err := sweep.SweepOrchestrator(ctx, sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error sweeping OpenSearch Serverless Security Policies for %s: %w", region, err))
-	}
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping OpenSearch Serverless Security Policies sweep for %s: %s", region, errs)
-		return nil
+		return fmt.Errorf("error sweeping OpenSearch Serverless Security Policies for %s: %w", region, err)
 	}
 
-	return errs.ErrorOrNil()
+	return nil
 }
 
 func sweepVPCEndpoints(region string) error {
@@ -273,14 +253,13 @@ func sweepVPCEndpoints(region string) error {
 
 	conn := client.OpenSearchServerlessClient(ctx)
 	sweepResources := make([]sweep.Sweepable, 0)
-	var errs *multierror.Error
 	input := &opensearchserverless.ListVpcEndpointsInput{}
 
 	pages := opensearchserverless.NewListVpcEndpointsPaginator(conn, input)
 
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-		if sweep.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) {
 			log.Printf("[WARN] Skipping OpenSearch Serverless VPC Endpoints sweep for %s: %s", region, err)
 			return nil
 		}
@@ -299,12 +278,8 @@ func sweepVPCEndpoints(region string) error {
 	}
 
 	if err := sweep.SweepOrchestrator(ctx, sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error sweeping OpenSearch Serverless VPC Endpoints for %s: %w", region, err))
-	}
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping OpenSearch Serverless VPC Endpoint sweep for %s: %s", region, errs)
-		return nil
+		return fmt.Errorf("error sweeping OpenSearch Serverless VPC Endpoints for %s: %w", region, err)
 	}
 
-	return errs.ErrorOrNil()
+	return nil
 }

--- a/internal/service/pipes/sweep.go
+++ b/internal/service/pipes/sweep.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/pipes"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
 )
 
 func init() {
@@ -36,7 +37,7 @@ func sweepPipes(region string) error {
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
-		if sweep.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) {
 			log.Printf("[WARN] Skipping Pipe sweep for %s: %s", region, err)
 			return nil
 		}

--- a/internal/service/qldb/sweep.go
+++ b/internal/service/qldb/sweep.go
@@ -15,6 +15,7 @@ import (
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
 )
 
 func init() {
@@ -47,7 +48,7 @@ func sweepLedgers(region string) error {
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
-		if sweep.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) {
 			log.Printf("[WARN] Skipping QLDB Ledger sweep for %s: %s", region, err)
 			return nil
 		}
@@ -89,7 +90,7 @@ func sweepStreams(region string) error {
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
-		if sweep.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) {
 			log.Printf("[WARN] Skipping QLDB Stream sweep for %s: %s", region, err)
 			return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
 		}
@@ -107,7 +108,7 @@ func sweepStreams(region string) error {
 			for pages.HasMorePages() {
 				page, err := pages.NextPage(ctx)
 
-				if sweep.SkipSweepError(err) {
+				if awsv2.SkipSweepError(err) {
 					continue
 				}
 

--- a/internal/service/resourceexplorer2/sweep.go
+++ b/internal/service/resourceexplorer2/sweep.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/resourceexplorer2"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/framework"
 )
 
@@ -38,7 +39,7 @@ func sweepIndexes(region string) error {
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
-		if sweep.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) {
 			log.Printf("[WARN] Skipping Resource Explorer Index sweep for %s: %s", region, err)
 			return nil
 		}

--- a/internal/service/scheduler/sweep.go
+++ b/internal/service/scheduler/sweep.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/scheduler"
-	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
 )
 
 func init() {
@@ -42,16 +42,17 @@ func sweepScheduleGroups(region string) error {
 
 	conn := client.SchedulerClient(ctx)
 	sweepResources := make([]sweep.Sweepable, 0)
-	var errs *multierror.Error
 
 	paginator := scheduler.NewListScheduleGroupsPaginator(conn, &scheduler.ListScheduleGroupsInput{})
 
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
-
+		if awsv2.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping Schedule Group sweep for %s: %s", region, err)
+			return nil
+		}
 		if err != nil {
-			errs = multierror.Append(errs, fmt.Errorf("listing Schedule Groups for %s: %w", region, err))
-			break
+			return fmt.Errorf("listing Schedule Groups for %s: %w", region, err)
 		}
 
 		for _, it := range page.ScheduleGroups {
@@ -71,15 +72,10 @@ func sweepScheduleGroups(region string) error {
 	}
 
 	if err := sweep.SweepOrchestrator(ctx, sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("sweeping Schedule Group for %s: %w", region, err))
+		return fmt.Errorf("sweeping Schedule Group for %s: %w", region, err)
 	}
 
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping Schedule Group sweep for %s: %s", region, errs)
-		return nil
-	}
-
-	return errs.ErrorOrNil()
+	return nil
 }
 
 func sweepSchedules(region string) error {
@@ -92,16 +88,17 @@ func sweepSchedules(region string) error {
 
 	conn := client.SchedulerClient(ctx)
 	sweepResources := make([]sweep.Sweepable, 0)
-	var errs *multierror.Error
 
 	paginator := scheduler.NewListSchedulesPaginator(conn, &scheduler.ListSchedulesInput{})
 
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
-
+		if awsv2.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping Schedule sweep for %s: %s", region, err)
+			return nil
+		}
 		if err != nil {
-			errs = multierror.Append(errs, fmt.Errorf("listing Schedules for %s: %w", region, err))
-			break
+			return fmt.Errorf("listing Schedules for %s: %w", region, err)
 		}
 
 		for _, it := range page.Schedules {
@@ -117,13 +114,8 @@ func sweepSchedules(region string) error {
 	}
 
 	if err := sweep.SweepOrchestrator(ctx, sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("sweeping Schedule for %s: %w", region, err))
+		return fmt.Errorf("sweeping Schedule for %s: %w", region, err)
 	}
 
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping Schedule sweep for %s: %s", region, errs)
-		return nil
-	}
-
-	return errs.ErrorOrNil()
+	return nil
 }

--- a/internal/service/sesv2/sweep.go
+++ b/internal/service/sesv2/sweep.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
 )
 
 func init() {
@@ -68,7 +69,7 @@ func sweepConfigurationSets(region string) error {
 		errs = multierror.Append(errs, fmt.Errorf("sweeping Configuration Sets for %s: %w", region, err))
 	}
 
-	if sweep.SkipSweepError(err) {
+	if awsv2.SkipSweepError(err) {
 		log.Printf("[WARN] Skipping Configuration Sets sweep for %s: %s", region, errs)
 		return nil
 	}
@@ -115,7 +116,7 @@ func sweepContactLists(region string) error {
 		errs = multierror.Append(errs, fmt.Errorf("sweeping Contact Lists for %s: %w", region, err))
 	}
 
-	if sweep.SkipSweepError(err) {
+	if awsv2.SkipSweepError(err) {
 		log.Printf("[WARN] Skipping Contact Lists sweep for %s: %s", region, errs)
 		return nil
 	}

--- a/internal/service/ssm/sweep.go
+++ b/internal/service/ssm/sweep.go
@@ -23,6 +23,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv1"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
@@ -66,6 +68,10 @@ func sweepResourceDefaultPatchBaselines(region string) error {
 	paginator := patchBaselinesPaginator(conn, ownerIsSelfFilter())
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
+		if awsv2.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping Default Patch Baselines sweep for %s: %s", region, errs)
+			break
+		}
 		if err != nil {
 			errs = multierror.Append(errs, fmt.Errorf("listing Default Patch Baselines for %s: %w", region, err))
 			break
@@ -89,11 +95,6 @@ func sweepResourceDefaultPatchBaselines(region string) error {
 
 	if err := sweep.SweepOrchestrator(ctx, sweepables); err != nil {
 		errs = multierror.Append(errs, fmt.Errorf("sweeping Default Patch Baselines for %s: %w", region, err))
-	}
-
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping Default Patch Baselines sweep for %s: %s", region, errs)
-		return nil
 	}
 
 	return errs.ErrorOrNil()
@@ -133,7 +134,7 @@ func sweepMaintenanceWindows(region string) error {
 	for {
 		output, err := conn.DescribeMaintenanceWindowsWithContext(ctx, input)
 
-		if sweep.SkipSweepError(err) {
+		if awsv1.SkipSweepError(err) {
 			log.Printf("[WARN] Skipping SSM Maintenance Window sweep for %s: %s", region, err)
 			return nil
 		}
@@ -157,9 +158,7 @@ func sweepMaintenanceWindows(region string) error {
 			}
 
 			if err != nil {
-				sweeperErr := fmt.Errorf("deleting SSM Maintenance Window (%s): %w", id, err)
-				log.Printf("[ERROR] %s", sweeperErr)
-				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+				sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("deleting SSM Maintenance Window (%s): %w", id, err))
 				continue
 			}
 		}
@@ -189,6 +188,10 @@ func sweepResourcePatchBaselines(region string) error {
 	paginator := patchBaselinesPaginator(conn, ownerIsSelfFilter())
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
+		if awsv2.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping Patch Baselines sweep for %s: %s", region, errs)
+			break
+		}
 		if err != nil {
 			errs = multierror.Append(errs, fmt.Errorf("listing Patch Baselines for %s: %w", region, err))
 			break
@@ -205,13 +208,8 @@ func sweepResourcePatchBaselines(region string) error {
 		}
 	}
 
-	if err := sweep.SweepOrchestrator(ctx, sweepables);err != nil {
+	if err := sweep.SweepOrchestrator(ctx, sweepables); err != nil {
 		errs = multierror.Append(errs, fmt.Errorf("sweeping Patch Baselines for %s: %w", region, err))
-	}
-
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping Patch Baselines sweep for %s: %s", region, errs)
-		return nil
 	}
 
 	return errs.ErrorOrNil()
@@ -258,7 +256,7 @@ func sweepResourceDataSyncs(region string) error {
 		errs = multierror.Append(errs, fmt.Errorf("sweeping SSM Resource Data Sync for %s: %w", region, err))
 	}
 
-	if sweep.SkipSweepError(errs.ErrorOrNil()) {
+	if awsv1.SkipSweepError(errs.ErrorOrNil()) {
 		log.Printf("[WARN] Skipping SSM Resource Data Sync sweep for %s: %s", region, errs)
 		return nil
 	}

--- a/internal/service/swf/sweep.go
+++ b/internal/service/swf/sweep.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/swf/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
 )
 
 func init() {
@@ -40,7 +41,7 @@ func sweepDomains(region string) error {
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
-		if sweep.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) {
 			log.Printf("[WARN] Skipping SWF Domain sweep for %s: %s", region, err)
 			return nil
 		}

--- a/internal/service/timestreamwrite/sweep.go
+++ b/internal/service/timestreamwrite/sweep.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/timestreamwrite"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
 )
 
 func init() {
@@ -43,7 +44,7 @@ func sweepDatabases(region string) error {
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
-		if sweep.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) {
 			log.Printf("[WARN] Skipping Timestream Database sweep for %s: %s", region, err)
 			return nil
 		}
@@ -84,7 +85,7 @@ func sweepTables(region string) error {
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
-		if sweep.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) {
 			log.Printf("[WARN] Skipping Timestream Table sweep for %s: %s", region, err)
 			return nil
 		}

--- a/internal/service/transcribe/sweep.go
+++ b/internal/service/transcribe/sweep.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/transcribe"
-	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
 )
 
 func init() {
@@ -62,14 +62,13 @@ func sweepLanguageModels(region string) error {
 	conn := client.TranscribeClient(ctx)
 	sweepResources := make([]sweep.Sweepable, 0)
 	in := &transcribe.ListLanguageModelsInput{}
-	var errs *multierror.Error
 
 	pages := transcribe.NewListLanguageModelsPaginator(conn, in)
 
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
-		if sweep.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) {
 			log.Println("[WARN] Skipping Transcribe Language Models sweep for %s: %s", region, err)
 			return nil
 		}
@@ -91,15 +90,10 @@ func sweepLanguageModels(region string) error {
 	}
 
 	if err := sweep.SweepOrchestrator(ctx, sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error sweeping Transcribe Language Models for %s: %w", region, err))
+		return fmt.Errorf("error sweeping Transcribe Language Models for %s: %w", region, err)
 	}
 
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping Transcribe Language Models sweep for %s: %s", region, errs)
-		return nil
-	}
-
-	return errs.ErrorOrNil()
+	return nil
 }
 
 func sweepMedicalVocabularies(region string) error {
@@ -112,11 +106,10 @@ func sweepMedicalVocabularies(region string) error {
 	conn := client.TranscribeClient(ctx)
 	sweepResources := make([]sweep.Sweepable, 0)
 	in := &transcribe.ListMedicalVocabulariesInput{}
-	var errs *multierror.Error
 
 	for {
 		out, err := conn.ListMedicalVocabularies(ctx, in)
-		if sweep.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) {
 			log.Println("[WARN] Skipping Transcribe Medical Vocabularies sweep for %s: %s", region, err)
 			return nil
 		}
@@ -142,15 +135,10 @@ func sweepMedicalVocabularies(region string) error {
 	}
 
 	if err := sweep.SweepOrchestrator(ctx, sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error sweeping Transcribe Medical Vocabularies for %s: %w", region, err))
+		return fmt.Errorf("error sweeping Transcribe Medical Vocabularies for %s: %w", region, err)
 	}
 
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping Transcribe Medical Vocabularies sweep for %s: %s", region, errs)
-		return nil
-	}
-
-	return errs.ErrorOrNil()
+	return nil
 }
 
 func sweepVocabularies(region string) error {
@@ -163,11 +151,10 @@ func sweepVocabularies(region string) error {
 	conn := client.TranscribeClient(ctx)
 	sweepResources := make([]sweep.Sweepable, 0)
 	in := &transcribe.ListVocabulariesInput{}
-	var errs *multierror.Error
 
 	for {
 		out, err := conn.ListVocabularies(ctx, in)
-		if sweep.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) {
 			log.Println("[WARN] Skipping Transcribe Vocabularies sweep for %s: %s", region, err)
 			return nil
 		}
@@ -193,15 +180,10 @@ func sweepVocabularies(region string) error {
 	}
 
 	if err := sweep.SweepOrchestrator(ctx, sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error sweeping Transcribe Vocabularies for %s: %w", region, err))
+		return fmt.Errorf("error sweeping Transcribe Vocabularies for %s: %w", region, err)
 	}
 
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping Transcribe Vocabularies sweep for %s: %s", region, errs)
-		return nil
-	}
-
-	return errs.ErrorOrNil()
+	return nil
 }
 
 func sweepVocabularyFilters(region string) error {
@@ -214,11 +196,10 @@ func sweepVocabularyFilters(region string) error {
 	conn := client.TranscribeClient(ctx)
 	sweepResources := make([]sweep.Sweepable, 0)
 	in := &transcribe.ListVocabularyFiltersInput{}
-	var errs *multierror.Error
 
 	for {
 		out, err := conn.ListVocabularyFilters(ctx, in)
-		if sweep.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) {
 			log.Println("[WARN] Skipping Transcribe Vocabulary Filter sweep for %s: %s", region, err)
 			return nil
 		}
@@ -245,13 +226,8 @@ func sweepVocabularyFilters(region string) error {
 	}
 
 	if err := sweep.SweepOrchestrator(ctx, sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error sweeping Transcribe Vocabulary Filters for %s: %w", region, err))
+		return fmt.Errorf("error sweeping Transcribe Vocabulary Filters for %s: %w", region, err)
 	}
 
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping Transcribe Vocabulary Filters sweep for %s: %s", region, errs)
-		return nil
-	}
-
-	return errs.ErrorOrNil()
+	return nil
 }

--- a/internal/service/vpclattice/sweep.go
+++ b/internal/service/vpclattice/sweep.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
 )
 
 func init() {
@@ -45,7 +46,7 @@ func sweepServices(region string) error {
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
-		if sweep.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) {
 			log.Printf("[WARN] Skipping VPC Lattice Service sweep for %s: %s", region, err)
 			return nil
 		}
@@ -86,7 +87,7 @@ func sweepServiceNetworks(region string) error {
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
-		if sweep.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) {
 			log.Printf("[WARN] Skipping VPC Lattice Service Network sweep for %s: %s", region, err)
 			return nil
 		}

--- a/internal/service/workspaces/sweep.go
+++ b/internal/service/workspaces/sweep.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/workspaces"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
 )
 
 func init() {
@@ -52,7 +53,7 @@ func sweepDirectories(region string) error {
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
 
-		if sweep.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) {
 			log.Printf("[WARN] Skipping WorkSpaces Directory sweep for %s: %s", region, err)
 			return nil
 		}
@@ -105,7 +106,7 @@ func sweepIPGroups(region string) error {
 		return !lastPage
 	})
 
-	if sweep.SkipSweepError(err) {
+	if awsv2.SkipSweepError(err) {
 		log.Printf("[WARN] Skipping WorkSpaces IP Group sweep for %s: %s", region, err)
 		return nil
 	}
@@ -154,7 +155,7 @@ func sweepWorkspace(region string) error {
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
 
-		if sweep.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) {
 			log.Printf("[WARN] Skipping WorkSpaces Workspace sweep for %s: %s", region, err)
 			return nil
 		}

--- a/internal/sweep/awsv1/skip.go
+++ b/internal/sweep/awsv1/skip.go
@@ -1,0 +1,76 @@
+package awsv1
+
+import (
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+)
+
+// Check sweeper API call error for reasons to skip sweeping
+// These include missing API endpoints and unsupported API calls
+func SkipSweepError(err error) bool {
+	// Ignore missing API endpoints for AWS SDK for Go v1
+	if tfawserr.ErrMessageContains(err, "RequestError", "send request failed") {
+		return true
+	}
+	// Ignore unsupported API calls
+	if tfawserr.ErrCodeEquals(err, "UnsupportedOperation") {
+		return true
+	}
+	// Ignore more unsupported API calls
+	// InvalidParameterValue: Use of cache security groups is not permitted in this API version for your account.
+	if tfawserr.ErrMessageContains(err, "InvalidParameterValue", "not permitted in this API version for your account") {
+		return true
+	}
+	// InvalidParameterValue: Access Denied to API Version: APIGlobalDatabases
+	if tfawserr.ErrMessageContains(err, "InvalidParameterValue", "Access Denied to API Version") {
+		return true
+	}
+	// GovCloud has endpoints that respond with (no message provided):
+	// AccessDeniedException:
+	// Since acceptance test sweepers are best effort and this response is very common,
+	// we allow bypassing this error globally instead of individual test sweeper fixes.
+	if tfawserr.ErrCodeEquals(err, "AccessDeniedException") {
+		return true
+	}
+	// Example: BadRequestException: vpc link not supported for region us-gov-west-1
+	if tfawserr.ErrMessageContains(err, "BadRequestException", "not supported") {
+		return true
+	}
+	// Example: InvalidAction: InvalidAction: Operation (ListPlatformApplications) is not supported in this region
+	if tfawserr.ErrMessageContains(err, "InvalidAction", "is not supported in this region") {
+		return true
+	}
+	// Example: InvalidAction: The action DescribeTransitGatewayAttachments is not valid for this web service
+	if tfawserr.ErrMessageContains(err, "InvalidAction", "is not valid") {
+		return true
+	}
+	// For example from GovCloud SES.SetActiveReceiptRuleSet.
+	if tfawserr.ErrMessageContains(err, "InvalidAction", "Unavailable Operation") {
+		return true
+	}
+	// For example from us-west-2 Route53 key signing key
+	if tfawserr.ErrMessageContains(err, "InvalidKeySigningKeyStatus", "cannot be deleted because") {
+		return true
+	}
+	// For example from us-west-2 Route53 zone
+	if tfawserr.ErrMessageContains(err, "KeySigningKeyInParentDSRecord", "Due to DNS lookup failure") {
+		return true
+	}
+	// For example from us-gov-west-1 EventBridge archive
+	if tfawserr.ErrMessageContains(err, "UnknownOperationException", "Operation is disabled in this region") {
+		return true
+	}
+	// For example from us-east-1 SageMaker
+	if tfawserr.ErrMessageContains(err, "UnknownOperationException", "The requested operation is not supported in the called region") {
+		return true
+	}
+	// For example from us-west-2 ECR public repository
+	if tfawserr.ErrMessageContains(err, "UnsupportedCommandException", "command is only supported in") {
+		return true
+	}
+	// For example from us-west-1 EMR studio
+	if tfawserr.ErrMessageContains(err, "ValidationException", "Account is not whitelisted to use this feature") {
+		return true
+	}
+
+	return false
+}

--- a/internal/sweep/awsv1/skip.go
+++ b/internal/sweep/awsv1/skip.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package awsv1
 
 import (

--- a/internal/sweep/awsv2/skip.go
+++ b/internal/sweep/awsv2/skip.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package awsv2
 
 import (

--- a/internal/sweep/awsv2/skip.go
+++ b/internal/sweep/awsv2/skip.go
@@ -1,0 +1,17 @@
+package awsv2
+
+import (
+	"net"
+
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+)
+
+// Check sweeper API call error for reasons to skip sweeping
+// These include missing API endpoints and unsupported API calls
+func SkipSweepError(err error) bool {
+	// Ignore missing API endpoints
+	if dnsErr, ok := errs.As[*net.DNSError](err); ok {
+		return dnsErr.IsNotFound
+	}
+	return false
+}

--- a/internal/sweep/sweep.go
+++ b/internal/sweep/sweep.go
@@ -116,6 +116,8 @@ func SweepOrchestrator(ctx context.Context, sweepables []Sweepable, optFns ...tf
 }
 
 // Deprecated: Usse awsv1.SkipSweepError
+//
+//nolint:stylecheck // It's not required for functions, so why for variables?
 var SkipSweepError = awsv1.SkipSweepError
 
 func Partition(region string) string {

--- a/internal/sweep/sweep.go
+++ b/internal/sweep/sweep.go
@@ -5,18 +5,16 @@ package sweep
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"net"
 	"os"
 	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/endpoints"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/envvar"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv1"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
@@ -62,7 +60,6 @@ func SharedRegionalSweepClient(ctx context.Context, region string) (*conns.AWSCl
 	meta.ServicePackages = servicePackageMap
 
 	conf := &conns.Config{
-		MaxRetries:       5,
 		Region:           region,
 		SuppressDebugLog: true,
 	}
@@ -118,81 +115,8 @@ func SweepOrchestrator(ctx context.Context, sweepables []Sweepable, optFns ...tf
 	return g.Wait().ErrorOrNil()
 }
 
-// Check sweeper API call error for reasons to skip sweeping
-// These include missing API endpoints and unsupported API calls
-func SkipSweepError(err error) bool {
-	// Ignore missing API endpoints for AWS SDK for Go v1
-	if tfawserr.ErrMessageContains(err, "RequestError", "send request failed") {
-		return true
-	}
-	// Ignore unsupported API calls
-	if tfawserr.ErrCodeEquals(err, "UnsupportedOperation") {
-		return true
-	}
-	// Ignore more unsupported API calls
-	// InvalidParameterValue: Use of cache security groups is not permitted in this API version for your account.
-	if tfawserr.ErrMessageContains(err, "InvalidParameterValue", "not permitted in this API version for your account") {
-		return true
-	}
-	// InvalidParameterValue: Access Denied to API Version: APIGlobalDatabases
-	if tfawserr.ErrMessageContains(err, "InvalidParameterValue", "Access Denied to API Version") {
-		return true
-	}
-	// GovCloud has endpoints that respond with (no message provided):
-	// AccessDeniedException:
-	// Since acceptance test sweepers are best effort and this response is very common,
-	// we allow bypassing this error globally instead of individual test sweeper fixes.
-	if tfawserr.ErrCodeEquals(err, "AccessDeniedException") {
-		return true
-	}
-	// Example: BadRequestException: vpc link not supported for region us-gov-west-1
-	if tfawserr.ErrMessageContains(err, "BadRequestException", "not supported") {
-		return true
-	}
-	// Example: InvalidAction: InvalidAction: Operation (ListPlatformApplications) is not supported in this region
-	if tfawserr.ErrMessageContains(err, "InvalidAction", "is not supported in this region") {
-		return true
-	}
-	// Example: InvalidAction: The action DescribeTransitGatewayAttachments is not valid for this web service
-	if tfawserr.ErrMessageContains(err, "InvalidAction", "is not valid") {
-		return true
-	}
-	// For example from GovCloud SES.SetActiveReceiptRuleSet.
-	if tfawserr.ErrMessageContains(err, "InvalidAction", "Unavailable Operation") {
-		return true
-	}
-	// For example from us-west-2 Route53 key signing key
-	if tfawserr.ErrMessageContains(err, "InvalidKeySigningKeyStatus", "cannot be deleted because") {
-		return true
-	}
-	// For example from us-west-2 Route53 zone
-	if tfawserr.ErrMessageContains(err, "KeySigningKeyInParentDSRecord", "Due to DNS lookup failure") {
-		return true
-	}
-	// For example from us-gov-west-1 EventBridge archive
-	if tfawserr.ErrMessageContains(err, "UnknownOperationException", "Operation is disabled in this region") {
-		return true
-	}
-	// For example from us-east-1 SageMaker
-	if tfawserr.ErrMessageContains(err, "UnknownOperationException", "The requested operation is not supported in the called region") {
-		return true
-	}
-	// For example from us-west-2 ECR public repository
-	if tfawserr.ErrMessageContains(err, "UnsupportedCommandException", "command is only supported in") {
-		return true
-	}
-	// For example from us-west-1 EMR studio
-	if tfawserr.ErrMessageContains(err, "ValidationException", "Account is not whitelisted to use this feature") {
-		return true
-	}
-
-	// Ignore missing API endpoints for AWS SDK for Go v2
-	var dnsErr *net.DNSError
-	if errors.As(err, &dnsErr) {
-		return dnsErr.IsNotFound
-	}
-	return false
-}
+// Deprecated: Usse awsv1.SkipSweepError
+var SkipSweepError = awsv1.SkipSweepError
 
 func Partition(region string) string {
 	if partition, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), region); ok {


### PR DESCRIPTION
### Description

Since AWS SDK for Go v1 and v2 have different error handling strategies and types, use separate skip checking functions in sweepers.

`awsv1.SkipSweepError` is aliased as `sweep. SkipSweepError`