### PR TITLE
Bug: Properly set DMS Replication Instance data source private/public IPs, VPC security group IDs

### DIFF
--- a/.changelog/32551.txt
+++ b/.changelog/32551.txt
@@ -1,2 +1,3 @@
 ```release-note:bug
 data-source/aws_dms_replication_instance: Fixed bug that caused `replication_instance_private_ips`, `replication_instance_public_ips`, and `vpc_security_group_ids` to always return `null`
+```

--- a/.changelog/32551.txt
+++ b/.changelog/32551.txt
@@ -1,0 +1,2 @@
+```release-note:bug
+data-source/aws_dms_replication_instance: Fixed bug that caused `replication_instance_private_ips`, `replication_instance_public_ips`, and `vpc_security_group_ids` to always return `null`

--- a/internal/service/dms/replication_instance_data_source_test.go
+++ b/internal/service/dms/replication_instance_data_source_test.go
@@ -31,6 +31,10 @@ func TestAccDMSReplicationInstanceDataSource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReplicationInstanceExists(ctx, dataSourceName),
 					resource.TestCheckResourceAttrPair(dataSourceName, "replication_instance_id", resourceName, "replication_instance_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "replication_instance_arn", resourceName, "replication_instance_arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "replication_instance_class", resourceName, "replication_instance_class"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "replication_instance_private_ips.#", resourceName, "replication_instance_private_ips.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "replication_instance_public_ips.#", resourceName, "replication_instance_public_ips.#"),
 				),
 			},
 		},

--- a/website/docs/d/dms_replication_instance.html.markdown
+++ b/website/docs/d/dms_replication_instance.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "DMS (Database Migration)"
 layout: "aws"
-page_title: "AWS: aws_dms_certificate"
+page_title: "AWS: aws_dms_replication_instance"
 description: |-
   Terraform data source for managing an AWS DMS (Database Migration) Replication Instance.
 ---
@@ -22,36 +22,23 @@ data "aws_dms_replication_instance" "test" {
 
 The following arguments are required:
 
-* `replication_instance_id` - (Required) The replication instance identifier. This parameter is stored as a lowercase string.
-
-    - Must contain from 1 to 63 alphanumeric characters or hyphens.
-    - First character must be a letter.
-    - Cannot end with a hyphen
-    - Cannot contain two consecutive hyphens.
+* `replication_instance_id` - (Required) The replication instance identifier.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `allocated_storage` - (Default: 50, Min: 5, Max: 6144) The amount of storage (in gigabytes) to be initially allocated for the replication instance.
-* `allow_major_version_upgrade` - (Default: false) Indicates that major version upgrades are allowed.
-* `apply_immediately` - (Default: false) Indicates whether the changes should be applied immediately or during the next maintenance window. Only used when updating an existing resource.
-* `auto_minor_version_upgrade` - (Default: false) Indicates that minor engine upgrades will be applied automatically to the replication instance during the maintenance window.
+* `allocated_storage` - The amount of storage (in gigabytes) to be initially allocated for the replication instance.
+* `auto_minor_version_upgrade` - Indicates that minor engine upgrades will be applied automatically to the replication instance during the maintenance window.
 * `availability_zone` - The EC2 Availability Zone that the replication instance will be created in.
 * `engine_version` - The engine version number of the replication instance.
-* `kms_key_arn` - The Amazon Resource Name (ARN) for the KMS key that will be used to encrypt the connection parameters. If you do not specify a value for `kms_key_arn`, then AWS DMS will use your default encryption key. AWS KMS creates the default encryption key for your AWS account. Your AWS account has a different default encryption key for each AWS region.
-* `multi_az` - Specifies if the replication instance is a multi-az deployment. You cannot set the `availability_zone` parameter if the `multi_az` parameter is set to `true`.
+* `kms_key_arn` - The Amazon Resource Name (ARN) for the KMS key used to encrypt the connection parameters.
+* `multi_az` - Specifies if the replication instance is a multi-az deployment.
 * `preferred_maintenance_window` - The weekly time range during which system maintenance can occur, in Universal Coordinated Time (UTC).
-
-    - Default: A 30-minute window selected at random from an 8-hour block of time per region, occurring on a random day of the week.
-    - Format: `ddd:hh24:mi-ddd:hh24:mi`
-    - Valid Days: `mon, tue, wed, thu, fri, sat, sun`
-    - Constraints: Minimum 30-minute window.
-
-* `publicly_accessible` - (Default: false) Specifies the accessibility options for the replication instance. A value of true represents an instance with a public IP address. A value of false represents an instance with a private IP address.
+* `publicly_accessible` - Specifies the accessibility options for the replication instance. A value of true represents an instance with a public IP address. A value of false represents an instance with a private IP address.
 * `replication_instance_arn` - The Amazon Resource Name (ARN) of the replication instance.
-* `replication_instance_class` - The compute and memory capacity of the replication instance as specified by the replication instance class. See [AWS DMS User Guide](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_ReplicationInstance.Types.html) for available instance sizes and advice on which one to choose.
+* `replication_instance_class` - The compute and memory capacity of the replication instance as specified by the replication instance class. See [AWS DMS User Guide](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_ReplicationInstance.Types.html) for information on instance classes.
 * `replication_instance_private_ips` - A list of the private IP addresses of the replication instance.
 * `replication_instance_public_ips` - A list of the public IP addresses of the replication instance.
-* `replication_subnet_group_id` - (Optional) A subnet group to associate with the replication instance.
-* `vpc_security_group_ids` - (Optional) A list of VPC security group IDs to be used with the replication instance. The VPC security groups must work with the VPC containing the replication instance.
+* `replication_subnet_group_id` - A subnet group to associate with the replication instance.
+* `vpc_security_group_ids` - A set of VPC security group IDs that are used with the replication instance.


### PR DESCRIPTION
### Description

This PR updates the `aws_dms_replication_instance` data source to properly set the `vpc_security_group_ids`, `replication_instance_private_ips` and `replication_instance_public_ips` values. While these attributes were in the schema, they were previously not being set once read.

In updating these, I've also removed the `allow_major_version_upgrade` and `apply_immediately` attributes, as these are not returned from the SDK (this appears to have been a case of copying over the resource schema to the data source, as they were also not actually being set by the read function).

The documentation for the data source has also been updated, as it was mostly a copy from the resource of the same name. The resource-oriented notes have been removed. 

### Relations

Relates #15406
Closes #32533

### References

- `dms.DescribeReplicationInstances` returns a slice of [`dms.ReplicationInstance`](https://docs.aws.amazon.com/sdk-for-go/api/service/databasemigrationservice/#ReplicationInstance)

### Output from Acceptance Testing

While I updated the acceptance test, I'm not able to run it due to what appears to be a permissions issue.
