### PR TITLE
r/aws_apigatewayv2_authorizer: Skip ttl when there are no identity sources

### DIFF
--- a/.changelog/xxx.txt
+++ b/.changelog/xxx.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_apigatewayv2_authorizer: Skip setting authorizer TTL when there are no identity sources
+```

--- a/internal/service/apigatewayv2/authorizer.go
+++ b/internal/service/apigatewayv2/authorizer.go
@@ -130,9 +130,10 @@ func resourceAuthorizerCreate(ctx context.Context, d *schema.ResourceData, meta 
 	}
 	if v, ok := d.GetOkExists("authorizer_result_ttl_in_seconds"); ok {
 		req.AuthorizerResultTtlInSeconds = aws.Int64(int64(v.(int)))
-	} else if protocolType == apigatewayv2.ProtocolTypeHttp && authorizerType == apigatewayv2.AuthorizerTypeRequest {
+	} else if protocolType == apigatewayv2.ProtocolTypeHttp && authorizerType == apigatewayv2.AuthorizerTypeRequest && len(req.IdentitySource) > 0 {
 		// Default in the AWS Console is 300 seconds.
 		// Explicitly set on creation so that we can correctly detect changes to the 0 value.
+		// This value should only be set when IdentitySources have been defined
 		req.AuthorizerResultTtlInSeconds = aws.Int64(300)
 	}
 	if v, ok := d.GetOk("authorizer_uri"); ok {

--- a/internal/service/apigatewayv2/authorizer_test.go
+++ b/internal/service/apigatewayv2/authorizer_test.go
@@ -49,6 +49,16 @@ func TestAccAPIGatewayV2Authorizer_basic(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccAuthorizerConfig_httpNoAuthenticationSources(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAuthorizerExists(ctx, resourceName, &apiId, &v),
+					resource.TestCheckResourceAttr(resourceName, "authorizer_type", "REQUEST"),
+					resource.TestCheckResourceAttr(resourceName, "identity_sources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+				),
+			},
+			{
 				ResourceName:      resourceName,
 				ImportStateIdFunc: testAccAuthorizerImportStateIdFunc(resourceName),
 				ImportState:       true,
@@ -568,6 +578,22 @@ resource "aws_apigatewayv2_authorizer" "test" {
   authorizer_uri                    = aws_lambda_function.test.invoke_arn
   enable_simple_responses           = true
   identity_sources                  = ["$request.header.Auth"]
+  name                              = %[1]q
+}
+`, rName))
+}
+
+func testAccAuthorizerConfig_httpNoAuthenticationSources(rName string) string {
+	return acctest.ConfigCompose(
+		testAccAuthorizerConfig_apiHTTP(rName),
+		testAccAuthorizerConfig_baseLambda(rName),
+		fmt.Sprintf(`
+resource "aws_apigatewayv2_authorizer" "test" {
+  api_id                            = aws_apigatewayv2_api.test.id
+  authorizer_payload_format_version = "2.0"
+  authorizer_type                   = "REQUEST"
+  authorizer_uri                    = aws_lambda_function.test.invoke_arn
+  enable_simple_responses           = true
   name                              = %[1]q
 }
 `, rName))


### PR DESCRIPTION
### Description

This change alters the Create behavior of `apigatewayv2_authorizer` to disable setting a TTL when there are no defined identity sources. Attempting to set the value is invalid and results in the following error:

    Error: creating API Gateway v2 authorizer: BadRequestException: Identity source must be set if authorizer caching is enabled (TTL is greater than 0)

#### Example

```tf
resource "aws_apigatewayv2_authorizer" "this" {
  api_id                            = "..."
  name                              = "missing-auth-token"
  authorizer_type                   = "REQUEST"
  authorizer_payload_format_version = "2.0"
  authorizer_uri                    = "..."
}
```

```
aws_apigatewayv2_authorizer.this: Creating...
╷
│ Error: creating API Gateway v2 authorizer: BadRequestException: Identity source must be set if authorizer caching is enabled (TTL is greater than 0)
│ 
│   with aws_apigatewayv2_authorizer.this,
│   on api-gateway.tf line 24, in resource "aws_apigatewayv2_authorizer" "this":
│   24: resource "aws_apigatewayv2_authorizer" "this" {
│ 
╵
Operation failed: failed running terraform apply (exit 1)

```

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccAPIGatewayV2Authorizer_basic pkg=apigatewayv2_test
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/... -v -count 1 -parallel 20 -run='TestAccAPIGatewayV2Authorizer_basic'  -timeout 180m
ok      github.com/hashicorp/terraform-provider-aws/internal/service/apigateway 5.469s [no tests to run]
=== RUN   TestAccAPIGatewayV2Authorizer_basic
=== PAUSE TestAccAPIGatewayV2Authorizer_basic
=== CONT  TestAccAPIGatewayV2Authorizer_basic
--- PASS: TestAccAPIGatewayV2Authorizer_basic (89.32s)
PASS
...
```
