### PR TITLE
docs(s3_bucket_lifecycle_configuration): add note about propagation delay

### DIFF
--- a/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
@@ -20,6 +20,10 @@ For more information see the Amazon S3 User Guide on [`Lifecycle Configuration E
 
 ~> **NOTE:** S3 Buckets only support a single lifecycle configuration. Declaring multiple `aws_s3_bucket_lifecycle_configuration` resources to the same S3 Bucket will cause a perpetual difference in configuration.
 
+~> **NOTE:** Lifecycle configurations may take some time to fully propagate to all AWS S3 systems.
+Running Terraform operations shortly after creating a lifecycle configuration may result in changes that affect configuration idempotence.
+See the Amazon S3 User Guide on [setting lifecycle configuration on a bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/how-to-set-lifecycle-configuration-intro.html).
+
 ## Example Usage
 
 ### With neither a filter nor prefix specified


### PR DESCRIPTION
### Description
Add a note in the `aws_s3_bucket_lifecycle_configuration` resource documentation page to warn about the way propagation delays for that resource can affect Terraform. In particular, the fact that lifecycle configurations are not immediately reliably available after creation can cause Terraform configuration to be unpredictably and non-deterministically non-idempotent.

### Relations
None.

### References
Propagation delay is explained in [user documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/how-to-set-lifecycle-configuration-intro.html), but not explicitly linked to the effects this could have on Terraform.

### Output from Acceptance Testing
None. The change is documentation only.
