### PR TITLE
r/aws_servicecatalog(test): rm unnecessary s3 bucket acl config

### DIFF
--- a/internal/service/servicecatalog/constraint_test.go
+++ b/internal/service/servicecatalog/constraint_test.go
@@ -169,11 +169,6 @@ resource "aws_s3_bucket" "test" {
   force_destroy = true
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_s3_object" "test" {
   bucket = aws_s3_bucket.test.id
   key    = "%[1]s.json"

--- a/internal/service/servicecatalog/provisioning_artifacts_data_source_test.go
+++ b/internal/service/servicecatalog/provisioning_artifacts_data_source_test.go
@@ -49,11 +49,6 @@ resource "aws_s3_bucket" "test" {
   force_destroy = true
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_s3_object" "test" {
   bucket = aws_s3_bucket.test.id
   key    = "%[1]s.json"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Fixes various ServiceCatalog acceptance tests currently failing due to unnecessary s3 bucket private ACL configurations. Ex.

```
=== CONT  TestAccServiceCatalogConstraint_basic
    constraint_test.go:29: Step 1/2 error: Error running apply: exit status 1

        Error: creating S3 bucket ACL for tf-acc-test-5666842783629746405: AccessControlListNotSupported: The bucket does not allow ACLs
          status code: 400, request id: 4GHHS9D69MGDNFGV, host id: 83QwDfKELY/mJXYy92Qsc8r4BUIYzeYOjNdzb0dQDXoZoFSYlwUU10387OOAKkr3qd3TJzq9mwk=

          with aws_s3_bucket_acl.test,
          on terraform_plugin_test.tf line 7, in resource "aws_s3_bucket_acl" "test":
           7: resource "aws_s3_bucket_acl" "test" {

--- FAIL: TestAccServiceCatalogConstraint_basic (198.42s)
FAIL
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #28353

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc PKG=servicecatalog TESTS="TestAccServiceCatalogConstraint|TestAccServiceCatalogPortfolioConstraintsDataSource_Constraint_basic|TestAccServiceCatalogProvisioningArtifactsDataSource_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/servicecatalog/... -v -count 1 -parallel 20 -run='TestAccServiceCatalogConstraint|TestAccServiceCatalogPortfolioConstraintsDataSource_Constraint_basic|TestAccServiceCatalogProvisioningArtifactsDataSource_basic'  -timeout 180m

--- PASS: TestAccServiceCatalogProvisioningArtifactsDataSource_basic (43.60s)
--- PASS: TestAccServiceCatalogConstraint_disappears (45.67s)
--- PASS: TestAccServiceCatalogConstraint_basic (51.78s)
--- PASS: TestAccServiceCatalogPortfolioConstraintsDataSource_Constraint_basic (51.87s)
--- PASS: TestAccServiceCatalogConstraintDataSource_basic (58.73s)
--- PASS: TestAccServiceCatalogConstraint_update (80.60s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/servicecatalog     83.593s
```
