### PR TITLE
`aws_lambda_function`: mention `java17` support for `snap_start`

### DIFF
--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -319,7 +319,7 @@ Container image configuration values that override the values in the container i
 
 ### snap_start
 
-Snap start settings for low-latency startups. This feature is currently only supported for `java11` runtimes. Remove this block to delete the associated settings (rather than setting `apply_on = "None"`).
+Snap start settings for low-latency startups. This feature is currently only supported for `java11` and `java17` runtimes. Remove this block to delete the associated settings (rather than setting `apply_on = "None"`).
 
 * `apply_on` - (Required) Conditions where snap start is enabled. Valid values are `PublishedVersions`.
 


### PR DESCRIPTION
### Description

This PR adds `java17` to the runtimes that are mentioned as supported by the `snap_start` setting, bringing the documentation in line with reality.

### Relations

Closes #32953

### References

- [AWS: Improving startup performance with Lambda SnapStart](https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html#snapstart-runtimes)

> SnapStart supports the Java 11 and Java 17 (`java11` and `java17`) [managed runtimes](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html).

### Output from Acceptance Testing

N/a, docs
