### PR TITLE
Remove indication that `identifier` and `identifier_prefix` arguments of `aws_db_instance` force new on change

### DIFF
--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -239,10 +239,8 @@ when this DB instance is deleted. Must be provided if `skip_final_snapshot` is
 set to `false`. The value must begin with a letter, only contain alphanumeric characters and hyphens, and not end with a hyphen or contain two consecutive hyphens. Must not be provided when deleting a read replica.
 * `iam_database_authentication_enabled` - (Optional) Specifies whether mappings of AWS Identity and Access Management (IAM) accounts to database
 accounts is enabled.
-* `identifier` - (Optional, Forces new resource) The name of the RDS instance,
-if omitted, Terraform will assign a random, unique identifier. Required if `restore_to_point_in_time` is specified.
-* `identifier_prefix` - (Optional, Forces new resource) Creates a unique
-identifier beginning with the specified prefix. Conflicts with `identifier`.
+* `identifier` - (Optional) The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier. Required if `restore_to_point_in_time` is specified.
+* `identifier_prefix` - (Optional) Creates a unique identifier beginning with the specified prefix. Conflicts with `identifier`.
 * `instance_class` - (Required) The instance type of the RDS instance.
 * `iops` - (Optional) The amount of provisioned IOPS. Setting this implies a
 storage_type of "io1". Can only be set when `storage_type` is `"io1"` or `"gp3"`.


### PR DESCRIPTION
### Description

The `identifier` and `identifier_prefix` arguments of the `aws_db_instance` resource used to ForceNew on change, however, no longer do. This PR updates the documentation to align with current behavior.

### Relations

Closes #32590

### References

- [Schema](https://github.com/hashicorp/terraform-provider-aws/blob/10937b0e5d83aac494baa44f9b35e14564573be6/internal/service/rds/instance.go#L280-L293)

### Output from Acceptance Testing

N/a, docs
