### PR TITLE
fix: Skip listing tags on `aws_vpclattice_service_network` data source when shared via RAM

### DIFF
--- a/.changelog/32939.txt
+++ b/.changelog/32939.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-data/aws_vpclattice_service_network: Avoid listing tags when service network has been shared via AWS Resource Access Manager (RAM)
+data-source/aws_vpclattice_service_network: Avoid listing tags when service network has been shared via AWS Resource Access Manager (RAM)
 ```

--- a/.changelog/32939.txt
+++ b/.changelog/32939.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data/aws_vpclattice_service_network: Avoid listing tags when service network has been shared via AWS Resource Access Manager (RAM)
+```

--- a/.changelog/32939.txt
+++ b/.changelog/32939.txt
@@ -1,3 +1,7 @@
 ```release-note:bug
-data-source/aws_vpclattice_service_network: Avoid listing tags when service network has been shared via AWS Resource Access Manager (RAM)
+data-source/aws_vpclattice_service_network: Avoid listing tags when the service network has been shared to the current account via AWS Resource Access Manager (RAM)
+```
+
+```release-note:bug
+data-source/aws_vpclattice_service: Avoid listing tags when the service has been shared to the current account via AWS Resource Access Manager (RAM)
 ```

--- a/internal/service/vpclattice/service_data_source.go
+++ b/internal/service/vpclattice/service_data_source.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice/types"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -18,6 +19,7 @@ import (
 )
 
 // @SDKDataSource("aws_vpclattice_service")
+// @Tags
 func dataSourceService() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceServiceRead,
@@ -76,15 +78,11 @@ func dataSourceService() *schema.Resource {
 	}
 }
 
-const (
-	DSNameService = "Service Data Source"
-)
-
 func dataSourceServiceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	var out *vpclattice.GetServiceOutput
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
+	var out *vpclattice.GetServiceOutput
 	if v, ok := d.GetOk("service_identifier"); ok {
 		serviceID := v.(string)
 		service, err := findServiceByID(ctx, conn, serviceID)
@@ -113,16 +111,9 @@ func dataSourceServiceRead(ctx context.Context, d *schema.ResourceData, meta int
 		out = service
 	}
 
-	//
-	// If you don't set the ID, the data source will not be stored in state. In
-	// fact, that's how a resource can be removed from state - clearing its ID.
-	//
-	// If this data source is a companion to a resource, often both will use the
-	// same ID. Otherwise, the ID will be a unique identifier such as an AWS
-	// identifier, ARN, or name.
 	d.SetId(aws.ToString(out.Id))
-
-	d.Set("arn", out.Arn)
+	serviceARN := aws.ToString(out.Arn)
+	d.Set("arn", serviceARN)
 	d.Set("auth_type", out.AuthType)
 	d.Set("certificate_arn", out.CertificateArn)
 	d.Set("custom_domain_name", out.CustomDomainName)
@@ -136,6 +127,24 @@ func dataSourceServiceRead(ctx context.Context, d *schema.ResourceData, meta int
 	d.Set("name", out.Name)
 	d.Set("service_identifier", out.Id)
 	d.Set("status", out.Status)
+
+	// https://docs.aws.amazon.com/vpc-lattice/latest/ug/sharing.html#sharing-perms
+	// Owners and consumers can list tags and can tag/untag resources in a service network that the account created.
+	// They can't list tags and tag/untag resources in a service network that aren't created by the account.
+	parsedARN, err := arn.Parse(serviceARN)
+	if err != nil {
+		return sdkdiag.AppendFromErr(diags, err)
+	}
+
+	if parsedARN.AccountID == meta.(*conns.AWSClient).AccountID {
+		tags, err := listTags(ctx, conn, serviceARN)
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "listing tags for VPC Lattice Service (%s): %s", serviceARN, err)
+		}
+
+		setTagsOut(ctx, Tags(tags))
+	}
 
 	return nil
 }

--- a/internal/service/vpclattice/service_data_source.go
+++ b/internal/service/vpclattice/service_data_source.go
@@ -134,6 +134,7 @@ func dataSourceServiceRead(ctx context.Context, d *schema.ResourceData, meta int
 		d.Set("dns_entry", nil)
 	}
 	d.Set("name", out.Name)
