### PR TITLE
Redshift: Fix acceptance test failures

### DIFF
--- a/internal/service/redshift/find.go
+++ b/internal/service/redshift/find.go
@@ -5,7 +5,6 @@ package redshift
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/redshift"
@@ -111,54 +110,6 @@ func FindScheduledActionByName(ctx context.Context, conn *redshift.Redshift, nam
 	}
 
 	return output.ScheduledActions[0], nil
-}
-
-func FindScheduleAssociationById(ctx context.Context, conn *redshift.Redshift, id string) (string, *redshift.ClusterAssociatedToSchedule, error) {
-	clusterIdentifier, scheduleIdentifier, err := SnapshotScheduleAssociationParseID(id)
-	if err != nil {
-		return "", nil, fmt.Errorf("parsing Redshift Cluster Snapshot Schedule Association ID %s: %s", id, err)
-	}
-
-	input := &redshift.DescribeSnapshotSchedulesInput{
-		ClusterIdentifier:  aws.String(clusterIdentifier),
-		ScheduleIdentifier: aws.String(scheduleIdentifier),
-	}
-	resp, err := conn.DescribeSnapshotSchedulesWithContext(ctx, input)
-
-	if tfawserr.ErrCodeEquals(err, redshift.ErrCodeSnapshotScheduleNotFoundFault) {
-		return "", nil, &retry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
-		}
-	}
-
-	if err != nil {
-		return "", nil, err
-	}
-
-	if resp.SnapshotSchedules == nil || len(resp.SnapshotSchedules) == 0 {
-		return "", nil, tfresource.NewEmptyResultError(input)
-	}
-
-	snapshotSchedule := resp.SnapshotSchedules[0]
-
-	if snapshotSchedule == nil {
-		return "", nil, tfresource.NewEmptyResultError(input)
-	}
-
-	var associatedCluster *redshift.ClusterAssociatedToSchedule
-	for _, cluster := range snapshotSchedule.AssociatedClusters {
-		if aws.StringValue(cluster.ClusterIdentifier) == clusterIdentifier {
-			associatedCluster = cluster
-			break
-		}
-	}
-
-	if associatedCluster == nil {
-		return "", nil, tfresource.NewEmptyResultError(input)
-	}
-
-	return aws.StringValue(snapshotSchedule.ScheduleIdentifier), associatedCluster, nil
 }
 
 func FindHSMClientCertificateByID(ctx context.Context, conn *redshift.Redshift, id string) (*redshift.HsmClientCertificate, error) {

--- a/internal/service/redshift/snapshot_copy_grant.go
+++ b/internal/service/redshift/snapshot_copy_grant.go
@@ -84,7 +84,7 @@ func resourceSnapshotCopyGrantCreate(ctx context.Context, d *schema.ResourceData
 	d.SetId(name)
 
 	_, err = tfresource.RetryWhenNotFound(ctx, 3*time.Minute, func() (any, error) {
-		return findSnapshotCopyGrant(ctx, conn, d.Id())
+		return FindSnapshotCopyGrantByName(ctx, conn, d.Id())
 	})
 
 	if err != nil {
@@ -98,16 +98,16 @@ func resourceSnapshotCopyGrantRead(ctx context.Context, d *schema.ResourceData, 
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RedshiftConn(ctx)
 
-	grantName := d.Id()
+	grant, err := FindSnapshotCopyGrantByName(ctx, conn, d.Id())
 
-	grant, err := findSnapshotCopyGrant(ctx, conn, grantName)
 	if !d.IsNewResource() && tfresource.NotFound(err) {
-		log.Printf("[WARN] Redshift Snapshot Copy Grant (%s) not found, removing from state", grantName)
+		log.Printf("[WARN] Redshift Snapshot Copy Grant (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
 	}
+
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "reading Redshift Snapshot Copy Grant (%s): %s", grantName, err)
+		return sdkdiag.AppendErrorf(diags, "reading Redshift Snapshot Copy Grant (%s): %s", d.Id(), err)
 	}
 
 	arn := arn.ARN{
@@ -115,11 +115,9 @@ func resourceSnapshotCopyGrantRead(ctx context.Context, d *schema.ResourceData, 
 		Service:   "redshift",
 		Region:    meta.(*conns.AWSClient).Region,
 		AccountID: meta.(*conns.AWSClient).AccountID,
-		Resource:  fmt.Sprintf("snapshotcopygrant:%s", grantName),
+		Resource:  fmt.Sprintf("snapshotcopygrant:%s", d.Id()),
 	}.String()
-
 	d.Set("arn", arn)
-
 	d.Set("kms_key_id", grant.KmsKeyId)
 	d.Set("snapshot_copy_grant_name", grant.SnapshotCopyGrantName)
 
@@ -140,43 +138,36 @@ func resourceSnapshotCopyGrantDelete(ctx context.Context, d *schema.ResourceData
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RedshiftConn(ctx)
 
-	grantName := d.Id()
+	log.Printf("[DEBUG] DeletingRedshift Snapshot Copy Grant: %s", d.Id())
+	_, err := conn.DeleteSnapshotCopyGrantWithContext(ctx, &redshift.DeleteSnapshotCopyGrantInput{
+		SnapshotCopyGrantName: aws.String(d.Id()),
+	})
 
-	deleteInput := redshift.DeleteSnapshotCopyGrantInput{
-		SnapshotCopyGrantName: aws.String(grantName),
+	if tfawserr.ErrCodeEquals(err, redshift.ErrCodeSnapshotCopyGrantNotFoundFault) {
+		return diags
 	}
 
-	log.Printf("[DEBUG] Deleting snapshot copy grant: %s", grantName)
-	_, err := conn.DeleteSnapshotCopyGrantWithContext(ctx, &deleteInput)
-
 	if err != nil {
-		if tfawserr.ErrCodeEquals(err, redshift.ErrCodeSnapshotCopyGrantNotFoundFault) {
-			return diags
-		}
 		return sdkdiag.AppendErrorf(diags, "deleting Redshift Snapshot Copy Grant (%s): %s", d.Id(), err)
 	}
 
-	if err := WaitForSnapshotCopyGrantToBeDeleted(ctx, conn, grantName); err != nil {
-		return sdkdiag.AppendErrorf(diags, "deleting Redshift Snapshot Copy Grant (%s): waiting for completion: %s", d.Id(), err)
+	_, err = tfresource.RetryUntilNotFound(ctx, 3*time.Minute, func() (any, error) {
+		return FindSnapshotCopyGrantByName(ctx, conn, d.Id())
+	})
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "waiting for Redshift Snapshot Copy Grant (%s) delete: %s", d.Id(), err)
 	}
 
 	return diags
 }
 
-// Used by the tests as well
-func WaitForSnapshotCopyGrantToBeDeleted(ctx context.Context, conn *redshift.Redshift, grantName string) error {
-	_, err := tfresource.RetryUntilNotFound(ctx, 3*time.Minute, func() (any, error) {
-		return findSnapshotCopyGrant(ctx, conn, grantName)
-	})
-	return err
-}
-
-func findSnapshotCopyGrant(ctx context.Context, conn *redshift.Redshift, grantName string) (*redshift.SnapshotCopyGrant, error) {
-	input := redshift.DescribeSnapshotCopyGrantsInput{
-		SnapshotCopyGrantName: aws.String(grantName),
+func FindSnapshotCopyGrantByName(ctx context.Context, conn *redshift.Redshift, name string) (*redshift.SnapshotCopyGrant, error) {
+	input := &redshift.DescribeSnapshotCopyGrantsInput{
+		SnapshotCopyGrantName: aws.String(name),
 	}
 
-	out, err := conn.DescribeSnapshotCopyGrantsWithContext(ctx, &input)
+	output, err := conn.DescribeSnapshotCopyGrantsWithContext(ctx, input)
 
 	if tfawserr.ErrCodeEquals(err, redshift.ErrCodeSnapshotCopyGrantNotFoundFault) {
 		return nil, &retry.NotFoundError{
@@ -185,12 +176,13 @@ func findSnapshotCopyGrant(ctx context.Context, conn *redshift.Redshift, grantNa
 		}
 	}
 
-	if out == nil || len(out.SnapshotCopyGrants) == 0 {
-		return nil, tfresource.NewEmptyResultError(input)
-	}
-	if l := len(out.SnapshotCopyGrants); l > 1 {
-		return nil, tfresource.NewTooManyResultsError(1, nil)
+	if err != nil {
+		return nil, err
 	}
 
-	return out.SnapshotCopyGrants[0], nil
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return tfresource.AssertSinglePtrResult(output.SnapshotCopyGrants)
 }

--- a/internal/service/redshift/snapshot_copy_grant.go
+++ b/internal/service/redshift/snapshot_copy_grant.go
@@ -138,7 +138,7 @@ func resourceSnapshotCopyGrantDelete(ctx context.Context, d *schema.ResourceData
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RedshiftConn(ctx)
 
-	log.Printf("[DEBUG] DeletingRedshift Snapshot Copy Grant: %s", d.Id())
+	log.Printf("[DEBUG] Deleting Redshift Snapshot Copy Grant: %s", d.Id())
 	_, err := conn.DeleteSnapshotCopyGrantWithContext(ctx, &redshift.DeleteSnapshotCopyGrantInput{
 		SnapshotCopyGrantName: aws.String(d.Id()),
 	})

--- a/internal/service/redshift/snapshot_copy_grant_test.go
+++ b/internal/service/redshift/snapshot_copy_grant_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/redshift"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -16,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfredshift "github.com/hashicorp/terraform-provider-aws/internal/service/redshift"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func TestAccRedshiftSnapshotCopyGrant_basic(t *testing.T) {
@@ -33,54 +33,9 @@ func TestAccRedshiftSnapshotCopyGrant_basic(t *testing.T) {
 				Config: testAccSnapshotCopyGrantConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotCopyGrantExists(ctx, resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "kms_key_id"),
 					resource.TestCheckResourceAttr(resourceName, "snapshot_copy_grant_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
-					resource.TestCheckResourceAttrSet(resourceName, "kms_key_id"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccRedshiftSnapshotCopyGrant_update(t *testing.T) {
-	ctx := acctest.Context(t)
-	resourceName := "aws_redshift_snapshot_copy_grant.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, redshift.EndpointsID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckSnapshotCopyGrantDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccSnapshotCopyGrantConfig_tags(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSnapshotCopyGrantExists(ctx, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
-					resource.TestCheckResourceAttr(resourceName, "tags.Env", "Test"),
-				),
-			},
-			{
-				Config: testAccSnapshotCopyGrantConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSnapshotCopyGrantExists(ctx, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
-				),
-			},
-			{
-				Config: testAccSnapshotCopyGrantConfig_tags(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSnapshotCopyGrantExists(ctx, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
-					resource.TestCheckResourceAttr(resourceName, "tags.Env", "Test"),
 				),
 			},
 			{
@@ -115,6 +70,51 @@ func TestAccRedshiftSnapshotCopyGrant_disappears(t *testing.T) {
 	})
 }
 
+func TestAccRedshiftSnapshotCopyGrant_tags(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_redshift_snapshot_copy_grant.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, redshift.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSnapshotCopyGrantDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSnapshotCopyGrantConfig_tags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSnapshotCopyGrantExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccSnapshotCopyGrantConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSnapshotCopyGrantExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccSnapshotCopyGrantConfig_tags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSnapshotCopyGrantExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckSnapshotCopyGrantDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).RedshiftConn(ctx)
@@ -124,47 +124,35 @@ func testAccCheckSnapshotCopyGrantDestroy(ctx context.Context) resource.TestChec
 				continue
 			}
 
-			err := tfredshift.WaitForSnapshotCopyGrantToBeDeleted(ctx, conn, rs.Primary.ID)
-			return err
+			_, err := tfredshift.FindSnapshotCopyGrantByName(ctx, conn, rs.Primary.ID)
+
+			if tfresource.NotFound(err) {
+				continue
+			}
+
+			if err != nil {
+				return err
+			}
+
+			return fmt.Errorf("Redshift Snapshot Copy Grant %s still exists", rs.Primary.ID)
 		}
 
 		return nil
 	}
 }
 
-func testAccCheckSnapshotCopyGrantExists(ctx context.Context, name string) resource.TestCheckFunc {
+func testAccCheckSnapshotCopyGrantExists(ctx context.Context, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("not found: %s", name)
+			return fmt.Errorf("Not found: %s", n)
 		}
 
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("Snapshot Copy Grant ID (SnapshotCopyGrantName) is not set")
-		}
-
-		// retrieve the client from the test provider
 		conn := acctest.Provider.Meta().(*conns.AWSClient).RedshiftConn(ctx)
 
-		input := redshift.DescribeSnapshotCopyGrantsInput{
-			MaxRecords:            aws.Int64(100),
-			SnapshotCopyGrantName: aws.String(rs.Primary.ID),
-		}
+		_, err := tfredshift.FindSnapshotCopyGrantByName(ctx, conn, rs.Primary.ID)
 
-		response, err := conn.DescribeSnapshotCopyGrantsWithContext(ctx, &input)
-
-		if err != nil {
-			return err
-		}
-
-		// we expect only a single snapshot copy grant by this ID. If we find zero, or many,
-		// then we consider this an error
-		if len(response.SnapshotCopyGrants) != 1 ||
-			*response.SnapshotCopyGrants[0].SnapshotCopyGrantName != rs.Primary.ID {
-			return fmt.Errorf("Snapshot copy grant not found")
-		}
-
-		return nil
+		return err
 	}
 }
 
@@ -176,15 +164,27 @@ resource "aws_redshift_snapshot_copy_grant" "test" {
 `, rName)
 }
 
-func testAccSnapshotCopyGrantConfig_tags(rName string) string {
+func testAccSnapshotCopyGrantConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_redshift_snapshot_copy_grant" "test" {
   snapshot_copy_grant_name = %[1]q
 
   tags = {
-    Name = %[1]q
-    Env  = "Test"
+    %[2]q = %[3]q
   }
 }
-`, rName)
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccSnapshotCopyGrantConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_redshift_snapshot_copy_grant" "test" {
+  snapshot_copy_grant_name = %[1]q
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }

--- a/internal/service/redshift/snapshot_schedule.go
+++ b/internal/service/redshift/snapshot_schedule.go
@@ -169,12 +169,15 @@ func resourceSnapshotScheduleDelete(ctx context.Context, d *schema.ResourceData,
 		}
 	}
 
+	log.Printf("[DEBUG] Deleting Redshift Snapshot Schedule: %s", d.Id())
 	_, err := conn.DeleteSnapshotScheduleWithContext(ctx, &redshift.DeleteSnapshotScheduleInput{
 		ScheduleIdentifier: aws.String(d.Id()),
 	})
+
 	if tfawserr.ErrCodeEquals(err, redshift.ErrCodeSnapshotScheduleNotFoundFault) {
 		return diags
 	}
+
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "deleting Redshift Snapshot Schedule (%s): %s", d.Id(), err)
 	}

--- a/internal/service/redshift/snapshot_schedule.go
+++ b/internal/service/redshift/snapshot_schedule.go
@@ -150,13 +150,15 @@ func resourceSnapshotScheduleUpdate(ctx context.Context, d *schema.ResourceData,
 	conn := meta.(*conns.AWSClient).RedshiftConn(ctx)
 
 	if d.HasChange("definitions") {
-		modifyOpts := &redshift.ModifySnapshotScheduleInput{
-			ScheduleIdentifier:  aws.String(d.Id()),
+		input := &redshift.ModifySnapshotScheduleInput{
 			ScheduleDefinitions: flex.ExpandStringSet(d.Get("definitions").(*schema.Set)),
+			ScheduleIdentifier:  aws.String(d.Id()),
 		}
-		_, err := conn.ModifySnapshotScheduleWithContext(ctx, modifyOpts)
+
+		_, err := conn.ModifySnapshotScheduleWithContext(ctx, input)
+
 		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "modifying Redshift Snapshot Schedule %s: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating Redshift Snapshot Schedule (%s): %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/redshift/snapshot_schedule.go
+++ b/internal/service/redshift/snapshot_schedule.go
@@ -31,6 +31,7 @@ func ResourceSnapshotSchedule() *schema.Resource {
 		ReadWithoutTimeout:   resourceSnapshotScheduleRead,
 		UpdateWithoutTimeout: resourceSnapshotScheduleUpdate,
 		DeleteWithoutTimeout: resourceSnapshotScheduleDelete,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -40,6 +41,21 @@ func ResourceSnapshotSchedule() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"definitions": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"force_destroy": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"identifier": {
 				Type:          schema.TypeString,
 				Optional:      true,
@@ -48,26 +64,11 @@ func ResourceSnapshotSchedule() *schema.Resource {
 				ConflictsWith: []string{"identifier_prefix"},
 			},
 			"identifier_prefix": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-			"definitions": {
-				Type:     schema.TypeSet,
-				Required: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
-			},
-			"force_destroy": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"identifier"},
 			},
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),

--- a/internal/service/redshift/snapshot_schedule_association_test.go
+++ b/internal/service/redshift/snapshot_schedule_association_test.go
@@ -32,7 +32,7 @@ func TestAccRedshiftSnapshotScheduleAssociation_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckSnapshotScheduleAssociationDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSnapshotScheduleAssociationConfig_basic(rName, "rate(12 hours)"),
+				Config: testAccSnapshotScheduleAssociationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotScheduleAssociationExists(ctx, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "schedule_identifier", snapshotScheduleResourceName, "id"),
@@ -60,7 +60,7 @@ func TestAccRedshiftSnapshotScheduleAssociation_disappears(t *testing.T) {
 		CheckDestroy:             testAccCheckSnapshotScheduleAssociationDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSnapshotScheduleAssociationConfig_basic(rName, "rate(12 hours)"),
+				Config: testAccSnapshotScheduleAssociationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotScheduleAssociationExists(ctx, resourceName),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfredshift.ResourceSnapshotScheduleAssociation(), resourceName),
@@ -84,7 +84,7 @@ func TestAccRedshiftSnapshotScheduleAssociation_disappears_cluster(t *testing.T)
 		CheckDestroy:             testAccCheckSnapshotScheduleAssociationDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSnapshotScheduleAssociationConfig_basic(rName, "rate(12 hours)"),
+				Config: testAccSnapshotScheduleAssociationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotScheduleAssociationExists(ctx, resourceName),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfredshift.ResourceCluster(), clusterResourceName),
@@ -140,8 +140,8 @@ func testAccCheckSnapshotScheduleAssociationExists(ctx context.Context, n string
 	}
 }
 
-func testAccSnapshotScheduleAssociationConfig_basic(rName, definition string) string {
-	return acctest.ConfigCompose(testAccClusterConfig_basic(rName), testAccSnapshotScheduleConfig_basic(rName, definition), `
+func testAccSnapshotScheduleAssociationConfig_basic(rName string) string {
+	return acctest.ConfigCompose(testAccClusterConfig_basic(rName), testAccSnapshotScheduleConfig_basic(rName), `
 resource "aws_redshift_snapshot_schedule_association" "test" {
   schedule_identifier = aws_redshift_snapshot_schedule.default.id
   cluster_identifier  = aws_redshift_cluster.test.id

--- a/internal/service/redshift/snapshot_schedule_test.go
+++ b/internal/service/redshift/snapshot_schedule_test.go
@@ -362,16 +362,17 @@ func testAccCheckSnapshotScheduleCreateSnapshotScheduleAssociation(ctx context.C
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).RedshiftConn(ctx)
 
-		if _, err := conn.ModifyClusterSnapshotScheduleWithContext(ctx, &redshift.ModifyClusterSnapshotScheduleInput{
+		_, err := conn.ModifyClusterSnapshotScheduleWithContext(ctx, &redshift.ModifyClusterSnapshotScheduleInput{
 			ClusterIdentifier:    cluster.ClusterIdentifier,
 			ScheduleIdentifier:   snapshotSchedule.ScheduleIdentifier,
 			DisassociateSchedule: aws.Bool(false),
-		}); err != nil {
-			return fmt.Errorf("Error associate Redshift Cluster and Snapshot Schedule: %s", err)
+		})
+
+		if err != nil {
+			return err
 		}
 
-		id := fmt.Sprintf("%s/%s", aws.StringValue(cluster.ClusterIdentifier), aws.StringValue(snapshotSchedule.ScheduleIdentifier))
-		if _, err := tfredshift.WaitScheduleAssociationActive(ctx, conn, id); err != nil {
+		if _, err := tfredshift.WaitSnapshotScheduleAssociationCreated(ctx, conn, aws.StringValue(cluster.ClusterIdentifier), aws.StringValue(snapshotSchedule.ScheduleIdentifier)); err != nil {
 			return err
 		}
 

--- a/internal/service/redshift/snapshot_schedule_test.go
+++ b/internal/service/redshift/snapshot_schedule_test.go
@@ -10,19 +10,21 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/redshift"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfredshift "github.com/hashicorp/terraform-provider-aws/internal/service/redshift"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func TestAccRedshiftSnapshotSchedule_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v redshift.SnapshotSchedule
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_redshift_snapshot_schedule.default"
+	resourceName := "aws_redshift_snapshot_schedule.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -31,17 +33,16 @@ func TestAccRedshiftSnapshotSchedule_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckSnapshotScheduleDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSnapshotScheduleConfig_basic(rName, "rate(12 hours)"),
-				Check: resource.ComposeTestCheckFunc(
+				Config: testAccSnapshotScheduleConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSnapshotScheduleExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "definitions.#", "1"),
-				),
-			},
-			{
-				Config: testAccSnapshotScheduleConfig_basic(rName, "cron(30 12 *)"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSnapshotScheduleExists(ctx, resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "definitions.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "definitions.*", "rate(12 hours)"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "identifier", rName),
+					resource.TestCheckResourceAttr(resourceName, "identifier_prefix", ""),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
@@ -56,11 +57,11 @@ func TestAccRedshiftSnapshotSchedule_basic(t *testing.T) {
 	})
 }
 
-func TestAccRedshiftSnapshotSchedule_withMultipleDefinition(t *testing.T) {
+func TestAccRedshiftSnapshotSchedule_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v redshift.SnapshotSchedule
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_redshift_snapshot_schedule.default"
+	resourceName := "aws_redshift_snapshot_schedule.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -69,17 +70,83 @@ func TestAccRedshiftSnapshotSchedule_withMultipleDefinition(t *testing.T) {
 		CheckDestroy:             testAccCheckSnapshotScheduleDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSnapshotScheduleConfig_multipleDefinition(rName, "cron(30 12 *)", "cron(15 6 *)"),
+				Config: testAccSnapshotScheduleConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotScheduleExists(ctx, resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "definitions.#", "2"),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfredshift.ResourceSnapshotSchedule(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccRedshiftSnapshotSchedule_tags(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v redshift.SnapshotSchedule
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_redshift_snapshot_schedule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, redshift.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSnapshotScheduleDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSnapshotScheduleConfig_tags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSnapshotScheduleExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
 			},
 			{
-				Config: testAccSnapshotScheduleConfig_multipleDefinition(rName, "cron(30 8 *)", "cron(15 10 *)"),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy",
+				},
+			},
+			{
+				Config: testAccSnapshotScheduleConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotScheduleExists(ctx, resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "definitions.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccSnapshotScheduleConfig_tags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSnapshotScheduleExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRedshiftSnapshotSchedule_identifierGenerated(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v redshift.SnapshotSchedule
+	resourceName := "aws_redshift_snapshot_schedule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, redshift.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSnapshotScheduleDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSnapshotScheduleConfig_identifierGenerated(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSnapshotScheduleExists(ctx, resourceName, &v),
+					acctest.CheckResourceAttrNameGenerated(resourceName, "identifier"),
+					resource.TestCheckResourceAttr(resourceName, "identifier_prefix", id.UniqueIdPrefix),
 				),
 			},
 			{
@@ -94,10 +161,10 @@ func TestAccRedshiftSnapshotSchedule_withMultipleDefinition(t *testing.T) {
 	})
 }
 
-func TestAccRedshiftSnapshotSchedule_withIdentifierPrefix(t *testing.T) {
+func TestAccRedshiftSnapshotSchedule_identifierPrefix(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v redshift.SnapshotSchedule
-	resourceName := "aws_redshift_snapshot_schedule.default"
+	resourceName := "aws_redshift_snapshot_schedule.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -106,9 +173,11 @@ func TestAccRedshiftSnapshotSchedule_withIdentifierPrefix(t *testing.T) {
 		CheckDestroy:             testAccCheckSnapshotScheduleDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSnapshotScheduleConfig_identifierPrefix,
+				Config: testAccSnapshotScheduleConfig_identifierPrefix("tf-acc-test-prefix-"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotScheduleExists(ctx, resourceName, &v),
+					acctest.CheckResourceAttrNameFromPrefix(resourceName, "identifier", "tf-acc-test-prefix-"),
+					resource.TestCheckResourceAttr(resourceName, "identifier_prefix", "tf-acc-test-prefix-"),
 				),
 			},
 			{
@@ -116,9 +185,58 @@ func TestAccRedshiftSnapshotSchedule_withIdentifierPrefix(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"identifier_prefix",
 					"force_destroy",
 				},
+			},
+		},
+	})
+}
+
+func TestAccRedshiftSnapshotSchedule_update(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v redshift.SnapshotSchedule
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_redshift_snapshot_schedule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, redshift.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSnapshotScheduleDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSnapshotScheduleConfig_multipleDefinitions(rName, "cron(30 12 *)", "cron(15 6 *)"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSnapshotScheduleExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "definitions.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "definitions.*", "cron(30 12 *)"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "definitions.*", "cron(15 6 *)"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy",
+				},
+			},
+			{
+				Config: testAccSnapshotScheduleConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSnapshotScheduleExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "definitions.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "definitions.*", "rate(12 hours)"),
+				),
+			},
+			{
+				Config: testAccSnapshotScheduleConfig_multipleDefinitions(rName, "cron(30 8 *)", "cron(15 10 *)"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSnapshotScheduleExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "definitions.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "definitions.*", "cron(30 8 *)"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "definitions.*", "cron(15 10 *)"),
+				),
 			},
 		},
 	})
