### PR TITLE
Added validation info to documentation for ssm contacts

### DIFF
--- a/website/docs/r/ssmcontacts_contact.html.markdown
+++ b/website/docs/r/ssmcontacts_contact.html.markdown
@@ -52,7 +52,7 @@ The following arguments are required:
 
 The following arguments are optional:
 
-- `display_name` - (Optional) Full friendly name of the contact or escalation plan. 1-255 characters, alphanumeric, _ (underscore), - (hyphen), and spaces.
+- `display_name` - (Optional) Full friendly name of the contact or escalation plan. If set, must be between 1 and 255 characters, and may contain alphanumerics, underscores (`_`), hyphens (`-`), periods (`.`), and spaces.
 
 - `tags` - (Optional) Map of tags to assign to the resource.
 

--- a/website/docs/r/ssmcontacts_contact.html.markdown
+++ b/website/docs/r/ssmcontacts_contact.html.markdown
@@ -45,14 +45,14 @@ resource "aws_ssmcontacts_contact" "example" {
 
 The following arguments are required:
 
-- `alias` - (Required) A unique and identifiable alias for the contact or escalation plan.
+- `alias` - (Required) A unique and identifiable alias for the contact or escalation plan. 1-50 characters, a-z, 0-9, _ (underscore), and - (hyphen).
 
 - `type` - (Required) The type of contact engaged. A single contact is type PERSONAL and an escalation
   plan is type ESCALATION.
 
 The following arguments are optional:
 
-- `display_name` - (Optional) Full friendly name of the contact or escalation plan.
+- `display_name` - (Optional) Full friendly name of the contact or escalation plan. 1-255 characters, alphanumeric, _ (underscore), - (hyphen), and spaces.
 
 - `tags` - (Optional) Map of tags to assign to the resource.
 

--- a/website/docs/r/ssmcontacts_contact.html.markdown
+++ b/website/docs/r/ssmcontacts_contact.html.markdown
@@ -45,7 +45,7 @@ resource "aws_ssmcontacts_contact" "example" {
 
 The following arguments are required:
 
-- `alias` - (Required) A unique and identifiable alias for the contact or escalation plan. 1-50 characters, a-z, 0-9, _ (underscore), and - (hyphen).
+- `alias` - (Required) A unique and identifiable alias for the contact or escalation plan. Must be between 1 and 255 characters, and may contain alphanumerics, underscores (`_`), and hyphens (`-`).
 
 - `type` - (Required) The type of contact engaged. A single contact is type PERSONAL and an escalation
   plan is type ESCALATION.

--- a/website/docs/r/ssmcontacts_contact_channel.html.markdown
+++ b/website/docs/r/ssmcontacts_contact_channel.html.markdown
@@ -57,7 +57,7 @@ The following arguments are required:
 
 - `delivery_address` - (Required) Block that contains contact engagement details. See details below.
 
-- `name` - (Required) Name of the contact channel. 1-50 characters, alphanumeric, _ (underscore), - (hyphen), and spaces.
+- `name` - (Required) Name of the contact channel. Must be between 1 and 255 characters, and may contain alphanumerics, underscores (`_`), hyphens (`-`), periods (`.`), and spaces.
 
 - `type` - (Required) Type of the contact channel. One of `SMS`, `VOICE` or `EMAIL`.
 

--- a/website/docs/r/ssmcontacts_contact_channel.html.markdown
+++ b/website/docs/r/ssmcontacts_contact_channel.html.markdown
@@ -57,7 +57,7 @@ The following arguments are required:
 
 - `delivery_address` - (Required) Block that contains contact engagement details. See details below.
 
-- `name` - (Required) Name of the contact channel.
+- `name` - (Required) Name of the contact channel. 1-50 characters, alphanumeric, _ (underscore), - (hyphen), and spaces.
 
 - `type` - (Required) Type of the contact channel. One of `SMS`, `VOICE` or `EMAIL`.
 


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Additional documentation to the "aws_ssmcontacts_contact" and "aws_ssmcontacts_contact_channel" to reflect the validation requirements on the alias and name arguments.


### References
I didn't find any documentation to reference, but I pulled the information from the error messages in the AWS console.



### Output from Acceptance Testing

No change to code
