### PR TITLE
r/glue_crawler - add hudi target support

### DIFF
--- a/.changelog/32898.txt
+++ b/.changelog/32898.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_glue_crawler: Add `hudi_target` argument
+```

--- a/internal/service/glue/crawler.go
+++ b/internal/service/glue/crawler.go
@@ -29,7 +29,7 @@ import (
 )
 
 func targets() []string {
-	return []string{"s3_target", "dynamodb_target", "mongodb_target", "jdbc_target", "catalog_target", "delta_target", "iceberg_target"}
+	return []string{"s3_target", "dynamodb_target", "mongodb_target", "jdbc_target", "catalog_target", "delta_target", "iceberg_target", "hudi_target"}
 }
 
 // @SDKResource("aws_glue_crawler", name="Crawler")
@@ -157,6 +157,35 @@ func ResourceCrawler() *schema.Resource {
 							Type:         schema.TypeFloat,
 							Optional:     true,
 							ValidateFunc: validation.FloatBetween(0.1, 1.5),
+						},
+					},
+				},
+			},
+			"hudi_target": {
+				Type:         schema.TypeList,
+				Optional:     true,
+				MinItems:     1,
+				AtLeastOneOf: targets(),
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"connection_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"exclusions": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"maximum_traversal_depth": {
+							Type:         schema.TypeInt,
+							Required:     true,
+							ValidateFunc: validation.IntBetween(1, 20),
+						},
+						"paths": {
+							Type:     schema.TypeSet,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 					},
 				},
@@ -520,6 +549,10 @@ func resourceCrawlerRead(ctx context.Context, d *schema.ResourceData, meta inter
 			return sdkdiag.AppendErrorf(diags, "setting delta_target: %s", err)
 		}
 
+		if err := d.Set("hudi_target", flattenHudiTargets(crawler.Targets.HudiTargets)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting hudi_target: %s", err)
+		}
+
 		if err := d.Set("iceberg_target", flattenIcebergTargets(crawler.Targets.IcebergTargets)); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting iceberg_target: %s", err)
 		}
@@ -772,6 +805,10 @@ func expandCrawlerTargets(d *schema.ResourceData) *glue.CrawlerTargets {
 		crawlerTargets.DeltaTargets = expandDeltaTargets(v.([]interface{}))
 	}
 
+	if v, ok := d.GetOk("hudi_target"); ok {
+		crawlerTargets.HudiTargets = expandHudiTargets(v.([]interface{}))
+	}
+
 	if v, ok := d.GetOk("iceberg_target"); ok {
 		crawlerTargets.IcebergTargets = expandIcebergTargets(v.([]interface{}))
 	}
@@ -960,6 +997,36 @@ func expandDeltaTarget(cfg map[string]interface{}) *glue.DeltaTarget {
 	return target
 }
 
+func expandHudiTargets(targets []interface{}) []*glue.HudiTarget {
+	if len(targets) < 1 {
+		return []*glue.HudiTarget{}
+	}
+
+	perms := make([]*glue.HudiTarget, len(targets))
+	for i, rawCfg := range targets {
+		cfg := rawCfg.(map[string]interface{})
+		perms[i] = expandHudiTarget(cfg)
+	}
+	return perms
+}
+
+func expandHudiTarget(cfg map[string]interface{}) *glue.HudiTarget {
+	target := &glue.HudiTarget{
+		Paths:                 flex.ExpandStringSet(cfg["paths"].(*schema.Set)),
+		MaximumTraversalDepth: aws.Int64(int64(cfg["maximum_traversal_depth"].(int))),
+	}
+
+	if v, ok := cfg["exclusions"]; ok {
+		target.Exclusions = flex.ExpandStringList(v.([]interface{}))
+	}
+
+	if v, ok := cfg["connection_name"].(string); ok {
+		target.ConnectionName = aws.String(v)
+	}
+
+	return target
+}
+
 func expandIcebergTargets(targets []interface{}) []*glue.IcebergTarget {
 	if len(targets) < 1 {
 		return []*glue.IcebergTarget{}
@@ -1079,6 +1146,21 @@ func flattenDeltaTargets(deltaTargets []*glue.DeltaTarget) []map[string]interfac
 		attrs["create_native_delta_table"] = aws.BoolValue(deltaTarget.CreateNativeDeltaTable)
 		attrs["delta_tables"] = flex.FlattenStringSet(deltaTarget.DeltaTables)
 		attrs["write_manifest"] = aws.BoolValue(deltaTarget.WriteManifest)
+
+		result = append(result, attrs)
+	}
+	return result
+}
+
+func flattenHudiTargets(hudiTargets []*glue.HudiTarget) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0)
+
+	for _, hudiTarget := range hudiTargets {
+		attrs := make(map[string]interface{})
+		attrs["connection_name"] = aws.StringValue(hudiTarget.ConnectionName)
+		attrs["maximum_traversal_depth"] = aws.Int64Value(hudiTarget.MaximumTraversalDepth)
+		attrs["paths"] = flex.FlattenStringSet(hudiTarget.Paths)
+		attrs["exclusions"] = flex.FlattenStringList(hudiTarget.Exclusions)
 
 		result = append(result, attrs)
 	}

--- a/website/docs/r/glue_crawler.html.markdown
+++ b/website/docs/r/glue_crawler.html.markdown
@@ -143,6 +143,7 @@ This argument supports the following arguments:
 * `jdbc_target` (Optional) List of nested JBDC target arguments. See [JDBC Target](#jdbc-target) below.
 * `s3_target` (Optional) List nested Amazon S3 target arguments. See [S3 Target](#s3-target) below.
 * `mongodb_target` (Optional) List nested MongoDB target arguments. See [MongoDB Target](#mongodb-target) below.
+* `hudi_target` (Optional) List nested Hudi target arguments. See [Iceberg Target](#hudi-target) below.
 * `iceberg_target` (Optional) List nested Iceberg target arguments. See [Iceberg Target](#iceberg-target) below.
 * `schedule` (Optional) A cron expression used to specify the schedule. For more information, see [Time-Based Schedules for Jobs and Crawlers](https://docs.aws.amazon.com/glue/latest/dg/monitor-data-warehouse-schedule.html). For example, to run something every day at 12:15 UTC, you would specify: `cron(15 12 * * ? *)`.
 * `schema_change_policy` (Optional) Policy for the crawler's update and deletion behavior. See [Schema Change Policy](#schema-change-policy) below.
@@ -192,6 +193,13 @@ This argument supports the following arguments:
 * `connection_name` - (Required) The name of the connection to use to connect to the Amazon DocumentDB or MongoDB target.
 * `path` - (Required) The path of the Amazon DocumentDB or MongoDB target (database/collection).
 * `scan_all` - (Optional) Indicates whether to scan all the records, or to sample rows from the table. Scanning all the records can take a long time when the table is not a high throughput table. Default value is `true`.
+
+### Hudi Target
+
+* `connection_name` - (Optional) The name of the connection to use to connect to the Hudi target.
+* `paths` - (Required) One or more Amazon S3 paths that contains Hudi metadata folders as s3://bucket/prefix.
+* `exclusions` - (Optional) A list of glob patterns used to exclude from the crawl.
+* `maximum_traversal_depth` - (Required) The maximum depth of Amazon S3 paths that the crawler can traverse to discover the Hudi metadata folder in your Amazon S3 path. Used to limit the crawler run time. Valid values are between `1` and `20`.
 
 ### Iceberg Target
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

[AWS announcement](https://aws.amazon.com/about-aws/whats-new/2023/07/aws-glue-crawlers-apache-hudi-tables/).

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccGlueCrawler_hudiTarget  PKG=glue

--- PASS: TestAccGlueCrawler_hudiTarget (85.72s)
```
