### PR TITLE
QuickSight: Use correct enums for template filters

### DIFF
--- a/.changelog/32822.txt
+++ b/.changelog/32822.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_quicksight_analysis: Fixed a bug that incorrectly determined the valid `select_all_options` values for `custom_filter_configuration`, `custom_filter_list_configuration`, `filter_list_configuration`, `numeric_equality_filter`, and `numeric_range_filter`
+```
+
+```release-note:bug
+resource/aws_quicksight_template: Fixed a bug that incorrectly determined the valid `select_all_options` values for `custom_filter_configuration`, `custom_filter_list_configuration`, `filter_list_configuration`, `numeric_equality_filter`, and `numeric_range_filter`
+```

--- a/internal/service/quicksight/schema/template_filter.go
+++ b/internal/service/quicksight/schema/template_filter.go
@@ -73,7 +73,7 @@ func categoryFilterSchema() *schema.Schema {
 												validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9]+`), ""),
 											),
 										},
-										"select_all_options": stringSchema(false, validation.StringInSlice(quicksight.SelectAllValueOptions_Values(), false)),
+										"select_all_options": stringSchema(false, validation.StringInSlice(quicksight.CategoryFilterSelectAllOptions_Values(), false)),
 									},
 								},
 							},
@@ -96,7 +96,7 @@ func categoryFilterSchema() *schema.Schema {
 												ValidateFunc: validation.StringLenBetween(1, 512),
 											},
 										},
-										"select_all_options": stringSchema(false, validation.StringInSlice(quicksight.SelectAllValueOptions_Values(), false)),
+										"select_all_options": stringSchema(false, validation.StringInSlice(quicksight.CategoryFilterSelectAllOptions_Values(), false)),
 									},
 								},
 							},
@@ -118,7 +118,7 @@ func categoryFilterSchema() *schema.Schema {
 												ValidateFunc: validation.StringLenBetween(1, 512),
 											},
 										},
-										"select_all_options": stringSchema(false, validation.StringInSlice(quicksight.SelectAllValueOptions_Values(), false)),
+										"select_all_options": stringSchema(false, validation.StringInSlice(quicksight.CategoryFilterSelectAllOptions_Values(), false)),
 									},
 								},
 							},
@@ -145,7 +145,7 @@ func numericEqualityFilterSchema() *schema.Schema {
 				"null_option":          stringSchema(true, validation.StringInSlice(quicksight.FilterNullOption_Values(), false)),
 				"aggregation_function": aggregationFunctionSchema(false), // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_AggregationFunction.html
 				"parameter_name":       parameterNameSchema(false),
-				"select_all_options":   stringSchema(false, validation.StringInSlice(quicksight.SelectAllValueOptions_Values(), false)),
+				"select_all_options":   stringSchema(false, validation.StringInSlice(quicksight.NumericFilterSelectAllOptions_Values(), false)),
 				"value": {
 					Type:     schema.TypeFloat,
 					Optional: true,
@@ -177,7 +177,7 @@ func numericRangeFilterSchema() *schema.Schema {
 				},
 				"range_maximum":      numericRangeFilterValueSchema(), // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_NumericRangeFilterValue.html
 				"range_minimum":      numericRangeFilterValueSchema(), // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_NumericRangeFilterValue.html
-				"select_all_options": stringSchema(false, validation.StringInSlice(quicksight.SelectAllValueOptions_Values(), false)),
+				"select_all_options": stringSchema(false, validation.StringInSlice(quicksight.NumericFilterSelectAllOptions_Values(), false)),
 			},
 		},
 	}


### PR DESCRIPTION
### Description

This PR corrects an issue with QuickSight resources that led to the incorrect function being used to return the list of valid values for `select_all_options`.

### Relations

Closes #32353

### References

These references point to the AWS Go SDK type definition for each of the affected filter types

- [`CustomFilterConfiguration`  (`category_filter.configuration.custom_filter_configuration`)](https://docs.aws.amazon.com/sdk-for-go/api/service/quicksight/#CustomFilterConfiguration)
- [`CustomFilterListConfiguration` (`category_filter.configuration.custom_filter_list_configuration`)](https://docs.aws.amazon.com/sdk-for-go/api/service/quicksight/#CustomFilterListConfiguration)
- [`FilterListConfiguration` (`category_filter.configuration.filter_list_configuration`)](https://docs.aws.amazon.com/sdk-for-go/api/service/quicksight/#FilterListConfiguration)
- [`NumericEqualityFilter` (`numeric_equality_filter`)](https://docs.aws.amazon.com/sdk-for-go/api/service/quicksight/#NumericEqualityFilter)
- [`NumericRangeFilter` (`numeric_range_filter`)](https://docs.aws.amazon.com/sdk-for-go/api/service/quicksight/#NumericRangeFilter)

Enums are defined in [this file](https://raw.githubusercontent.com/aws/aws-sdk-go/v1.44.296/service/quicksight/api.go) (sorry, it's too big for GitHub to render, so raw link will have to suffice).

### Output from Acceptance Testing

Unfortunately I'm not able to run QuickSight acceptance tests.