### PR TITLE
Fix Sagemaker Domain KMS Key ID fields

### DIFF
--- a/internal/service/sagemaker/domain.go
+++ b/internal/service/sagemaker/domain.go
@@ -491,9 +491,8 @@ func ResourceDomain() *schema.Resource {
 										ValidateFunc: validation.StringInSlice(sagemaker.NotebookOutputOption_Values(), false),
 									},
 									"s3_kms_key_id": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ValidateFunc: verify.ValidARN,
+										Type:     schema.TypeString,
+										Optional: true,
 									},
 									"s3_output_path": {
 										Type:     schema.TypeString,
@@ -629,10 +628,9 @@ func ResourceDomain() *schema.Resource {
 				Computed: true,
 			},
 			"kms_key_id": {
-				Type:         schema.TypeString,
-				ForceNew:     true,
-				Optional:     true,
-				ValidateFunc: verify.ValidARN,
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
 			},
 			"retention_policy": {
 				Type:     schema.TypeList,

--- a/internal/service/sagemaker/domain_test.go
+++ b/internal/service/sagemaker/domain_test.go
@@ -116,7 +116,7 @@ func testAccDomain_kms(t *testing.T) {
 				Config: testAccDomainConfig_kms(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(ctx, resourceName, &domain),
-					resource.TestCheckResourceAttrPair(resourceName, "kms_key_id", "aws_kms_key.test", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_key_id", "aws_kms_key.test", "key_id"),
 				),
 			},
 			{
@@ -233,7 +233,7 @@ func testAccDomain_sharingSettings(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.sharing_settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.sharing_settings.0.notebook_output_option", "Allowed"),
-					resource.TestCheckResourceAttrPair(resourceName, "default_user_settings.0.sharing_settings.0.s3_kms_key_id", "aws_kms_key.test", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "default_user_settings.0.sharing_settings.0.s3_kms_key_id", "aws_kms_key.test", "key_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "default_user_settings.0.sharing_settings.0.s3_output_path"),
 				),
 			},
@@ -719,7 +719,7 @@ func testAccDomain_defaultUserSettingsUpdated(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.sharing_settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.sharing_settings.0.notebook_output_option", "Allowed"),
-					resource.TestCheckResourceAttrPair(resourceName, "default_user_settings.0.sharing_settings.0.s3_kms_key_id", "aws_kms_key.test", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "default_user_settings.0.sharing_settings.0.s3_kms_key_id", "aws_kms_key.test", "key_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "default_user_settings.0.sharing_settings.0.s3_output_path"),
 				),
 			},
@@ -922,7 +922,7 @@ resource "aws_sagemaker_domain" "test" {
   auth_mode   = "IAM"
   vpc_id      = aws_vpc.test.id
   subnet_ids  = aws_subnet.test[*].id
-  kms_key_id  = aws_kms_key.test.arn
+  kms_key_id  = aws_kms_key.test.key_id
 
   default_user_settings {
     execution_role = aws_iam_role.test.arn
@@ -1066,7 +1066,7 @@ resource "aws_sagemaker_domain" "test" {
 
     sharing_settings {
       notebook_output_option = "Allowed"
-      s3_kms_key_id          = aws_kms_key.test.arn
+      s3_kms_key_id          = aws_kms_key.test.key_id
       s3_output_path         = "s3://${aws_s3_bucket.test.bucket}/sharing"
     }
   }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Fix SageMaker Studio Domain settings for KMS Keys. The current implementation enforces the usage of ARNs, but the service requires just the Key ID.
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #23429

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
make testacc TESTS=TestAccSageMaker_serial/Domain PKG=sagemaker
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sagemaker/... -v -count 1 -parallel 20 -run='TestAccSageMaker_serial/Domain'  -timeout 180m
=== RUN   TestAccSageMaker_serial
=== PAUSE TestAccSageMaker_serial
=== CONT  TestAccSageMaker_serial
=== RUN   TestAccSageMaker_serial/Domain
=== RUN   TestAccSageMaker_serial/Domain/kernelGatewayAppSettings_defaultResourceAndCustomImage
    domain_test.go:551: Environment variable SAGEMAKER_IMAGE_VERSION_BASE_IMAGE is not set
=== RUN   TestAccSageMaker_serial/Domain/jupyterServerAppSettings
=== RUN   TestAccSageMaker_serial/Domain/tensorboardAppSettingsWithImage
=== RUN   TestAccSageMaker_serial/Domain/defaultUserSettingsUpdated
=== RUN   TestAccSageMaker_serial/Domain/modelRegisterSettings
=== RUN   TestAccSageMaker_serial/Domain/domainSettings
=== RUN   TestAccSageMaker_serial/Domain/rSessionAppSettings
=== RUN   TestAccSageMaker_serial/Domain/tags
=== RUN   TestAccSageMaker_serial/Domain/kernelGatewayAppSettings
=== RUN   TestAccSageMaker_serial/Domain/kernelGatewayAppSettings_lifecycleConfig
=== RUN   TestAccSageMaker_serial/Domain/canvas
=== RUN   TestAccSageMaker_serial/Domain/rStudioServerProAppSettings
=== RUN   TestAccSageMaker_serial/Domain/code
=== RUN   TestAccSageMaker_serial/Domain/basic
=== RUN   TestAccSageMaker_serial/Domain/tensorboardAppSettings
=== RUN   TestAccSageMaker_serial/Domain/kernelGatewayAppSettings_customImage
    domain_test.go:512: Environment variable SAGEMAKER_IMAGE_VERSION_BASE_IMAGE is not set
=== RUN   TestAccSageMaker_serial/Domain/kms
=== RUN   TestAccSageMaker_serial/Domain/securityGroup
=== RUN   TestAccSageMaker_serial/Domain/sharingSettings
=== RUN   TestAccSageMaker_serial/Domain/spaceSettingsKernelGatewayAppSettings
=== RUN   TestAccSageMaker_serial/Domain/disappears
--- PASS: TestAccSageMaker_serial (4698.69s)
    --- PASS: TestAccSageMaker_serial/Domain (4698.69s)
        --- SKIP: TestAccSageMaker_serial/Domain/kernelGatewayAppSettings_defaultResourceAndCustomImage (0.00s)
        --- PASS: TestAccSageMaker_serial/Domain/jupyterServerAppSettings (249.49s)
        --- PASS: TestAccSageMaker_serial/Domain/tensorboardAppSettingsWithImage (306.61s)
        --- PASS: TestAccSageMaker_serial/Domain/defaultUserSettingsUpdated (266.21s)
        --- PASS: TestAccSageMaker_serial/Domain/modelRegisterSettings (247.70s)
        --- PASS: TestAccSageMaker_serial/Domain/domainSettings (261.84s)
        --- PASS: TestAccSageMaker_serial/Domain/rSessionAppSettings (247.43s)
        --- PASS: TestAccSageMaker_serial/Domain/tags (245.58s)
        --- PASS: TestAccSageMaker_serial/Domain/kernelGatewayAppSettings (248.24s)
        --- PASS: TestAccSageMaker_serial/Domain/kernelGatewayAppSettings_lifecycleConfig (247.24s)
        --- PASS: TestAccSageMaker_serial/Domain/canvas (247.39s)
        --- PASS: TestAccSageMaker_serial/Domain/rStudioServerProAppSettings (197.71s)
        --- PASS: TestAccSageMaker_serial/Domain/code (247.58s)
        --- PASS: TestAccSageMaker_serial/Domain/basic (247.34s)
        --- PASS: TestAccSageMaker_serial/Domain/tensorboardAppSettings (137.62s)
        --- SKIP: TestAccSageMaker_serial/Domain/kernelGatewayAppSettings_customImage (0.00s)
        --- PASS: TestAccSageMaker_serial/Domain/kms (247.90s)
        --- PASS: TestAccSageMaker_serial/Domain/securityGroup (421.16s)
        --- PASS: TestAccSageMaker_serial/Domain/sharingSettings (227.58s)
        --- PASS: TestAccSageMaker_serial/Domain/spaceSettingsKernelGatewayAppSettings (131.16s)
        --- PASS: TestAccSageMaker_serial/Domain/disappears (272.89s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker	4702.942s
...
```
