### PR TITLE
TeamCity: Add failure condition to sweeper run to match region failures

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -447,6 +447,16 @@ object Sweeper : BuildType({
         }
     }
 
+    failureConditions {
+        failOnText {
+            conditionType = BuildFailureOnText.ConditionType.REGEXP
+            pattern = """Sweeper Tests for region \(([-a-z0-9]+)\) ran unsuccessfully"""
+            failureMessage = """Sweeper failure for region "${'$'}1""""
+            reverse = false
+            reportOnlyFirstMatch = false
+        }
+    }
+
     features {
         feature {
             type = "JetBrains.SharedResources"

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -2,6 +2,8 @@ import jetbrains.buildServer.configs.kotlin.* // ktlint-disable no-wildcard-impo
 import jetbrains.buildServer.configs.kotlin.buildFeatures.golang
 import jetbrains.buildServer.configs.kotlin.buildFeatures.notifications
 import jetbrains.buildServer.configs.kotlin.buildSteps.script
+import jetbrains.buildServer.configs.kotlin.failureConditions.failOnText
+import jetbrains.buildServer.configs.kotlin.failureConditions.BuildFailureOnText
 import jetbrains.buildServer.configs.kotlin.triggers.schedule
 import java.io.File
 import java.time.Duration


### PR DESCRIPTION
### Description

Adds failure condition to sweeper run to match region failures. This will highlight each regional failure in the Build Problems list

<img width="406" alt="image" src="https://github.com/hashicorp/terraform-provider-aws/assets/1148298/1198b9fe-04ad-4b2d-8988-0dc0af9885e9">

