### PR TITLE
S3: Fix acceptance test errors

### DIFF
--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -1102,7 +1102,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 		return diags
 	}
 
-	if err != nil && !tfawserr.ErrMessageContains(err, ErrCodeServerSideEncryptionConfigurationNotFound, "encryption configuration was not found") {
+	if err != nil && !tfawserr.ErrMessageContains(err, errCodeServerSideEncryptionConfigurationNotFound, "encryption configuration was not found") {
 		return sdkdiag.AppendErrorf(diags, "getting S3 Bucket encryption: %s", err)
 	}
 

--- a/internal/service/s3/bucket_logging_test.go
+++ b/internal/service/s3/bucket_logging_test.go
@@ -564,6 +564,8 @@ resource "aws_s3_bucket_ownership_controls" "test" {
 }
 
 resource "aws_s3_bucket_logging" "test" {
+  depends_on = [aws_s3_bucket_ownership_controls.test]
+
   bucket = aws_s3_bucket.test.id
 
   target_bucket = aws_s3_bucket.log_bucket.id
@@ -612,6 +614,8 @@ resource "aws_s3_bucket_ownership_controls" "test" {
 }
 
 resource "aws_s3_bucket_logging" "test" {
+  depends_on = [aws_s3_bucket_ownership_controls.test]
+
   bucket = aws_s3_bucket.test.id
 
   target_bucket = aws_s3_bucket.log_bucket.id
@@ -662,6 +666,8 @@ resource "aws_s3_bucket_ownership_controls" "test" {
 }
 
 resource "aws_s3_bucket_logging" "test" {
+  depends_on = [aws_s3_bucket_ownership_controls.test]
+
   bucket = aws_s3_bucket.test.id
 
   target_bucket = aws_s3_bucket.log_bucket.id

--- a/internal/service/s3/bucket_server_side_encryption_configuration.go
+++ b/internal/service/s3/bucket_server_side_encryption_configuration.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -81,7 +82,6 @@ func resourceBucketServerSideEncryptionConfigurationCreate(ctx context.Context, 
 
 	bucket := d.Get("bucket").(string)
 	expectedBucketOwner := d.Get("expected_bucket_owner").(string)
-
 	input := &s3.PutBucketEncryptionInput{
 		Bucket: aws.String(bucket),
 		ServerSideEncryptionConfiguration: &s3.ServerSideEncryptionConfiguration{
@@ -102,10 +102,18 @@ func resourceBucketServerSideEncryptionConfigurationCreate(ctx context.Context, 
 	)
 
 	if err != nil {
-		return diag.Errorf("creating S3 bucket (%s) server-side encryption configuration: %s", bucket, err)
+		return diag.Errorf("creating S3 Bucket (%s) Server-side Encryption Configuration: %s", bucket, err)
 	}
 
 	d.SetId(CreateResourceID(bucket, expectedBucketOwner))
+
+	_, err = tfresource.RetryWhenNotFound(ctx, propagationTimeout, func() (interface{}, error) {
+		return FindBucketServerSideEncryptionConfiguration(ctx, conn, bucket, expectedBucketOwner)
+	})
+
+	if err != nil {
+		return diag.Errorf("waiting for S3 Bucket Server-side Encryption Configuration (%s) create: %s", d.Id(), err)
+	}
 
 	return resourceBucketServerSideEncryptionConfigurationRead(ctx, d, meta)
 }
@@ -118,43 +126,17 @@ func resourceBucketServerSideEncryptionConfigurationRead(ctx context.Context, d 
 		return diag.FromErr(err)
 	}
 
-	input := &s3.GetBucketEncryptionInput{
-		Bucket: aws.String(bucket),
-	}
+	sse, err := FindBucketServerSideEncryptionConfiguration(ctx, conn, bucket, expectedBucketOwner)
 
-	if expectedBucketOwner != "" {
-		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
-	}
-
-	resp, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout,
-		func() (interface{}, error) {
-			return conn.GetBucketEncryptionWithContext(ctx, input)
-		},
-		s3.ErrCodeNoSuchBucket,
-		ErrCodeServerSideEncryptionConfigurationNotFound,
-	)
-
-	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket, ErrCodeServerSideEncryptionConfigurationNotFound) {
-		log.Printf("[WARN] S3 Bucket Server-Side Encryption Configuration (%s) not found, removing from state", d.Id())
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] S3 Bucket Server-side Encryption Configuration (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 
 	if err != nil {
-		return diag.Errorf("reading S3 bucket server-side encryption configuration (%s): %s", d.Id(), err)
+		return diag.Errorf("reading S3 Bucket Server-side Encryption Configuration (%s): %s", d.Id(), err)
 	}
-
-	output, ok := resp.(*s3.GetBucketEncryptionOutput)
-	if !ok || output.ServerSideEncryptionConfiguration == nil {
-		if d.IsNewResource() {
-			return diag.Errorf("reading S3 bucket server-side encryption configuration (%s): empty output", d.Id())
-		}
-		log.Printf("[WARN] S3 Bucket Server-Side Encryption Configuration (%s) not found, removing from state", d.Id())
-		d.SetId("")
-		return nil
-	}
-
-	sse := output.ServerSideEncryptionConfiguration
 
 	d.Set("bucket", bucket)
 	d.Set("expected_bucket_owner", expectedBucketOwner)
@@ -193,7 +175,7 @@ func resourceBucketServerSideEncryptionConfigurationUpdate(ctx context.Context, 
 	)
 
 	if err != nil {
-		return diag.Errorf("updating S3 bucket (%s) server-side encryption configuration: %s", d.Id(), err)
+		return diag.Errorf("updating S3 Bucket Server-side Encryption Configuration (%s): %s", d.Id(), err)
 	}
 
 	return resourceBucketServerSideEncryptionConfigurationRead(ctx, d, meta)
@@ -217,15 +199,51 @@ func resourceBucketServerSideEncryptionConfigurationDelete(ctx context.Context, 
 
 	_, err = conn.DeleteBucketEncryptionWithContext(ctx, input)
 
-	if tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket, ErrCodeServerSideEncryptionConfigurationNotFound) {
+	if tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket, errCodeServerSideEncryptionConfigurationNotFound) {
 		return nil
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting S3 bucket server-side encryption configuration (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting S3 Bucket Server-side Encryption Configuration (%s): %s", d.Id(), err)
+	}
+
+	_, err = tfresource.RetryUntilNotFound(ctx, propagationTimeout, func() (interface{}, error) {
+		return FindBucketServerSideEncryptionConfiguration(ctx, conn, bucket, expectedBucketOwner)
+	})
+
+	if err != nil {
+		return diag.Errorf("waiting for S3 Bucket Server-side Encryption Configuration (%s) delete: %s", d.Id(), err)
 	}
 
 	return nil
+}
+
+func FindBucketServerSideEncryptionConfiguration(ctx context.Context, conn *s3.S3, bucketName, expectedBucketOwner string) (*s3.ServerSideEncryptionConfiguration, error) {
+	input := &s3.GetBucketEncryptionInput{
+		Bucket: aws.String(bucketName),
+	}
+	if expectedBucketOwner != "" {
+		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
+	}
+
+	output, err := conn.GetBucketEncryptionWithContext(ctx, input)
+
+	if tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket, errCodeServerSideEncryptionConfigurationNotFound) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.ServerSideEncryptionConfiguration == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.ServerSideEncryptionConfiguration, nil
 }
 
 func expandBucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefault(l []interface{}) *s3.ServerSideEncryptionByDefault {

--- a/internal/service/s3/bucket_server_side_encryption_configuration.go
+++ b/internal/service/s3/bucket_server_side_encryption_configuration.go
@@ -88,7 +88,6 @@ func resourceBucketServerSideEncryptionConfigurationCreate(ctx context.Context, 
 			Rules: expandBucketServerSideEncryptionConfigurationRules(d.Get("rule").(*schema.Set).List()),
 		},
 	}
-
 	if expectedBucketOwner != "" {
 		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
 	}
@@ -161,7 +160,6 @@ func resourceBucketServerSideEncryptionConfigurationUpdate(ctx context.Context, 
 			Rules: expandBucketServerSideEncryptionConfigurationRules(d.Get("rule").(*schema.Set).List()),
 		},
 	}
-
 	if expectedBucketOwner != "" {
 		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
 	}
@@ -192,7 +190,6 @@ func resourceBucketServerSideEncryptionConfigurationDelete(ctx context.Context, 
 	input := &s3.DeleteBucketEncryptionInput{
 		Bucket: aws.String(bucket),
 	}
-
 	if expectedBucketOwner != "" {
 		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
 	}
@@ -205,14 +202,6 @@ func resourceBucketServerSideEncryptionConfigurationDelete(ctx context.Context, 
 
 	if err != nil {
 		return diag.Errorf("deleting S3 Bucket Server-side Encryption Configuration (%s): %s", d.Id(), err)
-	}
-
-	_, err = tfresource.RetryUntilNotFound(ctx, propagationTimeout, func() (interface{}, error) {
-		return FindBucketServerSideEncryptionConfiguration(ctx, conn, bucket, expectedBucketOwner)
-	})
-
-	if err != nil {
-		return diag.Errorf("waiting for S3 Bucket Server-side Encryption Configuration (%s) delete: %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/s3/bucket_server_side_encryption_configuration_test.go
+++ b/internal/service/s3/bucket_server_side_encryption_configuration_test.go
@@ -8,15 +8,14 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfs3 "github.com/hashicorp/terraform-provider-aws/internal/service/s3"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func TestAccS3BucketServerSideEncryptionConfiguration_basic(t *testing.T) {
@@ -36,8 +35,10 @@ func TestAccS3BucketServerSideEncryptionConfiguration_basic(t *testing.T) {
 					testAccCheckBucketServerSideEncryptionConfigurationExists(ctx, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "bucket", "aws_s3_bucket.test", "bucket"),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "rule.0.apply_server_side_encryption_by_default.#", "0"),
-					resource.TestCheckNoResourceAttr(resourceName, "rule.0.bucket_key_enabled"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.apply_server_side_encryption_by_default.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.apply_server_side_encryption_by_default.0.kms_master_key_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.apply_server_side_encryption_by_default.0.sse_algorithm", "AES256"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.bucket_key_enabled", "false"),
 				),
 			},
 			{
@@ -417,70 +418,40 @@ func testAccCheckBucketServerSideEncryptionConfigurationDestroy(ctx context.Cont
 				return err
 			}
 
-			input := &s3.GetBucketEncryptionInput{
-				Bucket: aws.String(bucket),
-			}
+			_, err = tfs3.FindBucketServerSideEncryptionConfiguration(ctx, conn, bucket, expectedBucketOwner)
 
-			if expectedBucketOwner != "" {
-				input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
-			}
-
-			output, err := conn.GetBucketEncryptionWithContext(ctx, input)
-
-			if tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket, tfs3.ErrCodeServerSideEncryptionConfigurationNotFound) {
+			if tfresource.NotFound(err) {
 				continue
 			}
 
 			if err != nil {
-				return fmt.Errorf("error getting S3 Bucket server-side encryption configuration (%s): %w", rs.Primary.ID, err)
+				return err
 			}
 
-			if output != nil && output.ServerSideEncryptionConfiguration != nil {
-				return fmt.Errorf("S3 Bucket server-side encryption configuration (%s) still exists", rs.Primary.ID)
-			}
+			return fmt.Errorf("S3 Bucket Server-side Encryption Configuration %s still exists", rs.Primary.ID)
 		}
 
 		return nil
 	}
 }
 
-func testAccCheckBucketServerSideEncryptionConfigurationExists(ctx context.Context, resourceName string) resource.TestCheckFunc {
+func testAccCheckBucketServerSideEncryptionConfigurationExists(ctx context.Context, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[resourceName]
+		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
+			return fmt.Errorf("Not found: %s", n)
 		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("Resource (%s) ID not set", resourceName)
-		}
-
-		conn := acctest.Provider.Meta().(*conns.AWSClient).S3Conn(ctx)
 
 		bucket, expectedBucketOwner, err := tfs3.ParseResourceID(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
 
-		input := &s3.GetBucketEncryptionInput{
-			Bucket: aws.String(bucket),
-		}
+		conn := acctest.Provider.Meta().(*conns.AWSClient).S3Conn(ctx)
 
-		if expectedBucketOwner != "" {
-			input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
-		}
+		_, err = tfs3.FindBucketServerSideEncryptionConfiguration(ctx, conn, bucket, expectedBucketOwner)
 
-		output, err := conn.GetBucketEncryptionWithContext(ctx, input)
-
-		if err != nil {
-			return fmt.Errorf("error getting S3 Bucket server-side encryption configuration (%s): %w", rs.Primary.ID, err)
-		}
-
-		if output == nil || output.ServerSideEncryptionConfiguration == nil {
-			return fmt.Errorf("S3 Bucket server-side encryption configuration (%s) not found", rs.Primary.ID)
-		}
-
-		return nil
+		return err
 	}
 }
 

--- a/internal/service/s3/bucket_server_side_encryption_configuration_test.go
+++ b/internal/service/s3/bucket_server_side_encryption_configuration_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfs3 "github.com/hashicorp/terraform-provider-aws/internal/service/s3"
-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func TestAccS3BucketServerSideEncryptionConfiguration_basic(t *testing.T) {
@@ -27,7 +26,7 @@ func TestAccS3BucketServerSideEncryptionConfiguration_basic(t *testing.T) {
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, s3.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBucketServerSideEncryptionConfigurationDestroy(ctx),
+		CheckDestroy:             acctest.CheckDestroyNoop,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBucketServerSideEncryptionConfigurationConfig_basic(rName),
@@ -59,7 +58,7 @@ func TestAccS3BucketServerSideEncryptionConfiguration_disappears(t *testing.T) {
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, s3.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBucketServerSideEncryptionConfigurationDestroy(ctx),
+		CheckDestroy:             acctest.CheckDestroyNoop,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBucketServerSideEncryptionConfigurationConfig_basic(rName),
@@ -82,7 +81,7 @@ func TestAccS3BucketServerSideEncryptionConfiguration_ApplySEEByDefault_AES256(t
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, s3.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBucketServerSideEncryptionConfigurationDestroy(ctx),
+		CheckDestroy:             acctest.CheckDestroyNoop,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBucketServerSideEncryptionConfigurationConfig_applySSEByDefaultSSEAlgorithm(rName, s3.ServerSideEncryptionAes256),
@@ -112,7 +111,7 @@ func TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMS(t *t
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, s3.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBucketServerSideEncryptionConfigurationDestroy(ctx),
+		CheckDestroy:             acctest.CheckDestroyNoop,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBucketServerSideEncryptionConfigurationConfig_applySSEByDefaultSSEAlgorithm(rName, s3.ServerSideEncryptionAwsKms),
@@ -142,7 +141,7 @@ func TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_UpdateSS
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, s3.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBucketServerSideEncryptionConfigurationDestroy(ctx),
+		CheckDestroy:             acctest.CheckDestroyNoop,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBucketServerSideEncryptionConfigurationConfig_applySSEByDefaultSSEAlgorithm(rName, s3.ServerSideEncryptionAwsKms),
@@ -185,7 +184,7 @@ func TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMSWithM
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, s3.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBucketServerSideEncryptionConfigurationDestroy(ctx),
+		CheckDestroy:             acctest.CheckDestroyNoop,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBucketServerSideEncryptionConfigurationConfig_applySSEByDefaultKMSMasterKeyARN(rName),
@@ -215,7 +214,7 @@ func TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMSWithM
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, s3.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBucketServerSideEncryptionConfigurationDestroy(ctx),
+		CheckDestroy:             acctest.CheckDestroyNoop,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBucketServerSideEncryptionConfigurationConfig_applySSEByDefaultKMSMasterKeyID(rName),
@@ -245,7 +244,7 @@ func TestAccS3BucketServerSideEncryptionConfiguration_BucketKeyEnabled(t *testin
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, s3.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBucketServerSideEncryptionConfigurationDestroy(ctx),
+		CheckDestroy:             acctest.CheckDestroyNoop,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBucketServerSideEncryptionConfigurationConfig_keyEnabled(rName, true),
@@ -288,7 +287,7 @@ func TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_BucketKe
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, s3.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBucketServerSideEncryptionConfigurationDestroy(ctx),
+		CheckDestroy:             acctest.CheckDestroyNoop,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBucketServerSideEncryptionConfigurationConfig_applySSEByDefaultKeyEnabled(rName, true),
@@ -338,7 +337,7 @@ func TestAccS3BucketServerSideEncryptionConfiguration_migrate_noChange(t *testin
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, s3.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBucketServerSideEncryptionConfigurationDestroy(ctx),
+		CheckDestroy:             acctest.CheckDestroyNoop,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBucketConfig_defaultEncryptionDefaultKey(rName, s3.ServerSideEncryptionAwsKms),
@@ -376,7 +375,7 @@ func TestAccS3BucketServerSideEncryptionConfiguration_migrate_withChange(t *test
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, s3.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBucketServerSideEncryptionConfigurationDestroy(ctx),
+		CheckDestroy:             acctest.CheckDestroyNoop,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBucketConfig_defaultEncryptionDefaultKey(rName, s3.ServerSideEncryptionAwsKms),
@@ -402,37 +401,6 @@ func TestAccS3BucketServerSideEncryptionConfiguration_migrate_withChange(t *test
 			},
 		},
 	})
-}
-
-func testAccCheckBucketServerSideEncryptionConfigurationDestroy(ctx context.Context) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).S3Conn(ctx)
-
-		for _, rs := range s.RootModule().Resources {
-			if rs.Type != "aws_s3_bucket_server_side_encryption_configuration" {
-				continue
-			}
-
-			bucket, expectedBucketOwner, err := tfs3.ParseResourceID(rs.Primary.ID)
-			if err != nil {
-				return err
-			}
-
-			_, err = tfs3.FindBucketServerSideEncryptionConfiguration(ctx, conn, bucket, expectedBucketOwner)
-
-			if tfresource.NotFound(err) {
-				continue
-			}
-
-			if err != nil {
-				return err
-			}
-
-			return fmt.Errorf("S3 Bucket Server-side Encryption Configuration %s still exists", rs.Primary.ID)
-		}
-
-		return nil
-	}
 }
 
 func testAccCheckBucketServerSideEncryptionConfigurationExists(ctx context.Context, n string) resource.TestCheckFunc {

--- a/internal/service/s3/bucket_server_side_encryption_configuration_test.go
+++ b/internal/service/s3/bucket_server_side_encryption_configuration_test.go
@@ -37,36 +37,12 @@ func TestAccS3BucketServerSideEncryptionConfiguration_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "rule.0.apply_server_side_encryption_by_default.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "rule.0.apply_server_side_encryption_by_default.0.kms_master_key_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "rule.0.apply_server_side_encryption_by_default.0.sse_algorithm", "AES256"),
-					resource.TestCheckResourceAttr(resourceName, "rule.0.bucket_key_enabled", "false"),
 				),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccS3BucketServerSideEncryptionConfiguration_disappears(t *testing.T) {
-	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_s3_bucket_server_side_encryption_configuration.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, s3.EndpointsID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             acctest.CheckDestroyNoop,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccBucketServerSideEncryptionConfigurationConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBucketServerSideEncryptionConfigurationExists(ctx, resourceName),
-					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfs3.ResourceBucketServerSideEncryptionConfiguration(), resourceName),
-				),
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -432,7 +408,12 @@ resource "aws_s3_bucket" "test" {
 resource "aws_s3_bucket_server_side_encryption_configuration" "test" {
   bucket = aws_s3_bucket.test.id
 
-  rule {}
+  rule {
+    # This is Amazon S3 bucket default encryption.
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
 }
 `, rName)
 }
@@ -513,6 +494,11 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "test" {
   bucket = aws_s3_bucket.test.id
 
   rule {
+    # This is Amazon S3 bucket default encryption.
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+
     bucket_key_enabled = %[2]t
   }
 }

--- a/internal/service/s3/errors.go
+++ b/internal/service/s3/errors.go
@@ -27,7 +27,7 @@ const (
 	errCodeObjectLockConfigurationNotFound           = "ObjectLockConfigurationNotFound"
 	errCodeOperationAborted                          = "OperationAborted"
 	ErrCodeReplicationConfigurationNotFound          = "ReplicationConfigurationNotFoundError"
-	ErrCodeServerSideEncryptionConfigurationNotFound = "ServerSideEncryptionConfigurationNotFoundError"
+	errCodeServerSideEncryptionConfigurationNotFound = "ServerSideEncryptionConfigurationNotFoundError"
 	errCodeUnsupportedArgument                       = "UnsupportedArgument"
 	// errCodeXNotImplemented is returned from Third Party S3 implementations
 	// and so far has been noticed with calls to GetBucketWebsite.

--- a/website/docs/r/s3_bucket_server_side_encryption_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_server_side_encryption_configuration.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides a S3 bucket server-side encryption configuration resource.
 
+~> **NOTE:** Destroying an `aws_s3_bucket_server_side_encryption_configuration` resource resets the bucket to [Amazon S3 bucket default encryption](https://docs.aws.amazon.com/AmazonS3/latest/userguide/default-encryption-faq.html).
+
 ## Example Usage
 
 ```terraform


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

In CI:

```
=== RUN   TestAccS3BucketLogging_TargetGrantByID
=== PAUSE TestAccS3BucketLogging_TargetGrantByID
=== CONT  TestAccS3BucketLogging_TargetGrantByID
    bucket_logging_test.go:135: Step 1/5 error: Error running apply: exit status 1
        Error: putting S3 Bucket (tf-acc-test-8739557163735717587) Logging: AccessControlListNotSupported: Target grants not allowed for bucket owner enforced buckets
          status code: 400, request id: 73DCYBG0A6MCFTHP, host id: n09yProXlsJSmeGGT2jZV0ePTsMvMncvsYlsfx2izZFD8sxN/XM0A6LVdmUJoXB8X4QgL/kOwFk=
          with aws_s3_bucket_logging.test,
          on terraform_plugin_test.tf line 33, in resource "aws_s3_bucket_logging" "test":
          33: resource "aws_s3_bucket_logging" "test" {
--- FAIL: TestAccS3BucketLogging_TargetGrantByID (165.24s)
```

Relates https://github.com/hashicorp/terraform-provider-aws/issues/28353.

```
=== RUN   TestAccS3BucketServerSideEncryptionConfiguration_BucketKeyEnabled
=== PAUSE TestAccS3BucketServerSideEncryptionConfiguration_BucketKeyEnabled
=== CONT  TestAccS3BucketServerSideEncryptionConfiguration_BucketKeyEnabled
    bucket_server_side_encryption_configuration_test.go:243: Step 1/4 error: After applying this test step and performing a `terraform refresh`, the plan was not empty.
        stdout
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        Terraform will perform the following actions:
          # aws_s3_bucket_server_side_encryption_configuration.test will be updated in-place
          ~ resource "aws_s3_bucket_server_side_encryption_configuration" "test" {
                id     = "tf-acc-test-5463471888088080093"
                # (1 unchanged attribute hidden)
              - rule {
                  - bucket_key_enabled = true -> null
                  - apply_server_side_encryption_by_default {
                      - sse_algorithm = "AES256" -> null
                    }
                }
              + rule {
                  + bucket_key_enabled = true
                }
            }
        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccS3BucketServerSideEncryptionConfiguration_BucketKeyEnabled (326.14s)
```

Relates https://github.com/hashicorp/terraform-provider-aws/issues/28701.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccS3BucketLogging_TargetGrantByGroup\|TestAccS3BucketLogging_TargetGrantByID' PKG=s3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20  -run=TestAccS3BucketLogging_TargetGrantByGroup\|TestAccS3BucketLogging_TargetGrantByID -timeout 180m
=== RUN   TestAccS3BucketLogging_TargetGrantByID
=== PAUSE TestAccS3BucketLogging_TargetGrantByID
=== RUN   TestAccS3BucketLogging_TargetGrantByGroup
=== PAUSE TestAccS3BucketLogging_TargetGrantByGroup
=== CONT  TestAccS3BucketLogging_TargetGrantByID
=== CONT  TestAccS3BucketLogging_TargetGrantByGroup
--- PASS: TestAccS3BucketLogging_TargetGrantByGroup (76.23s)
--- PASS: TestAccS3BucketLogging_TargetGrantByID (79.68s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	84.616s
```
```console
% make testacc TESTARGS='-run=TestAccS3BucketServerSideEncryptionConfiguration_' PKG=s3     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20  -run=TestAccS3BucketServerSideEncryptionConfiguration_ -timeout 180m
=== RUN   TestAccS3BucketServerSideEncryptionConfiguration_basic
=== PAUSE TestAccS3BucketServerSideEncryptionConfiguration_basic
=== RUN   TestAccS3BucketServerSideEncryptionConfiguration_ApplySEEByDefault_AES256
=== PAUSE TestAccS3BucketServerSideEncryptionConfiguration_ApplySEEByDefault_AES256
=== RUN   TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMS
=== PAUSE TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMS
=== RUN   TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_UpdateSSEAlgorithm
=== PAUSE TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_UpdateSSEAlgorithm
=== RUN   TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMSWithMasterKeyARN
=== PAUSE TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMSWithMasterKeyARN
=== RUN   TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMSWithMasterKeyID
=== PAUSE TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMSWithMasterKeyID
=== RUN   TestAccS3BucketServerSideEncryptionConfiguration_BucketKeyEnabled
=== PAUSE TestAccS3BucketServerSideEncryptionConfiguration_BucketKeyEnabled
=== RUN   TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_BucketKeyEnabled
=== PAUSE TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_BucketKeyEnabled
=== RUN   TestAccS3BucketServerSideEncryptionConfiguration_migrate_noChange
=== PAUSE TestAccS3BucketServerSideEncryptionConfiguration_migrate_noChange
=== RUN   TestAccS3BucketServerSideEncryptionConfiguration_migrate_withChange
=== PAUSE TestAccS3BucketServerSideEncryptionConfiguration_migrate_withChange
=== CONT  TestAccS3BucketServerSideEncryptionConfiguration_basic
=== CONT  TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMSWithMasterKeyID
=== CONT  TestAccS3BucketServerSideEncryptionConfiguration_migrate_noChange
=== CONT  TestAccS3BucketServerSideEncryptionConfiguration_migrate_withChange
=== CONT  TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMS
=== CONT  TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMSWithMasterKeyARN
=== CONT  TestAccS3BucketServerSideEncryptionConfiguration_BucketKeyEnabled
=== CONT  TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_UpdateSSEAlgorithm
=== CONT  TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_BucketKeyEnabled
=== CONT  TestAccS3BucketServerSideEncryptionConfiguration_ApplySEEByDefault_AES256
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMS (97.24s)
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMSWithMasterKeyARN (97.27s)
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_ApplySEEByDefault_AES256 (97.27s)
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_basic (97.96s)
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMSWithMasterKeyID (98.29s)
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_migrate_withChange (121.41s)
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_migrate_noChange (121.58s)
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_UpdateSSEAlgorithm (131.38s)
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_BucketKeyEnabled (131.62s)
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_BucketKeyEnabled (131.64s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	137.364s
```
