### PR TITLE
r/aws_appstream_fleet: Update `max_user_duration_in_seconds` to `432000`

### DIFF
--- a/.changelog/32933.txt
+++ b/.changelog/32933.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_appstream_fleet: Increased upper limit of `max_duration_in_seconds` to 432000
+resource/aws_appstream_fleet: Increased upper limit of `max_user_duration_in_seconds` to 432000
 ```

--- a/.changelog/32933.txt
+++ b/.changelog/32933.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_appstream_fleet: Increased upper limit of `max_duration_in_seconds` to 432000
+```

--- a/internal/service/appstream/fleet.go
+++ b/internal/service/appstream/fleet.go
@@ -158,7 +158,7 @@ func ResourceFleet() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validation.IntBetween(600, 360000),
+				ValidateFunc: validation.IntBetween(600, 432000),
 			},
 			"name": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
### Description

This PR updates the `aws_appstream_fleet` resource's `max_user_duration_in_seconds` argument validation to allow the use of up to `432000`, as per the AWS API documentation.

### Relations

Closes #32874

### References

- [AWS API: CreateFleet](https://docs.aws.amazon.com/appstream2/latest/APIReference/API_CreateFleet.html#AppStream2-CreateFleet-request-MaxUserDurationInSeconds)

### Output from Acceptance Testing

I don't have the necessary permissions to successfully run the tests in the accounts I have access to, unfortunately.