### PR TITLE
sweepers: Prevent panic with `nil` error

### DIFF
--- a/internal/service/iam/sweep.go
+++ b/internal/service/iam/sweep.go
@@ -470,15 +470,15 @@ func newPolicySweeper(resource *schema.Resource, d *schema.ResourceData, client 
 }
 
 func (ps policySweeper) Delete(ctx context.Context, timeout time.Duration, optFns ...tfresource.OptionsFunc) error {
-	err := ps.sweepable.Delete(ctx, timeout, optFns...)
-
-	accessDenied := regexp.MustCompile(`AccessDenied: .+ with an explicit deny`)
-	if accessDenied.MatchString(err.Error()) {
-		log.Printf("[DEBUG] Skipping IAM Policy (%s): %s", ps.d.Id(), err)
-		return nil
+	if err := ps.sweepable.Delete(ctx, timeout, optFns...); err != nil {
+		accessDenied := regexp.MustCompile(`AccessDenied: .+ with an explicit deny`)
+		if accessDenied.MatchString(err.Error()) {
+			log.Printf("[DEBUG] Skipping IAM Policy (%s): %s", ps.d.Id(), err)
+			return nil
+		}
+		return err
 	}
-
-	return err
+	return nil
 }
 
 func sweepRoles(region string) error {
@@ -944,8 +944,7 @@ func sweepVirtualMFADevice(region string) error {
 				continue
 			}
 
-			err := sdk.DeleteResource(ctx, r, d, client)
-			if err != nil {
+			if err := sdk.DeleteResource(ctx, r, d, client); err != nil {
 				if accessDenied.MatchString(err.Error()) {
 					log.Printf("[DEBUG] Skipping IAM Virtual MFA Device (%s): %s", serialNum, err)
 					continue

--- a/internal/service/ssoadmin/sweep.go
+++ b/internal/service/ssoadmin/sweep.go
@@ -53,14 +53,11 @@ func sweepAccountAssignments(region string) error {
 	ds := DataSourceInstances()
 	dsData := ds.Data(nil)
 
-	err = sdk.ReadResource(ctx, ds, dsData, client)
-
-	if accessDenied.MatchString(err.Error()) {
-		log.Printf("[WARN] Skipping SSO Account Assignment sweep for %s: %s", region, err)
-		return nil
-	}
-
-	if err != nil {
+	if err := sdk.ReadResource(ctx, ds, dsData, client); err != nil {
+		if accessDenied.MatchString(err.Error()) {
+			log.Printf("[WARN] Skipping SSO Account Assignment sweep for %s: %s", region, err)
+			return nil
+		}
 		return err
 	}
 
@@ -160,14 +157,11 @@ func sweepPermissionSets(region string) error {
 	ds := DataSourceInstances()
 	dsData := ds.Data(nil)
 
-	err = sdk.ReadResource(ctx, ds, dsData, client)
-
-	if accessDenied.MatchString(err.Error()) {
-		log.Printf("[WARN] Skipping SSO Permission Set sweep for %s: %s", region, err)
-		return nil
-	}
-
-	if err != nil {
+	if err := sdk.ReadResource(ctx, ds, dsData, client); err != nil {
+		if accessDenied.MatchString(err.Error()) {
+			log.Printf("[WARN] Skipping SSO Permission Set sweep for %s: %s", region, err)
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
### Description

In some cases, a `nil` error can cause a panic in several sweepers.
