### PR TITLE
Add `skaff` `--include-tags` flag

### DIFF
--- a/docs/skaff.md
+++ b/docs/skaff.md
@@ -70,6 +70,8 @@ Create scaffolding for a data source
 
 ```console
 $ skaff datasource --help
+Create scaffolding for a data source
+
 Usage:
   skaff datasource [flags]
 
@@ -77,6 +79,7 @@ Flags:
   -c, --clear-comments     do not include instructional comments in source
   -f, --force              force creation, overwriting existing files
   -h, --help               help for datasource
+  -t, --include-tags       Indicate that this resource has tags and the code for tagging should be generated
   -n, --name string        name of the entity
   -p, --plugin-framework   generate for Terraform Plugin-Framework
   -s, --snakename string   if skaff doesn't get it right, explicitly give name in snake case (e.g., db_vpc_instance)
@@ -89,6 +92,8 @@ Create scaffolding for a resource
 
 ```console
 $ skaff resource --help
+Create scaffolding for a resource
+
 Usage:
   skaff resource [flags]
 
@@ -96,6 +101,7 @@ Flags:
   -c, --clear-comments     do not include instructional comments in source
   -f, --force              force creation, overwriting existing files
   -h, --help               help for resource
+  -t, --include-tags       Indicate that this resource has tags and the code for tagging should be generated
   -n, --name string        name of the entity
   -p, --plugin-framework   generate for Terraform Plugin-Framework
   -s, --snakename string   if skaff doesn't get it right, explicitly give name in snake case (e.g., db_vpc_instance)

--- a/skaff/cmd/datasource.go
+++ b/skaff/cmd/datasource.go
@@ -12,7 +12,7 @@ var datasourceCmd = &cobra.Command{
 	Use:   "datasource",
 	Short: "Create scaffolding for a data source",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return datasource.Create(name, snakeName, !clearComments, force, !v1, pluginFramework)
+		return datasource.Create(name, snakeName, !clearComments, force, !v1, pluginFramework, includeTags)
 	},
 }
 
@@ -24,4 +24,5 @@ func init() {
 	datasourceCmd.Flags().BoolVarP(&force, "force", "f", false, "force creation, overwriting existing files")
 	datasourceCmd.Flags().BoolVarP(&v1, "v1", "o", false, "generate for AWS Go SDK v1 (some existing services)")
 	datasourceCmd.Flags().BoolVarP(&pluginFramework, "plugin-framework", "p", false, "generate for Terraform Plugin-Framework")
+	datasourceCmd.Flags().BoolVarP(&includeTags, "include-tags", "t", false, "Indicate that this resource has tags and the code for tagging should be generated")
 }

--- a/skaff/cmd/resource.go
+++ b/skaff/cmd/resource.go
@@ -15,13 +15,14 @@ var (
 	force           bool
 	v1              bool
 	pluginFramework bool
+	includeTags     bool
 )
 
 var resourceCmd = &cobra.Command{
 	Use:   "resource",
 	Short: "Create scaffolding for a resource",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return resource.Create(name, snakeName, !clearComments, force, !v1, pluginFramework)
+		return resource.Create(name, snakeName, !clearComments, force, !v1, pluginFramework, includeTags)
 	},
 }
 
@@ -33,4 +34,5 @@ func init() {
 	resourceCmd.Flags().BoolVarP(&force, "force", "f", false, "force creation, overwriting existing files")
 	resourceCmd.Flags().BoolVarP(&v1, "v1", "o", false, "generate for AWS Go SDK v1 (some existing services)")
 	resourceCmd.Flags().BoolVarP(&pluginFramework, "plugin-framework", "p", false, "generate for Terraform Plugin-Framework")
+	resourceCmd.Flags().BoolVarP(&includeTags, "include-tags", "t", false, "Indicate that this resource has tags and the code for tagging should be generated")
 }

