### PR TITLE
Fix `aws_cloudtrail` docs examples

### DIFF
--- a/website/docs/r/cloudtrail.html.markdown
+++ b/website/docs/r/cloudtrail.html.markdown
@@ -244,7 +244,7 @@ resource "aws_cloudtrail" "example" {
       field = "resources.ARN"
 
       #The trailing slash is intentional; do not exclude it.
-      equals = [
+      starts_with = [
         "${data.aws_s3_bucket.important-bucket-1.arn}/",
         "${data.aws_s3_bucket.important-bucket-2.arn}/"
       ]
@@ -277,7 +277,6 @@ resource "aws_cloudtrail" "example" {
     field_selector {
       field = "resources.ARN"
 
-      #The trailing slash is intentional; do not exclude it.
       equals = [
         "${data.aws_s3_bucket.important-bucket-3.arn}/important-prefix"
       ]


### PR DESCRIPTION
### Description

This PR fixes an example in the `aws_cloudtrail` documentation. This `advanced_event_selector`'s name is `"Log PutObject and DeleteObject events for two S3 buckets"`, so with a `field_selector.field` of `"resources.ARN"`, `starts_with` should be used instead of `equals` in order to catch the objects in the bucket, rather than the bucket itself.

Also removed a comment of `#The trailing slash is intentional; do not exclude it.`, as there was no trailing slash where it was referenced.

### Relations

Closes #32619
Relates #28582

### Output from Acceptance Testing

N/a, docs
