### PR TITLE
vpc/route_table: Allow local inline routes

### DIFF
--- a/.changelog/32794.txt
+++ b/.changelog/32794.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_route_table: Allow a `route` with `gateway_id = "local"` to be imported and modified
+```

--- a/.changelog/32794.txt
+++ b/.changelog/32794.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_route_table: Allow an existing route to be changed to/from a `local` target such as `gateway_id = "local"` and `network_interface_id = "eni-0bf6fcb204c94231e"`
+resource/aws_route_table: Allow an existing local route to be adopted or imported and the target to be updated
 ```

--- a/.changelog/32794.txt
+++ b/.changelog/32794.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_route_table: Allow a `route` with `gateway_id = "local"` to be imported and modified
+resource/aws_route_table: Allow an existing route to be changed to/from a `local` target such as `gateway_id = "local"` and `network_interface_id = "eni-0bf6fcb204c94231e"`
 ```

--- a/internal/service/ec2/vpc_route_data_source_test.go
+++ b/internal/service/ec2/vpc_route_data_source_test.go
@@ -280,7 +280,7 @@ resource "aws_instance" "test" {
 resource "aws_route" "instance" {
   route_table_id         = aws_route_table.test.id
   destination_cidr_block = "10.0.1.0/24"
-  instance_id            = aws_instance.test.id
+  network_interface_id   = aws_instance.test.primary_network_interface_id
 }
 
 data "aws_route" "by_peering_connection_id" {

--- a/internal/service/ec2/vpc_route_table.go
+++ b/internal/service/ec2/vpc_route_table.go
@@ -869,11 +869,13 @@ func flattenRoutes(ctx context.Context, d *schema.ResourceData, conn *ec2.EC2, a
 	return tfList
 }
 
-// hasLocalConfig along with flattenRoutes prevents default "local" routes made
-// by AWS from getting stored in state. They do this by checking the
-// ResourceData. Normally, you can't count on ResourceData to represent config.
-// However, in this case, a local gateway route in ResourceData must come from
-// config because of the gatekeeping done by hasLocalConfig and flattenRoutes.
+// hasLocalConfig along with flattenRoutes prevents default local routes from
+// being stored in state but allows configured local routes to be stored in
+// state. hasLocalConfig checks the ResourceData and flattenRoutes skips or
+// includes the route. Normally, you can't count on ResourceData to represent
+// config. However, in this case, a local gateway route in ResourceData must
+// come from config because of the gatekeeping done by hasLocalConfig and
+// flattenRoutes.
 func hasLocalConfig(d *schema.ResourceData, apiObject *ec2.Route) bool {
 	if apiObject.GatewayId == nil {
 		return false

--- a/internal/service/ec2/vpc_route_table.go
+++ b/internal/service/ec2/vpc_route_table.go
@@ -507,7 +507,6 @@ func routeTableAddRoute(ctx context.Context, conn *ec2.EC2, routeTableID string,
 		errCodeInvalidTransitGatewayIDNotFound,
 	)
 
-	// local routes can be adopted
 	if err != nil {
 		return fmt.Errorf("creating Route in Route Table (%s) with destination (%s): %w", routeTableID, destination, err)
 	}

--- a/internal/service/ec2/vpc_route_table.go
+++ b/internal/service/ec2/vpc_route_table.go
@@ -243,7 +243,7 @@ func resourceRouteTableRead(ctx context.Context, d *schema.ResourceData, meta in
 	if err := d.Set("propagating_vgws", propagatingVGWs); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting propagating_vgws: %s", err)
 	}
-	if err := d.Set("route", flattenRoutes(ctx, d, conn, routeTable.Routes)); err != nil {
+	if err := d.Set("route", flattenRoutes(ctx, conn, d, routeTable.Routes)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting route: %s", err)
 	}
 	d.Set("vpc_id", routeTable.VpcId)
@@ -835,7 +835,7 @@ func flattenRoute(apiObject *ec2.Route) map[string]interface{} {
 	return tfMap
 }
 
-func flattenRoutes(ctx context.Context, d *schema.ResourceData, conn *ec2.EC2, apiObjects []*ec2.Route) []interface{} {
+func flattenRoutes(ctx context.Context, conn *ec2.EC2, d *schema.ResourceData, apiObjects []*ec2.Route) []interface{} {
 	if len(apiObjects) == 0 {
 		return nil
 	}

--- a/internal/service/ec2/vpc_route_table_test.go
+++ b/internal/service/ec2/vpc_route_table_test.go
@@ -1810,6 +1810,10 @@ func testAccVPCRouteTableConfig_ipv4EndpointID(rName, destinationCidr string) st
 		fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 
+data "aws_iam_session_context" "current" {
+  arn = data.aws_caller_identity.current.arn
+}
+
 resource "aws_vpc" "test" {
   cidr_block = "10.10.10.0/25"
 
@@ -1839,7 +1843,7 @@ resource "aws_lb" "test" {
 
 resource "aws_vpc_endpoint_service" "test" {
   acceptance_required        = false
-  allowed_principals         = [data.aws_caller_identity.current.arn]
+  allowed_principals         = [data.aws_iam_session_context.current.issuer_arn]
   gateway_load_balancer_arns = [aws_lb.test.arn]
 
   tags = {

--- a/internal/service/ec2/vpc_route_table_test.go
+++ b/internal/service/ec2/vpc_route_table_test.go
@@ -1147,33 +1147,6 @@ func TestAccVPCRouteTable_localRouteUpdate(t *testing.T) {
 	})
 }
 
-func testAccCreateRouteTable(ctx context.Context, v *ec2.Vpc) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Conn(ctx)
-		if v.VpcId == nil {
-			return fmt.Errorf("no VPC ID")
-		}
-		input := &ec2.CreateRouteTableInput{
-			VpcId: v.VpcId,
-		}
-
-		output, err := conn.CreateRouteTableWithContext(ctx, input)
-
-		if err != nil {
-			return fmt.Errorf("test creating route table: %w", err)
-		}
-
-		if output == nil || output.RouteTable == nil {
-			return fmt.Errorf("test creating route table: %s", "nil output")
-		}
-
-		if _, err := tfec2.WaitRouteTableReady(ctx, conn, aws.StringValue(output.RouteTable.RouteTableId), time.Minute*2); err != nil {
-			return fmt.Errorf("waiting for test creating route table: %s", err)
-		}
-		return nil
-	}
-}
-
 func testAccCheckRouteTableExists(ctx context.Context, n string, v *ec2.RouteTable) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/internal/service/ec2/vpc_route_table_test.go
+++ b/internal/service/ec2/vpc_route_table_test.go
@@ -1033,6 +1033,147 @@ func TestAccVPCRouteTable_prefixListToInternetGateway(t *testing.T) {
 	})
 }
 
+func TestAccVPCRouteTable_localRoute(t *testing.T) {
+	ctx := acctest.Context(t)
+	var routeTable ec2.RouteTable
+	var vpc ec2.Vpc
+	resourceName := "aws_route_table.test"
+	vpcResourceName := "aws_vpc.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRouteDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCRouteTableConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckVPCExists(ctx, vpcResourceName, &vpc),
+					testAccCheckRouteTableExists(ctx, resourceName, &routeTable),
+					testAccCheckRouteTableNumberOfRoutes(&routeTable, 1),
+				),
+			},
+			{
+				Config:            testAccVPCRouteTableConfig_ipv4Local(rName),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccVPCRouteTable_localRouteUpdate(t *testing.T) {
+	ctx := acctest.Context(t)
+	var routeTable ec2.RouteTable
+	var vpc ec2.Vpc
+	resourceName := "aws_route_table.test"
+	rteResourceName := "aws_route.test"
+	vpcResourceName := "aws_vpc.test"
+	eniResourceName := "aws_network_interface.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	vpcCIDR := "10.1.0.0/16"
+	eniCIDR := "10.1.0.0/16"
+	subnetCIDR := "10.1.1.0/24"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRouteDestroy(ctx),
+		Steps: []resource.TestStep{
+			// This test is a little wonky. Because there's no way (that I
+			// could figure anyway) to use aws_route_table to import a local
+			// route and then persist it to the next step since the route is
+			// inline rather than a separate resource. Instead, it uses
+			// aws_route config rather than aws_route_table w/ inline routes
+			// for steps 1-3 and then does slight of hand, switching
+			// to aws_route_table to finish the test.
+			{
+				Config: testAccVPCRouteConfig_ipv4NoRoute(rName),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckVPCExists(ctx, vpcResourceName, &vpc),
+					testAccCheckRouteTableExists(ctx, resourceName, &routeTable),
+					testAccCheckRouteTableNumberOfRoutes(&routeTable, 1),
+				),
+			},
+			{
+				Config:       testAccVPCRouteConfig_ipv4Local(rName),
+				ResourceName: rteResourceName,
+				ImportState:  true,
+				ImportStateIdFunc: func(rt *ec2.RouteTable, v *ec2.Vpc) resource.ImportStateIdFunc {
+					return func(s *terraform.State) (string, error) {
+						return fmt.Sprintf("%s_%s", aws.StringValue(rt.RouteTableId), aws.StringValue(v.CidrBlock)), nil
+					}
+				}(&routeTable, &vpc),
+				ImportStatePersist: true,
+				// Don't verify the state as the local route isn't actually in the pre-import state.
+				// Just running ImportState verifies that we can import a local route.
+				ImportStateVerify: false,
+			},
+			{
+				Config: testAccVPCRouteConfig_ipv4LocalToNetworkInterface(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckVPCExists(ctx, vpcResourceName, &vpc),
+					testAccCheckRouteTableExists(ctx, resourceName, &routeTable),
+					testAccCheckRouteTableNumberOfRoutes(&routeTable, 1),
+					resource.TestCheckResourceAttr(rteResourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttrPair(rteResourceName, "network_interface_id", eniResourceName, "id"),
+				),
+			},
+			{
+				Config: testAccVPCRouteTableConfig_ipv4LocalNetworkInterface(rName, vpcCIDR, eniCIDR, subnetCIDR),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckVPCExists(ctx, vpcResourceName, &vpc),
+					testAccCheckRouteTableExists(ctx, resourceName, &routeTable),
+					testAccCheckRouteTableNumberOfRoutes(&routeTable, 1),
+					testAccCheckRouteTableRoute(resourceName, "cidr_block", vpcCIDR, "network_interface_id", eniResourceName, "id"),
+				),
+			},
+			{
+				Config: testAccVPCRouteTableConfig_ipv4NetworkInterfaceToLocal(rName, vpcCIDR, eniCIDR, subnetCIDR),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckVPCExists(ctx, vpcResourceName, &vpc),
+					testAccCheckRouteTableExists(ctx, resourceName, &routeTable),
+					testAccCheckRouteTableNumberOfRoutes(&routeTable, 1),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "route.*", map[string]string{
+						"gateway_id": "local",
+					}),
+				),
+			},
+		},
+	})
+}
+
+func testAccCreateRouteTable(ctx context.Context, v *ec2.Vpc) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Conn(ctx)
+		if v.VpcId == nil {
+			return fmt.Errorf("no VPC ID")
+		}
+		input := &ec2.CreateRouteTableInput{
+			VpcId: v.VpcId,
+		}
+
+		output, err := conn.CreateRouteTableWithContext(ctx, input)
+
+		if err != nil {
+			return fmt.Errorf("test creating route table: %w", err)
+		}
+
+		if output == nil || output.RouteTable == nil {
+			return fmt.Errorf("test creating route table: %s", "nil output")
+		}
+
+		if _, err := tfec2.WaitRouteTableReady(ctx, conn, aws.StringValue(output.RouteTable.RouteTableId), time.Minute*2); err != nil {
+			return fmt.Errorf("waiting for test creating route table: %s", err)
+		}
+		return nil
+	}
+}
+
 func testAccCheckRouteTableExists(ctx context.Context, n string, v *ec2.RouteTable) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -2259,4 +2400,109 @@ resource "aws_route_table" "test" {
   }
 }
 `, rName)
