### PR TITLE
RDS AccTests - KMS Keys

### DIFF
--- a/internal/service/rds/cluster_instance_test.go
+++ b/internal/service/rds/cluster_instance_test.go
@@ -1303,6 +1303,9 @@ func testAccClusterInstanceConfig_kmsKey(rName string) string {
 		acctest.ConfigAvailableAZsNoOptIn(),
 		testAccClusterInstanceConfig_orderableEngineBase("aurora-mysql", false),
 		fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+
 resource "aws_kms_key" "test" {
   description = %[1]q
 
@@ -1315,7 +1318,7 @@ resource "aws_kms_key" "test" {
       "Sid": "Enable IAM User Permissions",
       "Effect": "Allow",
       "Principal": {
-        "AWS": "*"
+        "AWS": "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
       },
       "Action": "kms:*",
       "Resource": "*"

--- a/internal/service/rds/cluster_test.go
+++ b/internal/service/rds/cluster_test.go
@@ -3212,8 +3212,7 @@ resource "aws_kms_key" "foo" {
       "Sid": "Enable IAM User Permissions",
       "Effect": "Allow",
       "Principal": {
-        "AWS": "*"
-        "AWS" = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
+        "AWS": "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
       },
       "Action": "kms:*",
       "Resource": "*"
@@ -3649,8 +3648,8 @@ data "aws_availability_zones" "available" {
   }
 }
 
-data "aws_partition" "current" {}
 data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
 data "aws_region" "current" {}
 
 resource "aws_rds_cluster_parameter_group" "test" {
@@ -3698,8 +3697,7 @@ resource "aws_kms_key" "test" {
       "Sid": "Enable IAM User Permissions",
       "Effect": "Allow",
       "Principal": {
-        "AWS": "*"
-		"AWS" = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
+        "AWS": "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
       },
       "Action": "kms:*",
       "Resource": "*"

--- a/internal/service/rds/cluster_test.go
+++ b/internal/service/rds/cluster_test.go
@@ -3197,6 +3197,8 @@ resource "aws_rds_cluster" "test" {
 
 func testAccClusterConfig_kmsKey(n int) string {
 	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
 
 resource "aws_kms_key" "foo" {
   description = "Terraform acc test %[1]d"
@@ -3211,6 +3213,7 @@ resource "aws_kms_key" "foo" {
       "Effect": "Allow",
       "Principal": {
         "AWS": "*"
+        "AWS" = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
       },
       "Action": "kms:*",
       "Resource": "*"
@@ -3646,8 +3649,8 @@ data "aws_availability_zones" "available" {
   }
 }
 
+data "aws_partition" "current" {}
 data "aws_caller_identity" "current" {}
-
 data "aws_region" "current" {}
 
 resource "aws_rds_cluster_parameter_group" "test" {
@@ -3696,6 +3699,7 @@ resource "aws_kms_key" "test" {
       "Effect": "Allow",
       "Principal": {
         "AWS": "*"
+		"AWS" = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
       },
       "Action": "kms:*",
       "Resource": "*"

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -5954,6 +5954,9 @@ func testAccInstanceConfig_kmsKeyID(rName string) string {
 	return acctest.ConfigCompose(
 		testAccInstanceConfig_orderableClassMySQL(),
 		fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+
 resource "aws_kms_key" "test" {
   description = %[1]q
 
@@ -5966,7 +5969,7 @@ resource "aws_kms_key" "test" {
       "Sid": "Enable IAM User Permissions",
       "Effect": "Allow",
       "Principal": {
-        "AWS": "*"
+        "AWS": "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
       },
       "Action": "kms:*",
       "Resource": "*"
@@ -9931,6 +9934,9 @@ resource "aws_db_instance" "test" {
 
 func testAccInstanceConfig_ReplicateSourceDB_performanceInsightsEnabled(rName string) string {
 	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+
 resource "aws_kms_key" "test" {
   description = "Terraform acc test"
 
@@ -9943,7 +9949,7 @@ resource "aws_kms_key" "test" {
       "Sid": "Enable IAM User Permissions",
       "Effect": "Allow",
       "Principal": {
-        "AWS": "*"
+        "AWS": "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
       },
       "Action": "kms:*",
       "Resource": "*"
@@ -9992,6 +9998,9 @@ resource "aws_db_instance" "test" {
 
 func testAccInstanceConfig_SnapshotID_performanceInsightsEnabled(rName string) string {
 	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+
 resource "aws_kms_key" "test" {
   description = "Terraform acc test"
 
@@ -10005,6 +10014,7 @@ resource "aws_kms_key" "test" {
       "Effect": "Allow",
       "Principal": {
         "AWS": "*"
+        "AWS": "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
       },
       "Action": "kms:*",
       "Resource": "*"

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -10013,7 +10013,6 @@ resource "aws_kms_key" "test" {
       "Sid": "Enable IAM User Permissions",
       "Effect": "Allow",
       "Principal": {
-        "AWS": "*"
         "AWS": "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
       },
       "Action": "kms:*",


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Updated AccTests that use KMS keys to limit Principal.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
make testacc TESTARGS='-run=TestAccRDSInstance_SnapshotIdentifier_performanceInsightsEnabled\|TestAccRDSInstance_ReplicateSourceDB_performanceInsightsEnabled\|TestAccRDSInstance_ManagedMasterPassword_managedSpecificKMSKey\|TestAccRDSClusterInstance_kmsKey\|TestAccRDSCluster_kmsKey\|TestAccRDSCluster_ReplicationSourceIdentifier_kmsKeyID\|TestAccRDSInstance_kmsKey' PKG=rds ACCTEST_PARALLELISM=4
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 4  -run=TestAccRDSInstance_SnapshotIdentifier_performanceInsightsEnabled\|TestAccRDSInstance_ReplicateSourceDB_performanceInsightsEnabled\|TestAccRDSInstance_ManagedMasterPassword_managedSpecificKMSKey\|TestAccRDSClusterInstance_kmsKey\|TestAccRDSCluster_kmsKey\|TestAccRDSCluster_ReplicationSourceIdentifier_kmsKeyID\|TestAccRDSInstance_kmsKey -timeout 180m
=== RUN   TestAccRDSClusterInstance_kmsKey
=== PAUSE TestAccRDSClusterInstance_kmsKey
=== RUN   TestAccRDSCluster_kmsKey
=== PAUSE TestAccRDSCluster_kmsKey
=== RUN   TestAccRDSCluster_ReplicationSourceIdentifier_kmsKeyID
=== PAUSE TestAccRDSCluster_ReplicationSourceIdentifier_kmsKeyID
=== RUN   TestAccRDSInstance_kmsKey
=== PAUSE TestAccRDSInstance_kmsKey
=== RUN   TestAccRDSInstance_ManagedMasterPassword_managedSpecificKMSKey
=== PAUSE TestAccRDSInstance_ManagedMasterPassword_managedSpecificKMSKey
=== RUN   TestAccRDSInstance_ReplicateSourceDB_performanceInsightsEnabled
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_performanceInsightsEnabled
=== RUN   TestAccRDSInstance_SnapshotIdentifier_performanceInsightsEnabled
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_performanceInsightsEnabled
=== CONT  TestAccRDSClusterInstance_kmsKey
=== CONT  TestAccRDSInstance_ManagedMasterPassword_managedSpecificKMSKey
=== CONT  TestAccRDSInstance_SnapshotIdentifier_performanceInsightsEnabled
=== CONT  TestAccRDSCluster_ReplicationSourceIdentifier_kmsKeyID
    acctest.go:829: AWS_DEFAULT_REGION and AWS_ALTERNATE_REGION must be set to different values for acceptance tests
--- FAIL: TestAccRDSCluster_ReplicationSourceIdentifier_kmsKeyID (0.23s)
=== CONT  TestAccRDSInstance_kmsKey
--- PASS: TestAccRDSInstance_ManagedMasterPassword_managedSpecificKMSKey (540.65s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_performanceInsightsEnabled
--- PASS: TestAccRDSInstance_kmsKey (648.25s)
=== CONT  TestAccRDSCluster_kmsKey
--- PASS: TestAccRDSCluster_kmsKey (204.66s)
--- PASS: TestAccRDSClusterInstance_kmsKey (1352.60s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_performanceInsightsEnabled (1417.95s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_performanceInsightsEnabled (1630.88s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/rds        2171.824s
FAIL
make: *** [testacc] Error 1

...
```
