### PR TITLE
Workflows: Token generation as a step rather than a job

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -20,42 +20,43 @@ jobs:
       # https://docs.github.com/en/actions/learn-github-actions/expressions#example
       username: ${{ github.event.action == 'assigned' && github.event.assignee.login || github.event.issue.user.login }}
 
-  generate_token:
-    name: 'Generate Token'
+  automation_labeler:
+    name: 'Automation Labeler'
+    needs: community_check
     runs-on: ubuntu-latest
-    outputs:
-      token: ${{ steps.generate.outputs.token }}
+    env:
+      ISSUE_URL: ${{ github.event.issue.html_url }}
     steps:
-      - name: 'Generate'
-        id: generate
+      - name: 'Generate Token'
+        id: token
         uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
         with:
           app_id: ${{ secrets.APP_ID }}
           installation_id: ${{ secrets.INSTALLATION_ID }}
           private_key: ${{ secrets.APP_PEM }}
 
-  automation_labeler:
-    name: 'Automation Labeler'
-    needs: [community_check, generate_token]
-    runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ needs.generate_token.outputs.token }}
-      ISSUE_URL: ${{ github.event.issue.html_url }}
-    steps:
       - name: 'Add needs-triage for non-maintainer'
         if: github.event.action == 'opened' && needs.community_check.outputs.maintainer == 'false'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: gh issue edit ${{ env.ISSUE_URL }} --add-label needs-triage
 
       - name: 'Add prioritized when assigned to maintainers'
         if: github.event.action == 'assigned' && needs.community_check.outputs.maintainer == 'true'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: gh issue edit ${{ env.ISSUE_URL }} --add-label prioritized
 
       - name: 'Add prioritized to regressions'
         if: github.event.label.name == 'regression'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: gh issue edit ${{ env.ISSUE_URL }} --add-label prioritized
 
       - name: 'Remove unnecessary labels on closure'
         if: github.event.action == 'closed'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: gh issue edit ${{ env.ISSUE_URL }} --remove-label needs-triage,waiting-response
 
   service_labeler:
@@ -74,9 +75,8 @@ jobs:
   add_to_project:
     name: 'Add to Project'
     runs-on: ubuntu-latest
-    needs: [community_check, generate_token]
+    needs: community_check
     env:
-      GH_TOKEN: ${{ needs.generate_token.outputs.token }}
       # Some gh project calls take the project's ID, some take the project's number
       PROJECT_ID: "PVT_kwDOAAuecM4AF-7h"
       PROJECT_NUMBER: "196"
@@ -84,14 +84,26 @@ jobs:
       VIEW_FIELD_ID: "PVTSSF_lADOAAuecM4AF-7hzgMRB34"
       ITEM_URL: ${{ github.event.issue.html_url }}
     steps:
+      - name: 'Generate Token'
+        id: token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          installation_id: ${{ secrets.INSTALLATION_ID }}
+          private_key: ${{ secrets.APP_PEM }}
+
       - name: 'Maintainer Issues'
         if: github.event.action == 'opened' && needs.community_check.outputs.maintainer == 'true'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
           PROJECT_ITEM_ID=$(gh project item-add ${{ env.PROJECT_NUMBER }} --owner "hashicorp" --url ${{ env.ITEM_URL }} --format json | jq '.id')
           gh project item-edit --id "$PROJECT_ITEM_ID" --project-id ${{ env.PROJECT_ID }} --field-id ${{ env.VIEW_FIELD_ID }} --single-select-option-id ${{ vars.team_project_view_working_board }}
 
       - name: 'Assigned to Maintainer'
         if: github.event.action == 'assigned' && needs.community_check.outputs.maintainer == 'true'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
           PROJECT_ITEM_ID=$(gh project item-add ${{ env.PROJECT_NUMBER }} --owner "hashicorp" --url ${{ env.ITEM_URL }} --format json | jq '.id')
           gh project item-edit --id "$PROJECT_ITEM_ID" --project-id ${{ env.PROJECT_ID }} --field-id ${{ env.STATUS_FIELD_ID }} --single-select-option-id ${{ vars.team_project_status_in_progress }}
