### PR TITLE
Remove unused links from `aws_default_route_table` docs

### DIFF
--- a/website/docs/r/default_route_table.html.markdown
+++ b/website/docs/r/default_route_table.html.markdown
@@ -122,6 +122,4 @@ Using `terraform import`, import Default VPC route tables using the `vpc_id`. Fo
 % terraform import aws_default_route_table.example vpc-33cc44dd
 ```
 
-[aws-route-tables]: http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Route_Tables.html#Route_Replacing_Main_Table
-[tf-route-tables]: /docs/providers/aws/r/route_table.html
 [tf-main-route-table-association]: /docs/providers/aws/r/main_route_table_association.html


### PR DESCRIPTION
### Description

This PR removes two unused links at the bottom of `aws_default_route_table` that are causing strange rendering in the Registry.

### Relations

Closes #32691

### References

- [Registry docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_route_table#import)

### Output from Acceptance Testing

N/a, docs
