### PR TITLE
Increase mwaa_environment create timeout to 4 hours

### DIFF
--- a/internal/service/mwaa/environment.go
+++ b/internal/service/mwaa/environment.go
@@ -44,7 +44,7 @@ func ResourceEnvironment() *schema.Resource {
 		},
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(120 * time.Minute),
+			Create: schema.DefaultTimeout(240 * time.Minute),
 			Update: schema.DefaultTimeout(90 * time.Minute),
 			Delete: schema.DefaultTimeout(90 * time.Minute),
 		},

--- a/website/docs/cdktf/python/r/mwaa_environment.html.markdown
+++ b/website/docs/cdktf/python/r/mwaa_environment.html.markdown
@@ -219,7 +219,7 @@ This resource exports the following attributes in addition to the arguments abov
 
 [Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
 
-- `create` - (Default `120m`)
+- `create` - (Default `240m`)
 - `update` - (Default `90m`)
 - `delete` - (Default `90m`)
 

--- a/website/docs/cdktf/typescript/r/mwaa_environment.html.markdown
+++ b/website/docs/cdktf/typescript/r/mwaa_environment.html.markdown
@@ -231,7 +231,7 @@ This resource exports the following attributes in addition to the arguments abov
 
 [Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
 
-- `create` - (Default `120M`)
+- `create` - (Default `240M`)
 - `update` - (Default `90M`)
 - `delete` - (Default `90M`)
 

--- a/website/docs/r/mwaa_environment.html.markdown
+++ b/website/docs/r/mwaa_environment.html.markdown
@@ -189,7 +189,7 @@ This resource exports the following attributes in addition to the arguments abov
 
 [Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
 
-- `create` - (Default `120m`)
+- `create` - (Default `240m`)
 - `update` - (Default `90m`)
 - `delete` - (Default `90m`)
 


### PR DESCRIPTION
### Description

While the current value (2 hours) may already sound huge, it may not always be enough.
For example, I had a run with a configuration that turned out to be invalid, that took around 3h (I believe my network setup was lacking NAT gateways during this specific attempt).

I'm unsure, reading the guidelines, if this change is big enough to mandate a changelog entry. Please let me know if I should add one.

### Relations
N/A

### References
N/A

### Output from Acceptance Testing
I don't believe timeout values are covered by acceptance tests, are they ?
