### PR TITLE
docs: Add examples and AWS documentation to aws_opensearchserverless_access…

### DIFF
--- a/website/docs/r/opensearchserverless_access_policy.html.markdown
+++ b/website/docs/r/opensearchserverless_access_policy.html.markdown
@@ -8,38 +8,121 @@ description: |-
 
 # Resource: aws_opensearchserverless_access_policy
 
-Terraform resource for managing an AWS OpenSearch Serverless Access Policy.
+Terraform resource for managing an AWS OpenSearch Serverless Access Policy. See AWS documentation for [data access policies](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-data-access.html) and [supported data access policy permissions](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-data-access.html#serverless-data-supported-permissions).
 
 ## Example Usage
 
-### Basic Usage
+### Grant all collection and index permissions
 
 ```terraform
 data "aws_caller_identity" "current" {}
-data "aws_partition" "current" {}
 
-resource "aws_opensearchserverless_access_policy" "test" {
-  name = "example"
-  type = "data"
+resource "aws_opensearchserverless_access_policy" "example" {
+  name        = "example"
+  type        = "data"
+  description = "read and write permissions"
   policy = jsonencode([
     {
-      "Rules" : [
+      Rules = [
         {
-          "ResourceType" : "index",
-          "Resource" : [
-            "index/books/*"
+          ResourceType = "index",
+          Resource = [
+            "index/example-collection/*"
           ],
-          "Permission" : [
-            "aoss:CreateIndex",
-            "aoss:ReadDocument",
-            "aoss:UpdateIndex",
-            "aoss:DeleteIndex",
-            "aoss:WriteDocument"
+          Permission = [
+            "aoss:*"
+          ]
+        },
+        {
+          ResourceType = "collection",
+          Resource = [
+            "collection/example-collection"
+          ],
+          Permission = [
+            "aoss:*"
           ]
         }
       ],
-      "Principal" : [
-        "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:user/admin"
+      Principal = [
+        data.aws_caller_identity.current.arn
+      ]
+    }
+  ])
+}
+```
+
+### Grant read-only collection and index permissions
+
+```
+data "aws_caller_identity" "current" {}
+
+resource "aws_opensearchserverless_access_policy" "example" {
+  name        = "example"
+  type        = "data"
+  description = "read-only permissions"
+  policy = jsonencode([
+    {
+      Rules = [
+        {
+          ResourceType = "index",
+          Resource = [
+            "index/example-collection/*"
+          ],
+          Permission = [
+            "aoss:DescribeIndex",
+            "aoss:ReadDocument",
+          ]
+        },
+        {
+          ResourceType = "collection",
+          Resource = [
+            "collection/example-collection"
+          ],
+          Permission = [
+            "aoss:DescribeCollectionItems"
+          ]
+        }
+      ],
+      Principal = [
+        data.aws_caller_identity.current.arn
+      ]
+    }
+  ])
+}
+```
+
+### Grant SAML identity permissions
+
+```
+resource "aws_opensearchserverless_access_policy" "example" {
+  name = "example"
+  type = "data"
+  description = "saml permissions"
+  policy = jsonencode([
+    {
+      Rules = [
+        {
+          ResourceType = "index",
+          Resource = [
+            "index/example-collection/*"
+          ],
+          Permission = [
+            "aoss:*"
+          ]
+        },
+        {
+          ResourceType = "collection",
+          Resource = [
+            "collection/example-collection"
+          ],
+          Permission = [
+            "aoss:*"
+          ]
+        }
+      ],
+      Principal = [
+        "saml/123456789012/myprovider/user/Annie",
+        "saml/123456789012/anotherprovider/group/Accounting"
       ]
     }
   ])


### PR DESCRIPTION
…_policy resource

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
- Adds additional examples on how to use the `aws_opensearchserverless_access_policy` resource
- Links to AWS documentation as argument values are likely to update over time


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

N/A

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-data-access.html
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/opensearchserverless_access_policy

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

N/A

### Additional Testing

Verified the Terraform configurations were valid by applying `terraform apply`.

```
$ terraform apply

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_opensearchserverless_access_policy.example1 will be created
...
  # aws_opensearchserverless_access_policy.example2 will be created
...
  # aws_opensearchserverless_access_policy.example3 will be created
...
Plan: 3 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

...

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
```


