### PR TITLE
r/aws_quicksight: grid layout `optimized_view_port_width` argument is optional

### DIFF
--- a/.changelog/32644.txt
+++ b/.changelog/32644.txt
@@ -1,0 +1,11 @@
+```release-note:bug
+aws_quicksight_analysis: grid layout `optimized_view_port_width` argument changed to optional
+```
+
+```release-note:bug
+aws_quicksight_dashboard: grid layout `optimized_view_port_width` argument changed to optional
+```
+
+```release-note:bug
+aws_quicksight_template: grid layout `optimized_view_port_width` argument changed to optional
+```

--- a/internal/service/quicksight/schema/template_sheet.go
+++ b/internal/service/quicksight/schema/template_sheet.go
@@ -378,7 +378,7 @@ func gridLayoutConfigurationSchema() *schema.Schema {
 									Schema: map[string]*schema.Schema{
 										"optimized_view_port_width": {
 											Type:     schema.TypeString,
-											Required: true,
+											Optional: true,
 										},
 										"resize_option": stringSchema(true, validation.StringInSlice(quicksight.ResizeOption_Values(), false)),
 									},


### PR DESCRIPTION

### Description
Changes the grid layout `optimized_view_port_width` argument to optional, aligning with the [AWS API object](https://docs.aws.amazon.com/quicksight/latest/APIReference/API_GridLayoutScreenCanvasSizeOptions.html).


### Relations

Closes #32344

### References
- https://docs.aws.amazon.com/quicksight/latest/APIReference/API_GridLayoutScreenCanvasSizeOptions.html

### Output from Acceptance Testing


```console
$ make testacc PKG=quicksight TESTS="TestAccQuickSightAnalysis_|TestAccQuickSightDashboard_|TestAccQuickSightTemplate_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/quicksight/... -v -count 1 -parallel 20 -run='TestAccQuickSightAnalysis_|TestAccQuickSightDashboard_|TestAccQuickSightTemplate_'  -timeout 180m

--- PASS: TestAccQuickSightTemplate_disappears (79.72s)
--- PASS: TestAccQuickSightTemplate_barChart (85.97s)
--- PASS: TestAccQuickSightTemplate_basic (86.96s)
--- PASS: TestAccQuickSightAnalysis_disappears (91.69s)
--- PASS: TestAccQuickSightAnalysis_forceDelete (92.25s)
--- PASS: TestAccQuickSightDashboard_disappears (92.64s)
--- PASS: TestAccQuickSightTemplate_sourceEntity (95.85s)
--- PASS: TestAccQuickSightDashboard_dashboardSpecificConfig (96.99s)
--- PASS: TestAccQuickSightAnalysis_parametersConfig (99.70s)
--- PASS: TestAccQuickSightAnalysis_basic (99.90s)
--- PASS: TestAccQuickSightDashboard_basic (100.01s)
--- PASS: TestAccQuickSightDashboard_sourceEntity (102.55s)
--- PASS: TestAccQuickSightAnalysis_sourceEntity (103.67s)
--- PASS: TestAccQuickSightTemplate_table (126.31s)
--- PASS: TestAccQuickSightTemplate_update (129.14s)
--- PASS: TestAccQuickSightAnalysis_update (139.08s)
--- PASS: TestAccQuickSightDashboard_updateVersionNumber (140.40s)
--- PASS: TestAccQuickSightTemplate_tags (145.35s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/quicksight 148.319s
```
