### PR TITLE
Auto Scaling Plans: Fix acceptance test failures

### DIFF
--- a/internal/service/autoscalingplans/scaling_plan_test.go
+++ b/internal/service/autoscalingplans/scaling_plan_test.go
@@ -6,13 +6,13 @@ package autoscalingplans_test
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"sort"
 	"strconv"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscalingplans"
+	"github.com/google/go-cmp/cmp"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -437,7 +437,7 @@ func testAccCheckApplicationSourceTags(scalingPlan *autoscalingplans.ScalingPlan
 
 			sort.Strings(values)
 			sort.Strings(expectedValues)
-			if !reflect.DeepEqual(values, expectedValues) {
+			if !cmp.Equal(values, expectedValues) {
 				return fmt.Errorf("Scaling plan application source tag filter values %q, expected %q", values, expectedValues)
 			}
 		}
@@ -446,13 +446,14 @@ func testAccCheckApplicationSourceTags(scalingPlan *autoscalingplans.ScalingPlan
 	}
 }
 
-func testAccScalingPlanConfigBase(rName, tagName string) string {
+func testAccScalingPlanConfig_base(rName, tagName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHVMEBSAMI(),
 		acctest.ConfigAvailableAZsNoOptInDefaultExclude(),
 		acctest.AvailableEC2InstanceTypeForRegion("t3.micro", "t2.micro"),
 		fmt.Sprintf(`
 resource "aws_launch_configuration" "test" {
+  name          = %[1]q
   image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = data.aws_ec2_instance_type_offering.available.instance_type
 }
@@ -467,21 +468,17 @@ resource "aws_autoscaling_group" "test" {
   max_size         = 3
   desired_capacity = 0
 
-  tags = [
-    {
-      key                 = %[2]q
-      value               = %[2]q
-      propagate_at_launch = true
-    },
-  ]
+  tag {
+    key                 = %[2]q
+    value               = %[2]q
+    propagate_at_launch = true
+  }
 }
 `, rName, tagName))
 }
 
 func testAccScalingPlanConfig_basicDynamicScaling(rName, tagName string) string {
-	return acctest.ConfigCompose(
-		testAccScalingPlanConfigBase(rName, tagName),
-		fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccScalingPlanConfig_base(rName, tagName), fmt.Sprintf(`
 resource "aws_autoscalingplans_scaling_plan" "test" {
   name = %[1]q
 
@@ -512,9 +509,7 @@ resource "aws_autoscalingplans_scaling_plan" "test" {
 }
 
 func testAccScalingPlanConfig_basicPredictiveScaling(rName, tagName string) string {
-	return acctest.ConfigCompose(
-		testAccScalingPlanConfigBase(rName, tagName),
-		fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccScalingPlanConfig_base(rName, tagName), fmt.Sprintf(`
 resource "aws_autoscalingplans_scaling_plan" "test" {
   name = %[1]q
 
@@ -554,9 +549,7 @@ resource "aws_autoscalingplans_scaling_plan" "test" {
 }
 
 func testAccScalingPlanConfig_dynamicScalingCustomizedScalingMetricSpecification(rName, tagName string, targetValue int) string {
-	return acctest.ConfigCompose(
-		testAccScalingPlanConfigBase(rName, tagName),
-		fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccScalingPlanConfig_base(rName, tagName), fmt.Sprintf(`
 resource "aws_autoscalingplans_scaling_plan" "test" {
   name = %[1]q
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

In CI:

```
=== RUN   TestAccAutoScalingPlansScalingPlan_basicUpdate
=== PAUSE TestAccAutoScalingPlansScalingPlan_basicUpdate
=== CONT  TestAccAutoScalingPlansScalingPlan_basicUpdate
    scaling_plan_test.go:152: Step 1/3 error: Error running pre-apply refresh: exit status 1
        Error: Unsupported argument
          on terraform_plugin_test.tf line 51, in resource "aws_autoscaling_group" "test":
          51:   tags = [
        An argument named "tags" is not expected here.
--- FAIL: TestAccAutoScalingPlansScalingPlan_basicUpdate (9.20s)
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/30842.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccAutoScalingPlansScalingPlan_' PKG=autoscalingplans ACCTEST_PARALLELISM=2 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/autoscalingplans/... -v -count 1 -parallel 2  -run=TestAccAutoScalingPlansScalingPlan_ -timeout 180m
=== RUN   TestAccAutoScalingPlansScalingPlan_basicDynamicScaling
=== PAUSE TestAccAutoScalingPlansScalingPlan_basicDynamicScaling
=== RUN   TestAccAutoScalingPlansScalingPlan_basicPredictiveScaling
=== PAUSE TestAccAutoScalingPlansScalingPlan_basicPredictiveScaling
=== RUN   TestAccAutoScalingPlansScalingPlan_basicUpdate
=== PAUSE TestAccAutoScalingPlansScalingPlan_basicUpdate
=== RUN   TestAccAutoScalingPlansScalingPlan_disappears
=== PAUSE TestAccAutoScalingPlansScalingPlan_disappears
=== RUN   TestAccAutoScalingPlansScalingPlan_DynamicScaling_customizedScalingMetricSpecification
=== PAUSE TestAccAutoScalingPlansScalingPlan_DynamicScaling_customizedScalingMetricSpecification
=== CONT  TestAccAutoScalingPlansScalingPlan_basicDynamicScaling
=== CONT  TestAccAutoScalingPlansScalingPlan_disappears
--- PASS: TestAccAutoScalingPlansScalingPlan_disappears (78.37s)
=== CONT  TestAccAutoScalingPlansScalingPlan_DynamicScaling_customizedScalingMetricSpecification
--- PASS: TestAccAutoScalingPlansScalingPlan_basicDynamicScaling (82.53s)
=== CONT  TestAccAutoScalingPlansScalingPlan_basicUpdate
--- PASS: TestAccAutoScalingPlansScalingPlan_basicUpdate (120.62s)
=== CONT  TestAccAutoScalingPlansScalingPlan_basicPredictiveScaling
--- PASS: TestAccAutoScalingPlansScalingPlan_DynamicScaling_customizedScalingMetricSpecification (132.61s)
--- PASS: TestAccAutoScalingPlansScalingPlan_basicPredictiveScaling (87.73s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/autoscalingplans	296.072s
```
