### PR TITLE
sweepers: Fixes

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,4 @@
-SWEEP               ?= us-west-2,us-east-1,us-east-2
+SWEEP               ?= us-west-2,us-east-1,us-east-2,us-west-1
 TEST                ?= ./...
 SWEEP_DIR           ?= ./internal/sweep
 PKG_NAME            ?= internal

--- a/internal/service/opensearchserverless/sweep.go
+++ b/internal/service/opensearchserverless/sweep.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/opensearchserverless"
 	"github.com/aws/aws-sdk-go-v2/service/opensearchserverless/types"
+	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
@@ -60,7 +61,7 @@ func sweepAccessPolicies(region string) error {
 
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-		if awsv2.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) || skipSweepErr(err) {
 			log.Printf("[WARN] Skipping OpenSearch Serverless Access Policies sweep for %s: %s", region, err)
 			return nil
 		}
@@ -103,7 +104,7 @@ func sweepCollections(region string) error {
 
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-		if awsv2.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) || skipSweepErr(err) {
 			log.Printf("[WARN] Skipping OpenSearch Serverless Collections sweep for %s: %s", region, err)
 			return nil
 		}
@@ -146,7 +147,7 @@ func sweepSecurityConfigs(region string) error {
 
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-		if awsv2.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) || skipSweepErr(err) {
 			log.Printf("[WARN] Skipping OpenSearch Serverless Security Configs sweep for %s: %s", region, err)
 			return nil
 		}
@@ -189,7 +190,7 @@ func sweepSecurityPolicies(region string) error {
 
 	for pagesEncryption.HasMorePages() {
 		page, err := pagesEncryption.NextPage(ctx)
-		if awsv2.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) || skipSweepErr(err) {
 			log.Printf("[WARN] Skipping OpenSearch Serverless Security Policies sweep for %s: %s", region, err)
 			return nil
 		}
@@ -216,7 +217,7 @@ func sweepSecurityPolicies(region string) error {
 
 	for pagesNetwork.HasMorePages() {
 		page, err := pagesNetwork.NextPage(ctx)
-		if awsv2.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) || skipSweepErr(err) {
 			log.Printf("[WARN] Skipping OpenSearch Serverless Security Policies sweep for %s: %s", region, err)
 			return nil
 		}
@@ -259,7 +260,7 @@ func sweepVPCEndpoints(region string) error {
 
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-		if awsv2.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) || skipSweepErr(err) {
 			log.Printf("[WARN] Skipping OpenSearch Serverless VPC Endpoints sweep for %s: %s", region, err)
 			return nil
 		}
@@ -282,4 +283,9 @@ func sweepVPCEndpoints(region string) error {
 	}
 
 	return nil
+}
+
+func skipSweepErr(err error) bool {
+	// OpenSearch Serverless returns this error when the service is not supported in the region
+	return tfawserr.ErrMessageContains(err, "AccessDeniedException", "UnknownError")
 }

--- a/internal/service/route53resolver/sweep.go
+++ b/internal/service/route53resolver/sweep.go
@@ -68,7 +68,7 @@ func init() {
 
 	resource.AddTestSweepers("aws_route53_resolver_query_log_config_association", &resource.Sweeper{
 		Name: "aws_route53_resolver_query_log_config_association",
-		F:    sweepQueryLogAssociationsConfigs,
+		F:    sweepQueryLogConfigAssociations,
 	})
 
 	resource.AddTestSweepers("aws_route53_resolver_query_log_config", &resource.Sweeper{
@@ -426,7 +426,7 @@ func sweepFirewallRules(region string) error {
 	return sweeperErrs.ErrorOrNil()
 }
 
-func sweepQueryLogAssociationsConfigs(region string) error {
+func sweepQueryLogConfigAssociations(region string) error {
 	ctx := sweep.Context(region)
 	client, err := sweep.SharedRegionalSweepClient(ctx, region)
 	if err != nil {

--- a/internal/service/ses/sweep.go
+++ b/internal/service/ses/sweep.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv1"
 )
 
 func init() {
@@ -52,7 +53,7 @@ func sweepConfigurationSets(region string) error {
 
 	for {
 		output, err := conn.ListConfigurationSetsWithContext(ctx, input)
-		if sweep.SkipSweepError(err) {
+		if awsv1.SkipSweepError(err) {
 			log.Printf("[WARN] Skipping SES Configuration Sets sweep for %s: %s", region, err)
 			return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
 		}
@@ -122,7 +123,7 @@ func sweepIdentities(region, identityType string) error {
 
 		return !lastPage
 	})
-	if sweep.SkipSweepError(err) {
+	if awsv1.SkipSweepError(err) {
 		log.Printf("[WARN] Skipping SES Identities sweep for %s: %s", region, err)
 		return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
 	}
@@ -142,10 +143,11 @@ func sweepReceiptRuleSets(region string) error {
 	conn := client.SESConn(ctx)
 
 	// You cannot delete the receipt rule set that is currently active.
-	// Setting the name of the receipt rule set to make active to null disables all email receiving.
+	// Setting the name of the active receipt rule set to null disables all email receiving.
 	log.Printf("[INFO] Disabling any currently active SES Receipt Rule Set")
 	_, err = conn.SetActiveReceiptRuleSetWithContext(ctx, &ses.SetActiveReceiptRuleSetInput{})
-	if sweep.SkipSweepError(err) {
+	// In some regions, this will return "InvalidAction" with no message
+	if awsv1.SkipSweepError(err) || tfawserr.ErrCodeEquals(err, "InvalidAction") {
 		log.Printf("[WARN] Skipping SES Receipt Rule Sets sweep for %s: %s", region, err)
 		return nil
 	}
@@ -158,7 +160,7 @@ func sweepReceiptRuleSets(region string) error {
 
 	for {
 		output, err := conn.ListReceiptRuleSetsWithContext(ctx, input)
-		if sweep.SkipSweepError(err) {
+		if awsv1.SkipSweepError(err) {
 			log.Printf("[WARN] Skipping SES Receipt Rule Sets sweep for %s: %s", region, err)
 			return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
 		}

--- a/internal/service/vpclattice/sweep.go
+++ b/internal/service/vpclattice/sweep.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
+	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
@@ -46,7 +47,7 @@ func sweepServices(region string) error {
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
-		if awsv2.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) || skipSweepErr(err) {
 			log.Printf("[WARN] Skipping VPC Lattice Service sweep for %s: %s", region, err)
 			return nil
 		}
@@ -87,7 +88,7 @@ func sweepServiceNetworks(region string) error {
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
-		if awsv2.SkipSweepError(err) {
+		if awsv2.SkipSweepError(err) || skipSweepErr(err) {
 			log.Printf("[WARN] Skipping VPC Lattice Service Network sweep for %s: %s", region, err)
 			return nil
 		}
@@ -112,4 +113,8 @@ func sweepServiceNetworks(region string) error {
 	}
 
 	return nil
+}
+
+func skipSweepErr(err error) bool {
+	return tfawserr.ErrCodeEquals(err, "AccessDeniedException")
 }


### PR DESCRIPTION
### Description

Ignores `InvalidAction` error returned by some regions when attempting to disable SES

Ignores `AccessDeniedException: UnknownError` error returned by OpenSearch Serverless in unsupported regions

Ignores `AccessDeniedException` error returned by VPC Lattice

Adds `us-west-1` to sweeper regions in `Makefile` to match CI config