+}
+
+func testAccVPCRouteTableConfig_ipv4Local(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  route {
+    cidr_block = aws_vpc.test.cidr_block
+    gateway_id = "local"
+  }
+}
+`, rName)
+}
+
+func testAccVPCRouteTableConfig_ipv4LocalNetworkInterface(rName, vpcCIDR, eniCIDR, subnetCIDR string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = %[2]q
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  route {
+    cidr_block           = aws_vpc.test.cidr_block
+    network_interface_id = aws_network_interface.test.id
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test" {
+  cidr_block = %[4]q
+  vpc_id     = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_network_interface" "test" {
+  subnet_id = aws_subnet.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName, vpcCIDR, eniCIDR, subnetCIDR)
+}
+
+func testAccVPCRouteTableConfig_ipv4NetworkInterfaceToLocal(rName, vpcCIDR, gatewayCIDR, subnetCIDR string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = %[2]q
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  route {
+    cidr_block = %[3]q
+    gateway_id = "local"
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test" {
+  cidr_block = %[4]q
+  vpc_id     = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_network_interface" "test" {
+  subnet_id = aws_subnet.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName, vpcCIDR, gatewayCIDR, subnetCIDR)
 }

--- a/internal/service/ec2/vpc_route_test.go
+++ b/internal/service/ec2/vpc_route_test.go
@@ -3316,6 +3316,10 @@ func testAccVPCRouteConfig_resourceIPv4Endpoint(rName, destinationCidr string) s
 		fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 
+data "aws_iam_session_context" "current" {
+  arn = data.aws_caller_identity.current.arn
+}
+
 resource "aws_vpc" "test" {
   cidr_block = "10.10.10.0/25"
 
@@ -3345,7 +3349,7 @@ resource "aws_lb" "test" {
 
 resource "aws_vpc_endpoint_service" "test" {
   acceptance_required        = false
-  allowed_principals         = [data.aws_caller_identity.current.arn]
+  allowed_principals         = [data.aws_iam_session_context.current.issuer_arn]
   gateway_load_balancer_arns = [aws_lb.test.arn]
 
   tags = {
@@ -3386,6 +3390,10 @@ func testAccVPCRouteConfig_resourceIPv6Endpoint(rName, destinationIpv6Cidr strin
 		fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 
+data "aws_iam_session_context" "current" {
+  arn = data.aws_caller_identity.current.arn
+}
+
 resource "aws_vpc" "test" {
   cidr_block = "10.10.10.0/25"
 
@@ -3415,7 +3423,7 @@ resource "aws_lb" "test" {
 
 resource "aws_vpc_endpoint_service" "test" {
   acceptance_required        = false
-  allowed_principals         = [data.aws_caller_identity.current.arn]
+  allowed_principals         = [data.aws_iam_session_context.current.issuer_arn]
   gateway_load_balancer_arns = [aws_lb.test.arn]
 
   tags = {
@@ -3570,6 +3578,10 @@ resource "aws_nat_gateway" "test" {
 
 data "aws_caller_identity" "current" {}
 
+data "aws_iam_session_context" "current" {
+  arn = data.aws_caller_identity.current.arn
+}
+
 resource "aws_lb" "test" {
   load_balancer_type = "gateway"
   name               = %[1]q
@@ -3581,7 +3593,7 @@ resource "aws_lb" "test" {
 
 resource "aws_vpc_endpoint_service" "test" {
   acceptance_required        = false
-  allowed_principals         = [data.aws_caller_identity.current.arn]
+  allowed_principals         = [data.aws_iam_session_context.current.issuer_arn]
   gateway_load_balancer_arns = [aws_lb.test.arn]
 
   tags = {

--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -76,10 +76,6 @@ First, adopt an existing AWS-created route:
 ```terraform
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
-
-  tags = {
-    Name = "leibovitz"
-  }
 }
 
 resource "aws_route_table" "test" {
@@ -90,10 +86,6 @@ resource "aws_route_table" "test" {
     cidr_block = "10.1.0.0/16"
     gateway_id = "local"
   }
-
-  tags = {
-    Name = "leibovitz"
-  }
 }
 ```
 
@@ -102,10 +94,6 @@ Next, update the target of the route:
 ```terraform
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
-
-  tags = {
-    Name = "leibovitz"
-  }
 }
 
 resource "aws_route_table" "test" {
@@ -115,27 +103,15 @@ resource "aws_route_table" "test" {
     cidr_block           = aws_vpc.test.cidr_block
     network_interface_id = aws_network_interface.test.id
   }
-
-  tags = {
-    Name = "leibovitz"
-  }
 }
 
 resource "aws_subnet" "test" {
   cidr_block = "10.1.1.0/24"
   vpc_id     = aws_vpc.test.id
-
-  tags = {
-    Name = "leibovitz"
-  }
 }
 
 resource "aws_network_interface" "test" {
   subnet_id = aws_subnet.test.id
-
-  tags = {
-    Name = "leibovitz"
-  }
 }
 ```
 

--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -86,7 +86,7 @@ resource "aws_route_table" "test" {
   vpc_id = aws_vpc.test.id
 
   # since this is exactly the route AWS will create, the route will be adopted
-  route { 
+  route {
     cidr_block = "10.1.0.0/16"
     gateway_id = "local"
   }

--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -31,6 +31,8 @@ the separate resource.
 
 ## Example Usage
 
+### Basic example
+
 ```terraform
 resource "aws_route_table" "example" {
   vpc_id = aws_vpc.example.id
@@ -65,6 +67,80 @@ resource "aws_route_table" "example" {
 }
 ```
 
+### Adopting an existing local route
+
+AWS creates certain routes that the AWS provider mostly ignores. You can manage them by importing or adopting them. See [Import](#import) below for information on importing. This example shows adopting a route and then updating its target.
+
+First, adopt an existing AWS-created route:
+
+```terraform
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = "leibovitz"
+  }
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  # since this is exactly the route AWS will create, the route will be adopted
+  route { 
+    cidr_block = "10.1.0.0/16"
+    gateway_id = "local"
+  }
+
+  tags = {
+    Name = "leibovitz"
+  }
+}
+```
+
+Next, update the target of the route:
+
+```terraform
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = "lihaspoj"
+  }
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  route {
+    cidr_block           = aws_vpc.test.cidr_block
+    network_interface_id = aws_network_interface.test.id
+  }
+
+  tags = {
+    Name = "lihaspoj"
+  }
+}
+
+resource "aws_subnet" "test" {
+  cidr_block = "10.1.1.0/24"
+  vpc_id     = aws_vpc.test.id
+
+  tags = {
+    Name = "lihaspoj"
+  }
+}
+
+resource "aws_network_interface" "test" {
+  subnet_id = aws_subnet.test.id
+
+  tags = {
+    Name = "lihaspoj"
+  }
+}
+```
+
+The target could then be updated again back to `local`.
+
 ## Argument Reference
 
 This resource supports the following arguments:
@@ -90,7 +166,7 @@ One of the following target arguments must be supplied:
 * `carrier_gateway_id` - (Optional) Identifier of a carrier gateway. This attribute can only be used when the VPC contains a subnet which is associated with a Wavelength Zone.
 * `core_network_arn` - (Optional) The Amazon Resource Name (ARN) of a core network.
 * `egress_only_gateway_id` - (Optional) Identifier of a VPC Egress Only Internet Gateway.
-* `gateway_id` - (Optional) Identifier of a VPC internet gateway or a virtual private gateway.
+* `gateway_id` - (Optional) Identifier of a VPC internet gateway, virtual private gateway, or `local`. `local` routes cannot be created but can be adopted or imported. See the [example](#adopting-an-existing-local-route) above.
 * `local_gateway_id` - (Optional) Identifier of a Outpost local gateway.
 * `nat_gateway_id` - (Optional) Identifier of a VPC NAT gateway.
 * `network_interface_id` - (Optional) Identifier of an EC2 network interface.

--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -104,7 +104,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
   tags = {
-    Name = "lihaspoj"
+    Name = "leibovitz"
   }
 }
 
@@ -117,7 +117,7 @@ resource "aws_route_table" "test" {
   }
 
   tags = {
-    Name = "lihaspoj"
+    Name = "leibovitz"
   }
 }
 
@@ -126,7 +126,7 @@ resource "aws_subnet" "test" {
   vpc_id     = aws_vpc.test.id
 
   tags = {
-    Name = "lihaspoj"
+    Name = "leibovitz"
   }
 }
 
@@ -134,7 +134,7 @@ resource "aws_network_interface" "test" {
   subnet_id = aws_subnet.test.id
 
   tags = {
-    Name = "lihaspoj"
+    Name = "leibovitz"
   }
 }
 ```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is similar to the changes made in #24507, which addressed `aws_route`. This PR addresses `aws_route_table` inline routes.

