### PR TITLE
[Docs]: `aws_lb_target_group_attachment` add multiple targets example

### DIFF
--- a/website/docs/r/lb_target_group_attachment.html.markdown
+++ b/website/docs/r/lb_target_group_attachment.html.markdown
@@ -60,6 +60,32 @@ resource "aws_lb_target_group_attachment" "test" {
 }
 ```
 
+### Registering Multiple Targets
+
+```terraform
+resource "aws_instance" "example" {
+  count = 3
+  # ... other configuration ...
+}
+
+resource "aws_lb_target_group" "example" {
+  # ... other configuration ...
+}
+
+resource "aws_lb_target_group_attachment" "example" {
+  # covert a list of instance objects to a map with instance ID as the key, and an instance
+  # object as the value.
+  for_each = {
+    for k, v in aws_instance.example :
+    v.id => v
+  }
+
+  target_group_arn = aws_lb_target_group.example.arn
+  target_id        = each.value.id
+  port             = 80
+}
+```
+
 ## Argument Reference
 
 The following arguments are required:


### PR DESCRIPTION

### Description
Adds an additional example for the `aws_lb_target_group_attachment` resource demonstrating how to use the [`for_each`](https://developer.hashicorp.com/terraform/language/meta-arguments/for_each) Terraform meta-argument to register multiple targets.


### Relations
Relates #9901 




### Output from Acceptance Testing
N/a docs.
