### PR TITLE
Reflect new Amazon MQ for RabbitMQ support for configuration

### DIFF
--- a/internal/service/mq/configuration.go
+++ b/internal/service/mq/configuration.go
@@ -253,3 +253,18 @@ func suppressXMLEquivalentConfig(k, old, new string, d *schema.ResourceData) boo
 
 	return os == ns
 }
+
+func suppressCuttlefishEquivalentConfig(k, old, new string, d *schema.ResourceData) bool {
+	os, err := CanonicalCuttlefish(old)
+	if err != nil {
+		log.Printf("[ERR] Error getting canonicalCuttlefish from state (%s): %s", k, err)
+		return false
+	}
+	ns, err := CanonicalCuttlefish(new)
+	if err != nil {
+		log.Printf("[ERR] Error getting canonicalCuttlefish from config (%s): %s", k, err)
+		return false
+	}
+
+	return os == ns
+}

--- a/internal/service/mq/forge.go
+++ b/internal/service/mq/forge.go
@@ -27,3 +27,39 @@ func CanonicalXML(s string) (string, error) {
 	results := re.ReplaceAllString(rawString, "")
 	return results, nil
 }
+
+// CanonicalCuttlefish reads Cuttlefish in a string and re-writes it canonically, used for
+// comparing Cuttlefish for logical equivalency
+func CanonicalCuttlefish(input string) (string, error) {
+	commentRex := regexp.MustCompile(`^\s*(#.*)?$`)
+	includeRex := regexp.MustCompile(`^\s*include\s*([A-Za-z0-9-\_\.\*\/]+)\s*(#.*)?`)
+	settingRex := regexp.MustCompile(`^\s*([A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)*)\s*=\s*([^\s]+)\s*(#.*)?`)
+
+	v := []string{}
+	s := strings.Split(input, "\n")
+
+	for _, x := range s {
+		comment := commentRex.FindStringSubmatch(x)
+		include := includeRex.FindStringSubmatch(x)
+		setting := settingRex.FindStringSubmatch(x)
+
+		if comment != nil {
+			trimmedComment := strings.TrimSpace(comment[1])
+			if len(trimmedComment) > 0 {
+				v = append(v, trimmedComment)
+			}
+		}
+
+		if include != nil {
+			trimmedComment := strings.TrimSpace(include[2])
+			v = append(v, fmt.Sprintf("include %s%s", include[1], trimmedComment))
+		}
+
+		if setting != nil {
+			trimmedComment := strings.TrimSpace(setting[4])
+			v = append(v, fmt.Sprintf("%s=%s%s", setting[1], setting[3], trimmedComment))
+		}
+	}
+
+	return strings.Join(v[:], "\n"), nil
+}

--- a/website/docs/r/mq_broker.html.markdown
+++ b/website/docs/r/mq_broker.html.markdown
@@ -12,7 +12,7 @@ Provides an Amazon MQ broker resource. This resources also manages users for the
 
 -> For more information on Amazon MQ, see [Amazon MQ documentation](https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/welcome.html).
 
-~> **NOTE:** Amazon MQ currently places limits on **RabbitMQ** brokers. For example, a RabbitMQ broker cannot have: instances with an associated IP address of an ENI attached to the broker, an associated LDAP server to authenticate and authorize broker connections, storage type `EFS`, audit logging, or `configuration` blocks. Although this resource allows you to create RabbitMQ users, RabbitMQ users cannot have console access or groups. Also, Amazon MQ does not return information about RabbitMQ users so drift detection is not possible.
+~> **NOTE:** Amazon MQ currently places limits on **RabbitMQ** brokers. For example, a RabbitMQ broker cannot have: instances with an associated IP address of an ENI attached to the broker, an associated LDAP server to authenticate and authorize broker connections, storage type `EFS`, or audit logging. Although this resource allows you to create RabbitMQ users, RabbitMQ users cannot have console access or groups. Also, Amazon MQ does not return information about RabbitMQ users so drift detection is not possible.
 
 ~> **NOTE:** Changes to an MQ Broker can occur when you change a parameter, such as `configuration` or `user`, and are reflected in the next maintenance window. Because of this, Terraform may report a difference in its planning phase because a modification has not yet taken place. You can use the `apply_immediately` flag to instruct the service to apply the change immediately (see documentation below). Using `apply_immediately` can result in a brief downtime as the broker reboots.
 
@@ -84,7 +84,7 @@ The following arguments are optional:
 * `apply_immediately` - (Optional) Specifies whether any broker modifications are applied immediately, or during the next maintenance window. Default is `false`.
 * `authentication_strategy` - (Optional) Authentication strategy used to secure the broker. Valid values are `simple` and `ldap`. `ldap` is not supported for `engine_type` `RabbitMQ`.
 * `auto_minor_version_upgrade` - (Optional) Whether to automatically upgrade to new minor versions of brokers as Amazon MQ makes releases available.
-* `configuration` - (Optional) Configuration block for broker configuration. Applies to `engine_type` of `ActiveMQ` only. Detailed below.
+* `configuration` - (Optional) Configuration block for broker configuration. Detailed below.
 * `deployment_mode` - (Optional) Deployment mode of the broker. Valid values are `SINGLE_INSTANCE`, `ACTIVE_STANDBY_MULTI_AZ`, and `CLUSTER_MULTI_AZ`. Default is `SINGLE_INSTANCE`.
 * `encryption_options` - (Optional) Configuration block containing encryption options. Detailed below.
 * `ldap_server_metadata` - (Optional) Configuration block for the LDAP server used to authenticate and authorize connections to the broker. Not supported for `engine_type` `RabbitMQ`. Detailed below. (Currently, AWS may not process changes to LDAP server metadata.)

--- a/website/docs/r/mq_configuration.html.markdown
+++ b/website/docs/r/mq_configuration.html.markdown
@@ -38,7 +38,7 @@ DATA
 
 The following arguments are required:
 
-* `data` - (Required) Broker configuration in XML format. See [official docs](https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/amazon-mq-broker-configuration-parameters.html) for supported parameters and format of the XML.
+* `data` - (Required) Broker configuration in XML format for `engine_type` `ActiveMQ` and in Cuttlefish format for `engine_type` `RabbitMQ`. See [official docs](https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/amazon-mq-broker-configuration-parameters.html) for supported parameters and format.
 * `engine_type` - (Required) Type of broker engine. Valid values are `ActiveMQ` and `RabbitMQ`.
 * `engine_version` - (Required) Version of the broker engine.
 * `name` - (Required) Name of the configuration.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Amazon MQ released configuration support for RabbitMQ brokers. The RabbitMQ configuration files are in Cuttlefish format, while ActiveMQ uses XML.

I've updated the documentation so `aws_mq_broker` mentions that `configuration` applies to both `ActiveMQ` and `RabbitMQ`. Also the warning box at the top of the documentation for `aws_mq_broker` no longer mentions that RabbitMQ imposes restrictions on `configuration` blocks.

I am not very proficient in golang, but I wrote a function to produce canonical Cuttlefish configurations. I am not sure how to plug it with the rest of the code as I am unfamiliar with this codebase, and at first glance it seemed a bit involved to do.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #30797

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```

I have not updated the tests yet.