### PR TITLE
r/aws_fsx_lustre_file_system(test): rm unnecessary s3 bucket acl config

### DIFF
--- a/internal/service/fsx/lustre_file_system_test.go
+++ b/internal/service/fsx/lustre_file_system_test.go
@@ -1024,11 +1024,6 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_fsx_lustre_file_system" "test" {
   export_path      = "s3://${aws_s3_bucket.test.bucket}%[2]s"
   import_path      = "s3://${aws_s3_bucket.test.bucket}"
@@ -1045,11 +1040,6 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_fsx_lustre_file_system" "test" {
   import_path      = "s3://${aws_s3_bucket.test.bucket}%[2]s"
   storage_capacity = 1200
@@ -1063,11 +1053,6 @@ func testAccLustreFileSystemConfig_importedChunkSize(rName string, importedFileC
 	return acctest.ConfigCompose(testAccLustreFileSystemBaseConfig(), fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
-}
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
 }
 
 resource "aws_fsx_lustre_file_system" "test" {
@@ -1371,11 +1356,6 @@ func testAccLustreFileSystemConfig_autoImportPolicy(rName, exportPrefix, policy 
 	return acctest.ConfigCompose(testAccLustreFileSystemBaseConfig(), fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
-}
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
 }
 
 resource "aws_fsx_lustre_file_system" "test" {


### PR DESCRIPTION
### Description
Fixes various Fsx Lustre File System acceptance tests. Ex.

```
=== RUN   TestAccFSxLustreFileSystem_importPath
=== PAUSE TestAccFSxLustreFileSystem_importPath
=== CONT  TestAccFSxLustreFileSystem_importPath
    lustre_file_system_test.go:188: Step 1/3 error: Error running apply: exit status 1
        Error: creating S3 bucket ACL for tf-acc-test-3952770834720244221: AccessControlListNotSupported: The bucket does not allow ACLs
          status code: 400, request id: 4DDSKPHFA35Z8HNZ, host id: /TifripjoiLbjfcBU0XCc5OT0r5clLgHs4b4wMrjTrbBRlFFkzLuqB0m5vDPzxNmH9Dh/bXKvsIrkW4Q6EryTQ==
          with aws_s3_bucket_acl.test,
          on terraform_plugin_test.tf line 27, in resource "aws_s3_bucket_acl" "test":
          27: resource "aws_s3_bucket_acl" "test" {
--- FAIL: TestAccFSxLustreFileSystem_importPath (1096.68s)
FAIL
```

### Relations
Relates #28353


### Output from Acceptance Testing


```console
$ make testacc PKG=fsx TESTS=TestAccFSxLustreFileSystem_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/fsx/... -v -count 1 -parallel 20 -run='TestAccFSxLustreFileSystem_'  -timeout 180m

--- PASS: TestAccFSxLustreFileSystem_dailyAutomaticBackupStartTime (671.41s)
=== CONT  TestAccFSxLustreFileSystem_logConfig
--- PASS: TestAccFSxLustreFileSystem_automaticBackupRetentionDays (696.08s)
=== CONT  TestAccFSxLustreFileSystem_deploymentTypePersistent2
--- PASS: TestAccFSxLustreFileSystem_storageTypeHddDriveCacheNone (712.60s)
=== CONT  TestAccFSxLustreFileSystem_copyTagsToBackups
--- PASS: TestAccFSxLustreFileSystem_disappears (719.63s)
=== CONT  TestAccFSxLustreFileSystem_deploymentTypePersistent1
--- PASS: TestAccFSxLustreFileSystem_tags (729.70s)
=== CONT  TestAccFSxLustreFileSystem_deploymentTypeScratch2
--- PASS: TestAccFSxLustreFileSystem_weeklyMaintenanceStartTime (732.33s)
--- PASS: TestAccFSxLustreFileSystem_dataCompression (770.18s)
--- PASS: TestAccFSxLustreFileSystem_basic (774.08s)
--- PASS: TestAccFSxLustreFileSystem_storageTypeHddDriveCacheRead (795.13s)
--- PASS: TestAccFSxLustreFileSystem_rootSquashConfig (796.69s)
--- PASS: TestAccFSxLustreFileSystem_securityGroupIDs (1242.21s)
--- PASS: TestAccFSxLustreFileSystem_autoImportPolicy (1260.04s)
--- PASS: TestAccFSxLustreFileSystem_fileSystemTypeVersion (1299.90s)
--- PASS: TestAccFSxLustreFileSystem_deploymentTypePersistent2 (634.22s)
--- PASS: TestAccFSxLustreFileSystem_deploymentTypePersistent1 (625.10s)
--- PASS: TestAccFSxLustreFileSystem_kmsKeyID (1370.82s)
--- PASS: TestAccFSxLustreFileSystem_deploymentTypeScratch2 (655.32s)
--- PASS: TestAccFSxLustreFileSystem_fromBackup (1387.64s)
--- PASS: TestAccFSxLustreFileSystem_storageCapacity (1402.12s)
--- PASS: TestAccFSxLustreFileSystem_logConfig (818.80s)
--- PASS: TestAccFSxLustreFileSystem_copyTagsToBackups (777.64s)
--- PASS: TestAccFSxLustreFileSystem_importedFileChunkSize (1667.77s)
--- PASS: TestAccFSxLustreFileSystem_exportPath (1808.55s)
--- PASS: TestAccFSxLustreFileSystem_importPath (1850.47s)
--- PASS: TestAccFSxLustreFileSystem_storageCapacityUpdate (2451.57s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/fsx        2454.640s
```
