### PR TITLE
[TechDebt]: AuditManager acceptance test fixes

### DIFF
--- a/internal/service/auditmanager/assessment_delegation_test.go
+++ b/internal/service/auditmanager/assessment_delegation_test.go
@@ -245,11 +245,6 @@ resource "aws_s3_bucket" "test" {
   force_destroy = true
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 data "aws_iam_policy_document" "test" {
   statement {
     actions = ["sts:AssumeRole"]

--- a/internal/service/auditmanager/assessment_report_test.go
+++ b/internal/service/auditmanager/assessment_report_test.go
@@ -189,11 +189,6 @@ resource "aws_s3_bucket" "test" {
   force_destroy = true
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_iam_role" "test" {
   name = %[1]q
 


### PR DESCRIPTION

### Description
Fixes various AuditManager acceptance tests currently failing due to unnecessary S3 bucket ACL configurations. 


### Relations
Relates #28353



### Output from Acceptance Testing

```console
$ make testacc PKG=auditmanager TESTS=TestAccAuditManagerAssessmentReport_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/auditmanager/... -v -count 1 -parallel 20 -run='TestAccAuditManagerAssessmentReport_'  -timeout 180m

--- PASS: TestAccAuditManagerAssessmentReport_disappears (34.13s)
--- PASS: TestAccAuditManagerAssessmentReport_basic (36.60s)
--- PASS: TestAccAuditManagerAssessmentReport_optional (71.64s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/auditmanager       74.712s
```

```console
$ make testacc PKG=auditmanager TESTS=TestAccAuditManagerAssessmentDelegation_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/auditmanager/... -v -count 1 -parallel 20 -run='TestAccAuditManagerAssessmentDelegation_'  -timeout 180m

--- PASS: TestAccAuditManagerAssessmentDelegation_disappears (28.03s)
--- PASS: TestAccAuditManagerAssessmentDelegation_basic (30.51s)
--- PASS: TestAccAuditManagerAssessmentDelegation_multiple (33.77s)
--- PASS: TestAccAuditManagerAssessmentDelegation_optional (66.84s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/auditmanager       69.726s
```
