### PR TITLE
r/aws_transfer_access(test): rm unnecessary s3 bucket acl config

### DIFF
--- a/internal/service/transfer/access_test.go
+++ b/internal/service/transfer/access_test.go
@@ -320,11 +320,6 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_iam_role_policy" "test" {
   name = %[1]q
   role = aws_iam_role.test.id


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Removes unnecessary s3 bucket private ACL configuration from the Transfer Access acceptance test S3 configuration.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #28353

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc PKG=transfer TESTS=TestAccTransfer_serial/Access/S3Basic
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/transfer/... -v -count 1 -parallel 20 -run='TestAccTransfer_serial/Access/S3Basic'  -timeout 180m
=== RUN   TestAccTransfer_serial
=== PAUSE TestAccTransfer_serial
=== CONT  TestAccTransfer_serial
=== RUN   TestAccTransfer_serial/Access
=== RUN   TestAccTransfer_serial/Access/S3Basic
--- PASS: TestAccTransfer_serial (972.65s)
    --- PASS: TestAccTransfer_serial/Access (972.65s)
        --- PASS: TestAccTransfer_serial/Access/S3Basic (972.65s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/transfer   975.883s
```
