### PR TITLE
Correct `aws_ecs_task_execution` data source `container_overrides` expander

### DIFF
--- a/.changelog/32793.txt
+++ b/.changelog/32793.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_ecs_task_execution: Fixed bug that incorrectly mapped the value of `container_overrides.memory` to `container_overrides.memory_reservation`
+```

--- a/internal/service/ecs/task_execution_data_source.go
+++ b/internal/service/ecs/task_execution_data_source.go
@@ -433,7 +433,7 @@ func expandContainerOverride(tfList []interface{}) []*ecs.ContainerOverride {
 			co.Memory = aws.Int64(int64(v.(int)))
 		}
 		if v, ok := tfMap["memory_reservation"]; ok {
-			co.Memory = aws.Int64(int64(v.(int)))
+			co.MemoryReservation = aws.Int64(int64(v.(int)))
 		}
 		if v, ok := tfMap["resource_requirements"]; ok {
 			co.ResourceRequirements = expandResourceRequirements(v.(*schema.Set))


### PR DESCRIPTION
### Description

This PR corrects an issue where the `container_overrides` expander of the `aws_ecs_task_execution` data source incorrectly set the value of `memory_reservation` to the value of `memory`.

### Relations

Closes #32785

### References

- [`ecs.ContainerOverride`](https://docs.aws.amazon.com/sdk-for-go/api/service/ecs/#ContainerOverride)

### Output from Acceptance Testing

```console
$ make testacc TESTS=TestAccECSTaskExecutionDataSource PKG=ecs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSTaskExecutionDataSource'  -timeout 180m
=== RUN   TestAccECSTaskExecutionDataSource_basic
=== PAUSE TestAccECSTaskExecutionDataSource_basic
=== RUN   TestAccECSTaskExecutionDataSource_overrides
=== PAUSE TestAccECSTaskExecutionDataSource_overrides
=== RUN   TestAccECSTaskExecutionDataSource_tags
=== PAUSE TestAccECSTaskExecutionDataSource_tags
=== CONT  TestAccECSTaskExecutionDataSource_basic
=== CONT  TestAccECSTaskExecutionDataSource_tags
=== CONT  TestAccECSTaskExecutionDataSource_overrides
--- PASS: TestAccECSTaskExecutionDataSource_basic (291.62s)
--- PASS: TestAccECSTaskExecutionDataSource_tags (294.08s)
--- PASS: TestAccECSTaskExecutionDataSource_overrides (294.54s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecs        297.653s
```
