### PR TITLE
fix: fixed ValidateFunc for phone_number

### DIFF
--- a/internal/service/account/primary_contact.go
+++ b/internal/service/account/primary_contact.go
@@ -76,7 +76,7 @@ func resourcePrimaryContact() *schema.Resource {
 			"phone_number": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[\s0-9()+-]+$`), "must be a valid phone number"),
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[+][\s0-9()-]+$`), "must be a valid phone number"),
 			},
 			"postal_code": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
I fixed a bug ValidateFunc in `aws_account_primary_contact` resource. AlternateContact and PrimaryContact have different PhoneNumber validation.

See https://docs.aws.amazon.com/accounts/latest/reference/API_ContactInformation.html#API_ContactInformation_Contents

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.


Relates #0000
or 
Closes #0000
--->
https://github.com/hashicorp/terraform-provider-aws/pull/26123

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

PrimaryContact
https://docs.aws.amazon.com/accounts/latest/reference/API_ContactInformation.html#API_ContactInformation_Contents

AlternateContact
https://docs.aws.amazon.com/accounts/latest/reference/API_AlternateContact.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
%  make testacc TESTS=testAccPrimaryContact_basic PKG=account
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/account/... -v -count 1 -parallel 20 -run='testAccPrimaryContact_basic'  -timeout 180m
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/account    2.052s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/account/retry      0.432s [no tests to run]
...
```
