### PR TITLE
r/aws_cloudwatch_log_subscription_filter(test): rm unnecessary s3 bucket acl config

### DIFF
--- a/internal/service/logs/subscription_filter_test.go
+++ b/internal/service/logs/subscription_filter_test.go
@@ -460,11 +460,6 @@ resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
   force_destroy = true
 }
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
 `, rName)
 }
 


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Fixes `TestAccLogsSubscriptionFilter_DestinationARN_kinesisDataFirehose`. Ex.

```
=== CONT  TestAccLogsSubscriptionFilter_DestinationARN_kinesisDataFirehose
    subscription_filter_test.go:131: Step 1/2 error: Error running apply: exit status 1
        Error: creating S3 bucket ACL for tf-acc-test-8101964666717860644: AccessControlListNotSupported: The bucket does not allow ACLs
          status code: 400, request id: 60M3E3945ZDRNC9P, host id: eDX4jJLFVUnjK23WBdIhT6v4N1vEbsDpsm00/xrPBNuJCK6J/2najOcToHUgUeGkMEudUeVJ1ds=
          with aws_s3_bucket_acl.test,
          on terraform_plugin_test.tf line 123, in resource "aws_s3_bucket_acl" "test":
         123: resource "aws_s3_bucket_acl" "test" {
--- FAIL: TestAccLogsSubscriptionFilter_DestinationARN_kinesisDataFirehose (276.53s)
FAIL
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #28353

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc PKG=logs TESTS=TestAccLogsSubscriptionFilter_DestinationARN_kinesisDataFirehose
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/logs/... -v -count 1 -parallel 20 -run='TestAccLogsSubscriptionFilter_DestinationARN_kinesisDataFirehose'  -timeout 180m
=== RUN   TestAccLogsSubscriptionFilter_DestinationARN_kinesisDataFirehose
=== PAUSE TestAccLogsSubscriptionFilter_DestinationARN_kinesisDataFirehose
=== CONT  TestAccLogsSubscriptionFilter_DestinationARN_kinesisDataFirehose
--- PASS: TestAccLogsSubscriptionFilter_DestinationARN_kinesisDataFirehose (78.66s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/logs       81.662s
```