@@ -128,7 +246,7 @@ func TestAccRedshiftSnapshotSchedule_withDescription(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v redshift.SnapshotSchedule
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_redshift_snapshot_schedule.default"
+	resourceName := "aws_redshift_snapshot_schedule.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -140,50 +258,7 @@ func TestAccRedshiftSnapshotSchedule_withDescription(t *testing.T) {
 				Config: testAccSnapshotScheduleConfig_description(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotScheduleExists(ctx, resourceName, &v),
-					resource.TestCheckResourceAttr(
-						resourceName, "description", "Test Schedule"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"force_destroy",
-				},
-			},
-		},
-	})
-}
-
-func TestAccRedshiftSnapshotSchedule_withTags(t *testing.T) {
-	ctx := acctest.Context(t)
-	var v redshift.SnapshotSchedule
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_redshift_snapshot_schedule.default"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, redshift.EndpointsID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckSnapshotScheduleDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccSnapshotScheduleConfig_tags(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSnapshotScheduleExists(ctx, resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
-					resource.TestCheckResourceAttr(resourceName, "tags.fizz", "buzz"),
-				),
-			},
-			{
-				Config: testAccSnapshotScheduleConfig_tagsUpdate(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSnapshotScheduleExists(ctx, resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.good", "bad"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Test Schedule"),
 				),
 			},
 			{
@@ -203,7 +278,7 @@ func TestAccRedshiftSnapshotSchedule_withForceDestroy(t *testing.T) {
 	var snapshotSchedule redshift.SnapshotSchedule
 	var cluster redshift.Cluster
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_redshift_snapshot_schedule.default"
+	resourceName := "aws_redshift_snapshot_schedule.test"
 	clusterResourceName := "aws_redshift_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -234,27 +309,24 @@ func TestAccRedshiftSnapshotSchedule_withForceDestroy(t *testing.T) {
 
 func testAccCheckSnapshotScheduleDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).RedshiftConn(ctx)
+
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_redshift_snapshot_schedule" {
 				continue
 			}
 
