### PR TITLE
r/aws_flow_log: rm unnecessary s3 bucket acl config

### DIFF
--- a/internal/service/ec2/vpc_flow_log_test.go
+++ b/internal/service/ec2/vpc_flow_log_test.go
@@ -1241,11 +1241,6 @@ resource "aws_s3_bucket" "bucket" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "bucket_acl" {
-  bucket = aws_s3_bucket.bucket.id
-  acl    = "private"
-}
-
 resource "aws_iam_role" "test" {
   name = %[1]q
 


### PR DESCRIPTION

### Description
Fixes `TestAccVPCFlowLog_LogDestinationType_kinesisFirehose`.


```
=== CONT  TestAccVPCFlowLog_LogDestinationType_kinesisFirehose
    vpc_flow_log_test.go:241: Step 1/2 error: Error running apply: exit status 1

        Error: creating S3 bucket ACL for tf-acc-test-3743026901492570258: AccessControlListNotSupported: The bucket does not allow ACLs
                status code: 400, request id: QS66CNJCRGPHZTK1, host id: HPiQQnD2kgRVJuFyQsNyc2YI0ZJxqoDIW2bKFYsnN9dx3XMZnEKkO1a8686hF9JXPfcrvAs0THQ=

          with aws_s3_bucket_acl.bucket_acl,
          on terraform_plugin_test.tf line 61, in resource "aws_s3_bucket_acl" "bucket_acl":
          61: resource "aws_s3_bucket_acl" "bucket_acl" {

--- FAIL: TestAccVPCFlowLog_LogDestinationType_kinesisFirehose (124.90s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/ec2        127.960s
```

### Relations
Relates #28353




### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ ake testacc PKG=ec2 TESTS=TestAccVPCFlowLog_LogDestinationType_kinesisFirehose
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCFlowLog_LogDestinationType_kinesisFirehose'  -timeout 180m
=== RUN   TestAccVPCFlowLog_LogDestinationType_kinesisFirehose
=== PAUSE TestAccVPCFlowLog_LogDestinationType_kinesisFirehose
=== CONT  TestAccVPCFlowLog_LogDestinationType_kinesisFirehose
--- PASS: TestAccVPCFlowLog_LogDestinationType_kinesisFirehose (142.02s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        145.025s
```
