### PR TITLE
b/aws_chimesdkvoice_global_settings: retry if cdr_bucket is empty

### DIFF
--- a/internal/service/chimesdkvoice/global_settings.go
+++ b/internal/service/chimesdkvoice/global_settings.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	ResNameGlobalSettings            = "Global Settings"
-	globalSettingsPropagationTimeout = time.Second * 10
+	globalSettingsPropagationTimeout = 20 * time.Second
 )
 
 // @SDKResource("aws_chimesdkvoice_global_settings")
@@ -65,10 +65,12 @@ func resourceGlobalSettingsRead(ctx context.Context, d *schema.ResourceData, met
 	err := tfresource.Retry(ctx, globalSettingsPropagationTimeout, func() *retry.RetryError {
 		var getErr error
 		out, getErr = conn.GetGlobalSettingsWithContext(ctx, &chimesdkvoice.GetGlobalSettingsInput{})
+
 		if getErr != nil {
 			return retry.NonRetryableError(getErr)
 		}
-		if out.VoiceConnector == nil {
+
+		if out.VoiceConnector == nil || out.VoiceConnector.CdrBucket == nil {
 			return retry.RetryableError(tfresource.NewEmptyResultError(&chimesdkvoice.GetGlobalSettingsInput{}))
 		}
 

--- a/internal/service/chimesdkvoice/global_settings_test.go
+++ b/internal/service/chimesdkvoice/global_settings_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -90,7 +91,10 @@ func testAccGlobalSettings_update(t *testing.T) {
 	bucketResourceName := "aws_s3_bucket.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID) // run test in us-east-1 only since eventual consistency causes intermittent failures in other regions.
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckGlobalSettingsDestroy(ctx),


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

retry for eventual consistency

```
------- Stdout: -------
=== RUN   TestAccChimeSDKVoiceGlobalSettings_serial
=== PAUSE TestAccChimeSDKVoiceGlobalSettings_serial
=== CONT  TestAccChimeSDKVoiceGlobalSettings_serial
=== RUN   TestAccChimeSDKVoiceGlobalSettings_serial/basic
    global_settings_test.go:42: Step 1/2 error: Check failed: 1 error occurred:
          * Check 1/1 error: aws_chimesdkvoice_global_settings.test: Attribute 'voice_connector.0.cdr_bucket' expected "tf-acc-test-1708425151533450177", got ""
=== RUN   TestAccChimeSDKVoiceGlobalSettings_serial/disappears
=== RUN   TestAccChimeSDKVoiceGlobalSettings_serial/update
    global_settings_test.go:92: Step 1/2 error: Check failed: 1 error occurred:
          * Check 1/1 error: aws_chimesdkvoice_global_settings.test: Attribute 'voice_connector.0.cdr_bucket' expected "tf-acc-test-8451547168035188546", got ""
--- FAIL: TestAccChimeSDKVoiceGlobalSettings_serial (102.93s)
    --- FAIL: TestAccChimeSDKVoiceGlobalSettings_serial/basic (27.64s)
    --- PASS: TestAccChimeSDKVoiceGlobalSettings_serial/disappears (46.29s)
    --- FAIL: TestAccChimeSDKVoiceGlobalSettings_serial/update (29.00s)
FAIL
```
### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:


--->


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ AWS_DEFAULT_REGION=us-east-1 make testacc TESTARGS="-run=TestAccChimeSDKVoiceGlobalSettings_serial" PKG=chimesdkvoice

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/chimesdkvoice/... -v -count 1 -parallel 20  -run=TestAccChimeSDKVoiceGlobalSettings_serial -timeout 180m
=== RUN   TestAccChimeSDKVoiceGlobalSettings_serial
=== PAUSE TestAccChimeSDKVoiceGlobalSettings_serial
=== CONT  TestAccChimeSDKVoiceGlobalSettings_serial
=== RUN   TestAccChimeSDKVoiceGlobalSettings_serial/basic
=== RUN   TestAccChimeSDKVoiceGlobalSettings_serial/disappears
=== RUN   TestAccChimeSDKVoiceGlobalSettings_serial/update
--- PASS: TestAccChimeSDKVoiceGlobalSettings_serial (84.53s)
    --- PASS: TestAccChimeSDKVoiceGlobalSettings_serial/basic (19.21s)
    --- PASS: TestAccChimeSDKVoiceGlobalSettings_serial/disappears (35.68s)
    --- PASS: TestAccChimeSDKVoiceGlobalSettings_serial/update (29.64s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/chimesdkvoice	87.405s
```
