### PR TITLE
r/aws_ses_receipt_rule(test): fix s3 bucket acl config

### DIFF
--- a/internal/service/ses/receipt_rule_test.go
+++ b/internal/service/ses/receipt_rule_test.go
@@ -474,7 +474,28 @@ resource "aws_s3_bucket" "test" {
   force_destroy = "true"
 }
 
+resource "aws_s3_bucket_public_access_block" "test" {
+  bucket = aws_s3_bucket.test.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_ownership_controls" "test" {
+  bucket = aws_s3_bucket.test.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "test" {
+  depends_on = [
+    aws_s3_bucket_public_access_block.test,
+    aws_s3_bucket_ownership_controls.test,
+  ]
+
   bucket = aws_s3_bucket.test.id
   acl    = "public-read-write"
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Fixes `TestAccSESReceiptRule_s3Action`. With the recent S3 security changes, the bucket ACL configuration now also requires public access and bucket ownership resources. 

Ex.

```
=== CONT  TestAccSESReceiptRule_s3Action
    receipt_rule_test.go:75: Step 1/2 error: Error running apply: exit status 1

        Error: creating S3 bucket ACL for tf-acc-test-3436288263627848983: AccessDenied: Access Denied
          status code: 403, request id: VPT00NNST9HPF5WH, host id: 8QCykSjzxw4JXwfYx+JvTFVLIWUXCWuXgR12yJjR6+s05Klr3Nsyf1RcZ6xwuaJPoItoU/0aHj0=

          with aws_s3_bucket_acl.test,
          on terraform_plugin_test.tf line 11, in resource "aws_s3_bucket_acl" "test":
          11: resource "aws_s3_bucket_acl" "test" {

--- FAIL: TestAccSESReceiptRule_s3Action (187.20s)
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #28353

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=ses TESTS=TestAccSESReceiptRule_s3Action
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ses/... -v -count 1 -parallel 20 -run='TestAccSESReceiptRule_s3Action'  -timeout 180m
=== RUN   TestAccSESReceiptRule_s3Action
=== PAUSE TestAccSESReceiptRule_s3Action
=== CONT  TestAccSESReceiptRule_s3Action
--- PASS: TestAccSESReceiptRule_s3Action (26.96s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ses        29.998s
```
