### PR TITLE
fix: allow setting offpeakwindow at 00:00

### DIFF
--- a/internal/service/opensearch/domain_structure.go
+++ b/internal/service/opensearch/domain_structure.go
@@ -212,11 +212,11 @@ func expandWindowStartTime(tfMap map[string]interface{}) *opensearchservice.Wind
 
 	apiObject := &opensearchservice.WindowStartTime{}
 
-	if v, ok := tfMap["hours"].(int); ok && v != 0 {
+	if v, ok := tfMap["hours"].(int); ok {
 		apiObject.Hours = aws.Int64(int64(v))
 	}
 
-	if v, ok := tfMap["minutes"].(int); ok && v != 0 {
+	if v, ok := tfMap["minutes"].(int); ok {
 		apiObject.Minutes = aws.Int64(int64(v))
 	}
 

--- a/internal/service/opensearch/domain_test.go
+++ b/internal/service/opensearch/domain_test.go
@@ -1529,6 +1529,18 @@ func TestAccOpenSearchDomain_offPeakWindowOptions(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "off_peak_window_options.0.off_peak_window.0.window_start_time.0.minutes", "15"),
 				),
 			},
+			{
+				Config: testAccDomainConfig_offPeakWindowOptions(rName, 0, 0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "off_peak_window_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "off_peak_window_options.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "off_peak_window_options.0.off_peak_window.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "off_peak_window_options.0.off_peak_window.0.window_start_time.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "off_peak_window_options.0.off_peak_window.0.window_start_time.0.hours", "0"),
+					resource.TestCheckResourceAttr(resourceName, "off_peak_window_options.0.off_peak_window.0.window_start_time.0.minutes", "0"),
+				),
+			},
 		},
 	})
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Address the issue https://github.com/hashicorp/terraform-provider-aws/issues/32701 by allowing the user to set an `offpeakwindow` for an `aws_opensearch_domain` resource at `00:00` (it's the default behaviour when enabling it using the AWS CLI (https://docs.aws.amazon.com/opensearch-service/latest/developerguide/off-peak.html#off-peak-enable -> `If you don't specify a custom window start time, it defaults to 00:00 UTC.`).

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes [#32701](https://github.com/hashicorp/terraform-provider-aws/issues/32701)

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccOpenSearchDomain_offPeakWindowOptions PKG=opensearch

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/opensearch/... -v -count 1 -parallel 20 -run='TestAccOpenSearchDomain_offPeakWindowOptions'  -timeout 180m
=== RUN   TestAccOpenSearchDomain_offPeakWindowOptions
=== PAUSE TestAccOpenSearchDomain_offPeakWindowOptions
=== CONT  TestAccOpenSearchDomain_offPeakWindowOptions
--- PASS: TestAccOpenSearchDomain_offPeakWindowOptions (3036.64s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/opensearch 3038.802s
...
```
