### PR TITLE
VPC Traffic Mirror: Handle "resource not found" errors on Delete

### DIFF
--- a/internal/service/ec2/errors.go
+++ b/internal/service/ec2/errors.go
@@ -91,6 +91,7 @@ const (
 	errCodeInvalidSubnetIDNotFound                           = "InvalidSubnetID.NotFound"
 	errCodeInvalidSubnetIdNotFound                           = "InvalidSubnetId.NotFound"
 	errCodeInvalidTrafficMirrorFilterIdNotFound              = "InvalidTrafficMirrorFilterId.NotFound"
+	errCodeInvalidTrafficMirrorFilterRuleIdNotFound          = "InvalidTrafficMirrorFilterRuleId.NotFound"
 	errCodeInvalidTrafficMirrorSessionIdNotFound             = "InvalidTrafficMirrorSessionId.NotFound"
 	errCodeInvalidTrafficMirrorTargetIdNotFound              = "InvalidTrafficMirrorTargetId.NotFound"
 	errCodeInvalidTransitGatewayAttachmentIDNotFound         = "InvalidTransitGatewayAttachmentID.NotFound"

--- a/internal/service/ec2/vpc_traffic_mirror_filter.go
+++ b/internal/service/ec2/vpc_traffic_mirror_filter.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -167,6 +168,10 @@ func resourceTrafficMirrorFilterDelete(ctx context.Context, d *schema.ResourceDa
 	_, err := conn.DeleteTrafficMirrorFilterWithContext(ctx, &ec2.DeleteTrafficMirrorFilterInput{
 		TrafficMirrorFilterId: aws.String(d.Id()),
 	})
+
+	if tfawserr.ErrCodeEquals(err, errCodeInvalidTrafficMirrorFilterIdNotFound) {
+		return diags
+	}
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "deleting EC2 Traffic Mirror Filter (%s): %s", d.Id(), err)

--- a/internal/service/ec2/vpc_traffic_mirror_filter_rule.go
+++ b/internal/service/ec2/vpc_traffic_mirror_filter_rule.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -294,6 +295,10 @@ func resourceTrafficMirrorFilterRuleDelete(ctx context.Context, d *schema.Resour
 	_, err := conn.DeleteTrafficMirrorFilterRuleWithContext(ctx, &ec2.DeleteTrafficMirrorFilterRuleInput{
 		TrafficMirrorFilterRuleId: aws.String(d.Id()),
 	})
+
+	if tfawserr.ErrCodeEquals(err, errCodeInvalidTrafficMirrorFilterRuleIdNotFound) {
+		return diags
+	}
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "deleting EC2 Traffic Mirror Filter Rule (%s): %s", d.Id(), err)

--- a/internal/service/ec2/vpc_traffic_mirror_session.go
+++ b/internal/service/ec2/vpc_traffic_mirror_session.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -229,6 +230,10 @@ func resourceTrafficMirrorSessionDelete(ctx context.Context, d *schema.ResourceD
 	_, err := conn.DeleteTrafficMirrorSessionWithContext(ctx, &ec2.DeleteTrafficMirrorSessionInput{
 		TrafficMirrorSessionId: aws.String(d.Id()),
 	})
+
+	if tfawserr.ErrCodeEquals(err, errCodeInvalidTrafficMirrorSessionIdNotFound) {
+		return diags
+	}
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "deleting EC2 Traffic Mirror Session (%s): %s", d.Id(), err)

--- a/internal/service/ec2/vpc_traffic_mirror_session_test.go
+++ b/internal/service/ec2/vpc_traffic_mirror_session_test.go
@@ -293,10 +293,18 @@ resource "aws_lb" "test" {
   enable_deletion_protection = false
 }
 
-resource "aws_ec2_traffic_mirror_filter" "test" {}
+resource "aws_ec2_traffic_mirror_filter" "test" {
+  tags = {
+    Name = %[1]q
+  }
+}
 
 resource "aws_ec2_traffic_mirror_target" "test" {
   network_load_balancer_arn = aws_lb.test.arn
+
+  tags = {
+    Name = %[1]q
+  }
 }
 `, rName))
 }
@@ -385,10 +393,16 @@ resource "aws_ec2_traffic_mirror_target" "test" {
   count = 2
 
   network_interface_id = aws_instance.target[count.index].primary_network_interface_id
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 resource "aws_ec2_traffic_mirror_filter" "test" {
-  description = %[1]q
+  tags = {
+    Name = %[1]q
+  }
 }
 
 resource "aws_ec2_traffic_mirror_session" "test" {
@@ -397,6 +411,10 @@ resource "aws_ec2_traffic_mirror_session" "test" {
   traffic_mirror_target_id = aws_ec2_traffic_mirror_target.test[%[2]d].id
   network_interface_id     = aws_instance.test.primary_network_interface_id
   session_number           = %[3]d
+
+  tags = {
+    Name = %[1]q
+  }
 }
 `, rName, idx, session))
 }

