### PR TITLE
Correct typo in quicksight `schema.flattenInsightConfiguration`

### DIFF
--- a/.changelog/32791.txt
+++ b/.changelog/32791.txt
@@ -1,0 +1,11 @@
+```release-note:bug
+resource/aws_quicksight_analysis: Fix an error related to setting the value for `definition.sheets.visuals.insight_visual.insight_configuration.computation`
+```
+
+```release-note:bug
+resource/aws_quicksight_dashboard: Fix an error related to setting the value for `definition.sheets.visuals.insight_visual.insight_configuration.computation`
+```
+
+```release-note:bug
+resource/aws_quicksight_template: Fix an error related to setting the value for `definition.sheets.visuals.insight_visual.insight_configuration.computation`
+```

--- a/internal/service/quicksight/schema/visual_insight.go
+++ b/internal/service/quicksight/schema/visual_insight.go
@@ -746,7 +746,7 @@ func flattenInsightConfiguration(apiObject *quicksight.InsightConfiguration) []i
 
 	tfMap := map[string]interface{}{}
 	if apiObject.Computations != nil {
-		tfMap["computations"] = flattenComputation(apiObject.Computations)
+		tfMap["computation"] = flattenComputation(apiObject.Computations)
 	}
 	if apiObject.CustomNarrative != nil {
 		tfMap["custom_narrative"] = flattenCustomNarrativeOptions(apiObject.CustomNarrative)


### PR DESCRIPTION
### Description

This PR corrects a typo in the `flattenInsightConfiguration` function for QuickSight that caused the following error:

```shell
Error: setting definition: Invalid address to set: []string{"definition", "0", "sheets", "6", "visuals", "0", "insight_visual", "0", "insight_configuration", "0", "computations"}
```

The correct address to set is `computation` rather than `computations`.

### Relations

Closes #32788

### References

- [Schema reference (`insightVisualSchema`)](https://github.com/hashicorp/terraform-provider-aws/blob/216156267f7cdc1aa2f9160a7d26a4e841ac40f5/internal/service/quicksight/schema/visual_insight.go#L31)


### Output from Acceptance Testing

I'm not able to run the acceptance tests for this one, unfortunately.