### PR TITLE
Top-level `go.mod` dependabot check times out

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,6 @@ updates:
       aws-sdk-go:
         patterns:
           - "github.com/aws/aws-sdk-go"
-          - "github.com/aws/aws-sdk-go-v2"
           - "github.com/aws/aws-sdk-go-v2/*"
       aws-sdk-go-base:
         patterns:


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

The dependabot checks for the top-level `go.mod` have started to time out, e.g. https://github.com/hashicorp/terraform-provider-aws/network/updates/704989584.

Maybe the change introduced in #32733 is to blame?

This PR reverts that change to see what happens...

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/32733.