### PR TITLE
Move `issues` and `pull_request_target` workflows to GitHub App

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -20,12 +20,26 @@ jobs:
       # https://docs.github.com/en/actions/learn-github-actions/expressions#example
       username: ${{ github.event.action == 'assigned' && github.event.assignee.login || github.event.issue.user.login }}
 
+  generate_token:
+    name: 'Generate Token'
+    runs-on: ubuntu-latest
+    outputs:
+      token: ${{ steps.generate.outputs.token }}
+    steps:
+      - name: 'Generate'
+        id: generate
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          installation_id: ${{ secrets.INSTALLATION_ID }}
+          private_key: ${{ secrets.APP_PEM }}
+
   automation_labeler:
     name: 'Automation Labeler'
-    needs: community_check
+    needs: [community_check, generate_token]
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ github.token }}
+      GH_TOKEN: ${{ needs.generate_token.outputs.token }}
       ISSUE_URL: ${{ github.event.issue.html_url }}
     steps:
       - name: 'Add needs-triage for non-maintainer'
@@ -60,9 +74,9 @@ jobs:
   add_to_project:
     name: 'Add to Project'
     runs-on: ubuntu-latest
-    needs: community_check
+    needs: [community_check, generate_token]
     env:
-      GH_TOKEN: ${{ secrets.PROJECT_SCOPED_TOKEN }}
+      GH_TOKEN: ${{ needs.generate_token.outputs.token }}
       # Some gh project calls take the project's ID, some take the project's number
       PROJECT_ID: "PVT_kwDOAAuecM4AF-7h"
       PROJECT_NUMBER: "196"

--- a/.github/workflows/pull_request_target.yml
+++ b/.github/workflows/pull_request_target.yml
@@ -21,12 +21,26 @@ jobs:
       # https://docs.github.com/en/actions/learn-github-actions/expressions#example
       username: ${{ github.event.action == 'assigned' && github.event.assignee.login || github.event.pull_request.user.login }}
 
+  generate_token:
+    name: 'Generate Token'
+    runs-on: ubuntu-latest
+    outputs:
+      token: ${{ steps.generate.outputs.token }}
+    steps:
+      - name: 'Generate'
+        id: generate
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          installation_id: ${{ secrets.INSTALLATION_ID }}
+          private_key: ${{ secrets.APP_PEM }}
+
   labeler:
     name: 'Automation Labeler'
-    needs: community_check
+    needs: [community_check, generate_token]
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ github.token }}
+      GH_TOKEN: ${{ needs.generate_token.outputs.token }}
       PR_URL: ${{ github.event.pull_request.html_url }}
     steps:
       - name: 'Add needs-triage for non-maintainers'
@@ -92,9 +106,9 @@ jobs:
   add_to_project:
     name: 'Add to Project'
     runs-on: ubuntu-latest
-    needs: community_check
+    needs: [community_check, generate_token]
     env:
-      GH_TOKEN: ${{ secrets.PROJECT_SCOPED_TOKEN }}
+      GH_TOKEN: ${{ needs.generate_token.outputs.token }}
       # Some gh project calls take the project's ID, some take the project's number
       PROJECT_ID: "PVT_kwDOAAuecM4AF-7h"
       PROJECT_NUMBER: "196"


### PR DESCRIPTION
### Description

This PR moves the `issues.yml` and `pull_request_target.yml` workflows over to use a GitHub App for authentication when labeling or adding items to the GitHub Project. This is necessary, as using the automatically generated GitHub token does not allow the workflow to trigger itself, so when the workflows label something (e.g. with `partner`), it won't re-trigger the workflow, causing the `label` event, which is what we rely on to add the item to the project.

Note: this will require ensuring that our GitHub App has write permissions for issues and pull requests, as well as read/write for organization projects.

### References

- [An example](https://github.com/hashicorp/terraform-provider-aws/actions/runs/5754481875/job/15599855690) of a partner PR being opened, labeled appropriately, and not being added to the project
- [GitHub Documentation](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow) indicating the limitation that we're hitting:

> When you use the repository's `GITHUB_TOKEN` to perform tasks, events triggered by the `GITHUB_TOKEN`, with the exception of `workflow_dispatch` and `repository_dispatch`, will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs. For example, if a workflow run pushes code using the repository's `GITHUB_TOKEN`, a new workflow will not run even when the repository contains a workflow configured to run when push events occur. For more information, see "[Automatic token authentication](https://docs.github.com/en/actions/security-guides/automatic-token-authentication)."
> 
> If you do want to trigger a workflow from within a workflow run, you can use a GitHub App installation access token or a personal access token instead of GITHUB_TOKEN to trigger events that require a token.

### Output from Acceptance Testing

N/a, Actions
