### PR TITLE
[New Resource]: `aws_cloudfront_continuous_deployment_policy`

### DIFF
--- a/.changelog/32936.txt
+++ b/.changelog/32936.txt
@@ -1,0 +1,7 @@
+```release-note:new-resource
+aws_cloudfront_continuous_deployment_policy
+```
+
+```release-note:enhancement
+resource/aws_cloudfront_distribution: Add `continuous_deployment_policy_id` and `staging` arguments to support continuous deployments
+```

--- a/internal/service/cloudfront/continuous_deployment_policy.go
+++ b/internal/service/cloudfront/continuous_deployment_policy.go
@@ -1,0 +1,629 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cloudfront
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource(name="Continuous Deployment Policy")
+func newResourceContinuousDeploymentPolicy(_ context.Context) (resource.ResourceWithConfigure, error) {
+	return &resourceContinuousDeploymentPolicy{}, nil
+}
+
+const (
+	ResNameContinuousDeploymentPolicy = "Continuous Deployment Policy"
+)
+
+type resourceContinuousDeploymentPolicy struct {
+	framework.ResourceWithConfigure
+}
+
+func (r *resourceContinuousDeploymentPolicy) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "aws_cloudfront_continuous_deployment_policy"
+}
+
+func (r *resourceContinuousDeploymentPolicy) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"enabled": schema.BoolAttribute{
+				Required: true,
+			},
+			"etag": schema.StringAttribute{
+				Computed: true,
+			},
+			"id": framework.IDAttribute(),
+			"last_modified_time": schema.StringAttribute{
+				Computed: true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"staging_distribution_dns_names": schema.ListNestedBlock{
+				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"items": schema.SetAttribute{
+							ElementType: types.StringType,
+							Optional:    true,
+						},
+						"quantity": schema.Int64Attribute{
+							Required: true,
+						},
+					},
+				},
+			},
+			"traffic_config": schema.ListNestedBlock{
+				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"type": schema.StringAttribute{
+							Required: true,
+						},
+					},
+					Blocks: map[string]schema.Block{
+						"single_header_config": schema.ListNestedBlock{
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"header": schema.StringAttribute{
+										Required: true,
+									},
+									"value": schema.StringAttribute{
+										Required: true,
+									},
+								},
+							},
+						},
+						"single_weight_config": schema.ListNestedBlock{
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"weight": schema.Float64Attribute{
+										Required: true,
+									},
+								},
+								Blocks: map[string]schema.Block{
+									"session_stickiness_config": schema.ListNestedBlock{
+										Validators: []validator.List{
+											listvalidator.SizeAtMost(1),
+										},
+										NestedObject: schema.NestedBlockObject{
+											Attributes: map[string]schema.Attribute{
+												"idle_ttl": schema.Int64Attribute{
+													Required: true,
+												},
+												"maximum_ttl": schema.Int64Attribute{
+													Required: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r *resourceContinuousDeploymentPolicy) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().CloudFrontConn(ctx)
+
+	var plan resourceContinuousDeploymentPolicyData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	cfg, d := expandContinuousDeploymentPolicyConfig(ctx, plan)
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := &cloudfront.CreateContinuousDeploymentPolicyInput{
+		ContinuousDeploymentPolicyConfig: cfg,
+	}
+
+	out, err := conn.CreateContinuousDeploymentPolicyWithContext(ctx, in)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.CloudFront, create.ErrActionCreating, ResNameContinuousDeploymentPolicy, "", err),
+			err.Error(),
+		)
+		return
+	}
+	if out == nil || out.ContinuousDeploymentPolicy == nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.CloudFront, create.ErrActionCreating, ResNameContinuousDeploymentPolicy, "", nil),
+			errors.New("empty output").Error(),
+		)
+		return
+	}
+
+	plan.ETag = flex.StringToFramework(ctx, out.ETag)
+	plan.ID = flex.StringToFramework(ctx, out.ContinuousDeploymentPolicy.Id)
+	plan.LastModifiedTime = flex.StringValueToFramework(ctx, out.ContinuousDeploymentPolicy.LastModifiedTime.Format(time.RFC3339))
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *resourceContinuousDeploymentPolicy) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().CloudFrontConn(ctx)
+
+	var state resourceContinuousDeploymentPolicyData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := FindContinuousDeploymentPolicyByID(ctx, conn, state.ID.ValueString())
+	if tfresource.NotFound(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.CloudFront, create.ErrActionSetting, ResNameContinuousDeploymentPolicy, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	state.ETag = flex.StringToFramework(ctx, out.ETag)
+	policy := out.ContinuousDeploymentPolicy
+	state.ID = flex.StringToFramework(ctx, policy.Id)
+	state.LastModifiedTime = flex.StringValueToFramework(ctx, policy.LastModifiedTime.Format(time.RFC3339))
+	resp.Diagnostics.Append(state.refresh(ctx, policy.ContinuousDeploymentPolicyConfig)...)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *resourceContinuousDeploymentPolicy) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	conn := r.Meta().CloudFrontConn(ctx)
+
+	var plan, state resourceContinuousDeploymentPolicyData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !plan.Enabled.Equal(state.Enabled) ||
+		!plan.StagingDistributionDNSNames.Equal(state.StagingDistributionDNSNames) ||
+		!plan.TrafficConfig.Equal(state.TrafficConfig) {
+		cfg, d := expandContinuousDeploymentPolicyConfig(ctx, plan)
+		resp.Diagnostics.Append(d...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		in := &cloudfront.UpdateContinuousDeploymentPolicyInput{
+			Id: aws.String(plan.ID.ValueString()),
+			// Use state ETag value. The planned value will be unknown.
+			IfMatch:                          aws.String(state.ETag.ValueString()),
+			ContinuousDeploymentPolicyConfig: cfg,
+		}
+
+		out, err := conn.UpdateContinuousDeploymentPolicyWithContext(ctx, in)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.CloudFront, create.ErrActionUpdating, ResNameContinuousDeploymentPolicy, plan.ID.String(), err),
+				err.Error(),
+			)
+			return
+		}
+		if out == nil || out.ContinuousDeploymentPolicy == nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.CloudFront, create.ErrActionUpdating, ResNameContinuousDeploymentPolicy, plan.ID.String(), nil),
+				errors.New("empty output").Error(),
+			)
+			return
+		}
+
+		plan.ETag = flex.StringToFramework(ctx, out.ETag)
+		plan.ID = flex.StringToFramework(ctx, out.ContinuousDeploymentPolicy.Id)
+		plan.LastModifiedTime = flex.StringValueToFramework(ctx, out.ContinuousDeploymentPolicy.LastModifiedTime.Format(time.RFC3339))
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *resourceContinuousDeploymentPolicy) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	conn := r.Meta().CloudFrontConn(ctx)
+
+	var state resourceContinuousDeploymentPolicyData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := &cloudfront.DeleteContinuousDeploymentPolicyInput{
+		Id:      aws.String(state.ID.ValueString()),
+		IfMatch: aws.String(state.ETag.ValueString()),
+	}
+
+	_, err := conn.DeleteContinuousDeploymentPolicyWithContext(ctx, in)
+	if err != nil {
+		if tfawserr.ErrCodeEquals(err, cloudfront.ErrCodeNoSuchContinuousDeploymentPolicy) {
+			return
+		}
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.CloudFront, create.ErrActionDeleting, ResNameContinuousDeploymentPolicy, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+}
+
+func (r *resourceContinuousDeploymentPolicy) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func FindContinuousDeploymentPolicyByID(ctx context.Context, conn *cloudfront.CloudFront, id string) (*cloudfront.GetContinuousDeploymentPolicyOutput, error) {
+	in := &cloudfront.GetContinuousDeploymentPolicyInput{
+		Id: aws.String(id),
+	}
+
+	out, err := conn.GetContinuousDeploymentPolicyWithContext(ctx, in)
+	if tfawserr.ErrCodeEquals(err, cloudfront.ErrCodeNoSuchContinuousDeploymentPolicy) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: in,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if out == nil || out.ContinuousDeploymentPolicy == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return out, nil
+}
+
+func flattenStagingDistributionDNSNames(ctx context.Context, apiObject *cloudfront.StagingDistributionDnsNames) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	elemType := types.ObjectType{AttrTypes: stagingDistributionDNSNamesAttrTypes}
+
+	if apiObject == nil {
+		return types.ListNull(elemType), diags
+	}
+
+	obj := map[string]attr.Value{
+		"items":    flex.FlattenFrameworkStringSet(ctx, apiObject.Items),
+		"quantity": flex.Int64ToFramework(ctx, apiObject.Quantity),
+	}
+	objVal, d := types.ObjectValue(stagingDistributionDNSNamesAttrTypes, obj)
+	diags.Append(d...)
+
+	listVal, d := types.ListValue(elemType, []attr.Value{objVal})
+	diags.Append(d...)
+
+	return listVal, diags
+}
+
+func flattenTrafficConfig(ctx context.Context, apiObject *cloudfront.TrafficConfig) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	elemType := types.ObjectType{AttrTypes: trafficConfigAttrTypes}
+
+	if apiObject == nil {
+		return types.ListNull(elemType), diags
+	}
+
+	singleHeaderConfig, d := flattenSingleHeaderConfig(ctx, apiObject.SingleHeaderConfig)
+	diags.Append(d...)
+
+	singleWeightConfig, d := flattenSingleWeightConfig(ctx, apiObject.SingleWeightConfig)
+	diags.Append(d...)
+
+	obj := map[string]attr.Value{
+		"type":                 flex.StringToFramework(ctx, apiObject.Type),
+		"single_header_config": singleHeaderConfig,
+		"single_weight_config": singleWeightConfig,
+	}
+	objVal, d := types.ObjectValue(trafficConfigAttrTypes, obj)
+	diags.Append(d...)
+
+	listVal, d := types.ListValue(elemType, []attr.Value{objVal})
+	diags.Append(d...)
+
+	return listVal, diags
+}
+
+func flattenSingleHeaderConfig(ctx context.Context, apiObject *cloudfront.ContinuousDeploymentSingleHeaderConfig) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	elemType := types.ObjectType{AttrTypes: singleHeaderConfigAttrTypes}
+
+	if apiObject == nil {
+		return types.ListNull(elemType), diags
+	}
+
+	obj := map[string]attr.Value{
+		"header": flex.StringToFramework(ctx, apiObject.Header),
+		"value":  flex.StringToFramework(ctx, apiObject.Value),
+	}
+	objVal, d := types.ObjectValue(singleHeaderConfigAttrTypes, obj)
+	diags.Append(d...)
+
+	listVal, d := types.ListValue(elemType, []attr.Value{objVal})
+	diags.Append(d...)
+
+	return listVal, diags
+}
+
+func flattenSingleWeightConfig(ctx context.Context, apiObject *cloudfront.ContinuousDeploymentSingleWeightConfig) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	elemType := types.ObjectType{AttrTypes: singleWeightConfigAttrTypes}
+
+	if apiObject == nil {
+		return types.ListNull(elemType), diags
+	}
+
+	sessionStickinessConfig, d := flattenSessionStickinessConfig(ctx, apiObject.SessionStickinessConfig)
+	diags.Append(d...)
+
+	obj := map[string]attr.Value{
+		"session_stickiness_config": sessionStickinessConfig,
+		"weight":                    flex.Float64ToFramework(ctx, apiObject.Weight),
+	}
+	objVal, d := types.ObjectValue(singleWeightConfigAttrTypes, obj)
+	diags.Append(d...)
+
+	listVal, d := types.ListValue(elemType, []attr.Value{objVal})
+	diags.Append(d...)
+
+	return listVal, diags
+}
+
+func flattenSessionStickinessConfig(ctx context.Context, apiObject *cloudfront.SessionStickinessConfig) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	elemType := types.ObjectType{AttrTypes: sessionStickinessConfigAttrTypes}
+
+	if apiObject == nil {
+		return types.ListNull(elemType), diags
+	}
+
+	obj := map[string]attr.Value{
+		"idle_ttl":    flex.Int64ToFramework(ctx, apiObject.IdleTTL),
+		"maximum_ttl": flex.Int64ToFramework(ctx, apiObject.MaximumTTL),
+	}
+	objVal, d := types.ObjectValue(sessionStickinessConfigAttrTypes, obj)
+	diags.Append(d...)
+
+	listVal, d := types.ListValue(elemType, []attr.Value{objVal})
+	diags.Append(d...)
+
+	return listVal, diags
+}
+
+// expandContinuousDeploymentPolicyConfig translates a resource plan into a
+// continuous deployment policy config
+func expandContinuousDeploymentPolicyConfig(ctx context.Context, data resourceContinuousDeploymentPolicyData) (*cloudfront.ContinuousDeploymentPolicyConfig, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	var stagingDistributionDNSNames []stagingDistributionDNSNamesData
+	diags.Append(data.StagingDistributionDNSNames.ElementsAs(ctx, &stagingDistributionDNSNames, false)...)
+
+	apiObject := &cloudfront.ContinuousDeploymentPolicyConfig{
+		Enabled:                     aws.Bool(data.Enabled.ValueBool()),
+		StagingDistributionDnsNames: expandStagingDistributionDNSNames(ctx, stagingDistributionDNSNames),
+	}
+	if !data.TrafficConfig.IsNull() {
+		var tcData []trafficConfigData
+		diags.Append(data.TrafficConfig.ElementsAs(ctx, &tcData, false)...)
+
+		trafficConfig, d := expandTrafficConfig(ctx, tcData)
+		diags.Append(d...)
+
+		apiObject.TrafficConfig = trafficConfig
+	}
+
+	return apiObject, diags
+}
+
+func expandStagingDistributionDNSNames(ctx context.Context, tfList []stagingDistributionDNSNamesData) *cloudfront.StagingDistributionDnsNames {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	tfObj := tfList[0]
+	apiObject := &cloudfront.StagingDistributionDnsNames{
+		Quantity: aws.Int64(tfObj.Quantity.ValueInt64()),
+		Items:    flex.ExpandFrameworkStringSet(ctx, tfObj.Items),
+	}
+
+	return apiObject
+}
+
+func expandTrafficConfig(ctx context.Context, tfList []trafficConfigData) (*cloudfront.TrafficConfig, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if len(tfList) == 0 {
+		return nil, diags
+	}
+
+	tfObj := tfList[0]
+	apiObject := &cloudfront.TrafficConfig{
+		Type: aws.String(tfObj.Type.ValueString()),
+	}
+	if !tfObj.SingleHeaderConfig.IsNull() {
+		var data []singleHeaderConfigData
+		diags.Append(tfObj.SingleHeaderConfig.ElementsAs(ctx, &data, false)...)
+
+		apiObject.SingleHeaderConfig = expandSingleHeaderConfig(data)
+	}
+	if !tfObj.SingleWeightConfig.IsNull() {
+		var data []singleWeightConfigData
+		diags.Append(tfObj.SingleWeightConfig.ElementsAs(ctx, &data, false)...)
+
+		singleWeightConfig, d := expandSingleWeightConfig(ctx, data)
+		diags.Append(d...)
+
+		apiObject.SingleWeightConfig = singleWeightConfig
+	}
+
+	return apiObject, diags
+}
+
+func expandSingleHeaderConfig(tfList []singleHeaderConfigData) *cloudfront.ContinuousDeploymentSingleHeaderConfig {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	tfObj := tfList[0]
+	apiObject := &cloudfront.ContinuousDeploymentSingleHeaderConfig{
+		Header: aws.String(tfObj.Header.ValueString()),
+		Value:  aws.String(tfObj.Value.ValueString()),
+	}
+
+	return apiObject
+}
+
+func expandSingleWeightConfig(ctx context.Context, tfList []singleWeightConfigData) (*cloudfront.ContinuousDeploymentSingleWeightConfig, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if len(tfList) == 0 {
+		return nil, diags
+	}
+
+	tfObj := tfList[0]
+	apiObject := &cloudfront.ContinuousDeploymentSingleWeightConfig{
+		Weight: aws.Float64(tfObj.Weight.ValueFloat64()),
+	}
+	if !tfObj.SessionStickinessConfig.IsNull() {
+		var data []sessionStickinessConfigData
+		diags.Append(tfObj.SessionStickinessConfig.ElementsAs(ctx, &data, false)...)
+
+		apiObject.SessionStickinessConfig = expandSessionStickinessConfig(data)
+	}
+
+	return apiObject, diags
+}
+
+func expandSessionStickinessConfig(tfList []sessionStickinessConfigData) *cloudfront.SessionStickinessConfig {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	tfObj := tfList[0]
+	apiObject := &cloudfront.SessionStickinessConfig{
+		IdleTTL:    aws.Int64(tfObj.IdleTTL.ValueInt64()),
+		MaximumTTL: aws.Int64(tfObj.MaximumTTL.ValueInt64()),
+	}
+
+	return apiObject
+}
+
+type resourceContinuousDeploymentPolicyData struct {
+	Enabled                     types.Bool   `tfsdk:"enabled"`
+	ETag                        types.String `tfsdk:"etag"`
+	ID                          types.String `tfsdk:"id"`
+	LastModifiedTime            types.String `tfsdk:"last_modified_time"`
+	StagingDistributionDNSNames types.List   `tfsdk:"staging_distribution_dns_names"`
+	TrafficConfig               types.List   `tfsdk:"traffic_config"`
+}
+
+type stagingDistributionDNSNamesData struct {
+	Items    types.Set   `tfsdk:"items"`
+	Quantity types.Int64 `tfsdk:"quantity"`
+}
+
+type trafficConfigData struct {
+	SingleHeaderConfig types.List   `tfsdk:"single_header_config"`
+	SingleWeightConfig types.List   `tfsdk:"single_weight_config"`
+	Type               types.String `tfsdk:"type"`
+}
+
+type singleHeaderConfigData struct {
+	Header types.String `tfsdk:"header"`
+	Value  types.String `tfsdk:"value"`
+}
+
+type singleWeightConfigData struct {
+	SessionStickinessConfig types.List    `tfsdk:"session_stickiness_config"`
+	Weight                  types.Float64 `tfsdk:"weight"`
+}
+
+type sessionStickinessConfigData struct {
+	IdleTTL    types.Int64 `tfsdk:"idle_ttl"`
+	MaximumTTL types.Int64 `tfsdk:"maximum_ttl"`
+}
+
+var stagingDistributionDNSNamesAttrTypes = map[string]attr.Type{
+	"items":    types.SetType{ElemType: types.StringType},
+	"quantity": types.Int64Type,
+}
+
+var trafficConfigAttrTypes = map[string]attr.Type{
+	"single_header_config": types.ListType{ElemType: types.ObjectType{AttrTypes: singleHeaderConfigAttrTypes}},
+	"single_weight_config": types.ListType{ElemType: types.ObjectType{AttrTypes: singleWeightConfigAttrTypes}},
+	"type":                 types.StringType,
+}
+
+var singleHeaderConfigAttrTypes = map[string]attr.Type{
+	"header": types.StringType,
+	"value":  types.StringType,
+}
+
+var singleWeightConfigAttrTypes = map[string]attr.Type{
+	"session_stickiness_config": types.ListType{ElemType: types.ObjectType{AttrTypes: sessionStickinessConfigAttrTypes}},
+	"weight":                    types.Float64Type,
+}
+
+var sessionStickinessConfigAttrTypes = map[string]attr.Type{
+	"idle_ttl":    types.Int64Type,
+	"maximum_ttl": types.Int64Type,
+}
+
+// refresh updates state data from the returned API response
+func (rd *resourceContinuousDeploymentPolicyData) refresh(ctx context.Context, apiObject *cloudfront.ContinuousDeploymentPolicyConfig) diag.Diagnostics {
+	var diags diag.Diagnostics
+	if apiObject == nil {
+		return diags
+	}
+
+	rd.Enabled = flex.BoolToFramework(ctx, apiObject.Enabled)
+
+	stagingDistributionDNSNames, d := flattenStagingDistributionDNSNames(ctx, apiObject.StagingDistributionDnsNames)
+	diags.Append(d...)
+	rd.StagingDistributionDNSNames = stagingDistributionDNSNames
+
+	trafficConfig, d := flattenTrafficConfig(ctx, apiObject.TrafficConfig)
+	diags.Append(d...)
+	rd.TrafficConfig = trafficConfig
+
+	return diags
+}