--- a/internal/service/ec2/vpc_traffic_mirror_target.go
+++ b/internal/service/ec2/vpc_traffic_mirror_target.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -174,6 +175,10 @@ func resourceTrafficMirrorTargetDelete(ctx context.Context, d *schema.ResourceDa
 	_, err := conn.DeleteTrafficMirrorTargetWithContext(ctx, &ec2.DeleteTrafficMirrorTargetInput{
 		TrafficMirrorTargetId: aws.String(d.Id()),
 	})
+
+	if tfawserr.ErrCodeEquals(err, errCodeInvalidTrafficMirrorTargetIdNotFound) {
+		return diags
+	}
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "deleting EC2 Traffic Mirror Target (%s): %s", d.Id(), err)

--- a/internal/service/ec2/vpc_traffic_mirror_target_test.go
+++ b/internal/service/ec2/vpc_traffic_mirror_target_test.go
@@ -77,7 +77,6 @@ func TestAccVPCTrafficMirrorTarget_eni(t *testing.T) {
 					testAccCheckTrafficMirrorTargetExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
 					resource.TestMatchResourceAttr(resourceName, "network_interface_id", regexp.MustCompile("eni-.*")),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
@@ -285,6 +284,10 @@ resource "aws_instance" "test" {
 resource "aws_ec2_traffic_mirror_target" "test" {
   description          = %[2]q
   network_interface_id = aws_instance.test.primary_network_interface_id
+
+  tags = {
+    Name = %[1]q
+  }
 }
 `, rName, description))
 }
@@ -339,10 +342,14 @@ func testAccVPCTrafficMirrorTargetConfig_gwlb(rName, description string) string 
 		testAccVPCEndpointConfig_gatewayLoadBalancer(rName),
 		fmt.Sprintf(`
 resource "aws_ec2_traffic_mirror_target" "test" {
-  description                       = %[1]q
+  description                       = %[2]q
   gateway_load_balancer_endpoint_id = aws_vpc_endpoint.test.id
+
+  tags = {
+    Name = %[1]q
+  }
 }
-`, description))
+`, rName, description))
 }
 
 func testAccPreCheckTrafficMirrorTarget(ctx context.Context, t *testing.T) {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Check for "resource not found" error codes on Delete and return no error if matched.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/32589.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccVPCTrafficMirror' PKG=ec2 ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 2  -run=TestAccVPCTrafficMirror -timeout 180m
=== RUN   TestAccVPCTrafficMirrorFilterRule_basic
=== PAUSE TestAccVPCTrafficMirrorFilterRule_basic
=== RUN   TestAccVPCTrafficMirrorFilterRule_disappears
=== PAUSE TestAccVPCTrafficMirrorFilterRule_disappears
=== RUN   TestAccVPCTrafficMirrorFilter_basic
=== PAUSE TestAccVPCTrafficMirrorFilter_basic
=== RUN   TestAccVPCTrafficMirrorFilter_tags
=== PAUSE TestAccVPCTrafficMirrorFilter_tags
=== RUN   TestAccVPCTrafficMirrorFilter_disappears
=== PAUSE TestAccVPCTrafficMirrorFilter_disappears
=== RUN   TestAccVPCTrafficMirrorSession_basic
=== PAUSE TestAccVPCTrafficMirrorSession_basic
=== RUN   TestAccVPCTrafficMirrorSession_tags
=== PAUSE TestAccVPCTrafficMirrorSession_tags
=== RUN   TestAccVPCTrafficMirrorSession_disappears
=== PAUSE TestAccVPCTrafficMirrorSession_disappears
=== RUN   TestAccVPCTrafficMirrorSession_updateTrafficMirrorTarget
=== PAUSE TestAccVPCTrafficMirrorSession_updateTrafficMirrorTarget
=== RUN   TestAccVPCTrafficMirrorTarget_nlb
=== PAUSE TestAccVPCTrafficMirrorTarget_nlb
=== RUN   TestAccVPCTrafficMirrorTarget_eni
=== PAUSE TestAccVPCTrafficMirrorTarget_eni
=== RUN   TestAccVPCTrafficMirrorTarget_tags
=== PAUSE TestAccVPCTrafficMirrorTarget_tags
=== RUN   TestAccVPCTrafficMirrorTarget_disappears
=== PAUSE TestAccVPCTrafficMirrorTarget_disappears
=== RUN   TestAccVPCTrafficMirrorTarget_gwlb
=== PAUSE TestAccVPCTrafficMirrorTarget_gwlb
=== CONT  TestAccVPCTrafficMirrorFilterRule_basic
=== CONT  TestAccVPCTrafficMirrorSession_disappears
--- PASS: TestAccVPCTrafficMirrorFilterRule_basic (85.95s)
=== CONT  TestAccVPCTrafficMirrorTarget_tags
--- PASS: TestAccVPCTrafficMirrorSession_disappears (258.09s)
=== CONT  TestAccVPCTrafficMirrorTarget_gwlb
--- PASS: TestAccVPCTrafficMirrorTarget_tags (294.68s)
=== CONT  TestAccVPCTrafficMirrorTarget_disappears
--- PASS: TestAccVPCTrafficMirrorTarget_disappears (230.18s)
=== CONT  TestAccVPCTrafficMirrorTarget_nlb
--- PASS: TestAccVPCTrafficMirrorTarget_gwlb (410.29s)
=== CONT  TestAccVPCTrafficMirrorTarget_eni
--- PASS: TestAccVPCTrafficMirrorTarget_eni (116.33s)
=== CONT  TestAccVPCTrafficMirrorFilter_disappears
--- PASS: TestAccVPCTrafficMirrorFilter_disappears (20.98s)
=== CONT  TestAccVPCTrafficMirrorSession_tags
--- PASS: TestAccVPCTrafficMirrorTarget_nlb (233.16s)
=== CONT  TestAccVPCTrafficMirrorSession_basic
--- PASS: TestAccVPCTrafficMirrorSession_tags (325.67s)
=== CONT  TestAccVPCTrafficMirrorFilter_basic
--- PASS: TestAccVPCTrafficMirrorSession_basic (335.87s)
=== CONT  TestAccVPCTrafficMirrorFilter_tags
--- PASS: TestAccVPCTrafficMirrorFilter_basic (57.94s)
=== CONT  TestAccVPCTrafficMirrorSession_updateTrafficMirrorTarget
--- PASS: TestAccVPCTrafficMirrorFilter_tags (59.87s)
=== CONT  TestAccVPCTrafficMirrorFilterRule_disappears
--- PASS: TestAccVPCTrafficMirrorFilterRule_disappears (23.23s)
--- PASS: TestAccVPCTrafficMirrorSession_updateTrafficMirrorTarget (179.34s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	1374.472s
```
