### PR TITLE
S3 Bucket Server Side Encryption: add `aws:kms:dsse` to list of supported `sse_algorithm`

### DIFF
--- a/internal/service/s3/bucket_server_side_encryption_configuration_test.go
+++ b/internal/service/s3/bucket_server_side_encryption_configuration_test.go
@@ -108,6 +108,36 @@ func TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMS(t *t
 	})
 }
 
+func TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMSDSSE(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_server_side_encryption_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, s3.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketServerSideEncryptionConfigurationConfig_applySSEByDefaultSSEAlgorithm(rName, s3.ServerSideEncryptionAwsKmsDsse),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketServerSideEncryptionConfigurationExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.apply_server_side_encryption_by_default.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.apply_server_side_encryption_by_default.0.sse_algorithm", s3.ServerSideEncryptionAwsKmsDsse),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.apply_server_side_encryption_by_default.0.kms_master_key_id", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_UpdateSSEAlgorithm(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/website/docs/r/s3_bucket_server_side_encryption_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_server_side_encryption_configuration.html.markdown
@@ -55,7 +55,7 @@ The `rule` configuration block supports the following arguments:
 
 The `apply_server_side_encryption_by_default` configuration block supports the following arguments:
 
-* `sse_algorithm` - (Required) Server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`
+* `sse_algorithm` - (Required) Server-side encryption algorithm to use. Valid values are `AES256`, `aws:kms`, and `aws:kms:dsse`
 * `kms_master_key_id` - (Optional) AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sse_algorithm` as `aws:kms`. The default `aws/s3` AWS KMS master key is used if this element is absent while the `sse_algorithm` is `aws:kms`.
 
 ## Attribute Reference


### PR DESCRIPTION
### Description

This PR updates the documentation for the `aws_s3_bucket_server_side_encryption_configuration` resource to indicate that `aws:kms:dsse` is supported as an `sse_algorithm`. This has been the case since `5.4.0` / AWS SDK version 1.44.282. For good stewardship's sake, added test coverage as well.

### Relations

Closes #32951

### References

- Support added to the SDK in https://github.com/aws/aws-sdk-go/pull/4882

### Output from Acceptance Testing

```console
$ make testacc TESTS=TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMSDSSE PKG=s3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMSDSSE'  -timeout 180m
=== RUN   TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMSDSSE
=== PAUSE TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMSDSSE
=== CONT  TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMSDSSE
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMSDSSE (22.02s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 25.241s
```
