### PR TITLE
Add `runtime` to Glue Ray job command

### DIFF
--- a/internal/service/glue/job.go
+++ b/internal/service/glue/job.go
@@ -64,6 +64,12 @@ func ResourceJob() *schema.Resource {
 							Computed:     true,
 							ValidateFunc: validation.StringInSlice([]string{"2", "3", "3.9"}, true),
 						},
+						"runtime": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.StringInSlice([]string{"Ray2.4"}, true),
+						},
 					},
 				},
 			},
@@ -438,6 +444,10 @@ func expandJobCommand(l []interface{}) *glue.JobCommand {
 		jobCommand.PythonVersion = aws.String(v)
 	}
 
+	if v, ok := m["runtime"].(string); ok && v != "" {
+		jobCommand.Runtime = aws.String(v)
+	}
+
 	return jobCommand
 }
 
@@ -480,6 +490,7 @@ func flattenJobCommand(jobCommand *glue.JobCommand) []map[string]interface{} {
 		"name":            aws.StringValue(jobCommand.Name),
 		"script_location": aws.StringValue(jobCommand.ScriptLocation),
 		"python_version":  aws.StringValue(jobCommand.PythonVersion),
+		"runtime":         aws.StringValue(jobCommand.Runtime),
 	}
 
 	return []map[string]interface{}{m}

--- a/internal/service/glue/job_test.go
+++ b/internal/service/glue/job_test.go
@@ -726,6 +726,34 @@ func TestAccGlueJob_pythonShell(t *testing.T) {
 	})
 }
 