--- a/skaff/datasource/datasource.go
+++ b/skaff/datasource/datasource.go
@@ -35,6 +35,7 @@ type TemplateData struct {
 	DataSourceLower      string
 	DataSourceSnake      string
 	IncludeComments      bool
+	IncludeTags          bool
 	HumanFriendlyService string
 	ServicePackage       string
 	Service              string
@@ -46,7 +47,7 @@ type TemplateData struct {
 	ProviderResourceName string
 }
 
-func Create(dsName, snakeName string, comments, force, v2, pluginFramework bool) error {
+func Create(dsName, snakeName string, comments, force, v2, pluginFramework, tags bool) error {
 	wd, err := os.Getwd() // os.Getenv("GOPACKAGE") not available since this is not run with go generate
 	if err != nil {
 		return fmt.Errorf("error reading working directory: %s", err)
@@ -89,6 +90,7 @@ func Create(dsName, snakeName string, comments, force, v2, pluginFramework bool)
 		DataSourceSnake:      snakeName,
 		HumanFriendlyService: hf,
 		IncludeComments:      comments,
+		IncludeTags:          tags,
 		ServicePackage:       servicePackage,
 		Service:              s,
 		ServiceLower:         strings.ToLower(s),

--- a/skaff/datasource/datasource.tmpl
+++ b/skaff/datasource/datasource.tmpl
@@ -138,7 +138,9 @@ func DataSource{{ .DataSource }}() *schema.Resource {
 					},
 				},
 			},
+			{{- if .IncludeTags }}
 			"tags":         tftags.TagsSchemaComputed(), {{- if .IncludeComments }} // TIP: Many, but not all, data sources have `tags` attributes.{{- end }}
+			{{- end }}
 		},
 	}
 }
