### PR TITLE
r/aws_ssm_maintenance_window_task(test): rm unnecessary s3 bucket acl config

### DIFF
--- a/internal/service/ssm/maintenance_window_task_test.go
+++ b/internal/service/ssm/maintenance_window_task_test.go
@@ -908,11 +908,6 @@ resource "aws_s3_bucket" "test" {
   force_destroy = true
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_ssm_maintenance_window_task" "test" {
   window_id        = aws_ssm_maintenance_window.test.id
   task_type        = "AUTOMATION"
@@ -1020,11 +1015,6 @@ func testAccMaintenanceWindowTaskConfig_runCommandUpdate(rName, comment string, 
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
   force_destroy = true
-}
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
 }
 
 resource "aws_ssm_maintenance_window_task" "test" {


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Fixes various SSM maintenance window task acceptance tests currently failing due to unnecessary s3 bucket private ACL configurations. Ex.

```
=== CONT  TestAccSSMMaintenanceWindowTask_taskInvocationAutomationParameters
    maintenance_window_task_test.go:236: Step 2/3 error: Error running apply: exit status 1

        Error: creating S3 bucket ACL for tf-acc-test-3829482191630859843: AccessControlListNotSupported: The bucket does not allow ACLs
          status code: 400, request id: ZSNDXNGS8P2GCSPY, host id: k8oRkw9osENclKT/NV1nUWWc3YAhut2daUPhHOp8QDvaXptX3FtSj4yEH74/nmfizp0wJ3KHRe8=

          with aws_s3_bucket_acl.test,
          on terraform_plugin_test.tf line 61, in resource "aws_s3_bucket_acl" "test":
          61: resource "aws_s3_bucket_acl" "test" {

--- FAIL: TestAccSSMMaintenanceWindowTask_taskInvocationAutomationParameters (443.94s)
FAIL
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #28353

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc PKG=ssm TESTS=TestAccSSMMaintenanceWindowTask_taskInvocation
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ssm/... -v -count 1 -parallel 20 -run='TestAccSSMMaintenanceWindowTask_taskInvocation'  -timeout 180m

--- PASS: TestAccSSMMaintenanceWindowTask_taskInvocationStepFunctionParameters (24.53s)
--- PASS: TestAccSSMMaintenanceWindowTask_taskInvocationLambdaParameters (40.34s)
--- PASS: TestAccSSMMaintenanceWindowTask_taskInvocationAutomationParameters (42.08s)
--- PASS: TestAccSSMMaintenanceWindowTask_taskInvocationRunCommandParameters (42.61s)
--- PASS: TestAccSSMMaintenanceWindowTask_taskInvocationRunCommandParametersCloudWatch (52.14s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssm        55.231s
```
