### PR TITLE
`aws_wafv2_web_acl_logging_configuration`: Clarify destination naming requirements

### DIFF
--- a/website/docs/r/wafv2_web_acl_logging_configuration.html.markdown
+++ b/website/docs/r/wafv2_web_acl_logging_configuration.html.markdown
@@ -120,7 +120,7 @@ data "aws_caller_identity" "current" {}
 
 This resource supports the following arguments:
 
-* `log_destination_configs` - (Required) Configuration block that allows you to associate Amazon Kinesis Data Firehose, Cloudwatch Log log group, or S3 bucket Amazon Resource Names (ARNs) with the web ACL.
+* `log_destination_configs` - (Required) Configuration block that allows you to associate Amazon Kinesis Data Firehose, Cloudwatch Log log group, or S3 bucket Amazon Resource Names (ARNs) with the web ACL. **Note:** data firehose, log group, or bucket name **must** be prefixed with `aws-waf-logs-`, e.g. `aws-waf-logs-example-firehose`, `aws-waf-logs-example-log-group`, or `aws-waf-logs-example-bucket`.
 * `logging_filter` - (Optional) Configuration block that specifies which web requests are kept in the logs and which are dropped. It allows filtering based on the rule action and the web request labels applied by matching rules during web ACL evaluation. For more details, refer to the [Logging Filter](#logging-filter) section below.
 * `redacted_fields` - (Optional) Configuration for parts of the request that you want to keep out of the logs. Up to 100 `redacted_fields` blocks are supported. See [Redacted Fields](#redacted-fields) below for more details.
 * `resource_arn` - (Required) Amazon Resource Name (ARN) of the web ACL that you want to associate with `log_destination_configs`.


### PR DESCRIPTION
### Description

This PR aims to make the documentation of `aws_wafv2_web_acl_logging_configuration` more clear about the requirement that the destination defined by `log_destination_configs` must be prefixed with `aws-waf-logs-`

### Relations

Closes #32262

### References

- [WAF: Amazon CloudWatch Logs](https://docs.aws.amazon.com/waf/latest/developerguide/logging-cw-logs.html)
- [WAF: Amazon Simple Storage Service](https://docs.aws.amazon.com/waf/latest/developerguide/logging-s3.html)
- [WAF: Amazon Kinesis Data Firehose](https://docs.aws.amazon.com/waf/latest/developerguide/logging-kinesis.html)

### Output from Acceptance Testing

N/a, docs
