### PR TITLE
Fix XSS Protection mode_block docs

### DIFF
--- a/website/docs/r/cloudfront_response_headers_policy.html.markdown
+++ b/website/docs/r/cloudfront_response_headers_policy.html.markdown
@@ -154,7 +154,7 @@ The following arguments are supported:
 
 ### XSS Protection
 
-* `mode_block` - (Required) Whether CloudFront includes the `mode=block` directive in the `X-XSS-Protection` header.
+* `mode_block` - (Optional) Whether CloudFront includes the `mode=block` directive in the `X-XSS-Protection` header.
 * `override` - (Required) Whether CloudFront overrides the `X-XSS-Protection` HTTP response header received from the origin with the one specified in this response headers policy.
 * `protection` - (Required) A Boolean value that determines the value of the `X-XSS-Protection` HTTP response header. When this setting is `true`, the value of the `X-XSS-Protection` header is `1`. When this setting is `false`, the value of the `X-XSS-Protection` header is `0`.
 * `report_uri` - (Optional) A reporting URI, which CloudFront uses as the value of the report directive in the `X-XSS-Protection` header. You cannot specify a `report_uri` when `mode_block` is `true`.


### PR DESCRIPTION
### Description
`mode_block` is optional.

See response header policy:
https://github.com/hashicorp/terraform-provider-aws/blob/efceda4e38ed9881af230a7cabdd5442973c9ecf/internal/service/cloudfront/response_headers_policy.go#L283

Update the docs accordingly.

### Relations



### References



### Output from Acceptance Testing


