### PR TITLE
r/aws_lambda_permission(test): rm unnecessary s3 bucket acl config

### DIFF
--- a/internal/service/lambda/permission_test.go
+++ b/internal/service/lambda/permission_test.go
@@ -953,12 +953,7 @@ resource "aws_lambda_permission" "test" {
 }
 
 resource "aws_s3_bucket" "test" {
-  bucket = "%s"
-}
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
+  bucket = %[1]q
 }
 `, rName))
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Fixes `TestAccLambdaPermission_s3`. Ex.

```
=== CONT  TestAccLambdaPermission_s3
    permission_test.go:538: Step 1/2 error: Error running apply: exit status 1
        Error: creating S3 bucket ACL for tf-acc-test-2858722411593140646: AccessControlListNotSupported: The bucket does not allow ACLs
          status code: 400, request id: A3AWWVHDKM1Z3CTF, host id: Xo+b7xd9YhwQ+wYRq1MJWl/3ArXHAFHoKLXm7rt52xS8Y2X39Nyn+0Fq187aK3uhHu8HuRTEhFk=
          with aws_s3_bucket_acl.test,
          on terraform_plugin_test.tf line 42, in resource "aws_s3_bucket_acl" "test":
          42: resource "aws_s3_bucket_acl" "test" {
--- FAIL: TestAccLambdaPermission_s3 (164.94s)
```


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #28353

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc PKG=lambda TESTS=TestAccLambdaPermission_s3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaPermission_s3'  -timeout 180m
=== RUN   TestAccLambdaPermission_s3
=== PAUSE TestAccLambdaPermission_s3
=== CONT  TestAccLambdaPermission_s3
--- PASS: TestAccLambdaPermission_s3 (35.95s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     39.009s
```
