### PR TITLE
docs: Add additional documentation for `aws_opensearchserverless_collection`

### DIFF
--- a/website/docs/r/opensearchserverless_collection.html.markdown
+++ b/website/docs/r/opensearchserverless_collection.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Terraform resource for managing an AWS OpenSearch Serverless Collection.
 
-~> **NOTE:** An `aws_opensearchserverless_collection` cannot be created without having an applicable [encryption security policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/opensearchserverless_security_policy). Use the [`depends_on`](https://developer.hashicorp.com/terraform/language/meta-arguments/depends_on) to define this dependency.
+~> **NOTE:** An `aws_opensearchserverless_collection` cannot be created without having an applicable [encryption security policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/opensearchserverless_security_policy). Use the [`depends_on`](https://developer.hashicorp.com/terraform/language/meta-arguments/depends_on) meta-argument to define this dependency.
 
 ~> **NOTE:** An `aws_opensearchserverless_collection` is not accessible without configuring an applicable [network security policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/opensearchserverless_security_policy). Data cannot be accessed without configuring an applicable [data access policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/opensearchserverless_access_policy).
 

--- a/website/docs/r/opensearchserverless_collection.html.markdown
+++ b/website/docs/r/opensearchserverless_collection.html.markdown
@@ -10,6 +10,10 @@ description: |-
 
 Terraform resource for managing an AWS OpenSearch Serverless Collection.
 
+~> **NOTE:** An `aws_opensearchserverless_collection` cannot be created without having an applicable [encryption security policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/opensearchserverless_security_policy). Use the [`depends_on`](https://developer.hashicorp.com/terraform/language/meta-arguments/depends_on) to define this dependency.
+
+~> **NOTE:** An `aws_opensearchserverless_collection` is not accessible without configuring an applicable [network security policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/opensearchserverless_security_policy). Data cannot be accessed without configuring an applicable [data access policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/opensearchserverless_access_policy).
+
 ## Example Usage
 
 ### Basic Usage
@@ -48,7 +52,7 @@ The following arguments are optional:
 
 * `description` - (Optional) Description of the collection.
 * `tags` - (Optional) A map of tags to assign to the collection. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
-* `type` - (Optional) Type of collection. One of `SEARCH` or `TIMESERIES`.
+* `type` - (Optional) Type of collection. One of `SEARCH` or `TIMESERIES`. Defaults to `TIMESERIES`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
- Added notices that `aws_opensearchserverless_security_policy` and `aws_opensearchserverless_access_policy` are required for network and data access
- Added default value for `aws_opensearchserverless_collection` `type`


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

N/A

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/opensearchserverless_collection
- https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-encryption.html
- https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-network.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

N/A
