### PR TITLE
Correct type in Quicksight flattener `flattenDataLabelOptions`

### DIFF
--- a/.changelog/32668.txt
+++ b/.changelog/32668.txt
@@ -1,0 +1,11 @@
+```release-note:bug
+resource/aws_quicksight_analysis: Fix exception thrown when setting the value for `definition.sheets.visuals.pie_chart_visual.chart_configuration.data_labels.measure_label_visibility`
+```
+
+```release-note:bug
+resource/aws_quicksight_dashboard: Fix exception thrown when setting the value for `definition.sheets.visuals.pie_chart_visual.chart_configuration.data_labels.measure_label_visibility`
+```
+
+```release-note:bug
+resource/aws_quicksight_template: Fix exception thrown when setting the value for `definition.sheets.visuals.pie_chart_visual.chart_configuration.data_labels.measure_label_visibility`
+```

--- a/internal/service/quicksight/schema/visual.go
+++ b/internal/service/quicksight/schema/visual.go
@@ -1476,7 +1476,7 @@ func flattenDataLabelOptions(apiObject *quicksight.DataLabelOptions) []interface
 		tfMap["label_font_configuration"] = flattenFontConfiguration(apiObject.LabelFontConfiguration)
 	}
 	if apiObject.MeasureLabelVisibility != nil {
-		tfMap["measure_visibility"] = aws.StringValue(apiObject.MeasureLabelVisibility)
+		tfMap["measure_label_visibility"] = aws.StringValue(apiObject.MeasureLabelVisibility)
 	}
 	if apiObject.Overlap != nil {
 		tfMap["overlap"] = aws.StringValue(apiObject.Overlap)


### PR DESCRIPTION
### Description

This PR corrects a typo in the flattener `flattenDataLabelOptions`. Previously, an error was thrown of:

```shell
Error: setting definition: Invalid address to set: []string{"definition", "0", "sheets", "0", "visuals", "0", "pie_chart_visual", "0", "chart_configuration", "0", "data_labels", "0", "measure_visibility"}
```

This was due to the incorrect usage of `measure_visibility` over `measure_label_visibility`.

### Relations

Closes #32652

### Output from Acceptance Testing

I'm unfortunately not able to run these tests due to account restrictions