### PR TITLE
docs: api_gateway_method_settings: Document Cloudwatch Logging Examples

### DIFF
--- a/website/docs/r/api_gateway_method_settings.html.markdown
+++ b/website/docs/r/api_gateway_method_settings.html.markdown
@@ -14,7 +14,11 @@ Manages API Gateway Stage Method Settings. For example, CloudWatch logging and m
 
 ## Example Usage
 
+### End-to-end
+
 An end-to-end example of a REST API configured with OpenAPI can be found in the [`/examples/api-gateway-rest-api-openapi` directory within the GitHub repository](https://github.com/hashicorp/terraform-provider-aws/tree/main/examples/api-gateway-rest-api-openapi).
+
+### Basic Usage
 
 ```terraform
 resource "aws_api_gateway_rest_api" "example" {
@@ -78,6 +82,72 @@ resource "aws_api_gateway_method_settings" "path_specific" {
   settings {
     metrics_enabled = true
     logging_level   = "INFO"
+  }
+}
+```
+
+### CloudWatch Logging and Tracing
+
+The AWS Console API Gateway Editor displays multiple options for CloudWatch Logs that don't directly map to the options in the AWS API and Terraform. These examples show the `settings` blocks that are equivalent to the options the AWS Console gives for CloudWatch Logs.
+
+#### Off
+
+```terraform
+resource "aws_api_gateway_method_settings" "path_specific" {
+  rest_api_id = aws_api_gateway_rest_api.example.id
+  stage_name  = aws_api_gateway_stage.example.stage_name
+  method_path = "path1/GET"
+
+  settings {
+    logging_level = "OFF"
+  }
+}
+```
+
+#### Errors Only
+
+```terraform
+resource "aws_api_gateway_method_settings" "path_specific" {
+  rest_api_id = aws_api_gateway_rest_api.example.id
+  stage_name  = aws_api_gateway_stage.example.stage_name
+  method_path = "path1/GET"
+
+  settings {
+    logging_level      = "ERROR"
+    metrics_enabled    = true
+    data_trace_enabled = false
+  }
+}
+```
+
+#### Errors and Info Logs
+
+```terraform
+resource "aws_api_gateway_method_settings" "path_specific" {
+  rest_api_id = aws_api_gateway_rest_api.example.id
+  stage_name  = aws_api_gateway_stage.example.stage_name
+  method_path = "path1/GET"
+
+  settings {
+    logging_level      = "INFO"
+    metrics_enabled    = true
+    data_trace_enabled = false
+  }
+}
+```
+
+#### Full Request and Response Logs
+
+```terraform
+resource "aws_api_gateway_method_settings" "path_specific" {
+  rest_api_id = aws_api_gateway_rest_api.example.id
+  stage_name  = aws_api_gateway_stage.example.stage_name
+  method_path = "path1/GET"
+
+  settings {
+    logging_level      = "INFO"
+    metrics_enabled    = true
+    data_trace_enabled = true
   }
 }
 ```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

Documentation update to `api_gateway_method_settings` in order to add examples that clarify to users of the AWS Console how CloudWatch Logging options match up to Terraform/AWS API options. These examples are also useful generically, as they give examples of the different logging/tracing capabilities of the resource.

<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #29770

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
The AWS Console options in question:
![image](https://github.com/hashicorp/terraform-provider-aws/assets/13051767/803e2012-585a-4238-810d-9321924eeb0d)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Docs-only PR
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
