### PR TITLE
Add additional attribute to `aws_vpc_endpoint` data source

### DIFF
--- a/.changelog/32517.txt
+++ b/.changelog/32517.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_vpc_endpoint: Add `dns_options.private_dns_only_for_inbound_resolver_endpoint`
+````

--- a/internal/service/ec2/vpc_endpoint_data_source.go
+++ b/internal/service/ec2/vpc_endpoint_data_source.go
@@ -64,6 +64,10 @@ func DataSourceVPCEndpoint() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"private_dns_only_for_inbound_resolver_endpoint": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
 					},
 				},
 			},

--- a/website/docs/d/vpc_endpoint.html.markdown
+++ b/website/docs/d/vpc_endpoint.html.markdown
@@ -53,7 +53,8 @@ In addition to all arguments above except `filter`, the following attributes are
 
 * `arn` - ARN of the VPC endpoint.
 * `cidr_blocks` - List of CIDR blocks for the exposed AWS service. Applicable for endpoints of type `Gateway`.
-* `dns_entry` - DNS entries for the VPC Endpoint. Applicable for endpoints of type `Interface`. DNS blocks are documented below.
+* `dns_entry` - DNS entries for the VPC Endpoint. Applicable for endpoints of type `Interface`. [DNS entry blocks are documented below](#dns_entry-block).
+* `dns_options` - DNS options for the VPC Endpoint. [DNS options blocks are documented below](#dns_options-block).
 * `network_interface_ids` - One or more network interfaces for the VPC Endpoint. Applicable for endpoints of type `Interface`.
 * `owner_id` - ID of the AWS account that owns the VPC endpoint.
 * `policy` - Policy document associated with the VPC Endpoint. Applicable for endpoints of type `Gateway`.
@@ -65,10 +66,19 @@ In addition to all arguments above except `filter`, the following attributes are
 * `subnet_ids` - One or more subnets in which the VPC Endpoint is located. Applicable for endpoints of type `Interface`.
 * `vpc_endpoint_type` - VPC Endpoint type, `Gateway` or `Interface`.
 
+### `dns_entry` Block
+
 DNS blocks (for `dns_entry`) support the following attributes:
 
 * `dns_name` - DNS name.
 * `hosted_zone_id` - ID of the private hosted zone.
+
+### `dns_options` Block
+
+DNS options (for `dns_options`) support the following attributes:
+
+* `dns_record_ip_type` - The DNS records created for the endpoint.
+* `private_dns_only_for_inbound_resolver_endpoint` - Indicates whether to enable private DNS only for inbound endpoints.
 
 ## Timeouts
 


### PR DESCRIPTION
### Description

This PR adds the `private_dns_only_for_inbound_resolver_endpoint` attribute to `data.aws_vpc_endpoint.dns_options`, and documents the `data.aws_vpc_endpoint.dns_options` block, which was missing from the documentation. 

### Relations

Closes #32508

### References

- [Where `dns_options` is already set](https://github.com/hashicorp/terraform-provider-aws/blob/172bc9ac324df7d0e0388bf65df83e57e4af1877/internal/service/ec2/vpc_endpoint_data_source.go#L195-L198)
- [`flattenDNSOptions` function](https://github.com/hashicorp/terraform-provider-aws/blob/172bc9ac324df7d0e0388bf65df83e57e4af1877/internal/service/ec2/vpc_endpoint.go#L568-L584)
- [API reference](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DnsOptions.html)

### Output from Acceptance Testing

```
$ make testacc TESTS=TestAccVPCEndpointDataSource PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCEndpointDataSource'  -timeout 180m
=== RUN   TestAccVPCEndpointDataSource_gatewayBasic
=== PAUSE TestAccVPCEndpointDataSource_gatewayBasic
=== RUN   TestAccVPCEndpointDataSource_byID
=== PAUSE TestAccVPCEndpointDataSource_byID
=== RUN   TestAccVPCEndpointDataSource_byFilter
=== PAUSE TestAccVPCEndpointDataSource_byFilter
=== RUN   TestAccVPCEndpointDataSource_byTags
=== PAUSE TestAccVPCEndpointDataSource_byTags
=== RUN   TestAccVPCEndpointDataSource_gatewayWithRouteTableAndTags
=== PAUSE TestAccVPCEndpointDataSource_gatewayWithRouteTableAndTags
=== RUN   TestAccVPCEndpointDataSource_interface
=== PAUSE TestAccVPCEndpointDataSource_interface
=== CONT  TestAccVPCEndpointDataSource_gatewayBasic
=== CONT  TestAccVPCEndpointDataSource_byTags
=== CONT  TestAccVPCEndpointDataSource_byFilter
=== CONT  TestAccVPCEndpointDataSource_interface
=== CONT  TestAccVPCEndpointDataSource_byID
=== CONT  TestAccVPCEndpointDataSource_gatewayWithRouteTableAndTags
--- PASS: TestAccVPCEndpointDataSource_byID (37.64s)
--- PASS: TestAccVPCEndpointDataSource_byTags (38.11s)
--- PASS: TestAccVPCEndpointDataSource_gatewayBasic (38.15s)
--- PASS: TestAccVPCEndpointDataSource_byFilter (38.43s)
--- PASS: TestAccVPCEndpointDataSource_gatewayWithRouteTableAndTags (44.43s)
--- PASS: TestAccVPCEndpointDataSource_interface (203.60s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        206.810s
```
