### PR TITLE
r/aws_ivschat_loggin_configuration(test): rm unnecessary s3 bucket acl config

### DIFF
--- a/internal/service/ivschat/logging_configuration_test.go
+++ b/internal/service/ivschat/logging_configuration_test.go
@@ -404,11 +404,6 @@ resource "aws_s3_bucket" "test" {
   bucket_prefix = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_iam_role" "test" {
   name = %[1]q
 


### PR DESCRIPTION

### Description
Fixes `TestAccIVSChatLoggingConfiguration_basic_firehose`.

```
=== CONT  TestAccIVSChatLoggingConfiguration_basic_firehose
    logging_configuration_test.go:70: Step 1/2 error: Error running apply: exit status 1
        Error: creating S3 bucket ACL for tf-acc-test-381536221974398185420230801090445376900000001: AccessControlListNotSupported: The bucket does not allow ACLs
          status code: 400, request id: 6AQ88AKKRA4DFQ62, host id: Gc6Oiv/nvJ8BA2iDYfkJc+zwP6nazJnbcOwVBn6mm2vuQ6s/lGUYLR3cSsbsNzsQawC4bYi4C5I=
```

### Relations
Relates #28353




### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc PKG=ivschat TESTS=TestAccIVSChatLoggingConfiguration_basic_firehose
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ivschat/... -v -count 1 -parallel 20 -run='TestAccIVSChatLoggingConfiguration_basic_firehose'  -timeout 180m
=== RUN   TestAccIVSChatLoggingConfiguration_basic_firehose
=== PAUSE TestAccIVSChatLoggingConfiguration_basic_firehose
=== CONT  TestAccIVSChatLoggingConfiguration_basic_firehose
--- PASS: TestAccIVSChatLoggingConfiguration_basic_firehose (101.40s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ivschat    104.381s
```
