### PR TITLE
F aws transfer server structured logging destinations

### DIFF
--- a/.changelog/32654.txt
+++ b/.changelog/32654.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
-resource/aws_transfer_server: Add `structured_log_destinations` attribute
+resource/aws_transfer_server: Add `structured_log_destinations` argument
+```
+
+```release-note:enhancement
+data-source/aws_transfer_server: Add `structured_log_destinations` attribute
 ```

--- a/.changelog/32654.txt
+++ b/.changelog/32654.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_transfer_server: Add `structured_log_destinations` attribute
+```

--- a/internal/service/transfer/server.go
+++ b/internal/service/transfer/server.go
@@ -63,15 +63,6 @@ func ResourceServer() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: verify.ValidARN,
 			},
-			"structured_log_destinations": {
-				Type: schema.TypeSet,
-				Elem: &schema.Schema{
-					Type:         schema.TypeString,
-					ValidateFunc: verify.ValidARN,
-				},
-				Description: "This is a set of arns of destinations that will receive structured logs from the transfer server",
-				Optional:    true,
-			},
 			"directory_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -236,6 +227,15 @@ func ResourceServer() *schema.Resource {
 				Default:      SecurityPolicyName2018_11,
 				ValidateFunc: validation.StringInSlice(SecurityPolicyName_Values(), false),
 			},
+			"structured_log_destinations": {
+				Type: schema.TypeSet,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: verify.ValidARN,
+				},
+				Description: "This is a set of arns of destinations that will receive structured logs from the transfer server",
+				Optional:    true,
+			},
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"url": {
@@ -380,7 +380,7 @@ func resourceServerCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		input.SecurityPolicyName = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("structured_log_destinations"); ok {
+	if v, ok := d.GetOk("structured_log_destinations"); ok && v.(*schema.Set).Len() > 0 {
 		input.StructuredLogDestinations = flex.ExpandStringSet(v.(*schema.Set))
 	}
 
@@ -680,7 +680,7 @@ func resourceServerUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			input.SecurityPolicyName = aws.String(d.Get("security_policy_name").(string))
 		}
 
-		// per the docs it does not matter if this field has changed,
+		// Per the docs it does not matter if this field has changed,
 		// if the update passes this as empty the structured logging will be turned off,
 		// so we need to always pass the new.
 		input.StructuredLogDestinations = flex.ExpandStringSet(d.Get("structured_log_destinations").(*schema.Set))

--- a/internal/service/transfer/server_data_source.go
+++ b/internal/service/transfer/server_data_source.go
@@ -22,7 +22,6 @@ func DataSourceServer() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
 			"certificate": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -31,32 +30,26 @@ func DataSourceServer() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
 			"endpoint": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
 			"endpoint_type": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
 			"identity_provider_type": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
 			"invocation_role": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
 			"logging_role": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
 			"protocols": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -64,17 +57,21 @@ func DataSourceServer() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-
 			"security_policy_name": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
 			"server_id": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-
+			"structured_log_destinations": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 			"url": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -112,6 +109,7 @@ func dataSourceServerRead(ctx context.Context, d *schema.ResourceData, meta inte
 	d.Set("logging_role", output.LoggingRole)
 	d.Set("protocols", aws.StringValueSlice(output.Protocols))
 	d.Set("security_policy_name", output.SecurityPolicyName)
+	d.Set("structured_log_destinations", aws.StringValueSlice(output.StructuredLogDestinations))
 	if output.IdentityProviderDetails != nil {
 		d.Set("url", output.IdentityProviderDetails.Url)
 	} else {

--- a/internal/service/transfer/server_data_source_test.go
+++ b/internal/service/transfer/server_data_source_test.go
@@ -31,6 +31,7 @@ func testAccServerDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, "endpoint", resourceName, "endpoint"),
 					resource.TestCheckResourceAttrPair(datasourceName, "identity_provider_type", resourceName, "identity_provider_type"),
 					resource.TestCheckResourceAttrPair(datasourceName, "logging_role", resourceName, "logging_role"),
+					resource.TestCheckResourceAttrPair(datasourceName, "structured_log_destinations.#", resourceName, "structured_log_destinations.#"),
 				),
 			},
 		},

