### PR TITLE
Remove `backlog` Project Status variable

### DIFF
--- a/infrastructure/repository/projects.tf
+++ b/infrastructure/repository/projects.tf
@@ -17,7 +17,6 @@ variable "team_project_field_status_values" {
     "Waiting"       = "e85f2e5d",
     "Maintainer PR" = "28a034bc",
     "Pending Merge" = "043bc06e",
-    "Backlog"       = "ef47b7a3",
     "Done"          = "98236657"
   }
 }


### PR DESCRIPTION
### Description

"Backlog" is no longer one of our Status options in the Project, so removing the variable from the infrastructure configuration.

### Output from Acceptance Testing

N/a, Actions/Infra related