### PR TITLE
Add conditionals to community comment jobs

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -97,10 +97,10 @@ jobs:
 
   community_note:
     name: 'Add Community Note'
+    if: github.event.action == 'opened'
     runs-on: ubuntu-latest
     steps:
       - name: 'Add community note to new Issues'
-        if: github.event.action == 'opened'
         uses: peter-evans/create-or-update-comment@c6c9a1a66007646a28c153e2a8580a5bad27bcfa
         with:
           issue-number: ${{ github.event.issue.number }}

--- a/.github/workflows/pull_request_target.yml
+++ b/.github/workflows/pull_request_target.yml
@@ -171,6 +171,7 @@ jobs:
 
   community_note:
     name: 'Community Note'
+    if: github.event.action == 'opened'
     runs-on: ubuntu-latest
     steps:
       - name: 'Add community note to new Pull Requests'
@@ -194,6 +195,7 @@ jobs:
 
   first_contribution_note:
     name: 'New Contributor Note'
+    if: github.event.action == 'opened'
     runs-on: ubuntu-latest
     steps:
       - name: 'Add comment to add helpful context for new contributors'
@@ -211,7 +213,7 @@ jobs:
 
   permissions_check:
     name: 'Verify Maintainers Editable'
-    if: ${{ !github.event.pull_request.maintainer_can_modify }}
+    if: github.event.action == 'opened' && !github.event.pull_request.maintainer_can_modify
     runs-on: ubuntu-latest
     steps:
       - name: 'Comment if maintainers cannot edit'


### PR DESCRIPTION
### Description

This PR corrects a few jobs related to `pull_request_target` and `issues` events so that community notes are only added when issues/PRs are opened, rather than on every event type.

### Relations

Relates #32605

### Output from Acceptance Testing

N/a, actions
