### PR TITLE
Add REJECT action to Network Firewall rule group stateful rule actions

### DIFF
--- a/.changelog/32746.txt
+++ b/.changelog/32746.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_networkfirewall_rule_group: Add support for `REJECT` action in stateful rule actions
+```

--- a/internal/service/networkfirewall/rule_group_test.go
+++ b/internal/service/networkfirewall/rule_group_test.go
@@ -768,6 +768,19 @@ func TestAccNetworkFirewallRuleGroup_StatefulRule_action(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccRuleGroupConfig_statefulAction(rName, networkfirewall.StatefulActionReject),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRuleGroupExists(ctx, resourceName, &ruleGroup),
+					resource.TestCheckResourceAttr(resourceName, "rule_group.0.rules_source.0.stateful_rule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rule_group.0.rules_source.0.stateful_rule.0.action", networkfirewall.StatefulActionReject),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/website/docs/r/networkfirewall_rule_group.html.markdown
+++ b/website/docs/r/networkfirewall_rule_group.html.markdown
@@ -382,7 +382,7 @@ The `rules_source_list` block supports the following arguments:
 
 The `stateful_rule` block supports the following arguments:
 
-* `action` - (Required) Action to take with packets in a traffic flow when the flow matches the stateful rule criteria. For all actions, AWS Network Firewall performs the specified action and discontinues stateful inspection of the traffic flow. Valid values: `ALERT`, `DROP` or `PASS`.
+* `action` - (Required) Action to take with packets in a traffic flow when the flow matches the stateful rule criteria. For all actions, AWS Network Firewall performs the specified action and discontinues stateful inspection of the traffic flow. Valid values: `ALERT`, `DROP`, `PASS`, or `REJECT`.
 
 * `header` - (Required) A configuration block containing the stateful 5-tuple inspection criteria for the rule, used to inspect traffic flows. See [Header](#header) below for details.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

Adds formal support for the REJECT stateful rule action in the `aws_networkfirewall_rule_group` resource by adding acceptance tests and updating the documentation. Note that setting the REJECT action was possible previously due to the validation in `networkfirewall.StatefulAction_Values()`, but was not documented nor checked as part of the acceptance tests.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #28957

### References

What's New: https://aws.amazon.com/about-aws/whats-new/2023/01/aws-network-firewall-support-reject-action-tcp-traffic/
API: https://docs.aws.amazon.com/network-firewall/latest/APIReference/API_StatefulRule.html#networkfirewall-Type-StatefulRule-Action
SDK: https://github.com/aws/aws-sdk-go-v2/blob/service/networkfirewall/v1.28.5/service/networkfirewall/types/enums.go#L291


### Output from Acceptance Testing

```console
$ make testacc TESTARGS='-run=TestAccNetworkFirewallRuleGroup_StatefulRule_action' PKG=networkfirewall                                             
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/networkfirewall/... -v -count 1 -parallel 20  -run=TestAccNetworkFirewallRuleGroup_StatefulRule_action -timeout 180m
=== RUN   TestAccNetworkFirewallRuleGroup_StatefulRule_action
=== PAUSE TestAccNetworkFirewallRuleGroup_StatefulRule_action
=== CONT  TestAccNetworkFirewallRuleGroup_StatefulRule_action
--- PASS: TestAccNetworkFirewallRuleGroup_StatefulRule_action (208.34s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/networkfirewall    211.177s
```