+func TestAccGlueJob_rayJob(t *testing.T) {
+	ctx := acctest.Context(t)
+	var job glue.Job
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_glue_job.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, glue.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckJobDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccJobConfig_rayJob(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckJobExists(ctx, resourceName, &job),
+					resource.TestCheckResourceAttr(resourceName, "command.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "command.0.script_location", "testscriptlocation"),
+					resource.TestCheckResourceAttr(resourceName, "command.0.name", "glueray"),
+					resource.TestCheckResourceAttr(resourceName, "command.0.python_version", "3.9"),
+					resource.TestCheckResourceAttr(resourceName, "command.0.runtime", "Ray2.4"),
+					resource.TestCheckResourceAttr(resourceName, "worker_type", "Z.2X"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccGlueJob_maxCapacity(t *testing.T) {
 	ctx := acctest.Context(t)
 	var job glue.Job
@@ -1196,6 +1224,27 @@ resource "aws_glue_job" "test" {
   depends_on = [aws_iam_role_policy_attachment.test]
 }
 `, rName, pythonVersion))
+}
+
+func testAccJobConfig_rayJob(rName string) string {
+	return acctest.ConfigCompose(testAccJobConfig_base(rName), fmt.Sprintf(`
+resource "aws_glue_job" "test" {
+  glue_version      = "4.0"
+  name              = %[1]q
+  role_arn          = aws_iam_role.test.arn
+  worker_type       = "Z.2X"
+  number_of_workers = 10
+
+  command {
+	name			= "glueray"
+	python_version  = "3.9"
+	runtime         = "Ray2.4"
+    script_location = "testscriptlocation"
+  }
+
+  depends_on = [aws_iam_role_policy_attachment.test]
+}
+`, rName))
 }
 
 func testAccJobConfig_maxCapacity(rName string, maxCapacity float64) string {

--- a/website/docs/r/glue_job.html.markdown
+++ b/website/docs/r/glue_job.html.markdown
@@ -27,6 +27,24 @@ resource "aws_glue_job" "example" {
 }
 ```
 
+### Ray Job
+
+```terraform
+resource "aws_glue_job" "example" {
+  name         = "example"
+  role_arn     = aws_iam_role.example.arn
+  glue_version = "4.0"
+  worker_type  = "Z.2X"
+
+  command {
+    name            = "glueray"
+    python_version  = "3.9"
+    runtime         = "Ray2.4"
+    script_location = "s3://${aws_s3_bucket.example.bucket}/example.py"
+  }
+}
+```
+
 ### Scala Job
 
 ```terraform
@@ -89,7 +107,7 @@ The following arguments are supported:
 * `non_overridable_arguments` – (Optional) Non-overridable arguments for this job, specified as name-value pairs.
 * `description` – (Optional) Description of the job.
 * `execution_property` – (Optional) Execution property of the job. Defined below.
-* `glue_version` - (Optional) The version of glue to use, for example "1.0". For information about available versions, see the [AWS Glue Release Notes](https://docs.aws.amazon.com/glue/latest/dg/release-notes.html).
+* `glue_version` - (Optional) The version of glue to use, for example "1.0". Ray jobs should set this to 4.0 or greater. For information about available versions, see the [AWS Glue Release Notes](https://docs.aws.amazon.com/glue/latest/dg/release-notes.html).
 * `execution_class` - (Optional) Indicates whether the job is run with a standard or flexible execution class. The standard execution class is ideal for time-sensitive workloads that require fast job startup and dedicated resources. Valid value: `FLEX`, `STANDARD`.
 * `max_capacity` – (Optional) The maximum number of AWS Glue data processing units (DPUs) that can be allocated when this job runs. `Required` when `pythonshell` is set, accept either `0.0625` or `1.0`. Use `number_of_workers` and `worker_type` arguments instead with `glue_version` `2.0` and above.
 * `max_retries` – (Optional) The maximum number of times to retry this job if it fails.
@@ -99,14 +117,36 @@ The following arguments are supported:
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `timeout` – (Optional) The job timeout in minutes. The default is 2880 minutes (48 hours) for `glueetl` and `pythonshell` jobs, and null (unlimited) for `gluestreaming` jobs.
 * `security_configuration` - (Optional) The name of the Security Configuration to be associated with the job.
-* `worker_type` - (Optional) The type of predefined worker that is allocated when a job runs. Accepts a value of Standard, G.1X, or G.2X.
+* `worker_type` - (Optional) The type of predefined worker that is allocated when a job runs. Accepts a value of Standard, G.1X, G.2X, or G.025X for Spark jobs. Accepts the value
+	 Z.2X for Ray jobs.
+   
+	    * For the Standard worker type, each worker provides 4 vCPU, 16 GB of
+	    memory and a 50GB disk, and 2 executors per worker.
+	
+	    * For the G.1X worker type, each worker maps to 1 DPU (4 vCPU, 16 GB of
+	    memory, 64 GB disk), and provides 1 executor per worker. We recommend
+	    this worker type for memory-intensive jobs.
+	
+	    * For the G.2X worker type, each worker maps to 2 DPU (8 vCPU, 32 GB of
+	    memory, 128 GB disk), and provides 1 executor per worker. We recommend
+	    this worker type for memory-intensive jobs.
+	
+	    * For the G.025X worker type, each worker maps to 0.25 DPU (2 vCPU, 4
+	    GB of memory, 64 GB disk), and provides 1 executor per worker. We recommend
+	    this worker type for low volume streaming jobs. This worker type is only
+	    available for Glue version 3.0 streaming jobs.
+	
+	    * For the Z.2X worker type, each worker maps to 2 M-DPU (8vCPU, 64 GB
+	    of m emory, 128 GB disk), and provides up to 8 Ray workers based on the
+	    autoscaler.
 * `number_of_workers` - (Optional) The number of workers of a defined workerType that are allocated when a job runs.
 
 ### command Argument Reference
 
-* `name` - (Optional) The name of the job command. Defaults to `glueetl`. Use `pythonshell` for Python Shell Job Type, or `gluestreaming` for Streaming Job Type. `max_capacity` needs to be set if `pythonshell` is chosen.
+* `name` - (Optional) The name of the job command. Defaults to `glueetl`. Use `pythonshell` for Python Shell Job Type, `glueray` for Ray Job Type, or `gluestreaming` for Streaming Job Type. `max_capacity` needs to be set if `pythonshell` is chosen.
 * `script_location` - (Required) Specifies the S3 path to a script that executes a job.
 * `python_version` - (Optional) The Python version being used to execute a Python shell job. Allowed values are 2, 3 or 3.9. Version 3 refers to Python 3.6.
+* `runtime` - (Optional) In Ray jobs, runtime is used to specify the versions of Ray, Python and additional libraries available in your environment. This field is not used in other job types. For supported runtime environment values, see [Working with Ray jobs](https://docs.aws.amazon.com/glue/latest/dg/ray-jobs-section.html#author-job-ray-runtimes) in the Glue Developer Guide.
 
 ### execution_property Argument Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds runtime parameter for Glue Ray job command.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes [#29180](https://github.com/hashicorp/terraform-provider-aws/issues/29180)

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS='TestAccGlueJob_' PKG=glue
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/glue/... -v -count 1 -parallel 20 -run='TestAccGlueJob_'  -timeout 180m
=== RUN   TestAccGlueJob_basic
=== PAUSE TestAccGlueJob_basic
=== RUN   TestAccGlueJob_disappears
=== PAUSE TestAccGlueJob_disappears
=== RUN   TestAccGlueJob_basicStreaming
=== PAUSE TestAccGlueJob_basicStreaming
=== RUN   TestAccGlueJob_command
=== PAUSE TestAccGlueJob_command
=== RUN   TestAccGlueJob_defaultArguments
=== PAUSE TestAccGlueJob_defaultArguments
=== RUN   TestAccGlueJob_nonOverridableArguments
=== PAUSE TestAccGlueJob_nonOverridableArguments
=== RUN   TestAccGlueJob_description
=== PAUSE TestAccGlueJob_description
=== RUN   TestAccGlueJob_glueVersion
=== PAUSE TestAccGlueJob_glueVersion
=== RUN   TestAccGlueJob_executionClass
=== PAUSE TestAccGlueJob_executionClass
=== RUN   TestAccGlueJob_executionProperty
=== PAUSE TestAccGlueJob_executionProperty
=== RUN   TestAccGlueJob_maxRetries
=== PAUSE TestAccGlueJob_maxRetries
=== RUN   TestAccGlueJob_notificationProperty
=== PAUSE TestAccGlueJob_notificationProperty
=== RUN   TestAccGlueJob_tags
=== PAUSE TestAccGlueJob_tags
=== RUN   TestAccGlueJob_streamingTimeout
=== PAUSE TestAccGlueJob_streamingTimeout
=== RUN   TestAccGlueJob_timeout
=== PAUSE TestAccGlueJob_timeout
=== RUN   TestAccGlueJob_security
=== PAUSE TestAccGlueJob_security
=== RUN   TestAccGlueJob_workerType
=== PAUSE TestAccGlueJob_workerType
=== RUN   TestAccGlueJob_pythonShell
=== PAUSE TestAccGlueJob_pythonShell
=== RUN   TestAccGlueJob_rayJob
=== PAUSE TestAccGlueJob_rayJob
=== RUN   TestAccGlueJob_maxCapacity
=== PAUSE TestAccGlueJob_maxCapacity
=== CONT  TestAccGlueJob_basic
=== CONT  TestAccGlueJob_streamingTimeout
=== CONT  TestAccGlueJob_nonOverridableArguments
=== CONT  TestAccGlueJob_command
=== CONT  TestAccGlueJob_tags
=== CONT  TestAccGlueJob_maxRetries
=== CONT  TestAccGlueJob_pythonShell
=== CONT  TestAccGlueJob_description
=== CONT  TestAccGlueJob_executionClass
=== CONT  TestAccGlueJob_executionProperty
=== CONT  TestAccGlueJob_workerType
=== CONT  TestAccGlueJob_basicStreaming
=== CONT  TestAccGlueJob_notificationProperty
=== CONT  TestAccGlueJob_glueVersion
=== CONT  TestAccGlueJob_defaultArguments
=== CONT  TestAccGlueJob_disappears
=== CONT  TestAccGlueJob_maxCapacity
=== CONT  TestAccGlueJob_timeout
=== CONT  TestAccGlueJob_security
=== CONT  TestAccGlueJob_rayJob
--- PASS: TestAccGlueJob_rayJob (90.62s)
--- PASS: TestAccGlueJob_disappears (93.16s)
--- PASS: TestAccGlueJob_basic (101.99s)
--- PASS: TestAccGlueJob_basicStreaming (101.99s)
--- PASS: TestAccGlueJob_executionClass (145.76s)
--- PASS: TestAccGlueJob_executionProperty (165.46s)
--- PASS: TestAccGlueJob_security (165.46s)
--- PASS: TestAccGlueJob_maxCapacity (165.46s)
--- PASS: TestAccGlueJob_description (165.56s)
--- PASS: TestAccGlueJob_timeout (165.56s)
--- PASS: TestAccGlueJob_defaultArguments (165.57s)
--- PASS: TestAccGlueJob_nonOverridableArguments (165.67s)
--- PASS: TestAccGlueJob_streamingTimeout (165.75s)
--- PASS: TestAccGlueJob_maxRetries (165.86s)
--- PASS: TestAccGlueJob_command (165.98s)
--- PASS: TestAccGlueJob_notificationProperty (167.44s)
--- PASS: TestAccGlueJob_tags (186.83s)
--- PASS: TestAccGlueJob_workerType (188.79s)
--- PASS: TestAccGlueJob_glueVersion (190.02s)
--- PASS: TestAccGlueJob_pythonShell (211.81s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/glue	239.694s
```
