### PR TITLE
Quicksight: raise limit for maximum allowed visuals per sheet to 50

### DIFF
--- a/internal/service/quicksight/schema/visual.go
+++ b/internal/service/quicksight/schema/visual.go
@@ -22,7 +22,7 @@ func visualsSchema() *schema.Schema {
 	return &schema.Schema{ // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_SheetControlLayout.html
 		Type:     schema.TypeList,
 		MinItems: 1,
-		MaxItems: 30,
+		MaxItems: 50,
 		Optional: true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR corrects number of allowed visuals per sheet in Quicksight analysis and raises limit from 30 to 50.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #32855

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

https://docs.aws.amazon.com/quicksight/latest/APIReference/API_SheetDefinition.html#API_SheetDefinition_Contents

> Visuals
> A list of the visuals that are on a sheet. Visual placement is determined by the layout of the sheet.
> 
> Type: Array of [Visual](https://docs.aws.amazon.com/quicksight/latest/APIReference/API_Visual.html) objects
> 
> Array Members: Maximum number of 50 items.
> 
> Required: No

Limit was raised from 30 to 50: https://community.amazonquicksight.com/t/30-visual-limit/2869/16

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Unfortunately, I'm not able to run the acceptance tests.