### PR TITLE
Allow usage of service principals for KMS grants

### DIFF
--- a/.changelog/32595.txt
+++ b/.changelog/32595.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+resource/aws_kms_grant: Allow usage of service principal as grantee and revoker.
+```

--- a/internal/service/kms/grant_test.go
+++ b/internal/service/kms/grant_test.go
@@ -277,6 +277,41 @@ func TestAccKMSGrant_crossAccountARN(t *testing.T) {
 	})
 }
 
+func TestAccKMSGrant_service(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_kms_grant.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	servicePrincipal := "dynamodb.us-west-1.amazonaws.com" //lintignore:AWSAT003
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, kms.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGrantDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGrantConfig_service(rName, "\"Encrypt\", \"Decrypt\"", servicePrincipal),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGrantExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "grantee_principal", servicePrincipal),
+					resource.TestCheckResourceAttr(resourceName, "retiring_principal", servicePrincipal),
+					resource.TestCheckResourceAttr(resourceName, "operations.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "operations.*", "Encrypt"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "operations.*", "Decrypt"),
+					resource.TestCheckResourceAttrPair(resourceName, "key_id", "aws_kms_key.test", "key_id"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"grant_token", "retire_on_delete"},
+			},
+		},
+	})
+}
+
 func testAccCheckGrantDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).KMSConn(ctx)
@@ -495,4 +530,16 @@ resource "aws_kms_grant" "test" {
   operations        = [%[2]s]
 }
 `, rName, operations))
+}
+
+func testAccGrantConfig_service(rName string, operations string, servicePrincipal string) string {
+	return acctest.ConfigCompose(testAccGrantConfig_base(rName), fmt.Sprintf(`
+resource "aws_kms_grant" "test" {
+  name               = %[1]q
+  key_id             = aws_kms_key.test.key_id
+  operations         = [%[2]s]
+  grantee_principal  = %[3]q
+  retiring_principal = %[3]q
+}
+`, rName, operations, servicePrincipal))
 }

--- a/internal/verify/validate.go
+++ b/internal/verify/validate.go
@@ -27,6 +27,9 @@ var accountIDRegexp = regexp.MustCompile(`^(aws|aws-managed|third-party|\d{12}|c
 var partitionRegexp = regexp.MustCompile(`^aws(-[a-z]+)*$`)
 var regionRegexp = regexp.MustCompile(`^[a-z]{2}(-[a-z]+)+-\d$`)
 
+// validates all listed in https://gist.github.com/shortjared/4c1e3fe52bdfa47522cfe5b41e5d6f22
+var servicePrincipalRegexp = regexp.MustCompile(`^([a-z0-9-]+\.){1,4}(amazonaws|amazon)\.com$`)
+
 func Valid4ByteASN(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 
@@ -478,4 +481,22 @@ func ValidAnyDiag(validators ...schema.SchemaValidateDiagFunc) schema.SchemaVali
 		}
 		return results
 	}
+}
+
+func ValidServicePrincipal(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+
+	if value == "" {
+		return ws, errors
+	}
+
+	if !IsServicePrincipal(value) {
+		errors = append(errors, fmt.Errorf("%q (%s) is an invalid Service Principal: invalid prefix value (expecting to match regular expression: %s)", k, value, servicePrincipalRegexp))
+	}
+
+	return ws, errors
+}
+
+func IsServicePrincipal(value string) (valid bool) {
+	return servicePrincipalRegexp.MatchString(value)
 }

--- a/internal/verify/validate_test.go
+++ b/internal/verify/validate_test.go
@@ -737,3 +737,41 @@ func TestFloatGreaterThan(t *testing.T) {
 		}
 	}
 }
+
+func TestValidServicePrincipal(t *testing.T) {
+	t.Parallel()
+
+	v := ""
+	_, errors := ValidServicePrincipal(v, "test.google.com")
+	if len(errors) != 0 {
+		t.Fatalf("%q should not be validated as an Service Principal name: %q", v, errors)
+	}
+
+	validNames := []string{
+		"a4b.amazonaws.com",
+		"appstream.application-autoscaling.amazonaws.com",
+		"alexa-appkit.amazon.com",
+		"member.org.stacksets.cloudformation.amazonaws.com",
+		"vpc-flow-logs.amazonaws.com",
+		"logs.eu-central-1.amazonaws.com",
+	}
+	for _, v := range validNames {
+		_, errors := ValidServicePrincipal(v, "arn")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid Service Principal: %q", v, errors)
+		}
+	}
+
+	invalidNames := []string{
+		"test.google.com",
+		"transfer.amz.com",
+		"test",
+		"testwithwildcard*",
+	}
+	for _, v := range invalidNames {
+		_, errors := ValidServicePrincipal(v, "arn")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be an invalid Service Principal", v)
+		}
+	}
+}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Allow usage of service principals for KMS grants

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #25360

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
--- PASS: TestAccKMSGrant_service (22.83s)
--- PASS: TestAccKMSGrant_arn (33.14s)
--- PASS: TestAccKMSGrant_basic (33.30s)
--- PASS: TestAccKMSGrant_bare (40.71s)
--- PASS: TestAccKMSGrant_withRetiringPrincipal (41.12s)
--- PASS: TestAccKMSGrant_asymmetricKey (41.21s)
--- PASS: TestAccKMSGrant_withConstraints (53.18s)
--- PASS: TestAccKMSGrant_disappears (209.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kms        212.279s
...
```
