### PR TITLE
td/mediapackage: convert to sdkv2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.39.0
 	github.com/aws/aws-sdk-go-v2/service/lightsail v1.28.0
 	github.com/aws/aws-sdk-go-v2/service/medialive v1.33.0
+	github.com/aws/aws-sdk-go-v2/service/mediapackage v1.22.0
 	github.com/aws/aws-sdk-go-v2/service/oam v1.2.0
 	github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.4.0
 	github.com/aws/aws-sdk-go-v2/service/pipes v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,8 @@ github.com/aws/aws-sdk-go-v2/service/lightsail v1.28.0 h1:uPcs5wJMkNs1oqPCZG7Mpz
 github.com/aws/aws-sdk-go-v2/service/lightsail v1.28.0/go.mod h1:0+AaCxJlxNKV1nGRPmmnHWKcZzdwyP30IULufraPhUo=
 github.com/aws/aws-sdk-go-v2/service/medialive v1.33.0 h1:5c92kxyd/XDoCL/z/TYhwH4rqacYX/Vncoq2qpM//qs=
 github.com/aws/aws-sdk-go-v2/service/medialive v1.33.0/go.mod h1:NEPP6VehNNOlBGGqP3k/wzSbfthSLJhOLKj19jlIqDw=
+github.com/aws/aws-sdk-go-v2/service/mediapackage v1.22.0 h1:o0VJt1OZudBoA8JK2G7Q/OQOFok2f3vudRBciIYahbU=
+github.com/aws/aws-sdk-go-v2/service/mediapackage v1.22.0/go.mod h1:1U0FuoIvRvKia+HOI7KSom/wK8JLSg+GqRpHIBJEX6M=
 github.com/aws/aws-sdk-go-v2/service/oam v1.2.0 h1:OmuZfJhTIozUY2DYuywOPscyZhpyT0tbXaTK0E7scRQ=
 github.com/aws/aws-sdk-go-v2/service/oam v1.2.0/go.mod h1:0o69v1eI37ZwMUjiFBR3KaeoYuI1wG35nfV+nwDM/+Q=
 github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.4.0 h1:if9GJsdhxevdCm8I15fulht96PgFGfacpUPKKSFKLO0=

--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -162,7 +162,6 @@ import (
 	managedgrafana_sdkv1 "github.com/aws/aws-sdk-go/service/managedgrafana"
 	mediaconnect_sdkv1 "github.com/aws/aws-sdk-go/service/mediaconnect"
 	mediaconvert_sdkv1 "github.com/aws/aws-sdk-go/service/mediaconvert"
-	mediapackage_sdkv1 "github.com/aws/aws-sdk-go/service/mediapackage"
 	mediastore_sdkv1 "github.com/aws/aws-sdk-go/service/mediastore"
 	memorydb_sdkv1 "github.com/aws/aws-sdk-go/service/memorydb"
 	mq_sdkv1 "github.com/aws/aws-sdk-go/service/mq"
@@ -753,10 +752,6 @@ func (c *AWSClient) MediaConvertConn(ctx context.Context) *mediaconvert_sdkv1.Me
 
 func (c *AWSClient) MediaLiveClient(ctx context.Context) *medialive_sdkv2.Client {
 	return errs.Must(client[*medialive_sdkv2.Client](ctx, c, names.MediaLive))
-}
-
-func (c *AWSClient) MediaPackageConn(ctx context.Context) *mediapackage_sdkv1.MediaPackage {
-	return errs.Must(conn[*mediapackage_sdkv1.MediaPackage](ctx, c, names.MediaPackage))
 }
 
 func (c *AWSClient) MediaPackageClient(ctx context.Context) *mediapackage_sdkv2.Client {

--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -31,6 +31,7 @@ import (
 	lambda_sdkv2 "github.com/aws/aws-sdk-go-v2/service/lambda"
 	lightsail_sdkv2 "github.com/aws/aws-sdk-go-v2/service/lightsail"
 	medialive_sdkv2 "github.com/aws/aws-sdk-go-v2/service/medialive"
+	mediapackage_sdkv2 "github.com/aws/aws-sdk-go-v2/service/mediapackage"
 	oam_sdkv2 "github.com/aws/aws-sdk-go-v2/service/oam"
 	opensearchserverless_sdkv2 "github.com/aws/aws-sdk-go-v2/service/opensearchserverless"
 	pipes_sdkv2 "github.com/aws/aws-sdk-go-v2/service/pipes"
@@ -756,6 +757,10 @@ func (c *AWSClient) MediaLiveClient(ctx context.Context) *medialive_sdkv2.Client
 
 func (c *AWSClient) MediaPackageConn(ctx context.Context) *mediapackage_sdkv1.MediaPackage {
 	return errs.Must(conn[*mediapackage_sdkv1.MediaPackage](ctx, c, names.MediaPackage))
+}
+
+func (c *AWSClient) MediaPackageClient(ctx context.Context) *mediapackage_sdkv2.Client {
+	return errs.Must(client[*mediapackage_sdkv2.Client](ctx, c, names.MediaPackage))
 }
 
 func (c *AWSClient) MediaStoreConn(ctx context.Context) *mediastore_sdkv1.MediaStore {

--- a/internal/service/mediapackage/channel.go
+++ b/internal/service/mediapackage/channel.go
@@ -115,14 +115,15 @@ func resourceChannelRead(ctx context.Context, d *schema.ResourceData, meta inter
 	conn := meta.(*conns.AWSClient).MediaPackageClient(ctx)
 
 	resp, err := findChannelByID(ctx, conn, d.Id())
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "describing MediaPackage Channel: %s", err)
-	}
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] MediaPackage Channel (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
+	}
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading MediaPackage Channel: %s", err)
 	}
 
 	d.Set("arn", resp.Arn)

--- a/internal/service/mediapackage/channel.go
+++ b/internal/service/mediapackage/channel.go
@@ -234,6 +234,8 @@ func findChannelByID(ctx context.Context, conn *mediapackage.Client, id string) 
 				LastError:   err,
 			}
 		}
