### PR TITLE
Fix misidentification of parent folder at grandchild level or deeper.

### DIFF
--- a/.changelog/32592.txt
+++ b/.changelog/32592.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_quicksight_folder: Fix misidentification of parent folder at grandchild level or deeper
+```

--- a/internal/service/quicksight/folder.go
+++ b/internal/service/quicksight/folder.go
@@ -207,7 +207,7 @@ func resourceFolderRead(ctx context.Context, d *schema.ResourceData, meta interf
 	d.Set("name", out.Name)
 
 	if len(out.FolderPath) > 0 {
-		d.Set("parent_folder_arn", out.FolderPath[0])
+		d.Set("parent_folder_arn", out.FolderPath[len(out.FolderPath)-1])
 	}
 
 	if err := d.Set("folder_path", flex.FlattenStringList(out.FolderPath)); err != nil {

--- a/internal/service/quicksight/folder_test.go
+++ b/internal/service/quicksight/folder_test.go
@@ -231,7 +231,7 @@ func TestAccQuickSightFolder_parentFolder(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccFolderConfig_parentFolder(rId, rName, parentId2, parentName2),
+				Config: testAccFolderConfig_parentFolder2(rId, rName, parentId1, parentName1, parentId2, parentName2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFolderExists(ctx, resourceName, &folder),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "parent_folder_arn", "quicksight", fmt.Sprintf("folder/%s", parentId2)),
@@ -398,4 +398,25 @@ resource "aws_quicksight_folder" "test" {
   parent_folder_arn = aws_quicksight_folder.parent.arn
 }
 `, rId, rName, parentId, parentName)
+}
+
+func testAccFolderConfig_parentFolder2(rId, rName, parentId, parentName, parentId2, parentName2 string) string {
+	return fmt.Sprintf(`
+resource "aws_quicksight_folder" "parent" {
+  folder_id = %[3]q
+  name      = %[4]q
+}
+
+resource "aws_quicksight_folder" "parent2" {
+  folder_id = %[5]q
+  name      = %[6]q
+  parent_folder_arn = aws_quicksight_folder.parent.arn
+}
+
+resource "aws_quicksight_folder" "test" {
+  folder_id         = %[1]q
+  name              = %[2]q
+  parent_folder_arn = aws_quicksight_folder.parent2.arn
+}
+`, rId, rName, parentId, parentName, parentId2, parentName2)
 }


### PR DESCRIPTION
### Description

Bug fix for `aws_quicksight_folder`.
`FolderPath` seems to be ordered by older ancestors, this change ensures the correct parent folder is used.

### Relations

Closes #31922 

### Output from Acceptance Testing

```
make testacc TESTS=TestAccQuickSightFolder_ PKG=quicksight
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/quicksight/... -v -count 1 -parallel 20 -run='TestAccQuickSightFolder_'  -timeout 180m
?       github.com/hashicorp/terraform-provider-aws/internal/service/quicksight/schema  [no test files]
=== RUN   TestAccQuickSightFolder_basic
=== PAUSE TestAccQuickSightFolder_basic
=== RUN   TestAccQuickSightFolder_disappears
=== PAUSE TestAccQuickSightFolder_disappears
=== RUN   TestAccQuickSightFolder_permissions
=== PAUSE TestAccQuickSightFolder_permissions
=== RUN   TestAccQuickSightFolder_tags
=== PAUSE TestAccQuickSightFolder_tags
=== RUN   TestAccQuickSightFolder_parentFolder
=== PAUSE TestAccQuickSightFolder_parentFolder
=== CONT  TestAccQuickSightFolder_basic
=== CONT  TestAccQuickSightFolder_tags
=== CONT  TestAccQuickSightFolder_permissions
=== CONT  TestAccQuickSightFolder_parentFolder
=== CONT  TestAccQuickSightFolder_disappears
--- PASS: TestAccQuickSightFolder_disappears (31.16s)
--- PASS: TestAccQuickSightFolder_basic (39.88s)
--- PASS: TestAccQuickSightFolder_parentFolder (69.81s)
--- PASS: TestAccQuickSightFolder_tags (82.15s)
--- PASS: TestAccQuickSightFolder_permissions (98.91s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/quicksight 101.579s
```