+	d.Set("service_identifier", out.Id)
 	d.Set("status", out.Status)
 
 	return nil

--- a/internal/service/vpclattice/service_data_source_test.go
+++ b/internal/service/vpclattice/service_data_source_test.go
@@ -5,10 +5,8 @@ package vpclattice_test
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
-	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
@@ -17,8 +15,8 @@ import (
 
 func TestAccVPCLatticeServiceDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	var service vpclattice.GetServiceOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_vpclattice_service.test"
 	dataSourceName := "data.aws_vpclattice_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -29,15 +27,18 @@ func TestAccVPCLatticeServiceDataSource_basic(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckServiceDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServiceDataSourceConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceExists(ctx, dataSourceName, &service),
-					resource.TestCheckResourceAttr(dataSourceName, "name", rName),
-					resource.TestCheckResourceAttr(dataSourceName, "auth_type", "NONE"),
-					acctest.MatchResourceAttrRegionalARN(dataSourceName, "arn", "vpc-lattice", regexp.MustCompile(`service/.+$`)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "auth_type", dataSourceName, "auth_type"),
+					resource.TestCheckResourceAttrPair(resourceName, "certificate_arn", dataSourceName, "certificate_arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "custom_domain_name", dataSourceName, "custom_domain_name"),
+					resource.TestCheckResourceAttrPair(resourceName, "dns_entry.#", dataSourceName, "dns_entry.#"),
+					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "status", dataSourceName, "status"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.%", dataSourceName, "tags.%"),
 				),
 			},
 		},
@@ -46,8 +47,8 @@ func TestAccVPCLatticeServiceDataSource_basic(t *testing.T) {
 
 func TestAccVPCLatticeServiceDataSource_byName(t *testing.T) {
 	ctx := acctest.Context(t)
-	var service vpclattice.GetServiceOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_vpclattice_service.test"
 	dataSourceName := "data.aws_vpclattice_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -58,15 +59,19 @@ func TestAccVPCLatticeServiceDataSource_byName(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckServiceDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServiceDataSourceConfig_byName(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceExists(ctx, dataSourceName, &service),
-					resource.TestCheckResourceAttr(dataSourceName, "name", rName),
-					resource.TestCheckResourceAttr(dataSourceName, "auth_type", "NONE"),
-					acctest.MatchResourceAttrRegionalARN(dataSourceName, "arn", "vpc-lattice", regexp.MustCompile(`service/.+$`)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "auth_type", dataSourceName, "auth_type"),
+					resource.TestCheckResourceAttrPair(resourceName, "certificate_arn", dataSourceName, "certificate_arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "custom_domain_name", dataSourceName, "custom_domain_name"),
+					resource.TestCheckResourceAttrPair(resourceName, "dns_entry.#", dataSourceName, "dns_entry.#"),
+					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "service_identifier"),
+					resource.TestCheckResourceAttrPair(resourceName, "status", dataSourceName, "status"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.%", dataSourceName, "tags.%"),
 				),
 			},
 		},

--- a/internal/service/vpclattice/service_data_source_test.go
+++ b/internal/service/vpclattice/service_data_source_test.go
@@ -78,10 +78,47 @@ func TestAccVPCLatticeServiceDataSource_byName(t *testing.T) {
 	})
 }
 
