### PR TITLE
Adds check so deferred input values

### DIFF
--- a/.changelog/32706.txt
+++ b/.changelog/32706.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lambda_invocation: Fix plan failing with deferred input values
+```

--- a/internal/service/lambda/diff.go
+++ b/internal/service/lambda/diff.go
@@ -17,6 +17,11 @@ func customizeDiffValidateInput(_ context.Context, diff *schema.ResourceDiff, v 
 	if diff.Get("lifecycle_scope") == lifecycleScopeCreateOnly {
 		return nil
 	}
+
+	if !diff.GetRawPlan().GetAttr("input").IsWhollyKnown() {
+		return nil
+	}
+
 	// input is validated to be valid JSON in the schema already.
 	inputNoSpaces := strings.TrimSpace(diff.Get("input").(string))
 	if strings.HasPrefix(inputNoSpaces, "{") && strings.HasSuffix(inputNoSpaces, "}") {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
---> Adds check so deferred input values in CRUD lifecycle mode plans successfully.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #32118

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
> make testacc TESTS=TestAccLambdaInvocation_ PKG=lambda
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaInvocation_'  -timeout 180m
--- PASS: TestAccLambdaInvocation_terraformKey (57.31s)
--- PASS: TestAccLambdaInvocation_lifecycle_scopeCRUDUpdateInput (57.78s)
--- PASS: TestAccLambdaInvocation_complex (68.52s)
--- PASS: TestAccLambdaInvocation_basic (74.43s)
--- PASS: TestAccLambdaInvocation_lifecycle_scopeCreateOnlyToCRUD (76.12s)
--- PASS: TestAccLambdaInvocation_lifecycle_scopeCRUDCreate (92.90s)
--- PASS: TestAccLambdaInvocation_lifecycle_scopeCreateOnlyUpdateInput (98.90s)
--- PASS: TestAccLambdaInvocation_triggers (111.09s)
--- PASS: TestAccLambdaInvocation_lifecycle_scopeCRUDDestroy (111.61s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     114.727s

...
```