-			conn := acctest.Provider.Meta().(*conns.AWSClient).RedshiftConn(ctx)
-			resp, err := conn.DescribeSnapshotSchedulesWithContext(ctx, &redshift.DescribeSnapshotSchedulesInput{
-				ScheduleIdentifier: aws.String(rs.Primary.ID),
-			})
+			_, err := tfredshift.FindSnapshotScheduleByID(ctx, conn, rs.Primary.ID)
 
-			if err == nil {
-				if len(resp.SnapshotSchedules) != 0 {
-					for _, s := range resp.SnapshotSchedules {
-						if *s.ScheduleIdentifier == rs.Primary.ID {
-							return fmt.Errorf("Redshift Cluster Snapshot Schedule %s still exists", rs.Primary.ID)
-						}
-					}
-				}
+			if tfresource.NotFound(err) {
+				continue
 			}
 
-			return err
+			if err != nil {
+				return err
+			}
+
+			return fmt.Errorf("Redshift Snapshot Schedule %s still exists", rs.Primary.ID)
 		}
 
 		return nil
@@ -273,22 +345,16 @@ func testAccCheckSnapshotScheduleExists(ctx context.Context, n string, v *redshi
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).RedshiftConn(ctx)
-		resp, err := conn.DescribeSnapshotSchedulesWithContext(ctx, &redshift.DescribeSnapshotSchedulesInput{
-			ScheduleIdentifier: aws.String(rs.Primary.ID),
-		})
+
+		output, err := tfredshift.FindSnapshotScheduleByID(ctx, conn, rs.Primary.ID)
 
 		if err != nil {
 			return err
 		}
 
