### PR TITLE
r/aws_elasticsearch_domain: omit iops/throughput when not supported

### DIFF
--- a/.changelog/32659.txt
+++ b/.changelog/32659.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_elasticsearch_domain: Omit `throughput` and `iops` for unsupported volume types
+```

--- a/.changelog/32659.txt
+++ b/.changelog/32659.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_elasticsearch_domain: Omit `throughput` and `iops` for unsupported volume types
+resource/aws_elasticsearch_domain: Omit `ebs_options.throughput` and `ebs_options.iops` for unsupported volume types
 ```

--- a/internal/service/elasticsearch/domain.go
+++ b/internal/service/elasticsearch/domain.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elasticsearchservice"
 	elasticsearch "github.com/aws/aws-sdk-go/service/elasticsearchservice"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	awspolicy "github.com/hashicorp/awspolicyequivalence"
@@ -1248,4 +1249,32 @@ func advancedOptionsIgnoreDefault(o map[string]interface{}, n map[string]interfa
 	}
 
 	return n
+}
+
+// EBSVolumeTypePermitsIopsInput returns true if the volume type supports the Iops input
+//
+// This check prevents a ValidationException when updating EBS volume types from a value
+// that supports IOPS (ex. gp3) to one that doesn't (ex. gp2).
+func EBSVolumeTypePermitsIopsInput(volumeType string) bool {
+	permittedTypes := []string{elasticsearchservice.VolumeTypeGp3, elasticsearchservice.VolumeTypeIo1}
+	for _, t := range permittedTypes {
+		if volumeType == t {
+			return true
+		}
+	}
+	return false
+}
+
+// EBSVolumeTypePermitsIopsInput returns true if the volume type supports the Throughput input
+//
+// This check prevents a ValidationException when updating EBS volume types from a value
+// that supports Throughput (ex. gp3) to one that doesn't (ex. gp2).
+func EBSVolumeTypePermitsThroughputInput(volumeType string) bool {
+	permittedTypes := []string{elasticsearchservice.VolumeTypeGp3}
+	for _, t := range permittedTypes {
+		if volumeType == t {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/service/elasticsearch/domain.go
+++ b/internal/service/elasticsearch/domain.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/elasticsearchservice"
 	elasticsearch "github.com/aws/aws-sdk-go/service/elasticsearchservice"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	awspolicy "github.com/hashicorp/awspolicyequivalence"
@@ -1256,7 +1255,7 @@ func advancedOptionsIgnoreDefault(o map[string]interface{}, n map[string]interfa
 // This check prevents a ValidationException when updating EBS volume types from a value
 // that supports IOPS (ex. gp3) to one that doesn't (ex. gp2).
 func EBSVolumeTypePermitsIopsInput(volumeType string) bool {
-	permittedTypes := []string{elasticsearchservice.VolumeTypeGp3, elasticsearchservice.VolumeTypeIo1}
+	permittedTypes := []string{elasticsearch.VolumeTypeGp3, elasticsearch.VolumeTypeIo1}
 	for _, t := range permittedTypes {
 		if volumeType == t {
 			return true
@@ -1270,7 +1269,7 @@ func EBSVolumeTypePermitsIopsInput(volumeType string) bool {
 // This check prevents a ValidationException when updating EBS volume types from a value
 // that supports Throughput (ex. gp3) to one that doesn't (ex. gp2).
 func EBSVolumeTypePermitsThroughputInput(volumeType string) bool {
-	permittedTypes := []string{elasticsearchservice.VolumeTypeGp3}
+	permittedTypes := []string{elasticsearch.VolumeTypeGp3}
 	for _, t := range permittedTypes {
 		if volumeType == t {
 			return true

--- a/internal/service/elasticsearch/domain_test.go
+++ b/internal/service/elasticsearch/domain_test.go
@@ -2223,14 +2223,15 @@ resource "aws_elasticsearch_domain" "test" {
 func testAccDomainConfig_clusterEBSVolumeGP3DefaultIopsThroughput(rName string, volumeSize int) string {
 	return fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "test" {
-  domain_name = %[1]q
+  domain_name           = %[1]q
   elasticsearch_version = "7.10"
+
   ebs_options {
     ebs_enabled = true
     volume_size = %[2]d
     volume_type = "gp3"
-
   }
+
   cluster_config {
     instance_type = "t3.small.elasticsearch"
   }
@@ -2241,13 +2242,15 @@ resource "aws_elasticsearch_domain" "test" {
 func testAccDomainConfig_clusterEBSVolumeGP2(rName string, volumeSize int) string {
 	return fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "test" {
-  domain_name = %[1]q
+  domain_name           = %[1]q
   elasticsearch_version = "7.10"
+
   ebs_options {
     ebs_enabled = true
     volume_size = %[2]d
     volume_type = "gp2"
   }
+
   cluster_config {
     instance_type = "t3.small.elasticsearch"
   }

--- a/internal/service/elasticsearch/domain_test.go
+++ b/internal/service/elasticsearch/domain_test.go
@@ -12,7 +12,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
+	"github.com/aws/aws-sdk-go/service/elasticsearchservice"
 	elasticsearch "github.com/aws/aws-sdk-go/service/elasticsearchservice"
+	"github.com/aws/aws-sdk-go/service/opensearchservice"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -21,6 +23,58 @@ import (
 	tfelasticsearch "github.com/hashicorp/terraform-provider-aws/internal/service/elasticsearch"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
+
+func TestEBSVolumeTypePermitsIopsInput(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		volumeType string
+		want       bool
+	}{
+		{"empty", "", false},
+		{"gp2", elasticsearchservice.VolumeTypeGp2, false},
+		{"gp3", elasticsearchservice.VolumeTypeGp3, true},
+		{"io1", elasticsearchservice.VolumeTypeIo1, true},
+		{"standard", elasticsearchservice.VolumeTypeStandard, false},
+	}
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tfelasticsearch.EBSVolumeTypePermitsIopsInput(testCase.volumeType); got != testCase.want {
+				t.Errorf("EBSVolumeTypePermitsIopsInput() = %v, want %v", got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestEBSVolumeTypePermitsThroughputInput(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		volumeType string
+		want       bool
+	}{
+		{"empty", "", false},
+		{"gp2", elasticsearchservice.VolumeTypeGp2, false},
+		{"gp3", elasticsearchservice.VolumeTypeGp3, true},
+		{"io1", elasticsearchservice.VolumeTypeIo1, false},
+		{"standard", elasticsearchservice.VolumeTypeStandard, false},
+	}
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tfelasticsearch.EBSVolumeTypePermitsThroughputInput(testCase.volumeType); got != testCase.want {
+				t.Errorf("EBSVolumeTypePermitsThroughputInput() = %v, want %v", got, testCase.want)
+			}
+		})
+	}
+}
 
 func TestAccElasticsearchDomain_basic(t *testing.T) {
 	ctx := acctest.Context(t)
@@ -1429,6 +1483,55 @@ func TestAccElasticsearchDomain_VolumeType_update(t *testing.T) {
 		}})
 }
 
+// Verifies that EBS volume_type can be changed from gp3 to a type which does not
+// support the throughput and iops input values (ex. gp2)
+//
+// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/32613
+func TestAccElasticsearchDomain_VolumeType_gp3ToGP2(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var input elasticsearch.ElasticsearchDomainStatus
+	rName := testAccRandomDomainName()
+	resourceName := "aws_elasticsearch_domain.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIAMServiceLinkedRole(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, opensearchservice.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDomainDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainConfig_clusterEBSVolumeGP3DefaultIopsThroughput(rName, 10),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName, &input),
+					resource.TestCheckResourceAttr(resourceName, "ebs_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_options.0.ebs_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_options.0.volume_size", "10"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_options.0.volume_type", "gp3"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateId:     rName,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDomainConfig_clusterEBSVolumeGP2(rName, 10),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName, &input),
+					resource.TestCheckResourceAttr(resourceName, "ebs_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_options.0.ebs_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_options.0.volume_size", "10"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_options.0.volume_type", "gp2"),
+				),
+			},
+		}})
+}
+
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/13867
 func TestAccElasticsearchDomain_VolumeType_missing(t *testing.T) {
 	if testing.Short() {
@@ -2115,6 +2218,41 @@ resource "aws_elasticsearch_domain" "test" {
   }
 }
 `, rName, volumeSize, volumeThroughput, volumeIops)
+}
+
+func testAccDomainConfig_clusterEBSVolumeGP3DefaultIopsThroughput(rName string, volumeSize int) string {
+	return fmt.Sprintf(`
+resource "aws_elasticsearch_domain" "test" {
+  domain_name = %[1]q
+  elasticsearch_version = "7.10"
+  ebs_options {
+    ebs_enabled = true
+    volume_size = %[2]d
+    volume_type = "gp3"
+
+  }
+  cluster_config {
+    instance_type = "t3.small.elasticsearch"
+  }
+}
+`, rName, volumeSize)
+}
+
+func testAccDomainConfig_clusterEBSVolumeGP2(rName string, volumeSize int) string {
+	return fmt.Sprintf(`
+resource "aws_elasticsearch_domain" "test" {
+  domain_name = %[1]q
+  elasticsearch_version = "7.10"
+  ebs_options {
+    ebs_enabled = true
+    volume_size = %[2]d
+    volume_type = "gp2"
+  }
+  cluster_config {
+    instance_type = "t3.small.elasticsearch"
+  }
+}
+`, rName, volumeSize)
 }
 
 func testAccDomainConfig_clusterUpdateVersion(rName, version string) string {
@@ -2915,16 +3053,16 @@ func testAccDomainConfig_logPublishingOptions(rName, logType string) string {
 			  master_user_password = "Barbarbarbar1!"
 			}
 	  	}
-	
+
 		domain_endpoint_options {
 	  		enforce_https       = true
 	  		tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
 		}
-	
+
 		encrypt_at_rest {
 			enabled = true
 		}
-	
+
 		node_to_node_encryption {
 			enabled = true
 		}`

--- a/internal/service/elasticsearch/domain_test.go
+++ b/internal/service/elasticsearch/domain_test.go
@@ -12,9 +12,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
-	"github.com/aws/aws-sdk-go/service/elasticsearchservice"
 	elasticsearch "github.com/aws/aws-sdk-go/service/elasticsearchservice"
-	"github.com/aws/aws-sdk-go/service/opensearchservice"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -33,10 +31,10 @@ func TestEBSVolumeTypePermitsIopsInput(t *testing.T) {
 		want       bool
 	}{
 		{"empty", "", false},
-		{"gp2", elasticsearchservice.VolumeTypeGp2, false},
-		{"gp3", elasticsearchservice.VolumeTypeGp3, true},
-		{"io1", elasticsearchservice.VolumeTypeIo1, true},
-		{"standard", elasticsearchservice.VolumeTypeStandard, false},
+		{"gp2", elasticsearch.VolumeTypeGp2, false},
+		{"gp3", elasticsearch.VolumeTypeGp3, true},
+		{"io1", elasticsearch.VolumeTypeIo1, true},
+		{"standard", elasticsearch.VolumeTypeStandard, false},
 	}
 	for _, testCase := range testCases {
 		testCase := testCase
@@ -59,10 +57,10 @@ func TestEBSVolumeTypePermitsThroughputInput(t *testing.T) {
 		want       bool
 	}{
 		{"empty", "", false},
-		{"gp2", elasticsearchservice.VolumeTypeGp2, false},
-		{"gp3", elasticsearchservice.VolumeTypeGp3, true},
-		{"io1", elasticsearchservice.VolumeTypeIo1, false},
-		{"standard", elasticsearchservice.VolumeTypeStandard, false},
+		{"gp2", elasticsearch.VolumeTypeGp2, false},
+		{"gp3", elasticsearch.VolumeTypeGp3, true},
+		{"io1", elasticsearch.VolumeTypeIo1, false},
+		{"standard", elasticsearch.VolumeTypeStandard, false},
 	}
 	for _, testCase := range testCases {
 		testCase := testCase
@@ -1499,7 +1497,7 @@ func TestAccElasticsearchDomain_VolumeType_gp3ToGP2(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIAMServiceLinkedRole(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, opensearchservice.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, elasticsearch.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDomainDestroy(ctx),
 		Steps: []resource.TestStep{

--- a/internal/service/elasticsearch/flex.go
+++ b/internal/service/elasticsearch/flex.go
@@ -79,18 +79,21 @@ func expandEBSOptions(m map[string]interface{}) *elasticsearch.EBSOptions {
 		options.EBSEnabled = aws.Bool(ebsEnabled.(bool))
 
 		if ebsEnabled.(bool) {
-			if v, ok := m["iops"]; ok && v.(int) > 0 {
-				options.Iops = aws.Int64(int64(v.(int)))
-			}
-			if v, ok := m["throughput"]; ok && v.(int) > 0 {
-				options.Throughput = aws.Int64(int64(v.(int)))
-			}
 			if v, ok := m["volume_size"]; ok && v.(int) > 0 {
 				options.VolumeSize = aws.Int64(int64(v.(int)))
 			}
+			var volumeType string
 			if v, ok := m["volume_type"]; ok && v.(string) != "" {
-				options.VolumeType = aws.String(v.(string))
+				volumeType = v.(string)
+				options.VolumeType = aws.String(volumeType)
 			}
+			if v, ok := m["iops"]; ok && v.(int) > 0 && EBSVolumeTypePermitsIopsInput(volumeType) {
+				options.Iops = aws.Int64(int64(v.(int)))
+			}
+			if v, ok := m["throughput"]; ok && v.(int) > 0 && EBSVolumeTypePermitsThroughputInput(volumeType) {
+				options.Throughput = aws.Int64(int64(v.(int)))
+			}
+
 		}
 	}
 

--- a/internal/service/elasticsearch/flex.go
+++ b/internal/service/elasticsearch/flex.go
@@ -93,7 +93,6 @@ func expandEBSOptions(m map[string]interface{}) *elasticsearch.EBSOptions {
 			if v, ok := m["throughput"]; ok && v.(int) > 0 && EBSVolumeTypePermitsThroughputInput(volumeType) {
 				options.Throughput = aws.Int64(int64(v.(int)))
 			}
-
 		}
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
This fix ensures that the Throughput and Iops EBS features are not incorporated when the selected volume type doesn't support them, for instance, gp2 EBS volume type.

This specifically can occur when a setup utilizes a gp3 volume type without mentioning iops or throughput, and then the volume type switches to a type that doesn't accept these parameters, like gp2. During the first terraform apply, the default values provided by AWS are written to state, and subsequent terraform apply should be excluded from the UpdateDomain request input to prevent error `Error: ValidationException: Throughput is only valid when volume type is GP3.`


### Relations
Closes [#32613](https://github.com/hashicorp/terraform-provider-aws/issues/32613).

### References
Same issue raised here with opensearch https://github.com/hashicorp/terraform-provider-aws/issues/27467, and resolved here https://github.com/hashicorp/terraform-provider-aws/pull/28862.

### Output from Acceptance Testing
```console
➜  terraform-provider-aws git:(b-elasticsearch-ebs-options) ✗ make testacc PKG=elasticsearch TESTS=TestAccElasticsearchDomain_VolumeType_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elasticsearch/... -v -count 1 -parallel 20 -run='TestAccElasticsearchDomain_VolumeType_'  -timeout 180m
=== RUN   TestAccElasticsearchDomain_VolumeType_update
=== PAUSE TestAccElasticsearchDomain_VolumeType_update
=== RUN   TestAccElasticsearchDomain_VolumeType_gp3ToGP2
=== PAUSE TestAccElasticsearchDomain_VolumeType_gp3ToGP2
=== RUN   TestAccElasticsearchDomain_VolumeType_missing
=== PAUSE TestAccElasticsearchDomain_VolumeType_missing
=== CONT  TestAccElasticsearchDomain_VolumeType_update
=== CONT  TestAccElasticsearchDomain_VolumeType_missing
=== CONT  TestAccElasticsearchDomain_VolumeType_gp3ToGP2
--- PASS: TestAccElasticsearchDomain_VolumeType_missing (1396.16s)
--- PASS: TestAccElasticsearchDomain_VolumeType_gp3ToGP2 (2985.81s)
--- PASS: TestAccElasticsearchDomain_VolumeType_update (4440.89s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticsearch	4442.801s
```
