### PR TITLE
Fix name of `partner-contribution` variable

### DIFF
--- a/infrastructure/repository/projects.tf
+++ b/infrastructure/repository/projects.tf
@@ -27,7 +27,7 @@ variable "team_project_field_view_values" {
   description = "A mapping of the options in the view field in the main team project to their IDs"
   default = {
     "Working Board"          = "8d366764",
-    "Partner Contributions"  = "b0492564",
+    "Partner Contribution"   = "b0492564",
     "External Maintainer"    = "f17c472c",
     "S3 Backend"             = "5c656f1e",
     "Engineering Initiative" = "a62d09b9"


### PR DESCRIPTION
### Description

This PR aligns the name of the Actions variable for the `partner-contribution` field value with reality. This prevents failures due to a misnamed variable as observed in the workflow run in the references section. 

### References

- [Failed workflow run](https://github.com/hashicorp/terraform-provider-aws/actions/runs/5670211330/job/15364600945)

### Output from Acceptance Testing

N/a, Actions