--- a/internal/service/cloudfront/continuous_deployment_policy_test.go
+++ b/internal/service/cloudfront/continuous_deployment_policy_test.go
@@ -1,0 +1,503 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cloudfront_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tfcloudfront "github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccCloudFrontContinuousDeploymentPolicy_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	var policy cloudfront.GetContinuousDeploymentPolicyOutput
+	var stagingDistribution cloudfront.Distribution
+	var productionDistribution cloudfront.Distribution
+	resourceName := "aws_cloudfront_continuous_deployment_policy.test"
+	stagingDistributionResourceName := "aws_cloudfront_distribution.staging"
+	productionDistributionResourceName := "aws_cloudfront_distribution.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, cloudfront.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, cloudfront.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckContinuousDeploymentPolicyDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContinuousDeploymentPolicyConfig_init(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDistributionExists(ctx, stagingDistributionResourceName, &stagingDistribution),
+					testAccCheckDistributionExists(ctx, productionDistributionResourceName, &productionDistribution),
+					testAccCheckContinuousDeploymentPolicyExists(ctx, resourceName, &policy),
+				),
+			},
+			{
+				Config: testAccContinuousDeploymentPolicyConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContinuousDeploymentPolicyExists(ctx, resourceName, &policy),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "staging_distribution_dns_names.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "staging_distribution_dns_names.0.quantity", "1"),
+					resource.TestCheckResourceAttr(resourceName, "staging_distribution_dns_names.0.items.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "staging_distribution_dns_names.0.items.0", stagingDistributionResourceName, "domain_name"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "traffic_config.*", map[string]string{
+						"type":                          "SingleWeight",
+						"single_weight_config.#":        "1",
+						"single_weight_config.0.weight": "0.01",
+					}),
+					resource.TestCheckResourceAttrSet(resourceName, "etag"),
+					resource.TestCheckResourceAttrSet(resourceName, "last_modified_time"),
+					resource.TestCheckResourceAttrPair(productionDistributionResourceName, "continuous_deployment_policy_id", resourceName, "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccCloudFrontContinuousDeploymentPolicy_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	var policy cloudfront.GetContinuousDeploymentPolicyOutput
+	var stagingDistribution cloudfront.Distribution
+	var productionDistribution cloudfront.Distribution
+	resourceName := "aws_cloudfront_continuous_deployment_policy.test"
+	stagingDistributionResourceName := "aws_cloudfront_distribution.staging"
+	productionDistributionResourceName := "aws_cloudfront_distribution.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, cloudfront.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, cloudfront.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckContinuousDeploymentPolicyDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContinuousDeploymentPolicyConfig_init(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDistributionExists(ctx, stagingDistributionResourceName, &stagingDistribution),
+					testAccCheckDistributionExists(ctx, productionDistributionResourceName, &productionDistribution),
+					testAccCheckContinuousDeploymentPolicyExists(ctx, resourceName, &policy),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfcloudfront.ResourceContinuousDeploymentPolicy, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccCloudFrontContinuousDeploymentPolicy_trafficConfig(t *testing.T) {
+	ctx := acctest.Context(t)
+	var policy cloudfront.GetContinuousDeploymentPolicyOutput
+	var stagingDistribution cloudfront.Distribution
+	var productionDistribution cloudfront.Distribution
+	resourceName := "aws_cloudfront_continuous_deployment_policy.test"
+	stagingDistributionResourceName := "aws_cloudfront_distribution.staging"
+	productionDistributionResourceName := "aws_cloudfront_distribution.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, cloudfront.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, cloudfront.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckContinuousDeploymentPolicyDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContinuousDeploymentPolicyConfig_init(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDistributionExists(ctx, stagingDistributionResourceName, &stagingDistribution),
+					testAccCheckDistributionExists(ctx, productionDistributionResourceName, &productionDistribution),
+					testAccCheckContinuousDeploymentPolicyExists(ctx, resourceName, &policy),
+				),
+			},
+			{
+				Config: testAccContinuousDeploymentPolicyConfig_TrafficConfig_singleWeight(false, "0.01", 300, 600),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContinuousDeploymentPolicyExists(ctx, resourceName, &policy),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "traffic_config.*", map[string]string{
+						"type":                          "SingleWeight",
+						"single_weight_config.#":        "1",
+						"single_weight_config.0.weight": "0.01",
+						"single_weight_config.0.session_stickiness_config.#":             "1",
+						"single_weight_config.0.session_stickiness_config.0.idle_ttl":    "300",
+						"single_weight_config.0.session_stickiness_config.0.maximum_ttl": "600",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccContinuousDeploymentPolicyConfig_TrafficConfig_singleWeight(true, "0.02", 600, 1200),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContinuousDeploymentPolicyExists(ctx, resourceName, &policy),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "traffic_config.*", map[string]string{
+						"type":                          "SingleWeight",
+						"single_weight_config.#":        "1",
+						"single_weight_config.0.weight": "0.02",
+						"single_weight_config.0.session_stickiness_config.#":             "1",
+						"single_weight_config.0.session_stickiness_config.0.idle_ttl":    "600",
+						"single_weight_config.0.session_stickiness_config.0.maximum_ttl": "1200",
+					}),
+				),
+			},
+			{
+				Config: testAccContinuousDeploymentPolicyConfig_TrafficConfig_singleHeader(false, "aws-cf-cd-test", "test"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContinuousDeploymentPolicyExists(ctx, resourceName, &policy),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "traffic_config.*", map[string]string{
+						"type":                          "SingleHeader",
+						"single_header_config.#":        "1",
+						"single_header_config.0.header": "aws-cf-cd-test",
+						"single_header_config.0.value":  "test",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccContinuousDeploymentPolicyConfig_TrafficConfig_singleHeader(true, "aws-cf-cd-test2", "test2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContinuousDeploymentPolicyExists(ctx, resourceName, &policy),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "traffic_config.*", map[string]string{
+						"type":                          "SingleHeader",
+						"single_header_config.#":        "1",
+						"single_header_config.0.header": "aws-cf-cd-test2",
+						"single_header_config.0.value":  "test2",
+					}),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckContinuousDeploymentPolicyDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).CloudFrontConn(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_cloudfront_continuous_deployment_policy" {
+				continue
+			}
+
+			_, err := tfcloudfront.FindContinuousDeploymentPolicyByID(ctx, conn, rs.Primary.ID)
+			if tfawserr.ErrCodeEquals(err, cloudfront.ErrCodeNoSuchContinuousDeploymentPolicy) {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+
+			return create.Error(names.CloudFront, create.ErrActionCheckingDestroyed, tfcloudfront.ResNameContinuousDeploymentPolicy, rs.Primary.ID, errors.New("not destroyed"))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckContinuousDeploymentPolicyExists(ctx context.Context, name string, policy *cloudfront.GetContinuousDeploymentPolicyOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.CloudFront, create.ErrActionCheckingExistence, tfcloudfront.ResNameContinuousDeploymentPolicy, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.CloudFront, create.ErrActionCheckingExistence, tfcloudfront.ResNameContinuousDeploymentPolicy, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).CloudFrontConn(ctx)
+		resp, err := tfcloudfront.FindContinuousDeploymentPolicyByID(ctx, conn, rs.Primary.ID)
+		if err != nil {
+			return create.Error(names.CloudFront, create.ErrActionCheckingExistence, tfcloudfront.ResNameContinuousDeploymentPolicy, rs.Primary.ID, err)
+		}
+
+		*policy = *resp
+
+		return nil
+	}
+}
+
+func testAccContinuousDeploymentPolicyConfigBase_staging() string {
+	return `
+resource "aws_cloudfront_distribution" "staging" {
+  enabled          = true
+  retain_on_delete = false
+  staging          = true
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "test"
+    viewer_protocol_policy = "allow-all"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "all"
+      }
+    }
+  }
+
+  origin {
+    domain_name = "www.example.com"
+    origin_id   = "test"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}
+`
+}
+
+// The initial production distribution must be created _without_ the continuous
+// deployment policy attached. Example error:
+//
+// InvalidArgument: Continuous deployment policy is not supported during distribution creation.
+func testAccContinuousDeploymentPolicyConfigBase_productionInit() string {
+	return `
+resource "aws_cloudfront_distribution" "test" {
+  enabled          = true
+  retain_on_delete = false
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "test"
+    viewer_protocol_policy = "allow-all"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "all"
+      }
+    }
+  }
+
+  origin {
+    domain_name = "www.example.com"
+    origin_id   = "test"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}
+`
+}
+
+func testAccContinuousDeploymentPolicyConfigBase_production() string {
+	return `
+resource "aws_cloudfront_distribution" "test" {
+  enabled          = true
+  retain_on_delete = false
+
+  continuous_deployment_policy_id = aws_cloudfront_continuous_deployment_policy.test.id
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "test"
+    viewer_protocol_policy = "allow-all"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "all"
+      }
+    }
+  }
+
+  origin {
+    domain_name = "www.example.com"
+    origin_id   = "test"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}
+`
+}
+
+// testAccContinuousDeploymentPolicyConfig_init initializes the staging and production
+// distributions and creates the continuous deployment policy, but does not yet
+// associate it with the production distribution. Association with a production distribution
+// must be done in sunsequent steps, so this will always be the first configuration deployed.
+//
+// A fortunate side effect of the initial deployment without a production distribution
+// association is that it allows the the policy to be "disappeared" out of band safely,
+// avoiding errors like the following:
+//
+// ContinuousDeploymentPolicyInUse: The specified continuous deployment policy is
+// currently associated with a distribution.
+func testAccContinuousDeploymentPolicyConfig_init() string {
+	return acctest.ConfigCompose(
+		testAccContinuousDeploymentPolicyConfigBase_staging(),
+		testAccContinuousDeploymentPolicyConfigBase_productionInit(),
+		`
+resource "aws_cloudfront_continuous_deployment_policy" "test" {
+  enabled = false
+
+  staging_distribution_dns_names {
+    items    = [aws_cloudfront_distribution.staging.domain_name]
+    quantity = 1
+  }
+
+  traffic_config {
+    type = "SingleWeight"
+    single_weight_config {
+      weight = "0.01"
+    }
+  }
+}
+`)
+}
+
+func testAccContinuousDeploymentPolicyConfig_basic() string {
+	return acctest.ConfigCompose(
+		testAccContinuousDeploymentPolicyConfigBase_staging(),
+		testAccContinuousDeploymentPolicyConfigBase_production(),
+		`
+resource "aws_cloudfront_continuous_deployment_policy" "test" {
+  enabled = false
+
+  staging_distribution_dns_names {
+    items    = [aws_cloudfront_distribution.staging.domain_name]
+    quantity = 1
+  }
+
+  traffic_config {
+    type = "SingleWeight"
+    single_weight_config {
+      weight = "0.01"
+    }
+  }
+}
+`)
+}
+
+func testAccContinuousDeploymentPolicyConfig_TrafficConfig_singleWeight(enabled bool, weight string, idleTTL, maxTTL int) string {
+	return acctest.ConfigCompose(
+		testAccContinuousDeploymentPolicyConfigBase_staging(),
+		testAccContinuousDeploymentPolicyConfigBase_production(),
+		fmt.Sprintf(`
+resource "aws_cloudfront_continuous_deployment_policy" "test" {
+  enabled = %[1]t
+
+  staging_distribution_dns_names {
+    items    = [aws_cloudfront_distribution.staging.domain_name]
+    quantity = 1
+  }
+
+  traffic_config {
+    type = "SingleWeight"
+    single_weight_config {
+      weight = %[2]q
+      session_stickiness_config {
+        idle_ttl    = %[3]d
+        maximum_ttl = %[4]d
+      }
+    }
+  }
+}
+`, enabled, weight, idleTTL, maxTTL))
+}
+
+func testAccContinuousDeploymentPolicyConfig_TrafficConfig_singleHeader(enabled bool, header, value string) string {
+	return acctest.ConfigCompose(
+		testAccContinuousDeploymentPolicyConfigBase_staging(),
+		testAccContinuousDeploymentPolicyConfigBase_production(),
+		fmt.Sprintf(`
+resource "aws_cloudfront_continuous_deployment_policy" "test" {
+  enabled = %[1]t
+
+  staging_distribution_dns_names {
+    items    = [aws_cloudfront_distribution.staging.domain_name]
+    quantity = 1
+  }
+
+  traffic_config {
+    type = "SingleHeader"
+    single_header_config {
+      header = %[2]q
+      value  = %[3]q
+    }
+  }
+}
+`, enabled, header, value))
+}