Because `aws_route_table` performs dual functions 1) as a parent in the parent-child relationship with `aws_route`, and 2) as a means of managing routes inline with `route` blocks, this enhancement is a bit more complicated than the scenario in `aws_route`.

Normally, `aws_route_table` ignores default `local` routes. In order to not introduce a massive breaking change, these changes preserve the previous behavior of typically ignoring the `local` routes created by AWS. However, now we want to manage these routes a bit more. We use `hasLocalConfig()` along with `flattenRoutes()` to prevent _default_ `local` routes from being stored in state (the previous behavior), while allowing _configured_ `local` routes to be updated and kept in state (preventing perpetual diffs) like other routes. `hasLocalConfig()` checks the `ResourceData` to distinguish default `local` routes from configured `local` routes. Normally, you can't count on `ResourceData` to represent config. However, in this case, a `local` gateway route in `ResourceData` must come from the config because of the gatekeeping done by `hasLocalConfig()` and `flattenRoutes()` to prevent default `local` routes from being stored in state as `ResourceData`.

This PR is likely a **step on the road** to fully support all the possibilities described in AWS's [Deployment models for AWS Network Firewall](https://aws.amazon.com/blogs/networking-and-content-delivery/deployment-models-for-aws-network-firewall/). After this is merged, please open new issues to describe what yet remains to make your route/firewall dreams come true.

