### PR TITLE
Fix: Enabling IPv6 apply error

### DIFF
--- a/.changelog/32896.txt
+++ b/.changelog/32896.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_subnet: Fix allowing IPv6 to be enabled in an update after initial creation with IPv4 only
+```

--- a/.github/labeler-pr-triage.yml
+++ b/.github/labeler-pr-triage.yml
@@ -26,7 +26,7 @@ linter:
   - '.github/workflows/acctest-terraform-lint.yml'
   - '.github/workflows/providerlint.yml'
   - '.github/workflows/semgrep-ci.yml'
-  - '.github/workflows/terraform_provider.yml'
+  - '.github/workflows/provider.yml'
   - '.github/workflows/website.yml'
   - '.github/workflows/workflow-lint.yml'
 pre-service-packages:

--- a/.github/workflows/provider.yml
+++ b/.github/workflows/provider.yml
@@ -7,7 +7,7 @@ on:
       - "release/**"
   pull_request:
     paths:
-      - .github/workflows/terraform_provider.yml
+      - .github/workflows/provider.yml
       - .ci/.golangci.yml
       - .ci/tools/go.mod
       - .markdownlint.yml
@@ -116,7 +116,7 @@ jobs:
   go_test:
     name: go test
     needs: [go_build]
-    runs-on: [custom, linux, large]
+    runs-on: [custom, linux, xl]
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -105,7 +105,7 @@ jobs:
       - run: terrafmt diff ./website --check --pattern '*.markdown'
 
   tflint:
-    runs-on: ubuntu-latest
+    runs-on: [custom, linux, xl]
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:

--- a/internal/generate/prlabels/file.tmpl
+++ b/internal/generate/prlabels/file.tmpl
@@ -26,7 +26,7 @@ linter:
   - '.github/workflows/acctest-terraform-lint.yml'
   - '.github/workflows/providerlint.yml'
   - '.github/workflows/semgrep-ci.yml'
-  - '.github/workflows/terraform_provider.yml'
+  - '.github/workflows/provider.yml'
   - '.github/workflows/website.yml'
   - '.github/workflows/workflow-lint.yml'
 pre-service-packages:

--- a/internal/service/ec2/vpc_subnet_test.go
+++ b/internal/service/ec2/vpc_subnet_test.go
@@ -799,6 +799,42 @@ func TestAccVPCSubnet_enableDNS64(t *testing.T) {
 	})
 }
 
+func TestAccVPCSubnet_ipv4ToIPv6(t *testing.T) {
+	ctx := acctest.Context(t)
+	var subnet ec2.Subnet
+	resourceName := "aws_subnet.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSubnetDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCSubnetConfig_ipv4ToIPv6Before(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSubnetExists(ctx, resourceName, &subnet),
+					resource.TestCheckResourceAttr(resourceName, "assign_ipv6_address_on_creation", "false"),
+					resource.TestCheckResourceAttr(resourceName, "enable_dns64", "false"),
+					resource.TestCheckResourceAttr(resourceName, "enable_resource_name_dns_aaaa_record_on_launch", "false"),
+					resource.TestCheckResourceAttr(resourceName, "ipv6_cidr_block", ""),
+				),
+			},
+			{
+				Config: testAccVPCSubnetConfig_ipv4ToIPv6After(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSubnetExists(ctx, resourceName, &subnet),
+					resource.TestCheckResourceAttr(resourceName, "assign_ipv6_address_on_creation", "true"),
+					resource.TestCheckResourceAttr(resourceName, "enable_dns64", "true"),
+					resource.TestCheckResourceAttr(resourceName, "enable_resource_name_dns_aaaa_record_on_launch", "true"),
+					resource.TestCheckResourceAttrSet(resourceName, "ipv6_cidr_block"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccVPCSubnet_enableLNIAtDeviceIndex(t *testing.T) {
 	ctx := acctest.Context(t)
 	var subnet ec2.Subnet
@@ -1490,6 +1526,58 @@ resource "aws_subnet" "test" {
   cidr_block        = "10.1.1.0/24"
   outpost_arn       = data.aws_outposts_outpost.test.arn
   vpc_id            = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName)
+}
+
+func testAccVPCSubnetConfig_ipv4ToIPv6Before(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block                       = "10.10.0.0/16"
+  assign_generated_ipv6_cidr_block = false
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test" {
+  assign_ipv6_address_on_creation                = false
+  cidr_block                                     = cidrsubnet(aws_vpc.test.cidr_block, 8, 1)
+  enable_dns64                                   = false
+  enable_resource_name_dns_aaaa_record_on_launch = false
+  ipv6_cidr_block                                = null
+  vpc_id                                         = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName)
+}
+
+func testAccVPCSubnetConfig_ipv4ToIPv6After(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block                       = "10.10.0.0/16"
+  assign_generated_ipv6_cidr_block = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test" {
+  assign_ipv6_address_on_creation                = true
+  cidr_block                                     = cidrsubnet(aws_vpc.test.cidr_block, 8, 1)
+  enable_dns64                                   = true
+  enable_resource_name_dns_aaaa_record_on_launch = true
+  ipv6_cidr_block                                = cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 1)
+  vpc_id                                         = aws_vpc.test.id
 
   tags = {
     Name = %[1]q


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

enabling dns64 and resource_name_dns_aaaa_record_on_launch, need IPv6 CIDR block.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/32897

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
❯ make testacc PKG=ec2 TESTS="TestAccVPC*"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPC*'  -timeout 180m
=== RUN   TestAccVPCDataSource_basic
=== PAUSE TestAccVPCDataSource_basic
=== RUN   TestAccVPCDataSource_CIDRBlockAssociations_multiple
=== PAUSE TestAccVPCDataSource_CIDRBlockAssociations_multiple
=== RUN   TestAccVPCDefaultNetworkACL_basic
=== PAUSE TestAccVPCDefaultNetworkACL_basic
=== RUN   TestAccVPCDefaultNetworkACL_basicIPv6VPC
=== PAUSE TestAccVPCDefaultNetworkACL_basicIPv6VPC
=== RUN   TestAccVPCDefaultNetworkACL_tags
=== PAUSE TestAccVPCDefaultNetworkACL_tags
=== RUN   TestAccVPCDefaultNetworkACL_Deny_ingress
=== PAUSE TestAccVPCDefaultNetworkACL_Deny_ingress
=== RUN   TestAccVPCDefaultNetworkACL_withIPv6Ingress
=== PAUSE TestAccVPCDefaultNetworkACL_withIPv6Ingress
=== RUN   TestAccVPCDefaultNetworkACL_subnetRemoval
=== PAUSE TestAccVPCDefaultNetworkACL_subnetRemoval
=== RUN   TestAccVPCDefaultNetworkACL_subnetReassign
=== PAUSE TestAccVPCDefaultNetworkACL_subnetReassign
=== RUN   TestAccVPCDefaultRouteTable_basic
=== PAUSE TestAccVPCDefaultRouteTable_basic
=== RUN   TestAccVPCDefaultRouteTable_Disappears_vpc
=== PAUSE TestAccVPCDefaultRouteTable_Disappears_vpc
=== RUN   TestAccVPCDefaultRouteTable_Route_mode
=== PAUSE TestAccVPCDefaultRouteTable_Route_mode
=== RUN   TestAccVPCDefaultRouteTable_swap
=== PAUSE TestAccVPCDefaultRouteTable_swap
=== RUN   TestAccVPCDefaultRouteTable_ipv4ToTransitGateway
=== PAUSE TestAccVPCDefaultRouteTable_ipv4ToTransitGateway
=== RUN   TestAccVPCDefaultRouteTable_ipv4ToVPCEndpoint
=== PAUSE TestAccVPCDefaultRouteTable_ipv4ToVPCEndpoint
=== RUN   TestAccVPCDefaultRouteTable_vpcEndpointAssociation
=== PAUSE TestAccVPCDefaultRouteTable_vpcEndpointAssociation
=== RUN   TestAccVPCDefaultRouteTable_tags
=== PAUSE TestAccVPCDefaultRouteTable_tags
=== RUN   TestAccVPCDefaultRouteTable_conditionalCIDRBlock
=== PAUSE TestAccVPCDefaultRouteTable_conditionalCIDRBlock
=== RUN   TestAccVPCDefaultRouteTable_prefixListToInternetGateway
=== PAUSE TestAccVPCDefaultRouteTable_prefixListToInternetGateway
=== RUN   TestAccVPCDefaultRouteTable_revokeExistingRules
=== PAUSE TestAccVPCDefaultRouteTable_revokeExistingRules
=== RUN   TestAccVPCDefaultSecurityGroup_basic
=== PAUSE TestAccVPCDefaultSecurityGroup_basic
=== RUN   TestAccVPCDefaultSecurityGroup_empty
=== PAUSE TestAccVPCDefaultSecurityGroup_empty
=== RUN   TestAccVPCDefaultVPCDHCPOptions_serial
=== PAUSE TestAccVPCDefaultVPCDHCPOptions_serial
=== RUN   TestAccVPCDefaultVPCAndSubnet_serial
=== PAUSE TestAccVPCDefaultVPCAndSubnet_serial
=== RUN   TestAccVPCDHCPOptionsAssociation_basic
=== PAUSE TestAccVPCDHCPOptionsAssociation_basic
=== RUN   TestAccVPCDHCPOptionsAssociation_Disappears_vpc
=== PAUSE TestAccVPCDHCPOptionsAssociation_Disappears_vpc
=== RUN   TestAccVPCDHCPOptionsAssociation_Disappears_dhcp
=== PAUSE TestAccVPCDHCPOptionsAssociation_Disappears_dhcp
=== RUN   TestAccVPCDHCPOptionsAssociation_disappears
=== PAUSE TestAccVPCDHCPOptionsAssociation_disappears
=== RUN   TestAccVPCDHCPOptionsAssociation_default
=== PAUSE TestAccVPCDHCPOptionsAssociation_default
=== RUN   TestAccVPCDHCPOptionsDataSource_basic
=== PAUSE TestAccVPCDHCPOptionsDataSource_basic
=== RUN   TestAccVPCDHCPOptionsDataSource_filter
=== PAUSE TestAccVPCDHCPOptionsDataSource_filter
=== RUN   TestAccVPCDHCPOptions_basic
=== PAUSE TestAccVPCDHCPOptions_basic
=== RUN   TestAccVPCDHCPOptions_full
=== PAUSE TestAccVPCDHCPOptions_full
=== RUN   TestAccVPCDHCPOptions_tags
=== PAUSE TestAccVPCDHCPOptions_tags
=== RUN   TestAccVPCDHCPOptions_disappears
=== PAUSE TestAccVPCDHCPOptions_disappears
=== RUN   TestAccVPCEgressOnlyInternetGateway_basic
=== PAUSE TestAccVPCEgressOnlyInternetGateway_basic
=== RUN   TestAccVPCEgressOnlyInternetGateway_tags
=== PAUSE TestAccVPCEgressOnlyInternetGateway_tags
=== RUN   TestAccVPCEndpointConnectionAccepter_crossAccount
    acctest.go:243: at least one environment variable of [AWS_PROFILE AWS_ACCESS_KEY_ID AWS_CONTAINER_CREDENTIALS_FULL_URI] must be set. Usage: credentials for running acceptance testing
--- FAIL: TestAccVPCEndpointConnectionAccepter_crossAccount (0.00s)
=== RUN   TestAccVPCEndpointConnectionNotification_basic
=== PAUSE TestAccVPCEndpointConnectionNotification_basic
=== RUN   TestAccVPCEndpointDataSource_gatewayBasic
=== PAUSE TestAccVPCEndpointDataSource_gatewayBasic
=== RUN   TestAccVPCEndpointDataSource_byID
=== PAUSE TestAccVPCEndpointDataSource_byID
=== RUN   TestAccVPCEndpointDataSource_byFilter
=== PAUSE TestAccVPCEndpointDataSource_byFilter
=== RUN   TestAccVPCEndpointDataSource_byTags
=== PAUSE TestAccVPCEndpointDataSource_byTags
=== RUN   TestAccVPCEndpointDataSource_gatewayWithRouteTableAndTags
=== PAUSE TestAccVPCEndpointDataSource_gatewayWithRouteTableAndTags
=== RUN   TestAccVPCEndpointDataSource_interface
=== PAUSE TestAccVPCEndpointDataSource_interface
=== RUN   TestAccVPCEndpointPolicy_basic
=== PAUSE TestAccVPCEndpointPolicy_basic
=== RUN   TestAccVPCEndpointPolicy_disappears
=== PAUSE TestAccVPCEndpointPolicy_disappears
=== RUN   TestAccVPCEndpointPolicy_disappears_endpoint
=== PAUSE TestAccVPCEndpointPolicy_disappears_endpoint
=== RUN   TestAccVPCEndpointRouteTableAssociation_basic
=== PAUSE TestAccVPCEndpointRouteTableAssociation_basic
=== RUN   TestAccVPCEndpointRouteTableAssociation_disappears
=== PAUSE TestAccVPCEndpointRouteTableAssociation_disappears
=== RUN   TestAccVPCEndpointSecurityGroupAssociation_basic
=== PAUSE TestAccVPCEndpointSecurityGroupAssociation_basic
=== RUN   TestAccVPCEndpointSecurityGroupAssociation_disappears
=== PAUSE TestAccVPCEndpointSecurityGroupAssociation_disappears
=== RUN   TestAccVPCEndpointSecurityGroupAssociation_multiple
=== PAUSE TestAccVPCEndpointSecurityGroupAssociation_multiple
=== RUN   TestAccVPCEndpointSecurityGroupAssociation_replaceDefaultAssociation
=== PAUSE TestAccVPCEndpointSecurityGroupAssociation_replaceDefaultAssociation
=== RUN   TestAccVPCEndpointServiceAllowedPrincipal_basic
=== PAUSE TestAccVPCEndpointServiceAllowedPrincipal_basic
=== RUN   TestAccVPCEndpointServiceAllowedPrincipal_multiple
=== PAUSE TestAccVPCEndpointServiceAllowedPrincipal_multiple
=== RUN   TestAccVPCEndpointServiceAllowedPrincipal_tags
=== PAUSE TestAccVPCEndpointServiceAllowedPrincipal_tags
=== RUN   TestAccVPCEndpointServiceAllowedPrincipal_migrateID
=== PAUSE TestAccVPCEndpointServiceAllowedPrincipal_migrateID
=== RUN   TestAccVPCEndpointServiceAllowedPrincipal_migrateAndTag
=== PAUSE TestAccVPCEndpointServiceAllowedPrincipal_migrateAndTag
=== RUN   TestAccVPCEndpointServiceDataSource_gateway
=== PAUSE TestAccVPCEndpointServiceDataSource_gateway
=== RUN   TestAccVPCEndpointServiceDataSource_interface
=== PAUSE TestAccVPCEndpointServiceDataSource_interface
=== RUN   TestAccVPCEndpointServiceDataSource_custom
=== PAUSE TestAccVPCEndpointServiceDataSource_custom
=== RUN   TestAccVPCEndpointServiceDataSource_Custom_filter
=== PAUSE TestAccVPCEndpointServiceDataSource_Custom_filter
=== RUN   TestAccVPCEndpointServiceDataSource_CustomFilter_tags
=== PAUSE TestAccVPCEndpointServiceDataSource_CustomFilter_tags
=== RUN   TestAccVPCEndpointServiceDataSource_ServiceType_gateway
=== PAUSE TestAccVPCEndpointServiceDataSource_ServiceType_gateway
=== RUN   TestAccVPCEndpointServiceDataSource_ServiceType_interface
=== PAUSE TestAccVPCEndpointServiceDataSource_ServiceType_interface
=== RUN   TestAccVPCEndpointService_basic
=== PAUSE TestAccVPCEndpointService_basic
=== RUN   TestAccVPCEndpointService_disappears
=== PAUSE TestAccVPCEndpointService_disappears
=== RUN   TestAccVPCEndpointService_tags
=== PAUSE TestAccVPCEndpointService_tags
=== RUN   TestAccVPCEndpointService_networkLoadBalancerARNs
=== PAUSE TestAccVPCEndpointService_networkLoadBalancerARNs
=== RUN   TestAccVPCEndpointService_supportedIPAddressTypes
=== PAUSE TestAccVPCEndpointService_supportedIPAddressTypes
=== RUN   TestAccVPCEndpointService_allowedPrincipals
=== PAUSE TestAccVPCEndpointService_allowedPrincipals
=== RUN   TestAccVPCEndpointService_gatewayLoadBalancerARNs
=== PAUSE TestAccVPCEndpointService_gatewayLoadBalancerARNs
=== RUN   TestAccVPCEndpointService_privateDNSName
=== PAUSE TestAccVPCEndpointService_privateDNSName
=== RUN   TestAccVPCEndpointSubnetAssociation_basic
=== PAUSE TestAccVPCEndpointSubnetAssociation_basic
=== RUN   TestAccVPCEndpointSubnetAssociation_disappears
=== PAUSE TestAccVPCEndpointSubnetAssociation_disappears
=== RUN   TestAccVPCEndpointSubnetAssociation_multiple
=== PAUSE TestAccVPCEndpointSubnetAssociation_multiple
=== RUN   TestAccVPCEndpoint_gatewayBasic
=== PAUSE TestAccVPCEndpoint_gatewayBasic
=== RUN   TestAccVPCEndpoint_interfaceBasic
=== PAUSE TestAccVPCEndpoint_interfaceBasic
=== RUN   TestAccVPCEndpoint_interfacePrivateDNS
=== PAUSE TestAccVPCEndpoint_interfacePrivateDNS
=== RUN   TestAccVPCEndpoint_interfacePrivateDNSNoGateway
=== PAUSE TestAccVPCEndpoint_interfacePrivateDNSNoGateway
=== RUN   TestAccVPCEndpoint_disappears
=== PAUSE TestAccVPCEndpoint_disappears
=== RUN   TestAccVPCEndpoint_tags
=== PAUSE TestAccVPCEndpoint_tags
=== RUN   TestAccVPCEndpoint_gatewayWithRouteTableAndPolicy
=== PAUSE TestAccVPCEndpoint_gatewayWithRouteTableAndPolicy
=== RUN   TestAccVPCEndpoint_gatewayPolicy
=== PAUSE TestAccVPCEndpoint_gatewayPolicy
=== RUN   TestAccVPCEndpoint_ignoreEquivalent
=== PAUSE TestAccVPCEndpoint_ignoreEquivalent
=== RUN   TestAccVPCEndpoint_ipAddressType
=== PAUSE TestAccVPCEndpoint_ipAddressType
=== RUN   TestAccVPCEndpoint_interfaceWithSubnetAndSecurityGroup
=== PAUSE TestAccVPCEndpoint_interfaceWithSubnetAndSecurityGroup
=== RUN   TestAccVPCEndpoint_interfaceNonAWSServiceAcceptOnCreate
=== PAUSE TestAccVPCEndpoint_interfaceNonAWSServiceAcceptOnCreate
=== RUN   TestAccVPCEndpoint_interfaceNonAWSServiceAcceptOnUpdate
=== PAUSE TestAccVPCEndpoint_interfaceNonAWSServiceAcceptOnUpdate
=== RUN   TestAccVPCEndpoint_VPCEndpointType_gatewayLoadBalancer
=== PAUSE TestAccVPCEndpoint_VPCEndpointType_gatewayLoadBalancer
=== RUN   TestAccVPCFlowLog_basic
=== PAUSE TestAccVPCFlowLog_basic
=== RUN   TestAccVPCFlowLog_logFormat
=== PAUSE TestAccVPCFlowLog_logFormat
=== RUN   TestAccVPCFlowLog_subnetID
=== PAUSE TestAccVPCFlowLog_subnetID
=== RUN   TestAccVPCFlowLog_transitGatewayID
=== PAUSE TestAccVPCFlowLog_transitGatewayID
=== RUN   TestAccVPCFlowLog_transitGatewayAttachmentID
=== PAUSE TestAccVPCFlowLog_transitGatewayAttachmentID
=== RUN   TestAccVPCFlowLog_LogDestinationType_cloudWatchLogs
=== PAUSE TestAccVPCFlowLog_LogDestinationType_cloudWatchLogs
=== RUN   TestAccVPCFlowLog_LogDestinationType_kinesisFirehose
=== PAUSE TestAccVPCFlowLog_LogDestinationType_kinesisFirehose
=== RUN   TestAccVPCFlowLog_LogDestinationType_s3
=== PAUSE TestAccVPCFlowLog_LogDestinationType_s3
=== RUN   TestAccVPCFlowLog_LogDestinationTypeS3_invalid
=== PAUSE TestAccVPCFlowLog_LogDestinationTypeS3_invalid
=== RUN   TestAccVPCFlowLog_LogDestinationTypeS3DO_plainText
=== PAUSE TestAccVPCFlowLog_LogDestinationTypeS3DO_plainText
=== RUN   TestAccVPCFlowLog_LogDestinationTypeS3DOPlainText_hiveCompatible
=== PAUSE TestAccVPCFlowLog_LogDestinationTypeS3DOPlainText_hiveCompatible
=== RUN   TestAccVPCFlowLog_LogDestinationTypeS3DO_parquet
=== PAUSE TestAccVPCFlowLog_LogDestinationTypeS3DO_parquet
=== RUN   TestAccVPCFlowLog_LogDestinationTypeS3DOParquet_hiveCompatible
=== PAUSE TestAccVPCFlowLog_LogDestinationTypeS3DOParquet_hiveCompatible
=== RUN   TestAccVPCFlowLog_LogDestinationTypeS3DOParquetHiveCompatible_perHour
=== PAUSE TestAccVPCFlowLog_LogDestinationTypeS3DOParquetHiveCompatible_perHour
=== RUN   TestAccVPCFlowLog_LogDestinationType_maxAggregationInterval
=== PAUSE TestAccVPCFlowLog_LogDestinationType_maxAggregationInterval
=== RUN   TestAccVPCFlowLog_tags
=== PAUSE TestAccVPCFlowLog_tags
=== RUN   TestAccVPCFlowLog_disappears
=== PAUSE TestAccVPCFlowLog_disappears
=== RUN   TestAccVPCInternetGatewayAttachment_basic
=== PAUSE TestAccVPCInternetGatewayAttachment_basic
=== RUN   TestAccVPCInternetGatewayAttachment_disappears
=== PAUSE TestAccVPCInternetGatewayAttachment_disappears
=== RUN   TestAccVPCInternetGatewayDataSource_basic
=== PAUSE TestAccVPCInternetGatewayDataSource_basic
=== RUN   TestAccVPCInternetGateway_basic
=== PAUSE TestAccVPCInternetGateway_basic
=== RUN   TestAccVPCInternetGateway_disappears
=== PAUSE TestAccVPCInternetGateway_disappears
=== RUN   TestAccVPCInternetGateway_Attachment
=== PAUSE TestAccVPCInternetGateway_Attachment
=== RUN   TestAccVPCInternetGateway_Tags
=== PAUSE TestAccVPCInternetGateway_Tags
=== RUN   TestAccVPCIPv4CIDRBlockAssociation_basic
=== PAUSE TestAccVPCIPv4CIDRBlockAssociation_basic
=== RUN   TestAccVPCIPv4CIDRBlockAssociation_disappears
=== PAUSE TestAccVPCIPv4CIDRBlockAssociation_disappears
=== RUN   TestAccVPCIPv4CIDRBlockAssociation_ipamBasic
=== PAUSE TestAccVPCIPv4CIDRBlockAssociation_ipamBasic
=== RUN   TestAccVPCIPv4CIDRBlockAssociation_ipamBasicExplicitCIDR
=== PAUSE TestAccVPCIPv4CIDRBlockAssociation_ipamBasicExplicitCIDR
=== RUN   TestAccVPCMainRouteTableAssociation_basic
=== PAUSE TestAccVPCMainRouteTableAssociation_basic
=== RUN   TestAccVPCManagedPrefixListDataSource_basic
=== PAUSE TestAccVPCManagedPrefixListDataSource_basic
=== RUN   TestAccVPCManagedPrefixListDataSource_filter
=== PAUSE TestAccVPCManagedPrefixListDataSource_filter
=== RUN   TestAccVPCManagedPrefixListDataSource_matchesTooMany
=== PAUSE TestAccVPCManagedPrefixListDataSource_matchesTooMany
=== RUN   TestAccVPCManagedPrefixListEntry_ipv4
=== PAUSE TestAccVPCManagedPrefixListEntry_ipv4
=== RUN   TestAccVPCManagedPrefixListEntry_ipv4Multiple
=== PAUSE TestAccVPCManagedPrefixListEntry_ipv4Multiple
=== RUN   TestAccVPCManagedPrefixListEntry_ipv6
=== PAUSE TestAccVPCManagedPrefixListEntry_ipv6
=== RUN   TestAccVPCManagedPrefixListEntry_expectInvalidTypeError
=== PAUSE TestAccVPCManagedPrefixListEntry_expectInvalidTypeError
=== RUN   TestAccVPCManagedPrefixListEntry_expectInvalidCIDR
=== PAUSE TestAccVPCManagedPrefixListEntry_expectInvalidCIDR
=== RUN   TestAccVPCManagedPrefixListEntry_description
=== PAUSE TestAccVPCManagedPrefixListEntry_description
=== RUN   TestAccVPCManagedPrefixListEntry_disappears
=== PAUSE TestAccVPCManagedPrefixListEntry_disappears
=== RUN   TestAccVPCManagedPrefixList_basic
=== PAUSE TestAccVPCManagedPrefixList_basic
=== RUN   TestAccVPCManagedPrefixList_disappears
=== PAUSE TestAccVPCManagedPrefixList_disappears
=== RUN   TestAccVPCManagedPrefixList_AddressFamily_ipv6
=== PAUSE TestAccVPCManagedPrefixList_AddressFamily_ipv6
=== RUN   TestAccVPCManagedPrefixList_Entry_cidr
=== PAUSE TestAccVPCManagedPrefixList_Entry_cidr
=== RUN   TestAccVPCManagedPrefixList_Entry_description
=== PAUSE TestAccVPCManagedPrefixList_Entry_description
=== RUN   TestAccVPCManagedPrefixList_updateEntryAndMaxEntry
=== PAUSE TestAccVPCManagedPrefixList_updateEntryAndMaxEntry
=== RUN   TestAccVPCManagedPrefixList_name
=== PAUSE TestAccVPCManagedPrefixList_name
=== RUN   TestAccVPCManagedPrefixList_tags
=== PAUSE TestAccVPCManagedPrefixList_tags
=== RUN   TestAccVPCManagedPrefixListsDataSource_basic
=== PAUSE TestAccVPCManagedPrefixListsDataSource_basic
=== RUN   TestAccVPCManagedPrefixListsDataSource_tags
=== PAUSE TestAccVPCManagedPrefixListsDataSource_tags
=== RUN   TestAccVPCManagedPrefixListsDataSource_noMatches
=== PAUSE TestAccVPCManagedPrefixListsDataSource_noMatches
=== RUN   TestAccVPCNATGatewayDataSource_basic
=== PAUSE TestAccVPCNATGatewayDataSource_basic
=== RUN   TestAccVPCNATGateway_basic
=== PAUSE TestAccVPCNATGateway_basic
=== RUN   TestAccVPCNATGateway_disappears
=== PAUSE TestAccVPCNATGateway_disappears
=== RUN   TestAccVPCNATGateway_ConnectivityType_private
=== PAUSE TestAccVPCNATGateway_ConnectivityType_private
=== RUN   TestAccVPCNATGateway_privateIP
=== PAUSE TestAccVPCNATGateway_privateIP
=== RUN   TestAccVPCNATGateway_tags
=== PAUSE TestAccVPCNATGateway_tags
=== RUN   TestAccVPCNATGateway_secondaryAllocationIDs
=== PAUSE TestAccVPCNATGateway_secondaryAllocationIDs
=== RUN   TestAccVPCNATGateway_secondaryPrivateIPAddressCount
=== PAUSE TestAccVPCNATGateway_secondaryPrivateIPAddressCount
=== RUN   TestAccVPCNATGateway_secondaryPrivateIPAddresses
=== PAUSE TestAccVPCNATGateway_secondaryPrivateIPAddresses
=== RUN   TestAccVPCNATGateway_SecondaryPrivateIPAddresses_private
=== PAUSE TestAccVPCNATGateway_SecondaryPrivateIPAddresses_private
=== RUN   TestAccVPCNATGatewaysDataSource_basic
=== PAUSE TestAccVPCNATGatewaysDataSource_basic
=== RUN   TestAccVPCNetworkACLAssociation_basic
=== PAUSE TestAccVPCNetworkACLAssociation_basic
=== RUN   TestAccVPCNetworkACLAssociation_disappears
=== PAUSE TestAccVPCNetworkACLAssociation_disappears
=== RUN   TestAccVPCNetworkACLAssociation_disappears_NACL
=== PAUSE TestAccVPCNetworkACLAssociation_disappears_NACL
=== RUN   TestAccVPCNetworkACLAssociation_disappears_Subnet
=== PAUSE TestAccVPCNetworkACLAssociation_disappears_Subnet
=== RUN   TestAccVPCNetworkACLAssociation_twoAssociations
=== PAUSE TestAccVPCNetworkACLAssociation_twoAssociations
=== RUN   TestAccVPCNetworkACLAssociation_associateWithDefaultNACL
=== PAUSE TestAccVPCNetworkACLAssociation_associateWithDefaultNACL
=== RUN   TestAccVPCNetworkACLRule_basic
=== PAUSE TestAccVPCNetworkACLRule_basic
=== RUN   TestAccVPCNetworkACLRule_disappears
=== PAUSE TestAccVPCNetworkACLRule_disappears
=== RUN   TestAccVPCNetworkACLRule_Disappears_networkACL
=== PAUSE TestAccVPCNetworkACLRule_Disappears_networkACL
=== RUN   TestAccVPCNetworkACLRule_Disappears_ingressEgressSameNumber
=== PAUSE TestAccVPCNetworkACLRule_Disappears_ingressEgressSameNumber
=== RUN   TestAccVPCNetworkACLRule_ipv6
=== PAUSE TestAccVPCNetworkACLRule_ipv6
=== RUN   TestAccVPCNetworkACLRule_ipv6ICMP
=== PAUSE TestAccVPCNetworkACLRule_ipv6ICMP
=== RUN   TestAccVPCNetworkACLRule_ipv6VPCAssignGeneratedIPv6CIDRBlockUpdate
=== PAUSE TestAccVPCNetworkACLRule_ipv6VPCAssignGeneratedIPv6CIDRBlockUpdate
=== RUN   TestAccVPCNetworkACLRule_allProtocol
=== PAUSE TestAccVPCNetworkACLRule_allProtocol
=== RUN   TestAccVPCNetworkACLRule_tcpProtocol
=== PAUSE TestAccVPCNetworkACLRule_tcpProtocol
=== RUN   TestAccVPCNetworkACL_basic
=== PAUSE TestAccVPCNetworkACL_basic
=== RUN   TestAccVPCNetworkACL_disappears
=== PAUSE TestAccVPCNetworkACL_disappears
=== RUN   TestAccVPCNetworkACL_tags
=== PAUSE TestAccVPCNetworkACL_tags
=== RUN   TestAccVPCNetworkACL_Egress_mode
=== PAUSE TestAccVPCNetworkACL_Egress_mode
=== RUN   TestAccVPCNetworkACL_Ingress_mode
=== PAUSE TestAccVPCNetworkACL_Ingress_mode
=== RUN   TestAccVPCNetworkACL_egressAndIngressRules
=== PAUSE TestAccVPCNetworkACL_egressAndIngressRules
=== RUN   TestAccVPCNetworkACL_OnlyIngressRules_basic
=== PAUSE TestAccVPCNetworkACL_OnlyIngressRules_basic
=== RUN   TestAccVPCNetworkACL_OnlyIngressRules_update
=== PAUSE TestAccVPCNetworkACL_OnlyIngressRules_update
=== RUN   TestAccVPCNetworkACL_caseSensitivityNoChanges
=== PAUSE TestAccVPCNetworkACL_caseSensitivityNoChanges
=== RUN   TestAccVPCNetworkACL_onlyEgressRules
=== PAUSE TestAccVPCNetworkACL_onlyEgressRules
=== RUN   TestAccVPCNetworkACL_subnetChange
=== PAUSE TestAccVPCNetworkACL_subnetChange
=== RUN   TestAccVPCNetworkACL_subnets
=== PAUSE TestAccVPCNetworkACL_subnets
=== RUN   TestAccVPCNetworkACL_subnetsDelete
=== PAUSE TestAccVPCNetworkACL_subnetsDelete
=== RUN   TestAccVPCNetworkACL_ipv6Rules
=== PAUSE TestAccVPCNetworkACL_ipv6Rules
=== RUN   TestAccVPCNetworkACL_ipv6ICMPRules
=== PAUSE TestAccVPCNetworkACL_ipv6ICMPRules
=== RUN   TestAccVPCNetworkACL_ipv6VPCRules
=== PAUSE TestAccVPCNetworkACL_ipv6VPCRules
=== RUN   TestAccVPCNetworkACL_espProtocol
=== PAUSE TestAccVPCNetworkACL_espProtocol
=== RUN   TestAccVPCNetworkACLsDataSource_basic
=== PAUSE TestAccVPCNetworkACLsDataSource_basic
=== RUN   TestAccVPCNetworkACLsDataSource_filter
=== PAUSE TestAccVPCNetworkACLsDataSource_filter
=== RUN   TestAccVPCNetworkACLsDataSource_tags
=== PAUSE TestAccVPCNetworkACLsDataSource_tags
=== RUN   TestAccVPCNetworkACLsDataSource_vpcID
=== PAUSE TestAccVPCNetworkACLsDataSource_vpcID
=== RUN   TestAccVPCNetworkACLsDataSource_empty
=== PAUSE TestAccVPCNetworkACLsDataSource_empty
=== RUN   TestAccVPCNetworkInsightsAnalysisDataSource_basic
=== PAUSE TestAccVPCNetworkInsightsAnalysisDataSource_basic
=== RUN   TestAccVPCNetworkInsightsAnalysis_basic
=== PAUSE TestAccVPCNetworkInsightsAnalysis_basic
=== RUN   TestAccVPCNetworkInsightsAnalysis_disappears
=== PAUSE TestAccVPCNetworkInsightsAnalysis_disappears
=== RUN   TestAccVPCNetworkInsightsAnalysis_tags
=== PAUSE TestAccVPCNetworkInsightsAnalysis_tags
=== RUN   TestAccVPCNetworkInsightsAnalysis_filterInARNs
=== PAUSE TestAccVPCNetworkInsightsAnalysis_filterInARNs
=== RUN   TestAccVPCNetworkInsightsAnalysis_waitForCompletion
=== PAUSE TestAccVPCNetworkInsightsAnalysis_waitForCompletion
=== RUN   TestAccVPCNetworkInsightsPathDataSource_basic
=== PAUSE TestAccVPCNetworkInsightsPathDataSource_basic
=== RUN   TestAccVPCNetworkInsightsPath_basic
=== PAUSE TestAccVPCNetworkInsightsPath_basic
=== RUN   TestAccVPCNetworkInsightsPath_disappears
=== PAUSE TestAccVPCNetworkInsightsPath_disappears
=== RUN   TestAccVPCNetworkInsightsPath_tags
=== PAUSE TestAccVPCNetworkInsightsPath_tags
=== RUN   TestAccVPCNetworkInsightsPath_sourceIP
=== PAUSE TestAccVPCNetworkInsightsPath_sourceIP
=== RUN   TestAccVPCNetworkInsightsPath_destinationIP
=== PAUSE TestAccVPCNetworkInsightsPath_destinationIP
=== RUN   TestAccVPCNetworkInsightsPath_destinationPort
=== PAUSE TestAccVPCNetworkInsightsPath_destinationPort
=== RUN   TestAccVPCNetworkInterfaceAttachment_basic
=== PAUSE TestAccVPCNetworkInterfaceAttachment_basic
=== RUN   TestAccVPCNetworkInterfaceDataSource_basic
=== PAUSE TestAccVPCNetworkInterfaceDataSource_basic
=== RUN   TestAccVPCNetworkInterfaceDataSource_filters
=== PAUSE TestAccVPCNetworkInterfaceDataSource_filters
=== RUN   TestAccVPCNetworkInterfaceDataSource_carrierIPAssociation
=== PAUSE TestAccVPCNetworkInterfaceDataSource_carrierIPAssociation
=== RUN   TestAccVPCNetworkInterfaceDataSource_publicIPAssociation
=== PAUSE TestAccVPCNetworkInterfaceDataSource_publicIPAssociation
=== RUN   TestAccVPCNetworkInterfaceDataSource_attachment
=== PAUSE TestAccVPCNetworkInterfaceDataSource_attachment
=== RUN   TestAccVPCNetworkInterfaceSgAttachment_basic
=== PAUSE TestAccVPCNetworkInterfaceSgAttachment_basic
=== RUN   TestAccVPCNetworkInterfaceSgAttachment_disappears
=== PAUSE TestAccVPCNetworkInterfaceSgAttachment_disappears
=== RUN   TestAccVPCNetworkInterfaceSgAttachment_instance
=== PAUSE TestAccVPCNetworkInterfaceSgAttachment_instance
=== RUN   TestAccVPCNetworkInterfaceSgAttachment_multiple
=== PAUSE TestAccVPCNetworkInterfaceSgAttachment_multiple
=== RUN   TestAccVPCNetworkInterface_basic
=== PAUSE TestAccVPCNetworkInterface_basic
=== RUN   TestAccVPCNetworkInterface_ipv6
=== PAUSE TestAccVPCNetworkInterface_ipv6
=== RUN   TestAccVPCNetworkInterface_tags
=== PAUSE TestAccVPCNetworkInterface_tags
=== RUN   TestAccVPCNetworkInterface_ipv6Count
=== PAUSE TestAccVPCNetworkInterface_ipv6Count
=== RUN   TestAccVPCNetworkInterface_disappears
=== PAUSE TestAccVPCNetworkInterface_disappears
=== RUN   TestAccVPCNetworkInterface_description
=== PAUSE TestAccVPCNetworkInterface_description
=== RUN   TestAccVPCNetworkInterface_attachment
=== PAUSE TestAccVPCNetworkInterface_attachment
=== RUN   TestAccVPCNetworkInterface_ignoreExternalAttachment
=== PAUSE TestAccVPCNetworkInterface_ignoreExternalAttachment
=== RUN   TestAccVPCNetworkInterface_sourceDestCheck
=== PAUSE TestAccVPCNetworkInterface_sourceDestCheck
=== RUN   TestAccVPCNetworkInterface_privateIPsCount
=== PAUSE TestAccVPCNetworkInterface_privateIPsCount
=== RUN   TestAccVPCNetworkInterface_ENIInterfaceType_efa
=== PAUSE TestAccVPCNetworkInterface_ENIInterfaceType_efa
=== RUN   TestAccVPCNetworkInterface_ENI_ipv4Prefix
=== PAUSE TestAccVPCNetworkInterface_ENI_ipv4Prefix
=== RUN   TestAccVPCNetworkInterface_ENI_ipv4PrefixCount
=== PAUSE TestAccVPCNetworkInterface_ENI_ipv4PrefixCount
=== RUN   TestAccVPCNetworkInterface_ENI_ipv6Prefix
=== PAUSE TestAccVPCNetworkInterface_ENI_ipv6Prefix
=== RUN   TestAccVPCNetworkInterface_ENI_ipv6PrefixCount
=== PAUSE TestAccVPCNetworkInterface_ENI_ipv6PrefixCount
=== RUN   TestAccVPCNetworkInterface_privateIPSet
=== PAUSE TestAccVPCNetworkInterface_privateIPSet
=== RUN   TestAccVPCNetworkInterface_privateIPList
=== PAUSE TestAccVPCNetworkInterface_privateIPList
=== RUN   TestAccVPCNetworkInterfacesDataSource_filter
=== PAUSE TestAccVPCNetworkInterfacesDataSource_filter
=== RUN   TestAccVPCNetworkInterfacesDataSource_tags
=== PAUSE TestAccVPCNetworkInterfacesDataSource_tags
=== RUN   TestAccVPCNetworkInterfacesDataSource_empty
=== PAUSE TestAccVPCNetworkInterfacesDataSource_empty
=== RUN   TestAccVPCNetworkPerformanceMetricSubscription_serial
=== PAUSE TestAccVPCNetworkPerformanceMetricSubscription_serial
=== RUN   TestAccVPCPeeringConnectionAccepter_sameRegionSameAccount
=== PAUSE TestAccVPCPeeringConnectionAccepter_sameRegionSameAccount
=== RUN   TestAccVPCPeeringConnectionAccepter_differentRegionSameAccount
=== PAUSE TestAccVPCPeeringConnectionAccepter_differentRegionSameAccount
=== RUN   TestAccVPCPeeringConnectionAccepter_sameRegionDifferentAccount
=== PAUSE TestAccVPCPeeringConnectionAccepter_sameRegionDifferentAccount
=== RUN   TestAccVPCPeeringConnectionAccepter_differentRegionDifferentAccount
=== PAUSE TestAccVPCPeeringConnectionAccepter_differentRegionDifferentAccount
=== RUN   TestAccVPCPeeringConnectionDataSource_cidrBlock
=== PAUSE TestAccVPCPeeringConnectionDataSource_cidrBlock
=== RUN   TestAccVPCPeeringConnectionDataSource_id
=== PAUSE TestAccVPCPeeringConnectionDataSource_id
=== RUN   TestAccVPCPeeringConnectionDataSource_peerCIDRBlock
=== PAUSE TestAccVPCPeeringConnectionDataSource_peerCIDRBlock
=== RUN   TestAccVPCPeeringConnectionDataSource_peerVPCID
=== PAUSE TestAccVPCPeeringConnectionDataSource_peerVPCID
=== RUN   TestAccVPCPeeringConnectionDataSource_vpcID
=== PAUSE TestAccVPCPeeringConnectionDataSource_vpcID
=== RUN   TestAccVPCPeeringConnectionOptions_basic
=== PAUSE TestAccVPCPeeringConnectionOptions_basic
=== RUN   TestAccVPCPeeringConnectionOptions_differentRegionSameAccount
=== PAUSE TestAccVPCPeeringConnectionOptions_differentRegionSameAccount
=== RUN   TestAccVPCPeeringConnectionOptions_sameRegionDifferentAccount
=== PAUSE TestAccVPCPeeringConnectionOptions_sameRegionDifferentAccount
=== RUN   TestAccVPCPeeringConnection_basic
=== PAUSE TestAccVPCPeeringConnection_basic
=== RUN   TestAccVPCPeeringConnection_disappears
=== PAUSE TestAccVPCPeeringConnection_disappears
=== RUN   TestAccVPCPeeringConnection_tags
=== PAUSE TestAccVPCPeeringConnection_tags
=== RUN   TestAccVPCPeeringConnection_options
=== PAUSE TestAccVPCPeeringConnection_options
=== RUN   TestAccVPCPeeringConnection_failedState
=== PAUSE TestAccVPCPeeringConnection_failedState
=== RUN   TestAccVPCPeeringConnection_peerRegionAutoAccept
=== PAUSE TestAccVPCPeeringConnection_peerRegionAutoAccept
=== RUN   TestAccVPCPeeringConnection_region
=== PAUSE TestAccVPCPeeringConnection_region
=== RUN   TestAccVPCPeeringConnection_accept
=== PAUSE TestAccVPCPeeringConnection_accept
=== RUN   TestAccVPCPeeringConnection_optionsNoAutoAccept
=== PAUSE TestAccVPCPeeringConnection_optionsNoAutoAccept
=== RUN   TestAccVPCPeeringConnectionsDataSource_basic
=== PAUSE TestAccVPCPeeringConnectionsDataSource_basic
=== RUN   TestAccVPCPeeringConnectionsDataSource_NoMatches
=== PAUSE TestAccVPCPeeringConnectionsDataSource_NoMatches
=== RUN   TestAccVPCPrefixListDataSource_basic
=== PAUSE TestAccVPCPrefixListDataSource_basic
=== RUN   TestAccVPCPrefixListDataSource_filter
=== PAUSE TestAccVPCPrefixListDataSource_filter
=== RUN   TestAccVPCPrefixListDataSource_nameDoesNotOverrideFilter
=== PAUSE TestAccVPCPrefixListDataSource_nameDoesNotOverrideFilter
=== RUN   TestAccVPCRouteDataSource_basic
=== PAUSE TestAccVPCRouteDataSource_basic
=== RUN   TestAccVPCRouteDataSource_transitGatewayID
=== PAUSE TestAccVPCRouteDataSource_transitGatewayID
=== RUN   TestAccVPCRouteDataSource_ipv6DestinationCIDR
=== PAUSE TestAccVPCRouteDataSource_ipv6DestinationCIDR
=== RUN   TestAccVPCRouteDataSource_localGatewayID
=== PAUSE TestAccVPCRouteDataSource_localGatewayID
=== RUN   TestAccVPCRouteDataSource_carrierGatewayID
=== PAUSE TestAccVPCRouteDataSource_carrierGatewayID
=== RUN   TestAccVPCRouteDataSource_destinationPrefixListID
=== PAUSE TestAccVPCRouteDataSource_destinationPrefixListID
=== RUN   TestAccVPCRouteDataSource_gatewayVPCEndpoint
=== PAUSE TestAccVPCRouteDataSource_gatewayVPCEndpoint
=== RUN   TestAccVPCRouteTableAssociation_Subnet_basic
=== PAUSE TestAccVPCRouteTableAssociation_Subnet_basic
=== RUN   TestAccVPCRouteTableAssociation_Subnet_changeRouteTable
=== PAUSE TestAccVPCRouteTableAssociation_Subnet_changeRouteTable
=== RUN   TestAccVPCRouteTableAssociation_Gateway_basic
=== PAUSE TestAccVPCRouteTableAssociation_Gateway_basic
=== RUN   TestAccVPCRouteTableAssociation_Gateway_changeRouteTable
=== PAUSE TestAccVPCRouteTableAssociation_Gateway_changeRouteTable
=== RUN   TestAccVPCRouteTableAssociation_disappears
=== PAUSE TestAccVPCRouteTableAssociation_disappears
=== RUN   TestAccVPCRouteTableDataSource_basic
=== PAUSE TestAccVPCRouteTableDataSource_basic
=== RUN   TestAccVPCRouteTableDataSource_main
=== PAUSE TestAccVPCRouteTableDataSource_main
=== RUN   TestAccVPCRouteTable_basic
=== PAUSE TestAccVPCRouteTable_basic
=== RUN   TestAccVPCRouteTable_disappears
=== PAUSE TestAccVPCRouteTable_disappears
=== RUN   TestAccVPCRouteTable_Disappears_subnetAssociation
=== PAUSE TestAccVPCRouteTable_Disappears_subnetAssociation
=== RUN   TestAccVPCRouteTable_ipv4ToInternetGateway
=== PAUSE TestAccVPCRouteTable_ipv4ToInternetGateway
=== RUN   TestAccVPCRouteTable_ipv4ToInstance
=== PAUSE TestAccVPCRouteTable_ipv4ToInstance
=== RUN   TestAccVPCRouteTable_ipv6ToEgressOnlyInternetGateway
=== PAUSE TestAccVPCRouteTable_ipv6ToEgressOnlyInternetGateway
=== RUN   TestAccVPCRouteTable_tags
=== PAUSE TestAccVPCRouteTable_tags
=== RUN   TestAccVPCRouteTable_requireRouteDestination
=== PAUSE TestAccVPCRouteTable_requireRouteDestination
=== RUN   TestAccVPCRouteTable_requireRouteTarget
=== PAUSE TestAccVPCRouteTable_requireRouteTarget
=== RUN   TestAccVPCRouteTable_Route_mode
=== PAUSE TestAccVPCRouteTable_Route_mode
=== RUN   TestAccVPCRouteTable_ipv4ToTransitGateway
=== PAUSE TestAccVPCRouteTable_ipv4ToTransitGateway
=== RUN   TestAccVPCRouteTable_ipv4ToVPCEndpoint
=== PAUSE TestAccVPCRouteTable_ipv4ToVPCEndpoint
=== RUN   TestAccVPCRouteTable_ipv4ToCarrierGateway
=== PAUSE TestAccVPCRouteTable_ipv4ToCarrierGateway
=== RUN   TestAccVPCRouteTable_ipv4ToLocalGateway
=== PAUSE TestAccVPCRouteTable_ipv4ToLocalGateway
=== RUN   TestAccVPCRouteTable_ipv4ToVPCPeeringConnection
=== PAUSE TestAccVPCRouteTable_ipv4ToVPCPeeringConnection
=== RUN   TestAccVPCRouteTable_vgwRoutePropagation
=== PAUSE TestAccVPCRouteTable_vgwRoutePropagation
=== RUN   TestAccVPCRouteTable_conditionalCIDRBlock
=== PAUSE TestAccVPCRouteTable_conditionalCIDRBlock
=== RUN   TestAccVPCRouteTable_ipv4ToNatGateway
=== PAUSE TestAccVPCRouteTable_ipv4ToNatGateway
=== RUN   TestAccVPCRouteTable_IPv6ToNetworkInterface_unattached
=== PAUSE TestAccVPCRouteTable_IPv6ToNetworkInterface_unattached
=== RUN   TestAccVPCRouteTable_IPv4ToNetworkInterfaces_unattached
=== PAUSE TestAccVPCRouteTable_IPv4ToNetworkInterfaces_unattached
=== RUN   TestAccVPCRouteTable_vpcMultipleCIDRs
=== PAUSE TestAccVPCRouteTable_vpcMultipleCIDRs
=== RUN   TestAccVPCRouteTable_gatewayVPCEndpoint
=== PAUSE TestAccVPCRouteTable_gatewayVPCEndpoint
=== RUN   TestAccVPCRouteTable_multipleRoutes
=== PAUSE TestAccVPCRouteTable_multipleRoutes
=== RUN   TestAccVPCRouteTable_prefixListToInternetGateway
=== PAUSE TestAccVPCRouteTable_prefixListToInternetGateway
=== RUN   TestAccVPCRouteTable_localRoute
=== PAUSE TestAccVPCRouteTable_localRoute
=== RUN   TestAccVPCRouteTable_localRouteAdoptUpdate
=== PAUSE TestAccVPCRouteTable_localRouteAdoptUpdate
=== RUN   TestAccVPCRouteTable_localRouteImportUpdate
=== PAUSE TestAccVPCRouteTable_localRouteImportUpdate
=== RUN   TestAccVPCRouteTablesDataSource_basic
=== PAUSE TestAccVPCRouteTablesDataSource_basic
=== RUN   TestAccVPCRoute_basic
=== PAUSE TestAccVPCRoute_basic
=== RUN   TestAccVPCRoute_disappears
=== PAUSE TestAccVPCRoute_disappears
=== RUN   TestAccVPCRoute_Disappears_routeTable
=== PAUSE TestAccVPCRoute_Disappears_routeTable
=== RUN   TestAccVPCRoute_ipv6ToEgressOnlyInternetGateway
=== PAUSE TestAccVPCRoute_ipv6ToEgressOnlyInternetGateway
=== RUN   TestAccVPCRoute_ipv6ToInternetGateway
=== PAUSE TestAccVPCRoute_ipv6ToInternetGateway
=== RUN   TestAccVPCRoute_ipv6ToInstance
=== PAUSE TestAccVPCRoute_ipv6ToInstance
=== RUN   TestAccVPCRoute_IPv6ToNetworkInterface_unattached
=== PAUSE TestAccVPCRoute_IPv6ToNetworkInterface_unattached
=== RUN   TestAccVPCRoute_ipv6ToVPCPeeringConnection
=== PAUSE TestAccVPCRoute_ipv6ToVPCPeeringConnection
=== RUN   TestAccVPCRoute_ipv6ToVPNGateway
=== PAUSE TestAccVPCRoute_ipv6ToVPNGateway
=== RUN   TestAccVPCRoute_ipv4ToVPNGateway
=== PAUSE TestAccVPCRoute_ipv4ToVPNGateway
=== RUN   TestAccVPCRoute_ipv4ToInstance
=== PAUSE TestAccVPCRoute_ipv4ToInstance
=== RUN   TestAccVPCRoute_IPv4ToNetworkInterface_unattached
=== PAUSE TestAccVPCRoute_IPv4ToNetworkInterface_unattached
=== RUN   TestAccVPCRoute_IPv4ToNetworkInterface_attached
=== PAUSE TestAccVPCRoute_IPv4ToNetworkInterface_attached
=== RUN   TestAccVPCRoute_IPv4ToNetworkInterface_twoAttachments
=== PAUSE TestAccVPCRoute_IPv4ToNetworkInterface_twoAttachments
=== RUN   TestAccVPCRoute_ipv4ToVPCPeeringConnection
=== PAUSE TestAccVPCRoute_ipv4ToVPCPeeringConnection
=== RUN   TestAccVPCRoute_ipv4ToNatGateway
=== PAUSE TestAccVPCRoute_ipv4ToNatGateway
=== RUN   TestAccVPCRoute_ipv6ToNatGateway
=== PAUSE TestAccVPCRoute_ipv6ToNatGateway
=== RUN   TestAccVPCRoute_doesNotCrashWithVPCEndpoint
=== PAUSE TestAccVPCRoute_doesNotCrashWithVPCEndpoint
=== RUN   TestAccVPCRoute_ipv4ToTransitGateway
=== PAUSE TestAccVPCRoute_ipv4ToTransitGateway
=== RUN   TestAccVPCRoute_ipv6ToTransitGateway
=== PAUSE TestAccVPCRoute_ipv6ToTransitGateway
=== RUN   TestAccVPCRoute_ipv4ToCarrierGateway
=== PAUSE TestAccVPCRoute_ipv4ToCarrierGateway
=== RUN   TestAccVPCRoute_ipv4ToLocalGateway
=== PAUSE TestAccVPCRoute_ipv4ToLocalGateway
=== RUN   TestAccVPCRoute_ipv6ToLocalGateway
=== PAUSE TestAccVPCRoute_ipv6ToLocalGateway
=== RUN   TestAccVPCRoute_conditionalCIDRBlock
=== PAUSE TestAccVPCRoute_conditionalCIDRBlock
=== RUN   TestAccVPCRoute_IPv4Update_target
=== PAUSE TestAccVPCRoute_IPv4Update_target
=== RUN   TestAccVPCRoute_IPv6Update_target
=== PAUSE TestAccVPCRoute_IPv6Update_target
=== RUN   TestAccVPCRoute_ipv4ToVPCEndpoint
=== PAUSE TestAccVPCRoute_ipv4ToVPCEndpoint
=== RUN   TestAccVPCRoute_ipv6ToVPCEndpoint
=== PAUSE TestAccVPCRoute_ipv6ToVPCEndpoint
=== RUN   TestAccVPCRoute_localRoute
=== PAUSE TestAccVPCRoute_localRoute
=== RUN   TestAccVPCRoute_localRouteUpdate
=== PAUSE TestAccVPCRoute_localRouteUpdate
=== RUN   TestAccVPCRoute_prefixListToInternetGateway
=== PAUSE TestAccVPCRoute_prefixListToInternetGateway
=== RUN   TestAccVPCRoute_prefixListToVPNGateway
=== PAUSE TestAccVPCRoute_prefixListToVPNGateway
=== RUN   TestAccVPCRoute_prefixListToInstance
=== PAUSE TestAccVPCRoute_prefixListToInstance
=== RUN   TestAccVPCRoute_PrefixListToNetworkInterface_unattached
=== PAUSE TestAccVPCRoute_PrefixListToNetworkInterface_unattached
=== RUN   TestAccVPCRoute_PrefixListToNetworkInterface_attached
=== PAUSE TestAccVPCRoute_PrefixListToNetworkInterface_attached
=== RUN   TestAccVPCRoute_prefixListToVPCPeeringConnection
=== PAUSE TestAccVPCRoute_prefixListToVPCPeeringConnection
=== RUN   TestAccVPCRoute_prefixListToNatGateway
=== PAUSE TestAccVPCRoute_prefixListToNatGateway
=== RUN   TestAccVPCRoute_prefixListToTransitGateway
=== PAUSE TestAccVPCRoute_prefixListToTransitGateway
=== RUN   TestAccVPCRoute_prefixListToCarrierGateway
=== PAUSE TestAccVPCRoute_prefixListToCarrierGateway
=== RUN   TestAccVPCRoute_prefixListToLocalGateway
=== PAUSE TestAccVPCRoute_prefixListToLocalGateway
=== RUN   TestAccVPCRoute_prefixListToEgressOnlyInternetGateway
=== PAUSE TestAccVPCRoute_prefixListToEgressOnlyInternetGateway
=== RUN   TestAccVPCSecurityGroupDataSource_basic
=== PAUSE TestAccVPCSecurityGroupDataSource_basic
=== RUN   TestAccVPCSecurityGroupEgressRule_basic
=== PAUSE TestAccVPCSecurityGroupEgressRule_basic
=== RUN   TestAccVPCSecurityGroupEgressRule_disappears
=== PAUSE TestAccVPCSecurityGroupEgressRule_disappears
=== RUN   TestAccVPCSecurityGroupIngressRule_basic
=== PAUSE TestAccVPCSecurityGroupIngressRule_basic
=== RUN   TestAccVPCSecurityGroupIngressRule_disappears
=== PAUSE TestAccVPCSecurityGroupIngressRule_disappears
=== RUN   TestAccVPCSecurityGroupIngressRule_tags
=== PAUSE TestAccVPCSecurityGroupIngressRule_tags
=== RUN   TestAccVPCSecurityGroupIngressRule_tags_computed
=== PAUSE TestAccVPCSecurityGroupIngressRule_tags_computed
=== RUN   TestAccVPCSecurityGroupIngressRule_DefaultTags_providerOnly
=== PAUSE TestAccVPCSecurityGroupIngressRule_DefaultTags_providerOnly
=== RUN   TestAccVPCSecurityGroupIngressRule_DefaultTags_updateToProviderOnly
=== PAUSE TestAccVPCSecurityGroupIngressRule_DefaultTags_updateToProviderOnly
=== RUN   TestAccVPCSecurityGroupIngressRule_DefaultTags_updateToResourceOnly
=== PAUSE TestAccVPCSecurityGroupIngressRule_DefaultTags_updateToResourceOnly
=== RUN   TestAccVPCSecurityGroupIngressRule_DefaultTagsProviderAndResource_nonOverlappingTag
=== PAUSE TestAccVPCSecurityGroupIngressRule_DefaultTagsProviderAndResource_nonOverlappingTag
=== RUN   TestAccVPCSecurityGroupIngressRule_DefaultTagsProviderAndResource_overlappingTag
=== PAUSE TestAccVPCSecurityGroupIngressRule_DefaultTagsProviderAndResource_overlappingTag
=== RUN   TestAccVPCSecurityGroupIngressRule_DefaultTagsProviderAndResource_duplicateTag
=== PAUSE TestAccVPCSecurityGroupIngressRule_DefaultTagsProviderAndResource_duplicateTag
=== RUN   TestAccVPCSecurityGroupIngressRule_updateTagsKnownAtApply
=== PAUSE TestAccVPCSecurityGroupIngressRule_updateTagsKnownAtApply
=== RUN   TestAccVPCSecurityGroupIngressRule_defaultAndIgnoreTags
=== PAUSE TestAccVPCSecurityGroupIngressRule_defaultAndIgnoreTags
=== RUN   TestAccVPCSecurityGroupIngressRule_ignoreTags
=== PAUSE TestAccVPCSecurityGroupIngressRule_ignoreTags
=== RUN   TestAccVPCSecurityGroupIngressRule_cidrIPv4
=== PAUSE TestAccVPCSecurityGroupIngressRule_cidrIPv4
=== RUN   TestAccVPCSecurityGroupIngressRule_cidrIPv6
=== PAUSE TestAccVPCSecurityGroupIngressRule_cidrIPv6
=== RUN   TestAccVPCSecurityGroupIngressRule_description
=== PAUSE TestAccVPCSecurityGroupIngressRule_description
=== RUN   TestAccVPCSecurityGroupIngressRule_prefixListID
=== PAUSE TestAccVPCSecurityGroupIngressRule_prefixListID
=== RUN   TestAccVPCSecurityGroupIngressRule_referencedSecurityGroupID
=== PAUSE TestAccVPCSecurityGroupIngressRule_referencedSecurityGroupID
=== RUN   TestAccVPCSecurityGroupIngressRule_ReferencedSecurityGroupID_peerVPC
=== PAUSE TestAccVPCSecurityGroupIngressRule_ReferencedSecurityGroupID_peerVPC
=== RUN   TestAccVPCSecurityGroupIngressRule_updateSourceType
=== PAUSE TestAccVPCSecurityGroupIngressRule_updateSourceType
=== RUN   TestAccVPCSecurityGroupRuleDataSource_basic
=== PAUSE TestAccVPCSecurityGroupRuleDataSource_basic
=== RUN   TestAccVPCSecurityGroupRuleDataSource_filter
=== PAUSE TestAccVPCSecurityGroupRuleDataSource_filter
=== RUN   TestAccVPCSecurityGroupRule_Ingress_vpc
=== PAUSE TestAccVPCSecurityGroupRule_Ingress_vpc
=== RUN   TestAccVPCSecurityGroupRule_IngressSourceWithAccount_id
=== PAUSE TestAccVPCSecurityGroupRule_IngressSourceWithAccount_id
=== RUN   TestAccVPCSecurityGroupRule_Ingress_protocol
=== PAUSE TestAccVPCSecurityGroupRule_Ingress_protocol
=== RUN   TestAccVPCSecurityGroupRule_Ingress_icmpv6
=== PAUSE TestAccVPCSecurityGroupRule_Ingress_icmpv6
=== RUN   TestAccVPCSecurityGroupRule_Ingress_ipv6
=== PAUSE TestAccVPCSecurityGroupRule_Ingress_ipv6
=== RUN   TestAccVPCSecurityGroupRule_egress
=== PAUSE TestAccVPCSecurityGroupRule_egress
=== RUN   TestAccVPCSecurityGroupRule_selfReference
=== PAUSE TestAccVPCSecurityGroupRule_selfReference
=== RUN   TestAccVPCSecurityGroupRule_expectInvalidTypeError
=== PAUSE TestAccVPCSecurityGroupRule_expectInvalidTypeError
=== RUN   TestAccVPCSecurityGroupRule_expectInvalidCIDR
=== PAUSE TestAccVPCSecurityGroupRule_expectInvalidCIDR
=== RUN   TestAccVPCSecurityGroupRule_PartialMatching_basic
=== PAUSE TestAccVPCSecurityGroupRule_PartialMatching_basic
=== RUN   TestAccVPCSecurityGroupRule_PartialMatching_source
=== PAUSE TestAccVPCSecurityGroupRule_PartialMatching_source
=== RUN   TestAccVPCSecurityGroupRule_issue5310
=== PAUSE TestAccVPCSecurityGroupRule_issue5310
=== RUN   TestAccVPCSecurityGroupRule_race
=== PAUSE TestAccVPCSecurityGroupRule_race
=== RUN   TestAccVPCSecurityGroupRule_selfSource
=== PAUSE TestAccVPCSecurityGroupRule_selfSource
=== RUN   TestAccVPCSecurityGroupRule_prefixListEgress
=== PAUSE TestAccVPCSecurityGroupRule_prefixListEgress
=== RUN   TestAccVPCSecurityGroupRule_prefixListEmptyString
=== PAUSE TestAccVPCSecurityGroupRule_prefixListEmptyString
=== RUN   TestAccVPCSecurityGroupRule_ingressDescription
=== PAUSE TestAccVPCSecurityGroupRule_ingressDescription
=== RUN   TestAccVPCSecurityGroupRule_egressDescription
=== PAUSE TestAccVPCSecurityGroupRule_egressDescription
=== RUN   TestAccVPCSecurityGroupRule_IngressDescription_updates
=== PAUSE TestAccVPCSecurityGroupRule_IngressDescription_updates
=== RUN   TestAccVPCSecurityGroupRule_EgressDescription_updates
=== PAUSE TestAccVPCSecurityGroupRule_EgressDescription_updates
=== RUN   TestAccVPCSecurityGroupRule_Description_allPorts
=== PAUSE TestAccVPCSecurityGroupRule_Description_allPorts
=== RUN   TestAccVPCSecurityGroupRule_DescriptionAllPorts_nonZeroPorts
=== PAUSE TestAccVPCSecurityGroupRule_DescriptionAllPorts_nonZeroPorts
=== RUN   TestAccVPCSecurityGroupRule_MultipleRuleSearching_allProtocolCrash
=== PAUSE TestAccVPCSecurityGroupRule_MultipleRuleSearching_allProtocolCrash
=== RUN   TestAccVPCSecurityGroupRule_multiDescription
=== PAUSE TestAccVPCSecurityGroupRule_multiDescription
=== RUN   TestAccVPCSecurityGroupRule_Ingress_multipleIPv6
=== PAUSE TestAccVPCSecurityGroupRule_Ingress_multipleIPv6
=== RUN   TestAccVPCSecurityGroupRule_Ingress_multiplePrefixLists
=== PAUSE TestAccVPCSecurityGroupRule_Ingress_multiplePrefixLists
=== RUN   TestAccVPCSecurityGroupRule_Ingress_peeredVPC
=== PAUSE TestAccVPCSecurityGroupRule_Ingress_peeredVPC
=== RUN   TestAccVPCSecurityGroupRule_Ingress_ipv4AndIPv6
=== PAUSE TestAccVPCSecurityGroupRule_Ingress_ipv4AndIPv6
=== RUN   TestAccVPCSecurityGroupRule_Ingress_prefixListAndSelf
=== PAUSE TestAccVPCSecurityGroupRule_Ingress_prefixListAndSelf
=== RUN   TestAccVPCSecurityGroupRule_Ingress_prefixListAndSource
=== PAUSE TestAccVPCSecurityGroupRule_Ingress_prefixListAndSource
=== RUN   TestAccVPCSecurityGroupRule_protocolChange
=== PAUSE TestAccVPCSecurityGroupRule_protocolChange
=== RUN   TestAccVPCSecurityGroupRulesDataSource_basic
=== PAUSE TestAccVPCSecurityGroupRulesDataSource_basic
=== RUN   TestAccVPCSecurityGroupRulesDataSource_tags
=== PAUSE TestAccVPCSecurityGroupRulesDataSource_tags
=== RUN   TestAccVPCSecurityGroup_basic
=== PAUSE TestAccVPCSecurityGroup_basic
=== RUN   TestAccVPCSecurityGroup_disappears
=== PAUSE TestAccVPCSecurityGroup_disappears
=== RUN   TestAccVPCSecurityGroup_noVPC
=== PAUSE TestAccVPCSecurityGroup_noVPC
=== RUN   TestAccVPCSecurityGroup_nameGenerated
=== PAUSE TestAccVPCSecurityGroup_nameGenerated
=== RUN   TestAccVPCSecurityGroup_nameTerraformPrefix
=== PAUSE TestAccVPCSecurityGroup_nameTerraformPrefix
=== RUN   TestAccVPCSecurityGroup_namePrefix
=== PAUSE TestAccVPCSecurityGroup_namePrefix
=== RUN   TestAccVPCSecurityGroup_namePrefixTerraform
=== PAUSE TestAccVPCSecurityGroup_namePrefixTerraform
=== RUN   TestAccVPCSecurityGroup_tags
=== PAUSE TestAccVPCSecurityGroup_tags
=== RUN   TestAccVPCSecurityGroup_allowAll
=== PAUSE TestAccVPCSecurityGroup_allowAll
=== RUN   TestAccVPCSecurityGroup_sourceSecurityGroup
=== PAUSE TestAccVPCSecurityGroup_sourceSecurityGroup
=== RUN   TestAccVPCSecurityGroup_ipRangeAndSecurityGroupWithSameRules
=== PAUSE TestAccVPCSecurityGroup_ipRangeAndSecurityGroupWithSameRules
=== RUN   TestAccVPCSecurityGroup_ipRangesWithSameRules
=== PAUSE TestAccVPCSecurityGroup_ipRangesWithSameRules
=== RUN   TestAccVPCSecurityGroup_egressMode
=== PAUSE TestAccVPCSecurityGroup_egressMode
=== RUN   TestAccVPCSecurityGroup_ingressMode
=== PAUSE TestAccVPCSecurityGroup_ingressMode
=== RUN   TestAccVPCSecurityGroup_ruleGathering
=== PAUSE TestAccVPCSecurityGroup_ruleGathering
=== RUN   TestAccVPCSecurityGroup_forceRevokeRulesTrue
=== PAUSE TestAccVPCSecurityGroup_forceRevokeRulesTrue
=== RUN   TestAccVPCSecurityGroup_forceRevokeRulesFalse
=== PAUSE TestAccVPCSecurityGroup_forceRevokeRulesFalse
=== RUN   TestAccVPCSecurityGroup_change
=== PAUSE TestAccVPCSecurityGroup_change
=== RUN   TestAccVPCSecurityGroup_ipv6
=== PAUSE TestAccVPCSecurityGroup_ipv6
=== RUN   TestAccVPCSecurityGroup_self
=== PAUSE TestAccVPCSecurityGroup_self
=== RUN   TestAccVPCSecurityGroup_vpc
=== PAUSE TestAccVPCSecurityGroup_vpc
=== RUN   TestAccVPCSecurityGroup_vpcNegOneIngress
=== PAUSE TestAccVPCSecurityGroup_vpcNegOneIngress
=== RUN   TestAccVPCSecurityGroup_vpcProtoNumIngress
=== PAUSE TestAccVPCSecurityGroup_vpcProtoNumIngress
=== RUN   TestAccVPCSecurityGroup_multiIngress
=== PAUSE TestAccVPCSecurityGroup_multiIngress
=== RUN   TestAccVPCSecurityGroup_vpcAllEgress
=== PAUSE TestAccVPCSecurityGroup_vpcAllEgress
=== RUN   TestAccVPCSecurityGroup_ruleDescription
=== PAUSE TestAccVPCSecurityGroup_ruleDescription
=== RUN   TestAccVPCSecurityGroup_defaultEgressVPC
=== PAUSE TestAccVPCSecurityGroup_defaultEgressVPC
=== RUN   TestAccVPCSecurityGroup_driftComplex
=== PAUSE TestAccVPCSecurityGroup_driftComplex
=== RUN   TestAccVPCSecurityGroup_invalidCIDRBlock
=== PAUSE TestAccVPCSecurityGroup_invalidCIDRBlock
=== RUN   TestAccVPCSecurityGroup_cidrAndGroups
=== PAUSE TestAccVPCSecurityGroup_cidrAndGroups
=== RUN   TestAccVPCSecurityGroup_ingressWithCIDRAndSGsVPC
=== PAUSE TestAccVPCSecurityGroup_ingressWithCIDRAndSGsVPC
=== RUN   TestAccVPCSecurityGroup_egressWithPrefixList
=== PAUSE TestAccVPCSecurityGroup_egressWithPrefixList
=== RUN   TestAccVPCSecurityGroup_ingressWithPrefixList
=== PAUSE TestAccVPCSecurityGroup_ingressWithPrefixList
=== RUN   TestAccVPCSecurityGroup_ipv4AndIPv6Egress
=== PAUSE TestAccVPCSecurityGroup_ipv4AndIPv6Egress
=== RUN   TestAccVPCSecurityGroup_failWithDiffMismatch
=== PAUSE TestAccVPCSecurityGroup_failWithDiffMismatch
=== RUN   TestAccVPCSecurityGroup_RuleLimit_exceededAppend
cannot run Terraform provider tests: error calling terraform version command: exit status 1
time="2023-08-08T18:10:38+09:00" level=fatal msg="aqua failed" aqua_version=2.9.0 doc="https://aquaproj.github.io/docs/reference/codes/004" env=darwin/amd64 error="command is not found" exe_name=terraform program=aqua

FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	3.539s
FAIL
make: *** [testacc] Error 1
```
