### PR TITLE
r/aws_datasync_agent: handle computed `private_link_endpoint` values

### DIFF
--- a/.changelog/32546.txt
+++ b/.changelog/32546.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_datasync_agent: Prevent persistent diffs when `private_link_endpoint` is not explicitly configured.
+```

--- a/internal/service/datasync/agent.go
+++ b/internal/service/datasync/agent.go
@@ -65,6 +65,7 @@ func ResourceAgent() *schema.Resource {
 			"private_link_endpoint": {
 				Type:          schema.TypeString,
 				Optional:      true,
+				Computed:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"activation_key"},
 			},


### PR DESCRIPTION

### Description
Prevent persistent diffs on `aws_datasync_agent` configurations where `private_link_endpoint` is not explicitly configured but is returned by the AWS API.


### Relations

Closes #19947



### Output from Acceptance Testing

```console
$ make testacc PKG=datasync TESTS=TestAccDataSyncAgent_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/datasync/... -v -count 1 -parallel 20 -run='TestAccDataSyncAgent_'  -timeout 180m

--- PASS: TestAccDataSyncAgent_disappears (106.23s)
--- PASS: TestAccDataSyncAgent_basic (111.66s)
--- PASS: TestAccDataSyncAgent_tags (150.82s)
--- PASS: TestAccDataSyncAgent_agentName (172.15s)
--- PASS: TestAccDataSyncAgent_vpcEndpointID (292.41s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/datasync   295.587s
```
