### PR TITLE
r/aws_lightsail_domain_entry: support for AAAA record type

### DIFF
--- a/.changelog/32664.txt
+++ b/.changelog/32664.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lightsail_domain_entry: Support for AAAA record type
+```

--- a/.changelog/32664.txt
+++ b/.changelog/32664.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_lightsail_domain_entry: Support for AAAA record type
+resource/aws_lightsail_domain_entry: Add support for `AAAA` `type` value
 ```

--- a/internal/service/lightsail/domain_entry.go
+++ b/internal/service/lightsail/domain_entry.go
@@ -65,6 +65,7 @@ func ResourceDomainEntry() *schema.Resource {
 				Required: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					"A",
+					"AAAA",
 					"CNAME",
 					"MX",
 					"NS",

--- a/internal/service/lightsail/domain_entry_test.go
+++ b/internal/service/lightsail/domain_entry_test.go
@@ -167,6 +167,46 @@ func TestAccLightsailDomainEntry_disappears(t *testing.T) {
 	})
 }
 
+func TestAccLightsailDomainEntry_typeAAAA(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_lightsail_domain_entry.test"
+	domainName := acctest.RandomDomainName()
+	domainEntryName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckRegion(t, string(types.RegionNameUsEast1)) },
+		ErrorCheck:               acctest.ErrorCheck(t, strings.ToLower(lightsail.ServiceID)),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDomainEntryDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainEntryConfig_typeAAAA(domainName, domainEntryName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDomainEntryExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "domain_name", domainName),
+					resource.TestCheckResourceAttr(resourceName, "name", domainEntryName),
+					resource.TestCheckResourceAttr(resourceName, "target", "::1"),
+					resource.TestCheckResourceAttr(resourceName, "type", "AAAA"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Validate that we can import an existing resource using the legacy separator
+			// Validate that the ID is updated to use the new common separator
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccDomainEntryStateLegacyIdFunc(resourceName),
+				ImportStateVerify: true,
+				Check:             resource.TestCheckResourceAttr(resourceName, "id", fmt.Sprintf("%s,%s,%s,%s", domainEntryName, domainName, "AAAA", "::1")),
+			},
+		},
+	})
+}
+
 func testAccCheckDomainEntryExists(ctx context.Context, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -232,6 +272,21 @@ resource "aws_lightsail_domain_entry" "test" {
   name        = %[2]q
   type        = "A"
   target      = "127.0.0.1"
+}
+`, domainName, domainEntryName)
+}
+
+func testAccDomainEntryConfig_typeAAAA(domainName string, domainEntryName string) string {
+	return fmt.Sprintf(`
+resource "aws_lightsail_domain" "test" {
+  domain_name = %[1]q
+}
+
+resource "aws_lightsail_domain_entry" "test" {
+  domain_name = aws_lightsail_domain.test.id
+  name        = %[2]q
+  type        = "AAAA"
+  target      = "::1"
 }
 `, domainName, domainEntryName)
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

When I try to add an AAAA record with `aws_lightsail_domain_entry`, I get an error with `terraform validate`.
```
Error: expected type to be one of [A CNAME MX NS SOA SRV TXT], got AAAA
```
Fixed `aws_lightsail_domain_entry` to support AAAA record type.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #27309

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

IPv6 (AAAA) domain entry type is allowed in aws cli.
https://docs.aws.amazon.com/cli/latest/reference/lightsail/create-domain-entry.html#options

> The type of domain entry, such as address for IPv4 (A), address for IPv6 (AAAA), canonical name (CNAME), mail exchanger (MX), name server (NS), start of authority (SOA), service locator (SRV), or text (TXT).

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
make testacc TESTS=TestAccLightsailDomainEntry PKG=lightsail
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lightsail/... -v -count 1 -parallel 20 -run='TestAccLightsailDomainEntry'  -timeout 180m
=== RUN   TestAccLightsailDomainEntry_basic
=== PAUSE TestAccLightsailDomainEntry_basic
=== RUN   TestAccLightsailDomainEntry_underscore
=== PAUSE TestAccLightsailDomainEntry_underscore
=== RUN   TestAccLightsailDomainEntry_apex
=== PAUSE TestAccLightsailDomainEntry_apex
=== RUN   TestAccLightsailDomainEntry_disappears
=== PAUSE TestAccLightsailDomainEntry_disappears
=== RUN   TestAccLightsailDomainEntry_typeAAAA
=== PAUSE TestAccLightsailDomainEntry_typeAAAA
=== CONT  TestAccLightsailDomainEntry_basic
=== CONT  TestAccLightsailDomainEntry_disappears
=== CONT  TestAccLightsailDomainEntry_apex
=== CONT  TestAccLightsailDomainEntry_typeAAAA
=== CONT  TestAccLightsailDomainEntry_underscore
--- PASS: TestAccLightsailDomainEntry_disappears (45.91s)
--- PASS: TestAccLightsailDomainEntry_underscore (57.16s)
--- PASS: TestAccLightsailDomainEntry_typeAAAA (57.31s)
--- PASS: TestAccLightsailDomainEntry_basic (57.45s)
--- PASS: TestAccLightsailDomainEntry_apex (57.62s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lightsail  59.337s
```
