### PR TITLE
Update EKS Cluster docs example to limit OIDC thumbprint list

### DIFF
--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -122,7 +122,7 @@ data "tls_certificate" "example" {
 
 resource "aws_iam_openid_connect_provider" "example" {
   client_id_list  = ["sts.amazonaws.com"]
-  thumbprint_list = data.tls_certificate.example.certificates[*].sha1_fingerprint
+  thumbprint_list = [data.tls_certificate.example.certificates[0].sha1_fingerprint]
   url             = data.tls_certificate.example.url
 }
 


### PR DESCRIPTION
### Description

This update to the `aws_eks_cluster` documentation changes the value used for the `thumbprint_list` argument of the `aws_iam_openid_connect_provider` in one of the examples. OpenID Connect IdP can contain a maximum of 5 thumbprints; a limit that could be exceeded by using all of the thumbprints available in a given certificate. At the same time, AWS documents that only the top intermediate CA cert is needed. This change follows that pattern.

### Relations

Closes #32847

### References

- [AWS: Obtaining the thumbprint for an OpenID Connect Identity Provider](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html)

> When you [create an OpenID Connect (OIDC) identity provider](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html) in IAM, you must supply a thumbprint. IAM requires the thumbprint for the top intermediate certificate authority (CA) that signed the certificate used by the external identity provider (IdP).

- [AWS: Creating OpenID Connect (OIDC) identity providers](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html)

> An IAM OIDC identity provider must have at least one and can have a maximum of five thumbprints.

- [`tls_certificate` resource](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/data-sources/certificate)

> [certificates](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/data-sources/certificate#certificates) (List of Object) The certificates protecting the site, with the root of the chain first. (see [below for nested schema](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/data-sources/certificate#nestedatt--certificates))



### Output from Acceptance Testing

N/a, docs
