### PR TITLE
r/aws_rds_instance: Add 'backup_target' attribute

### DIFF
--- a/internal/service/rds/consts_test.go
+++ b/internal/service/rds/consts_test.go
@@ -13,4 +13,5 @@ const (
 	sqlServerPreferredInstanceClasses       = `"db.t2.small", "db.t3.small"`
 	sqlServerSEPreferredInstanceClasses     = `"db.m5.large", "db.m4.large", "db.r4.large"`
 	oracleSE2PreferredInstanceClasses       = `"db.m5.large", "db.m4.large", "db.r4.large"`
+	outpostPreferredInstanceClasses         = `"db.m5.large", "db.r5.large"` // https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-on-outposts.db-instance-classes.html
 )

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -83,6 +83,7 @@ func TestAccRDSInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "storage_type", "gp2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "username", "tfacctest"),
+					resource.TestCheckResourceAttr(resourceName, "backup_target", "region"),
 				),
 			},
 			{
@@ -160,6 +161,7 @@ func TestAccRDSInstance_manage_password(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "storage_type", "gp2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "username", "tfacctest"),
+					resource.TestCheckResourceAttr(resourceName, "backup_target", "region"),
 				),
 			},
 			{
@@ -4592,6 +4594,34 @@ func TestAccRDSInstance_CoIPEnabled_snapshotIdentifier(t *testing.T) {
 					testAccCheckDBSnapshotExists(ctx, snapshotResourceName, &dbSnapshot),
 					testAccCheckInstanceExists(ctx, resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "customer_owned_ip_enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRDSInstance_BackupTarget(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var v rds.DBInstance
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_db_instance.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckOutpostsOutposts(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, rds.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInstanceDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_Outpost_BackupTarget(rName, "outposts", 0),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInstanceExists(ctx, resourceName, &v),
+					testAccCheckInstanceAttributes(&v),
+					resource.TestCheckResourceAttr(resourceName, "backup_target", "outposts"),
 				),
 			},
 		},
@@ -10042,9 +10072,9 @@ resource "aws_db_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfig_Outpost_coIPEnabled(rName string, coipEnabled bool, backupRetentionPeriod int) string {
+func testAccInstanceConfig_Outpost(rName string) string {
 	return acctest.ConfigCompose(
-		testAccInstanceConfig_orderableClassMySQL(),
+		testAccInstanceConfig_orderableClass("mysql", "general-public-license", "standard", outpostPreferredInstanceClasses),
 		fmt.Sprintf(`
 data "aws_outposts_outposts" "test" {}
 
@@ -10088,7 +10118,13 @@ resource "aws_ec2_local_gateway_route_table_vpc_association" "test" {
     Name = %[1]q
   }
 }
+`, rName))
+}
 
+func testAccInstanceConfig_Outpost_coIPEnabled(rName string, coipEnabled bool, backupRetentionPeriod int) string {
+	return acctest.ConfigCompose(
+		testAccInstanceConfig_Outpost(rName),
+		fmt.Sprintf(`
 resource "aws_db_instance" "test" {
   identifier                = %[1]q
   allocated_storage         = 20
@@ -10144,6 +10180,29 @@ resource "aws_db_instance" "restore" {
   skip_final_snapshot       = true
 }
 `, rName, targetCoipEnabled))
+}
+
+func testAccInstanceConfig_Outpost_BackupTarget(rName string, backupTarget string, backupRetentionPeriod int) string {
+	return acctest.ConfigCompose(
+		testAccInstanceConfig_Outpost(rName),
+		fmt.Sprintf(`
+resource "aws_db_instance" "test" {
+  identifier                = %[1]q
+  allocated_storage         = 20
+  backup_retention_period   = %[3]d
+  engine                    = data.aws_rds_orderable_db_instance.test.engine
+  engine_version            = data.aws_rds_orderable_db_instance.test.engine_version
+  instance_class            = data.aws_rds_orderable_db_instance.test.instance_class
+  db_name                   = "test"
+  parameter_group_name      = "default.${data.aws_rds_engine_version.default.parameter_group_family}"
+  skip_final_snapshot       = true
+  password                  = "avoid-plaintext-passwords"
+  username                  = "tfacctest"
+  db_subnet_group_name      = aws_db_subnet_group.test.name
+  storage_encrypted         = true
+  backup_target             = %[2]q
+}
+`, rName, backupTarget, backupRetentionPeriod))
 }
 
 func testAccInstanceConfig_license(rName, license string) string {

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -207,6 +207,7 @@ Defaults to true.
   Must be greater than `0` if the database is used as a source for a [Read Replica][instance-replication],
   uses [low-downtime updates](#low-downtime-updates),
   or will use [RDS Blue/Green deployments][blue-green].
+* `backup_target` - (Optional, Forces new resource) Specifies where automated backups and manual snapshots are stored. Possible values are `region` (default) and `outposts`. See [Working with Amazon RDS on AWS Outposts](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-on-outposts.html) for more information.
 * `backup_window` - (Optional) The daily time range (in UTC) during which automated backups are created if they are enabled.
   Example: "09:46-10:16". Must not overlap with `maintenance_window`.
 * `blue_green_update` - (Optional) Enables low-downtime updates using [RDS Blue/Green deployments][blue-green].


### PR DESCRIPTION
### Description

- Add a `backup_target` attribute to the `aws_rds_instance` resource that allows selection of where backups are stored (either in region or on an Outpost) on creation
- Update `aws_rds_instance` acceptance tests to share common Outpost config for testing `backup_target` and `customer_owned_ip_enabled` attributes.
  - Update the common Outpost config to use a new, dedicated list of Preferred Instance Classes because Outposts only support a subset.

### Relations

Closes #31469

### References

- https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-on-outposts.html

### Output from Acceptance Testing

```
$ make testacc TESTS='TestAccRDSInstance_BackupTarget' PKG=rds
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSInstance_BackupTarget'  -timeout 180m
=== RUN   TestAccRDSInstance_BackupTarget
=== PAUSE TestAccRDSInstance_BackupTarget
=== CONT  TestAccRDSInstance_BackupTarget
--- PASS: TestAccRDSInstance_BackupTarget (498.17s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        498.259s
```