--- a/internal/service/transfer/server_test.go
+++ b/internal/service/transfer/server_test.go
@@ -1830,78 +1830,122 @@ func testAccServerConfig_structuredLogDestinations(rName string) string {
 		fmt.Sprintf(`
 		resource "aws_cloudwatch_log_group" "test" {
 			name_prefix = "transfer_test_"
-		  }
+		}
 		  
-		  data "aws_iam_policy_document" "test" {
+		data "aws_iam_policy_document" "test" {
 			statement {
-			  effect = "Allow"
-		  
-			  principals {
+				effect = "Allow"
+			
+				principals {
 				type        = "Service"
 				identifiers = ["transfer.amazonaws.com"]
-			  }
-		  
-			  actions = ["sts:AssumeRole"]
+				}
+			
+				actions = ["sts:AssumeRole"]
 			}
-		  }
-		  
-		  resource "aws_iam_role" "test" {
-			name_prefix         = "iam_for_transfer_"
-			assume_role_policy  = data.aws_iam_policy_document.test.json
-			managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AWSTransferLoggingAccess"]
-		  }
-		  
-		  resource "aws_transfer_server" "test" {
+		}
+		
+		resource "aws_iam_policy" "test" {
+			name_prefix = "transfer_logging_policy_"
+			policy = jsonencode({
+				"Version" : "2012-10-17",
+				"Statement" : [
+					{
+						"Effect" : "Allow",
+						"Action" : [
+						"logs:CreateLogStream",
+						"logs:DescribeLogStreams",
+						"logs:CreateLogGroup",
+						"logs:PutLogEvents"
+						],
+						"Resource" : "*"
+					}
+				]
+			})
+		}
+		
+		resource "aws_iam_role" "test" {
+			name_prefix        = "iam_for_transfer_"
+			assume_role_policy = data.aws_iam_policy_document.test.json
+		}
+		
+		resource "aws_iam_role_policy_attachment" "test" {
+			role       = aws_iam_role.test.name
+			policy_arn = aws_iam_policy.test.arn
+		}
+		
+		resource "aws_transfer_server" "test" {
 			endpoint_type = "PUBLIC"
 			logging_role  = aws_iam_role.test.arn
 			protocols     = ["SFTP"]
 			structured_log_destinations = [
-			  "${aws_cloudwatch_log_group.test.arn}:*"
+				"${aws_cloudwatch_log_group.test.arn}:*"
 			]
 			tags = {
-			  Name = %[1]q
+				Name = %[1]q
 			}
-		  }
+		}
 		`, rName),
 	)
 }
 
 func testAccServerConfig_structuredLogDestinationsUpdate() string {
-	return acctest.ConfigCompose(
-		fmt.Sprintf(`
-		resource "aws_cloudwatch_log_group" "test" {
-			name_prefix = "transfer_test_"
-		  }
-		  
-		  data "aws_iam_policy_document" "test" {
-			statement {
-			  effect = "Allow"
-		  
-			  principals {
-				type        = "Service"
-				identifiers = ["transfer.amazonaws.com"]
-			  }
-		  
-			  actions = ["sts:AssumeRole"]
+	return `
+	resource "aws_cloudwatch_log_group" "test" {
+		name_prefix = "transfer_test_"
+	}
+	  
+	data "aws_iam_policy_document" "test" {
+		statement {
+			effect = "Allow"
+		
+			principals {
+			type        = "Service"
+			identifiers = ["transfer.amazonaws.com"]
 			}
-		  }
-		  
-		  resource "aws_iam_role" "test" {
-			name_prefix         = "iam_for_transfer_"
-			assume_role_policy  = data.aws_iam_policy_document.test.json
-			managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AWSTransferLoggingAccess"]
-		  }
-		  
-		  resource "aws_transfer_server" "test" {
-			endpoint_type = "PUBLIC"
-			logging_role  = aws_iam_role.test.arn
-			protocols     = ["SFTP"]
-			structured_log_destinations = [
-			  "${aws_cloudwatch_log_group.test.arn}:*"
+		
+			actions = ["sts:AssumeRole"]
+		}
+	}
+	
+	resource "aws_iam_policy" "test" {
+		name_prefix = "transfer_logging_policy_"
+		policy = jsonencode({
+			"Version" : "2012-10-17",
+			"Statement" : [
+				{
+					"Effect" : "Allow",
+					"Action" : [
+					"logs:CreateLogStream",
+					"logs:DescribeLogStreams",
+					"logs:CreateLogGroup",
+					"logs:PutLogEvents"
+					],
+					"Resource" : "*"
+				}
 			]
-		  }
-		`),
-	)
+		})
+	}
+	
+	resource "aws_iam_role" "test" {
+		name_prefix        = "iam_for_transfer_"
+		assume_role_policy = data.aws_iam_policy_document.test.json
+	}
+	
+	resource "aws_iam_role_policy_attachment" "test" {
+		role       = aws_iam_role.test.name
+		policy_arn = aws_iam_policy.test.arn
+	}
+	
+	resource "aws_transfer_server" "test" {
+		endpoint_type = "PUBLIC"
+		logging_role  = aws_iam_role.test.arn
+		protocols     = ["SFTP"]
+		structured_log_destinations = [
+			"${aws_cloudwatch_log_group.test.arn}:*"
+		]
+	}
+	`
 }
 
 func testAccServerCheck_structuredLogDestinations(resourceName, cloudwatchLogGroupName string) func(s *terraform.State) error {

--- a/internal/service/transfer/server_test.go
+++ b/internal/service/transfer/server_test.go
@@ -72,6 +72,7 @@ func testAccServer_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "protocols.#", "1"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "protocols.*", "SFTP"),
 					resource.TestCheckResourceAttr(resourceName, "security_policy_name", "TransferSecurityPolicy-2018-11"),
+					resource.TestCheckResourceAttr(resourceName, "structured_log_destinations.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "url", ""),
 					resource.TestCheckResourceAttr(resourceName, "workflow_details.#", "0"),
@@ -769,7 +770,7 @@ func testAccServer_structuredLogDestinations(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 			{
-				Config: testAccServerConfig_structuredLogDestinationsUpdate(),
+				Config: testAccServerConfig_structuredLogDestinationsUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServerExists(ctx, resourceName, &s),
 					// resource.TestCheckTypeSetElemAttr(resourceName, "structured_logging_destinations.*", *s.StructuredLogDestinations[0]),
@@ -1256,6 +1257,32 @@ func testAccCheckServerDestroy(ctx context.Context) resource.TestCheckFunc {
 			return fmt.Errorf("Transfer Server %s still exists", rs.Primary.ID)
 		}
 
+		return nil
+	}
+}
+
+func testAccServerCheck_structuredLogDestinations(resourceName, cloudwatchLogGroupName string) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		cwResource, ok := s.RootModule().Resources[cloudwatchLogGroupName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", cloudwatchLogGroupName)
+		}
+		cwARN, ok := cwResource.Primary.Attributes["arn"]
+		if !ok {
+			return errors.New("cloudwatch group arn missing")
+		}
+		expectedSLD := fmt.Sprintf("%s:*", cwARN)
+		transferServerResource, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+		slds, ok := transferServerResource.Primary.Attributes["structured_log_destinations.0"]
+		if !ok {
+			return errors.New("transfer server structured logging destinations missing")
+		}
+		if expectedSLD != slds {
+			return fmt.Errorf("'%s' != '%s'", expectedSLD, slds)
+		}
 		return nil
 	}
 }
@@ -1825,11 +1852,10 @@ resource "aws_transfer_server" "test" {
 `, rName, hostKey)
 }
 
-func testAccServerConfig_structuredLogDestinations(rName string) string {
-	return acctest.ConfigCompose(
-		fmt.Sprintf(`
+func testAccServerConfig_structuredLogDestinationsBase(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_cloudwatch_log_group" "test" {
-  name_prefix = "transfer_test_"
+  name = %[1]q
 }
 
 data "aws_iam_policy_document" "test" {
@@ -1844,7 +1870,8 @@ data "aws_iam_policy_document" "test" {
 }
 
 resource "aws_iam_policy" "test" {
-  name_prefix = "transfer_logging_policy_"
+  name = %[1]q
+
   policy = jsonencode({
     "Version" : "2012-10-17",
     "Statement" : [
@@ -1863,7 +1890,7 @@ resource "aws_iam_policy" "test" {
 }
 
 resource "aws_iam_role" "test" {
-  name_prefix        = "iam_for_transfer_"
+  name               = %[1]q
   assume_role_policy = data.aws_iam_policy_document.test.json
 }
 
@@ -1871,7 +1898,11 @@ resource "aws_iam_role_policy_attachment" "test" {
   role       = aws_iam_role.test.name
   policy_arn = aws_iam_policy.test.arn
 }
+`, rName)
+}
 
+func testAccServerConfig_structuredLogDestinations(rName string) string {
+	return acctest.ConfigCompose(testAccServerConfig_structuredLogDestinationsBase(rName), fmt.Sprintf(`
 resource "aws_transfer_server" "test" {
   endpoint_type = "PUBLIC"
   logging_role  = aws_iam_role.test.arn
@@ -1879,62 +1910,16 @@ resource "aws_transfer_server" "test" {
   structured_log_destinations = [
     "${aws_cloudwatch_log_group.test.arn}:*"
   ]
+
   tags = {
     Name = %[1]q
   }
 }
-`, rName),
-	)
+`, rName))
 }
 
-func testAccServerConfig_structuredLogDestinationsUpdate() string {
-	return `
-resource "aws_cloudwatch_log_group" "test" {
-  name_prefix = "transfer_test_"
-}
-
-data "aws_iam_policy_document" "test" {
-  statement {
-    effect = "Allow"
-
-    principals {
-      type        = "Service"
-      identifiers = ["transfer.amazonaws.com"]
-    }
-
-    actions = ["sts:AssumeRole"]
-  }
-}
-
-resource "aws_iam_policy" "test" {
-  name_prefix = "transfer_logging_policy_"
-  policy = jsonencode({
-    "Version" : "2012-10-17",
-    "Statement" : [
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "logs:CreateLogStream",
-          "logs:DescribeLogStreams",
-          "logs:CreateLogGroup",
-          "logs:PutLogEvents"
-        ],
-        "Resource" : "*"
-      }
-    ]
-  })
-}
-
-resource "aws_iam_role" "test" {
-  name_prefix        = "iam_for_transfer_"
-  assume_role_policy = data.aws_iam_policy_document.test.json
-}
-
-resource "aws_iam_role_policy_attachment" "test" {
-  role       = aws_iam_role.test.name
-  policy_arn = aws_iam_policy.test.arn
-}
-
+func testAccServerConfig_structuredLogDestinationsUpdate(rName string) string {
+	return acctest.ConfigCompose(testAccServerConfig_structuredLogDestinationsBase(rName), fmt.Sprintf(`
 resource "aws_transfer_server" "test" {
   endpoint_type = "PUBLIC"
   logging_role  = aws_iam_role.test.arn
@@ -1942,34 +1927,15 @@ resource "aws_transfer_server" "test" {
   structured_log_destinations = [
     "${aws_cloudwatch_log_group.test.arn}:*"
   ]
-}
-`
-}
 
-func testAccServerCheck_structuredLogDestinations(resourceName, cloudwatchLogGroupName string) func(s *terraform.State) error {
-	return func(s *terraform.State) error {
-		cwResource, ok := s.RootModule().Resources[cloudwatchLogGroupName]
-		if !ok {
-			return fmt.Errorf("resource not found: %s", cloudwatchLogGroupName)
-		}
-		cwARN, ok := cwResource.Primary.Attributes["arn"]
-		if !ok {
-			return errors.New("cloudwatch group arn missing")
-		}
-		expectedSLD := fmt.Sprintf("%s:*", cwARN)
-		transferServerResource, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("resource not found: %s", resourceName)
-		}
-		slds, ok := transferServerResource.Primary.Attributes["structured_log_destinations.0"]
-		if !ok {
-			return errors.New("transfer server structured logging destinations missing")
-		}
-		if expectedSLD != slds {
-			return fmt.Errorf("'%s' != '%s'", expectedSLD, slds)
-		}
-		return nil
-	}
+  pre_authentication_login_banner  = "This system is for the use of authorized users only - pre"
+  post_authentication_login_banner = "This system is for the use of authorized users only - post"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName))
 }
 
 func testAccServerConfig_protocols(rName string) string {

--- a/internal/service/transfer/server_test.go
+++ b/internal/service/transfer/server_test.go
@@ -1828,124 +1828,122 @@ resource "aws_transfer_server" "test" {
 func testAccServerConfig_structuredLogDestinations(rName string) string {
 	return acctest.ConfigCompose(
 		fmt.Sprintf(`
-		resource "aws_cloudwatch_log_group" "test" {
-			name_prefix = "transfer_test_"
-		}
-		  
-		data "aws_iam_policy_document" "test" {
-			statement {
-				effect = "Allow"
-			
-				principals {
-				type        = "Service"
-				identifiers = ["transfer.amazonaws.com"]
-				}
-			
-				actions = ["sts:AssumeRole"]
-			}
-		}
-		
-		resource "aws_iam_policy" "test" {
-			name_prefix = "transfer_logging_policy_"
-			policy = jsonencode({
-				"Version" : "2012-10-17",
-				"Statement" : [
-					{
-						"Effect" : "Allow",
-						"Action" : [
-						"logs:CreateLogStream",
-						"logs:DescribeLogStreams",
-						"logs:CreateLogGroup",
-						"logs:PutLogEvents"
-						],
-						"Resource" : "*"
-					}
-				]
-			})
-		}
-		
-		resource "aws_iam_role" "test" {
-			name_prefix        = "iam_for_transfer_"
-			assume_role_policy = data.aws_iam_policy_document.test.json
-		}
-		
-		resource "aws_iam_role_policy_attachment" "test" {
-			role       = aws_iam_role.test.name
-			policy_arn = aws_iam_policy.test.arn
-		}
-		
-		resource "aws_transfer_server" "test" {
-			endpoint_type = "PUBLIC"
-			logging_role  = aws_iam_role.test.arn
-			protocols     = ["SFTP"]
-			structured_log_destinations = [
-				"${aws_cloudwatch_log_group.test.arn}:*"
-			]
-			tags = {
-				Name = %[1]q
-			}
-		}
-		`, rName),
+resource "aws_cloudwatch_log_group" "test" {
+  name_prefix = "transfer_test_"
+}
+
+data "aws_iam_policy_document" "test" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["transfer.amazonaws.com"]
+    }
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_policy" "test" {
+  name_prefix = "transfer_logging_policy_"
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "logs:CreateLogStream",
+          "logs:DescribeLogStreams",
+          "logs:CreateLogGroup",
+          "logs:PutLogEvents"
+        ],
+        "Resource" : "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role" "test" {
+  name_prefix        = "iam_for_transfer_"
+  assume_role_policy = data.aws_iam_policy_document.test.json
+}
+
+resource "aws_iam_role_policy_attachment" "test" {
+  role       = aws_iam_role.test.name
+  policy_arn = aws_iam_policy.test.arn
+}
+
+resource "aws_transfer_server" "test" {
+  endpoint_type = "PUBLIC"
+  logging_role  = aws_iam_role.test.arn
+  protocols     = ["SFTP"]
+  structured_log_destinations = [
+    "${aws_cloudwatch_log_group.test.arn}:*"
+  ]
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName),
 	)
 }
 
 func testAccServerConfig_structuredLogDestinationsUpdate() string {
 	return `
-	resource "aws_cloudwatch_log_group" "test" {
-		name_prefix = "transfer_test_"
-	}
-	  
-	data "aws_iam_policy_document" "test" {
-		statement {
-			effect = "Allow"
-		
-			principals {
-			type        = "Service"
-			identifiers = ["transfer.amazonaws.com"]
-			}
-		
-			actions = ["sts:AssumeRole"]
-		}
-	}
-	
-	resource "aws_iam_policy" "test" {
-		name_prefix = "transfer_logging_policy_"
-		policy = jsonencode({
-			"Version" : "2012-10-17",
-			"Statement" : [
-				{
-					"Effect" : "Allow",
-					"Action" : [
-					"logs:CreateLogStream",
-					"logs:DescribeLogStreams",
-					"logs:CreateLogGroup",
-					"logs:PutLogEvents"
-					],
-					"Resource" : "*"
-				}
-			]
-		})
-	}
-	
-	resource "aws_iam_role" "test" {
-		name_prefix        = "iam_for_transfer_"
-		assume_role_policy = data.aws_iam_policy_document.test.json
-	}
-	
-	resource "aws_iam_role_policy_attachment" "test" {
-		role       = aws_iam_role.test.name
-		policy_arn = aws_iam_policy.test.arn
-	}
-	
-	resource "aws_transfer_server" "test" {
-		endpoint_type = "PUBLIC"
-		logging_role  = aws_iam_role.test.arn
-		protocols     = ["SFTP"]
-		structured_log_destinations = [
-			"${aws_cloudwatch_log_group.test.arn}:*"
-		]
-	}
-	`
+resource "aws_cloudwatch_log_group" "test" {
+  name_prefix = "transfer_test_"
+}
+
+data "aws_iam_policy_document" "test" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["transfer.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_policy" "test" {
+  name_prefix = "transfer_logging_policy_"
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "logs:CreateLogStream",
+          "logs:DescribeLogStreams",
+          "logs:CreateLogGroup",
+          "logs:PutLogEvents"
+        ],
+        "Resource" : "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role" "test" {
+  name_prefix        = "iam_for_transfer_"
+  assume_role_policy = data.aws_iam_policy_document.test.json
+}
+
+resource "aws_iam_role_policy_attachment" "test" {
+  role       = aws_iam_role.test.name
+  policy_arn = aws_iam_policy.test.arn
+}
+
+resource "aws_transfer_server" "test" {
+  endpoint_type = "PUBLIC"
+  logging_role  = aws_iam_role.test.arn
+  protocols     = ["SFTP"]
+  structured_log_destinations = [
+    "${aws_cloudwatch_log_group.test.arn}:*"
+  ]
+}
+`
 }
 
 func testAccServerCheck_structuredLogDestinations(resourceName, cloudwatchLogGroupName string) func(s *terraform.State) error {

--- a/internal/service/transfer/transfer_test.go
+++ b/internal/service/transfer/transfer_test.go
@@ -42,6 +42,7 @@ func TestAccTransfer_serial(t *testing.T) {
 			"Protocols":                     testAccServer_protocols,
 			"ProtocolDetails":               testAccServer_protocolDetails,
 			"SecurityPolicy":                testAccServer_securityPolicy,
+			"StructuredLogDestinations":     testAccServer_structuredLogDestinations,
 			"UpdateEndpointTypePublicToVPC": testAccServer_updateEndpointType_publicToVPC,
 			"UpdateEndpointTypePublicToVPCAddressAllocationIDs":      testAccServer_updateEndpointType_publicToVPC_addressAllocationIDs,
 			"UpdateEndpointTypeVPCEndpointToVPC":                     testAccServer_updateEndpointType_vpcEndpointToVPC,

--- a/website/docs/d/transfer_server.html.markdown
+++ b/website/docs/d/transfer_server.html.markdown
@@ -37,4 +37,5 @@ This data source exports the following attributes in addition to the arguments a
 * `logging_role` - ARN of an IAM role that allows the service to write your SFTP users’ activity to your Amazon CloudWatch logs for monitoring and auditing purposes.
 * `protocols` - File transfer protocol or protocols over which your file transfer protocol client can connect to your server's endpoint.
 * `security_policy_name` - The name of the security policy that is attached to the server.
+* `structured_logging_destinations` - A set of ARNs of destinations that will receive structured logs from the transfer server such as CloudWatch Log Group ARNs.
 * `url` - URL of the service endpoint used to authenticate users with an `identity_provider_type` of `API_GATEWAY`.

--- a/website/docs/r/transfer_server.html.markdown
+++ b/website/docs/r/transfer_server.html.markdown
@@ -86,6 +86,7 @@ resource "aws_transfer_server" "example" {
 ```
 
 ### Using Structured Logging Destinations
+
 ```terraform
 resource "aws_cloudwatch_log_group" "transfer" {
   name_prefix = "transfer_test_"

--- a/website/docs/r/transfer_server.html.markdown
+++ b/website/docs/r/transfer_server.html.markdown
@@ -85,6 +85,41 @@ resource "aws_transfer_server" "example" {
 }
 ```
 
+### Using Structured Logging Destinations
+```terraform
+resource "aws_cloudwatch_log_group" "transfer" {
+  name_prefix = "transfer_test_"
+}
+
+data "aws_iam_policy_document" "transfer_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["transfer.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "iam_for_transfer" {
+  name_prefix         = "iam_for_transfer_"
+  assume_role_policy  = data.aws_iam_policy_document.transfer_assume_role.json
+  managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AWSTransferLoggingAccess"]
+}
+
+resource "aws_transfer_server" "transfer" {
+  endpoint_type = "PUBLIC"
+  logging_role  = aws_iam_role.iam_for_transfer.arn
+  protocols     = ["SFTP"]
+  structured_log_destinations = [
+    "${aws_cloudwatch_log_group.transfer.arn}:*"
+  ]
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -110,6 +145,7 @@ The following arguments are supported:
 * `pre_authentication_login_banner`- (Optional) Specify a string to display when users connect to a server. This string is displayed before the user authenticates.
 * `protocol_details`- (Optional) The protocol settings that are configured for your server.
 * `security_policy_name` - (Optional) Specifies the name of the security policy that is attached to the server. Possible values are `TransferSecurityPolicy-2018-11`, `TransferSecurityPolicy-2020-06`, `TransferSecurityPolicy-FIPS-2020-06`, `TransferSecurityPolicy-2022-03` and `TransferSecurityPolicy-2023-05`. Default value is: `TransferSecurityPolicy-2018-11`.
+* `structured_logging_destinations` - (Optional) A set of ARNs of destinations that will receive structured logs from the transfer server such as CloudWatch Log Group ARNs. If provided this enables the transfer server to emit structured logs to the specified locations.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `workflow_details` - (Optional) Specifies the workflow details. See Workflow Details below.
 


### PR DESCRIPTION
### Description

This PR adds support for the AWS Transfer Server Structured Logging Destinations property.

The AWS transfer module talks about this property [here](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/transfer#CreateServerInput)


### Relations

Closes #32653 

### References

Here is some sample terraform that uses the new property and shows that the changes work, assuming that you are overriding the aws provider with the version built with this PRs code.

```terraform
terraform {
  required_providers {
    aws = {
      source = "hashicorp/aws"
    }
  }
}

resource "aws_cloudwatch_log_group" "test" {
  name_prefix = "transfer_test_"
}

data "aws_iam_policy_document" "test" {
  statement {
    effect = "Allow"

    principals {
      type        = "Service"
      identifiers = ["transfer.amazonaws.com"]
    }

    actions = ["sts:AssumeRole"]
  }
}

resource "aws_iam_role" "test" {
  name_prefix         = "iam_for_transfer_"
  assume_role_policy  = data.aws_iam_policy_document.test.json
  managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AWSTransferLoggingAccess"]
}

resource "aws_transfer_server" "test" {
  endpoint_type = "PUBLIC"
  logging_role  = aws_iam_role.test.arn
  protocols     = ["SFTP"]
  structured_log_destinations = [
    "${aws_cloudwatch_log_group.test.arn}:*"
  ]
}

```


### Output from Acceptance Testing

The acceptance test is working. Was not sure how to get computed value for testing the value in the structured log destinations, so write a function to test using terraform state. Please let me know if there was a better way to do what I wanted to do.

```console
% make testacc TESTS=TestAccTransfer_serial/Server/StructuredLogDestinations PKG=transfer
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/transfer/... -v -count 1 -parallel 20 -run='TestAccTransfer_serial/Server/StructuredLogDestinations'  -timeout 180m
=== RUN   TestAccTransfer_serial
=== PAUSE TestAccTransfer_serial
=== CONT  TestAccTransfer_serial
=== RUN   TestAccTransfer_serial/Server
=== RUN   TestAccTransfer_serial/Server/StructuredLogDestinations
--- PASS: TestAccTransfer_serial (246.13s)
    --- PASS: TestAccTransfer_serial/Server (246.13s)
        --- PASS: TestAccTransfer_serial/Server/StructuredLogDestinations (246.13s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/transfer   246.333s
...
```
