### PR TITLE
elasticache/replication_group: Fix acc test for v7

### DIFF
--- a/internal/service/elasticache/replication_group_test.go
+++ b/internal/service/elasticache/replication_group_test.go
@@ -2733,6 +2733,13 @@ resource "aws_elasticache_replication_group" "test" {
   description          = "test description"
   node_type            = "cache.t3.small"
   engine_version       = "7.0"
+  parameter_group_name = aws_elasticache_parameter_group.test.name
+  engine               = "redis"
+}
+
+resource "aws_elasticache_parameter_group" "test" {
+  name   = %[1]q
+  family = "redis7"
 }
 `, rName)
 }

--- a/internal/service/elasticache/replication_group_test.go
+++ b/internal/service/elasticache/replication_group_test.go
@@ -2729,10 +2729,10 @@ resource "aws_elasticache_replication_group" "test" {
 func testAccReplicationGroupConfig_v7(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = %[1]q
-  replication_group_description = "test description"
-  node_type                     = "cache.t3.small"
-  engine_version                = "7.0"
+  replication_group_id = %[1]q
+  description          = "test description"
+  node_type            = "cache.t3.small"
+  engine_version       = "7.0"
 }
 `, rName)
 }


### PR DESCRIPTION
- elasticache/rep_group: Fix test
- elasticache/rep-group: Add pg to test

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #32252
Relates #31264

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccElastiCacheReplicationGroup_EngineVersion_v7 K=elasticache
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheReplicationGroup_EngineVersion_v7'  -timeout 180m
=== RUN   TestAccElastiCacheReplicationGroup_EngineVersion_v7
=== PAUSE TestAccElastiCacheReplicationGroup_EngineVersion_v7
=== CONT  TestAccElastiCacheReplicationGroup_EngineVersion_v7
--- PASS: TestAccElastiCacheReplicationGroup_EngineVersion_v7 (878.21s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticache	880.103s
```
