### PR TITLE
r/aws_grafana_workspace: Allow in-place version updates

### DIFF
--- a/.changelog/32679.txt
+++ b/.changelog/32679.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_grafana_workspace: Allow `grafana_version` to be updated in-place
+```

--- a/internal/service/grafana/wait.go
+++ b/internal/service/grafana/wait.go
@@ -30,7 +30,7 @@ func waitWorkspaceCreated(ctx context.Context, conn *managedgrafana.ManagedGrafa
 
 func waitWorkspaceUpdated(ctx context.Context, conn *managedgrafana.ManagedGrafana, id string, timeout time.Duration) (*managedgrafana.WorkspaceDescription, error) { //nolint:unparam
 	stateConf := &retry.StateChangeConf{
-		Pending: []string{managedgrafana.WorkspaceStatusUpdating},
+		Pending: []string{managedgrafana.WorkspaceStatusUpdating, managedgrafana.WorkspaceStatusVersionUpdating},
 		Target:  []string{managedgrafana.WorkspaceStatusActive},
 		Refresh: statusWorkspaceStatus(ctx, conn, id),
 		Timeout: timeout,

--- a/internal/service/grafana/workspace.go
+++ b/internal/service/grafana/workspace.go
@@ -407,11 +407,8 @@ func resourceWorkspaceUpdate(ctx context.Context, d *schema.ResourceData, meta i
 
 	if d.HasChanges("configuration", "grafana_version") {
 		input := &managedgrafana.UpdateWorkspaceConfigurationInput{
-			WorkspaceId: aws.String(d.Id()),
-		}
-
-		if d.HasChange("configuration") {
-			input.Configuration = aws.String(d.Get("configuration").(string))
+			Configuration: aws.String(d.Get("configuration").(string)),
+			WorkspaceId:   aws.String(d.Id()),
 		}
 
 		if d.HasChange("grafana_version") {

--- a/internal/service/grafana/workspace.go
+++ b/internal/service/grafana/workspace.go
@@ -93,7 +93,6 @@ func ResourceWorkspace() *schema.Resource {
 			},
 			"grafana_version": {
 				Type:     schema.TypeString,
-				ForceNew: true,
 				Optional: true,
 				Computed: true,
 			},
@@ -333,7 +332,7 @@ func resourceWorkspaceUpdate(ctx context.Context, d *schema.ResourceData, meta i
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GrafanaConn(ctx)
 
-	if d.HasChangesExcept("configuration", "tags", "tags_all") {
+	if d.HasChangesExcept("configuration", "grafana_version", "tags", "tags_all") {
 		input := &managedgrafana.UpdateWorkspaceInput{
 			WorkspaceId: aws.String(d.Id()),
 		}
@@ -409,10 +408,17 @@ func resourceWorkspaceUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		}
 	}
 
-	if d.HasChange("configuration") {
+	if d.HasChanges("configuration", "grafana_version") {
 		input := &managedgrafana.UpdateWorkspaceConfigurationInput{
-			WorkspaceId:   aws.String(d.Id()),
-			Configuration: aws.String(d.Get("configuration").(string)),
+			WorkspaceId: aws.String(d.Id()),
+		}
+
+		if d.HasChange("configuration") {
+			input.Configuration = aws.String(d.Get("configuration").(string))
+		}
+
+		if d.HasChange("grafana_version") {
+			input.GrafanaVersion = aws.String(d.Get("grafana_version").(string))
 		}
 
 		_, err := conn.UpdateWorkspaceConfigurationWithContext(ctx, input)

--- a/internal/service/grafana/workspace_data_source_test.go
+++ b/internal/service/grafana/workspace_data_source_test.go
@@ -27,7 +27,6 @@ func testAccWorkspaceDataSource_basic(t *testing.T) {
 			{
 				Config: testAccWorkspaceDataSourceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckWorkspaceExists(ctx, dataSourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "account_access_type", dataSourceName, "account_access_type"),
 					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "authentication_providers.#", dataSourceName, "authentication_providers.#"),

--- a/internal/service/grafana/workspace_test.go
+++ b/internal/service/grafana/workspace_test.go
@@ -5,10 +5,12 @@ package grafana_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/managedgrafana"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -66,6 +68,7 @@ func TestAccGrafana_serial(t *testing.T) {
 
 func testAccWorkspace_saml(t *testing.T) {
 	ctx := acctest.Context(t)
+	var v managedgrafana.WorkspaceDescription
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_grafana_workspace.test"
 	iamRoleResourceName := "aws_iam_role.test"
@@ -79,7 +82,7 @@ func testAccWorkspace_saml(t *testing.T) {
 			{
 				Config: testAccWorkspaceConfig_authenticationProvider(rName, "SAML"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckWorkspaceExists(ctx, resourceName),
+					testAccCheckWorkspaceExists(ctx, resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "grafana", regexp.MustCompile(`/workspaces/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "account_access_type", managedgrafana.AccountAccessTypeCurrentAccount),
 					resource.TestCheckResourceAttr(resourceName, "authentication_providers.#", "1"),
