### PR TITLE
r/aws_finspace(test): serialize finspace managed kdb tests

### DIFF
--- a/docs/acc-test-environment-variables.md
+++ b/docs/acc-test-environment-variables.md
@@ -67,6 +67,7 @@ Environment variables (beyond standard AWS Go SDK ones) used by acceptance testi
 | `EC2_SECURITY_GROUP_RULES_PER_GROUP_LIMIT` | EC2 Quota for Rules per Security Group. Defaults to 50. **DEPRECATED:** Can be augmented or replaced with Service Quotas lookup. |
 | `EVENT_BRIDGE_PARTNER_EVENT_BUS_NAME` | Amazon EventBridge partner event bus name. |
 | `EVENT_BRIDGE_PARTNER_EVENT_SOURCE_NAME` | Amazon EventBridge partner event source name. |
+| `FINSPACE_MANAGED_KX_LICENSE_ENABLED` | Enables tests requiring a license to provision managed KX resources. |
 | `GCM_API_KEY` | API Key for Google Cloud Messaging in Pinpoint and SNS Platform Application testing. |
 | `GITHUB_TOKEN` | GitHub token for CodePipeline testing. |
 | `GLOBALACCERATOR_BYOIP_IPV4_ADDRESS` | IPv4 address from a BYOIP CIDR of AWS Account used for testing Global Accelerator's BYOIP accelerator. |

--- a/internal/service/finspace/finspace_test.go
+++ b/internal/service/finspace/finspace_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package finspace_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccFinSpace_serial(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]map[string]func(t *testing.T){
+		"KxCluster": {
+			"autoScaling":          testAccKxCluster_autoScaling,
+			"basic":                testAccKxCluster_basic,
+			"cacheConfigurations":  testAccKxCluster_cacheConfigurations,
+			"code":                 testAccKxCluster_code,
+			"commandLineArgs":      testAccKxCluster_commandLineArgs,
+			"database":             testAccKxCluster_database,
+			"description":          testAccKxCluster_description,
+			"disappears":           testAccKxCluster_disappears,
+			"executionRole":        testAccKxCluster_executionRole,
+			"initializationScript": testAccKxCluster_initializationScript,
+			"multiAZ":              testAccKxCluster_multiAZ,
+			"rdb":                  testAccKxCluster_rdb,
+			"tags":                 testAccKxCluster_tags,
+		},
+		"KxDatabase": {
+			"basic":       testAccKxDatabase_basic,
+			"description": testAccKxDatabase_description,
+			"disappears":  testAccKxDatabase_disappears,
+			"tags":        testAccKxDatabase_tags,
+		},
+		"KxEnvironment": {
+			"basic":          testAccKxEnvironment_basic,
+			"customDNS":      testAccKxEnvironment_customDNS,
+			"description":    testAccKxEnvironment_description,
+			"disappears":     testAccKxEnvironment_disappears,
+			"tags":           testAccKxEnvironment_tags,
+			"transitGateway": testAccKxEnvironment_transitGateway,
+			"updateName":     testAccKxEnvironment_updateName,
+		},
+		"KxUser": {
+			"basic":      testAccKxUser_basic,
+			"disappears": testAccKxUser_disappears,
+			"tags":       testAccKxUser_tags,
+			"updateRole": testAccKxUser_updateRole,
+		},
+	}
+
+	acctest.RunSerialTests2Levels(t, testCases, 0)
+}

--- a/internal/service/finspace/kx_cluster_test.go
+++ b/internal/service/finspace/kx_cluster_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccFinSpaceKxCluster_basic(t *testing.T) {
+func testAccKxCluster_basic(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -32,7 +32,7 @@ func TestAccFinSpaceKxCluster_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_finspace_kx_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
@@ -58,7 +58,7 @@ func TestAccFinSpaceKxCluster_basic(t *testing.T) {
 	})
 }
 
