### PR TITLE
Increase `MaxItems` of `aws_lambda_event_source_mapping.filter_critera.filter` from 5 to 10

### DIFF
--- a/.changelog/32890.txt
+++ b/.changelog/32890.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_lambda_event_source_mapping: Increased the maximum number of filters to 10
+```

--- a/internal/service/lambda/event_source_mapping.go
+++ b/internal/service/lambda/event_source_mapping.go
@@ -164,7 +164,7 @@ func ResourceEventSourceMapping() *schema.Resource {
 						"filter": {
 							Type:     schema.TypeSet,
 							Optional: true,
-							MaxItems: 5,
+							MaxItems: 10,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"pattern": {


### PR DESCRIPTION
### Description

This pull request updates the `MaxItems` of `aws_lambda_event_source_mapping.filter_critera.filter` from 5 to 10; while 5 is the default maximum, users can request AWS to increase their limit up to 10.

### Relations

Closes #32806

### References

- [AWS: Lamda event filtering](https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventfiltering.html)

> If you need to define more than five filters for an event source, you can request a quota increase up to 10 filters for each event source. If you attempt to add more filters than your current quota permits, Lambda will return an error when you try and create the event source.

### Output from Acceptance Testing

```console
$ make testacc TESTS=TestAccLambdaEventSourceMapping PKG=lambda
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaEventSourceMapping'  -timeout 180m
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_basic
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_basic
=== RUN   TestAccLambdaEventSourceMapping_SQS_basic
=== PAUSE TestAccLambdaEventSourceMapping_SQS_basic
=== RUN   TestAccLambdaEventSourceMapping_DynamoDB_basic
=== PAUSE TestAccLambdaEventSourceMapping_DynamoDB_basic
=== RUN   TestAccLambdaEventSourceMapping_DynamoDB_functionResponseTypes
=== PAUSE TestAccLambdaEventSourceMapping_DynamoDB_functionResponseTypes
=== RUN   TestAccLambdaEventSourceMapping_DynamoDB_streamAdded
=== PAUSE TestAccLambdaEventSourceMapping_DynamoDB_streamAdded
=== RUN   TestAccLambdaEventSourceMapping_SQS_batchWindow
=== PAUSE TestAccLambdaEventSourceMapping_SQS_batchWindow
=== RUN   TestAccLambdaEventSourceMapping_disappears
=== PAUSE TestAccLambdaEventSourceMapping_disappears
=== RUN   TestAccLambdaEventSourceMapping_SQS_changesInEnabledAreDetected
=== PAUSE TestAccLambdaEventSourceMapping_SQS_changesInEnabledAreDetected
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_startingPositionTimestamp
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_startingPositionTimestamp
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_batchWindow
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_batchWindow
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_parallelizationFactor
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_parallelizationFactor
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_tumblingWindowInSeconds
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_tumblingWindowInSeconds
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttempts
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttempts
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsZero
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsZero
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsNegativeOne
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsNegativeOne
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSeconds
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSeconds
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSecondsNegativeOne
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSecondsNegativeOne
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_bisectBatch
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_bisectBatch
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_destination
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_destination
=== RUN   TestAccLambdaEventSourceMapping_msk
=== PAUSE TestAccLambdaEventSourceMapping_msk
=== RUN   TestAccLambdaEventSourceMapping_mskWithEventSourceConfig
=== PAUSE TestAccLambdaEventSourceMapping_mskWithEventSourceConfig
=== RUN   TestAccLambdaEventSourceMapping_selfManagedKafka
=== PAUSE TestAccLambdaEventSourceMapping_selfManagedKafka
=== RUN   TestAccLambdaEventSourceMapping_selfManagedKafkaWithEventSourceConfig
=== PAUSE TestAccLambdaEventSourceMapping_selfManagedKafkaWithEventSourceConfig
=== RUN   TestAccLambdaEventSourceMapping_activeMQ
=== PAUSE TestAccLambdaEventSourceMapping_activeMQ
=== RUN   TestAccLambdaEventSourceMapping_rabbitMQ
=== PAUSE TestAccLambdaEventSourceMapping_rabbitMQ
=== RUN   TestAccLambdaEventSourceMapping_SQS_filterCriteria
=== PAUSE TestAccLambdaEventSourceMapping_SQS_filterCriteria
=== RUN   TestAccLambdaEventSourceMapping_SQS_scalingConfig
=== PAUSE TestAccLambdaEventSourceMapping_SQS_scalingConfig
=== RUN   TestAccLambdaEventSourceMapping_documentDB                                                                                                                                                                                                                          
=== PAUSE TestAccLambdaEventSourceMapping_documentDB
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_basic
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsNegativeOne
=== CONT  TestAccLambdaEventSourceMapping_selfManagedKafka
=== CONT  TestAccLambdaEventSourceMapping_SQS_filterCriteria
=== CONT  TestAccLambdaEventSourceMapping_activeMQ
=== CONT  TestAccLambdaEventSourceMapping_selfManagedKafkaWithEventSourceConfig
=== CONT  TestAccLambdaEventSourceMapping_mskWithEventSourceConfig
=== CONT  TestAccLambdaEventSourceMapping_msk
=== CONT  TestAccLambdaEventSourceMapping_documentDB
=== CONT  TestAccLambdaEventSourceMapping_SQS_scalingConfig
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSecondsNegativeOne
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_bisectBatch
=== CONT  TestAccLambdaEventSourceMapping_SQS_changesInEnabledAreDetected
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsZero
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttempts
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_tumblingWindowInSeconds
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_parallelizationFactor
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_batchWindow
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_startingPositionTimestamp
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_destination
=== NAME  TestAccLambdaEventSourceMapping_documentDB
    event_source_mapping_test.go:1183: Step 1/2 error: Error running apply: exit status 1

        Error: creating DocumentDB cluster: DBClusterParameterGroupNotFound: DBClusterParameterGroup not found: default.docdb4.0
                status code: 404, request id: 05446d18-2864-459b-8aff-856bfc1d935d

          with aws_docdb_cluster.test,
          on terraform_plugin_test.tf line 106, in resource "aws_docdb_cluster" "test":
         106: resource "aws_docdb_cluster" "test" {

--- FAIL: TestAccLambdaEventSourceMapping_documentDB (100.38s)
=== CONT  TestAccLambdaEventSourceMapping_DynamoDB_streamAdded
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_tumblingWindowInSeconds (110.65s)
=== CONT  TestAccLambdaEventSourceMapping_disappears
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_startingPositionTimestamp (113.38s)
=== CONT  TestAccLambdaEventSourceMapping_SQS_batchWindow
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_destination (121.31s)
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSeconds
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_bisectBatch (128.32s)
=== CONT  TestAccLambdaEventSourceMapping_rabbitMQ
--- PASS: TestAccLambdaEventSourceMapping_selfManagedKafka (144.25s)
=== CONT  TestAccLambdaEventSourceMapping_DynamoDB_basic
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_parallelizationFactor (145.35s)
=== CONT  TestAccLambdaEventSourceMapping_DynamoDB_functionResponseTypes
--- PASS: TestAccLambdaEventSourceMapping_SQS_changesInEnabledAreDetected (146.17s)
=== CONT  TestAccLambdaEventSourceMapping_SQS_basic
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_batchWindow (173.69s)
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSecondsNegativeOne (179.26s)
--- PASS: TestAccLambdaEventSourceMapping_selfManagedKafkaWithEventSourceConfig (185.63s)
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttempts (189.77s)
--- PASS: TestAccLambdaEventSourceMapping_SQS_scalingConfig (217.19s)
--- PASS: TestAccLambdaEventSourceMapping_disappears (112.22s)
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsNegativeOne (234.42s)
--- PASS: TestAccLambdaEventSourceMapping_SQS_batchWindow (122.54s)
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsZero (238.83s)
--- PASS: TestAccLambdaEventSourceMapping_DynamoDB_streamAdded (145.57s)
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_basic (249.53s)
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSeconds (129.52s)
--- PASS: TestAccLambdaEventSourceMapping_DynamoDB_basic (125.45s)
--- PASS: TestAccLambdaEventSourceMapping_DynamoDB_functionResponseTypes (127.87s)
--- PASS: TestAccLambdaEventSourceMapping_SQS_basic (162.97s)
--- PASS: TestAccLambdaEventSourceMapping_SQS_filterCriteria (323.35s)
--- PASS: TestAccLambdaEventSourceMapping_rabbitMQ (745.97s)
--- PASS: TestAccLambdaEventSourceMapping_activeMQ (990.53s)
--- PASS: TestAccLambdaEventSourceMapping_mskWithEventSourceConfig (3068.36s)
--- PASS: TestAccLambdaEventSourceMapping_msk (3219.89s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/lambda     3222.974s
FAIL
make: *** [testacc] Error 1
```
