### PR TITLE
r/aws_s3control_access_point(_policy): Fix acceptance test `AccessDenied` errors

### DIFF
--- a/internal/service/s3control/access_point_test.go
+++ b/internal/service/s3control/access_point_test.go
@@ -147,11 +147,11 @@ func TestAccS3ControlAccessPoint_policy(t *testing.T) {
       "Sid": "",
       "Effect": "Allow",
       "Principal": {
-        "AWS": "*"
+        "AWS": "arn:%[1]s:iam::%[3]s:root"
       },
       "Action": "s3:GetObjectTagging",
       "Resource": [
-        "arn:%s:s3:%s:%s:accesspoint/%s/object/*"
+        "arn:%[1]s:s3:%[2]s:%[3]s:accesspoint/%[4]s/object/*"
       ]
     }
   ]
@@ -165,14 +165,14 @@ func TestAccS3ControlAccessPoint_policy(t *testing.T) {
       "Sid": "",
       "Effect": "Allow",
       "Principal": {
-        "AWS": "*"
+        "AWS": "arn:%[1]s:iam::%[3]s:root"
       },
       "Action": [
         "s3:GetObjectLegalHold",
         "s3:GetObjectRetention"
       ],
       "Resource": [
-        "arn:%s:s3:%s:%s:accesspoint/%s/object/*"
+        "arn:%[1]s:s3:%[2]s:%[3]s:accesspoint/%[4]s/object/*"
       ]
     }
   ]
@@ -193,7 +193,7 @@ func TestAccS3ControlAccessPoint_policy(t *testing.T) {
 					acctest.CheckResourceAttrAccountID(resourceName, "account_id"),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "s3", fmt.Sprintf("accesspoint/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "bucket", rName),
-					resource.TestCheckResourceAttr(resourceName, "has_public_access_policy", "true"),
+					resource.TestCheckResourceAttr(resourceName, "has_public_access_policy", "false"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "network_origin", "Internet"),
 					resource.TestCheckResourceAttr(resourceName, "public_access_block_configuration.#", "1"),
@@ -220,7 +220,6 @@ func TestAccS3ControlAccessPoint_policy(t *testing.T) {
 				Config: testAccAccessPointConfig_noPolicy(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAccessPointExists(ctx, resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "has_public_access_policy", "false"),
 					resource.TestCheckResourceAttr(resourceName, "policy", ""),
 				),
 			},
@@ -495,7 +494,7 @@ data "aws_iam_policy_document" "test" {
 
     principals {
       type        = "AWS"
-      identifiers = ["*"]
+      identifiers = ["arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"]
     }
   }
 }
@@ -540,7 +539,7 @@ data "aws_iam_policy_document" "test" {
 
     principals {
       type        = "AWS"
-      identifiers = ["*"]
+      identifiers = ["arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"]
     }
   }
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

In CI:

```
=== RUN   TestAccS3ControlAccessPoint_policy
=== PAUSE TestAccS3ControlAccessPoint_policy
=== CONT  TestAccS3ControlAccessPoint_policy
    access_point_test.go:182: Step 1/4 error: Error running apply: exit status 1
        Error: creating S3 Access Point (187416307283:tf-acc-test-4053537077800599509) policy: AccessDenied: Access Denied
          status code: 403, request id: VJ0Y2JRJ2S4XDVY8, host id: 0OvEyis7Cn9glXHblD2pAluefQaLv3GF1cTOCRBvC/h7xAtqG7AqV60TGDG6OoUY8xvfLqzzQNo=
          with aws_s3_access_point.test,
          on terraform_plugin_test.tf line 6, in resource "aws_s3_access_point" "test":
           6: resource "aws_s3_access_point" "test" {
--- FAIL: TestAccS3ControlAccessPoint_policy (171.18s)
```
```
=== RUN   TestAccS3ControlAccessPointPolicy_basic
=== PAUSE TestAccS3ControlAccessPointPolicy_basic
=== CONT  TestAccS3ControlAccessPointPolicy_basic
    access_point_policy_test.go:27: Step 1/2 error: Error running apply: exit status 1
        Error: creating S3 Access Point (187416307283:tf-acc-test-2114540063026579346) Policy: AccessDenied: Access Denied
          status code: 403, request id: Q81MCH9K4QHBN1XB, host id: skWFiODOwgQDjLvTfnOsgxZbzGG8+GPOV1V88RfmV1F5DGcuxa4VM6vBEPW0uyn3MszdAyzM4YU=
          with aws_s3control_access_point_policy.test,
          on terraform_plugin_test.tf line 22, in resource "aws_s3control_access_point_policy" "test":
          22: resource "aws_s3control_access_point_policy" "test" {
--- FAIL: TestAccS3ControlAccessPointPolicy_basic (174.57s)
```

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccS3ControlAccessPointPolicy_' PKG=s3control ACCTEST_PARALLELISM=2 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3control/... -v -count 1 -parallel 2  -run=TestAccS3ControlAccessPointPolicy_ -timeout 180m
=== RUN   TestAccS3ControlAccessPointPolicy_basic
=== PAUSE TestAccS3ControlAccessPointPolicy_basic
=== RUN   TestAccS3ControlAccessPointPolicy_disappears
=== PAUSE TestAccS3ControlAccessPointPolicy_disappears
=== RUN   TestAccS3ControlAccessPointPolicy_disappears_AccessPoint
=== PAUSE TestAccS3ControlAccessPointPolicy_disappears_AccessPoint
=== RUN   TestAccS3ControlAccessPointPolicy_update
=== PAUSE TestAccS3ControlAccessPointPolicy_update
=== CONT  TestAccS3ControlAccessPointPolicy_basic
=== CONT  TestAccS3ControlAccessPointPolicy_disappears_AccessPoint
--- PASS: TestAccS3ControlAccessPointPolicy_disappears_AccessPoint (29.06s)
=== CONT  TestAccS3ControlAccessPointPolicy_update
--- PASS: TestAccS3ControlAccessPointPolicy_basic (33.26s)
=== CONT  TestAccS3ControlAccessPointPolicy_disappears
--- PASS: TestAccS3ControlAccessPointPolicy_disappears (27.43s)
--- PASS: TestAccS3ControlAccessPointPolicy_update (52.81s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3control	87.133s
% make testacc TESTARGS='-run=TestAccS3ControlAccessPoint_policy' PKG=s3control ACCTEST_PARALLELISM=2
```
```console
% make testacc TESTARGS='-run=TestAccS3ControlAccessPoint_policy' PKG=s3control ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3control/... -v -count 1 -parallel 2  -run=TestAccS3ControlAccessPoint_policy -timeout 180m
=== RUN   TestAccS3ControlAccessPoint_policy
=== PAUSE TestAccS3ControlAccessPoint_policy
=== CONT  TestAccS3ControlAccessPoint_policy
--- PASS: TestAccS3ControlAccessPoint_policy (72.53s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3control	77.620s
```