-		for _, s := range resp.SnapshotSchedules {
-			if *s.ScheduleIdentifier == rs.Primary.ID {
-				*v = *s
-				return nil
-			}
-		}
+		*v = *output
 
-		return fmt.Errorf("Redshift Snapshot Schedule (%s) not found", rs.Primary.ID)
+		return nil
 	}
 }
 
@@ -313,33 +379,76 @@ func testAccCheckSnapshotScheduleCreateSnapshotScheduleAssociation(ctx context.C
 	}
 }
 
-const testAccSnapshotScheduleConfig_identifierPrefix = `
-resource "aws_redshift_snapshot_schedule" "default" {
-  identifier_prefix = "tf-acc-test"
+func testAccSnapshotScheduleConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_redshift_snapshot_schedule" "test" {
+  identifier = %[1]q
+  definitions = [
+    "rate(12 hours)",
+  ]
+}
+`, rName)
+}
+
+func testAccSnapshotScheduleConfig_tags1(rName, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_redshift_snapshot_schedule" "test" {
+  identifier = %[1]q
+  definitions = [
+    "rate(12 hours)",
+  ]
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccSnapshotScheduleConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_redshift_snapshot_schedule" "test" {
+  identifier = %[1]q
+  definitions = [
+    "rate(12 hours)",
+  ]
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}
+
+func testAccSnapshotScheduleConfig_identifierGenerated() string {
+	return `
+resource "aws_redshift_snapshot_schedule" "test" {
   definitions = [
     "rate(12 hours)",
   ]
 }
 `
+}
 
