### PR TITLE
docs(aws_eks_cluster_auth): update outdated note on resource imports

### DIFF
--- a/website/docs/cdktf/python/d/eks_cluster_auth.html.markdown
+++ b/website/docs/cdktf/python/d/eks_cluster_auth.html.markdown
@@ -17,7 +17,7 @@ Uses IAM credentials from the AWS provider to generate a temporary token that is
 This can be used to authenticate to an EKS cluster or to a cluster that has the AWS IAM Authenticator
 server configured.
 
-~> **NOTE:** Dynamically configuring a Terraform Provider via data sources currently has implications on [resource import support](https://github.com/hashicorp/terraform/issues/13018).
+~> **NOTE:** Dynamically configuring a Terraform Provider via data sources currently has implications on [resource import support](https://github.com/hashicorp/terraform/issues/13018) on Terraform `<1.3.0`.
 
 ## Example Usage
 

--- a/website/docs/cdktf/typescript/d/eks_cluster_auth.html.markdown
+++ b/website/docs/cdktf/typescript/d/eks_cluster_auth.html.markdown
@@ -17,7 +17,7 @@ Uses IAM credentials from the AWS provider to generate a temporary token that is
 This can be used to authenticate to an EKS cluster or to a cluster that has the AWS IAM Authenticator
 server configured.
 
-~> **NOTE:** Dynamically configuring a Terraform Provider via data sources currently has implications on [resource import support](https://github.com/hashicorp/terraform/issues/13018).
+~> **NOTE:** Dynamically configuring a Terraform Provider via data sources currently has implications on [resource import support](https://github.com/hashicorp/terraform/issues/13018) on Terraform `<1.3.0`.
 
 ## Example Usage
 

--- a/website/docs/d/eks_cluster_auth.html.markdown
+++ b/website/docs/d/eks_cluster_auth.html.markdown
@@ -15,7 +15,7 @@ Uses IAM credentials from the AWS provider to generate a temporary token that is
 This can be used to authenticate to an EKS cluster or to a cluster that has the AWS IAM Authenticator
 server configured.
 
-~> **NOTE:** Dynamically configuring a Terraform Provider via data sources currently has implications on [resource import support](https://github.com/hashicorp/terraform/issues/13018).
+~> **NOTE:** Dynamically configuring a Terraform Provider via data sources currently has implications on [resource import support](https://github.com/hashicorp/terraform/issues/13018) on Terraform `<1.3.0`.
 
 ## Example Usage
 


### PR DESCRIPTION
### Description
The documentation for [eks_cluster_auth](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) has a scary warning referring to a terraform limitation that has been solved since. I suggest we  mention in the note that only terraform versions `<1.3.0` are affected by the problem.

### Relations/References
* https://github.com/hashicorp/terraform/issues/13018#issuecomment-793108732
* https://github.com/hashicorp/terraform/issues/27934
* https://github.com/hashicorp/terraform/pull/31283

### Output from Acceptance Testing
N/A, this is a documentation change