### PR TITLE
[WIP] Correctly expand all QuickSight TransformOperations for a DataSet

### DIFF
--- a/internal/service/quicksight/data_set.go
+++ b/internal/service/quicksight/data_set.go
@@ -1372,61 +1372,64 @@ func expandDataSetDataTransforms(tfList []interface{}) []*quicksight.TransformOp
 		return nil
 	}
 
-	var transformOperations []*quicksight.TransformOperation
-	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+	tfMap := tfList[0].(map[string]interface{})
+
+	var transformedOperations []*quicksight.TransformOperation
+	for key, operations := range tfMap {
+		operations, ok := operations.([]interface{})
 		if !ok {
 			continue
 		}
 
-		transformOperation := expandDataSetDataTransform(tfMap)
-		if transformOperation == nil {
-			continue
-		}
+		// parse each operation and add it to operations list
+		for _, operation := range operations {
+			operation, ok := operation.(map[string]interface{})
+			if !ok {
+				continue
+			}
 
-		transformOperations = append(transformOperations, transformOperation)
+			transformedOperation := expandDataSetDataTransformOperation(key, operation)
+			transformedOperations = append(transformedOperations, transformedOperation)
+		}
 	}
 
-	return transformOperations
+	return transformedOperations
 }
 
-func expandDataSetDataTransform(tfMap map[string]interface{}) *quicksight.TransformOperation {
-	if tfMap == nil {
+func expandDataSetDataTransformOperation(key string, rawOperation map[string]interface{}) *quicksight.TransformOperation {
+	transformOperation := &quicksight.TransformOperation{}
+
+	if rawOperation == nil {
 		return nil
 	}
 
-	transformOperation := &quicksight.TransformOperation{}
-	if v, ok := tfMap["cast_column_type_operation"].([]interface{}); ok && len(v) > 0 {
-		transformOperation.CastColumnTypeOperation = expandDataSetCastColumnTypeOperation(v)
+	if key == "cast_column_type_operation" {
+		transformOperation.CastColumnTypeOperation = expandDataSetCastColumnTypeOperation(rawOperation)
 	}
-	if v, ok := tfMap["create_columns_operation"].([]interface{}); ok && len(v) > 0 {
-		transformOperation.CreateColumnsOperation = expandDataSetCreateColumnsOperation(v)
+	if key == "create_columns_operation" {
+		transformOperation.CreateColumnsOperation = expandDataSetCreateColumnsOperation(rawOperation)
 	}
-	if v, ok := tfMap["filter_operation"].([]interface{}); ok && len(v) > 0 {
-		transformOperation.FilterOperation = expandDataSetFilterOperation(v)
+	if key == "filter_operation" {
+		transformOperation.FilterOperation = expandDataSetFilterOperation(rawOperation)
 	}
-	if v, ok := tfMap["project_operation"].([]interface{}); ok && len(v) > 0 {
-		transformOperation.ProjectOperation = expandDataSetProjectOperation(v)
+	if key == "project_operation" {
+		transformOperation.ProjectOperation = expandDataSetProjectOperation(rawOperation)
 	}
-	if v, ok := tfMap["rename_column_operation"].([]interface{}); ok && len(v) > 0 {
-		transformOperation.RenameColumnOperation = expandDataSetRenameColumnOperation(v)
+	if key == "rename_column_operation" {
+		transformOperation.RenameColumnOperation = expandDataSetRenameColumnOperation(rawOperation)
 	}
-	if v, ok := tfMap["tag_column_operation"].([]interface{}); ok && len(v) > 0 {
-		transformOperation.TagColumnOperation = expandDataSetTagColumnOperation(v)
+	if key == "tag_column_operation" {
+		transformOperation.TagColumnOperation = expandDataSetTagColumnOperation(rawOperation)
 	}
-	if v, ok := tfMap["untag_column_operation"].([]interface{}); ok && len(v) > 0 {
-		transformOperation.UntagColumnOperation = expandDataSetUntagColumnOperation(v)
+	if key == "untag_column_operation" {
+		transformOperation.UntagColumnOperation = expandDataSetUntagColumnOperation(rawOperation)
 	}
 
 	return transformOperation
 }
 
-func expandDataSetCastColumnTypeOperation(tfList []interface{}) *quicksight.CastColumnTypeOperation {
-	if len(tfList) == 0 || tfList[0] == nil {
-		return nil
-	}
-	tfMap, ok := tfList[0].(map[string]interface{})
-	if !ok {
+func expandDataSetCastColumnTypeOperation(tfMap map[string]interface{}) *quicksight.CastColumnTypeOperation {
+	if tfMap == nil {
 		return nil
 	}
 
@@ -1444,12 +1447,8 @@ func expandDataSetCastColumnTypeOperation(tfList []interface{}) *quicksight.Cast
 	return castColumnTypeOperation
 }
 
-func expandDataSetCreateColumnsOperation(tfList []interface{}) *quicksight.CreateColumnsOperation {
-	if len(tfList) == 0 || tfList[0] == nil {
-		return nil
-	}
-	tfMap, ok := tfList[0].(map[string]interface{})
-	if !ok {
+func expandDataSetCreateColumnsOperation(tfMap map[string]interface{}) *quicksight.CreateColumnsOperation {
+	if tfMap == nil {
 		return nil
 	}
 
@@ -1503,12 +1502,8 @@ func expandDataSetCalculatedColumn(tfMap map[string]interface{}) *quicksight.Cal
 	return calculatedColumn
 }
 
-func expandDataSetFilterOperation(tfList []interface{}) *quicksight.FilterOperation {
-	if len(tfList) == 0 || tfList[0] == nil {
-		return nil
-	}
-	tfMap, ok := tfList[0].(map[string]interface{})
-	if !ok {
+func expandDataSetFilterOperation(tfMap map[string]interface{}) *quicksight.FilterOperation {
+	if tfMap == nil {
 		return nil
 	}
 
@@ -1520,12 +1515,8 @@ func expandDataSetFilterOperation(tfList []interface{}) *quicksight.FilterOperat
 	return filterOperation
 }
 
-func expandDataSetProjectOperation(tfList []interface{}) *quicksight.ProjectOperation {
-	if len(tfList) == 0 || tfList[0] == nil {
-		return nil
-	}
-	tfMap, ok := tfList[0].(map[string]interface{})
-	if !ok {
+func expandDataSetProjectOperation(tfMap map[string]interface{}) *quicksight.ProjectOperation {
+	if tfMap == nil {
 		return nil
 	}
 
@@ -1537,12 +1528,8 @@ func expandDataSetProjectOperation(tfList []interface{}) *quicksight.ProjectOper
 	return projectOperation
 }
 
-func expandDataSetRenameColumnOperation(tfList []interface{}) *quicksight.RenameColumnOperation {
-	if len(tfList) == 0 || tfList[0] == nil {
-		return nil
-	}
-	tfMap, ok := tfList[0].(map[string]interface{})
-	if !ok {
+func expandDataSetRenameColumnOperation(tfMap map[string]interface{}) *quicksight.RenameColumnOperation {
+	if tfMap == nil {
 		return nil
 	}
 
@@ -1557,12 +1544,8 @@ func expandDataSetRenameColumnOperation(tfList []interface{}) *quicksight.Rename
 	return renameColumnOperation
 }
 
-func expandDataSetTagColumnOperation(tfList []interface{}) *quicksight.TagColumnOperation {
-	if len(tfList) == 0 || tfList[0] == nil {
-		return nil
-	}
-	tfMap, ok := tfList[0].(map[string]interface{})
-	if !ok {
+func expandDataSetTagColumnOperation(tfMap map[string]interface{}) *quicksight.TagColumnOperation {
+	if tfMap == nil {
 		return nil
 	}
 
@@ -1629,12 +1612,8 @@ func expandDataSetColumnDescription(tfMap map[string]interface{}) *quicksight.Co
 	return columnDescription
 }
 
-func expandDataSetUntagColumnOperation(tfList []interface{}) *quicksight.UntagColumnOperation {
-	if len(tfList) == 0 || tfList[0] == nil {
-		return nil
-	}
-	tfMap, ok := tfList[0].(map[string]interface{})
-	if !ok {
+func expandDataSetUntagColumnOperation(tfMap map[string]interface{}) *quicksight.UntagColumnOperation {
+	if tfMap == nil {
 		return nil
 	}
 

--- a/internal/service/quicksight/data_set_test.go
+++ b/internal/service/quicksight/data_set_test.go
@@ -1158,3 +1158,94 @@ resource "aws_quicksight_data_set" "test" {
 }
 `, rId, rName))
 }
+
+func TestAccQuicksightDataTransforms_many(t *testing.T) {
+	ctx := acctest.Context(t)
+	var dataSet quicksight.DataSet
+	resourceName := "aws_quicksight_dataset.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, quicksight.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDataSetDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSetConfigManyDataTransforms(rId, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataSetExists(ctx, resourceName, &dataSet),
+					resource.TestCheckResourceAttr(resourceName, "data_set_id", rId),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "quicksight", fmt.Sprintf("dataset/%s", rId)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "import_mode", "SPICE"),
+					resource.TestCheckResourceAttr(resourceName, "physical_table_map.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logical_table_map.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logical_table_map.0.logical_table_map_id", rId),
+					resource.TestCheckResourceAttr(resourceName, "logical_table_map.0.alias", "Group1"),
+					resource.TestCheckResourceAttr(resourceName, "logical_table_map.0.source.0.physical_table_id", rId),
+					resource.TestCheckResourceAttr(resourceName, "logical_table_map.0.source.0.data_transforms.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "logical_table_map.0.source.0.data_transforms.cast_column_type_operation.0.column_name", "DateTimeAsStringColumn"),
+					resource.TestCheckResourceAttr(resourceName, "logical_table_map.0.source.0.data_transforms.cast_column_type_operation.0.new_column_type", "DATETIME"),
+					resource.TestCheckResourceAttr(resourceName, "logical_table_map.0.source.0.data_transforms.rename_column_operation.0.column_name", "DateTimeAsStringColumn"),
+					resource.TestCheckResourceAttr(resourceName, "logical_table_map.0.source.0.data_transforms.rename_column_operation.0.new_column_name", "DateTime"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccDataSetConfigManyDataTransforms(rId, rName string) string {
+	return acctest.ConfigCompose(
+		testAccDataSetConfigBase(rId, rName),
+		fmt.Sprintf(`
+resource "aws_quicksight_data_set" "test" {
+  data_set_id = %[1]q
+  name        = %[2]q
+  import_mode = "SPICE"
+  
+  physical_table_map {
+    physical_table_map_id = %[1]q
+    s3_source {
+    data_source_arn = aws_quicksight_data_source.test.arn
+    input_columns {
+      name = "DateTimeAsStringColumn"
+      type = "STRING"
+    }
+    upload_settings {}
+    }
+  }
+
+  logical_table_map {
+    logical_table_map_id = %[1]q
+    alias                = "Group1"
+    source {
+      physical_table_id = %[1]q
+    }
+
+    data_transforms {
+      cast_column_type_operation {
+        column_name = "DateTimeAsStringColumn"
+        new_column_type = "DATETIME"
+        format = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ"
+      }
+
+	  rename_column_operation {
+		column_name = "DateTimeAsStringColumn"
+		new_column_name = "DateTime"
+	  }
+    
+      project_operation {
+        projected_columns = ["DateTime"]
+      }
+    }
+  }
+}
+`, rId, rName))
+}


### PR DESCRIPTION
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

All TransformOperations provided to a LogicalTableMap should be in separate maps inside the array of TransformOperations. Previously, the provider would include all TransformOperations inside one map. This PR changes that behaviour to the expected structure.

For a concrete example with JSON objects of a data, see the related issue.


### Relations

Closes #32137


### References

The [DataTransforms field on a LogicalTable](https://docs.aws.amazon.com/quicksight/latest/APIReference/API_LogicalTable.html#QS-Type-LogicalTable-DataTransforms) is a list of [TransformOperations](https://docs.aws.amazon.com/quicksight/latest/APIReference/API_TransformOperation.html). The TransformOperations documentation states that: `For this structure to be valid, only one of the attributes can be non-null`. 

### Output from Acceptance Testing

I haven't been able to successfully run the newly added acceptance tests yet, it keeps hanging somewhere and I haven't been able to figure out where:

```
$ make testacc TESTS=TestAccQuicksightDataTransforms_many PKG=quicksight
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/quicksight/... -v -count 1 -parallel 20 -run='TestAccQuicksightDataTransforms_many'  -timeout 180m
?   	github.com/hashicorp/terraform-provider-aws/internal/service/quicksight/schema	[no test files]

```

P.S. I have very little experience developing Go applications, so please do tell if you notice anything off or if I missed anything. 