@@ -237,12 +239,14 @@ func dataSource{{ .DataSource }}Read(ctx context.Context, d *schema.ResourceData
 	// below. Many data sources do include tags so this a reminder to include them
 	// where possible.
 	{{- end }}
+	{{- if .IncludeTags }}
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	//lintignore:AWSR002
 	if err := d.Set("tags", KeyValueTags(out.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 		return append(diags, create.DiagError(names.{{ .Service }}, create.ErrActionSetting, DSName{{ .DataSource }}, d.Id(), err)...)
 	}
+	{{- end }}
 	{{ if .IncludeComments }}
 	// TIP: -- 6. Return diags
 	{{- end }}

--- a/skaff/datasource/datasourcefw.tmpl
+++ b/skaff/datasource/datasourcefw.tmpl
@@ -118,7 +118,9 @@ func (d *dataSource{{ .DataSource }}) Schema(ctx context.Context, req datasource
 			"name": schema.StringAttribute{
 				Required: true,
 			},
+			{{- if .IncludeTags }}
 			names.AttrTags: tftags.TagsAttribute(),
+			{{- end }}
 			"type": schema.StringAttribute{
 				Computed: true,
 			},
@@ -212,9 +214,11 @@ func (d *dataSource{{ .DataSource }}) Read(ctx context.Context, req datasource.R
 	{{ if .IncludeComments }}
 	// TIP: -- 5. Set the tags
 	{{- end }}
+	{{- if .IncludeTags }}
 	ignoreTagsConfig := d.Meta().IgnoreTagsConfig
 	tags := KeyValueTags(ctx, out.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 	data.Tags = flex.FlattenFrameworkStringValueMapLegacy(ctx, tags.Map())
+	{{- end }}
 	{{ if .IncludeComments }}
 	// TIP: -- 6. Set the state
 	{{- end }}
@@ -241,7 +245,9 @@ type dataSource{{ .DataSource }}Data struct {
 	Description     types.String   `tfsdk:"description"`
 	ID              types.String   `tfsdk:"id"`
 	Name            types.String   `tfsdk:"name"`
+	{{- if .IncludeTags }}
 	Tags            types.Map      `tfsdk:"tags"`
+	{{- end }}
 	Type            types.String   `tfsdk:"type"`
 }
 

--- a/skaff/datasource/datasourcefw.tmpl
+++ b/skaff/datasource/datasourcefw.tmpl
@@ -119,7 +119,7 @@ func (d *dataSource{{ .DataSource }}) Schema(ctx context.Context, req datasource
 				Required: true,
 			},
 			{{- if .IncludeTags }}
-			names.AttrTags: tftags.TagsAttribute(),
+			names.AttrTags: tftags.TagsAttributeComputedOnly(),
 			{{- end }}
 			"type": schema.StringAttribute{
 				Computed: true,

--- a/skaff/datasource/websitedoc.tmpl
+++ b/skaff/datasource/websitedoc.tmpl
@@ -46,3 +46,6 @@ In addition to all arguments above, the following attributes are exported:
 
 * `arn` - ARN of the {{ .HumanDataSourceName }}. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
 * `example_attribute` - Concise description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+{{- if .IncludeTags }}
+* `tags` - Mapping of Key-Value tags for the resource.
+{{- end }}

--- a/skaff/resource/resource.go
+++ b/skaff/resource/resource.go
@@ -36,6 +36,7 @@ type TemplateData struct {
 	ResourceSnake        string
 	HumanFriendlyService string
 	IncludeComments      bool
+	IncludeTags          bool
 	ServicePackage       string
 	Service              string
 	ServiceLower         string
@@ -70,7 +71,7 @@ func ProviderResourceName(servicePackage, snakeName string) string {
 	return fmt.Sprintf("aws_%s_%s", servicePackage, snakeName)
 }
 
-func Create(resName, snakeName string, comments, force, v2, pluginFramework bool) error {
+func Create(resName, snakeName string, comments, force, v2, pluginFramework, tags bool) error {
 	wd, err := os.Getwd() // os.Getenv("GOPACKAGE") not available since this is not run with go generate
 	if err != nil {
 		return fmt.Errorf("error reading working directory: %s", err)
@@ -113,6 +114,7 @@ func Create(resName, snakeName string, comments, force, v2, pluginFramework bool
 		ResourceSnake:        snakeName,
 		HumanFriendlyService: hf,
 		IncludeComments:      comments,
+		IncludeTags:          tags,
 		ServicePackage:       servicePackage,
 		Service:              s,
 		ServiceLower:         strings.ToLower(s),

--- a/skaff/resource/resource.tmpl
+++ b/skaff/resource/resource.tmpl
@@ -81,9 +81,11 @@ import (
 
 // Function annotations are used for resource registration to the Provider. DO NOT EDIT.
 // @SDKResource("{{ .ProviderResourceName }}", name="{{ .HumanResourceName }}")
+{{- if .IncludeTags }}
 // Tagging annotations are used for "transparent tagging".
 // Change the "identifierAttribute" value to the name of the attribute used in ListTags and UpdateTags calls (e.g. "arn").
 // @Tags(identifierAttribute="id")
+{{- end }}
 func Resource{{ .Resource }}() *schema.Resource {
 	return &schema.Resource{
 		{{- if .IncludeComments }}
@@ -190,11 +192,14 @@ func Resource{{ .Resource }}() *schema.Resource {
 					},
 				},
 			},
+			{{- if .IncludeTags }}
 			names.AttrTags:    tftags.TagsSchema(), {{- if .IncludeComments }} // TIP: Many, but not all, resources have `tags` and `tags_all` attributes.{{- end }}
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			{{- end }}
 		},
-
+		{{- if .IncludeTags }}
 		CustomizeDiff: verify.SetTagsDiff,
+		{{- end }}
 	}
 }
 
@@ -239,7 +244,9 @@ func resource{{ .Resource }}Create(ctx context.Context, d *schema.ResourceData, 
 		// below. Many resources do include tags so this a reminder to include them
 		// where possible.
 		{{- end }}
+		{{- if .IncludeTags }}
 		Tags: getTagsIn(ctx),
+		{{- end }}
 	}
 
 	if v, ok := d.GetOk("max_size"); ok {

--- a/skaff/resource/resourcefw.tmpl
+++ b/skaff/resource/resourcefw.tmpl
@@ -80,7 +80,9 @@ import (
 
 // Function annotations are used for resource registration to the Provider. DO NOT EDIT.
 // @FrameworkResource(name="{{ .HumanResourceName }}")
+{{- if .IncludeTags }}
 // @Tags(identifierAttribute="arn")
+{{- end }}
 func newResource{{ .Resource }}(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &resource{{ .Resource }}{}
 	{{ if .IncludeComments }}
@@ -177,8 +179,10 @@ func (r *resource{{ .Resource }}) Schema(ctx context.Context, req resource.Schem
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
+			{{- if .IncludeTags }}
 			names.AttrTags:    tftags.TagsAttribute(),
 			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
+			{{- end }}
 			"type": schema.StringAttribute{
 				Required: true,
 			},
@@ -261,6 +265,9 @@ func (r *resource{{ .Resource }}) Create(ctx context.Context, req resource.Creat
 		{{- end }}
 		{{ .Resource }}Name: aws.String(plan.Name.ValueString()),
 		{{ .Resource }}Type: aws.String(plan.Type.ValueString()),
+		{{- if .IncludeTags }}
+		Tags:             getTagsIn(ctx),
+		{{- end }}
 	}
 
 	if !plan.Description.IsNull() {
@@ -621,6 +628,13 @@ func (r *resource{{ .Resource }}) Delete(ctx context.Context, req resource.Delet
 func (r *resource{{ .Resource }}) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
+
+{{- if .IncludeTags }}
+func (r *resource{{ .Resource }}) ModifyPlan(ctx context.Context, request resource.ModifyPlanRequest, response *resource.ModifyPlanResponse) {
+	r.SetTagsAll(ctx, request, response)
+}
+{{- end }}
+
 {{ if .IncludeComments }}
 // TIP: ==== STATUS CONSTANTS ====
 // Create constants for states and statuses if the service does not
@@ -954,8 +968,10 @@ type resource{{ .Resource }}Data struct {
 	Description     types.String   `tfsdk:"description"`
 	ID              types.String   `tfsdk:"id"`
 	Name            types.String   `tfsdk:"name"`
+	{{- if .IncludeTags }}
 	Tags            types.Map      `tfsdk:"tags"`
 	TagsAll         types.Map      `tfsdk:"tags_all"`
+	{{- end }}
 	Timeouts        timeouts.Value `tfsdk:"timeouts"`
 	Type            types.String   `tfsdk:"type"`
 }

--- a/skaff/resource/websitedoc.tmpl
+++ b/skaff/resource/websitedoc.tmpl
@@ -38,6 +38,9 @@ The following arguments are required:
 The following arguments are optional:
 
 * `optional_arg` - (Optional) Concise argument description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+{{- if .IncludeTags }}
+* `tags` - (Optional) A map of tags assigned to the WorkSpaces Connection Alias. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+{{- end }}
 
 ## Attributes Reference
 
@@ -45,6 +48,9 @@ In addition to all arguments above, the following attributes are exported:
 
 * `arn` - ARN of the {{ .HumanResourceName }}. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
 * `example_attribute` - Concise description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+{{- if .IncludeTags }}
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
+{{- end }}
 
 ## Timeouts
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This pull request adds the `--include-tags` flag to the `skaff` tool. This makes the generated code be more targeted and relevant to resources that do or do not support tagging.  I have tested generating a resource with and without the flag and the outcome is as expected. When providing the flag, code is present for tags, and it is not present when omitting the flag. The same behavior is true for the generated docs. 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
➜ skaff (td-skaff-tags-flag) ✔ go test ./...
?       github.com/hashicorp/terraform-provider-aws/skaff       [no test files]
?       github.com/hashicorp/terraform-provider-aws/skaff/cmd   [no test files]
ok      github.com/hashicorp/terraform-provider-aws/skaff/datasource    (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-aws/skaff/resource      (cached)

...
```
