### PR TITLE
CloudWatch: Fix acceptance test failures

### DIFF
--- a/internal/service/cloudwatch/metric_stream_test.go
+++ b/internal/service/cloudwatch/metric_stream_test.go
@@ -575,7 +575,8 @@ EOF
 }
 
 resource "aws_s3_bucket" "bucket" {
-  bucket = %[1]q
+  bucket        = %[1]q
+  force_destroy = true
 }
 
 resource "aws_iam_role" "firehose_to_s3" {

--- a/internal/service/logs/resource_policy_test.go
+++ b/internal/service/logs/resource_policy_test.go
@@ -35,7 +35,7 @@ func TestAccLogsResourcePolicy_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourcePolicyExists(ctx, resourceName, &resourcePolicy),
 					resource.TestCheckResourceAttr(resourceName, "policy_name", rName),
-					resource.TestCheckResourceAttr(resourceName, "policy_document", fmt.Sprintf("{\"Statement\":[{\"Action\":[\"logs:PutLogEvents\",\"logs:CreateLogStream\"],\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"rds.%s\"},\"Resource\":\"arn:%s:logs:*:*:log-group:/aws/rds/*\",\"Sid\":\"\"}],\"Version\":\"2012-10-17\"}", acctest.PartitionDNSSuffix(), acctest.Partition())),
+					resource.TestCheckResourceAttr(resourceName, "policy_document", fmt.Sprintf("{\"Statement\":[{\"Action\":[\"logs:PutLogEvents\",\"logs:CreateLogStream\"],\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"rds.%s\"},\"Resource\":\"arn:%s:logs:*:*:log-group:/aws/rds/*\"}],\"Version\":\"2012-10-17\"}", acctest.PartitionDNSSuffix(), acctest.Partition())),
 				),
 			},
 			{
@@ -48,7 +48,7 @@ func TestAccLogsResourcePolicy_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourcePolicyExists(ctx, resourceName, &resourcePolicy),
 					resource.TestCheckResourceAttr(resourceName, "policy_name", rName),
-					resource.TestCheckResourceAttr(resourceName, "policy_document", fmt.Sprintf("{\"Statement\":[{\"Action\":[\"logs:PutLogEvents\",\"logs:CreateLogStream\"],\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"rds.%s\"},\"Resource\":\"arn:%s:logs:*:*:log-group:/aws/rds/example.com\",\"Sid\":\"\"}],\"Version\":\"2012-10-17\"}", acctest.PartitionDNSSuffix(), acctest.Partition())),
+					resource.TestCheckResourceAttr(resourceName, "policy_document", fmt.Sprintf("{\"Statement\":[{\"Action\":[\"logs:PutLogEvents\",\"logs:CreateLogStream\"],\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"rds.%s\"},\"Resource\":\"arn:%s:logs:*:*:log-group:/aws/rds/example.com\"}],\"Version\":\"2012-10-17\"}", acctest.PartitionDNSSuffix(), acctest.Partition())),
 				),
 			},
 		},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

In CI:

```
=== RUN   TestAccCloudWatchMetricStream_basic
=== PAUSE TestAccCloudWatchMetricStream_basic
=== CONT  TestAccCloudWatchMetricStream_basic
    testing_new.go:88: Error running post-test destroy, there may be dangling resources: exit status 1
        Error: deleting Amazon S3 (Simple Storage) Bucket (tf-acc-test-7630968413981012997): BucketNotEmpty: The bucket you tried to delete is not empty
          status code: 409, request id: A1FAY1WMQJB387TG, host id: GdxDA5OvTuwAwkMwD5C371HWIXXsDvpXmjgAN3gzJam3VysyRso5Z+99usu0uaC9ebvf0zjP4mI9LundoUbMWw==
--- FAIL: TestAccCloudWatchMetricStream_basic (480.11s)
```
```
=== RUN   TestAccLogsResourcePolicy_basic
=== PAUSE TestAccLogsResourcePolicy_basic
=== CONT  TestAccLogsResourcePolicy_basic
    resource_policy_test.go:27: Step 1/3 error: Check failed: Check 3/3 error: aws_cloudwatch_log_resource_policy.test: Attribute 'policy_document' expected "{\"Statement\":[{\"Action\":[\"logs:PutLogEvents\",\"logs:CreateLogStream\"],\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"rds.amazonaws.com\"},\"Resource\":\"arn:aws:logs:*:*:log-group:/aws/rds/*\",\"Sid\":\"\"}],\"Version\":\"2012-10-17\"}", got "{\"Statement\":[{\"Action\":[\"logs:PutLogEvents\",\"logs:CreateLogStream\"],\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"rds.amazonaws.com\"},\"Resource\":\"arn:aws:logs:*:*:log-group:/aws/rds/*\"}],\"Version\":\"2012-10-17\"}"
--- FAIL: TestAccLogsResourcePolicy_basic (191.17s)
```

