### PR TITLE
elbv2/lb: Check for duplicate name

### DIFF
--- a/.changelog/32941.txt
+++ b/.changelog/32941.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lb: Fix to avoid creating a load balancer with same name as an existing load balancer
+```

--- a/internal/service/elbv2/load_balancer.go
+++ b/internal/service/elbv2/load_balancer.go
@@ -316,6 +316,19 @@ func resourceLoadBalancerCreate(ctx context.Context, d *schema.ResourceData, met
 	} else {
 		name = id.PrefixedUniqueId("tf-lb-")
 	}
+
+	exist, err := FindLoadBalancer(ctx, conn, &elbv2.DescribeLoadBalancersInput{
+		Names: aws.StringSlice([]string{name}),
+	})
+
+	if err != nil && !tfresource.NotFound(err) {
+		return sdkdiag.AppendErrorf(diags, "reading ELBv2 Load Balancer (%s): %s", name, err)
+	}
+
+	if exist != nil {
+		return sdkdiag.AppendErrorf(diags, "ELBv2 Target Group (%s) already exists", name)
+	}
+
 	d.Set("name", name)
 
 	lbType := d.Get("load_balancer_type").(string)

--- a/internal/service/elbv2/load_balancer_test.go
+++ b/internal/service/elbv2/load_balancer_test.go
@@ -111,7 +111,7 @@ func TestAccELBV2LoadBalancer_NLB_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf elbv2.LoadBalancer
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_lb.lb_test"
+	resourceName := "aws_lb.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -284,7 +284,7 @@ func TestAccELBV2LoadBalancer_ALB_outpost(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf elbv2.LoadBalancer
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_lb.lb_test"
+	resourceName := "aws_lb.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckOutpostsOutposts(ctx, t) },
@@ -323,7 +323,7 @@ func TestAccELBV2LoadBalancer_ALB_outpost(t *testing.T) {
 func TestAccELBV2LoadBalancer_networkLoadBalancerEIP(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf elbv2.LoadBalancer
-	resourceName := "aws_lb.lb_test"
+	resourceName := "aws_lb.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -385,7 +385,7 @@ func TestAccELBV2LoadBalancer_backwardsCompatibility(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf elbv2.LoadBalancer
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_alb.lb_test"
+	resourceName := "aws_alb.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -421,7 +421,7 @@ func TestAccELBV2LoadBalancer_generatedName(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf elbv2.LoadBalancer
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_lb.lb_test"
+	resourceName := "aws_lb.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -444,7 +444,7 @@ func TestAccELBV2LoadBalancer_generatesNameForZeroValue(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf elbv2.LoadBalancer
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_lb.lb_test"
+	resourceName := "aws_lb.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -467,7 +467,7 @@ func TestAccELBV2LoadBalancer_namePrefix(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf elbv2.LoadBalancer
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_lb.lb_test"
+	resourceName := "aws_lb.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -560,7 +560,7 @@ func TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateCrossZone(t *testing.T) 
 	ctx := acctest.Context(t)
 	var pre, mid, post elbv2.LoadBalancer
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_lb.lb_test"
+	resourceName := "aws_lb.test"
 
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -606,7 +606,7 @@ func TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateHTTP2(t *testing.T) 
 	ctx := acctest.Context(t)
 	var pre, mid, post elbv2.LoadBalancer
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_lb.lb_test"
+	resourceName := "aws_lb.test"
 
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -666,26 +666,26 @@ func TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDropInvalidHeaderFie
 			{
 				Config: testAccLoadBalancerConfig_enableDropInvalidHeaderFields(rName, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckLoadBalancerExists(ctx, "aws_lb.lb_test", &pre),
-					testAccCheckLoadBalancerAttribute(ctx, "aws_lb.lb_test", "routing.http.drop_invalid_header_fields.enabled", "false"),
-					resource.TestCheckResourceAttr("aws_lb.lb_test", "drop_invalid_header_fields", "false"),
+					testAccCheckLoadBalancerExists(ctx, "aws_lb.test", &pre),
+					testAccCheckLoadBalancerAttribute(ctx, "aws_lb.test", "routing.http.drop_invalid_header_fields.enabled", "false"),
+					resource.TestCheckResourceAttr("aws_lb.test", "drop_invalid_header_fields", "false"),
 				),
 			},
 			{
 				Config: testAccLoadBalancerConfig_enableDropInvalidHeaderFields(rName, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckLoadBalancerExists(ctx, "aws_lb.lb_test", &mid),
-					testAccCheckLoadBalancerAttribute(ctx, "aws_lb.lb_test", "routing.http.drop_invalid_header_fields.enabled", "true"),
-					resource.TestCheckResourceAttr("aws_lb.lb_test", "drop_invalid_header_fields", "true"),
+					testAccCheckLoadBalancerExists(ctx, "aws_lb.test", &mid),
+					testAccCheckLoadBalancerAttribute(ctx, "aws_lb.test", "routing.http.drop_invalid_header_fields.enabled", "true"),
+					resource.TestCheckResourceAttr("aws_lb.test", "drop_invalid_header_fields", "true"),
 					testAccChecklbARNs(&pre, &mid),
 				),
 			},
 			{
 				Config: testAccLoadBalancerConfig_enableDropInvalidHeaderFields(rName, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckLoadBalancerExists(ctx, "aws_lb.lb_test", &post),
-					testAccCheckLoadBalancerAttribute(ctx, "aws_lb.lb_test", "routing.http.drop_invalid_header_fields.enabled", "false"),
-					resource.TestCheckResourceAttr("aws_lb.lb_test", "drop_invalid_header_fields", "false"),
+					testAccCheckLoadBalancerExists(ctx, "aws_lb.test", &post),
+					testAccCheckLoadBalancerAttribute(ctx, "aws_lb.test", "routing.http.drop_invalid_header_fields.enabled", "false"),
+					resource.TestCheckResourceAttr("aws_lb.test", "drop_invalid_header_fields", "false"),
 					testAccChecklbARNs(&mid, &post),
 				),
 			},
@@ -711,26 +711,26 @@ func TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatePreserveHostHeader(t
 			{
 				Config: testAccLoadBalancerConfig_enablePreserveHostHeader(rName, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckLoadBalancerExists(ctx, "aws_lb.lb_test", &pre),
-					testAccCheckLoadBalancerAttribute(ctx, "aws_lb.lb_test", "routing.http.preserve_host_header.enabled", "false"),
-					resource.TestCheckResourceAttr("aws_lb.lb_test", "preserve_host_header", "false"),
+					testAccCheckLoadBalancerExists(ctx, "aws_lb.test", &pre),
+					testAccCheckLoadBalancerAttribute(ctx, "aws_lb.test", "routing.http.preserve_host_header.enabled", "false"),
+					resource.TestCheckResourceAttr("aws_lb.test", "preserve_host_header", "false"),
 				),
 			},
 			{
 				Config: testAccLoadBalancerConfig_enablePreserveHostHeader(rName, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckLoadBalancerExists(ctx, "aws_lb.lb_test", &mid),
-					testAccCheckLoadBalancerAttribute(ctx, "aws_lb.lb_test", "routing.http.preserve_host_header.enabled", "true"),
-					resource.TestCheckResourceAttr("aws_lb.lb_test", "preserve_host_header", "true"),
+					testAccCheckLoadBalancerExists(ctx, "aws_lb.test", &mid),
+					testAccCheckLoadBalancerAttribute(ctx, "aws_lb.test", "routing.http.preserve_host_header.enabled", "true"),
+					resource.TestCheckResourceAttr("aws_lb.test", "preserve_host_header", "true"),
 					testAccChecklbARNs(&pre, &mid),
 				),
 			},
 			{
 				Config: testAccLoadBalancerConfig_enablePreserveHostHeader(rName, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckLoadBalancerExists(ctx, "aws_lb.lb_test", &post),
-					testAccCheckLoadBalancerAttribute(ctx, "aws_lb.lb_test", "routing.http.preserve_host_header.enabled", "false"),
-					resource.TestCheckResourceAttr("aws_lb.lb_test", "preserve_host_header", "false"),
+					testAccCheckLoadBalancerExists(ctx, "aws_lb.test", &post),
+					testAccCheckLoadBalancerAttribute(ctx, "aws_lb.test", "routing.http.preserve_host_header.enabled", "false"),
+					resource.TestCheckResourceAttr("aws_lb.test", "preserve_host_header", "false"),
 					testAccChecklbARNs(&mid, &post),
 				),
 			},
@@ -742,7 +742,7 @@ func TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDeletionProtection(t
 	ctx := acctest.Context(t)
 	var pre, mid, post elbv2.LoadBalancer
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_lb.lb_test"
+	resourceName := "aws_lb.test"
 
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -788,7 +788,7 @@ func TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateWAFFailOpen(t *testi
 	ctx := acctest.Context(t)
 	var pre, mid, post elbv2.LoadBalancer
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_lb.lb_test"
+	resourceName := "aws_lb.test"
 
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -841,7 +841,7 @@ func TestAccELBV2LoadBalancer_updatedIPAddressType(t *testing.T) {
 	ctx := acctest.Context(t)
 	var pre, post elbv2.LoadBalancer
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_lb.lb_test"
+	resourceName := "aws_lb.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -1746,10 +1746,10 @@ resource "aws_lb" "test" {
 
 func testAccLoadBalancerConfig_ipAddressTypeUpdated(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
-resource "aws_lb" "lb_test" {
+resource "aws_lb" "test" {
   name            = %[1]q
-  security_groups = [aws_security_group.alb_test.id]
-  subnets         = [aws_subnet.alb_test_1.id, aws_subnet.alb_test_2.id]
+  security_groups = [aws_security_group.test.id]
+  subnets         = [aws_subnet.test_1.id, aws_subnet.test_2.id]
 
   ip_address_type = "dualstack"
 
@@ -1762,7 +1762,7 @@ resource "aws_lb" "lb_test" {
 }
 
 resource "aws_lb_listener" "test" {
-  load_balancer_arn = aws_lb.lb_test.id
+  load_balancer_arn = aws_lb.test.id
   protocol          = "HTTP"
   port              = "80"
 
@@ -1776,7 +1776,7 @@ resource "aws_lb_target_group" "test" {
   name     = %[1]q
   port     = 80
   protocol = "HTTP"
-  vpc_id   = aws_vpc.alb_test.id
+  vpc_id   = aws_vpc.test.id
 
   deregistration_delay = 200
 
@@ -1798,10 +1798,10 @@ resource "aws_lb_target_group" "test" {
 }
 
 resource "aws_egress_only_internet_gateway" "igw" {
-  vpc_id = aws_vpc.alb_test.id
+  vpc_id = aws_vpc.test.id
 }
 
-resource "aws_vpc" "alb_test" {
+resource "aws_vpc" "test" {
   cidr_block                       = "10.0.0.0/16"
   assign_generated_ipv6_cidr_block = true
 
@@ -1811,37 +1811,37 @@ resource "aws_vpc" "alb_test" {
 }
 
 resource "aws_internet_gateway" "foo" {
-  vpc_id = aws_vpc.alb_test.id
+  vpc_id = aws_vpc.test.id
 }
 
-resource "aws_subnet" "alb_test_1" {
-  vpc_id                  = aws_vpc.alb_test.id
+resource "aws_subnet" "test_1" {
+  vpc_id                  = aws_vpc.test.id
   cidr_block              = "10.0.1.0/24"
   map_public_ip_on_launch = true
   availability_zone       = data.aws_availability_zones.available.names[0]
-  ipv6_cidr_block         = cidrsubnet(aws_vpc.alb_test.ipv6_cidr_block, 8, 1)
+  ipv6_cidr_block         = cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 1)
 
   tags = {
     Name = %[1]q
   }
 }
 
-resource "aws_subnet" "alb_test_2" {
-  vpc_id                  = aws_vpc.alb_test.id
+resource "aws_subnet" "test_2" {
+  vpc_id                  = aws_vpc.test.id
   cidr_block              = "10.0.2.0/24"
   map_public_ip_on_launch = true
   availability_zone       = data.aws_availability_zones.available.names[1]
-  ipv6_cidr_block         = cidrsubnet(aws_vpc.alb_test.ipv6_cidr_block, 8, 2)
+  ipv6_cidr_block         = cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 2)
 
   tags = {
     Name = %[1]q
   }
 }
 
-resource "aws_security_group" "alb_test" {
-  name        = "allow_all_alb_test"
+resource "aws_security_group" "test" {
+  name        = %[1]q
   description = "Used for ALB Testing"
-  vpc_id      = aws_vpc.alb_test.id
+  vpc_id      = aws_vpc.test.id
 
   ingress {
     from_port   = 0
@@ -1859,10 +1859,10 @@ resource "aws_security_group" "alb_test" {
 
 func testAccLoadBalancerConfig_ipAddressType(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
-resource "aws_lb" "lb_test" {
+resource "aws_lb" "test" {
   name            = %[1]q
-  security_groups = [aws_security_group.alb_test.id]
-  subnets         = [aws_subnet.alb_test_1.id, aws_subnet.alb_test_2.id]
+  security_groups = [aws_security_group.test.id]
+  subnets         = [aws_subnet.test_1.id, aws_subnet.test_2.id]
 
   ip_address_type = "ipv4"
 
@@ -1875,7 +1875,7 @@ resource "aws_lb" "lb_test" {
 }
 
 resource "aws_lb_listener" "test" {
-  load_balancer_arn = aws_lb.lb_test.id
+  load_balancer_arn = aws_lb.test.id
   protocol          = "HTTP"
   port              = "80"
 
@@ -1889,7 +1889,7 @@ resource "aws_lb_target_group" "test" {
   name     = %[1]q
   port     = 80
   protocol = "HTTP"
-  vpc_id   = aws_vpc.alb_test.id
+  vpc_id   = aws_vpc.test.id
 
   deregistration_delay = 200
 
@@ -1911,10 +1911,10 @@ resource "aws_lb_target_group" "test" {
 }
 
 resource "aws_egress_only_internet_gateway" "igw" {
-  vpc_id = aws_vpc.alb_test.id
+  vpc_id = aws_vpc.test.id
 }
 
-resource "aws_vpc" "alb_test" {
+resource "aws_vpc" "test" {
   cidr_block                       = "10.0.0.0/16"
   assign_generated_ipv6_cidr_block = true
 
@@ -1924,37 +1924,37 @@ resource "aws_vpc" "alb_test" {
 }
 
 resource "aws_internet_gateway" "foo" {
-  vpc_id = aws_vpc.alb_test.id
+  vpc_id = aws_vpc.test.id
 }
 
-resource "aws_subnet" "alb_test_1" {
-  vpc_id                  = aws_vpc.alb_test.id
+resource "aws_subnet" "test_1" {
+  vpc_id                  = aws_vpc.test.id
   cidr_block              = "10.0.1.0/24"
   map_public_ip_on_launch = true
   availability_zone       = data.aws_availability_zones.available.names[0]
-  ipv6_cidr_block         = cidrsubnet(aws_vpc.alb_test.ipv6_cidr_block, 8, 1)
+  ipv6_cidr_block         = cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 1)
 
   tags = {
     Name = %[1]q
   }
 }
 
-resource "aws_subnet" "alb_test_2" {
-  vpc_id                  = aws_vpc.alb_test.id
+resource "aws_subnet" "test_2" {
+  vpc_id                  = aws_vpc.test.id
   cidr_block              = "10.0.2.0/24"
   map_public_ip_on_launch = true
   availability_zone       = data.aws_availability_zones.available.names[1]
-  ipv6_cidr_block         = cidrsubnet(aws_vpc.alb_test.ipv6_cidr_block, 8, 2)
+  ipv6_cidr_block         = cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 2)
 
   tags = {
     Name = %[1]q
   }
 }
 
-resource "aws_security_group" "alb_test" {
-  name        = "allow_all_alb_test"
+resource "aws_security_group" "test" {
+  name        = %[1]q
   description = "Used for ALB Testing"
-  vpc_id      = aws_vpc.alb_test.id
+  vpc_id      = aws_vpc.test.id
 
   ingress {
     from_port   = 0
@@ -1988,33 +1988,33 @@ data "aws_ec2_local_gateway_route_table" "test" {
 
 resource "aws_ec2_local_gateway_route_table_vpc_association" "test" {
   local_gateway_route_table_id = data.aws_ec2_local_gateway_route_table.test.id
-  vpc_id                       = aws_vpc.alb_test.id
+  vpc_id                       = aws_vpc.test.id
 }
 
 resource "aws_route_table" "test" {
-  vpc_id     = aws_vpc.alb_test.id
+  vpc_id     = aws_vpc.test.id
   depends_on = [aws_ec2_local_gateway_route_table_vpc_association.test]
 }
 
 resource "aws_route_table_association" "a" {
-  subnet_id      = aws_subnet.alb_test.id
+  subnet_id      = aws_subnet.test.id
   route_table_id = aws_route_table.test.id
 }
 
-resource "aws_lb" "lb_test" {
+resource "aws_lb" "test" {
   name                       = %[1]q
-  security_groups            = [aws_security_group.alb_test.id]
+  security_groups            = [aws_security_group.test.id]
   customer_owned_ipv4_pool   = tolist(data.aws_ec2_coip_pools.test.pool_ids)[0]
   idle_timeout               = 30
   enable_deletion_protection = false
-  subnets                    = [aws_subnet.alb_test.id]
+  subnets                    = [aws_subnet.test.id]
 
   tags = {
     Name = %[1]q
   }
 }
 
-resource "aws_vpc" "alb_test" {
+resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
@@ -2022,8 +2022,8 @@ resource "aws_vpc" "alb_test" {
   }
 }
 
-resource "aws_subnet" "alb_test" {
-  vpc_id            = aws_vpc.alb_test.id
+resource "aws_subnet" "test" {
+  vpc_id            = aws_vpc.test.id
   cidr_block        = "10.0.0.0/24"
   availability_zone = data.aws_outposts_outpost.test.availability_zone
   outpost_arn       = data.aws_outposts_outpost.test.arn
@@ -2033,10 +2033,10 @@ resource "aws_subnet" "alb_test" {
   }
 }
 
-resource "aws_security_group" "alb_test" {
-  name        = "allow_all_alb_test"
+resource "aws_security_group" "test" {
+  name        = %[1]q
   description = "Used for ALB Testing"
-  vpc_id      = aws_vpc.alb_test.id
+  vpc_id      = aws_vpc.test.id
 
   ingress {
     from_port   = 0
@@ -2061,11 +2061,11 @@ resource "aws_security_group" "alb_test" {
 
 func testAccLoadBalancerConfig_enableHTTP2(rName string, http2 bool) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
-resource "aws_lb" "lb_test" {
+resource "aws_lb" "test" {
   name            = %[1]q
   internal        = true
-  security_groups = [aws_security_group.alb_test.id]
-  subnets         = aws_subnet.alb_test[*].id
+  security_groups = [aws_security_group.test.id]
+  subnets         = aws_subnet.test[*].id
 
   idle_timeout               = 30
   enable_deletion_protection = false
@@ -2082,7 +2082,7 @@ variable "subnets" {
   type    = list(string)
 }
 
-resource "aws_vpc" "alb_test" {
+resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
@@ -2090,22 +2090,22 @@ resource "aws_vpc" "alb_test" {
   }
 }
 
-resource "aws_subnet" "alb_test" {
+resource "aws_subnet" "test" {
   count                   = 2
-  vpc_id                  = aws_vpc.alb_test.id
+  vpc_id                  = aws_vpc.test.id
   cidr_block              = element(var.subnets, count.index)
   map_public_ip_on_launch = true
   availability_zone       = element(data.aws_availability_zones.available.names, count.index)
 
   tags = {
-    Name = "tf-acc-lb-basic-${count.index}"
+    Name = "%[1]s-${count.index}"
   }
 }
 
-resource "aws_security_group" "alb_test" {
-  name        = "allow_all_alb_test"
+resource "aws_security_group" "test" {
+  name        = %[1]q
   description = "Used for ALB Testing"
-  vpc_id      = aws_vpc.alb_test.id
+  vpc_id      = aws_vpc.test.id
 
   ingress {
     from_port   = 0
@@ -2130,11 +2130,11 @@ resource "aws_security_group" "alb_test" {
 
 func testAccLoadBalancerConfig_enableDropInvalidHeaderFields(rName string, dropInvalid bool) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
-resource "aws_lb" "lb_test" {
+resource "aws_lb" "test" {
   name            = %[1]q
   internal        = true
-  security_groups = [aws_security_group.alb_test.id]
-  subnets         = aws_subnet.alb_test[*].id
+  security_groups = [aws_security_group.test.id]
+  subnets         = aws_subnet.test[*].id
 
   idle_timeout               = 30
   enable_deletion_protection = false
@@ -2151,7 +2151,7 @@ variable "subnets" {
   type    = list(string)
 }
 
-resource "aws_vpc" "alb_test" {
+resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
@@ -2159,22 +2159,22 @@ resource "aws_vpc" "alb_test" {
   }
 }
 
-resource "aws_subnet" "alb_test" {
+resource "aws_subnet" "test" {
   count                   = 2
-  vpc_id                  = aws_vpc.alb_test.id
+  vpc_id                  = aws_vpc.test.id
   cidr_block              = element(var.subnets, count.index)
   map_public_ip_on_launch = true
   availability_zone       = element(data.aws_availability_zones.available.names, count.index)
 
   tags = {
-    Name = "tf-acc-lb-basic-${count.index}"
+    Name = "%[1]s-${count.index}"
   }
 }
 
-resource "aws_security_group" "alb_test" {
-  name        = "allow_all_alb_test"
+resource "aws_security_group" "test" {
+  name        = %[1]q
   description = "Used for ALB Testing"
-  vpc_id      = aws_vpc.alb_test.id
+  vpc_id      = aws_vpc.test.id
 
   ingress {
     from_port   = 0
@@ -2199,11 +2199,11 @@ resource "aws_security_group" "alb_test" {
 
 func testAccLoadBalancerConfig_enablePreserveHostHeader(rName string, enablePreserveHostHeader bool) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
-resource "aws_lb" "lb_test" {
+resource "aws_lb" "test" {
   name            = %[1]q
   internal        = true
-  security_groups = [aws_security_group.alb_test.id]
-  subnets         = aws_subnet.alb_test[*].id
+  security_groups = [aws_security_group.test.id]
+  subnets         = aws_subnet.test[*].id
 
   idle_timeout               = 30
   enable_deletion_protection = false
@@ -2220,7 +2220,7 @@ variable "subnets" {
   type    = list(string)
 }
 
-resource "aws_vpc" "alb_test" {
+resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
@@ -2228,22 +2228,22 @@ resource "aws_vpc" "alb_test" {
   }
 }
 
-resource "aws_subnet" "alb_test" {
+resource "aws_subnet" "test" {
   count                   = 2
-  vpc_id                  = aws_vpc.alb_test.id
+  vpc_id                  = aws_vpc.test.id
   cidr_block              = element(var.subnets, count.index)
   map_public_ip_on_launch = true
   availability_zone       = element(data.aws_availability_zones.available.names, count.index)
 
   tags = {
-    Name = "tf-acc-lb-basic-${count.index}"
+    Name = "%[1]s-${count.index}"
   }
 }
 
-resource "aws_security_group" "alb_test" {
-  name        = "allow_all_alb_test"
+resource "aws_security_group" "test" {
+  name        = %[1]q
   description = "Used for ALB Testing"
-  vpc_id      = aws_vpc.alb_test.id
+  vpc_id      = aws_vpc.test.id
 
   ingress {
     from_port   = 0
@@ -2268,11 +2268,11 @@ resource "aws_security_group" "alb_test" {
 
 func testAccLoadBalancerConfig_enableDeletionProtection(rName string, deletionProtection bool) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
-resource "aws_lb" "lb_test" {
+resource "aws_lb" "test" {
   name            = %[1]q
   internal        = true
-  security_groups = [aws_security_group.alb_test.id]
-  subnets         = aws_subnet.alb_test[*].id
+  security_groups = [aws_security_group.test.id]
+  subnets         = aws_subnet.test[*].id
 
   idle_timeout               = 30
   enable_deletion_protection = %[2]t
@@ -2287,7 +2287,7 @@ variable "subnets" {
   type    = list(string)
 }
 
-resource "aws_vpc" "alb_test" {
+resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
@@ -2295,22 +2295,22 @@ resource "aws_vpc" "alb_test" {
   }
 }
 
-resource "aws_subnet" "alb_test" {
+resource "aws_subnet" "test" {
   count                   = 2
-  vpc_id                  = aws_vpc.alb_test.id
+  vpc_id                  = aws_vpc.test.id
   cidr_block              = element(var.subnets, count.index)
   map_public_ip_on_launch = true
   availability_zone       = element(data.aws_availability_zones.available.names, count.index)
 
   tags = {
-    Name = "tf-acc-lb-basic-${count.index}"
+    Name = "%[1]s-${count.index}"
   }
 }
 
-resource "aws_security_group" "alb_test" {
-  name        = "allow_all_alb_test"
+resource "aws_security_group" "test" {
+  name        = %[1]q
   description = "Used for ALB Testing"
-  vpc_id      = aws_vpc.alb_test.id
+  vpc_id      = aws_vpc.test.id
 
   ingress {
     from_port   = 0
@@ -2337,11 +2337,11 @@ func testAccLoadBalancerConfig_enableWAFFailOpen(rName string, wafFailOpen bool)
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
-resource "aws_lb" "lb_test" {
+resource "aws_lb" "test" {
   name            = %[1]q
   internal        = true
-  security_groups = [aws_security_group.alb_test.id]
-  subnets         = aws_subnet.alb_test[*].id
+  security_groups = [aws_security_group.test.id]
+  subnets         = aws_subnet.test[*].id
 
   idle_timeout               = 30
   enable_deletion_protection = false
@@ -2358,7 +2358,7 @@ variable "subnets" {
   type    = list(string)
 }
 
-resource "aws_vpc" "alb_test" {
+resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
@@ -2366,22 +2366,22 @@ resource "aws_vpc" "alb_test" {
   }
 }
 
-resource "aws_subnet" "alb_test" {
+resource "aws_subnet" "test" {
   count                   = 2
-  vpc_id                  = aws_vpc.alb_test.id
+  vpc_id                  = aws_vpc.test.id
   cidr_block              = element(var.subnets, count.index)
   map_public_ip_on_launch = true
   availability_zone       = element(data.aws_availability_zones.available.names, count.index)
 
   tags = {
-    Name = "tf-acc-lb-basic-${count.index}"
+    Name = "%[1]s-${count.index}"
   }
 }
 
-resource "aws_security_group" "alb_test" {
-  name        = "allow_all_alb_test"
+resource "aws_security_group" "test" {
+  name        = %[1]q
   description = "Used for ALB Testing"
-  vpc_id      = aws_vpc.alb_test.id
+  vpc_id      = aws_vpc.test.id
 
   ingress {
     from_port   = 0
@@ -2406,7 +2406,7 @@ resource "aws_security_group" "alb_test" {
 
 func testAccLoadBalancerConfig_nlb(rName string, cz bool) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
-resource "aws_lb" "lb_test" {
+resource "aws_lb" "test" {
   name               = %[1]q
   internal           = true
   load_balancer_type = "network"
@@ -2415,7 +2415,7 @@ resource "aws_lb" "lb_test" {
   enable_cross_zone_load_balancing = %[2]t
 
   subnet_mapping {
-    subnet_id = aws_subnet.alb_test.id
+    subnet_id = aws_subnet.test.id
   }
 
   tags = {
@@ -2423,7 +2423,7 @@ resource "aws_lb" "lb_test" {
   }
 }
 
-resource "aws_vpc" "alb_test" {
+resource "aws_vpc" "test" {
   cidr_block = "10.10.0.0/16"
 
   tags = {
@@ -2431,8 +2431,8 @@ resource "aws_vpc" "alb_test" {
   }
 }
 
-resource "aws_subnet" "alb_test" {
-  vpc_id                  = aws_vpc.alb_test.id
+resource "aws_subnet" "test" {
+  vpc_id                  = aws_vpc.test.id
   cidr_block              = "10.10.0.0/21"
   map_public_ip_on_launch = true
   availability_zone       = data.aws_availability_zones.available.names[0]
@@ -2579,7 +2579,7 @@ resource "aws_subnet" "public" {
   vpc_id            = aws_vpc.main.id
 
   tags = {
-    Name = "tf-acc-lb-network-load-balancer-eip-${count.index}"
+    Name = "%[1]s-${count.index}"
   }
 }
 
@@ -2602,7 +2602,7 @@ resource "aws_route_table_association" "a" {
   route_table_id = aws_route_table.public.id
 }
 
-resource "aws_lb" "lb_test" {
+resource "aws_lb" "test" {
   name               = %[1]q
   load_balancer_type = "network"
 
@@ -2666,11 +2666,11 @@ resource "aws_subnet" "test" {
 
 func testAccLoadBalancerConfig_backwardsCompatibility(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
-resource "aws_alb" "lb_test" {
+resource "aws_alb" "test" {
   name            = %[1]q
   internal        = true
-  security_groups = [aws_security_group.alb_test.id]
-  subnets         = aws_subnet.alb_test[*].id
+  security_groups = [aws_security_group.test.id]
+  subnets         = aws_subnet.test[*].id
 
   idle_timeout               = 30
   enable_deletion_protection = false
@@ -2685,7 +2685,7 @@ variable "subnets" {
   type    = list(string)
 }
 
-resource "aws_vpc" "alb_test" {
+resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
@@ -2693,22 +2693,22 @@ resource "aws_vpc" "alb_test" {
   }
 }
 
-resource "aws_subnet" "alb_test" {
+resource "aws_subnet" "test" {
   count                   = 2
-  vpc_id                  = aws_vpc.alb_test.id
+  vpc_id                  = aws_vpc.test.id
   cidr_block              = element(var.subnets, count.index)
   map_public_ip_on_launch = true
   availability_zone       = element(data.aws_availability_zones.available.names, count.index)
 
   tags = {
-    Name = "tf-acc-lb-bc-${count.index}"
+    Name = "%[1]s-${count.index}"
   }
 }
 
-resource "aws_security_group" "alb_test" {
-  name        = "allow_all_alb_test"
+resource "aws_security_group" "test" {
+  name        = %[1]q
   description = "Used for ALB Testing"
-  vpc_id      = aws_vpc.alb_test.id
+  vpc_id      = aws_vpc.test.id
 
   ingress {
     from_port   = 0
@@ -2735,10 +2735,10 @@ func testAccLoadBalancerConfig_generatedName(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
-resource "aws_lb" "lb_test" {
+resource "aws_lb" "test" {
   internal        = true
-  security_groups = [aws_security_group.alb_test.id]
-  subnets         = aws_subnet.alb_test[*].id
+  security_groups = [aws_security_group.test.id]
+  subnets         = aws_subnet.test[*].id
 
   idle_timeout               = 30
   enable_deletion_protection = false
@@ -2753,7 +2753,7 @@ variable "subnets" {
   type    = list(string)
 }
 
-resource "aws_vpc" "alb_test" {
+resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
@@ -2762,16 +2762,16 @@ resource "aws_vpc" "alb_test" {
 }
 
 resource "aws_internet_gateway" "gw" {
-  vpc_id = aws_vpc.alb_test.id
+  vpc_id = aws_vpc.test.id
 
   tags = {
     Name = %[1]q
   }
 }
 
-resource "aws_subnet" "alb_test" {
+resource "aws_subnet" "test" {
   count                   = 2
-  vpc_id                  = aws_vpc.alb_test.id
+  vpc_id                  = aws_vpc.test.id
   cidr_block              = element(var.subnets, count.index)
   map_public_ip_on_launch = true
   availability_zone       = element(data.aws_availability_zones.available.names, count.index)
@@ -2781,10 +2781,10 @@ resource "aws_subnet" "alb_test" {
   }
 }
 
-resource "aws_security_group" "alb_test" {
-  name        = "allow_all_alb_test"
+resource "aws_security_group" "test" {
+  name        = %[1]q
   description = "Used for ALB Testing"
-  vpc_id      = aws_vpc.alb_test.id
+  vpc_id      = aws_vpc.test.id
 
   ingress {
     from_port   = 0
@@ -2811,11 +2811,11 @@ func testAccLoadBalancerConfig_zeroValueName(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
-resource "aws_lb" "lb_test" {
+resource "aws_lb" "test" {
   name            = ""
   internal        = true
-  security_groups = [aws_security_group.alb_test.id]
-  subnets         = aws_subnet.alb_test[*].id
+  security_groups = [aws_security_group.test.id]
+  subnets         = aws_subnet.test[*].id
 
   idle_timeout               = 30
   enable_deletion_protection = false
@@ -2827,7 +2827,7 @@ resource "aws_lb" "lb_test" {
 
 # See https://github.com/hashicorp/terraform-provider-aws/issues/2498
 output "lb_name" {
-  value = aws_lb.lb_test.name
+  value = aws_lb.test.name
 }
 
 variable "subnets" {
@@ -2835,7 +2835,7 @@ variable "subnets" {
   type    = list(string)
 }
 
-resource "aws_vpc" "alb_test" {
+resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
@@ -2844,29 +2844,29 @@ resource "aws_vpc" "alb_test" {
 }
 
 resource "aws_internet_gateway" "gw" {
-  vpc_id = aws_vpc.alb_test.id
+  vpc_id = aws_vpc.test.id
 
   tags = {
     Name = %[1]q
   }
 }
 
-resource "aws_subnet" "alb_test" {
+resource "aws_subnet" "test" {
   count                   = 2
-  vpc_id                  = aws_vpc.alb_test.id
+  vpc_id                  = aws_vpc.test.id
   cidr_block              = element(var.subnets, count.index)
   map_public_ip_on_launch = true
   availability_zone       = element(data.aws_availability_zones.available.names, count.index)
 
   tags = {
-    Name = "tf-acc-lb-zero-value-name-${count.index}"
+    Name = "%[1]s-${count.index}"
   }
 }
 
-resource "aws_security_group" "alb_test" {
-  name        = "allow_all_alb_test"
+resource "aws_security_group" "test" {
+  name        = %[1]q
   description = "Used for ALB Testing"
-  vpc_id      = aws_vpc.alb_test.id
+  vpc_id      = aws_vpc.test.id
 
   ingress {
     from_port   = 0
@@ -2893,11 +2893,11 @@ func testAccLoadBalancerConfig_namePrefix(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
-resource "aws_lb" "lb_test" {
+resource "aws_lb" "test" {
   name_prefix     = "tf-lb-"
   internal        = true
-  security_groups = [aws_security_group.alb_test.id]
-  subnets         = aws_subnet.alb_test[*].id
+  security_groups = [aws_security_group.test.id]
+  subnets         = aws_subnet.test[*].id
 
   idle_timeout               = 30
   enable_deletion_protection = false
@@ -2912,7 +2912,7 @@ variable "subnets" {
   type    = list(string)
 }
 
-resource "aws_vpc" "alb_test" {
+resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
@@ -2920,9 +2920,9 @@ resource "aws_vpc" "alb_test" {
   }
 }
 
-resource "aws_subnet" "alb_test" {
+resource "aws_subnet" "test" {
   count                   = 2
-  vpc_id                  = aws_vpc.alb_test.id
+  vpc_id                  = aws_vpc.test.id
   cidr_block              = element(var.subnets, count.index)
   map_public_ip_on_launch = true
   availability_zone       = element(data.aws_availability_zones.available.names, count.index)
@@ -2932,10 +2932,10 @@ resource "aws_subnet" "alb_test" {
   }
 }
 
-resource "aws_security_group" "alb_test" {
-  name        = "allow_all_alb_test"
+resource "aws_security_group" "test" {
+  name        = %[1]q
   description = "Used for ALB Testing"
-  vpc_id      = aws_vpc.alb_test.id
+  vpc_id      = aws_vpc.test.id
 
   ingress {
     from_port   = 0


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #32942

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccELBV2LoadBalancer_ K=elbv2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2LoadBalancer_'  -timeout 180m
=== RUN   TestAccELBV2LoadBalancer_ALB_basic
=== PAUSE TestAccELBV2LoadBalancer_ALB_basic
=== RUN   TestAccELBV2LoadBalancer_NLB_basic
=== PAUSE TestAccELBV2LoadBalancer_NLB_basic
=== RUN   TestAccELBV2LoadBalancer_LoadBalancerType_gateway
=== PAUSE TestAccELBV2LoadBalancer_LoadBalancerType_gateway
=== RUN   TestAccELBV2LoadBalancer_disappears
=== PAUSE TestAccELBV2LoadBalancer_disappears
=== RUN   TestAccELBV2LoadBalancer_ipv6SubnetMapping
=== PAUSE TestAccELBV2LoadBalancer_ipv6SubnetMapping
=== RUN   TestAccELBV2LoadBalancer_LoadBalancerTypeGateway_enableCrossZoneLoadBalancing
=== PAUSE TestAccELBV2LoadBalancer_LoadBalancerTypeGateway_enableCrossZoneLoadBalancing
=== RUN   TestAccELBV2LoadBalancer_ALB_outpost
=== PAUSE TestAccELBV2LoadBalancer_ALB_outpost
=== RUN   TestAccELBV2LoadBalancer_networkLoadBalancerEIP
=== PAUSE TestAccELBV2LoadBalancer_networkLoadBalancerEIP
=== RUN   TestAccELBV2LoadBalancer_NLB_privateIPv4Address
=== PAUSE TestAccELBV2LoadBalancer_NLB_privateIPv4Address
=== RUN   TestAccELBV2LoadBalancer_backwardsCompatibility
=== PAUSE TestAccELBV2LoadBalancer_backwardsCompatibility
=== RUN   TestAccELBV2LoadBalancer_generatedName
=== PAUSE TestAccELBV2LoadBalancer_generatedName
=== RUN   TestAccELBV2LoadBalancer_generatesNameForZeroValue
=== PAUSE TestAccELBV2LoadBalancer_generatesNameForZeroValue
=== RUN   TestAccELBV2LoadBalancer_namePrefix
=== PAUSE TestAccELBV2LoadBalancer_namePrefix
=== RUN   TestAccELBV2LoadBalancer_duplicateName
=== PAUSE TestAccELBV2LoadBalancer_duplicateName
=== RUN   TestAccELBV2LoadBalancer_tags
=== PAUSE TestAccELBV2LoadBalancer_tags
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateCrossZone
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateCrossZone
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateHTTP2
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateHTTP2
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDropInvalidHeaderFields
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDropInvalidHeaderFields
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatePreserveHostHeader
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatePreserveHostHeader
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDeletionProtection
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDeletionProtection
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateWAFFailOpen
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateWAFFailOpen
=== RUN   TestAccELBV2LoadBalancer_updatedIPAddressType
=== PAUSE TestAccELBV2LoadBalancer_updatedIPAddressType
=== RUN   TestAccELBV2LoadBalancer_updatedSecurityGroups
=== PAUSE TestAccELBV2LoadBalancer_updatedSecurityGroups
=== RUN   TestAccELBV2LoadBalancer_updatedSubnets
=== PAUSE TestAccELBV2LoadBalancer_updatedSubnets
=== RUN   TestAccELBV2LoadBalancer_noSecurityGroup
=== PAUSE TestAccELBV2LoadBalancer_noSecurityGroup
=== RUN   TestAccELBV2LoadBalancer_ALB_accessLogs
=== PAUSE TestAccELBV2LoadBalancer_ALB_accessLogs
=== RUN   TestAccELBV2LoadBalancer_ALBAccessLogs_prefix
=== PAUSE TestAccELBV2LoadBalancer_ALBAccessLogs_prefix
=== RUN   TestAccELBV2LoadBalancer_NLB_accessLogs
=== PAUSE TestAccELBV2LoadBalancer_NLB_accessLogs
=== RUN   TestAccELBV2LoadBalancer_NLBAccessLogs_prefix
=== PAUSE TestAccELBV2LoadBalancer_NLBAccessLogs_prefix
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancerSubnet_change
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancerSubnet_change
=== RUN   TestAccELBV2LoadBalancer_updateDesyncMitigationMode
=== PAUSE TestAccELBV2LoadBalancer_updateDesyncMitigationMode
=== RUN   TestAccELBV2LoadBalancer_ALB_updateTLSVersionAndCipherSuite
=== PAUSE TestAccELBV2LoadBalancer_ALB_updateTLSVersionAndCipherSuite
=== RUN   TestAccELBV2LoadBalancer_ALB_updateXffHeaderProcessingMode
=== PAUSE TestAccELBV2LoadBalancer_ALB_updateXffHeaderProcessingMode
=== RUN   TestAccELBV2LoadBalancer_ALB_updateXffClientPort
=== PAUSE TestAccELBV2LoadBalancer_ALB_updateXffClientPort
=== CONT  TestAccELBV2LoadBalancer_ALB_basic
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDropInvalidHeaderFields
=== CONT  TestAccELBV2LoadBalancer_backwardsCompatibility
=== CONT  TestAccELBV2LoadBalancer_ALB_outpost
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateHTTP2
=== CONT  TestAccELBV2LoadBalancer_ALB_updateXffClientPort
=== CONT  TestAccELBV2LoadBalancer_ALBAccessLogs_prefix
=== CONT  TestAccELBV2LoadBalancer_ALB_accessLogs
=== CONT  TestAccELBV2LoadBalancer_NLB_privateIPv4Address
=== CONT  TestAccELBV2LoadBalancer_networkLoadBalancerEIP
=== CONT  TestAccELBV2LoadBalancer_disappears
=== CONT  TestAccELBV2LoadBalancer_ipv6SubnetMapping
=== CONT  TestAccELBV2LoadBalancer_duplicateName
=== CONT  TestAccELBV2LoadBalancer_noSecurityGroup
=== CONT  TestAccELBV2LoadBalancer_updatedSubnets
=== CONT  TestAccELBV2LoadBalancer_updatedSecurityGroups
=== CONT  TestAccELBV2LoadBalancer_updatedIPAddressType
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateWAFFailOpen
=== CONT  TestAccELBV2LoadBalancer_LoadBalancerType_gateway
=== CONT  TestAccELBV2LoadBalancer_LoadBalancerTypeGateway_enableCrossZoneLoadBalancing
=== NAME  TestAccELBV2LoadBalancer_ALB_outpost
    acctest.go:1105: skipping since no Outposts found
--- SKIP: TestAccELBV2LoadBalancer_ALB_outpost (0.94s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDeletionProtection
--- PASS: TestAccELBV2LoadBalancer_disappears (187.16s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatePreserveHostHeader
--- PASS: TestAccELBV2LoadBalancer_noSecurityGroup (192.85s)
=== CONT  TestAccELBV2LoadBalancer_generatesNameForZeroValue
--- PASS: TestAccELBV2LoadBalancer_ALB_basic (195.47s)
=== CONT  TestAccELBV2LoadBalancer_namePrefix
--- PASS: TestAccELBV2LoadBalancer_duplicateName (219.34s)
=== CONT  TestAccELBV2LoadBalancer_updateDesyncMitigationMode
--- PASS: TestAccELBV2LoadBalancer_LoadBalancerType_gateway (246.57s)
=== CONT  TestAccELBV2LoadBalancer_ALB_updateXffHeaderProcessingMode
--- PASS: TestAccELBV2LoadBalancer_NLB_privateIPv4Address (258.26s)
=== CONT  TestAccELBV2LoadBalancer_ALB_updateTLSVersionAndCipherSuite
--- PASS: TestAccELBV2LoadBalancer_updatedSecurityGroups (260.11s)
=== CONT  TestAccELBV2LoadBalancer_NLB_basic
--- PASS: TestAccELBV2LoadBalancer_updatedSubnets (261.91s)
=== CONT  TestAccELBV2LoadBalancer_generatedName
--- PASS: TestAccELBV2LoadBalancer_backwardsCompatibility (263.94s)
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateCrossZone
--- PASS: TestAccELBV2LoadBalancer_networkLoadBalancerEIP (278.90s)
=== CONT  TestAccELBV2LoadBalancer_NLB_accessLogs
--- PASS: TestAccELBV2LoadBalancer_LoadBalancerTypeGateway_enableCrossZoneLoadBalancing (295.88s)
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancerSubnet_change
--- PASS: TestAccELBV2LoadBalancer_updatedIPAddressType (303.52s)
=== CONT  TestAccELBV2LoadBalancer_tags
--- PASS: TestAccELBV2LoadBalancer_ipv6SubnetMapping (315.78s)
=== CONT  TestAccELBV2LoadBalancer_NLBAccessLogs_prefix
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateHTTP2 (338.02s)
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDeletionProtection (337.20s)
--- PASS: TestAccELBV2LoadBalancer_ALB_updateXffClientPort (342.09s)
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateWAFFailOpen (368.94s)
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDropInvalidHeaderFields (369.20s)
--- PASS: TestAccELBV2LoadBalancer_ALBAccessLogs_prefix (370.85s)
--- PASS: TestAccELBV2LoadBalancer_generatesNameForZeroValue (185.04s)
--- PASS: TestAccELBV2LoadBalancer_namePrefix (184.93s)
--- PASS: TestAccELBV2LoadBalancer_ALB_accessLogs (417.00s)
--- PASS: TestAccELBV2LoadBalancer_generatedName (183.31s)
--- PASS: TestAccELBV2LoadBalancer_NLB_basic (230.16s)
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatePreserveHostHeader (305.90s)
--- PASS: TestAccELBV2LoadBalancer_updateDesyncMitigationMode (292.40s)
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancerSubnet_change (234.47s)
--- PASS: TestAccELBV2LoadBalancer_ALB_updateTLSVersionAndCipherSuite (294.11s)
--- PASS: TestAccELBV2LoadBalancer_ALB_updateXffHeaderProcessingMode (316.32s)
--- PASS: TestAccELBV2LoadBalancer_tags (289.31s)
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateCrossZone (350.20s)
--- PASS: TestAccELBV2LoadBalancer_NLBAccessLogs_prefix (374.06s)
--- PASS: TestAccELBV2LoadBalancer_NLB_accessLogs (411.52s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	692.305s
```
