### PR TITLE
B aws db instance empty restore to point in time bug 32907

### DIFF
--- a/.changelog/32928.txt
+++ b/.changelog/32928.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_db_instance: Fix crash creating resource with empty `restore_to_point_in_time` configuration block
+```

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -798,7 +798,8 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "creating RDS Cluster (restore from S3) (%s): %s", identifier, err)
 		}
-	} else if v, ok := d.GetOk("restore_to_point_in_time"); ok {
+	} else if v, ok := d.GetOk("restore_to_point_in_time"); ok && v.([]interface{})[0] != nil {
+
 		tfMap := v.([]interface{})[0].(map[string]interface{})
 		input := &rds.RestoreDBClusterToPointInTimeInput{
 			DBClusterIdentifier:       aws.String(identifier),

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -799,7 +799,6 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 			return sdkdiag.AppendErrorf(diags, "creating RDS Cluster (restore from S3) (%s): %s", identifier, err)
 		}
 	} else if v, ok := d.GetOk("restore_to_point_in_time"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-
 		tfMap := v.([]interface{})[0].(map[string]interface{})
 		input := &rds.RestoreDBClusterToPointInTimeInput{
 			DBClusterIdentifier:       aws.String(identifier),

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -798,7 +798,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "creating RDS Cluster (restore from S3) (%s): %s", identifier, err)
 		}
-	} else if v, ok := d.GetOk("restore_to_point_in_time"); ok && v.([]interface{})[0] != nil {
+	} else if v, ok := d.GetOk("restore_to_point_in_time"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 
 		tfMap := v.([]interface{})[0].(map[string]interface{})
 		input := &rds.RestoreDBClusterToPointInTimeInput{

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -1238,7 +1238,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 			output := outputRaw.(*rds.RestoreDBInstanceFromDBSnapshotOutput)
 			resourceID = aws.StringValue(output.DBInstance.DbiResourceId)
 		}
-	} else if v, ok := d.GetOk("restore_to_point_in_time"); ok && v.([]interface{})[0] != nil {
+	} else if v, ok := d.GetOk("restore_to_point_in_time"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 
 		tfMap := v.([]interface{})[0].(map[string]interface{})
 

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -1239,9 +1239,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 			resourceID = aws.StringValue(output.DBInstance.DbiResourceId)
 		}
 	} else if v, ok := d.GetOk("restore_to_point_in_time"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-
 		tfMap := v.([]interface{})[0].(map[string]interface{})
-
 		input := &rds.RestoreDBInstanceToPointInTimeInput{
 			AutoMinorVersionUpgrade:    aws.Bool(d.Get("auto_minor_version_upgrade").(bool)),
 			CopyTagsToSnapshot:         aws.Bool(d.Get("copy_tags_to_snapshot").(bool)),

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -1238,7 +1238,8 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 			output := outputRaw.(*rds.RestoreDBInstanceFromDBSnapshotOutput)
 			resourceID = aws.StringValue(output.DBInstance.DbiResourceId)
 		}
-	} else if v, ok := d.GetOk("restore_to_point_in_time"); ok {
+	} else if v, ok := d.GetOk("restore_to_point_in_time"); ok && v.([]interface{})[0] != nil {
+
 		tfMap := v.([]interface{})[0].(map[string]interface{})
 
 		input := &rds.RestoreDBInstanceToPointInTimeInput{


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This pull request resolves the bug related to the empty, not-null `restore_to_point_in_time` block for `aws_db_instance` resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #32907

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccRDSInstance_RestoreToPointInTime_sourceResourceID PKG=rds

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSInstance_RestoreToPointInTime_sourceResourceID'  -timeout 180m
=== RUN   TestAccRDSInstance_RestoreToPointInTime_sourceResourceID
=== PAUSE TestAccRDSInstance_RestoreToPointInTime_sourceResourceID
=== CONT  TestAccRDSInstance_RestoreToPointInTime_sourceResourceID
--- PASS: TestAccRDSInstance_RestoreToPointInTime_sourceResourceID (1344.35s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	1347.277s

% make testacc TESTS='TestAccRDSInstance_RestoreToPointInTime_sourceIdentifier|TestAccRDSInstance_RestoreToPointInTime_monitoring' PKG=rds

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSInstance_RestoreToPointInTime_sourceIdentifier|TestAccRDSInstance_RestoreToPointInTime_monitoring'  -timeout 180m
=== RUN   TestAccRDSInstance_RestoreToPointInTime_sourceIdentifier
=== PAUSE TestAccRDSInstance_RestoreToPointInTime_sourceIdentifier
=== RUN   TestAccRDSInstance_RestoreToPointInTime_monitoring
=== PAUSE TestAccRDSInstance_RestoreToPointInTime_monitoring
=== CONT  TestAccRDSInstance_RestoreToPointInTime_sourceIdentifier
=== CONT  TestAccRDSInstance_RestoreToPointInTime_monitoring
--- PASS: TestAccRDSInstance_RestoreToPointInTime_monitoring (1461.27s)
--- PASS: TestAccRDSInstance_RestoreToPointInTime_sourceIdentifier (1529.90s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	1532.802s

...
```
