### PR TITLE
Include top-level `github.com/aws/aws-sdk-go-v2` module in `aws-sdk-go` dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
       aws-sdk-go:
         patterns:
           - "github.com/aws/aws-sdk-go"
+          - "github.com/aws/aws-sdk-go-v2"
           - "github.com/aws/aws-sdk-go-v2/*"
       aws-sdk-go-base:
         patterns:


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

There is a top-level [`github.com/aws/aws-sdk-go-v2` Go module](https://github.com/aws/aws-sdk-go-v2/blob/main/go.mod) that should be included in the `aws-sdk-go` dependabot group.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/32422.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/32397.