### PR TITLE
Add missing 'budget_exceeded' attribute into website documentation 

### DIFF
--- a/website/docs/d/budgets_budget.html.markdown
+++ b/website/docs/d/budgets_budget.html.markdown
@@ -38,6 +38,7 @@ This data source exports the following attributes in addition to the arguments a
 * `auto_adjust_data` - Object containing [AutoAdjustData] which determines the budget amount for an auto-adjusting budget.
 * `budget_type` - Whether this budget tracks monetary cost or usage.
 * `budget_limit` - The total amount of cost, usage, RI utilization, RI coverage, Savings Plans utilization, or Savings Plans coverage that you want to track with your budget. Contains object [Spend](#spend)
+* `budget_exceeded` - Boolean indicating whether this budget has been exceeded or not
 * `calculated_spend` - The spend objects that are associated with this budget. The [actualSpend](#actual-spend) tracks how much you've used, cost, usage, RI units, or Savings Plans units and the [forecastedSpend](#forecasted-spend) tracks how much that you're predicted to spend based on your historical usage profile.
 * `cost_filter` - A list of [CostFilter](#cost-filter) name/values pair to apply to budget.
 * `cost_types` - Object containing [CostTypes](#cost-types) The types of cost included in a budget, such as tax and subscriptions.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adding missing 'budget_exceeded' attribute into `budgets_budget` data source


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->
N/A

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/budgets/budget_data_source.go#L259-L262

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
