### PR TITLE
FIX api_gateway_authorizer.html.markdown data reference

### DIFF
--- a/website/docs/r/api_gateway_authorizer.html.markdown
+++ b/website/docs/r/api_gateway_authorizer.html.markdown
@@ -40,7 +40,7 @@ data "aws_iam_role_policy_document" "invocation_assume_role" {
 resource "aws_iam_role" "invocation_role" {
   name               = "api_gateway_auth_invocation"
   path               = "/"
-  assume_role_policy = data.aws_iam_role_policy_document.assume_role.json
+  assume_role_policy = data.aws_iam_role_policy_document.invocation_assume_role.json
 }
 
 data "aws_iam_policy_document" "invocation_policy" {


### PR DESCRIPTION
### Description
Changing reference on `aws_iam_role.invocation_role` to refer `data.aws_iam_role_policy_document.invocation_assume_role.json` instead of  `data.aws_iam_role_policy_document.assume_role.json`


