### PR TITLE
Add `username` input to community check reusable workflow

### DIFF
--- a/.github/workflows/autoremove_labels.yml
+++ b/.github/workflows/autoremove_labels.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   community_check:
-    if: github.event_name == 'issues'
+    if: github.event.action == 'opened'
     uses: ./.github/workflows/community-check.yml
     secrets: inherit
     with:
@@ -17,7 +17,7 @@ jobs:
   RemoveNeedsTriageFromMaintainers:
     name: Remove needs-triage for Maintainers
     needs: community_check
-    if: github.event.action == 'opened' && needs.community_check.outputs.maintainer == 'true'
+    if: needs.community_check.outputs.maintainer == 'true'
     uses: ./.github/workflows/reusable-add-or-remove-labels.yml
     with:
       remove: needs-triage

--- a/.github/workflows/autoremove_labels.yml
+++ b/.github/workflows/autoremove_labels.yml
@@ -8,11 +8,14 @@ on:
 
 jobs:
   community_check:
+    if: github.event_name == 'issues'
     uses: ./.github/workflows/community-check.yml
     secrets: inherit
+    with:
+      username: ${{ github.event.issue.user.login }}
 
   RemoveNeedsTriageFromMaintainers:
-    name: 'Remove needs-triage for Maintainers'
+    name: Remove needs-triage for Maintainers
     needs: community_check
     if: github.event.action == 'opened' && needs.community_check.outputs.maintainer == 'true'
     uses: ./.github/workflows/reusable-add-or-remove-labels.yml
@@ -20,7 +23,7 @@ jobs:
       remove: needs-triage
 
   RemoveTriagingLabelsFromClosedIssueOrPR:
-    name: 'Remove Triaging Labels from Closed Items'
+    name: Remove Triaging Labels from Closed Items
     if: github.event.action == 'closed'
     uses: ./.github/workflows/reusable-add-or-remove-labels.yml
     with:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -22,7 +22,7 @@ jobs:
       changed: ${{ steps.filter.outputs.changed }}
     steps:
       - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50
-        if: github.event_name == 'pull_request_target' && needs.community_check.outputs.maintainer == 'false'
+        if: needs.community_check.outputs.maintainer == 'false'
         id: filter
         with:
           filters: |

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -8,8 +8,11 @@ on:
 
 jobs:
   community_check:
+    if: github.event_name == 'pull_request_target'
     uses: ./.github/workflows/community-check.yml
     secrets: inherit
+    with:
+      username: ${{ github.event.pull_request.user.login }}
 
   changes:
     needs: community_check

--- a/.github/workflows/community-check.yml
+++ b/.github/workflows/community-check.yml
@@ -1,13 +1,24 @@
 name: Community Check
+
 on:
   workflow_call:
+    inputs:
+      username:
+        description: The username to check the association of
+        type: string
+        required: true
+
     outputs:
       core_contributor:
+        description: Whether or not the user is a core contributor
         value: ${{ jobs.community_check.outputs.is_core_contributor }}
       maintainer:
+        description: Whether or not the user is a maintainer
         value: ${{ jobs.community_check.outputs.is_maintainer }}
       partner:
+        description: Whether or not the user is a partner
         value: ${{ jobs.community_check.outputs.is_partner }}
+
 jobs:
   community_check:
     name: Check community lists for username
@@ -38,11 +49,10 @@ jobs:
           echo "core_contributors_list=$CORE_CONTRIBUTORS_DECODED" >> $GITHUB_OUTPUT
           echo "maintainers_list=$MAINTAINERS_DECODED" >> $GITHUB_OUTPUT
           echo "partners_list=$PARTNERS_DECODED" >> $GITHUB_OUTPUT
+
       - name: Determine if user is in lists
         id: determination
-        env:
-          USER_LOGIN: ${{ github.event.issue.user.login || github.event.pull_request.user.login }}
         run: |
-          echo "is_core_contributor="${{ contains(fromJSON(steps.decode.outputs.core_contributors_list), env.USER_LOGIN) }} >> $GITHUB_OUTPUT
-          echo "is_maintainer="${{ contains(fromJSON(steps.decode.outputs.maintainers_list), env.USER_LOGIN) }} >> $GITHUB_OUTPUT
-          echo "is_partner="${{ contains(fromJSON(steps.decode.outputs.partners_list), env.USER_LOGIN) }} >> $GITHUB_OUTPUT
+          echo "is_core_contributor="${{ contains(fromJSON(steps.decode.outputs.core_contributors_list), inputs.username) }} >> $GITHUB_OUTPUT
+          echo "is_maintainer="${{ contains(fromJSON(steps.decode.outputs.maintainers_list), inputs.username) }} >> $GITHUB_OUTPUT
+          echo "is_partner="${{ contains(fromJSON(steps.decode.outputs.partners_list), inputs.username) }} >> $GITHUB_OUTPUT

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -9,8 +9,11 @@ on:
 
 jobs:
   community_check:
+    if: github.event_name == 'pull_request_target'
     uses: ./.github/workflows/community-check.yml
     secrets: inherit
+    with:
+      username: ${{ github.event.pull_request.user.login }}
 
   changes:
     needs: community_check

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -23,7 +23,7 @@ jobs:
       changed: ${{ steps.filter.outputs.changed }}
     steps:
       - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50
-        if: github.event_name == 'pull_request_target' && needs.community_check.outputs.maintainer == 'false'
+        if: needs.community_check.outputs.maintainer == 'false'
         id: filter
         with:
           filters: |

