### PR TITLE
Change the type of aws_codeartifact_domain asset_size_bytes to float …

### DIFF
--- a/.changelog/32926.txt
+++ b/.changelog/32926.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_codeartifact_domain: Change the type of asset_size_bytes to float (64) instead of int (32) to prevent `value out of range` panic
+```

--- a/internal/service/codeartifact/domain.go
+++ b/internal/service/codeartifact/domain.go
@@ -62,7 +62,7 @@ func ResourceDomain() *schema.Resource {
 				Computed: true,
 			},
 			"asset_size_bytes": {
-				Type:     schema.TypeInt,
+				Type:     schema.TypeFloat,
 				Computed: true,
 			},
 			"repository_count": {


### PR DESCRIPTION
…(64) instead of int (32)

Because this value can get really big and the Integer (signed 32 size) can overflow. The maximum int32 value is 2147483647. See https://pkg.go.dev/builtin#int That is roughly 2 GBi of data that is easy to reach.

Example of error:
```
panic: Error reading level state: strconv.ParseInt: parsing "15679188538": value out of range
```
