### PR TITLE
Add to Milestone: Conditional check for related issues

### DIFF
--- a/.ci/scripts/add-to-milestone.sh
+++ b/.ci/scripts/add-to-milestone.sh
@@ -77,4 +77,6 @@ ISSUES_URLS=($(jq \
 gh pr edit "$PULL_URL" --milestone "$MILESTONE_NAME"
 
 # Add issues to milestone
-gh issue edit "${ISSUES_URLS[@]}" --milestone "$MILESTONE_NAME"
+if [[ "${#ISSUES_URLS[@]}" -ne 0 ]]; then
+  gh issue edit "${ISSUES_URLS[@]}" --milestone "$MILESTONE_NAME"
+fi


### PR DESCRIPTION
### Description

This PR adds a condition to the `add-to-milestone.sh` script, used to add merged PRs and the issues that they close to the current milestone, such that failures don't occur when a merged PR doesn't close any additional issues.

### Relations

Relates #32707

### References

A couple of failed runs caused by not having this change:

- https://github.com/hashicorp/terraform-provider-aws/actions/runs/5684302407/job/15406701720
- https://github.com/hashicorp/terraform-provider-aws/actions/runs/5684283002/job/15406633532
- https://github.com/hashicorp/terraform-provider-aws/actions/runs/5684126080/job/15406151399

### Output from Acceptance Testing

N/a, actions
