### PR TITLE
r/aws_rds_export_task(test): rm unnecessary s3 bucket acl config

### DIFF
--- a/internal/service/rds/export_task_test.go
+++ b/internal/service/rds/export_task_test.go
@@ -175,11 +175,6 @@ resource "aws_s3_bucket" "test" {
   force_destroy = true
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_iam_role" "test" {
   name = %[1]q
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Fixes RDS Export Task acceptance test failures. Ex.

```
=== CONT  TestAccRDSExportTask_basic
    export_task_test.go:32: Step 1/2 error: Error running apply: exit status 1

        Error: creating S3 bucket ACL for tf-acc-test-7676331606515785310: AccessControlListNotSupported: The bucket does not allow ACLs
          status code: 400, request id: S49VN4QDVVDKSG9K, host id: 7un57y1qRcrAg8aTLn3W1jhFPb8z0XNsqwZAczD40Ute6whbyUo/Zkt7/9+mOkz3K7QXhMnre6c=

          with aws_s3_bucket_acl.test,
          on terraform_plugin_test.tf line 7, in resource "aws_s3_bucket_acl" "test":
           7: resource "aws_s3_bucket_acl" "test" {

--- FAIL: TestAccRDSExportTask_basic (1861.15s)
FAIL
```


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #28353

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc PKG=rds TESTS=TestAccRDSExportTask_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSExportTask_'  -timeout 180m
=== RUN   TestAccRDSExportTask_basic
=== PAUSE TestAccRDSExportTask_basic
=== RUN   TestAccRDSExportTask_optional
=== PAUSE TestAccRDSExportTask_optional
=== CONT  TestAccRDSExportTask_basic
=== CONT  TestAccRDSExportTask_optional
--- PASS: TestAccRDSExportTask_basic (1808.21s)
--- PASS: TestAccRDSExportTask_optional (1866.09s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        1869.141s
```
