### PR TITLE
Fix conditional for maintainer edit check

### DIFF
--- a/.github/workflows/pull_request_target.yml
+++ b/.github/workflows/pull_request_target.yml
@@ -213,7 +213,8 @@ jobs:
 
   permissions_check:
     name: 'Verify Maintainers Editable'
-    if: github.event.action == 'opened' && !github.event.pull_request.maintainer_can_modify
+    needs: community_check
+    if: github.event.action == 'opened' && needs.community_check.outputs.maintainer == 'false' && !github.event.pull_request.maintainer_can_modify
     runs-on: ubuntu-latest
     steps:
       - name: 'Comment if maintainers cannot edit'


### PR DESCRIPTION
### Description

It seems that pull requests from branches always have `maintainer_can_modify` set to `false`. This PR updates the conditional for the "Maintainers Can Modify" job to ensure that the comment isn't left on maintainer PRs by mistake.

### Relations

Relates #32605 

### Output from Acceptance Testing

N/a, Actions