### PR TITLE
enhancement: add support of tags to filter RDS instances (#2988)

### DIFF
--- a/internal/service/rds/instances_data_source.go
+++ b/internal/service/rds/instances_data_source.go
@@ -5,15 +5,16 @@ package rds
 
 import (
 	"context"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/generate/namevaluesfilters"
 	"github.com/hashicorp/terraform-provider-aws/names"
+	"log"
 )
 
 // @SDKDataSource("aws_db_instances")
@@ -22,6 +23,26 @@ func DataSourceInstances() *schema.Resource {
 		ReadWithoutTimeout: dataSourceInstancesRead,
 
 		Schema: map[string]*schema.Schema{
+			"filter": namevaluesfilters.Schema(),
+			"tag": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+						"value": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+					},
+				},
+			},
+			// Computed values.
 			"instance_arns": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -32,7 +53,6 @@ func DataSourceInstances() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"filter": namevaluesfilters.Schema(),
 		},
 	}
 }
@@ -45,32 +65,65 @@ func dataSourceInstancesRead(ctx context.Context, d *schema.ResourceData, meta i
 	conn := meta.(*conns.AWSClient).RDSConn(ctx)
 
 	input := &rds.DescribeDBInstancesInput{}
-
-	if v, ok := d.GetOk("filter"); ok {
-		input.Filters = namevaluesfilters.New(v.(*schema.Set)).RDSFilters()
-	}
-
 	var instanceARNS []string
 	var instanceIdentifiers []string
 
-	err := conn.DescribeDBInstancesPagesWithContext(ctx, input, func(page *rds.DescribeDBInstancesOutput, lastPage bool) bool {
-		if page == nil {
-			return !lastPage
-		}
+	if v, ok := d.GetOk("filter"); ok {
+		input.Filters = namevaluesfilters.New(v.(*schema.Set)).RDSFilters()
 
-		for _, dbInstance := range page.DBInstances {
-			if dbInstance == nil {
-				continue
+		err := conn.DescribeDBInstancesPagesWithContext(ctx, input, func(page *rds.DescribeDBInstancesOutput, lastPage bool) bool {
+			if page == nil {
+				return !lastPage
 			}
 
-			instanceARNS = append(instanceARNS, aws.StringValue(dbInstance.DBInstanceArn))
-			instanceIdentifiers = append(instanceIdentifiers, aws.StringValue(dbInstance.DBInstanceIdentifier))
+			for _, dbInstance := range page.DBInstances {
+				if dbInstance == nil {
+					continue
+				}
+
+				instanceARNS = append(instanceARNS, aws.StringValue(dbInstance.DBInstanceArn))
+				instanceIdentifiers = append(instanceIdentifiers, aws.StringValue(dbInstance.DBInstanceIdentifier))
+			}
+
+			return !lastPage
+		})
+		if err != nil {
+			return create.DiagError(names.RDS, create.ErrActionReading, DSNameInstances, "", err)
+		}
+	}
+
+	if v, ok := d.GetOk("tag"); ok {
+		// Build map of tags to check, based on user request.
+		tags := v.(*schema.Set).List()
+		tagsToCheck := make(map[string]string)
+		for _, tag := range tags {
+			tagMap := tag.(map[string]interface{})
+			key := tagMap["key"].(string)
+			value := tagMap["value"].(string)
+			tagsToCheck[key] = value
 		}
 
-		return !lastPage
-	})
-	if err != nil {
-		return create.DiagError(names.RDS, create.ErrActionReading, DSNameInstances, "", err)
+		err := conn.DescribeDBInstancesPagesWithContext(ctx, input, func(page *rds.DescribeDBInstancesOutput, lastPage bool) bool {
+			if page == nil {
+				return !lastPage
+			}
+
+			for _, dbInstance := range page.DBInstances {
+				log.Printf("[DEBUG] DBInstanceIdentifier: %v", aws.StringValue(dbInstance.DBInstanceIdentifier))
+				if tagMatchKeyAndValue(tagsToCheck, dbInstance.TagList) {
+					instanceIdentifiers = append(instanceIdentifiers, aws.StringValue(dbInstance.DBInstanceIdentifier))
+					instanceARNS = append(instanceARNS, aws.StringValue(dbInstance.DBInstanceArn))
+				}
+			}
+			return !lastPage
+		})
+
+		if err != nil {
+			return create.DiagError(names.RDS, create.ErrActionReading, DSNameInstances, "", err)
+		}
+
+		log.Printf("[DEBUG] instanceARNS: %+v\n", instanceARNS)
+		log.Printf("[DEBUG] instanceIdentifiers: %+v\n", instanceIdentifiers)
 	}
 
 	d.SetId(meta.(*conns.AWSClient).Region)
@@ -78,4 +131,26 @@ func dataSourceInstancesRead(ctx context.Context, d *schema.ResourceData, meta i
 	d.Set("instance_identifiers", instanceIdentifiers)
 
 	return nil
+}
+
+func tagMatchKeyAndValue(tagsToCheck map[string]string, rdsInstanceTags []*rds.Tag) bool {
+	log.Printf("[DEBUG] Check if the following tags are present in instance tags: %v", tagsToCheck)
+	for key, desiredValue := range tagsToCheck {
+		isAMatch := false
+		for _, tag := range rdsInstanceTags {
+			if aws.StringValue(tag.Key) == key {
+				if aws.StringValue(tag.Value) == desiredValue {
+					isAMatch = true
+					log.Printf("[DEBUG] Matching key (%v) and value (%v)", aws.StringValue(tag.Key), aws.StringValue(tag.Value))
+					break
+				} else {
+					log.Printf("[DEBUG] Matching key (%v) but not value (%v)", aws.StringValue(tag.Key), aws.StringValue(tag.Value))
+				}
+			}
+		}
+		if !isAMatch {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
### Description
This MR allow users to filter RDS instances with tags. Usage is the following:

```
data "aws_db_instances" "this" {
  tag {
    key   = "Team"
    value = "Blue"
  }
}
```

It output instances ARNs and identifiers, like the current filter.

### Relations
Closes #2988

### Output from Acceptance Testing
```console
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSInstancesDataSource_'  -timeout 180m
=== RUN   TestAccRDSInstancesDataSource_filter
=== PAUSE TestAccRDSInstancesDataSource_filter
=== RUN   TestAccRDSInstancesDataSource_tags
=== PAUSE TestAccRDSInstancesDataSource_tags
=== CONT  TestAccRDSInstancesDataSource_filter
=== CONT  TestAccRDSInstancesDataSource_tags
--- PASS: TestAccRDSInstancesDataSource_filter (523.76s)
--- PASS: TestAccRDSInstancesDataSource_tags (523.97s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        525.859s
```
