### PR TITLE
r/aws_config_config_rule: handle err during read

### DIFF
--- a/.changelog/32520.txt
+++ b/.changelog/32520.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_config_config_rule: Prevent crash from unhandled read error
+```

--- a/internal/service/configservice/config_rule.go
+++ b/internal/service/configservice/config_rule.go
@@ -189,6 +189,10 @@ func ResourceConfigRule() *schema.Resource {
 	}
 }
 
+const (
+	ResNameConfigRule = "Config Rule"
+)
+
 func resourceRulePutConfig(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ConfigServiceConn(ctx)
@@ -250,6 +254,9 @@ func resourceConfigRuleRead(ctx context.Context, d *schema.ResourceData, meta in
 		log.Printf("[WARN] ConfigService Config Rule (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
+	}
+	if err != nil {
+		return append(diags, create.DiagError(names.ConfigService, create.ErrActionReading, ResNameConfigRule, d.Id(), err)...)
 	}
 
 	arn := aws.StringValue(rule.ConfigRuleArn)

--- a/internal/service/configservice/config_rule.go
+++ b/internal/service/configservice/config_rule.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
-	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -236,7 +235,7 @@ func resourceRulePutConfig(ctx context.Context, d *schema.ResourceData, meta int
 		_, err = conn.PutConfigRuleWithContext(ctx, &input)
 	}
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "creating AWSConfig rule: %s", err)
+		return append(diags, create.DiagError(names.ConfigService, create.ErrActionUpdating, ResNameConfigRule, name, err)...)
 	}
 
 	d.SetId(name)
@@ -300,11 +299,11 @@ func resourceConfigRuleDelete(ctx context.Context, d *schema.ResourceData, meta 
 		_, err = conn.DeleteConfigRuleWithContext(ctx, input)
 	}
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Deleting Config Rule failed: %s", err)
+		return append(diags, create.DiagError(names.ConfigService, create.ErrActionDeleting, ResNameConfigRule, d.Id(), err)...)
 	}
 
 	if _, err := waitRuleDeleted(ctx, conn, d.Id()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "waiting for Config Service Rule (%s) to deleted: %s", d.Id(), err)
+		return append(diags, create.DiagError(names.ConfigService, create.ErrActionWaitingForDeletion, ResNameConfigRule, d.Id(), err)...)
 	}
 
 	return diags


### PR DESCRIPTION

### Description
Properly handles non-nil `err` values during Read operations.


### Relations
Closes #32512


### Output from Acceptance Testing

```console
$ make testacc PKG=configservice TESTARGS='-run=TestAccConfigService_serial/Config'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/configservice/... -v -count 1 -parallel 20  -run=TestAccConfigService_serial/Config -timeout 180m

--- PASS: TestAccConfigService_serial (1760.05s)
    --- PASS: TestAccConfigService_serial/RemediationConfiguration (642.15s)
        --- PASS: TestAccConfigService_serial/RemediationConfiguration/migrateParameters (101.87s)
        --- PASS: TestAccConfigService_serial/RemediationConfiguration/recreates (99.61s)
        --- PASS: TestAccConfigService_serial/RemediationConfiguration/updates (97.49s)
        --- PASS: TestAccConfigService_serial/RemediationConfiguration/values (86.29s)
        --- PASS: TestAccConfigService_serial/RemediationConfiguration/basic (86.43s)
        --- PASS: TestAccConfigService_serial/RemediationConfiguration/basicBackward (86.49s)
        --- PASS: TestAccConfigService_serial/RemediationConfiguration/disappears (83.98s)
    --- PASS: TestAccConfigService_serial/Config (851.36s)
        --- PASS: TestAccConfigService_serial/Config/tags (113.70s)
        --- PASS: TestAccConfigService_serial/Config/disappears (83.41s)
        --- PASS: TestAccConfigService_serial/Config/ownerAws (85.86s)
        --- PASS: TestAccConfigService_serial/Config/scopeTagKey (96.70s)
        --- PASS: TestAccConfigService_serial/Config/scopeTagKeyEmpty (83.06s)
        --- PASS: TestAccConfigService_serial/Config/scopeTagValue (96.79s)
        --- PASS: TestAccConfigService_serial/Config/basic (83.24s)
        --- PASS: TestAccConfigService_serial/Config/customlambda (122.67s)
        --- PASS: TestAccConfigService_serial/Config/customPolicy (85.92s)
    --- PASS: TestAccConfigService_serial/ConfigurationRecorder (132.31s)
        --- PASS: TestAccConfigService_serial/ConfigurationRecorder/allParams (32.00s)
        --- PASS: TestAccConfigService_serial/ConfigurationRecorder/recordStrategy (32.28s)
        --- PASS: TestAccConfigService_serial/ConfigurationRecorder/disappears (33.00s)
        --- PASS: TestAccConfigService_serial/ConfigurationRecorder/basic (35.03s)
    --- PASS: TestAccConfigService_serial/ConfigurationRecorderStatus (134.22s)
        --- PASS: TestAccConfigService_serial/ConfigurationRecorderStatus/basic (32.96s)
        --- PASS: TestAccConfigService_serial/ConfigurationRecorderStatus/startEnabled (65.10s)
        --- PASS: TestAccConfigService_serial/ConfigurationRecorderStatus/importBasic (36.15s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/configservice      1763.571s
```
