### PR TITLE
Add note on character limit for `aws_cloudwatch_event_rule.name_prefix`

### DIFF
--- a/website/docs/r/cloudwatch_event_rule.html.markdown
+++ b/website/docs/r/cloudwatch_event_rule.html.markdown
@@ -61,7 +61,7 @@ data "aws_iam_policy_document" "sns_topic_policy" {
 This resource supports the following arguments:
 
 * `name` - (Optional) The name of the rule. If omitted, Terraform will assign a random, unique name. Conflicts with `name_prefix`.
-* `name_prefix` - (Optional) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
+* `name_prefix` - (Optional) Creates a unique name beginning with the specified prefix. Conflicts with `name`. **Note**: Due to the length of the generated suffix, must be 38 characters or less.
 * `schedule_expression` - (Optional) The scheduling expression. For example, `cron(0 20 * * ? *)` or `rate(5 minutes)`. At least one of `schedule_expression` or `event_pattern` is required. Can only be used on the default event bus. For more information, refer to the AWS documentation [Schedule Expressions for Rules](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
 * `event_bus_name` - (Optional) The name or ARN of the event bus to associate with this rule.
   If you omit this, the `default` event bus is used.


### PR DESCRIPTION
### Description

The `name_prefix` argument of the `aws_cloudwatch_event_rule` resource generates a 26 character suffix, leaving 38 characters to stay under the 64 character limit of a rule's name. This PR adds a small note to the documentation as a helpful reminder of this limitation.

### Relations

Closes #32838

### References

- [Schema ValidateFunc](https://github.com/hashicorp/terraform-provider-aws/blob/5abea1af47a16e81007742638bdb8aa2c98ccfd0/internal/service/events/validate.go#L19-L22)

### Output from Acceptance Testing

N/a, docs