#### Import Example

#### Adopt Example

With this PR, in addition to importing a `local` route, you can now adopt a `local` route.

**Step 1. Create an `aws_route_table` and adopt an existing `local` route**

Here, the `local` route is created for you by AWS. Therefore, this configuration creates the route _table_ but _adopts_ the existing `local` route into management.

**CAUTION:** Since _you_ cannot create `local`-target routes, if you use the wrong CIDR block, you will get an error.
Apply:

```terraform
resource "aws_vpc" "test" {
  cidr_block = "10.1.0.0/16"

  tags = {
    Name = "lihaspoj"
  }
}

resource "aws_route_table" "test" {
  vpc_id = aws_vpc.test.id

  # since this is exactly the route AWS will create, the route will be adopted
  route { 
    cidr_block = "10.1.0.0/16"
    gateway_id = "local"
  }

  tags = {
    Name = "lihaspoj"
  }
}
```

**Step 2. Change the route to have an ENI target**

Here, the route (the AWS created route) will be updated to have an ENI target.

Apply:

```terraform
resource "aws_vpc" "test" {
  cidr_block = "10.1.0.0/16"

  tags = {
    Name = "lihaspoj"
  }
}

resource "aws_route_table" "test" {
  vpc_id = aws_vpc.test.id

  route {
    cidr_block           = aws_vpc.test.cidr_block
    network_interface_id = aws_network_interface.test.id
  }

  tags = {
    Name = "lihaspoj"
  }
}

resource "aws_subnet" "test" {
  cidr_block = "10.1.1.0/24"
  vpc_id     = aws_vpc.test.id

  tags = {
    Name = "lihaspoj"
  }
}

resource "aws_network_interface" "test" {
  subnet_id = aws_subnet.test.id

  tags = {
    Name = "lihaspoj"
  }
}
```