+
+		return nil, err
 	}
 
 	if out == nil {

--- a/internal/service/mediapackage/channel.go
+++ b/internal/service/mediapackage/channel.go
@@ -5,13 +5,14 @@ package mediapackage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/mediapackage"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/mediapackage"
+	"github.com/aws/aws-sdk-go-v2/service/mediapackage/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -90,7 +91,7 @@ func ResourceChannel() *schema.Resource {
 
 func resourceChannelCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).MediaPackageConn(ctx)
+	conn := meta.(*conns.AWSClient).MediaPackageClient(ctx)
 
 	input := &mediapackage.CreateChannelInput{
 		Id:          aws.String(d.Get("channel_id").(string)),
@@ -98,24 +99,24 @@ func resourceChannelCreate(ctx context.Context, d *schema.ResourceData, meta int
 		Tags:        getTagsIn(ctx),
 	}
 
-	resp, err := conn.CreateChannelWithContext(ctx, input)
+	resp, err := conn.CreateChannel(ctx, input)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating MediaPackage Channel: %s", err)
 	}
 
-	d.SetId(aws.StringValue(resp.Id))
+	d.SetId(aws.ToString(resp.Id))
 
 	return append(diags, resourceChannelRead(ctx, d, meta)...)
 }
 
 func resourceChannelRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).MediaPackageConn(ctx)
+	conn := meta.(*conns.AWSClient).MediaPackageClient(ctx)
 
 	input := &mediapackage.DescribeChannelInput{
 		Id: aws.String(d.Id()),
 	}
-	resp, err := conn.DescribeChannelWithContext(ctx, input)
+	resp, err := conn.DescribeChannel(ctx, input)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "describing MediaPackage Channel: %s", err)
 	}
@@ -134,14 +135,14 @@ func resourceChannelRead(ctx context.Context, d *schema.ResourceData, meta inter
 
 func resourceChannelUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).MediaPackageConn(ctx)
+	conn := meta.(*conns.AWSClient).MediaPackageClient(ctx)
 
 	input := &mediapackage.UpdateChannelInput{
 		Id:          aws.String(d.Id()),
 		Description: aws.String(d.Get("description").(string)),
 	}
 
-	_, err := conn.UpdateChannelWithContext(ctx, input)
+	_, err := conn.UpdateChannel(ctx, input)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "updating MediaPackage Channel: %s", err)
 	}
@@ -151,14 +152,15 @@ func resourceChannelUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 func resourceChannelDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).MediaPackageConn(ctx)
+	conn := meta.(*conns.AWSClient).MediaPackageClient(ctx)
 
 	input := &mediapackage.DeleteChannelInput{
 		Id: aws.String(d.Id()),
 	}