Relates https://github.com/hashicorp/terraform-provider-aws/pull/28539.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccCloudWatchMetricStream_' PKG=cloudwatch ACCTEST_PARALLELISM=2 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudwatch/... -v -count 1 -parallel 2  -run=TestAccCloudWatchMetricStream_ -timeout 180m
=== RUN   TestAccCloudWatchMetricStream_basic
=== PAUSE TestAccCloudWatchMetricStream_basic
=== RUN   TestAccCloudWatchMetricStream_disappears
=== PAUSE TestAccCloudWatchMetricStream_disappears
=== RUN   TestAccCloudWatchMetricStream_nameGenerated
=== PAUSE TestAccCloudWatchMetricStream_nameGenerated
=== RUN   TestAccCloudWatchMetricStream_namePrefix
=== PAUSE TestAccCloudWatchMetricStream_namePrefix
=== RUN   TestAccCloudWatchMetricStream_includeFilters
=== PAUSE TestAccCloudWatchMetricStream_includeFilters
=== RUN   TestAccCloudWatchMetricStream_includeFiltersWithMetricNames
=== PAUSE TestAccCloudWatchMetricStream_includeFiltersWithMetricNames
=== RUN   TestAccCloudWatchMetricStream_excludeFilters
=== PAUSE TestAccCloudWatchMetricStream_excludeFilters
=== RUN   TestAccCloudWatchMetricStream_excludeFiltersWithMetricNames
=== PAUSE TestAccCloudWatchMetricStream_excludeFiltersWithMetricNames
=== RUN   TestAccCloudWatchMetricStream_update
=== PAUSE TestAccCloudWatchMetricStream_update
=== RUN   TestAccCloudWatchMetricStream_tags
=== PAUSE TestAccCloudWatchMetricStream_tags
=== RUN   TestAccCloudWatchMetricStream_additional_statistics
=== PAUSE TestAccCloudWatchMetricStream_additional_statistics
=== RUN   TestAccCloudWatchMetricStream_includeLinkedAccountsMetrics
=== PAUSE TestAccCloudWatchMetricStream_includeLinkedAccountsMetrics
=== CONT  TestAccCloudWatchMetricStream_basic
=== CONT  TestAccCloudWatchMetricStream_excludeFilters
--- PASS: TestAccCloudWatchMetricStream_excludeFilters (27.58s)
=== CONT  TestAccCloudWatchMetricStream_namePrefix
--- PASS: TestAccCloudWatchMetricStream_namePrefix (126.40s)
=== CONT  TestAccCloudWatchMetricStream_includeFiltersWithMetricNames
--- PASS: TestAccCloudWatchMetricStream_includeFiltersWithMetricNames (25.52s)
=== CONT  TestAccCloudWatchMetricStream_includeFilters
--- PASS: TestAccCloudWatchMetricStream_includeFilters (25.48s)
=== CONT  TestAccCloudWatchMetricStream_tags
--- PASS: TestAccCloudWatchMetricStream_basic (209.17s)
=== CONT  TestAccCloudWatchMetricStream_includeLinkedAccountsMetrics
--- PASS: TestAccCloudWatchMetricStream_includeLinkedAccountsMetrics (226.51s)
=== CONT  TestAccCloudWatchMetricStream_additional_statistics
--- PASS: TestAccCloudWatchMetricStream_tags (292.82s)
=== CONT  TestAccCloudWatchMetricStream_update
--- PASS: TestAccCloudWatchMetricStream_additional_statistics (88.01s)
=== CONT  TestAccCloudWatchMetricStream_excludeFiltersWithMetricNames
--- PASS: TestAccCloudWatchMetricStream_excludeFiltersWithMetricNames (34.15s)
=== CONT  TestAccCloudWatchMetricStream_nameGenerated
--- PASS: TestAccCloudWatchMetricStream_update (107.30s)
=== CONT  TestAccCloudWatchMetricStream_disappears
--- PASS: TestAccCloudWatchMetricStream_nameGenerated (180.67s)
--- PASS: TestAccCloudWatchMetricStream_disappears (153.11s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudwatch	763.542s
```
```console
% make testacc TESTARGS='-run=TestAccLogsResourcePolicy_' PKG=logs ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/logs/... -v -count 1 -parallel 2  -run=TestAccLogsResourcePolicy_ -timeout 180m
=== RUN   TestAccLogsResourcePolicy_basic
=== PAUSE TestAccLogsResourcePolicy_basic
=== RUN   TestAccLogsResourcePolicy_ignoreEquivalent
=== PAUSE TestAccLogsResourcePolicy_ignoreEquivalent
=== CONT  TestAccLogsResourcePolicy_basic
=== CONT  TestAccLogsResourcePolicy_ignoreEquivalent
--- PASS: TestAccLogsResourcePolicy_ignoreEquivalent (41.89s)
--- PASS: TestAccLogsResourcePolicy_basic (47.60s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/logs	53.186s
```
