### PR TITLE
update lightsail_database docs to use the correct name argument

### DIFF
--- a/website/docs/r/lightsail_database.html.markdown
+++ b/website/docs/r/lightsail_database.html.markdown
@@ -20,13 +20,13 @@ for more information.
 
 ```terraform
 resource "aws_lightsail_database" "test" {
-  name                 = "test"
-  availability_zone    = "us-east-1a"
-  master_database_name = "testdatabasename"
-  master_password      = "testdatabasepassword"
-  master_username      = "test"
-  blueprint_id         = "mysql_8_0"
-  bundle_id            = "micro_1_0"
+  relational_database_name = "test"
+  availability_zone        = "us-east-1a"
+  master_database_name     = "testdatabasename"
+  master_password          = "testdatabasepassword"
+  master_username          = "test"
+  blueprint_id             = "mysql_8_0"
+  bundle_id                = "micro_1_0"
 }
 ```
 
@@ -34,13 +34,13 @@ resource "aws_lightsail_database" "test" {
 
 ```terraform
 resource "aws_lightsail_database" "test" {
-  name                 = "test"
-  availability_zone    = "us-east-1a"
-  master_database_name = "testdatabasename"
-  master_password      = "testdatabasepassword"
-  master_username      = "test"
-  blueprint_id         = "postgres_12"
-  bundle_id            = "micro_1_0"
+  relational_database_name = "test"
+  availability_zone        = "us-east-1a"
+  master_database_name     = "testdatabasename"
+  master_password          = "testdatabasepassword"
+  master_username          = "test"
+  blueprint_id             = "postgres_12"
+  bundle_id                = "micro_1_0"
 }
 ```
 
@@ -50,7 +50,7 @@ Below is an example that sets a custom backup and maintenance window. Times are 
 
 ```terraform
 resource "aws_lightsail_database" "test" {
-  name                         = "test"
+  relational_database_name     = "test"
   availability_zone            = "us-east-1a"
   master_database_name         = "testdatabasename"
   master_password              = "testdatabasepassword"
@@ -68,7 +68,7 @@ To enable creating a final snapshot of your database on deletion, use the `final
 
 ```terraform
 resource "aws_lightsail_database" "test" {
-  name                         = "test"
+  relational_database_name     = "test"
   availability_zone            = "us-east-1a"
   master_database_name         = "testdatabasename"
   master_password              = "testdatabasepassword"
@@ -87,14 +87,14 @@ To enable applying changes immediately instead of waiting for a maintiance windo
 
 ```terraform
 resource "aws_lightsail_database" "test" {
-  name                 = "test"
-  availability_zone    = "us-east-1a"
-  master_database_name = "testdatabasename"
-  master_password      = "testdatabasepassword"
-  master_username      = "test"
-  blueprint_id         = "postgres_12"
-  bundle_id            = "micro_1_0"
-  apply_immediately    = true
+  relational_database_name = "test"
+  availability_zone        = "us-east-1a"
+  master_database_name     = "testdatabasename"
+  master_password          = "testdatabasepassword"
+  master_username          = "test"
+  blueprint_id             = "postgres_12"
+  bundle_id                = "micro_1_0"
+  apply_immediately        = true
 }
 ```
 
@@ -102,7 +102,7 @@ resource "aws_lightsail_database" "test" {
 
 This resource supports the following arguments:
 
-* `name` - (Required) The name to use for your new Lightsail database resource. Names be unique within each AWS Region in your Lightsail account.
+* `relational_database_name` - (Required) The name to use for your new Lightsail database resource. Names be unique within each AWS Region in your Lightsail account.
 * `availability_zone` - The Availability Zone in which to create your new database. Use the us-east-2a case-sensitive format.
 * `master_database_name` - (Required) The name of the master database created when the Lightsail database resource is created.
 * `master_password` - (Sensitive) The password for the master user of your new database. The password can include any printable ASCII character except "/", """, or "@".


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The correct argument for the name of the database in `aws_lightsail_database` is `relational_database_name` instead of `name`


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
See `relational_database_name` in https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/lightsail/database.go 
