### PR TITLE
r/aws_finspace: add sweepers

### DIFF
--- a/internal/service/finspace/sweep.go
+++ b/internal/service/finspace/sweep.go
@@ -1,0 +1,69 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build sweep
+// +build sweep
+
+package finspace
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/finspace"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_finspace_kx_environment", &resource.Sweeper{
+		Name: "aws_finspace_kx_environment",
+		F:    sweepKxEnvironments,
+	})
+}
+
+func sweepKxEnvironments(region string) error {
+	ctx := sweep.Context(region)
+	client, err := sweep.SharedRegionalSweepClient(ctx, region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+
+	conn := client.FinSpaceClient(ctx)
+	sweepResources := make([]sweep.Sweepable, 0)
+	var errs *multierror.Error
+
+	input := &finspace.ListKxEnvironmentsInput{}
+	pages := finspace.NewListKxEnvironmentsPaginator(conn, input)
+
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+		if awsv2.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping FinSpace Kx Environment sweep for %s: %s", region, err)
+			return nil
+		}
+		if err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("listing FinSpace Kx Environments (%s): %w", region, err))
+		}
+
+		for _, env := range page.Environments {
+			r := ResourceKxEnvironment()
+			d := r.Data(nil)
+			id := aws.ToString(env.EnvironmentId)
+			d.SetId(id)
+
+			log.Printf("[INFO] Deleting FinSpace Kx Environment: %s", id)
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+	}
+
+	err = sweep.SweepOrchestrator(ctx, sweepResources)
+	if err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("sweeping FinSpace Kx Environments (%s): %w", region, err))
+	}
+
+	return errs.ErrorOrNil()
+}

--- a/internal/sweep/sweep_test.go
+++ b/internal/sweep/sweep_test.go
@@ -69,6 +69,7 @@ import (
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/emrserverless"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/events"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/evidently"
+	_ "github.com/hashicorp/terraform-provider-aws/internal/service/finspace"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/firehose"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/fis"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/fsx"


### PR DESCRIPTION

### Description
Adds a sweeper for the `aws_finspace_kx_environment` resource. All other `aws_finspace_kx_*` resources (cluster, database, user) live within an environment, so sweeping this resource will also delete those downstream components.


### Relations
Relates #31802 




### Output from Acceptance Testing

```console
$ make sweep SWEEPARGS="-sweep-run=aws_finspace"
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
# set SWEEPARGS=-sweep-allow-failures to continue after first failure
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./internal/sweep -v -tags=sweep -sweep=us-west-2,us-east-1,us-east-2,us-west-1 -sweep-run=aws_finspace -timeout 60m
2023/07/21 11:31:46 [DEBUG] Running Sweepers for region (us-west-2):
2023/07/21 11:31:46 [DEBUG] Running Sweeper (aws_finspace_kx_environment) in region (us-west-2)
...
2023/07/21 11:32:10 [DEBUG] Completed Sweeper (aws_finspace_kx_environment) in region (us-west-1) in 475.936292ms
2023/07/21 11:32:10 Completed Sweepers for region (us-west-1) in 476.043375ms
2023/07/21 11:32:10 Sweeper Tests for region (us-west-1) ran successfully:
        - aws_finspace_kx_environment
ok      github.com/hashicorp/terraform-provider-aws/internal/sweep      26.590s
```
