### PR TITLE
Add cross-account details to docs for `rds_cluster`

### DIFF
--- a/website/docs/r/rds_cluster.html.markdown
+++ b/website/docs/r/rds_cluster.html.markdown
@@ -313,7 +313,7 @@ resource "aws_rds_cluster" "example-clone" {
 }
 ```
 
-* `source_cluster_identifier` - (Required) Identifier of the source database cluster from which to restore.
+* `source_cluster_identifier` - (Required) Identifier of the source database cluster from which to restore. When restoring from a cluster in another AWS account, the identifier is the ARN of that cluster.
 * `restore_type` - (Optional) Type of restore to be performed.
    Valid options are `full-copy` (default) and `copy-on-write`.
 * `use_latest_restorable_time` - (Optional) Set to true to restore the database cluster to the latest restorable backup time. Defaults to false. Conflicts with `restore_to_time`.


### PR DESCRIPTION
### Description
Cross-account restores were [enabled back in 3.19.0](https://github.com/hashicorp/terraform-provider-aws/pull/16447), but the doc wasn't updated to reflect that sometimes an ARN is required instead of a cluster identifier.  

When following the current docs, providing a cluster identifier instead of ARN results in a successful `terraform plan` but an error during `terraform apply`:
```
│ Error: creating RDS Cluster (restore to point-in-time) (dest-clone-testing): DBClusterNotFoundFault: The source cluster could not be found or cannot be accessed: source-clone-testing
```

### References
The [AWS docs](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.Managing.Clone.html#Aurora.Managing.Clone.Cross-Account) specify that a cross-account restore requires an ARN with the `restore-db-cluster-to-point-in-time` command
> Throughout this process, the cluster is identified by its unique Amazon Resource Name (ARN).

```
aws rds restore-db-cluster-to-point-in-time \
  --source-db-cluster-identifier=arn:aws:rds:arn_details \
  --db-cluster-identifier=new_cluster_id \
  --restore-type=copy-on-write \
  --use-latest-restorable-time
```

### Output from Acceptance Testing
I've not been able to run acceptance testing