-func testAccSnapshotScheduleConfig_basic(rName, definition string) string {
+func testAccSnapshotScheduleConfig_identifierPrefix(prefix string) string {
 	return fmt.Sprintf(`
-resource "aws_redshift_snapshot_schedule" "default" {
-  identifier = %[1]q
+resource "aws_redshift_snapshot_schedule" "test" {
+  identifier_prefix = %[1]q
   definitions = [
-    "%[2]s",
+    "rate(12 hours)",
   ]
 }
-`, rName, definition)
+`, prefix)
 }
 
-func testAccSnapshotScheduleConfig_multipleDefinition(rName, definition1, definition2 string) string {
+func testAccSnapshotScheduleConfig_multipleDefinitions(rName, definition1, definition2 string) string {
 	return fmt.Sprintf(`
-resource "aws_redshift_snapshot_schedule" "default" {
+resource "aws_redshift_snapshot_schedule" "test" {
   identifier = %[1]q
   definitions = [
-    "%[2]s",
-    "%[3]s",
+    %[2]q,
+    %[3]q,
   ]
 }
 `, rName, definition1, definition2)
@@ -347,53 +456,20 @@ resource "aws_redshift_snapshot_schedule" "default" {
 
 func testAccSnapshotScheduleConfig_description(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_redshift_snapshot_schedule" "default" {
+resource "aws_redshift_snapshot_schedule" "test" {
   identifier  = %[1]q
   description = "Test Schedule"
   definitions = [
     "rate(12 hours)",
   ]
-}
-`, rName)
-}
-
-func testAccSnapshotScheduleConfig_tags(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_redshift_snapshot_schedule" "default" {
-  identifier = %[1]q
-  definitions = [
-    "rate(12 hours)",
-  ]
-
-  tags = {
-    foo  = "bar"
-    fizz = "buzz"
-  }
-}
-`, rName)
-}
-
-func testAccSnapshotScheduleConfig_tagsUpdate(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_redshift_snapshot_schedule" "default" {
-  identifier = %[1]q
-  definitions = [
-    "rate(12 hours)",
-  ]
-
-  tags = {
-    foo  = "bar2"
-    good = "bad"
-  }
 }
 `, rName)
 }
 
 func testAccSnapshotScheduleConfig_forceDestroy(rName string) string {
 	return acctest.ConfigCompose(testAccClusterConfig_basic(rName), fmt.Sprintf(`
-resource "aws_redshift_snapshot_schedule" "default" {
-  identifier  = %[1]q
-  description = "Test Schedule"
+resource "aws_redshift_snapshot_schedule" "test" {
+  identifier = %[1]q
   definitions = [
     "rate(12 hours)",
   ]

--- a/internal/service/redshift/status.go
+++ b/internal/service/redshift/status.go
@@ -76,22 +76,6 @@ func statusClusterAqua(ctx context.Context, conn *redshift.Redshift, id string) 
 	}
 }
 
-func statusScheduleAssociation(ctx context.Context, conn *redshift.Redshift, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		_, output, err := FindScheduleAssociationById(ctx, conn, id)
-
-		if tfresource.NotFound(err) {
-			return nil, "", nil
-		}
-
-		if err != nil {
-			return nil, "", err
-		}
-
-		return output, aws.StringValue(output.ScheduleAssociationState), nil
-	}
-}
-
 func statusEndpointAccess(ctx context.Context, conn *redshift.Redshift, name string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		output, err := FindEndpointAccessByName(ctx, conn, name)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

In CI:

```
=== RUN   TestAccRedshiftSnapshotCopyGrant_update
=== PAUSE TestAccRedshiftSnapshotCopyGrant_update
=== CONT  TestAccRedshiftSnapshotCopyGrant_update
    snapshot_copy_grant_test.go:55: Step 1/4 error: After applying this test step and performing a `terraform refresh`, the plan was not empty.
        stdout
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        Terraform will perform the following actions:
          # aws_redshift_snapshot_copy_grant.test will be updated in-place
          ~ resource "aws_redshift_snapshot_copy_grant" "test" {
                id                       = "tf-acc-test-1194731605999433216"
              ~ tags                     = {
                  + "Env"  = "Test"
                  + "Name" = "tf-acc-test-1194731605999433216"
                }
              ~ tags_all                 = {
                  + "Env"  = "Test"
                  + "Name" = "tf-acc-test-1194731605999433216"
                }
                # (3 unchanged attributes hidden)
            }
        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccRedshiftSnapshotCopyGrant_update (289.90s)
```
```
=== RUN   TestAccRedshiftSnapshotSchedule_withForceDestroy
=== PAUSE TestAccRedshiftSnapshotSchedule_withForceDestroy
=== CONT  TestAccRedshiftSnapshotSchedule_withForceDestroy
    testing_new.go:88: Error running post-test destroy, there may be dangling resources: exit status 1
        Error: deleting Redshift Snapshot Schedule (tf-acc-test-5678376540386802119): InvalidClusterSnapshotScheduleState: Schedule is currently associated with the following clusters [deleted-12970452]. Disassociate clusters before deleting schedule.
          status code: 400, request id: 934330f9-df2f-46ae-a589-656ba2ee59f6
--- FAIL: TestAccRedshiftSnapshotSchedule_withForceDestroy (497.64s)
```

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccRedshiftSnapshotCopyGrant_' PKG=redshift ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/redshift/... -v -count 1 -parallel 2  -run=TestAccRedshiftSnapshotCopyGrant_ -timeout 180m
=== RUN   TestAccRedshiftSnapshotCopyGrant_basic
=== PAUSE TestAccRedshiftSnapshotCopyGrant_basic
=== RUN   TestAccRedshiftSnapshotCopyGrant_disappears
=== PAUSE TestAccRedshiftSnapshotCopyGrant_disappears
=== RUN   TestAccRedshiftSnapshotCopyGrant_tags
=== PAUSE TestAccRedshiftSnapshotCopyGrant_tags
=== CONT  TestAccRedshiftSnapshotCopyGrant_basic
=== CONT  TestAccRedshiftSnapshotCopyGrant_tags
--- PASS: TestAccRedshiftSnapshotCopyGrant_basic (26.53s)
=== CONT  TestAccRedshiftSnapshotCopyGrant_disappears
--- PASS: TestAccRedshiftSnapshotCopyGrant_disappears (18.18s)
--- PASS: TestAccRedshiftSnapshotCopyGrant_tags (59.42s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/redshift	64.358s
```
```console
% make testacc TESTARGS='-run=TestAccRedshiftSnapshotSchedule_\|TestAccRedshiftSnapshotScheduleAssociation_' PKG=redshift ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/redshift/... -v -count 1 -parallel 2  -run=TestAccRedshiftSnapshotSchedule_\|TestAccRedshiftSnapshotScheduleAssociation_ -timeout 180m
=== RUN   TestAccRedshiftSnapshotScheduleAssociation_basic
=== PAUSE TestAccRedshiftSnapshotScheduleAssociation_basic
=== RUN   TestAccRedshiftSnapshotScheduleAssociation_disappears
=== PAUSE TestAccRedshiftSnapshotScheduleAssociation_disappears
=== RUN   TestAccRedshiftSnapshotScheduleAssociation_disappears_cluster
=== PAUSE TestAccRedshiftSnapshotScheduleAssociation_disappears_cluster
=== RUN   TestAccRedshiftSnapshotSchedule_basic
=== PAUSE TestAccRedshiftSnapshotSchedule_basic
=== RUN   TestAccRedshiftSnapshotSchedule_disappears
=== PAUSE TestAccRedshiftSnapshotSchedule_disappears
=== RUN   TestAccRedshiftSnapshotSchedule_tags
=== PAUSE TestAccRedshiftSnapshotSchedule_tags
=== RUN   TestAccRedshiftSnapshotSchedule_identifierGenerated
=== PAUSE TestAccRedshiftSnapshotSchedule_identifierGenerated
=== RUN   TestAccRedshiftSnapshotSchedule_identifierPrefix
=== PAUSE TestAccRedshiftSnapshotSchedule_identifierPrefix
=== RUN   TestAccRedshiftSnapshotSchedule_update
=== PAUSE TestAccRedshiftSnapshotSchedule_update
=== RUN   TestAccRedshiftSnapshotSchedule_withDescription
=== PAUSE TestAccRedshiftSnapshotSchedule_withDescription
=== RUN   TestAccRedshiftSnapshotSchedule_withForceDestroy
=== PAUSE TestAccRedshiftSnapshotSchedule_withForceDestroy
=== CONT  TestAccRedshiftSnapshotScheduleAssociation_basic
=== CONT  TestAccRedshiftSnapshotSchedule_identifierGenerated
--- PASS: TestAccRedshiftSnapshotSchedule_identifierGenerated (26.43s)
=== CONT  TestAccRedshiftSnapshotSchedule_basic
--- PASS: TestAccRedshiftSnapshotSchedule_basic (24.72s)
=== CONT  TestAccRedshiftSnapshotSchedule_tags
--- PASS: TestAccRedshiftSnapshotSchedule_tags (61.35s)
=== CONT  TestAccRedshiftSnapshotSchedule_disappears
--- PASS: TestAccRedshiftSnapshotSchedule_disappears (17.83s)
=== CONT  TestAccRedshiftSnapshotSchedule_withDescription
--- PASS: TestAccRedshiftSnapshotSchedule_withDescription (24.07s)
=== CONT  TestAccRedshiftSnapshotSchedule_withForceDestroy
--- PASS: TestAccRedshiftSnapshotScheduleAssociation_basic (291.61s)
=== CONT  TestAccRedshiftSnapshotScheduleAssociation_disappears_cluster
--- PASS: TestAccRedshiftSnapshotSchedule_withForceDestroy (278.20s)
=== CONT  TestAccRedshiftSnapshotSchedule_update
--- PASS: TestAccRedshiftSnapshotSchedule_update (56.05s)
=== CONT  TestAccRedshiftSnapshotSchedule_identifierPrefix
--- PASS: TestAccRedshiftSnapshotSchedule_identifierPrefix (25.61s)
=== CONT  TestAccRedshiftSnapshotScheduleAssociation_disappears
--- PASS: TestAccRedshiftSnapshotScheduleAssociation_disappears_cluster (319.23s)
--- PASS: TestAccRedshiftSnapshotScheduleAssociation_disappears (288.18s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/redshift	807.934s
```