### PR TITLE
fix: typo in autoscaling policy website docs

### DIFF
--- a/website/docs/r/autoscaling_policy.html.markdown
+++ b/website/docs/r/autoscaling_policy.html.markdown
@@ -41,7 +41,7 @@ resource "aws_autoscaling_group" "bar" {
 }
 ```
 
-### Create target tarcking scaling policy using metric math
+### Create target tracking scaling policy using metric math
 
 ```terraform
 resource "aws_autoscaling_policy" "example" {


### PR DESCRIPTION
### Description
Fixes a typo in the website docs.