--- a/.github/workflows/issue-comment-created.yml
+++ b/.github/workflows/issue-comment-created.yml
@@ -8,11 +8,13 @@ jobs:
   community_check:
     uses: ./.github/workflows/community-check.yml
     secrets: inherit
+    with:
+      username: ${{ github.event.comment.user.login }}
 
   issue_comment_triage:
-    name: 'Remove stale and waiting-response Labels on Response'
+    name: Remove stale and waiting-response Labels on Response
     needs: community_check
-    if: github.event_name == 'issue_comment' && needs.community_check.outputs.maintainer == 'false'
+    if: needs.community_check.outputs.maintainer == 'false'
     uses: ./.github/workflows/reusable-add-or-remove-labels.yml
     with:
       remove: stale,waiting-response

--- a/.github/workflows/maintainer-edit.yml
+++ b/.github/workflows/maintainer-edit.yml
@@ -7,6 +7,8 @@ jobs:
   community_check:
     uses: ./.github/workflows/community-check.yml
     secrets: inherit
+    with:
+      username: ${{ github.event.pull_request.user.login }}
 
   PermissionsCheck:
     needs: community_check

--- a/.github/workflows/new-project-automation.yml
+++ b/.github/workflows/new-project-automation.yml
@@ -1,33 +1,42 @@
-name: 'Team GitHub Projects (new) Automation'
+name: Team GitHub Projects (new) Automation
+
 on:
   issues:
     types: ["labeled", "milestoned", "opened"]
   pull_request_target:
     types: ["labeled", "opened", "ready_for_review"]
+
 jobs:
   community_check:
+    if: github.event_name == 'pull_request_target'
     uses: ./.github/workflows/community-check.yml
     secrets: inherit
+    with:
+      username: ${{ github.event.pull_request.user.login }}
+
   maintainer_prs:
-    name: 'Add Maintainer PRs that are Ready for Review'
+    name: Add Maintainer PRs that are Ready for Review
     needs: community_check
-    if: github.event_name == 'pull_request_target' && !github.event.pull_request.draft && needs.community_check.outputs.maintainer == 'true'
+    if: needs.community_check.outputs.maintainer == 'true' && !github.event.pull_request.draft
     uses: ./.github/workflows/reusable-team-project.yml
     secrets: inherit
     with:
       status: ${{ vars.team_project_status_maintainer_pr }}
+
   partner_prs:
-    name: 'Add Partner PRs that are Ready for Review'
+    name: Add Partner PRs that are Ready for Review
     if: github.event_name == 'pull_request_target' && !github.event.pull_request.draft && contains(github.event.pull_request.labels.*.name, 'partner')
     uses: ./.github/workflows/reusable-team-project.yml
     secrets: inherit
+
   roadmap:
-    name: 'Add Roadmap Items'
+    name: Add Roadmap Items
     if: github.event.label.name == 'roadmap' || github.event.*.milestone.title == 'Roadmap'
     uses: ./.github/workflows/reusable-team-project.yml
     secrets: inherit
+
   regressions:
-    name: 'Add Regressions'
+    name: Add Regressions
     if: github.event.label.name == 'regression'
     uses: ./.github/workflows/reusable-team-project.yml
     secrets: inherit

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -8,6 +8,8 @@ jobs:
   community_check:
     uses: ./.github/workflows/community-check.yml
     secrets: inherit
+    with:
+      username: ${{ github.event.pull_request.user.login }}
 
   WorkingBoardReview:
     needs: community_check

--- a/.github/workflows/pull_request_feed.yml
+++ b/.github/workflows/pull_request_feed.yml
@@ -1,4 +1,5 @@
 name: "Pull Request Feed"
+
 on:
   pull_request_target:
     types: [opened, closed]
@@ -12,6 +13,9 @@ jobs:
   community_check:
     uses: ./.github/workflows/community-check.yml
     secrets: inherit
+    with:
+      username: ${{ github.event.pull_request.user.login }}
+
   NotificationPRMerged:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
@@ -31,6 +35,7 @@ jobs:
                 }
               ]
             }
+
   NotificationMaintainerPROpened:
     needs: community_check
     runs-on: ubuntu-latest
@@ -51,6 +56,7 @@ jobs:
                 }
               ]
             }
+
   NotificationPartnerPROpened:
     needs: community_check
     runs-on: ubuntu-latest

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -1,12 +1,14 @@
+name: Pull Request Target (All types)
+
 on:
   - pull_request_target
-
-name: Pull Request Target (All types)
 
 jobs:
   community_check:
     uses: ./.github/workflows/community-check.yml
     secrets: inherit
+    with:
+      username: ${{ github.event.pull_request.user.login }}
 
   Labeler:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

Previously, the community check reusable workflow based its determination on `github.event.issue.user.login || github.event.pull_request.user.login`, which maps to the username of the user who created the issue or pull request. This, however, isn't always accurate when it comes to certain things we'd like to automate.

For example, for `issue_comment` events (such as is used in the `issue-comment-created` workflow, used to remove the `waiting-response` label when a non-maintainer comments on an issue or PR), this meant that when a comment was made, the determination was based on the original issue/PR author's username, rather than the commenter's username.

This PR adds a `username` input to the community check workflow to allow us to check a _specific_ username, and updates all workflows that use the workflow to include this now-required input. This also enables additional possibilities, such as adding an item to the team's Project board when it gets assigned to a maintainer, and possibly additional things down the line.

### Relations

N/a

### References

N/a


### Output from Acceptance Testing

N/a, Actions
