### PR TITLE
add example for threshold expression and

### DIFF
--- a/website/docs/r/ce_anomaly_subscription.html.markdown
+++ b/website/docs/r/ce_anomaly_subscription.html.markdown
@@ -84,16 +84,16 @@ resource "aws_ce_anomaly_subscription" "test" {
   threshold_expression {
     and {
       dimension {
-        key = "ANOMALY_TOTAL_IMPACT_ABSOLUTE"
+        key           = "ANOMALY_TOTAL_IMPACT_ABSOLUTE"
         match_options = ["GREATER_THAN_OR_EQUAL"]
-        values = ["100"]
+        values        = ["100"]
       }
     }
     and {
       dimension {
-        key = "ANOMALY_TOTAL_IMPACT_PERCENTAGE"
+        key           = "ANOMALY_TOTAL_IMPACT_PERCENTAGE"
         match_options = ["GREATER_THAN_OR_EQUAL"]
-        values = ["50"]
+        values        = ["50"]
       }
     }
   }

--- a/website/docs/r/ce_anomaly_subscription.html.markdown
+++ b/website/docs/r/ce_anomaly_subscription.html.markdown
@@ -37,7 +37,8 @@ resource "aws_ce_anomaly_subscription" "test" {
 }
 ```
 
-### Threshold Expression
+### Threshold Expression Example
+#### Configuration block for specific Dimension
 
 ```terraform
 resource "aws_ce_anomaly_subscription" "test" {
@@ -58,6 +59,39 @@ resource "aws_ce_anomaly_subscription" "test" {
       key           = "ANOMALY_TOTAL_IMPACT_ABSOLUTE"
       values        = ["100.0"]
       match_options = ["GREATER_THAN_OR_EQUAL"]
+    }
+  }
+}
+```
+#### Configuration block for and expression
+```terraform
+resource "aws_ce_anomaly_subscription" "test" {
+  name      = "AWSServiceMonitor"
+  frequency = "DAILY"
+
+  monitor_arn_list = [
+    aws_ce_anomaly_monitor.test.arn,
+  ]
+
+  subscriber {
+    type    = "EMAIL"
+    address = "abc@example.com"
+  }
+
+  threshold_expression {
+    and {
+      dimension {
+        key = "ANOMALY_TOTAL_IMPACT_ABSOLUTE"
+        match_options = ["GREATER_THAN_OR_EQUAL"]
+        values = ["100"]
+      }
+    }
+    and {
+      dimension {
+        key = "ANOMALY_TOTAL_IMPACT_PERCENTAGE"
+        match_options = ["GREATER_THAN_OR_EQUAL"]
+        values = ["50"]
+      }
     }
   }
 }

--- a/website/docs/r/ce_anomaly_subscription.html.markdown
+++ b/website/docs/r/ce_anomaly_subscription.html.markdown
@@ -38,7 +38,8 @@ resource "aws_ce_anomaly_subscription" "test" {
 ```
 
 ### Threshold Expression Example
-#### Configuration block for specific Dimension
+
+#### For a Specific Dimension
 
 ```terraform
 resource "aws_ce_anomaly_subscription" "test" {
@@ -63,7 +64,9 @@ resource "aws_ce_anomaly_subscription" "test" {
   }
 }
 ```
-#### Configuration block for and expression
+
+#### Using an `and` Expression
+
 ```terraform
 resource "aws_ce_anomaly_subscription" "test" {
   name      = "AWSServiceMonitor"


### PR DESCRIPTION
### Description
This pull request to improve documentation of `aws_ce_anomaly_susbcription` resource argument  which is`threshold_expression` about how add expression when we need to use `and` 


### Relations

Closes #32780
