### PR TITLE
r/aws_elastictranscoder_pipeline(test): rm unnecessary s3 bucket acl config

### DIFF
--- a/internal/service/elastictranscoder/pipeline_test.go
+++ b/internal/service/elastictranscoder/pipeline_test.go
@@ -337,11 +337,6 @@ EOF
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
 `, rName)
 }
 
@@ -399,11 +394,6 @@ EOF
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
 `, rName)
 }
 
@@ -449,27 +439,12 @@ resource "aws_s3_bucket" "content_bucket" {
   bucket = "%[1]s-content"
 }
 
-resource "aws_s3_bucket_acl" "content_bucket_acl" {
-  bucket = aws_s3_bucket.content_bucket.id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket" "input_bucket" {
   bucket = "%[1]s-input"
 }
 
-resource "aws_s3_bucket_acl" "input_bucket_acl" {
-  bucket = aws_s3_bucket.input_bucket.id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket" "thumb_bucket" {
   bucket = "%[1]s-thumb"
-}
-
-resource "aws_s3_bucket_acl" "thumb_bucket_acl" {
-  bucket = aws_s3_bucket.thumb_bucket.id
-  acl    = "private"
 }
 `, rName)
 }
@@ -516,27 +491,12 @@ resource "aws_s3_bucket" "content_bucket" {
   bucket = "%[1]s-content"
 }
 
-resource "aws_s3_bucket_acl" "content_bucket_acl" {
-  bucket = aws_s3_bucket.content_bucket.id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket" "input_bucket" {
   bucket = "%[1]s-input"
 }
 
-resource "aws_s3_bucket_acl" "input_bucket_acl" {
-  bucket = aws_s3_bucket.input_bucket.id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket" "thumb_bucket" {
   bucket = "%[1]s-thumb"
-}
-
-resource "aws_s3_bucket_acl" "thumb_bucket_acl" {
-  bucket = aws_s3_bucket.thumb_bucket.id
-  acl    = "private"
 }
 `, rName)
 }
@@ -594,11 +554,6 @@ EOF
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
 `, rName)
 }
 
@@ -638,11 +593,6 @@ EOF
 
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
-}
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
 }
 
 resource "aws_sns_topic" "test" {
@@ -702,11 +652,6 @@ EOF
 
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
-}
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
 }
 
 resource "aws_sns_topic" "test" {


### PR DESCRIPTION

### Description
Fixes various ElasticTranscoder Pipeline tests.

```
=== NAME  TestAccElasticTranscoderPipeline_disappears
    pipeline_test.go:220: Step 1/1 error: Error running apply: exit status 1

        Error: creating S3 bucket ACL for tf-acc-test-3280626804327899915: AccessControlListNotSupported: The bucket does not allow ACLs
                status code: 400, request id: QF9Y8KPSH0VP6VE8, host id: IxbRaPx/mON7t/AB+YkA2OGZ9GD6PWZfaKMYqQd2vnX1fD19r3VcDuEQLd6ZOnTc5QU5sn7mntY=

          with aws_s3_bucket_acl.test,
          on terraform_plugin_test.tf line 33, in resource "aws_s3_bucket_acl" "test":
          33: resource "aws_s3_bucket_acl" "test" {

--- FAIL: TestAccElasticTranscoderPipeline_disappears (20.86s)
```


### Relations

Relates #28353



### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc PKG=elastictranscoder TESTS=TestAccElasticTranscoderPipeline_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elastictranscoder/... -v -count 1 -parallel 20 -run='TestAccElasticTranscoderPipeline_'  -timeout 180m

--- PASS: TestAccElasticTranscoderPipeline_disappears (24.56s)
--- PASS: TestAccElasticTranscoderPipeline_withPermissions (26.92s)
--- PASS: TestAccElasticTranscoderPipeline_basic (27.25s)
--- PASS: TestAccElasticTranscoderPipeline_kmsKey (29.47s)
--- PASS: TestAccElasticTranscoderPipeline_notifications (42.65s)
--- PASS: TestAccElasticTranscoderPipeline_withContent (66.73s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elastictranscoder  70.688s
```