+func TestAccVPCLatticeServiceDataSource_shared(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_vpclattice_service.test"
+	dataSourceName := "data.aws_vpclattice_service.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckAlternateAccount(t)
+			acctest.PreCheckPartitionHasService(t, names.VPCLatticeEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesAlternate(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceDataSourceConfig_shared(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "auth_type", dataSourceName, "auth_type"),
+					resource.TestCheckResourceAttrPair(resourceName, "certificate_arn", dataSourceName, "certificate_arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "custom_domain_name", dataSourceName, "custom_domain_name"),
+					resource.TestCheckResourceAttrPair(resourceName, "dns_entry.#", dataSourceName, "dns_entry.#"),
+					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "status", dataSourceName, "status"),
+					resource.TestCheckNoResourceAttr(dataSourceName, "tags.%"),
+				),
+			},
+		},
+	})
+}
+
 func testAccServiceDataSourceConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpclattice_service" "test" {
   name = %[1]q
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 data "aws_vpclattice_service" "test" {
@@ -94,10 +131,55 @@ func testAccServiceDataSourceConfig_byName(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpclattice_service" "test" {
   name = %[1]q
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 data "aws_vpclattice_service" "test" {
   name = aws_vpclattice_service.test.name
 }
 `, rName)
+}
+
+func testAccServiceDataSourceConfig_shared(rName string) string {
+	return acctest.ConfigCompose(acctest.ConfigAlternateAccountProvider(), fmt.Sprintf(`
+data "aws_caller_identity" "source" {}
+
+data "aws_caller_identity" "target" {
+  provider = "awsalternate"
+}
+
+resource "aws_vpclattice_service" "test" {
+  name = %[1]q
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_ram_resource_share" "test" {
+  name                      = %[1]q
+  allow_external_principals = false
+}
+
+resource "aws_ram_resource_association" "test" {
+  resource_arn       = aws_vpclattice_service.test.arn
+  resource_share_arn = aws_ram_resource_share.test.arn
+}
+
+resource "aws_ram_principal_association" "test" {
+  principal          = data.aws_caller_identity.target.arn
+  resource_share_arn = aws_ram_resource_share.test.arn
+}
+
+data "aws_vpclattice_service" "test" {
+  provider = "awsalternate"
+
+  service_identifier = aws_vpclattice_service.test.id
+
+  depends_on = [aws_ram_resource_association.test, aws_ram_principal_association.test]
+}
+`, rName))
 }

--- a/internal/service/vpclattice/service_network_data_source.go
+++ b/internal/service/vpclattice/service_network_data_source.go
@@ -77,8 +77,8 @@ func dataSourceServiceNetworkRead(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	d.SetId(aws.ToString(out.Id))
-	outArn := aws.ToString(out.Arn)
-	d.Set("arn", outArn)
+	serviceNetworkARN := aws.ToString(out.Arn)
+	d.Set("arn", serviceNetworkARN)
 	d.Set("auth_type", out.AuthType)
 	d.Set("created_at", aws.ToTime(out.CreatedAt).String())
 	d.Set("last_updated_at", aws.ToTime(out.LastUpdatedAt).String())
@@ -92,16 +92,16 @@ func dataSourceServiceNetworkRead(ctx context.Context, d *schema.ResourceData, m
 	// They can't list tags and tag/untag resources in a service network that aren't created by the account.
 	var tags tftags.KeyValueTags
 
-	parsedArn, err := arn.Parse(outArn)
+	parsedARN, err := arn.Parse(serviceNetworkARN)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "parsing ARN: %s", err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	if parsedArn.AccountID == meta.(*conns.AWSClient).AccountID {
-		tags, err = listTags(ctx, conn, outArn)
+	if parsedARN.AccountID == meta.(*conns.AWSClient).AccountID {
+		tags, err = listTags(ctx, conn, serviceNetworkARN)
 
 		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "listing tags for VPC Lattice Service Network (%s): %s", outArn, err)
+			return sdkdiag.AppendErrorf(diags, "listing tags for VPC Lattice Service Network (%s): %s", serviceNetworkARN, err)
 		}
 	}
 

--- a/internal/service/vpclattice/service_network_data_source.go
+++ b/internal/service/vpclattice/service_network_data_source.go
@@ -7,10 +7,12 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -53,7 +55,7 @@ func DataSourceServiceNetwork() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"tags": tftags.TagsSchemaComputed(),
+			names.AttrTags: tftags.TagsSchemaComputed(),
 		},
 	}
 }
@@ -63,7 +65,9 @@ const (
 )
 
 func dataSourceServiceNetworkRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	serviceNetworkID := d.Get("service_network_identifier").(string)
 	out, err := findServiceNetworkByID(ctx, conn, serviceNetworkID)
@@ -73,7 +77,8 @@ func dataSourceServiceNetworkRead(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	d.SetId(aws.ToString(out.Id))
-	d.Set("arn", out.Arn)
+	outArn := aws.ToString(out.Arn)
+	d.Set("arn", outArn)
 	d.Set("auth_type", out.AuthType)
 	d.Set("created_at", aws.ToTime(out.CreatedAt).String())
 	d.Set("last_updated_at", aws.ToTime(out.LastUpdatedAt).String())
@@ -82,17 +87,27 @@ func dataSourceServiceNetworkRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set("number_of_associated_vpcs", out.NumberOfAssociatedVPCs)
 	d.Set("service_network_identifier", out.Id)
 
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
-	tags, err := listTags(ctx, conn, aws.ToString(out.Arn))
+	// https://docs.aws.amazon.com/vpc-lattice/latest/ug/sharing.html#sharing-perms
+	// Owners and consumers can list tags and can tag/untag resources in a service network that the account created.
+	// They can't list tags and tag/untag resources in a service network that aren't created by the account.
+	var tags tftags.KeyValueTags
 
+	parsedArn, err := arn.Parse(outArn)
 	if err != nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionReading, DSNameServiceNetwork, serviceNetworkID, err)
+		return sdkdiag.AppendErrorf(diags, "parsing ARN: %s", err)
 	}
 
-	//lintignore:AWSR002
+	if parsedArn.AccountID == meta.(*conns.AWSClient).AccountID {
+		tags, err = listTags(ctx, conn, outArn)
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "listing tags for VPC Lattice Service Network (%s): %s", outArn, err)
+		}
+	}
+
 	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionSetting, DSNameServiceNetwork, d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/vpclattice/service_network_data_source_test.go
+++ b/internal/service/vpclattice/service_network_data_source_test.go
@@ -27,7 +27,6 @@ func TestAccVPCLatticeServiceNetworkDataSource_basic(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckServiceNetworkDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServiceNetworkDataSourceConfig_basic(rName),
@@ -61,7 +60,6 @@ func TestAccVPCLatticeServiceNetworkDataSource_shared(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesAlternate(ctx, t),
-		CheckDestroy:             testAccCheckServiceNetworkDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServiceNetworkDataSourceConfig_shared(rName),

--- a/internal/service/vpclattice/service_package_gen.go
+++ b/internal/service/vpclattice/service_package_gen.go
@@ -42,10 +42,12 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  dataSourceService,
 			TypeName: "aws_vpclattice_service",
+			Tags:     &types.ServicePackageResourceTags{},
 		},
 		{
-			Factory:  DataSourceServiceNetwork,
+			Factory:  dataSourceServiceNetwork,
 			TypeName: "aws_vpclattice_service_network",
+			Tags:     &types.ServicePackageResourceTags{},
 		},
 	}
 }


### PR DESCRIPTION
### Relations

Closes #32938.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/26695.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
make testacc TESTARGS='-run=TestAccVPCLatticeServiceNetwork' PKG=vpclattice ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/vpclattice/... -v -count 1 -parallel 2  -run=TestAccVPCLatticeServiceNetwork -timeout 180m
=== RUN   TestAccVPCLatticeServiceNetworkDataSource_basic
=== PAUSE TestAccVPCLatticeServiceNetworkDataSource_basic
=== RUN   TestAccVPCLatticeServiceNetworkServiceAssociation_basic
=== PAUSE TestAccVPCLatticeServiceNetworkServiceAssociation_basic
=== RUN   TestAccVPCLatticeServiceNetworkServiceAssociation_arn
=== PAUSE TestAccVPCLatticeServiceNetworkServiceAssociation_arn
=== RUN   TestAccVPCLatticeServiceNetworkServiceAssociation_disappears
=== PAUSE TestAccVPCLatticeServiceNetworkServiceAssociation_disappears
=== RUN   TestAccVPCLatticeServiceNetworkServiceAssociation_tags
=== PAUSE TestAccVPCLatticeServiceNetworkServiceAssociation_tags
=== RUN   TestAccVPCLatticeServiceNetwork_basic
=== PAUSE TestAccVPCLatticeServiceNetwork_basic
=== RUN   TestAccVPCLatticeServiceNetwork_disappears
=== PAUSE TestAccVPCLatticeServiceNetwork_disappears
=== RUN   TestAccVPCLatticeServiceNetwork_full
=== PAUSE TestAccVPCLatticeServiceNetwork_full
=== RUN   TestAccVPCLatticeServiceNetwork_tags
=== PAUSE TestAccVPCLatticeServiceNetwork_tags
=== RUN   TestAccVPCLatticeServiceNetworkVPCAssociation_basic
=== PAUSE TestAccVPCLatticeServiceNetworkVPCAssociation_basic
=== RUN   TestAccVPCLatticeServiceNetworkVPCAssociation_arn
=== PAUSE TestAccVPCLatticeServiceNetworkVPCAssociation_arn
=== RUN   TestAccVPCLatticeServiceNetworkVPCAssociation_disappears
=== PAUSE TestAccVPCLatticeServiceNetworkVPCAssociation_disappears
=== RUN   TestAccVPCLatticeServiceNetworkVPCAssociation_full
=== PAUSE TestAccVPCLatticeServiceNetworkVPCAssociation_full
=== RUN   TestAccVPCLatticeServiceNetworkVPCAssociation_tags
=== PAUSE TestAccVPCLatticeServiceNetworkVPCAssociation_tags
=== CONT  TestAccVPCLatticeServiceNetworkDataSource_basic
=== CONT  TestAccVPCLatticeServiceNetworkVPCAssociation_full
--- PASS: TestAccVPCLatticeServiceNetworkDataSource_basic (39.14s)
=== CONT  TestAccVPCLatticeServiceNetworkVPCAssociation_tags
--- PASS: TestAccVPCLatticeServiceNetworkVPCAssociation_tags (149.51s)
=== CONT  TestAccVPCLatticeServiceNetwork_disappears
--- PASS: TestAccVPCLatticeServiceNetworkVPCAssociation_full (218.81s)
=== CONT  TestAccVPCLatticeServiceNetworkVPCAssociation_disappears
--- PASS: TestAccVPCLatticeServiceNetwork_disappears (32.55s)
=== CONT  TestAccVPCLatticeServiceNetworkVPCAssociation_arn
--- PASS: TestAccVPCLatticeServiceNetworkVPCAssociation_disappears (110.73s)
=== CONT  TestAccVPCLatticeServiceNetworkVPCAssociation_basic
--- PASS: TestAccVPCLatticeServiceNetworkVPCAssociation_arn (186.19s)
=== CONT  TestAccVPCLatticeServiceNetwork_full
--- PASS: TestAccVPCLatticeServiceNetworkVPCAssociation_basic (98.01s)
=== CONT  TestAccVPCLatticeServiceNetworkServiceAssociation_disappears
--- PASS: TestAccVPCLatticeServiceNetwork_full (43.06s)
=== CONT  TestAccVPCLatticeServiceNetwork_basic
--- PASS: TestAccVPCLatticeServiceNetworkServiceAssociation_disappears (47.09s)
=== CONT  TestAccVPCLatticeServiceNetworkServiceAssociation_tags
--- PASS: TestAccVPCLatticeServiceNetwork_basic (42.71s)
=== CONT  TestAccVPCLatticeServiceNetworkServiceAssociation_arn
--- PASS: TestAccVPCLatticeServiceNetworkServiceAssociation_arn (53.92s)
=== CONT  TestAccVPCLatticeServiceNetwork_tags
--- PASS: TestAccVPCLatticeServiceNetworkServiceAssociation_tags (111.34s)
=== CONT  TestAccVPCLatticeServiceNetworkServiceAssociation_basic
--- PASS: TestAccVPCLatticeServiceNetworkServiceAssociation_basic (55.63s)
--- PASS: TestAccVPCLatticeServiceNetwork_tags (101.55s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/vpclattice	648.799s
...
```