-func TestAccFinSpaceKxCluster_disappears(t *testing.T) {
+func testAccKxCluster_disappears(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -68,7 +68,7 @@ func TestAccFinSpaceKxCluster_disappears(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_finspace_kx_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
@@ -89,7 +89,7 @@ func TestAccFinSpaceKxCluster_disappears(t *testing.T) {
 	})
 }
 
-func TestAccFinSpaceKxCluster_description(t *testing.T) {
+func testAccKxCluster_description(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -99,7 +99,7 @@ func TestAccFinSpaceKxCluster_description(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_finspace_kx_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
@@ -119,7 +119,7 @@ func TestAccFinSpaceKxCluster_description(t *testing.T) {
 	})
 }
 
-func TestAccFinSpaceKxCluster_database(t *testing.T) {
+func testAccKxCluster_database(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -129,7 +129,7 @@ func TestAccFinSpaceKxCluster_database(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_finspace_kx_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
@@ -149,7 +149,7 @@ func TestAccFinSpaceKxCluster_database(t *testing.T) {
 	})
 }
 
-func TestAccFinSpaceKxCluster_cacheConfigurations(t *testing.T) {
+func testAccKxCluster_cacheConfigurations(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -159,7 +159,7 @@ func TestAccFinSpaceKxCluster_cacheConfigurations(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_finspace_kx_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
@@ -179,7 +179,7 @@ func TestAccFinSpaceKxCluster_cacheConfigurations(t *testing.T) {
 	})
 }
 
-func TestAccFinSpaceKxCluster_code(t *testing.T) {
+func testAccKxCluster_code(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -190,7 +190,7 @@ func TestAccFinSpaceKxCluster_code(t *testing.T) {
 	resourceName := "aws_finspace_kx_cluster.test"
 	codePath := "test-fixtures/code.zip"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
@@ -209,7 +209,7 @@ func TestAccFinSpaceKxCluster_code(t *testing.T) {
 	})
 }
 
-func TestAccFinSpaceKxCluster_multiAZ(t *testing.T) {
+func testAccKxCluster_multiAZ(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -219,7 +219,7 @@ func TestAccFinSpaceKxCluster_multiAZ(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_finspace_kx_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
@@ -239,7 +239,7 @@ func TestAccFinSpaceKxCluster_multiAZ(t *testing.T) {
 	})
 }
 
-func TestAccFinSpaceKxCluster_rdb(t *testing.T) {
+func testAccKxCluster_rdb(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -249,7 +249,7 @@ func TestAccFinSpaceKxCluster_rdb(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_finspace_kx_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
@@ -269,7 +269,7 @@ func TestAccFinSpaceKxCluster_rdb(t *testing.T) {
 	})
 }
 
-func TestAccFinSpaceKxCluster_executionRole(t *testing.T) {
+func testAccKxCluster_executionRole(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -279,7 +279,7 @@ func TestAccFinSpaceKxCluster_executionRole(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_finspace_kx_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
@@ -299,7 +299,7 @@ func TestAccFinSpaceKxCluster_executionRole(t *testing.T) {
 	})
 }
 
-func TestAccFinSpaceKxCluster_autoScaling(t *testing.T) {
+func testAccKxCluster_autoScaling(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -309,7 +309,7 @@ func TestAccFinSpaceKxCluster_autoScaling(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_finspace_kx_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
@@ -329,7 +329,7 @@ func TestAccFinSpaceKxCluster_autoScaling(t *testing.T) {
 	})
 }
 
-func TestAccFinSpaceKxCluster_initializationScript(t *testing.T) {
+func testAccKxCluster_initializationScript(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -342,7 +342,7 @@ func TestAccFinSpaceKxCluster_initializationScript(t *testing.T) {
 	codePath := "test-fixtures/code.zip"
 	initScriptPath := "code/helloworld.q"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
@@ -361,7 +361,7 @@ func TestAccFinSpaceKxCluster_initializationScript(t *testing.T) {
 	})
 }
 
-func TestAccFinSpaceKxCluster_commandLineArgs(t *testing.T) {
+func testAccKxCluster_commandLineArgs(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -371,7 +371,7 @@ func TestAccFinSpaceKxCluster_commandLineArgs(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_finspace_kx_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
@@ -392,7 +392,7 @@ func TestAccFinSpaceKxCluster_commandLineArgs(t *testing.T) {
 	})
 }
 
-func TestAccFinSpaceKxCluster_tags(t *testing.T) {
+func testAccKxCluster_tags(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -402,7 +402,7 @@ func TestAccFinSpaceKxCluster_tags(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_finspace_kx_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)

--- a/internal/service/finspace/kx_cluster_test.go
+++ b/internal/service/finspace/kx_cluster_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -22,6 +23,15 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
+func testAccPreCheckManagedKxLicenseEnabled(t *testing.T) {
+	if os.Getenv("FINSPACE_MANAGED_KX_LICENSE_ENABLED") == "" {
+		t.Skip(
+			"Environment variable FINSPACE_MANAGED_KX_LICENSE_ENABLED is not set. " +
+				"Certain managed KX resources require the target account to have an active " +
+				"license. Set the environment variable to any value to enable these tests.")
+	}
+}
+
 func testAccKxCluster_basic(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -36,6 +46,7 @@ func testAccKxCluster_basic(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
+			testAccPreCheckManagedKxLicenseEnabled(t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, finspace.ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -72,6 +83,7 @@ func testAccKxCluster_disappears(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
+			testAccPreCheckManagedKxLicenseEnabled(t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, finspace.ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -103,6 +115,7 @@ func testAccKxCluster_description(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
+			testAccPreCheckManagedKxLicenseEnabled(t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, finspace.ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -133,6 +146,7 @@ func testAccKxCluster_database(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
+			testAccPreCheckManagedKxLicenseEnabled(t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, finspace.ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -163,6 +177,7 @@ func testAccKxCluster_cacheConfigurations(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
+			testAccPreCheckManagedKxLicenseEnabled(t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, finspace.ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -194,6 +209,7 @@ func testAccKxCluster_code(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
+			testAccPreCheckManagedKxLicenseEnabled(t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, finspace.ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -223,6 +239,7 @@ func testAccKxCluster_multiAZ(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
+			testAccPreCheckManagedKxLicenseEnabled(t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, finspace.ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -253,6 +270,7 @@ func testAccKxCluster_rdb(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
+			testAccPreCheckManagedKxLicenseEnabled(t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, finspace.ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -283,6 +301,7 @@ func testAccKxCluster_executionRole(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
+			testAccPreCheckManagedKxLicenseEnabled(t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, finspace.ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -313,6 +332,7 @@ func testAccKxCluster_autoScaling(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
+			testAccPreCheckManagedKxLicenseEnabled(t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, finspace.ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -346,6 +366,7 @@ func testAccKxCluster_initializationScript(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
+			testAccPreCheckManagedKxLicenseEnabled(t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, finspace.ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -375,6 +396,7 @@ func testAccKxCluster_commandLineArgs(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
+			testAccPreCheckManagedKxLicenseEnabled(t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, finspace.ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -406,6 +428,7 @@ func testAccKxCluster_tags(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
+			testAccPreCheckManagedKxLicenseEnabled(t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, finspace.ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/finspace/kx_database_test.go
+++ b/internal/service/finspace/kx_database_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccFinSpaceKxDatabase_basic(t *testing.T) {
+func testAccKxDatabase_basic(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -32,7 +32,7 @@ func TestAccFinSpaceKxDatabase_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_finspace_kx_database.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
@@ -57,7 +57,7 @@ func TestAccFinSpaceKxDatabase_basic(t *testing.T) {
 	})
 }
 
-func TestAccFinSpaceKxDatabase_disappears(t *testing.T) {
+func testAccKxDatabase_disappears(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -67,7 +67,7 @@ func TestAccFinSpaceKxDatabase_disappears(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_finspace_kx_database.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
@@ -88,7 +88,7 @@ func TestAccFinSpaceKxDatabase_disappears(t *testing.T) {
 	})
 }
 
-func TestAccFinSpaceKxDatabase_description(t *testing.T) {
+func testAccKxDatabase_description(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -98,7 +98,7 @@ func TestAccFinSpaceKxDatabase_description(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_finspace_kx_database.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
@@ -125,7 +125,7 @@ func TestAccFinSpaceKxDatabase_description(t *testing.T) {
 	})
 }
 
-func TestAccFinSpaceKxDatabase_tags(t *testing.T) {
+func testAccKxDatabase_tags(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -135,7 +135,7 @@ func TestAccFinSpaceKxDatabase_tags(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_finspace_kx_database.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)

--- a/internal/service/finspace/kx_environment_test.go
+++ b/internal/service/finspace/kx_environment_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccFinSpaceKxEnvironment_basic(t *testing.T) {
+func testAccKxEnvironment_basic(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -33,7 +33,7 @@ func TestAccFinSpaceKxEnvironment_basic(t *testing.T) {
 	resourceName := "aws_finspace_kx_environment.test"
 	kmsKeyResourceName := "aws_kms_key.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
@@ -59,7 +59,7 @@ func TestAccFinSpaceKxEnvironment_basic(t *testing.T) {
 	})
 }
 
-func TestAccFinSpaceKxEnvironment_disappears(t *testing.T) {
+func testAccKxEnvironment_disappears(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -69,7 +69,7 @@ func TestAccFinSpaceKxEnvironment_disappears(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_finspace_kx_environment.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
@@ -90,7 +90,7 @@ func TestAccFinSpaceKxEnvironment_disappears(t *testing.T) {
 	})
 }
 
-func TestAccFinSpaceKxEnvironment_updateName(t *testing.T) {
+func testAccKxEnvironment_updateName(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -101,7 +101,7 @@ func TestAccFinSpaceKxEnvironment_updateName(t *testing.T) {
 	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_finspace_kx_environment.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
@@ -128,7 +128,7 @@ func TestAccFinSpaceKxEnvironment_updateName(t *testing.T) {
 	})
 }
 
-func TestAccFinSpaceKxEnvironment_description(t *testing.T) {
+func testAccKxEnvironment_description(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -138,7 +138,7 @@ func TestAccFinSpaceKxEnvironment_description(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_finspace_kx_environment.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
@@ -165,7 +165,7 @@ func TestAccFinSpaceKxEnvironment_description(t *testing.T) {
 	})
 }
 
-func TestAccFinSpaceKxEnvironment_customDNS(t *testing.T) {
+func testAccKxEnvironment_customDNS(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -175,7 +175,7 @@ func TestAccFinSpaceKxEnvironment_customDNS(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_finspace_kx_environment.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
@@ -208,7 +208,7 @@ func TestAccFinSpaceKxEnvironment_customDNS(t *testing.T) {
 	})
 }
 
-func TestAccFinSpaceKxEnvironment_transitGateway(t *testing.T) {
+func testAccKxEnvironment_transitGateway(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -218,7 +218,7 @@ func TestAccFinSpaceKxEnvironment_transitGateway(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_finspace_kx_environment.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
@@ -240,7 +240,7 @@ func TestAccFinSpaceKxEnvironment_transitGateway(t *testing.T) {
 	})
 }
 
-func TestAccFinSpaceKxEnvironment_tags(t *testing.T) {
+func testAccKxEnvironment_tags(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -250,7 +250,7 @@ func TestAccFinSpaceKxEnvironment_tags(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_finspace_kx_environment.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)

--- a/internal/service/finspace/kx_user_test.go
+++ b/internal/service/finspace/kx_user_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccFinSpaceKxUser_basic(t *testing.T) {
+func testAccKxUser_basic(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -33,7 +33,7 @@ func TestAccFinSpaceKxUser_basic(t *testing.T) {
 	userName := sdkacctest.RandString(sdkacctest.RandIntRange(1, 50))
 	resourceName := "aws_finspace_kx_user.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
@@ -58,7 +58,7 @@ func TestAccFinSpaceKxUser_basic(t *testing.T) {
 	})
 }
 
-func TestAccFinSpaceKxUser_disappears(t *testing.T) {
+func testAccKxUser_disappears(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -69,7 +69,7 @@ func TestAccFinSpaceKxUser_disappears(t *testing.T) {
 	userName := sdkacctest.RandString(sdkacctest.RandIntRange(1, 50))
 	resourceName := "aws_finspace_kx_user.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
@@ -90,7 +90,7 @@ func TestAccFinSpaceKxUser_disappears(t *testing.T) {
 	})
 }
 
-func TestAccFinSpaceKxUser_updateRole(t *testing.T) {
+func testAccKxUser_updateRole(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -101,7 +101,7 @@ func TestAccFinSpaceKxUser_updateRole(t *testing.T) {
 	userName := sdkacctest.RandString(sdkacctest.RandIntRange(1, 50))
 	resourceName := "aws_finspace_kx_user.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
@@ -126,7 +126,7 @@ func TestAccFinSpaceKxUser_updateRole(t *testing.T) {
 	})
 }
 
-func TestAccFinSpaceKxUser_tags(t *testing.T) {
+func testAccKxUser_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -137,7 +137,7 @@ func TestAccFinSpaceKxUser_tags(t *testing.T) {
 	userName := sdkacctest.RandString(sdkacctest.RandIntRange(1, 50))
 	resourceName := "aws_finspace_kx_user.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)


### PR DESCRIPTION
### Description
Serializes tests for FinSpace managed kdb resources, as the default quota for kdb environments in an account is 1. Also gates the Kx Cluster resource tests with an environment variable (`FINSPACE_MANAGED_KX_LICENSE_ENABLED`), as these require an active license before resources can be provisioned.


### Relations
Closes #32646 

### References
- https://docs.aws.amazon.com/finspace/latest/userguide/finspace-quotas.html


### Output from Acceptance Testing


```console
$ make testacc TESTARGS='-run=TestAccFinSpace_serial/KxUser' PKG=finspace
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/finspace/... -v -count 1 -parallel 20  -run=TestAccFinSpace_serial/KxUser -timeout 180m

--- PASS: TestAccFinSpace_serial (4054.43s)
    --- PASS: TestAccFinSpace_serial/KxUser (4054.43s)
        --- PASS: TestAccFinSpace_serial/KxUser/basic (1049.37s)
        --- PASS: TestAccFinSpace_serial/KxUser/disappears (1006.28s)
        --- PASS: TestAccFinSpace_serial/KxUser/tags (1034.16s)
        --- PASS: TestAccFinSpace_serial/KxUser/updateRole (964.62s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/finspace   4057.200s
```

```console
$ make testacc TESTARGS='-run=TestAccFinSpace_serial/KxDatabase' PKG=finspace
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/finspace/... -v -count 1 -parallel 20  -run=TestAccFinSpace_serial/KxDatabase -timeout 180m

--- PASS: TestAccFinSpace_serial (4369.34s)
    --- PASS: TestAccFinSpace_serial/KxDatabase (4369.34s)
        --- PASS: TestAccFinSpace_serial/KxDatabase/disappears (1075.31s)
        --- PASS: TestAccFinSpace_serial/KxDatabase/tags (1097.18s)
        --- PASS: TestAccFinSpace_serial/KxDatabase/basic (1038.65s)
        --- PASS: TestAccFinSpace_serial/KxDatabase/description (1158.20s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/finspace   4372.401s
```

```console
$ make testacc TESTARGS='-run=TestAccFinSpace_serial/KxEnvironment' PKG=finspace
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/finspace/... -v -count 1 -parallel 20  -run=TestAccFinSpace_serial/KxEnvironment -timeout 180m

--- PASS: TestAccFinSpace_serial (8372.82s)
    --- PASS: TestAccFinSpace_serial/KxEnvironment (8372.82s)
        --- PASS: TestAccFinSpace_serial/KxEnvironment/description (1035.45s)
        --- PASS: TestAccFinSpace_serial/KxEnvironment/disappears (1064.18s)
        --- PASS: TestAccFinSpace_serial/KxEnvironment/tags (1010.35s)
        --- PASS: TestAccFinSpace_serial/KxEnvironment/transitGateway (1806.44s)
        --- PASS: TestAccFinSpace_serial/KxEnvironment/updateName (1026.11s)
        --- PASS: TestAccFinSpace_serial/KxEnvironment/basic (972.01s)
        --- PASS: TestAccFinSpace_serial/KxEnvironment/customDNS (1458.29s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/finspace   8375.734s
```