### PR TITLE
Remove outdated note about Kinesis requirement for `aws_wafv2_web_acl_logging_configuration`

### DIFF
--- a/website/docs/r/wafv2_web_acl_logging_configuration.html.markdown
+++ b/website/docs/r/wafv2_web_acl_logging_configuration.html.markdown
@@ -10,8 +10,6 @@ description: |-
 
 This resource creates a WAFv2 Web ACL Logging Configuration.
 
-~> **NOTE:** To start logging from a WAFv2 Web ACL, you need to create an Amazon Kinesis Data Firehose resource, such as the [`aws_kinesis_firehose_delivery_stream`](/docs/providers/aws/r/kinesis_firehose_delivery_stream.html) resource. Make sure to create the firehose with a PUT source (not a stream) in the region where you are operating. If you are capturing logs for Amazon CloudFront, create the firehose in the US East (N. Virginia) region. It is important to name the data firehose, CloudWatch log group, and/or S3 bucket with a prefix of `aws-waf-logs-`.
-
 !> **WARNING:** When logging from a WAFv2 Web ACL to a CloudWatch Log Group, the WAFv2 service tries to create or update a generic Log Resource Policy named `AWSWAF-LOGS`. However, if there are a large number of Web ACLs or if the account frequently creates and deletes Web ACLs, this policy may exceed the maximum policy size. As a result, this resource type will fail to be created. More details about this issue can be found in [this issue](https://github.com/hashicorp/terraform-provider-aws/issues/25296). To prevent this issue, you can manage a specific resource policy. Please refer to the [example](#with-cloudwatch-log-group-and-managed-cloudwatch-log-resource-policy) below for managing a CloudWatch Log Group with a managed CloudWatch Log Resource Policy.
 
 ## Example Usage


### PR DESCRIPTION
### Description

This PR removes the note on `aws_wafv2_web_acl_logging_configuration` that indicated that an intermediate Kinesis Firehose Delivery Stream was required, as this requirement on the AWS side has been dropped.

### Relations

Closes #32544

### References

- [Blog post detailing the change](https://aws.amazon.com/blogs/mt/analyzing-aws-waf-logs-in-amazon-cloudwatch-logs/)

> Previously, WAF logs had to be sent via Amazon [Kinesis Data Firehose](https://aws.amazon.com/kinesis/data-firehose/) to [AWS OpenSearch](https://aws.amazon.com/opensearch-service/), third-party solutions for dashboards, or to [Amazon Simple Storage Service (Amazon S3)](https://aws.amazon.com/s3/) paired with [Amazon Athena](https://aws.amazon.com/athena/) for log analysis. Customers would have a high volume of incoming logs, where analyzing logs would become difficult as these configurations required the integration of multiple services for log analysis and dashboards. This was also expensive and customers needed separate teams to keep the solution up to date. To simplify this, logs can now be sent directly to CloudWatch for log analysis, dashboard creation, and viewing alarms in a single pane using CloudWatch features, such as metric filters, Logs Insights, Anomaly detection, and Contributor Insights.

### Output from Acceptance Testing

N/a, docs