**Step 3. Update the route again to have a `local` target**

Apply:

```terraform
resource "aws_vpc" "test" {
  cidr_block = "10.1.0.0/16"

  tags = {
    Name = "lihaspoj"
  }
}

resource "aws_route_table" "test" {
  vpc_id = aws_vpc.test.id

  route {
    cidr_block = "10.1.0.0/16"
    gateway_id = "local"
  }

  tags = {
    Name = "lihaspoj"
  }
}
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #21350
Relates #24507

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccVPCRoute K=vpc P=10           
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 10 -run='TestAccVPCRoute'  -timeout 180m
=== NAME  TestAccVPCRoute_ipv4ToLocalGateway
    acctest.go:1105: skipping since no Outposts found
--- SKIP: TestAccVPCRoute_ipv4ToLocalGateway (0.87s)
=== NAME  TestAccVPCRoute_prefixListToCarrierGateway
    wavelength_carrier_gateway_test.go:196: skipping since no Wavelength Zones are available
--- SKIP: TestAccVPCRoute_prefixListToCarrierGateway (1.03s)
=== NAME  TestAccVPCRoute_prefixListToLocalGateway
    acctest.go:1105: skipping since no Outposts found
--- SKIP: TestAccVPCRoute_prefixListToLocalGateway (1.13s)
--- PASS: TestAccVPCRoute_basic (41.10s)
--- PASS: TestAccVPCRoute_prefixListToVPCPeeringConnection (49.09s)
--- PASS: TestAccVPCRoute_PrefixListToNetworkInterface_unattached (51.59s)
--- PASS: TestAccVPCRoute_prefixListToEgressOnlyInternetGateway (60.33s)
--- PASS: TestAccVPCRouteDataSource_basic (76.26s)
--- PASS: TestAccVPCRoute_prefixListToInternetGateway (42.21s)
--- PASS: TestAccVPCRouteTablesDataSource_basic (31.82s)
--- PASS: TestAccVPCRoute_PrefixListToNetworkInterface_attached (94.75s)
--- PASS: TestAccVPCRoute_prefixListToInstance (102.24s)
--- PASS: TestAccVPCRouteTable_localRoute (36.68s)
--- PASS: TestAccVPCRoute_localRoute (38.17s)
--- PASS: TestAccVPCRoute_localRouteUpdate (88.19s)
--- PASS: TestAccVPCRoute_prefixListToVPNGateway (164.17s)
--- PASS: TestAccVPCRouteTable_prefixListToInternetGateway (41.54s)
--- PASS: TestAccVPCRouteTable_localRouteUpdate (131.53s)
--- PASS: TestAccVPCRoute_prefixListToTransitGateway (211.16s)
--- PASS: TestAccVPCRoute_prefixListToNatGateway (218.97s)
--- PASS: TestAccVPCRouteTable_gatewayVPCEndpoint (45.36s)
--- PASS: TestAccVPCRouteTable_vpcMultipleCIDRs (55.88s)
--- PASS: TestAccVPCRouteTable_IPv6ToNetworkInterface_unattached (49.39s)
--- PASS: TestAccVPCRouteTable_IPv4ToNetworkInterfaces_unattached (109.72s)
--- PASS: TestAccVPCRouteTable_conditionalCIDRBlock (67.32s)
    acctest.go:1105: skipping since no Outposts found
--- SKIP: TestAccVPCRouteTable_ipv4ToLocalGateway (0.41s)
    wavelength_carrier_gateway_test.go:196: skipping since no Wavelength Zones are available
--- SKIP: TestAccVPCRouteTable_ipv4ToCarrierGateway (0.19s)
--- PASS: TestAccVPCRouteTable_ipv4ToVPCPeeringConnection (36.10s)
--- PASS: TestAccVPCRouteTable_multipleRoutes (195.65s)
--- PASS: TestAccVPCRouteTable_requireRouteDestination (322.87s)
    acctest.go:1105: skipping since no Outposts found
--- SKIP: TestAccVPCRoute_ipv6ToLocalGateway (0.19s)
--- PASS: TestAccVPCRoute_IPv6Update_target (291.22s)
--- PASS: TestAccVPCRouteTable_ipv4ToNatGateway (194.17s)
--- PASS: TestAccVPCRoute_conditionalCIDRBlock (72.10s)
--- PASS: TestAccVPCRouteTable_requireRouteTarget (18.70s)
--- PASS: TestAccVPCRouteTableAssociation_disappears (38.43s)
--- PASS: TestAccVPCRouteTable_Route_mode (85.13s)
--- PASS: TestAccVPCRouteDataSource_gatewayVPCEndpoint (47.98s)
--- PASS: TestAccVPCRouteTableAssociation_Gateway_changeRouteTable (64.74s)
--- PASS: TestAccVPCRouteTableAssociation_Gateway_basic (43.11s)
--- PASS: TestAccVPCRoute_ipv6ToVPCEndpoint (418.76s)
--- PASS: TestAccVPCRouteTableAssociation_Subnet_basic (39.63s)
--- PASS: TestAccVPCRoute_ipv4ToVPCEndpoint (419.09s)
--- PASS: TestAccVPCRouteTableAssociation_Subnet_changeRouteTable (62.78s)
--- PASS: TestAccVPCRouteTable_Disappears_subnetAssociation (35.62s)
--- PASS: TestAccVPCRouteTable_disappears (34.99s)
--- PASS: TestAccVPCRouteTableDataSource_main (31.80s)
--- PASS: TestAccVPCRouteTable_basic (38.98s)
    acctest.go:1105: skipping since no Outposts found
--- SKIP: TestAccVPCRouteDataSource_localGatewayID (0.42s)
--- PASS: TestAccVPCRouteTable_ipv6ToEgressOnlyInternetGateway (67.35s)
--- PASS: TestAccVPCRouteTable_tags (88.49s)
    wavelength_carrier_gateway_test.go:196: skipping since no Wavelength Zones are available
--- SKIP: TestAccVPCRoute_ipv4ToCarrierGateway (0.40s)
--- PASS: TestAccVPCRouteTableDataSource_basic (35.32s)
--- PASS: TestAccVPCRouteTable_vgwRoutePropagation (334.67s)
--- PASS: TestAccVPCRoute_IPv4ToNetworkInterface_unattached (40.78s)
--- PASS: TestAccVPCRouteTable_ipv4ToInternetGateway (64.16s)
--- PASS: TestAccVPCRouteTable_ipv4ToInstance (130.70s)
--- PASS: TestAccVPCRouteTable_ipv4ToTransitGateway (286.77s)
--- PASS: TestAccVPCRoute_doesNotCrashWithVPCEndpoint (46.89s)
--- PASS: TestAccVPCRoute_ipv4ToVPCPeeringConnection (33.96s)
    wavelength_carrier_gateway_test.go:196: skipping since no Wavelength Zones are available
--- SKIP: TestAccVPCRouteDataSource_carrierGatewayID (0.37s)
--- PASS: TestAccVPCRouteDataSource_destinationPrefixListID (201.60s)
--- PASS: TestAccVPCRoute_IPv4ToNetworkInterface_attached (123.77s)
--- PASS: TestAccVPCRoute_IPv4Update_target (646.95s)
--- PASS: TestAccVPCRoute_IPv4ToNetworkInterface_twoAttachments (131.73s)
--- PASS: TestAccVPCRouteTable_ipv4ToVPCEndpoint (449.46s)
--- PASS: TestAccVPCRoute_ipv6ToInternetGateway (47.32s)
--- PASS: TestAccVPCRoute_ipv6ToEgressOnlyInternetGateway (61.53s)
--- PASS: TestAccVPCRoute_ipv4ToTransitGateway (251.38s)
--- PASS: TestAccVPCRoute_ipv6ToTransitGateway (261.44s)
--- PASS: TestAccVPCRoute_ipv6ToNatGateway (233.33s)
--- PASS: TestAccVPCRouteDataSource_ipv6DestinationCIDR (32.21s)
--- PASS: TestAccVPCRoute_ipv4ToNatGateway (232.79s)
--- PASS: TestAccVPCRoute_disappears (32.21s)
--- PASS: TestAccVPCRoute_ipv6ToInstance (114.96s)
--- PASS: TestAccVPCRoute_Disappears_routeTable (32.04s)
--- PASS: TestAccVPCRoute_ipv6ToVPCPeeringConnection (46.76s)
--- PASS: TestAccVPCRoute_IPv6ToNetworkInterface_unattached (48.98s)
--- PASS: TestAccVPCRoute_ipv4ToInstance (124.39s)
--- PASS: TestAccVPCRoute_ipv4ToVPNGateway (136.11s)
--- PASS: TestAccVPCRouteDataSource_transitGatewayID (259.20s)
--- PASS: TestAccVPCRoute_ipv6ToVPNGateway (143.99s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	971.548s
```
