### PR TITLE
r/aws_codepipeline(test): fix PreCheck panic

### DIFF
--- a/internal/service/codepipeline/codepipeline_test.go
+++ b/internal/service/codepipeline/codepipeline_test.go
@@ -670,7 +670,7 @@ func testAccPreCheckSupported(ctx context.Context, t *testing.T, regions ...stri
 		conf := &conns.Config{
 			Region: region,
 		}
-		client, diags := conf.ConfigureProvider(ctx, &conns.AWSClient{})
+		client, diags := conf.ConfigureProvider(ctx, acctest.Provider.Meta().(*conns.AWSClient))
 
 		if diags.HasError() {
 			t.Fatalf("error getting AWS client for region %s", region)

--- a/internal/service/codepipeline/codepipeline_test.go
+++ b/internal/service/codepipeline/codepipeline_test.go
@@ -1405,11 +1405,6 @@ func testAccS3Bucket(bucket, rName string) string {
 resource "aws_s3_bucket" "%[1]s" {
   bucket = "tf-test-pipeline-%[1]s-%[2]s"
 }
-
-resource "aws_s3_bucket_acl" "%[1]s" {
-  bucket = aws_s3_bucket.%[1]s.id
-  acl    = "private"
-}
 `, bucket, rName)
 }
 
@@ -1417,12 +1412,6 @@ func testAccS3BucketWithProvider(bucket, rName, provider string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "%[1]s" {
   bucket   = "tf-test-pipeline-%[1]s-%[2]s"
-  provider = %[3]s
-}
-
-resource "aws_s3_bucket_acl" "%[1]s" {
-  bucket   = aws_s3_bucket.%[1]s.id
-  acl      = "private"
   provider = %[3]s
 }
 `, bucket, rName, provider)
@@ -1492,11 +1481,6 @@ resource "aws_codestarconnections_connection" "test" {
 
 resource "aws_s3_bucket" "foo" {
   bucket = "tf-test-pipeline-%[1]s"
-}
-
-resource "aws_s3_bucket_acl" "foo_acl" {
-  bucket = aws_s3_bucket.foo.id
-  acl    = "private"
 }
 `, rName))
 }


### PR DESCRIPTION
### Description
Prevents a panic in the `testAccPreCheckSupported` caused by passing an empty AWSClient struct to the `ConfigureProvider` method. Also removes various AWS s3 bucket ACL configurations which are no longer necessary.


### Relations

Closes #32577


### Output from Acceptance Testing

Failure is unrelated to this change, which just fixes a PreCheck panic:

```console
$ make testacc PKG=codepipeline TESTS=TestAccCodePipeline_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/codepipeline/... -v -count 1 -parallel 20 -run='TestAccCodePipeline_'  -timeout 180m

--- PASS: TestAccCodePipeline_disappears (42.66s)
--- PASS: TestAccCodePipeline_emptyStageArtifacts (48.72s)
--- PASS: TestAccCodePipeline_withNamespace (52.21s)
--- PASS: TestAccCodePipeline_deployWithServiceRole (52.96s)
--- PASS: TestAccCodePipeline_ecr (53.31s)
--- PASS: TestAccCodePipeline_MultiRegion_basic (68.57s)
--- PASS: TestAccCodePipeline_basic (71.50s)
--- PASS: TestAccCodePipeline_MultiRegion_update (84.11s)
=== NAME  TestAccCodePipeline_MultiRegion_convertSingleRegion
    codepipeline_test.go:398: Step 3/4 error: Error running apply: exit status 1

        Error: region cannot be set for a single-region CodePipeline

          with aws_codepipeline.test,
          on terraform_plugin_test.tf line 62, in resource "aws_codepipeline" "test":
          62: resource "aws_codepipeline" "test" {

--- PASS: TestAccCodePipeline_tags (87.99s)
--- FAIL: TestAccCodePipeline_MultiRegion_convertSingleRegion (92.77s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/codepipeline       96.149s
```
