### PR TITLE
documentation update for ttl usage in dynamodb_table

### DIFF
--- a/website/docs/r/dynamodb_table.html.markdown
+++ b/website/docs/r/dynamodb_table.html.markdown
@@ -54,7 +54,7 @@ resource "aws_dynamodb_table" "basic-dynamodb-table" {
   }
 
   ttl {
-    attribute_name = "TimeToExist"
+    attribute_name = ""
     enabled        = false
   }
 
@@ -238,6 +238,8 @@ Optional arguments:
 
 * `enabled` - (Required) Whether TTL is enabled.
 * `attribute_name` - (Required) Name of the table attribute to store the TTL timestamp in.
+
+~> **Note:** If `enabled` is set to `false` then `attribute_name` must be an empty string `""`. Giving it any other name will result in an error during a subsequent `apply`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

This PR provides clarification on the use of `ttl` (time to live) in `dynamodb_table`. Many people seem to encounter an error due to a commonly copied documentation example.


### Relations

Closes #10304 

### References

[AWS docs on time to live (ttl)](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/time-to-live-ttl-how-to.html). When ttl is disabled there is no need for an attribute name. Thus any passed value is ignored leading to subsequent applies having issues.

I further explained [how I diagnosed this here](https://github.com/hashicorp/terraform-provider-aws/issues/10304#issuecomment-1672617928).

### Output from Acceptance Testing

N/A, documentation