@@ -99,12 +111,16 @@ jobs:
 
       - name: 'Labeled Prioritized or Regression'
         if: contains(fromJSON('["prioritized", "regression"]'), github.event.label.name)
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
           PROJECT_ITEM_ID=$(gh project item-add ${{ env.PROJECT_NUMBER }} --owner "hashicorp" --url ${{ env.ITEM_URL }} --format json | jq '.id')
           gh project item-edit --id "$PROJECT_ITEM_ID" --project-id ${{ env.PROJECT_ID }} --field-id ${{ env.VIEW_FIELD_ID }} --single-select-option-id ${{ vars.team_project_view_working_board }}
 
       - name: 'Labeled Engineering Initiative'
         if: github.event.label.name == 'engineering-initiative'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
           PROJECT_ITEM_ID=$(gh project item-add ${{ env.PROJECT_NUMBER }} --owner "hashicorp" --url ${{ env.ITEM_URL }} --format json | jq '.id')
           gh project item-edit --id "$PROJECT_ITEM_ID" --project-id ${{ env.PROJECT_ID }} --field-id ${{ env.VIEW_FIELD_ID }} --single-select-option-id ${{ vars.team_project_view_engineering_initiative }}

--- a/.github/workflows/pull_request_target.yml
+++ b/.github/workflows/pull_request_target.yml
@@ -21,52 +21,57 @@ jobs:
       # https://docs.github.com/en/actions/learn-github-actions/expressions#example
       username: ${{ github.event.action == 'assigned' && github.event.assignee.login || github.event.pull_request.user.login }}
 
-  generate_token:
-    name: 'Generate Token'
+  labeler:
+    name: 'Automation Labeler'
+    needs: community_check
     runs-on: ubuntu-latest
-    outputs:
-      token: ${{ steps.generate.outputs.token }}
+    env:
+      PR_URL: ${{ github.event.pull_request.html_url }}
     steps:
-      - name: 'Generate'
-        id: generate
+      - name: 'Generate Token'
+        id: token
         uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
         with:
           app_id: ${{ secrets.APP_ID }}
           installation_id: ${{ secrets.INSTALLATION_ID }}
           private_key: ${{ secrets.APP_PEM }}
 
-  labeler:
-    name: 'Automation Labeler'
-    needs: [community_check, generate_token]
-    runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ needs.generate_token.outputs.token }}
-      PR_URL: ${{ github.event.pull_request.html_url }}
-    steps:
       - name: 'Add needs-triage for non-maintainers'
         if: github.event.action == 'opened' && needs.community_check.outputs.maintainer == 'false'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: gh pr edit ${{ env.PR_URL }} --add-label needs-triage
 
       - name: 'Add prioritized to pull requests authored by or assigned to maintainers'
         # This conditional is basically an exact copy of an example provided by GitHub:
         # https://docs.github.com/en/actions/learn-github-actions/expressions#example-matching-an-array-of-strings
         if: contains(fromJSON('["opened", "assigned"]'), github.event.action) && needs.community_check.outputs.maintainer == 'true'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: gh pr edit ${{ env.PR_URL }} --add-label prioritized
 
       - name: 'Add partner to partner pull requests'
         if: github.event.action == 'opened' && needs.community_check.outputs.partner == 'true'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: gh pr edit ${{ env.PR_URL }} --add-label partner
 
       - name: 'Add external-maintainer to external maintainer pull requests'
         if: github.event.action == 'opened' && needs.community_check.outputs.core_contributor == 'true'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: gh pr edit ${{ env.PR_URL }} --add-label external-maintainer
 
       - name: 'Add prioritized to regressions'
         if: github.event.label.name == 'regression'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: gh pr edit ${{ env.PR_URL }} --add-label prioritized
 
       - name: 'Remove unnecessary labels on closure'
         if: github.event.action == 'closed'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: gh pr edit ${{ env.PR_URL }} --remove-label needs-triage,waiting-response
 
   service_labeler:
@@ -106,9 +111,8 @@ jobs:
   add_to_project:
     name: 'Add to Project'
     runs-on: ubuntu-latest
-    needs: [community_check, generate_token]
+    needs: community_check
     env:
-      GH_TOKEN: ${{ needs.generate_token.outputs.token }}
       # Some gh project calls take the project's ID, some take the project's number
       PROJECT_ID: "PVT_kwDOAAuecM4AF-7h"
       PROJECT_NUMBER: "196"
@@ -116,8 +120,18 @@ jobs:
       VIEW_FIELD_ID: "PVTSSF_lADOAAuecM4AF-7hzgMRB34"
       ITEM_URL: ${{ github.event.pull_request.html_url }}
     steps:
