### PR TITLE
d/aws_iam_openid_connect_provider(test): add thumbprint_list test config

### DIFF
--- a/internal/service/iam/openid_connect_provider_data_source_test.go
+++ b/internal/service/iam/openid_connect_provider_data_source_test.go
@@ -95,52 +95,52 @@ func TestAccIAMOpenidConnectProviderDataSource_tags(t *testing.T) {
 	})
 }
 
-func testAccOpenIDConnectProviderDataSourceConfig_basic(rString string) string {
+func testAccOpenIDConnectProviderDataSourceConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_openid_connect_provider" "test" {
-  url = "https://accounts.testle.com/%s"
+  url = "https://accounts.testle.com/%[1]s"
 
   client_id_list = [
     "266362248691-re108qaeld573ia0l6clj2i5ac7r7291.apps.testleusercontent.com",
   ]
 
-  thumbprint_list = []
+  thumbprint_list = ["cf23df2207d99a74fbe169e3eba035e633b65d94"]
 }
 
 data "aws_iam_openid_connect_provider" "test" {
   arn = aws_iam_openid_connect_provider.test.arn
 }
-`, rString)
+`, rName)
 }
 
-func testAccOpenIDConnectProviderDataSourceConfig_url(rString string) string {
+func testAccOpenIDConnectProviderDataSourceConfig_url(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_openid_connect_provider" "test" {
-  url = "https://accounts.testle.com/%s"
+  url = "https://accounts.testle.com/%[1]s"
 
   client_id_list = [
     "266362248691-re108qaeld573ia0l6clj2i5ac7r7291.apps.testleusercontent.com",
   ]
 
-  thumbprint_list = []
+  thumbprint_list = ["cf23df2207d99a74fbe169e3eba035e633b65d94"]
 }
 
 data "aws_iam_openid_connect_provider" "test" {
   url = "https://${aws_iam_openid_connect_provider.test.url}"
 }
-`, rString)
+`, rName)
 }
 
-func testAccOpenIDConnectProviderDataSourceConfig_tags(rString string) string {
+func testAccOpenIDConnectProviderDataSourceConfig_tags(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_openid_connect_provider" "test" {
-  url = "https://accounts.testle.com/%s"
+  url = "https://accounts.testle.com/%[1]s"
 
   client_id_list = [
     "266362248691-re108qaeld573ia0l6clj2i5ac7r7291.apps.testleusercontent.com",
   ]
 
-  thumbprint_list = []
+  thumbprint_list = ["cf23df2207d99a74fbe169e3eba035e633b65d94"]
 
   tags = {
     tag1 = "test-value1"
@@ -151,5 +151,5 @@ resource "aws_iam_openid_connect_provider" "test" {
 data "aws_iam_openid_connect_provider" "test" {
   arn = aws_iam_openid_connect_provider.test.arn
 }
-`, rString)
+`, rName)
 }


### PR DESCRIPTION

### Description
Fixes broken `aws_iam_openid_connect_provider` data source tests by providing a non-empty `thumbprint_lists` entry. This brings the data source test config into alignment with the corresponding resource tests.

```console
$ make testacc PKG=iam TESTS=TestAccIAMOpenidConnectProviderDataSource_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMOpenidConnectProviderDataSource_'  -timeout 180m

=== NAME  TestAccIAMOpenidConnectProviderDataSource_basic
    openid_connect_provider_data_source_test.go:22: Step 1/1 error: Error running apply: exit status 1

        Error: creating IAM OIDC Provider: InvalidInput: Thumbprint list must contain at least one entry.
                status code: 400, request id: f122213d-a611-49fe-94fb-667be982618f

          with aws_iam_openid_connect_provider.test,
          on terraform_plugin_test.tf line 2, in resource "aws_iam_openid_connect_provider" "test":
           2: resource "aws_iam_openid_connect_provider" "test" {

=== NAME  TestAccIAMOpenidConnectProviderDataSource_tags
    openid_connect_provider_data_source_test.go:76: Step 1/1 error: Error running apply: exit status 1

        Error: creating IAM OIDC Provider: InvalidInput: Thumbprint list must contain at least one entry.
                status code: 400, request id: 56bdfea3-9799-4cae-b2f7-3a14419f6772

          with aws_iam_openid_connect_provider.test,
          on terraform_plugin_test.tf line 2, in resource "aws_iam_openid_connect_provider" "test":
           2: resource "aws_iam_openid_connect_provider" "test" {

=== NAME  TestAccIAMOpenidConnectProviderDataSource_url
    openid_connect_provider_data_source_test.go:49: Step 1/1 error: Error running apply: exit status 1

        Error: creating IAM OIDC Provider: InvalidInput: Thumbprint list must contain at least one entry.
                status code: 400, request id: bbd8d82d-81f0-4730-8948-fbcf6ac7e49e

          with aws_iam_openid_connect_provider.test,
          on terraform_plugin_test.tf line 2, in resource "aws_iam_openid_connect_provider" "test":
           2: resource "aws_iam_openid_connect_provider" "test" {

--- FAIL: TestAccIAMOpenidConnectProviderDataSource_basic (7.43s)
--- FAIL: TestAccIAMOpenidConnectProviderDataSource_tags (7.43s)
--- FAIL: TestAccIAMOpenidConnectProviderDataSource_url (7.44s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/iam        10.363s
```


### Output from Acceptance Testing


```console
$ make testacc PKG=iam TESTS=TestAccIAMOpenidConnectProviderDataSource_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMOpenidConnectProviderDataSource_'  -timeout 180m

--- PASS: TestAccIAMOpenidConnectProviderDataSource_basic (17.67s)
--- PASS: TestAccIAMOpenidConnectProviderDataSource_url (17.74s)
--- PASS: TestAccIAMOpenidConnectProviderDataSource_tags (17.74s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        20.811s
```
