### PR TITLE
Ignore additional error when deleting fleet

### DIFF
--- a/.changelog/32866.txt
+++ b/.changelog/32866.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_emr_instance_fleet: Fix fleet deletion failing for terminated clusters
+```

--- a/internal/service/emr/instance_fleet.go
+++ b/internal/service/emr/instance_fleet.go
@@ -332,7 +332,11 @@ func resourceInstanceFleetDelete(ctx context.Context, d *schema.ResourceData, me
 		},
 	})
 
+	// Ignore certain errors that indicate the fleet is already (being) deleted
 	if tfawserr.ErrMessageContains(err, emr.ErrCodeInvalidRequestException, "instance fleet may only be modified when the cluster is running or waiting") {
+		return diags
+	}
+	if tfawserr.ErrMessageContains(err, emr.ErrCodeInvalidRequestException, "A job flow that is shutting down, terminated, or finished may not be modified") {
 		return diags
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
This adds another error message from the AWS api to be ignored when trying to delete an AWS EMR Instance Fleet which does not support "delete". Its lifecycle is instead linked to the EMR cluster.


### Relations


Closes #31375

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
The acceptance testing failed but I'm fairly certain this is due to the locked down nature of the AWS Accounts that I have access to in my org. I would be very grateful if someone with a known working acceptance testing setup could reproduce this and maybe add their output.
I verified the fix with a cluster setup that was failing for my org using the published provider versions.

```console
% make testacc TESTARGS='-run=TestAccEMRCluster_ebs\|TestAccEMRCluster_basic' PKG=emr ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/emr/... -v -count 1 -parallel 2  -run=TestAccEMRCluster_ebs\|TestAccEMRCluster_basic -timeout 180m
=== RUN   TestAccEMRCluster_basic
=== PAUSE TestAccEMRCluster_basic
=== RUN   TestAccEMRCluster_ebs
=== PAUSE TestAccEMRCluster_ebs
=== CONT  TestAccEMRCluster_basic
=== CONT  TestAccEMRCluster_ebs
    cluster_test.go:1537: Step 1/2 error: Error running apply: exit status 1
        
        Error: running EMR Job Flow: ValidationException: Invalid InstanceProfile: EMR_EC2_DefaultRole.
        	status code: 400, request id: e7786da7-64bd-4280-adf3-6b41ae0028b5
        
          with aws_emr_cluster.test,
          on terraform_plugin_test.tf line 88, in resource "aws_emr_cluster" "test":
          88: resource "aws_emr_cluster" "test" {
        
--- FAIL: TestAccEMRCluster_ebs (189.08s)
--- PASS: TestAccEMRCluster_basic (457.25s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/emr	459.257s
FAIL
make: *** [testacc] Error 1
```