+      - name: 'Generate Token'
+        id: token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          installation_id: ${{ secrets.INSTALLATION_ID }}
+          private_key: ${{ secrets.APP_PEM }}
+
       - name: 'Maintainer Pull Requests'
         if: github.event.action == 'opened' && needs.community_check.outputs.maintainer == 'true'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
           # In order to update the item's Status field, we need to capture the project item id from the output
           PROJECT_ITEM_ID=$(gh project item-add ${{ env.PROJECT_NUMBER }} --owner "hashicorp" --url ${{ env.ITEM_URL }} --format json | jq '.id')
@@ -126,6 +140,8 @@ jobs:
 
       - name: 'Assigned to Maintainers'
         if: github.event.action == 'assigned' && needs.community_check.outputs.maintainer == 'true'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
           PROJECT_ITEM_ID=$(gh project item-add ${{ env.PROJECT_NUMBER }} --owner "hashicorp" --url ${{ env.ITEM_URL }} --format json | jq '.id')
           gh project item-edit --id "$PROJECT_ITEM_ID" --project-id ${{ env.PROJECT_ID }} --field-id ${{ env.STATUS_FIELD_ID }} --single-select-option-id ${{ vars.team_project_status_in_progress }}
@@ -133,24 +149,32 @@ jobs:
 
       - name: 'Partner Pull Requests'
         if: github.event.label.name == 'partner'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
           PROJECT_ITEM_ID=$(gh project item-add ${{ env.PROJECT_NUMBER }} --owner "hashicorp" --url ${{ env.ITEM_URL }} --format json | jq '.id')
           gh project item-edit --id "$PROJECT_ITEM_ID" --project-id ${{ env.PROJECT_ID }} --field-id ${{ env.VIEW_FIELD_ID }} --single-select-option-id ${{ vars.team_project_view_partner_contribution }}
 
       - name: 'External Maintainer Pull Requests'
         if: github.event.label.name == 'external-maintainer'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
           PROJECT_ITEM_ID=$(gh project item-add ${{ env.PROJECT_NUMBER }} --owner "hashicorp" --url ${{ env.ITEM_URL }} --format json | jq '.id')
           gh project item-edit --id "$PROJECT_ITEM_ID" --project-id ${{ env.PROJECT_ID }} --field-id ${{ env.VIEW_FIELD_ID }} --single-select-option-id ${{ vars.team_project_view_external_maintainer }}
 
       - name: 'Labeled Prioritized or Regression'
         if: contains(fromJSON('["prioritized", "regression"]'), github.event.label.name)
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
           PROJECT_ITEM_ID=$(gh project item-add ${{ env.PROJECT_NUMBER }} --owner "hashicorp" --url ${{ env.ITEM_URL }} --format json | jq '.id')
           gh project item-edit --id "$PROJECT_ITEM_ID" --project-id ${{ env.PROJECT_ID }} --field-id ${{ env.VIEW_FIELD_ID }} --single-select-option-id ${{ vars.team_project_view_working_board }}
 
       - name: 'Labeled Engineering Initiative'
         if: github.event.label.name == 'engineering-initiative'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
           PROJECT_ITEM_ID=$(gh project item-add ${{ env.PROJECT_NUMBER }} --owner "hashicorp" --url ${{ env.ITEM_URL }} --format json | jq '.id')
           gh project item-edit --id "$PROJECT_ITEM_ID" --project-id ${{ env.PROJECT_ID }} --field-id ${{ env.VIEW_FIELD_ID }} --single-select-option-id ${{ vars.team_project_view_engineering_initiative }}


### PR DESCRIPTION
### Description

While #32849 correctly moved authentication to a GitHub App generated token, it did not take into account another caveat to Actions: job outputs that contain sensitive data are dropped and not emitted by runners. This PR moves token generation to a step within the jobs that need it to overcome this.

### Relations

Relates #32849

### References

- [Failed workflow run caused by this](https://github.com/hashicorp/terraform-provider-aws/actions/runs/5764070009)
- [GitHub Reference](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idoutputs):

> Job outputs containing expressions are evaluated on the runner at the end of each job. Outputs containing secrets are redacted on the runner and not sent to GitHub Actions.

### Output from Acceptance Testing

N/a, Actions
