### PR TITLE
Fix api_gateway_authorizer documentation example

### DIFF
--- a/website/docs/r/api_gateway_authorizer.html.markdown
+++ b/website/docs/r/api_gateway_authorizer.html.markdown
@@ -24,13 +24,13 @@ resource "aws_api_gateway_rest_api" "demo" {
   name = "auth-demo"
 }
 
-data "aws_iam_role_policy_document" "invocation_assume_role" {
+data "aws_iam_policy_document" "invocation_assume_role" {
   statement {
     effect = "Allow"
 
     principals {
-      type       = "Service"
-      identifier = ["apigateway.amazonaws.com"]
+      type        = "Service"
+      identifiers = ["apigateway.amazonaws.com"]
     }
 
     actions = ["sts:AssumeRole"]
@@ -40,7 +40,7 @@ data "aws_iam_role_policy_document" "invocation_assume_role" {
 resource "aws_iam_role" "invocation_role" {
   name               = "api_gateway_auth_invocation"
   path               = "/"
-  assume_role_policy = data.aws_iam_role_policy_document.invocation_assume_role.json
+  assume_role_policy = data.aws_iam_policy_document.invocation_assume_role.json
 }
 
 data "aws_iam_policy_document" "invocation_policy" {


### PR DESCRIPTION
### Description

It looks like the documentation of aws_api_gateway_authorizer contain an invalid datasource for role definition in the provided example.
This changes `aws_iam_role_policy_document` to `aws_iam_policy_document`.

### Relations
NA

### References
NA
