### PR TITLE
Issue #32568 aws_wafv2_web_acl_logging_configuration doc fix

### DIFF
--- a/website/docs/r/wafv2_web_acl_logging_configuration.html.markdown
+++ b/website/docs/r/wafv2_web_acl_logging_configuration.html.markdown
@@ -96,7 +96,7 @@ data "aws_iam_policy_document" "example" {
     effect = "Allow"
     principals {
       identifiers = ["delivery.logs.amazonaws.com"]
-      type        = "AWS"
+      type        = "Service"
     }
     actions   = ["logs:CreateLogStream", "logs:PutLogEvents"]
     resources = ["${aws_cloudwatch_log_group.example.arn}:*"]


### PR DESCRIPTION
fix to aws_wafv2_web_acl_logging_configuration doc in cloudwatch example

### Description

This PR fixes an issue with an example in the docs [here](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_logging_configuration#with-cloudwatch-log-group-and-managed-cloudwatch-log-resource-policy)

The example has a service in the principals identifier, but the type is `AWS` not `Service` More details are in the linked issue

### Relations

Closes #32568

### References

Please see description on the [related issue](https://github.com/hashicorp/terraform-provider-aws/issues/32568)