-	_, err := conn.DeleteChannelWithContext(ctx, input)
+	_, err := conn.DeleteChannel(ctx, input)
 	if err != nil {
-		if tfawserr.ErrCodeEquals(err, mediapackage.ErrCodeNotFoundException) {
+		var nfe *types.NotFoundException
+		if errors.As(err, &nfe) {
 			return diags
 		}
 		return sdkdiag.AppendErrorf(diags, "deleting MediaPackage Channel: %s", err)
@@ -168,9 +170,10 @@ func resourceChannelDelete(ctx context.Context, d *schema.ResourceData, meta int
 		Id: aws.String(d.Id()),
 	}
 	err = retry.RetryContext(ctx, 5*time.Minute, func() *retry.RetryError {
-		_, err := conn.DescribeChannelWithContext(ctx, dcinput)
+		_, err := conn.DescribeChannel(ctx, dcinput)
 		if err != nil {
-			if tfawserr.ErrCodeEquals(err, mediapackage.ErrCodeNotFoundException) {
+			var nfe *types.NotFoundException
+			if errors.As(err, &nfe) {
 				return nil
 			}
 			return retry.NonRetryableError(err)
@@ -178,7 +181,7 @@ func resourceChannelDelete(ctx context.Context, d *schema.ResourceData, meta int
 		return retry.RetryableError(fmt.Errorf("MediaPackage Channel (%s) still exists", d.Id()))
 	})
 	if tfresource.TimedOut(err) {
-		_, err = conn.DescribeChannelWithContext(ctx, dcinput)
+		_, err = conn.DescribeChannel(ctx, dcinput)
 	}
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for MediaPackage Channel (%s) deletion: %s", d.Id(), err)
@@ -187,7 +190,7 @@ func resourceChannelDelete(ctx context.Context, d *schema.ResourceData, meta int
 	return diags
 }
 
-func flattenHLSIngest(h *mediapackage.HlsIngest) []map[string]interface{} {
+func flattenHLSIngest(h *types.HlsIngest) []map[string]interface{} {
 	if h.IngestEndpoints == nil {
 		return []map[string]interface{}{
 			{"ingest_endpoints": []map[string]interface{}{}},
@@ -197,9 +200,9 @@ func flattenHLSIngest(h *mediapackage.HlsIngest) []map[string]interface{} {
 	var ingestEndpoints []map[string]interface{}
 	for _, e := range h.IngestEndpoints {
 		endpoint := map[string]interface{}{
-			"password": aws.StringValue(e.Password),
-			"url":      aws.StringValue(e.Url),
-			"username": aws.StringValue(e.Username),
+			"password": aws.ToString(e.Password),
+			"url":      aws.ToString(e.Url),
+			"username": aws.ToString(e.Username),
 		}
 
 		ingestEndpoints = append(ingestEndpoints, endpoint)

--- a/internal/service/mediapackage/channel_test.go
+++ b/internal/service/mediapackage/channel_test.go
@@ -27,7 +27,11 @@ func TestAccMediaPackageChannel_basic(t *testing.T) {
 	resourceName := "aws_media_package_channel.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, strings.ToLower(mediapackage.ServiceID))
+			testAccPreCheck(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, strings.ToLower(mediapackage.ServiceID)),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckChannelDestroy(ctx),
@@ -60,7 +64,11 @@ func TestAccMediaPackageChannel_description(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, strings.ToLower(mediapackage.ServiceID))
+			testAccPreCheck(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, strings.ToLower(mediapackage.ServiceID)),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckChannelDestroy(ctx),
@@ -94,7 +102,11 @@ func TestAccMediaPackageChannel_tags(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, strings.ToLower(mediapackage.ServiceID))
+			testAccPreCheck(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, strings.ToLower(mediapackage.ServiceID)),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckChannelDestroy(ctx),
@@ -128,6 +140,33 @@ func TestAccMediaPackageChannel_tags(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Update", "true"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccMediaPackageChannel_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_media_package_channel.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, strings.ToLower(mediapackage.ServiceID))
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, strings.ToLower(mediapackage.ServiceID)),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckChannelDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccChannelConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckChannelExists(ctx, resourceName),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfmediapackage.ResourceChannel(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/service/mediapackage/channel_test.go
+++ b/internal/service/mediapackage/channel_test.go
@@ -7,30 +7,33 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/mediapackage"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/mediapackage"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfmediapackage "github.com/hashicorp/terraform-provider-aws/internal/service/mediapackage"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func TestAccMediaPackageChannel_basic(t *testing.T) {
 	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_media_package_channel.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, mediapackage.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, strings.ToLower(mediapackage.ServiceID)),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckChannelDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccChannelConfig_basic(sdkacctest.RandString(5)),
+				Config: testAccChannelConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckChannelExists(ctx, resourceName),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "mediapackage", regexp.MustCompile(`channels/.+`)),
@@ -58,7 +61,7 @@ func TestAccMediaPackageChannel_description(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, mediapackage.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, strings.ToLower(mediapackage.ServiceID)),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckChannelDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -92,7 +95,7 @@ func TestAccMediaPackageChannel_tags(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, mediapackage.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, strings.ToLower(mediapackage.ServiceID)),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckChannelDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -132,23 +135,23 @@ func TestAccMediaPackageChannel_tags(t *testing.T) {
 
 func testAccCheckChannelDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).MediaPackageConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).MediaPackageClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_media_package_channel" {
 				continue
 			}
 
-			input := &mediapackage.DescribeChannelInput{
-				Id: aws.String(rs.Primary.ID),
-			}
-
-			_, err := conn.DescribeChannelWithContext(ctx, input)
+			_, err := tfmediapackage.FindChannelByID(ctx, conn, rs.Primary.ID)
 			if err == nil {
 				return fmt.Errorf("MediaPackage Channel (%s) not deleted", rs.Primary.ID)
 			}
 
-			if !tfawserr.ErrCodeEquals(err, mediapackage.ErrCodeNotFoundException) {
+			if tfresource.NotFound(err) {
+				continue
+			}
+
+			if err != nil {
 				return err
 			}
 		}
@@ -164,24 +167,24 @@ func testAccCheckChannelExists(ctx context.Context, name string) resource.TestCh
 			return fmt.Errorf("Not found: %s", name)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).MediaPackageConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).MediaPackageClient(ctx)
 
 		input := &mediapackage.DescribeChannelInput{
 			Id: aws.String(rs.Primary.ID),
 		}
 
-		_, err := conn.DescribeChannelWithContext(ctx, input)
+		_, err := conn.DescribeChannel(ctx, input)
 
 		return err
 	}
 }
 
 func testAccPreCheck(ctx context.Context, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).MediaPackageConn(ctx)
+	conn := acctest.Provider.Meta().(*conns.AWSClient).MediaPackageClient(ctx)
 
 	input := &mediapackage.ListChannelsInput{}
 
-	_, err := conn.ListChannelsWithContext(ctx, input)
+	_, err := conn.ListChannels(ctx, input)
 
 	if acctest.PreCheckSkipError(err) {
 		t.Skipf("skipping acceptance testing: %s", err)
@@ -195,7 +198,7 @@ func testAccPreCheck(ctx context.Context, t *testing.T) {
 func testAccChannelConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_media_package_channel" "test" {
-  channel_id = "tf_mediachannel_%s"
+  channel_id = %[1]q
 }
 `, rName)
 }
@@ -203,8 +206,8 @@ resource "aws_media_package_channel" "test" {
 func testAccChannelConfig_description(rName, description string) string {
 	return fmt.Sprintf(`
 resource "aws_media_package_channel" "test" {
-  channel_id  = %q
-  description = %q
+  channel_id  = %[1]q
+  description = %[2]q
 }
 `, rName, description)
 }
@@ -212,12 +215,12 @@ resource "aws_media_package_channel" "test" {
 func testAccChannelConfig_tags(rName, key, value string) string {
 	return fmt.Sprintf(`
 resource "aws_media_package_channel" "test" {
-  channel_id = "%[1]s"
+  channel_id = %[1]q
 
   tags = {
-    Name = "%[1]s"
+    Name = %[1]q
 
-    %[2]s = "%[3]s"
+    %[2]s = %[3]q
   }
 }
 `, rName, key, value)

--- a/internal/service/mediapackage/export_test.go
+++ b/internal/service/mediapackage/export_test.go
@@ -1,0 +1,9 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package mediapackage
+
+// Exports for use in tests only.
+var (
+	FindChannelByID = findChannelByID
+)

--- a/internal/service/mediapackage/generate.go
+++ b/internal/service/mediapackage/generate.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-//go:generate go run ../../generate/tags/main.go -ListTags -ServiceTagsMap -UpdateTags
+//go:generate go run ../../generate/tags/main.go -AWSSDKVersion=2 -SkipTypesImp=true -KVTValues -ListTags -ServiceTagsMap -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/mediapackage/service_package_gen.go
+++ b/internal/service/mediapackage/service_package_gen.go
@@ -7,9 +7,6 @@ import (
 
 	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
 	mediapackage_sdkv2 "github.com/aws/aws-sdk-go-v2/service/mediapackage"
-	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
-	session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
-	mediapackage_sdkv1 "github.com/aws/aws-sdk-go/service/mediapackage"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -44,13 +41,6 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 
 func (p *servicePackage) ServicePackageName() string {
 	return names.MediaPackage
-}
-
-// NewConn returns a new AWS SDK for Go v1 client for this service package's AWS API.
-func (p *servicePackage) NewConn(ctx context.Context, config map[string]any) (*mediapackage_sdkv1.MediaPackage, error) {
-	sess := config["session"].(*session_sdkv1.Session)
-
-	return mediapackage_sdkv1.New(sess.Copy(&aws_sdkv1.Config{Endpoint: aws_sdkv1.String(config["endpoint"].(string))})), nil
 }
 
 // NewClient returns a new AWS SDK for Go v2 client for this service package's AWS API.

--- a/internal/service/mediapackage/service_package_gen.go
+++ b/internal/service/mediapackage/service_package_gen.go
@@ -5,6 +5,8 @@ package mediapackage
 import (
 	"context"
 
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	mediapackage_sdkv2 "github.com/aws/aws-sdk-go-v2/service/mediapackage"
 	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
 	session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
 	mediapackage_sdkv1 "github.com/aws/aws-sdk-go/service/mediapackage"
@@ -49,6 +51,17 @@ func (p *servicePackage) NewConn(ctx context.Context, config map[string]any) (*m
 	sess := config["session"].(*session_sdkv1.Session)
 
 	return mediapackage_sdkv1.New(sess.Copy(&aws_sdkv1.Config{Endpoint: aws_sdkv1.String(config["endpoint"].(string))})), nil
+}
+
+// NewClient returns a new AWS SDK for Go v2 client for this service package's AWS API.
+func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (*mediapackage_sdkv2.Client, error) {
+	cfg := *(config["aws_sdkv2_config"].(*aws_sdkv2.Config))
+
+	return mediapackage_sdkv2.NewFromConfig(cfg, func(o *mediapackage_sdkv2.Options) {
+		if endpoint := config["endpoint"].(string); endpoint != "" {
+			o.EndpointResolver = mediapackage_sdkv2.EndpointResolverFromURL(endpoint)
+		}
+	}), nil
 }
 
 func ServicePackage(ctx context.Context) conns.ServicePackage {

--- a/internal/service/mediapackage/sweep.go
+++ b/internal/service/mediapackage/sweep.go
@@ -1,0 +1,69 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build sweep
+// +build sweep
+
+package mediapackage
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/mediapackage"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_media_package_channel", &resource.Sweeper{
+		Name: "aws_media_package_channel",
+		F:    sweepChannels,
+	})
+}
+
+func sweepChannels(region string) error {
+	ctx := sweep.Context(region)
+	client, err := sweep.SharedRegionalSweepClient(ctx, region)
+	if err != nil {
+		return fmt.Errorf("getting client: %s", err)
+	}
+
+	conn := client.MediaPackageClient(ctx)
+	sweepResources := make([]sweep.Sweepable, 0)
+	in := &mediapackage.ListChannelsInput{}
+
+	pages := mediapackage.NewListChannelsPaginator(conn, in)
+
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+
+		if awsv2.SkipSweepError(err) {
+			log.Println("[WARN] Skipping MediaPackage Channels sweep for %s: %s", region, err)
+			return nil
+		}
+
+		if err != nil {
+			return fmt.Errorf("retrieving MediaPackage Channels: %w", err)
+		}
+
+		for _, channel := range page.Channels {
+			id := aws.ToString(channel.Id)
+			log.Printf("[INFO] Deleting MediaChannel Channel: %s", id)
+
+			r := ResourceChannel()
+			d := r.Data(nil)
+			d.SetId(id)
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+	}
+
+	if err := sweep.SweepOrchestrator(ctx, sweepResources); err != nil {
+		return fmt.Errorf("sweeping Mediapackage Channels for %s: %w", region, err)
+	}
+
+	return nil
+}

--- a/internal/service/mediapackage/tags_gen.go
+++ b/internal/service/mediapackage/tags_gen.go
@@ -5,9 +5,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/mediapackage"
-	"github.com/aws/aws-sdk-go/service/mediapackage/mediapackageiface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/mediapackage"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/types"
@@ -17,12 +16,12 @@ import (
 // listTags lists mediapackage service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn mediapackageiface.MediaPackageAPI, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *mediapackage.Client, identifier string) (tftags.KeyValueTags, error) {
 	input := &mediapackage.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResourceWithContext(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -34,7 +33,7 @@ func listTags(ctx context.Context, conn mediapackageiface.MediaPackageAPI, ident
 // ListTags lists mediapackage service tags and set them in Context.
 // It is called from outside this package.
 func (p *servicePackage) ListTags(ctx context.Context, meta any, identifier string) error {
-	tags, err := listTags(ctx, meta.(*conns.AWSClient).MediaPackageConn(ctx), identifier)
+	tags, err := listTags(ctx, meta.(*conns.AWSClient).MediaPackageClient(ctx), identifier)
 
 	if err != nil {
 		return err
@@ -47,21 +46,21 @@ func (p *servicePackage) ListTags(ctx context.Context, meta any, identifier stri
 	return nil
 }
 
-// map[string]*string handling
+// map[string]string handling
 
 // Tags returns mediapackage service tags.
-func Tags(tags tftags.KeyValueTags) map[string]*string {
-	return aws.StringMap(tags.Map())
+func Tags(tags tftags.KeyValueTags) map[string]string {
+	return tags.Map()
 }
 
 // KeyValueTags creates tftags.KeyValueTags from mediapackage service tags.
-func KeyValueTags(ctx context.Context, tags map[string]*string) tftags.KeyValueTags {
+func KeyValueTags(ctx context.Context, tags map[string]string) tftags.KeyValueTags {
 	return tftags.New(ctx, tags)
 }
 
 // getTagsIn returns mediapackage service tags from Context.
 // nil is returned if there are no input tags.
-func getTagsIn(ctx context.Context) map[string]*string {
+func getTagsIn(ctx context.Context) map[string]string {
 	if inContext, ok := tftags.FromContext(ctx); ok {
 		if tags := Tags(inContext.TagsIn.UnwrapOrDefault()); len(tags) > 0 {
 			return tags
@@ -72,7 +71,7 @@ func getTagsIn(ctx context.Context) map[string]*string {
 }
 
 // setTagsOut sets mediapackage service tags in Context.
-func setTagsOut(ctx context.Context, tags map[string]*string) {
+func setTagsOut(ctx context.Context, tags map[string]string) {
 	if inContext, ok := tftags.FromContext(ctx); ok {
 		inContext.TagsOut = types.Some(KeyValueTags(ctx, tags))
 	}
@@ -81,7 +80,7 @@ func setTagsOut(ctx context.Context, tags map[string]*string) {
 // updateTags updates mediapackage service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn mediapackageiface.MediaPackageAPI, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *mediapackage.Client, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -90,10 +89,10 @@ func updateTags(ctx context.Context, conn mediapackageiface.MediaPackageAPI, ide
 	if len(removedTags) > 0 {
 		input := &mediapackage.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.Keys()),
+			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResourceWithContext(ctx, input)
+		_, err := conn.UntagResource(ctx, input)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -108,7 +107,7 @@ func updateTags(ctx context.Context, conn mediapackageiface.MediaPackageAPI, ide
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResourceWithContext(ctx, input)
+		_, err := conn.TagResource(ctx, input)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)
@@ -121,5 +120,5 @@ func updateTags(ctx context.Context, conn mediapackageiface.MediaPackageAPI, ide
 // UpdateTags updates mediapackage service tags.
 // It is called from outside this package.
 func (p *servicePackage) UpdateTags(ctx context.Context, meta any, identifier string, oldTags, newTags any) error {
-	return updateTags(ctx, meta.(*conns.AWSClient).MediaPackageConn(ctx), identifier, oldTags, newTags)
+	return updateTags(ctx, meta.(*conns.AWSClient).MediaPackageClient(ctx), identifier, oldTags, newTags)
 }

--- a/internal/sweep/sweep_test.go
+++ b/internal/sweep/sweep_test.go
@@ -99,6 +99,7 @@ import (
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/location"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/logs"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/medialive"
+	_ "github.com/hashicorp/terraform-provider-aws/internal/service/mediapackage"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/memorydb"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/mq"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/mwaa"

--- a/names/names_data.csv
+++ b/names/names_data.csv
@@ -141,7 +141,7 @@ elb,elb,elb,elasticloadbalancing,,elb,,elasticloadbalancing,ELB,ELB,,1,,aws_(app
 mediaconnect,mediaconnect,mediaconnect,mediaconnect,,mediaconnect,,,MediaConnect,MediaConnect,,1,,,aws_mediaconnect_,,media_connect_,Elemental MediaConnect,AWS,,,,,,
 mediaconvert,mediaconvert,mediaconvert,mediaconvert,,mediaconvert,,,MediaConvert,MediaConvert,,1,,aws_media_convert_,aws_mediaconvert_,,media_convert_,Elemental MediaConvert,AWS,,,,,,
 medialive,medialive,medialive,medialive,,medialive,,,MediaLive,MediaLive,,,2,,aws_medialive_,,medialive_,Elemental MediaLive,AWS,,,,,,
-mediapackage,mediapackage,mediapackage,mediapackage,,mediapackage,,,MediaPackage,MediaPackage,,1,,aws_media_package_,aws_mediapackage_,,media_package_,Elemental MediaPackage,AWS,,,,,,
+mediapackage,mediapackage,mediapackage,mediapackage,,mediapackage,,,MediaPackage,MediaPackage,,1,2,aws_media_package_,aws_mediapackage_,,media_package_,Elemental MediaPackage,AWS,,,,,,
 mediapackage-vod,mediapackagevod,mediapackagevod,mediapackagevod,,mediapackagevod,,,MediaPackageVOD,MediaPackageVod,,1,,,aws_mediapackagevod_,,mediapackagevod_,Elemental MediaPackage VOD,AWS,,x,,,,
 mediastore,mediastore,mediastore,mediastore,,mediastore,,,MediaStore,MediaStore,,1,,aws_media_store_,aws_mediastore_,,media_store_,Elemental MediaStore,AWS,,,,,,
 mediastore-data,mediastoredata,mediastoredata,mediastoredata,,mediastoredata,,,MediaStoreData,MediaStoreData,,1,,,aws_mediastoredata_,,mediastoredata_,Elemental MediaStore Data,AWS,,x,,,,

--- a/names/names_data.csv
+++ b/names/names_data.csv
@@ -141,7 +141,7 @@ elb,elb,elb,elasticloadbalancing,,elb,,elasticloadbalancing,ELB,ELB,,1,,aws_(app
 mediaconnect,mediaconnect,mediaconnect,mediaconnect,,mediaconnect,,,MediaConnect,MediaConnect,,1,,,aws_mediaconnect_,,media_connect_,Elemental MediaConnect,AWS,,,,,,
 mediaconvert,mediaconvert,mediaconvert,mediaconvert,,mediaconvert,,,MediaConvert,MediaConvert,,1,,aws_media_convert_,aws_mediaconvert_,,media_convert_,Elemental MediaConvert,AWS,,,,,,
 medialive,medialive,medialive,medialive,,medialive,,,MediaLive,MediaLive,,,2,,aws_medialive_,,medialive_,Elemental MediaLive,AWS,,,,,,
-mediapackage,mediapackage,mediapackage,mediapackage,,mediapackage,,,MediaPackage,MediaPackage,,1,2,aws_media_package_,aws_mediapackage_,,media_package_,Elemental MediaPackage,AWS,,,,,,
+mediapackage,mediapackage,mediapackage,mediapackage,,mediapackage,,,MediaPackage,MediaPackage,,,2,aws_media_package_,aws_mediapackage_,,media_package_,Elemental MediaPackage,AWS,,,,,,
 mediapackage-vod,mediapackagevod,mediapackagevod,mediapackagevod,,mediapackagevod,,,MediaPackageVOD,MediaPackageVod,,1,,,aws_mediapackagevod_,,mediapackagevod_,Elemental MediaPackage VOD,AWS,,x,,,,
 mediastore,mediastore,mediastore,mediastore,,mediastore,,,MediaStore,MediaStore,,1,,aws_media_store_,aws_mediastore_,,media_store_,Elemental MediaStore,AWS,,,,,,
 mediastore-data,mediastoredata,mediastoredata,mediastoredata,,mediastoredata,,,MediaStoreData,MediaStoreData,,1,,,aws_mediastoredata_,,mediastoredata_,Elemental MediaStore Data,AWS,,x,,,,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

sdkv1 -> sdkv2

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTARGS='-run=TestAccMediaPackageChannel_' PKG=mediapackage

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/mediapackage/... -v -count 1 -parallel 20  -run=TestAccMediaPackageChannel_ -timeout 180m
--- PASS: TestAccMediaPackageChannel_disappears (17.76s)
--- PASS: TestAccMediaPackageChannel_basic (22.48s)
--- PASS: TestAccMediaPackageChannel_description (35.69s)
--- PASS: TestAccMediaPackageChannel_tags (52.90s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/mediapackage	56.004s
```


### Sweepers

```console
$ make sweep SWEEPARGS=-sweep-run=aws_media_package_channel

# make sweep SWEEPARGS=-sweep-run=aws_example_thing
# set SWEEPARGS=-sweep-allow-failures to continue after first failure
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./internal/sweep -v -tags=sweep -sweep=us-west-2,us-east-1,us-east-2,us-west-1 -sweep-run=aws_media_package_channel -timeout 60m
2023/08/01 11:55:31 [DEBUG] Running Sweepers for region (us-west-2):
2023/08/01 11:55:31 [DEBUG] Running Sweeper (aws_media_package_channel) in region (us-west-2)
2023/08/01 11:55:32 [DEBUG] Completed Sweeper (aws_media_package_channel) in region (us-west-2) in 1.014490292s
2023/08/01 11:55:32 Completed Sweepers for region (us-west-2) in 1.014714542s
2023/08/01 11:55:32 Sweeper Tests for region (us-west-2) ran successfully:
2023/08/01 11:55:32 	- aws_media_package_channel
2023/08/01 11:55:32 [DEBUG] Running Sweepers for region (us-east-1):
2023/08/01 11:55:32 [DEBUG] Running Sweeper (aws_media_package_channel) in region (us-east-1)
2023/08/01 11:55:33 [DEBUG] Completed Sweeper (aws_media_package_channel) in region (us-east-1) in 777.970375ms
2023/08/01 11:55:33 Completed Sweepers for region (us-east-1) in 778.006834ms
2023/08/01 11:55:33 Sweeper Tests for region (us-east-1) ran successfully:
2023/08/01 11:55:33 	- aws_media_package_channel
2023/08/01 11:55:33 [DEBUG] Running Sweepers for region (us-east-2):
2023/08/01 11:55:33 [DEBUG] Running Sweeper (aws_media_package_channel) in region (us-east-2)
2023/08/01 11:55:34 [DEBUG] Completed Sweeper (aws_media_package_channel) in region (us-east-2) in 642.179417ms
2023/08/01 11:55:34 Completed Sweepers for region (us-east-2) in 642.265167ms
2023/08/01 11:55:34 Sweeper Tests for region (us-east-2) ran successfully:
2023/08/01 11:55:34 	- aws_media_package_channel
2023/08/01 11:55:34 [DEBUG] Running Sweepers for region (us-west-1):
2023/08/01 11:55:34 [DEBUG] Running Sweeper (aws_media_package_channel) in region (us-west-1)
2023/08/01 11:55:35 [DEBUG] Completed Sweeper (aws_media_package_channel) in region (us-west-1) in 928.965917ms
2023/08/01 11:55:35 Completed Sweepers for region (us-west-1) in 929.016458ms
2023/08/01 11:55:35 Sweeper Tests for region (us-west-1) ran successfully:
2023/08/01 11:55:35 	- aws_media_package_channel
ok  	github.com/hashicorp/terraform-provider-aws/internal/sweep	6.300s
```