### PR TITLE
d/aws_kinesis_firehose_delivery_stream(test): rm unnecessary s3 bucket acl config

### DIFF
--- a/internal/service/firehose/delivery_stream_data_source_test.go
+++ b/internal/service/firehose/delivery_stream_data_source_test.go
@@ -102,11 +102,6 @@ resource "aws_s3_bucket" "bucket" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.bucket.id
-  acl    = "private"
-}
-
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   name        = %[1]q
   destination = "extended_s3"


### PR DESCRIPTION

### Description
Fixes `TestAccFirehoseDeliveryStreamDataSource_basic`

```console
$ make testacc PKG=firehose TESTS=TestAccFirehoseDeliveryStreamDataSource_basic
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/firehose/... -v -count 1 -parallel 20 -run='TestAccFirehoseDeliveryStreamDataSource_basic'  -timeout 180m
=== RUN   TestAccFirehoseDeliveryStreamDataSource_basic
=== PAUSE TestAccFirehoseDeliveryStreamDataSource_basic
=== CONT  TestAccFirehoseDeliveryStreamDataSource_basic
    delivery_stream_data_source_test.go:22: Step 1/1 error: Error running apply: exit status 1

        Error: creating S3 bucket ACL for tf-acc-test-7814311428223815511: AccessControlListNotSupported: The bucket does not allow ACLs
                status code: 400, request id: CDJJX5A0NMYPE93X, host id: x/r4mn9Glp/egVY03etDOEQx9PMf24uwJsY50QRzRSYHyxZm64WGZerzvvLsPzT6Gc1YKNZvAFM=

          with aws_s3_bucket_acl.test,
          on terraform_plugin_test.tf line 66, in resource "aws_s3_bucket_acl" "test":
          66: resource "aws_s3_bucket_acl" "test" {

--- FAIL: TestAccFirehoseDeliveryStreamDataSource_basic (190.58s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/firehose   193.604s
```


### Relations

Relates #28353



### Output from Acceptance Testing


```console
$ make testacc PKG=firehose TESTS=TestAccFirehoseDeliveryStreamDataSource_basic
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/firehose/... -v -count 1 -parallel 20 -run='TestAccFirehoseDeliveryStreamDataSource_basic'  -timeout 180m

--- PASS: TestAccFirehoseDeliveryStreamDataSource_basic (168.20s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/firehose   171.195s
```
