### PR TITLE
r/aws_mskconnect_custom_plugin(test): rm unnecessary s3 bucket acl config

### DIFF
--- a/internal/service/kafkaconnect/custom_plugin_test.go
+++ b/internal/service/kafkaconnect/custom_plugin_test.go
@@ -184,13 +184,8 @@ resource "aws_s3_bucket" "test" {
   force_destroy = true
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket_versioning" "test" {
-  bucket = aws_s3_bucket_acl.test.bucket
+  bucket = aws_s3_bucket.test.bucket
 
   versioning_configuration {
     status = %[2]t ? "Enabled" : "Suspended"


### PR DESCRIPTION
### Description
Fixes all KafkaConnect acceptance tests. Ex.

```
=== CONT  TestAccKafkaConnectCustomPlugin_basic
    custom_plugin_test.go:26: Step 1/2 error: Error running apply: exit status 1
        Error: creating S3 bucket ACL for tf-acc-test-1956275692564207789: AccessControlListNotSupported: The bucket does not allow ACLs
          status code: 400, request id: VKPTC8VAYD8HK0C8, host id: 41E3II9kxBBvOaq+4CFLV3Q+ncBwRHagK5IWGVTrKmdR7IzJst6E7gaz8EmFuZ/bYovRyEMupt8=
          with aws_s3_bucket_acl.test,
          on terraform_plugin_test.tf line 7, in resource "aws_s3_bucket_acl" "test":
           7: resource "aws_s3_bucket_acl" "test" {
--- FAIL: TestAccKafkaConnectCustomPlugin_basic (93.71s)
```


### Relations
Relates #28353



### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc PKG=kafkaconnect TESTS=TestAccKafkaConnect
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/kafkaconnect/... -v -count 1 -parallel 20 -run='TestAccKafkaConnect'  -timeout 180m

--- PASS: TestAccKafkaConnectWorkerConfigurationDataSource_basic (27.89s)
--- PASS: TestAccKafkaConnectWorkerConfiguration_description (28.79s)
--- PASS: TestAccKafkaConnectWorkerConfiguration_basic (35.88s)
--- PASS: TestAccKafkaConnectCustomPlugin_disappears (51.53s)
--- PASS: TestAccKafkaConnectCustomPluginDataSource_basic (53.36s)
--- PASS: TestAccKafkaConnectCustomPlugin_basic (55.65s)
--- PASS: TestAccKafkaConnectCustomPlugin_description (55.75s)
--- PASS: TestAccKafkaConnectCustomPlugin_objectVersion (55.84s)
--- PASS: TestAccKafkaConnectConnectorDataSource_basic (2389.89s)
--- PASS: TestAccKafkaConnectConnector_basic (2471.41s)
--- PASS: TestAccKafkaConnectConnector_disappears (2476.79s)
--- PASS: TestAccKafkaConnectConnector_update (3080.68s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kafkaconnect       3083.609s
```