--- a/internal/service/cloudfront/distribution.go
+++ b/internal/service/cloudfront/distribution.go
@@ -229,6 +229,10 @@ func ResourceDistribution() *schema.Resource {
 					},
 				},
 			},
+			"continuous_deployment_policy_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"comment": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -821,6 +825,12 @@ func ResourceDistribution() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
+			},
+			"staging": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				ForceNew: true,
 			},
 
 			names.AttrTags:    tftags.TagsSchema(),

--- a/internal/service/cloudfront/distribution_configuration_structure.go
+++ b/internal/service/cloudfront/distribution_configuration_structure.go
@@ -31,18 +31,20 @@ import (
 // Used by the aws_cloudfront_distribution Create and Update functions.
 func expandDistributionConfig(d *schema.ResourceData) *cloudfront.DistributionConfig {
 	distributionConfig := &cloudfront.DistributionConfig{
-		CacheBehaviors:       expandCacheBehaviors(d.Get("ordered_cache_behavior").([]interface{})),
-		CallerReference:      aws.String(id.UniqueId()),
-		Comment:              aws.String(d.Get("comment").(string)),
-		CustomErrorResponses: ExpandCustomErrorResponses(d.Get("custom_error_response").(*schema.Set)),
-		DefaultCacheBehavior: ExpandDefaultCacheBehavior(d.Get("default_cache_behavior").([]interface{})[0].(map[string]interface{})),
-		DefaultRootObject:    aws.String(d.Get("default_root_object").(string)),
-		Enabled:              aws.Bool(d.Get("enabled").(bool)),
-		IsIPV6Enabled:        aws.Bool(d.Get("is_ipv6_enabled").(bool)),
-		HttpVersion:          aws.String(d.Get("http_version").(string)),
-		Origins:              ExpandOrigins(d.Get("origin").(*schema.Set)),
-		PriceClass:           aws.String(d.Get("price_class").(string)),
-		WebACLId:             aws.String(d.Get("web_acl_id").(string)),
+		CacheBehaviors:               expandCacheBehaviors(d.Get("ordered_cache_behavior").([]interface{})),
+		CallerReference:              aws.String(id.UniqueId()),
+		Comment:                      aws.String(d.Get("comment").(string)),
+		ContinuousDeploymentPolicyId: aws.String(d.Get("continuous_deployment_policy_id").(string)),
+		CustomErrorResponses:         ExpandCustomErrorResponses(d.Get("custom_error_response").(*schema.Set)),
+		DefaultCacheBehavior:         ExpandDefaultCacheBehavior(d.Get("default_cache_behavior").([]interface{})[0].(map[string]interface{})),
+		DefaultRootObject:            aws.String(d.Get("default_root_object").(string)),
+		Enabled:                      aws.Bool(d.Get("enabled").(bool)),
+		IsIPV6Enabled:                aws.Bool(d.Get("is_ipv6_enabled").(bool)),
+		HttpVersion:                  aws.String(d.Get("http_version").(string)),
+		Origins:                      ExpandOrigins(d.Get("origin").(*schema.Set)),
+		PriceClass:                   aws.String(d.Get("price_class").(string)),
+		Staging:                      aws.Bool(d.Get("staging").(bool)),
+		WebACLId:                     aws.String(d.Get("web_acl_id").(string)),
 	}
 
 	// This sets CallerReference if it's still pending computation (ie: new resource)
@@ -102,7 +104,16 @@ func flattenDistributionConfig(d *schema.ResourceData, distributionConfig *cloud
 	}
 	d.Set("default_root_object", distributionConfig.DefaultRootObject)
 	d.Set("http_version", distributionConfig.HttpVersion)
+	d.Set("staging", distributionConfig.Staging)
 	d.Set("web_acl_id", distributionConfig.WebACLId)
+
+	if !aws.BoolValue(distributionConfig.Staging) {
+		// Only set this for production distributions. While staging distributions do
+		// return a value when their domain name is referenced in a continuous deployment
+		// policy, this attribute is optional (not optional/computed) to correctly
+		// trigger changes when a policy is removed from a production distribution.
+		d.Set("continuous_deployment_policy_id", distributionConfig.ContinuousDeploymentPolicyId)
+	}
 
 	if distributionConfig.CustomErrorResponses != nil {
 		err = d.Set("custom_error_response", FlattenCustomErrorResponses(distributionConfig.CustomErrorResponses))

--- a/internal/service/cloudfront/exports_test.go
+++ b/internal/service/cloudfront/exports_test.go
@@ -1,0 +1,9 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cloudfront
+
+// Exports for use in tests only.
+var (
+	ResourceContinuousDeploymentPolicy = newResourceContinuousDeploymentPolicy
+)

--- a/internal/service/cloudfront/service_package_gen.go
+++ b/internal/service/cloudfront/service_package_gen.go
@@ -20,7 +20,12 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.Serv
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.ServicePackageFrameworkResource {
-	return []*types.ServicePackageFrameworkResource{}
+	return []*types.ServicePackageFrameworkResource{
+		{
+			Factory: newResourceContinuousDeploymentPolicy,
+			Name:    "Continuous Deployment Policy",
+		},
+	}
 }
 
 func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePackageSDKDataSource {

--- a/website/docs/r/cloudfront_continuous_deployment_policy.html.markdown
+++ b/website/docs/r/cloudfront_continuous_deployment_policy.html.markdown
@@ -1,0 +1,153 @@
+---
+subcategory: "CloudFront"
+layout: "aws"
+page_title: "AWS: aws_cloudfront_continuous_deployment_policy"
+description: |-
+  Terraform resource for managing an AWS CloudFront Continuous Deployment Policy.
+---
+# Resource: aws_cloudfront_continuous_deployment_policy
+
+Terraform resource for managing an AWS CloudFront Continuous Deployment Policy.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_cloudfront_distribution" "staging" {
+  enabled = true
+  staging = true
+
+  # ... other configuration ...
+}
+
+resource "aws_cloudfront_continuous_deployment_policy" "example" {
+  enabled = true
+
+  staging_distribution_dns_names {
+    items    = [aws_cloudfront_distribution.staging.domain_name]
+    quantity = 1
+  }
+
+  traffic_config {
+    type = "SingleWeight"
+    single_weight_config {
+      weight = "0.01"
+    }
+  }
+}
+
+resource "aws_cloudfront_distribution" "production" {
+  enabled = true
+
+  # NOTE: A continuous deployment policy cannot be associated to distribution
+  # on creation. Set this argument once the resource exists.
+  continuous_deployment_policy_id = aws_cloudfront_continuous_deployment_policy.example.id
+
+  # ... other configuration ...
+}
+```
+
+### Single Weight Config with Session Stickiness
+
+```terraform
+resource "aws_cloudfront_continuous_deployment_policy" "example" {
+  enabled = true
+
+  staging_distribution_dns_names {
+    items    = [aws_cloudfront_distribution.staging.domain_name]
+    quantity = 1
+  }
+
+  traffic_config {
+    type = "SingleWeight"
+    single_weight_config {
+      weight = "0.01"
+      session_stickiness_config {
+        idle_ttl    = 300
+        maximum_ttl = 600
+      }
+    }
+  }
+}
+```
+
+### Single Header Config
+
+```terraform
+resource "aws_cloudfront_continuous_deployment_policy" "example" {
+  enabled = true
+
+  staging_distribution_dns_names {
+    items    = [aws_cloudfront_distribution.staging.domain_name]
+    quantity = 1
+  }
+
+  traffic_config {
+    type = "SingleHeader"
+    single_header_config {
+      header = "aws-cf-cd-example"
+      value  = "example"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `enabled` - (Required) Whether this continuous deployment policy is enabled.
+* `staging_distribution_dns_names` - (Required) CloudFront domain name of the staging distribution. See [`staging_distribution_dns_names`](#staging_distribution_dns_names).
+* `traffic_config` - (Required) Parameters for routing production traffic from primary to staging distributions. See [`traffic_config`](#traffic_config).
+
+### `staging_distribution_dns_names`
+
+* `items` - (Required) A list of CloudFront domain names for the staging distribution.
+* `quantity` - (Required) Number of CloudFront domain names in the staging distribution.
+
+### `traffic_config`
+
+* `type` - (Required) Type of traffic configuration. Valid values are `SingleWeight` and `SingleHeader`.
+* `single_header_config` - (Optional) Determines which HTTP requests are sent to the staging distribution. See [`single_header_config`](#single_header_config).
+* `single_weight_config` - (Optional) Contains the percentage of traffic to send to the staging distribution. See [`single_weight_config`](#single_weight_config).
+
+### `single_header_config`
+
+* `header` - (Required) Request header name to send to the staging distribution. The header must contain the prefix `aws-cf-cd-`.
+* `value` - (Required) Request header value.
+
+### `single_weight_config`
+
+* `weight` - (Required) The percentage of traffic to send to a staging distribution, expressed as a decimal number between `0` and `.15`.
+* `session_stickiness_config` - (Optional) Session stickiness provides the ability to define multiple requests from a single viewer as a single session. This prevents the potentially inconsistent experience of sending some of a given user's requests to the staging distribution, while others are sent to the primary distribution. Define the session duration using TTL values. See [`session_stickiness_config`](#session_stickiness_config).
+
+### `session_stickiness_config`
+
+* `idle_ttl` - (Required) The amount of time in seconds after which sessions will cease if no requests are received. Valid values are `300` – `3600` (5–60 minutes). The value must be less than or equal to `maximum_ttl`.
+* `maximum_ttl` - (Required) The maximum amount of time in seconds to consider requests from the viewer as being part of the same session. Valid values are `300` – `3600` (5–60 minutes). The value must be greater than or equal to `idle_ttl`.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `etag` - Current version of the continuous distribution policy.
+* `id` - Identifier of the continuous deployment policy.
+* `last_modified_time` - Date and time the continuous deployment policy was last modified.
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import CloudFront Continuous Deployment Policy using the `id`. For example:
+
+```terraform
+import {
+  to = aws_cloudfront_continuous_deployment_policy.example
+  id = "abcd-1234"
+}
+```
+
+Using `terraform import`, import CloudFront Continuous Deployment Policy using the `id`. For example:
+
+```console
+% terraform import aws_cloudfront_continuous_deployment_policy.example abcd-1234 
+```

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -244,6 +244,7 @@ The CloudFront distribution argument layout is a complex structure composed of s
 
 * `aliases` (Optional) - Extra CNAMEs (alternate domain names), if any, for this distribution.
 * `comment` (Optional) - Any comments you want to include about the distribution.
+* `continuous_deployment_policy_id` (Optional) - Identifier of a continuous deployment policy. This argument should only be set on a production distribution. See the [`aws_cloudfront_continuous_deployment_policy` resource](./cloudfront_continuous_deployment_policy.html.markdown) for additional details.
 * `custom_error_response` (Optional) - One or more [custom error response](#custom-error-response-arguments) elements (multiples allowed).
 * `default_cache_behavior` (Required) - [Default cache behavior](#default-cache-behavior-arguments) for this distribution (maximum one). Requires either `cache_policy_id` (preferred) or `forwarded_values` (deprecated) be set.
 * `default_root_object` (Optional) - Object that you want CloudFront to return (for example, index.html) when an end user requests the root URL.
@@ -256,6 +257,7 @@ The CloudFront distribution argument layout is a complex structure composed of s
 * `origin_group` (Optional) - One or more [origin_group](#origin-group-arguments) for this distribution (multiples allowed).
 * `price_class` (Optional) - Price class for this distribution. One of `PriceClass_All`, `PriceClass_200`, `PriceClass_100`.
 * `restrictions` (Required) - The [restriction configuration](#restrictions-arguments) for this distribution (maximum one).
+* `staging` (Optional) - A Boolean that indicates whether this is a staging distribution. Defaults to `false`.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `viewer_certificate` (Required) - The [SSL configuration](#viewer-certificate-arguments) for this distribution (maximum one).
 * `web_acl_id` (Optional) - Unique identifier that specifies the AWS WAF web ACL, if any, to associate with this distribution. To specify a web ACL created using the latest version of AWS WAF (WAFv2), use the ACL ARN, for example `aws_wafv2_web_acl.example.arn`. To specify a web ACL created using AWS WAF Classic, use the ACL ID, for example `aws_waf_web_acl.example.id`. The WAF Web ACL must exist in the WAF Global (CloudFront) region and the credentials configuring this argument must have `waf:GetWebACL` permissions assigned.


### PR DESCRIPTION
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds continuous deployment support for CloudFront distributions.

- Adds a new `aws_cloudfront_continuous_deployment_policy` resource
- Adds `staging` and `continuous_deployment_policy_id` arguments to the `aws_cloudfront_distribution` resource

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #28920

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://aws.amazon.com/about-aws/whats-new/2022/11/amazon-cloudfront-continuous-deployment-support/
- https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CreateContinuousDeploymentPolicy.html
- https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_GetContinuousDeploymentPolicy.html
- https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_UpdateContinuousDeploymentPolicy.html
- https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_DeleteContinuousDeploymentPolicy.html



### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=cloudfront TESTS=TestAccCloudFrontContinuousDeploymentPolicy_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudfront/... -v -count 1 -parallel 20 -run='TestAccCloudFrontContinuousDeploymentPolicy_'  -timeout 180m

--- PASS: TestAccCloudFrontContinuousDeploymentPolicy_disappears (440.58s)
--- PASS: TestAccCloudFrontContinuousDeploymentPolicy_basic (1029.81s)
--- PASS: TestAccCloudFrontContinuousDeploymentPolicy_trafficConfig (1186.88s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront 1189.948s
```

```console
% make testacc PKG=cloudfront TESTS=TestAccCloudFrontDistribution_ ACCTEST_PARALLELISM=10
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudfront/... -v -count 1 -parallel 10 -run='TestAccCloudFrontDistribution_'  -timeout 180m

--- PASS: TestAccCloudFrontDistribution_ViewerCertificateACMCertificateARN_conflictsWithCloudFrontDefaultCertificate (220.63s)
=== CONT  TestAccCloudFrontDistribution_orderedCacheBehavior
--- PASS: TestAccCloudFrontDistribution_basic (224.47s)
=== CONT  TestAccCloudFrontDistribution_multiOrigin
--- PASS: TestAccCloudFrontDistribution_orderedCacheBehaviorCachePolicy (440.62s)
=== CONT  TestAccCloudFrontDistribution_originPolicyOrdered
--- PASS: TestAccCloudFrontDistribution_http11 (445.44s)
=== CONT  TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValues_headers
--- PASS: TestAccCloudFrontDistribution_orderedCacheBehaviorResponseHeadersPolicy (446.96s)
=== CONT  TestAccCloudFrontDistribution_ViewerCertificate_acmCertificateARN
--- PASS: TestAccCloudFrontDistribution_originGroups (478.98s)
=== CONT  TestAccCloudFrontDistribution_s3Origin
--- PASS: TestAccCloudFrontDistribution_originPolicyDefault (481.05s)
=== CONT  TestAccCloudFrontDistribution_customOrigin
--- PASS: TestAccCloudFrontDistribution_waitForDeployment (518.14s)
=== CONT  TestAccCloudFrontDistribution_tags
--- PASS: TestAccCloudFrontDistribution_preconditionFailed (928.87s)
=== CONT  TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedKeyGroups
--- PASS: TestAccCloudFrontDistribution_orderedCacheBehavior (710.37s)
=== CONT  TestAccCloudFrontDistribution_OrderedCacheBehavior_realtimeLogARN
--- PASS: TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValues_headers (488.61s)
=== CONT  TestAccCloudFrontDistribution_DefaultCacheBehavior_realtimeLogARN
--- PASS: TestAccCloudFrontDistribution_multiOrigin (713.65s)
=== CONT  TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedSigners
--- PASS: TestAccCloudFrontDistribution_enabled (939.58s)
=== CONT  TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValuesCookies_whitelistedNames
--- PASS: TestAccCloudFrontDistribution_ViewerCertificate_acmCertificateARN (504.89s)
=== CONT  TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValuesCookies_whitelistedNames
--- PASS: TestAccCloudFrontDistribution_tags (462.20s)
=== CONT  TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValues_headers
--- PASS: TestAccCloudFrontDistribution_customOrigin (691.53s)
=== CONT  TestAccCloudFrontDistribution_retainOnDelete
--- PASS: TestAccCloudFrontDistribution_originPolicyOrdered (732.42s)
=== CONT  TestAccCloudFrontDistribution_disappears
--- PASS: TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValuesCookies_whitelistedNames (222.39s)
=== CONT  TestAccCloudFrontDistribution_noCustomErrorResponse
--- PASS: TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedKeyGroups (246.46s)
=== CONT  TestAccCloudFrontDistribution_isIPV6Enabled
--- PASS: TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedSigners (237.48s)
=== CONT  TestAccCloudFrontDistribution_Origin_connectionTimeout
--- PASS: TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValuesCookies_whitelistedNames (236.54s)
=== CONT  TestAccCloudFrontDistribution_noOptionalItems
--- PASS: TestAccCloudFrontDistribution_s3Origin (701.72s)
=== CONT  TestAccCloudFrontDistribution_Origin_originAccessControl
--- PASS: TestAccCloudFrontDistribution_OrderedCacheBehavior_realtimeLogARN (255.31s)
=== CONT  TestAccCloudFrontDistribution_Origin_originShield
--- PASS: TestAccCloudFrontDistribution_DefaultCacheBehavior_realtimeLogARN (254.10s)
=== CONT  TestAccCloudFrontDistribution_Origin_emptyOriginID
--- PASS: TestAccCloudFrontDistribution_Origin_emptyOriginID (1.13s)
=== CONT  TestAccCloudFrontDistribution_Origin_connectionAttempts
--- PASS: TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValues_headers (239.65s)
=== CONT  TestAccCloudFrontDistribution_Origin_emptyDomainName
--- PASS: TestAccCloudFrontDistribution_Origin_emptyDomainName (1.29s)
=== CONT  TestAccCloudFrontDistribution_forwardedValuesToCachePolicy
--- PASS: TestAccCloudFrontDistribution_disappears (212.79s)
--- PASS: TestAccCloudFrontDistribution_retainOnDelete (399.85s)
--- PASS: TestAccCloudFrontDistribution_isIPV6Enabled (427.02s)
--- PASS: TestAccCloudFrontDistribution_noOptionalItems (431.18s)
--- PASS: TestAccCloudFrontDistribution_noCustomErrorResponse (435.40s)
--- PASS: TestAccCloudFrontDistribution_Origin_originShield (457.91s)
--- PASS: TestAccCloudFrontDistribution_Origin_connectionTimeout (469.16s)
--- PASS: TestAccCloudFrontDistribution_Origin_connectionAttempts (498.04s)
--- PASS: TestAccCloudFrontDistribution_forwardedValuesToCachePolicy (703.78s)
--- PASS: TestAccCloudFrontDistribution_Origin_originAccessControl (749.62s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront 1933.918s
```