### PR TITLE
Update CIDR arguments in various resource docs to use a private range

### DIFF
--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -35,12 +35,12 @@ resource, it is recommended to reference that resource's `vpc_id` attribute to e
 ```terraform
 resource "aws_vpc_ipv4_cidr_block_association" "secondary_cidr" {
   vpc_id     = aws_vpc.main.id
-  cidr_block = "172.2.0.0/16"
+  cidr_block = "172.20.0.0/16"
 }
 
 resource "aws_subnet" "in_secondary_cidr" {
   vpc_id     = aws_vpc_ipv4_cidr_block_association.secondary_cidr.vpc_id
-  cidr_block = "172.2.0.0/24"
+  cidr_block = "172.20.0.0/24"
 }
 ```
 

--- a/website/docs/r/vpc.html.markdown
+++ b/website/docs/r/vpc.html.markdown
@@ -52,7 +52,7 @@ resource "aws_vpc_ipam_pool" "test" {
 
 resource "aws_vpc_ipam_pool_cidr" "test" {
   ipam_pool_id = aws_vpc_ipam_pool.test.id
-  cidr         = "172.2.0.0/16"
+  cidr         = "172.20.0.0/16"
 }
 
 resource "aws_vpc" "test" {

--- a/website/docs/r/vpc_ipam_pool.html.markdown
+++ b/website/docs/r/vpc_ipam_pool.html.markdown
@@ -48,7 +48,7 @@ resource "aws_vpc_ipam_pool" "parent" {
 
 resource "aws_vpc_ipam_pool_cidr" "parent_test" {
   ipam_pool_id = aws_vpc_ipam_pool.parent.id
-  cidr         = "172.2.0.0/16"
+  cidr         = "172.20.0.0/16"
 }
 
 resource "aws_vpc_ipam_pool" "child" {
@@ -61,7 +61,7 @@ resource "aws_vpc_ipam_pool" "child" {
 
 resource "aws_vpc_ipam_pool_cidr" "child_test" {
   ipam_pool_id = aws_vpc_ipam_pool.child.id
-  cidr         = "172.2.0.0/24"
+  cidr         = "172.20.0.0/24"
 }
 ```
 

--- a/website/docs/r/vpc_ipam_pool_cidr.html.markdown
+++ b/website/docs/r/vpc_ipam_pool_cidr.html.markdown
@@ -36,7 +36,7 @@ resource "aws_vpc_ipam_pool" "example" {
 
 resource "aws_vpc_ipam_pool_cidr" "example" {
   ipam_pool_id = aws_vpc_ipam_pool.example.id
-  cidr         = "172.2.0.0/16"
+  cidr         = "172.20.0.0/16"
 }
 ```
 
@@ -100,7 +100,7 @@ In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashico
 ```terraform
 import {
   to = aws_vpc_ipam_pool_cidr.example
-  id = "172.2.0.0/24_ipam-pool-0e634f5a1517cccdc"
+  id = "172.20.0.0/24_ipam-pool-0e634f5a1517cccdc"
 }
 ```
 
@@ -109,5 +109,5 @@ Using `terraform import`, import IPAMs using the `<cidr>_<ipam-pool-id>`. For ex
 **NOTE:** Do not use the IPAM Pool Cidr ID as this was introduced after the resource already existed.
 
 ```console
-% terraform import aws_vpc_ipam_pool_cidr.example 172.2.0.0/24_ipam-pool-0e634f5a1517cccdc
+% terraform import aws_vpc_ipam_pool_cidr.example 172.20.0.0/24_ipam-pool-0e634f5a1517cccdc
 ```

--- a/website/docs/r/vpc_ipam_pool_cidr_allocation.html.markdown
+++ b/website/docs/r/vpc_ipam_pool_cidr_allocation.html.markdown
@@ -19,7 +19,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_ipam_pool_cidr_allocation" "example" {
   ipam_pool_id = aws_vpc_ipam_pool.example.id
-  cidr         = "172.2.0.0/24"
+  cidr         = "172.20.0.0/24"
   depends_on = [
     aws_vpc_ipam_pool_cidr.example
   ]
@@ -27,7 +27,7 @@ resource "aws_vpc_ipam_pool_cidr_allocation" "example" {
 
 resource "aws_vpc_ipam_pool_cidr" "example" {
   ipam_pool_id = aws_vpc_ipam_pool.example.id
-  cidr         = "172.2.0.0/16"
+  cidr         = "172.20.0.0/16"
 }
 
 resource "aws_vpc_ipam_pool" "example" {
@@ -53,7 +53,7 @@ resource "aws_vpc_ipam_pool_cidr_allocation" "example" {
   netmask_length = 28
 
   disallowed_cidrs = [
-    "172.2.0.0/28"
+    "172.20.0.0/28"
   ]
 
   depends_on = [
@@ -63,7 +63,7 @@ resource "aws_vpc_ipam_pool_cidr_allocation" "example" {
 
 resource "aws_vpc_ipam_pool_cidr" "example" {
   ipam_pool_id = aws_vpc_ipam_pool.example.id
-  cidr         = "172.2.0.0/16"
+  cidr         = "172.20.0.0/16"
 }
 
 resource "aws_vpc_ipam_pool" "example" {

--- a/website/docs/r/vpc_ipam_preview_next_cidr.html.markdown
+++ b/website/docs/r/vpc_ipam_preview_next_cidr.html.markdown
@@ -32,7 +32,7 @@ resource "aws_vpc_ipam_preview_next_cidr" "example" {
 
 resource "aws_vpc_ipam_pool_cidr" "example" {
   ipam_pool_id = aws_vpc_ipam_pool.example.id
-  cidr         = "172.2.0.0/16"
+  cidr         = "172.20.0.0/16"
 }
 
 resource "aws_vpc_ipam_pool" "example" {

--- a/website/docs/r/vpc_ipv4_cidr_block_association.html.markdown
+++ b/website/docs/r/vpc_ipv4_cidr_block_association.html.markdown
@@ -22,7 +22,7 @@ resource "aws_vpc" "main" {
 
 resource "aws_vpc_ipv4_cidr_block_association" "secondary_cidr" {
   vpc_id     = aws_vpc.main.id
-  cidr_block = "172.2.0.0/16"
+  cidr_block = "172.20.0.0/16"
 }
 ```
 


### PR DESCRIPTION
### Description

This PR corrects an issue with a few resource's examples that previously used a public CIDR range, rather than a public range.

### Relations

Closes #30675

### References

- [IPv4 Private Address Space and Filtering](https://www.arin.net/reference/research/statistics/address_filters/)

### Output from Acceptance Testing

N/a, docs