### PR TITLE
r/aws_codepipeline_webhook(test): rm unnecessary s3 bucket acl config

### DIFF
--- a/internal/service/codepipeline/webhook_test.go
+++ b/internal/service/codepipeline/webhook_test.go
@@ -463,11 +463,6 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_iam_role" "test" {
   name = %[1]q
 


### PR DESCRIPTION

### Description
Fixes various failing CodePipeline webhook tests.

```
=== RUN   TestAccCodePipelineWebhook_basic
    webhook_test.go:33: Step 1/4 error: Error running apply: exit status 1
        Error: creating S3 bucket ACL for tf-acc-test-9087582508599795569: AccessControlListNotSupported: The bucket does not allow ACLs
          status code: 400, request id: N6C694HZWNDV0CE1, host id: KD7bXq7B+xTRj/mnXYzJq0ELZMB47mLeti6JkcjnpODryTmWKUE/xIkAD0ZUwdw/eFpilchUMFk=
          with aws_s3_bucket_acl.test,
          on terraform_plugin_test.tf line 6, in resource "aws_s3_bucket_acl" "test":
           6: resource "aws_s3_bucket_acl" "test" {
--- FAIL: TestAccCodePipelineWebhook_basic (190.90s)
FAIL
```

### Relations

Relates #28353



### Output from Acceptance Testing
Acceptance testing requires configuration of a github token, so it has been omitted for this small change.


