### PR TITLE
enhancement: add tests for ECS task definition EFS volume (#24921)

### DIFF
--- a/internal/service/ecs/task_definition_test.go
+++ b/internal/service/ecs/task_definition_test.go
@@ -2053,9 +2053,10 @@ TASK_DEFINITION
     name = %[1]q
 
     efs_volume_configuration {
-      file_system_id          = aws_efs_file_system.test.id
-      root_directory          = "/"
-      transit_encryption      = "DISABLED"
+      file_system_id     = aws_efs_file_system.test.id
+      root_directory     = "/"
+      transit_encryption = "DISABLED"
+
       authorization_config {
         iam = "DISABLED"
       }

--- a/internal/service/ecs/task_definition_test.go
+++ b/internal/service/ecs/task_definition_test.go
@@ -432,6 +432,43 @@ func TestAccECSTaskDefinition_EFSVolume_transitEncryption(t *testing.T) {
 	})
 }
 
+func TestAccECSTaskDefinition_EFSVolume_transitEncryptionDisabled(t *testing.T) {
+	ctx := acctest.Context(t)
+	var def ecs.TaskDefinition
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_ecs_task_definition.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ecs.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTaskDefinitionDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTaskDefinitionConfig_transitEncryptionEFSVolumeDisabled(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTaskDefinitionExists(ctx, resourceName, &def),
+					resource.TestCheckResourceAttr(resourceName, "volume.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "volume.*", map[string]string{
+						"name":                       rName,
+						"efs_volume_configuration.#": "1",
+						"efs_volume_configuration.0.root_directory":     "/",
+						"efs_volume_configuration.0.transit_encryption": "DISABLED",
+					}),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "volume.*.efs_volume_configuration.0.file_system_id", "aws_efs_file_system.test", "id"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateIdFunc:       testAccTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
+			},
+		},
+	})
+}
+
 func TestAccECSTaskDefinition_EFSVolume_accessPoint(t *testing.T) {
 	ctx := acctest.Context(t)
 	var def ecs.TaskDefinition
@@ -1988,6 +2025,44 @@ TASK_DEFINITION
   }
 }
 `, rName, tEnc, tEncPort)
+}
+
+func testAccTaskDefinitionConfig_transitEncryptionEFSVolumeDisabled(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_efs_file_system" "test" {
+  creation_token = %[1]q
+}
+
+resource "aws_ecs_task_definition" "test" {
+  family = %[1]q
+
+  container_definitions = <<TASK_DEFINITION
+[
+  {
+    "name": "sleep",
+    "image": "busybox",
+    "cpu": 10,
+    "command": ["sleep","360"],
+    "memory": 10,
+    "essential": true
+  }
+]
+TASK_DEFINITION
+
+  volume {
+    name = %[1]q
+
+    efs_volume_configuration {
+      file_system_id          = aws_efs_file_system.test.id
+      root_directory          = "/"
+      transit_encryption      = "DISABLED"
+      authorization_config {
+        iam = "DISABLED"
+      }
+    }
+  }
+}
+`, rName)
 }
 
 func testAccTaskDefinitionConfig_efsAccessPoint(rName, useIam string) string {


### PR DESCRIPTION
### Description
Trying to qualifying issue #23541, I've seen that no test were covering this case (ECS task definition with encryption set to disabled and authorization_config also set to disable.

### Relations
Closes #23541
Closes #19549


### Output from Acceptance Testing
New test added: TestAccECSTaskDefinition_EFSVolume_transitEncryptionDisabled
Output:

```console
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSTaskDefinition_EFSVolume_transitEncryptionDisabled'  -timeout 180m
=== RUN   TestAccECSTaskDefinition_EFSVolume_transitEncryptionDisabled
=== PAUSE TestAccECSTaskDefinition_EFSVolume_transitEncryptionDisabled
=== CONT  TestAccECSTaskDefinition_EFSVolume_transitEncryptionDisabled
--- PASS: TestAccECSTaskDefinition_EFSVolume_transitEncryptionDisabled (37.11s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecs        39.007s
```