@@ -112,6 +115,7 @@ func testAccWorkspace_saml(t *testing.T) {
 
 func testAccWorkspace_vpc(t *testing.T) {
 	ctx := acctest.Context(t)
+	var v managedgrafana.WorkspaceDescription
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_grafana_workspace.test"
 
@@ -124,7 +128,7 @@ func testAccWorkspace_vpc(t *testing.T) {
 			{
 				Config: testAccWorkspaceConfig_vpc(rName, 2),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckWorkspaceExists(ctx, resourceName),
+					testAccCheckWorkspaceExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "vpc_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "vpc_configuration.0.security_group_ids.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "vpc_configuration.0.subnet_ids.#", "2"),
@@ -138,7 +142,7 @@ func testAccWorkspace_vpc(t *testing.T) {
 			{
 				Config: testAccWorkspaceConfig_vpc(rName, 3),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckWorkspaceExists(ctx, resourceName),
+					testAccCheckWorkspaceExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "vpc_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "vpc_configuration.0.security_group_ids.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "vpc_configuration.0.subnet_ids.#", "3"),
@@ -147,7 +151,7 @@ func testAccWorkspace_vpc(t *testing.T) {
 			{
 				Config: testAccWorkspaceConfig_vpcRemoved(rName, 3),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckWorkspaceExists(ctx, resourceName),
+					testAccCheckWorkspaceExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "vpc_configuration.#", "0"),
 				),
 			},
@@ -157,6 +161,7 @@ func testAccWorkspace_vpc(t *testing.T) {
 
 func testAccWorkspace_sso(t *testing.T) {
 	ctx := acctest.Context(t)
+	var v managedgrafana.WorkspaceDescription
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_grafana_workspace.test"
 	iamRoleResourceName := "aws_iam_role.test"
@@ -174,7 +179,7 @@ func testAccWorkspace_sso(t *testing.T) {
 			{
 				Config: testAccWorkspaceConfig_authenticationProvider(rName, "AWS_SSO"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckWorkspaceExists(ctx, resourceName),
+					testAccCheckWorkspaceExists(ctx, resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "grafana", regexp.MustCompile(`/workspaces/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "account_access_type", managedgrafana.AccountAccessTypeCurrentAccount),
 					resource.TestCheckResourceAttr(resourceName, "authentication_providers.#", "1"),
@@ -205,6 +210,7 @@ func testAccWorkspace_sso(t *testing.T) {
 
 func testAccWorkspace_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
+	var v managedgrafana.WorkspaceDescription
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_grafana_workspace.test"
 
@@ -217,7 +223,7 @@ func testAccWorkspace_disappears(t *testing.T) {
 			{
 				Config: testAccWorkspaceConfig_authenticationProvider(rName, "SAML"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckWorkspaceExists(ctx, resourceName),
+					testAccCheckWorkspaceExists(ctx, resourceName, &v),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfgrafana.ResourceWorkspace(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -228,6 +234,7 @@ func testAccWorkspace_disappears(t *testing.T) {
 
 func testAccWorkspace_organization(t *testing.T) {
 	ctx := acctest.Context(t)
+	var v managedgrafana.WorkspaceDescription
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_grafana_workspace.test"
 
@@ -245,7 +252,7 @@ func testAccWorkspace_organization(t *testing.T) {
 			{
 				Config: testAccWorkspaceConfig_organization(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckWorkspaceExists(ctx, resourceName),
+					testAccCheckWorkspaceExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "account_access_type", managedgrafana.AccountAccessTypeOrganization),
 					resource.TestCheckResourceAttr(resourceName, "authentication_providers.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "authentication_providers.0", managedgrafana.AuthenticationProviderTypesSaml),
@@ -264,6 +271,7 @@ func testAccWorkspace_organization(t *testing.T) {
 
 func testAccWorkspace_tags(t *testing.T) {
 	ctx := acctest.Context(t)
+	var v managedgrafana.WorkspaceDescription
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_grafana_workspace.test"
 
@@ -276,7 +284,7 @@ func testAccWorkspace_tags(t *testing.T) {
 			{
 				Config: testAccWorkspaceConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckWorkspaceExists(ctx, resourceName),
+					testAccCheckWorkspaceExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
@@ -289,7 +297,7 @@ func testAccWorkspace_tags(t *testing.T) {
 			{
 				Config: testAccWorkspaceConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckWorkspaceExists(ctx, resourceName),
+					testAccCheckWorkspaceExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
@@ -298,7 +306,7 @@ func testAccWorkspace_tags(t *testing.T) {
 			{
 				Config: testAccWorkspaceConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckWorkspaceExists(ctx, resourceName),
+					testAccCheckWorkspaceExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
@@ -309,6 +317,7 @@ func testAccWorkspace_tags(t *testing.T) {
 
 func testAccWorkspace_dataSources(t *testing.T) {
 	ctx := acctest.Context(t)
+	var v managedgrafana.WorkspaceDescription
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_grafana_workspace.test"
 	iamRoleResourceName := "aws_iam_role.test"
@@ -322,7 +331,7 @@ func testAccWorkspace_dataSources(t *testing.T) {
 			{
 				Config: testAccWorkspaceConfig_dataSources(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckWorkspaceExists(ctx, resourceName),
+					testAccCheckWorkspaceExists(ctx, resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "grafana", regexp.MustCompile(`/workspaces/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "account_access_type", managedgrafana.AccountAccessTypeCurrentAccount),
 					resource.TestCheckResourceAttr(resourceName, "authentication_providers.#", "1"),
@@ -355,6 +364,7 @@ func testAccWorkspace_dataSources(t *testing.T) {
 
 func testAccWorkspace_permissionType(t *testing.T) {
 	ctx := acctest.Context(t)
+	var v managedgrafana.WorkspaceDescription
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_grafana_workspace.test"
 
@@ -367,7 +377,7 @@ func testAccWorkspace_permissionType(t *testing.T) {
 			{
 				Config: testAccWorkspaceConfig_permissionType(rName, "CUSTOMER_MANAGED"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckWorkspaceExists(ctx, resourceName),
+					testAccCheckWorkspaceExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "permission_type", managedgrafana.PermissionTypeCustomerManaged),
 				),
 			},
@@ -379,7 +389,7 @@ func testAccWorkspace_permissionType(t *testing.T) {
 			{
 				Config: testAccWorkspaceConfig_permissionType(rName, "SERVICE_MANAGED"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckWorkspaceExists(ctx, resourceName),
+					testAccCheckWorkspaceExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "permission_type", managedgrafana.PermissionTypeServiceManaged),
 				),
 			},
@@ -389,6 +399,7 @@ func testAccWorkspace_permissionType(t *testing.T) {
 
 func testAccWorkspace_notificationDestinations(t *testing.T) {
 	ctx := acctest.Context(t)
+	var v managedgrafana.WorkspaceDescription
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_grafana_workspace.test"
 
@@ -401,7 +412,7 @@ func testAccWorkspace_notificationDestinations(t *testing.T) {
 			{
 				Config: testAccWorkspaceConfig_authenticationProvider(rName, "SAML"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckWorkspaceExists(ctx, resourceName),
+					testAccCheckWorkspaceExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttrSet(resourceName, "name"),
 					resource.TestCheckResourceAttr(resourceName, "notification_destinations.#", "0"),
@@ -410,7 +421,7 @@ func testAccWorkspace_notificationDestinations(t *testing.T) {
 			{
 				Config: testAccWorkspaceConfig_notificationDestinations(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckWorkspaceExists(ctx, resourceName),
+					testAccCheckWorkspaceExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "description", rName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "notification_destinations.#", "1"),
@@ -428,6 +439,7 @@ func testAccWorkspace_notificationDestinations(t *testing.T) {
 
 func testAccWorkspace_configuration(t *testing.T) {
 	ctx := acctest.Context(t)
+	var v managedgrafana.WorkspaceDescription
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_grafana_workspace.test"
 
@@ -440,7 +452,7 @@ func testAccWorkspace_configuration(t *testing.T) {
 			{
 				Config: testAccWorkspaceConfig_configuration(rName, `{"unifiedAlerting": { "enabled": true }}`),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckWorkspaceExists(ctx, resourceName),
+					testAccCheckWorkspaceExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "configuration", `{"unifiedAlerting":{"enabled":true}}`),
 				),
 			},
@@ -452,7 +464,7 @@ func testAccWorkspace_configuration(t *testing.T) {
 			{
 				Config: testAccWorkspaceConfig_configuration(rName, `{"unifiedAlerting": { "enabled": false }}`),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckWorkspaceExists(ctx, resourceName),
+					testAccCheckWorkspaceExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "configuration", `{"unifiedAlerting":{"enabled":false}}`),
 				),
 			},
@@ -462,6 +474,7 @@ func testAccWorkspace_configuration(t *testing.T) {
 
 func testAccWorkspace_networkAccess(t *testing.T) {
 	ctx := acctest.Context(t)
+	var v managedgrafana.WorkspaceDescription
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_grafana_workspace.test"
 
@@ -474,7 +487,7 @@ func testAccWorkspace_networkAccess(t *testing.T) {
 			{
 				Config: testAccWorkspaceConfig_networkAccess(rName, 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckWorkspaceExists(ctx, resourceName),
+					testAccCheckWorkspaceExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "network_access_control.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "network_access_control.0.prefix_list_ids.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "network_access_control.0.vpce_ids.#", "1"),
@@ -488,7 +501,7 @@ func testAccWorkspace_networkAccess(t *testing.T) {
 			{
 				Config: testAccWorkspaceConfig_networkAccess(rName, 2),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckWorkspaceExists(ctx, resourceName),
+					testAccCheckWorkspaceExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "network_access_control.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "network_access_control.0.prefix_list_ids.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "network_access_control.0.vpce_ids.#", "2"),
@@ -497,7 +510,7 @@ func testAccWorkspace_networkAccess(t *testing.T) {
 			{
 				Config: testAccWorkspaceConfig_networkAccessRemoved(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckWorkspaceExists(ctx, resourceName),
+					testAccCheckWorkspaceExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "network_access_control.#", "0"),
 				),
 			},
@@ -507,6 +520,7 @@ func testAccWorkspace_networkAccess(t *testing.T) {
 
 func testAccWorkspace_version(t *testing.T) {
 	ctx := acctest.Context(t)
+	var v1, v2 managedgrafana.WorkspaceDescription
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_grafana_workspace.test"
 
@@ -517,10 +531,10 @@ func testAccWorkspace_version(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkspaceConfig_version(rName, "9.4"),
+				Config: testAccWorkspaceConfig_version(rName, "8.4"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckWorkspaceExists(ctx, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "grafana_version", "9.4"),
+					testAccCheckWorkspaceExists(ctx, resourceName, &v1),
+					resource.TestCheckResourceAttr(resourceName, "grafana_version", "8.4"),
 				),
 			},
 			{
@@ -528,15 +542,23 @@ func testAccWorkspace_version(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccWorkspaceConfig_version(rName, "9.4"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckWorkspaceExists(ctx, resourceName, &v2),
+					resource.TestCheckResourceAttr(resourceName, "grafana_version", "9.4"),
+					testAccCheckWorkspaceNotRecreated(&v2, &v1),
+				),
+			},
 		},
 	})
 }
 
-func testAccCheckWorkspaceExists(ctx context.Context, name string) resource.TestCheckFunc {
+func testAccCheckWorkspaceExists(ctx context.Context, n string, v *managedgrafana.WorkspaceDescription) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
@@ -545,9 +567,15 @@ func testAccCheckWorkspaceExists(ctx context.Context, name string) resource.Test
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).GrafanaConn(ctx)
 
-		_, err := tfgrafana.FindWorkspaceByID(ctx, conn, rs.Primary.ID)
+		output, err := tfgrafana.FindWorkspaceByID(ctx, conn, rs.Primary.ID)
 
-		return err
+		if err != nil {
+			return err
+		}
+
+		*v = *output
+
+		return nil
 	}
 }
 
@@ -572,6 +600,16 @@ func testAccCheckWorkspaceDestroy(ctx context.Context) resource.TestCheckFunc {
 
 			return fmt.Errorf("Grafana Workspace %s still exists", rs.Primary.ID)
 		}
+		return nil
+	}
+}
+
+func testAccCheckWorkspaceNotRecreated(i, j *managedgrafana.WorkspaceDescription) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if aws.StringValue(i.Id) != aws.StringValue(j.Id) {
+			return errors.New("Grafana Workspace was recreated")
+		}
+
 		return nil
 	}
 }

--- a/website/docs/r/grafana_workspace.html.markdown
+++ b/website/docs/r/grafana_workspace.html.markdown
@@ -53,7 +53,7 @@ The following arguments are optional:
 * `configuration` - (Optional) The configuration string for the workspace that you create. For more information about the format and configuration options available, see [Working in your Grafana workspace](https://docs.aws.amazon.com/grafana/latest/userguide/AMG-configure-workspace.html).
 * `data_sources` - (Optional) The data sources for the workspace. Valid values are `AMAZON_OPENSEARCH_SERVICE`, `ATHENA`, `CLOUDWATCH`, `PROMETHEUS`, `REDSHIFT`, `SITEWISE`, `TIMESTREAM`, `XRAY`
 * `description` - (Optional) The workspace description.
-* `grafana_version` - (Optional) Specifies the version of Grafana to support in the new workspace. Supported values are `8.4` and `9.4`. If not specified, defaults to `8.4`. Upgrading the workspace version isn't supported, however it's possible to copy content from the old version to the new one using AWS official [migration tool](https://github.com/aws-observability/amazon-managed-grafana-migrator).
+* `grafana_version` - (Optional) Specifies the version of Grafana to support in the new workspace. Supported values are `8.4` and `9.4`. If not specified, defaults to `8.4`.
 * `name` - (Optional) The Grafana workspace name.
 * `network_access_control` - (Optional) Configuration for network access to your workspace.See [Network Access Control](#network-access-control) below.
 * `notification_destinations` - (Optional) The notification destinations. If a data source is specified here, Amazon Managed Grafana will create IAM roles and permissions needed to use these destinations. Must be set to `SNS`.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR updates the `aws_grafana_workspace` resource to allow in-place updates of the Grafana Version.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.
--->

There don't seem to be any issues related to this.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

The AWS API was updated to allow in-place upgrades of the workspace on or around July 19th ([blog post](https://aws.amazon.com/about-aws/whats-new/2023/07/amazon-managed-grafana-in-place-update-version-9-4/), [API documentation](https://docs.aws.amazon.com/grafana/latest/APIReference/API_UpdateWorkspaceConfiguration.html)).


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
I have not been able to run the acceptance testing for this PR, as I'm unsure how to modify the acceptance tests to test an in-place upgrade. I have located the existing `testAccWorkspace_version` test and read the documentation, but I didn't find the documentation particularly useful in this case. Sorry.