### PR TITLE
bugfix: surface licencemanager InvalidParameterValueException error

### DIFF
--- a/internal/service/licensemanager/license_configuration.go
+++ b/internal/service/licensemanager/license_configuration.go
@@ -183,10 +183,6 @@ func resourceLicenseConfigurationDelete(ctx context.Context, d *schema.ResourceD
 		LicenseConfigurationArn: aws.String(d.Id()),
 	})
 
-	if tfawserr.ErrCodeEquals(err, licensemanager.ErrCodeInvalidParameterValueException) {
-		return nil
-	}
-
 	if err != nil {
 		return diag.Errorf("deleting License Manager License Configuration (%s): %s", d.Id(), err)
 	}


### PR DESCRIPTION
### Description
Fixes bug in which InvalidParameterValueException errors were not surfaced during the destruction of a resource, and the resource was removed from state silently

### Relations
Closes #32832

### Output from Acceptance Testing
```console
make testacc TESTS=TestAccLicenseManagerLicenseConfiguration PKG=licensemanager ACCTEST_PARALLELISM=5
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/licensemanager/... -v -count 1 -parallel 5 -run='TestAccLicenseManagerLicenseConfiguration'  -timeout 180m
=== RUN   TestAccLicenseManagerLicenseConfiguration_basic
=== PAUSE TestAccLicenseManagerLicenseConfiguration_basic
=== RUN   TestAccLicenseManagerLicenseConfiguration_disappears
=== PAUSE TestAccLicenseManagerLicenseConfiguration_disappears
=== RUN   TestAccLicenseManagerLicenseConfiguration_tags
=== PAUSE TestAccLicenseManagerLicenseConfiguration_tags
=== RUN   TestAccLicenseManagerLicenseConfiguration_update
=== PAUSE TestAccLicenseManagerLicenseConfiguration_update
=== CONT  TestAccLicenseManagerLicenseConfiguration_basic
=== CONT  TestAccLicenseManagerLicenseConfiguration_tags
=== CONT  TestAccLicenseManagerLicenseConfiguration_update
=== CONT  TestAccLicenseManagerLicenseConfiguration_disappears
--- PASS: TestAccLicenseManagerLicenseConfiguration_disappears (8.52s)
--- PASS: TestAccLicenseManagerLicenseConfiguration_basic (10.99s)
--- PASS: TestAccLicenseManagerLicenseConfiguration_update (17.29s)
--- PASS: TestAccLicenseManagerLicenseConfiguration_tags (22.77s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/licensemanager	25.911s

...
```
