### PR TITLE
[TechDebt]: Fix `appstream` acceptance tests

### DIFF
--- a/.changelog/32958.txt
+++ b/.changelog/32958.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_appstream_fleet: Retry ConcurrentModificationException errors during creation
+```

--- a/internal/service/appstream/fleet.go
+++ b/internal/service/appstream/fleet.go
@@ -273,6 +273,10 @@ func resourceFleetCreate(ctx context.Context, d *schema.ResourceData, meta inter
 				return retry.RetryableError(err)
 			}
 
+			if tfawserr.ErrCodeEquals(err, appstream.ErrCodeConcurrentModificationException) {
+				return retry.RetryableError(err)
+			}
+
 			// Retry for IAM eventual consistency on error:
 			if tfawserr.ErrMessageContains(err, appstream.ErrCodeInvalidRoleException, "encountered an error because your IAM role") {
 				return retry.RetryableError(err)

--- a/internal/service/appstream/fleet.go
+++ b/internal/service/appstream/fleet.go
@@ -292,7 +292,7 @@ func resourceFleetCreate(ctx context.Context, d *schema.ResourceData, meta inter
 		output, err = conn.CreateFleetWithContext(ctx, input)
 	}
 	if err != nil {
-		return diag.Errorf("creating Appstream Fleet (%s): %s", d.Id(), err)
+		return diag.Errorf("creating Appstream Fleet (%s): %s", d.Get("name").(string), err)
 	}
 
 	d.SetId(aws.StringValue(output.Fleet.Name))

--- a/internal/service/appstream/fleet_stack_association_test.go
+++ b/internal/service/appstream/fleet_stack_association_test.go
@@ -131,11 +131,11 @@ func testAccCheckFleetStackAssociationDestroy(ctx context.Context) resource.Test
 }
 
 func testAccFleetStackAssociationConfig_basic(name string) string {
-	// "Amazon-AppStream2-Sample-Image-02-04-2019" is not available in GovCloud
+	// "Amazon-AppStream2-Sample-Image-03-11-2023" is not available in GovCloud
 	return fmt.Sprintf(`
 resource "aws_appstream_fleet" "test" {
   name          = %[1]q
-  image_name    = "Amazon-AppStream2-Sample-Image-02-04-2019"
+  image_name    = "Amazon-AppStream2-Sample-Image-03-11-2023"
   instance_type = "stream.standard.small"
 
   compute_capacity {

--- a/internal/service/appstream/fleet_test.go
+++ b/internal/service/appstream/fleet_test.go
@@ -361,11 +361,11 @@ func testAccCheckFleetDestroy(ctx context.Context) resource.TestCheckFunc {
 }
 
 func testAccFleetConfig_basic(name, instanceType string) string {
-	// "Amazon-AppStream2-Sample-Image-02-04-2019" is not available in GovCloud
+	// "Amazon-AppStream2-Sample-Image-03-11-2023" is not available in GovCloud
 	return fmt.Sprintf(`
 resource "aws_appstream_fleet" "test" {
   name          = %[1]q
-  image_name    = "Amazon-AppStream2-Sample-Image-02-04-2019"
+  image_name    = "Amazon-AppStream2-Sample-Image-03-11-2023"
   instance_type = %[2]q
 
   compute_capacity {
@@ -395,7 +395,7 @@ resource "aws_subnet" "test" {
 
 resource "aws_appstream_fleet" "test" {
   name      = %[1]q
-  image_arn = "arn:${data.aws_partition.current.partition}:appstream:${data.aws_region.current.name}::image/Amazon-AppStream2-Sample-Image-02-04-2019"
+  image_arn = "arn:${data.aws_partition.current.partition}:appstream:${data.aws_region.current.name}::image/Amazon-AppStream2-Sample-Image-03-11-2023"
 
   compute_capacity {
     desired_instances = 1
@@ -433,7 +433,7 @@ resource "aws_subnet" "test" {
 
 resource "aws_appstream_fleet" "test" {
   name       = %[1]q
-  image_name = "Amazon-AppStream2-Sample-Image-02-04-2019"
+  image_name = "Amazon-AppStream2-Sample-Image-03-11-2023"
 
   compute_capacity {
     desired_instances = 1
@@ -471,7 +471,7 @@ resource "aws_subnet" "test" {
 
 resource "aws_appstream_fleet" "test" {
   name       = %[1]q
-  image_name = "Amazon-AppStream2-Sample-Image-02-04-2019"
+  image_name = "Amazon-AppStream2-Sample-Image-03-11-2023"
 
   compute_capacity {
     desired_instances = 1
@@ -497,11 +497,11 @@ resource "aws_appstream_fleet" "test" {
 }
 
 func testAccFleetConfig_emptyDomainJoin(name, instanceType, empty string) string {
-	// "Amazon-AppStream2-Sample-Image-02-04-2019" is not available in GovCloud
+	// "Amazon-AppStream2-Sample-Image-03-11-2023" is not available in GovCloud
 	return fmt.Sprintf(`
 resource "aws_appstream_fleet" "test" {
   name          = %[1]q
-  image_name    = "Amazon-AppStream2-Sample-Image-02-04-2019"
+  image_name    = "Amazon-AppStream2-Sample-Image-03-11-2023"
   instance_type = %[2]q
 
   compute_capacity {

--- a/internal/service/appstream/image_builder_test.go
+++ b/internal/service/appstream/image_builder_test.go
@@ -53,7 +53,7 @@ func TestAccAppStreamImageBuilder_withIAMRole(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appstream_image_builder.test"
 	instanceType := "stream.standard.medium"
-	imageName := "AppStream-WinServer2019-07-12-2022"
+	imageName := "AppStream-WinServer2019-06-12-2023"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -202,7 +202,7 @@ func TestAccAppStreamImageBuilder_imageARN(t *testing.T) {
 	resourceName := "aws_appstream_image_builder.test"
 	// imageName selected from the available AWS Managed AppStream 2.0 Base Images
 	// Reference: https://docs.aws.amazon.com/appstream2/latest/developerguide/base-image-version-history.html
-	imageName := "AppStream-WinServer2019-07-12-2022"
+	imageName := "AppStream-WinServer2019-06-12-2023"
 	instanceType := "stream.standard.small"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -276,7 +276,7 @@ func testAccCheckImageBuilderDestroy(ctx context.Context) resource.TestCheckFunc
 func testAccImageBuilderConfig_basic(instanceType, rName string) string {
 	return fmt.Sprintf(`
 resource "aws_appstream_image_builder" "test" {
-  image_name    = "AppStream-WinServer2019-07-12-2022"
+  image_name    = "AppStream-WinServer2019-06-12-2023"
   instance_type = %[1]q
   name          = %[2]q
 }
@@ -286,7 +286,7 @@ resource "aws_appstream_image_builder" "test" {
 func testAccImageBuilderConfig_complete(rName, description, instanceType string) string {
 	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 1), fmt.Sprintf(`
 resource "aws_appstream_image_builder" "test" {
-  image_name                     = "AppStream-WinServer2019-07-12-2022"
+  image_name                     = "AppStream-WinServer2019-06-12-2023"
   name                           = %[1]q
   description                    = %[2]q
   enable_default_internet_access = false
@@ -301,7 +301,7 @@ resource "aws_appstream_image_builder" "test" {
 func testAccImageBuilderConfig_tags1(instanceType, rName, key, value string) string {
 	return fmt.Sprintf(`
 resource "aws_appstream_image_builder" "test" {
-  image_name    = "AppStream-WinServer2019-07-12-2022"
+  image_name    = "AppStream-WinServer2019-06-12-2023"
   instance_type = %[1]q
   name          = %[2]q
 
@@ -315,7 +315,7 @@ resource "aws_appstream_image_builder" "test" {
 func testAccImageBuilderConfig_tags2(instanceType, rName, key1, value1, key2, value2 string) string {
 	return fmt.Sprintf(`
 resource "aws_appstream_image_builder" "test" {
-  image_name    = "AppStream-WinServer2019-07-12-2022"
+  image_name    = "AppStream-WinServer2019-06-12-2023"
   instance_type = %[1]q
   name          = %[2]q
 

--- a/website/docs/r/appstream_fleet.html.markdown
+++ b/website/docs/r/appstream_fleet.html.markdown
@@ -25,7 +25,7 @@ resource "aws_appstream_fleet" "test_fleet" {
   display_name                       = "test-fleet"
   enable_default_internet_access     = false
   fleet_type                         = "ON_DEMAND"
-  image_name                         = "Amazon-AppStream2-Sample-Image-02-04-2019"
+  image_name                         = "Amazon-AppStream2-Sample-Image-03-11-2023"
   instance_type                      = "stream.standard.large"
   max_user_duration_in_seconds       = 600
 

--- a/website/docs/r/appstream_fleet_stack_association.html.markdown
+++ b/website/docs/r/appstream_fleet_stack_association.html.markdown
@@ -15,7 +15,7 @@ Manages an AppStream Fleet Stack association.
 ```terraform
 resource "aws_appstream_fleet" "example" {
   name          = "NAME"
-  image_name    = "Amazon-AppStream2-Sample-Image-02-04-2019"
+  image_name    = "Amazon-AppStream2-Sample-Image-03-11-2023"
   instance_type = "stream.standard.small"
 
   compute_capacity {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Fixes various AppStream acceptances tests which were failing due to the use of deprecated image names. Also updates associated documentation where applicable.

```
=== RUN   TestAccAppStreamFleet_basic
=== PAUSE TestAccAppStreamFleet_basic
=== CONT  TestAccAppStreamFleet_basic
    fleet_test.go:41: Step 1/2 error: Error running apply: exit status 1
        Error: creating Appstream Fleet (): ResourceNotAvailableException: The image Amazon-AppStream2-Sample-Image-02-04-2019 is DEPRECATED. The image must be in an AVAILABLE state for this action to succeed.
          with aws_appstream_fleet.test,
          on terraform_plugin_test.tf line 2, in resource "aws_appstream_fleet" "test":
           2: resource "aws_appstream_fleet" "test" {
--- FAIL: TestAccAppStreamFleet_basic (65.75s)
FAIL
```

```
=== RUN   TestAccAppStreamFleetStackAssociation_basic
=== PAUSE TestAccAppStreamFleetStackAssociation_basic
=== CONT  TestAccAppStreamFleetStackAssociation_basic
    fleet_stack_association_test.go:26: Step 1/2 error: Error running apply: exit status 1
        Error: creating Appstream Fleet (): ResourceNotAvailableException: The image Amazon-AppStream2-Sample-Image-02-04-2019 is DEPRECATED. The image must be in an AVAILABLE state for this action to succeed.
          with aws_appstream_fleet.test,
          on terraform_plugin_test.tf line 2, in resource "aws_appstream_fleet" "test":
           2: resource "aws_appstream_fleet" "test" {
--- FAIL: TestAccAppStreamFleetStackAssociation_basic (82.31s)
FAIL
```

```
=== RUN   TestAccAppStreamImageBuilder_basic
=== PAUSE TestAccAppStreamImageBuilder_basic
=== CONT  TestAccAppStreamImageBuilder_basic
    image_builder_test.go:27: Step 1/2 error: Error running apply: exit status 1
        Error: creating AppStream ImageBuilder (tf-acc-test-638513868540127945): ResourceNotAvailableException: The image AppStream-WinServer2019-07-12-2022 is DEPRECATED. The image must be in an AVAILABLE state for this action to succeed.
          with aws_appstream_image_builder.test,
          on terraform_plugin_test.tf line 2, in resource "aws_appstream_image_builder" "test":
           2: resource "aws_appstream_image_builder" "test" {
--- FAIL: TestAccAppStreamImageBuilder_basic (50.02s)
FAIL
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #22536

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/appstream2/latest/developerguide/base-image-version-history.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=appstream TESTS=TestAccAppStreamFleet_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/appstream/... -v -count 1 -parallel 20 -run='TestAccAppStreamFleet_'  -timeout 180m

--- PASS: TestAccAppStreamFleet_disappears (784.13s)
--- PASS: TestAccAppStreamFleet_basic (891.98s)
--- PASS: TestAccAppStreamFleet_completeWithoutStop (894.78s)
--- PASS: TestAccAppStreamFleet_emptyDomainJoin (894.97s)
--- PASS: TestAccAppStreamFleet_withTags (960.38s)
--- PASS: TestAccAppStreamFleet_completeWithStop (1766.62s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appstream  1769.666s
```

```console
% make testacc PKG=appstream TESTS=TestAccAppStreamFleetStackAssociation_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/appstream/... -v -count 1 -parallel 20 -run='TestAccAppStreamFleetStackAssociation_'  -timeout 180m

--- PASS: TestAccAppStreamFleetStackAssociation_basic (817.79s)
--- PASS: TestAccAppStreamFleetStackAssociation_disappears (856.47s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appstream  859.473s
```

```console
% make testacc PKG=appstream TESTS=TestAccAppStreamImageBuilder_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/appstream/... -v -count 1 -parallel 20 -run='TestAccAppStreamImageBuilder_'  -timeout 180m

--- PASS: TestAccAppStreamImageBuilder_withIAMRole (702.87s)
--- PASS: TestAccAppStreamImageBuilder_disappears (727.45s)
--- PASS: TestAccAppStreamImageBuilder_basic (1016.75s)
--- PASS: TestAccAppStreamImageBuilder_imageARN (1026.53s)
--- PASS: TestAccAppStreamImageBuilder_tags (1036.58s)
--- PASS: TestAccAppStreamImageBuilder_complete (1792.92s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appstream  1795.935s
```
