### PR TITLE
RAM: Fix acceptance test failures

### DIFF
--- a/internal/service/ram/find.go
+++ b/internal/service/ram/find.go
@@ -19,17 +19,6 @@ const (
 	FindResourceShareTimeout = 1 * time.Minute
 )
 
-// FindResourceShareOwnerOtherAccountsByARN returns the resource share owned by other accounts corresponding to the specified ARN.
-// Returns nil if no configuration is found.
-func FindResourceShareOwnerOtherAccountsByARN(ctx context.Context, conn *ram.RAM, arn string) (*ram.ResourceShare, error) {
-	listResourceSharesInput := &ram.GetResourceSharesInput{
-		ResourceOwner:     aws.String(ram.ResourceOwnerOtherAccounts),
-		ResourceShareArns: aws.StringSlice([]string{arn}),
-	}
-
-	return resourceShare(ctx, conn, listResourceSharesInput)
-}
-
 // FindResourceShareInvitationByResourceShareARNAndStatus returns the resource share invitation corresponding to the specified resource share ARN.
 // Returns nil if no configuration is found.
 func FindResourceShareInvitationByResourceShareARNAndStatus(ctx context.Context, conn *ram.RAM, resourceShareArn, status string) (*ram.ResourceShareInvitation, error) {

--- a/internal/service/ram/find.go
+++ b/internal/service/ram/find.go
@@ -30,17 +30,6 @@ func FindResourceShareOwnerOtherAccountsByARN(ctx context.Context, conn *ram.RAM
 	return resourceShare(ctx, conn, listResourceSharesInput)
 }
 
-// FindResourceShareOwnerSelfByARN returns the resource share owned by own account corresponding to the specified ARN.
-// Returns nil if no configuration is found.
-func FindResourceShareOwnerSelfByARN(ctx context.Context, conn *ram.RAM, arn string) (*ram.ResourceShare, error) {
-	listResourceSharesInput := &ram.GetResourceSharesInput{
-		ResourceOwner:     aws.String(ram.ResourceOwnerSelf),
-		ResourceShareArns: aws.StringSlice([]string{arn}),
-	}
-
-	return resourceShare(ctx, conn, listResourceSharesInput)
-}
-
 // FindResourceShareInvitationByResourceShareARNAndStatus returns the resource share invitation corresponding to the specified resource share ARN.
 // Returns nil if no configuration is found.
 func FindResourceShareInvitationByResourceShareARNAndStatus(ctx context.Context, conn *ram.RAM, resourceShareArn, status string) (*ram.ResourceShareInvitation, error) {

--- a/internal/service/ram/resource_share.go
+++ b/internal/service/ram/resource_share.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -88,7 +89,6 @@ func resourceResourceShareCreate(ctx context.Context, d *schema.ResourceData, me
 		input.PermissionArns = flex.ExpandStringSet(v.(*schema.Set))
 	}
 
-	log.Printf("[DEBUG] Creating RAM Resource Share: %s", input)
 	output, err := conn.CreateResourceShareWithContext(ctx, input)
 
 	if err != nil {
@@ -97,8 +97,16 @@ func resourceResourceShareCreate(ctx context.Context, d *schema.ResourceData, me
 
 	d.SetId(aws.StringValue(output.ResourceShare.ResourceShareArn))
 
-	if _, err = WaitResourceShareOwnedBySelfActive(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return sdkdiag.AppendErrorf(diags, "waiting for RAM Resource Share (%s) to become ready: %s", d.Id(), err)
+	_, err = tfresource.RetryWhenNotFound(ctx, FindResourceShareTimeout, func() (interface{}, error) {
+		return FindResourceShareOwnerSelfByARN(ctx, conn, d.Id())
+	})
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "waiting for RAM Resource Share (%s) create: %s", d.Id(), err)
+	}
+
+	if _, err := waitResourceShareOwnedBySelfActive(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "waiting for RAM Resource Share (%s) create: %s", d.Id(), err)
 	}
 
 	return append(diags, resourceResourceShareRead(ctx, d, meta)...)
@@ -110,7 +118,7 @@ func resourceResourceShareRead(ctx context.Context, d *schema.ResourceData, meta
 
 	resourceShare, err := FindResourceShareOwnerSelfByARN(ctx, conn, d.Id())
 
-	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, ram.ErrCodeUnknownResourceException) {
+	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] RAM Resource Share (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
@@ -120,33 +128,39 @@ func resourceResourceShareRead(ctx context.Context, d *schema.ResourceData, meta
 		return sdkdiag.AppendErrorf(diags, "reading RAM Resource Share (%s): %s", d.Id(), err)
 	}
 
-	if !d.IsNewResource() && aws.StringValue(resourceShare.Status) != ram.ResourceShareStatusActive {
-		log.Printf("[WARN] RAM Resource Share (%s) not active, removing from state", d.Id())
-		d.SetId("")
-		return diags
-	}
-
 	d.Set("allow_external_principals", resourceShare.AllowExternalPrincipals)
 	d.Set("arn", resourceShare.ResourceShareArn)
 	d.Set("name", resourceShare.Name)
 
 	setTagsOut(ctx, resourceShare.Tags)
 
-	perms, err := conn.ListResourceSharePermissionsWithContext(ctx, &ram.ListResourceSharePermissionsInput{
+	input := &ram.ListResourceSharePermissionsInput{
 		ResourceShareArn: aws.String(d.Id()),
+	}
+	var permissions []*ram.ResourceSharePermissionSummary
+
+	err = conn.ListResourceSharePermissionsPagesWithContext(ctx, input, func(page *ram.ListResourceSharePermissionsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, v := range page.Permissions {
+			if v != nil {
+				permissions = append(permissions, v)
+			}
+		}
+
+		return !lastPage
 	})
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing RAM Resource Share (%s) permissions: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading RAM Resource Share (%s) permissions: %s", d.Id(), err)
 	}
 
-	permissionARNs := make([]*string, 0, len(perms.Permissions))
-
-	for _, v := range perms.Permissions {
-		permissionARNs = append(permissionARNs, v.Arn)
-	}
-
-	d.Set("permission_arns", aws.StringValueSlice(permissionARNs))
+	permissionARNs := tfslices.ApplyToAll(permissions, func(r *ram.ResourceSharePermissionSummary) string {
+		return aws.StringValue(r.Arn)
+	})
+	d.Set("permission_arns", permissionARNs)
 
 	return diags
 }
@@ -155,14 +169,13 @@ func resourceResourceShareUpdate(ctx context.Context, d *schema.ResourceData, me
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RAMConn(ctx)
 
-	if d.HasChanges("name", "allow_external_principals") {
+	if d.HasChanges("allow_external_principals", "name") {
 		input := &ram.UpdateResourceShareInput{
 			AllowExternalPrincipals: aws.Bool(d.Get("allow_external_principals").(bool)),
 			Name:                    aws.String(d.Get("name").(string)),
 			ResourceShareArn:        aws.String(d.Id()),
 		}
 
-		log.Printf("[DEBUG] Updating RAM Resource Share: %s", input)
 		_, err := conn.UpdateResourceShareWithContext(ctx, input)
 
 		if err != nil {
@@ -190,11 +203,32 @@ func resourceResourceShareDelete(ctx context.Context, d *schema.ResourceData, me
 		return sdkdiag.AppendErrorf(diags, "deleting RAM Resource Share (%s): %s", d.Id(), err)
 	}
 
-	if _, err = WaitResourceShareOwnedBySelfDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
+	if _, err := waitResourceShareOwnedBySelfDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for RAM Resource Share (%s) delete: %s", d.Id(), err)
 	}
 
 	return diags
+}
+
+func FindResourceShareOwnerSelfByARN(ctx context.Context, conn *ram.RAM, arn string) (*ram.ResourceShare, error) {
+	input := &ram.GetResourceSharesInput{
+		ResourceOwner:     aws.String(ram.ResourceOwnerSelf),
+		ResourceShareArns: aws.StringSlice([]string{arn}),
+	}
+	output, err := findResourceShare(ctx, conn, input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if status := aws.StringValue(output.Status); status == ram.ResourceShareStatusDeleted {
+		return nil, &retry.NotFoundError{
+			Message:     status,
+			LastRequest: input,
+		}
+	}
+
+	return output, nil
 }
 
 func findResourceShare(ctx context.Context, conn *ram.RAM, input *ram.GetResourceSharesInput) (*ram.ResourceShare, error) {
@@ -236,4 +270,54 @@ func findResourceShares(ctx context.Context, conn *ram.RAM, input *ram.GetResour
 	}
 
 	return output, nil
+}
+
+func statusResourceShareOwnerSelf(ctx context.Context, conn *ram.RAM, arn string) retry.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := FindResourceShareOwnerSelfByARN(ctx, conn, arn)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, aws.StringValue(output.Status), nil
+	}
+}
+
+func waitResourceShareOwnedBySelfActive(ctx context.Context, conn *ram.RAM, arn string, timeout time.Duration) (*ram.ResourceShare, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{ram.ResourceShareStatusPending},
+		Target:  []string{ram.ResourceShareStatusActive},
+		Refresh: statusResourceShareOwnerSelf(ctx, conn, arn),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if v, ok := outputRaw.(*ram.ResourceShare); ok {
+		return v, err
+	}
+
+	return nil, err
+}
+
+func waitResourceShareOwnedBySelfDeleted(ctx context.Context, conn *ram.RAM, arn string, timeout time.Duration) (*ram.ResourceShare, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{ram.ResourceShareStatusDeleting},
+		Target:  []string{},
+		Refresh: statusResourceShareOwnerSelf(ctx, conn, arn),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if v, ok := outputRaw.(*ram.ResourceShare); ok {
+		return v, err
+	}
+
+	return nil, err
 }

--- a/internal/service/ram/resource_share.go
+++ b/internal/service/ram/resource_share.go
@@ -258,7 +258,7 @@ func findResourceShares(ctx context.Context, conn *ram.RAM, input *ram.GetResour
 		return !lastPage
 	})
 
-	if tfawserr.ErrCodeEquals(err, ram.ErrCodeUnknownResourceException) {
+	if tfawserr.ErrCodeEquals(err, ram.ErrCodeResourceArnNotFoundException, ram.ErrCodeUnknownResourceException) {
 		return nil, &retry.NotFoundError{
 			LastError:   err,
 			LastRequest: input,

--- a/internal/service/ram/resource_share_accepter.go
+++ b/internal/service/ram/resource_share_accepter.go
@@ -38,49 +38,42 @@ func ResourceResourceShareAccepter() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"share_arn": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-
 			"invitation_arn": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
-			"share_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"status": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
 			"receiver_account_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
-			"sender_account_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"share_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
 			"resources": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
+			},
+			"share_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"sender_account_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"share_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidARN,
+			},
+			"share_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 		},
 	}

--- a/internal/service/ram/resource_share_accepter.go
+++ b/internal/service/ram/resource_share_accepter.go
@@ -17,7 +17,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
-	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
@@ -141,50 +142,39 @@ func resourceResourceShareAccepterRead(ctx context.Context, d *schema.ResourceDa
 		d.Set("receiver_account_id", accountID)
 	}
 
-	resourceShare, err := FindResourceShareOwnerOtherAccountsByARN(ctx, conn, d.Id())
+	resourceShare, err := findResourceShareOwnerOtherAccountsByARN(ctx, conn, d.Id())
 
-	if !d.IsNewResource() && (tfawserr.ErrCodeEquals(err, ram.ErrCodeResourceArnNotFoundException) || tfawserr.ErrCodeEquals(err, ram.ErrCodeUnknownResourceException)) {
+	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] No RAM resource share with ARN (%s) found, removing from state", d.Id())
 		d.SetId("")
 		return diags
 	}
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "retrieving resource share: %s", err)
+		return sdkdiag.AppendErrorf(diags, "reading RAM Resource Share (%s): %s", d.Id(), err)
 	}
 
-	if resourceShare == nil {
-		return sdkdiag.AppendErrorf(diags, "getting resource share (%s): empty result", d.Id())
-	}
-
-	d.Set("status", resourceShare.Status)
 	d.Set("sender_account_id", resourceShare.OwningAccountId)
 	d.Set("share_arn", resourceShare.ResourceShareArn)
 	d.Set("share_id", resourceResourceShareGetIDFromARN(d.Id()))
 	d.Set("share_name", resourceShare.Name)
+	d.Set("status", resourceShare.Status)
 
-	listInput := &ram.ListResourcesInput{
+	inputL := &ram.ListResourcesInput{
 		MaxResults:        aws.Int64(500),
 		ResourceOwner:     aws.String(ram.ResourceOwnerOtherAccounts),
 		ResourceShareArns: aws.StringSlice([]string{d.Id()}),
 	}
-
-	var resourceARNs []*string
-	err = conn.ListResourcesPagesWithContext(ctx, listInput, func(page *ram.ListResourcesOutput, lastPage bool) bool {
-		for _, resource := range page.Resources {
-			resourceARNs = append(resourceARNs, resource.Arn)
-		}
-
-		return !lastPage
-	})
+	resources, err := findResources(ctx, conn, inputL)
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "reading RAM resource share resources %s: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading RAM Resource Share (%s) resources: %s", d.Id(), err)
 	}
 
-	if err := d.Set("resources", flex.FlattenStringList(resourceARNs)); err != nil {
-		return sdkdiag.AppendErrorf(diags, "unable to set resources: %s", err)
-	}
+	resourceARNs := tfslices.ApplyToAll(resources, func(r *ram.Resource) string {
+		return aws.StringValue(r.Arn)
+	})
+	d.Set("resources", resourceARNs)
 
 	return diags
 }
@@ -227,6 +217,22 @@ func resourceResourceShareAccepterDelete(ctx context.Context, d *schema.Resource
 
 func resourceResourceShareGetIDFromARN(arn string) string {
 	return strings.Replace(arn[strings.LastIndex(arn, ":")+1:], "resource-share/", "rs-", -1)
+}
+
+func findResourceShareOwnerOtherAccountsByARN(ctx context.Context, conn *ram.RAM, arn string) (*ram.ResourceShare, error) {
+	input := &ram.GetResourceSharesInput{
+		ResourceOwner:     aws.String(ram.ResourceOwnerOtherAccounts),
+		ResourceShareArns: aws.StringSlice([]string{arn}),
+	}
+	output, err := findResourceShare(ctx, conn, input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Deleted resource share OK.
+
+	return output, nil
 }
 
 func findResources(ctx context.Context, conn *ram.RAM, input *ram.ListResourcesInput) ([]*ram.Resource, error) {

--- a/internal/service/ram/resource_share_accepter_test.go
+++ b/internal/service/ram/resource_share_accepter_test.go
@@ -21,6 +21,16 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
+func init() {
+	acctest.RegisterServiceErrorCheckFunc(ram.EndpointsID, testAccErrorCheckSkip)
+}
+
+func testAccErrorCheckSkip(t *testing.T) resource.ErrorCheckFunc {
+	return acctest.ErrorCheckSkipMessagesContaining(t,
+		"this resource is not necessary",
+	)
+}
+
 func TestAccRAMResourceShareAccepter_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ram_resource_share_accepter.test"

--- a/internal/service/ram/resource_share_test.go
+++ b/internal/service/ram/resource_share_test.go
@@ -9,7 +9,6 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ram"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -17,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfram "github.com/hashicorp/terraform-provider-aws/internal/service/ram"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func TestAccRAMResourceShare_basic(t *testing.T) {
@@ -224,27 +224,19 @@ func TestAccRAMResourceShare_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckResourceShareExists(ctx context.Context, resourceName string, v *ram.ResourceShare) resource.TestCheckFunc {
+func testAccCheckResourceShareExists(ctx context.Context, n string, v *ram.ResourceShare) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).RAMConn(ctx)
 
-		rs, ok := s.RootModule().Resources[resourceName]
+		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
+			return fmt.Errorf("Not found: %s", n)
 		}
 
 		output, err := tfram.FindResourceShareOwnerSelfByARN(ctx, conn, rs.Primary.ID)
 
 		if err != nil {
 			return err
-		}
-
-		if aws.StringValue(output.Status) != ram.ResourceShareStatusActive {
-			return fmt.Errorf("RAM resource share (%s) delet(ing|ed)", rs.Primary.ID)
 		}
 
 		*v = *output
@@ -262,15 +254,17 @@ func testAccCheckResourceShareDestroy(ctx context.Context) resource.TestCheckFun
 				continue
 			}
 
-			resourceShare, err := tfram.FindResourceShareOwnerSelfByARN(ctx, conn, rs.Primary.ID)
+			_, err := tfram.FindResourceShareOwnerSelfByARN(ctx, conn, rs.Primary.ID)
+
+			if tfresource.NotFound(err) {
+				continue
+			}
 
 			if err != nil {
 				return err
 			}
 
-			if aws.StringValue(resourceShare.Status) != ram.ResourceShareStatusDeleted {
-				return fmt.Errorf("RAM resource share (%s) still exists", rs.Primary.ID)
-			}
+			return fmt.Errorf("RAM Resource Share %s still exists", rs.Primary.ID)
 		}
 
 		return nil

--- a/internal/service/ram/status.go
+++ b/internal/service/ram/status.go
@@ -17,9 +17,6 @@ const (
 	ResourceShareInvitationStatusNotFound = "NotFound"
 	ResourceShareInvitationStatusUnknown  = "Unknown"
 
-	ResourceShareStatusNotFound = "NotFound"
-	ResourceShareStatusUnknown  = "Unknown"
-
 	PrincipalAssociationStatusNotFound = "NotFound"
 )
 
@@ -37,27 +34,6 @@ func StatusResourceShareInvitation(ctx context.Context, conn *ram.RAM, arn strin
 		}
 
 		return invitation, aws.StringValue(invitation.Status), nil
-	}
-}
-
-// StatusResourceShareOwnerSelf fetches the ResourceShare and its Status
-func StatusResourceShareOwnerSelf(ctx context.Context, conn *ram.RAM, arn string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		share, err := FindResourceShareOwnerSelfByARN(ctx, conn, arn)
-
-		if tfawserr.ErrCodeEquals(err, ram.ErrCodeUnknownResourceException) {
-			return nil, ResourceShareStatusNotFound, nil
-		}
-
-		if err != nil {
-			return nil, ResourceShareStatusUnknown, err
-		}
-
-		if share == nil {
-			return nil, ResourceShareStatusNotFound, nil
-		}
-
-		return share, aws.StringValue(share.Status), nil
 	}
 }
 

--- a/internal/service/ram/wait.go
+++ b/internal/service/ram/wait.go
@@ -39,43 +39,7 @@ func WaitResourceShareOwnedBySelfDisassociated(ctx context.Context, conn *ram.RA
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{ram.ResourceShareAssociationStatusAssociated},
 		Target:  []string{},
-		Refresh: StatusResourceShareOwnerSelf(ctx, conn, arn),
-		Timeout: timeout,
-	}
-
-	outputRaw, err := stateConf.WaitForStateContext(ctx)
-
-	if v, ok := outputRaw.(*ram.ResourceShare); ok {
-		return v, err
-	}
-
-	return nil, err
-}
-
-// WaitResourceShareOwnedBySelfActive waits for a ResourceShare owned by own account to return ACTIVE
-func WaitResourceShareOwnedBySelfActive(ctx context.Context, conn *ram.RAM, arn string, timeout time.Duration) (*ram.ResourceShare, error) {
-	stateConf := &retry.StateChangeConf{
-		Pending: []string{ram.ResourceShareStatusPending},
-		Target:  []string{ram.ResourceShareStatusActive},
-		Refresh: StatusResourceShareOwnerSelf(ctx, conn, arn),
-		Timeout: timeout,
-	}
-
-	outputRaw, err := stateConf.WaitForStateContext(ctx)
-
-	if v, ok := outputRaw.(*ram.ResourceShare); ok {
-		return v, err
-	}
-
-	return nil, err
-}
-
-// WaitResourceShareOwnedBySelfDeleted waits for a ResourceShare owned by own account to return DELETED
-func WaitResourceShareOwnedBySelfDeleted(ctx context.Context, conn *ram.RAM, arn string, timeout time.Duration) (*ram.ResourceShare, error) {
-	stateConf := &retry.StateChangeConf{
-		Pending: []string{ram.ResourceShareStatusDeleting},
-		Target:  []string{ram.ResourceShareStatusDeleted},
-		Refresh: StatusResourceShareOwnerSelf(ctx, conn, arn),
+		Refresh: statusResourceShareOwnerSelf(ctx, conn, arn),
 		Timeout: timeout,
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

In CI:

```
=== RUN   TestAccRAMResourceShareAccepter_basic
=== PAUSE TestAccRAMResourceShareAccepter_basic
=== CONT  TestAccRAMResourceShareAccepter_basic
    resource_share_accepter_test.go:30: Step 1/2 error: Error running apply: exit status 1
        Error: No RAM Resource Share (arn:aws:ram:us-west-2:067819342479:resource-share/0623b688-527d-4869-9577-ebd7d14ddf29) invitation found
        NOTE: If both AWS accounts are in the same AWS Organization and RAM Sharing with AWS Organizations is enabled, this resource is not necessary
          with aws_ram_resource_share_accepter.test,
          on terraform_plugin_test.tf line 8, in resource "aws_ram_resource_share_accepter" "test":
           8: resource "aws_ram_resource_share_accepter" "test" {
--- FAIL: TestAccRAMResourceShareAccepter_basic (330.92s)
```

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccRAMResourceShare_' PKG=ram ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ram/... -v -count 1 -parallel 2  -run=TestAccRAMResourceShare_ -timeout 180m
=== RUN   TestAccRAMResourceShare_basic
=== PAUSE TestAccRAMResourceShare_basic
=== RUN   TestAccRAMResourceShare_permission
=== PAUSE TestAccRAMResourceShare_permission
=== RUN   TestAccRAMResourceShare_allowExternalPrincipals
=== PAUSE TestAccRAMResourceShare_allowExternalPrincipals
=== RUN   TestAccRAMResourceShare_name
=== PAUSE TestAccRAMResourceShare_name
=== RUN   TestAccRAMResourceShare_tags
=== PAUSE TestAccRAMResourceShare_tags
=== RUN   TestAccRAMResourceShare_disappears
=== PAUSE TestAccRAMResourceShare_disappears
=== CONT  TestAccRAMResourceShare_basic
=== CONT  TestAccRAMResourceShare_name
--- PASS: TestAccRAMResourceShare_basic (30.11s)
=== CONT  TestAccRAMResourceShare_allowExternalPrincipals
--- PASS: TestAccRAMResourceShare_name (51.37s)
=== CONT  TestAccRAMResourceShare_permission
--- PASS: TestAccRAMResourceShare_permission (28.48s)
=== CONT  TestAccRAMResourceShare_disappears
--- PASS: TestAccRAMResourceShare_allowExternalPrincipals (50.81s)
=== CONT  TestAccRAMResourceShare_tags
--- PASS: TestAccRAMResourceShare_disappears (22.63s)
--- PASS: TestAccRAMResourceShare_tags (63.67s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ram	149.404s
```
```console
% make testacc TESTARGS='-run=TestAccRAMResourceShareAccepter_' PKG=ram ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ram/... -v -count 1 -parallel 2  -run=TestAccRAMResourceShareAccepter_ -timeout 180m
=== RUN   TestAccRAMResourceShareAccepter_basic
=== PAUSE TestAccRAMResourceShareAccepter_basic
=== RUN   TestAccRAMResourceShareAccepter_disappears
=== PAUSE TestAccRAMResourceShareAccepter_disappears
=== RUN   TestAccRAMResourceShareAccepter_resourceAssociation
=== PAUSE TestAccRAMResourceShareAccepter_resourceAssociation
=== CONT  TestAccRAMResourceShareAccepter_basic
=== CONT  TestAccRAMResourceShareAccepter_resourceAssociation
    acctest.go:1419: skipping test for aws/us-west-2: Error running apply: exit status 1
        
        Error: No RAM Resource Share (arn:aws:ram:us-west-2:123456789012:resource-share/8a8faef8-667e-4925-833b-e512dd1894ba) invitation found
        
        NOTE: If both AWS accounts are in the same AWS Organization and RAM Sharing with AWS Organizations is enabled, this resource is not necessary
        
          with aws_ram_resource_share_accepter.test,
          on terraform_plugin_test.tf line 8, in resource "aws_ram_resource_share_accepter" "test":
           8: resource "aws_ram_resource_share_accepter" "test" {
        
=== NAME  TestAccRAMResourceShareAccepter_basic
    acctest.go:1419: skipping test for aws/us-west-2: Error running apply: exit status 1
        
        Error: No RAM Resource Share (arn:aws:ram:us-west-2:123456789012:resource-share/9543c6c9-5323-44d9-80a3-943abc230528) invitation found
        
        NOTE: If both AWS accounts are in the same AWS Organization and RAM Sharing with AWS Organizations is enabled, this resource is not necessary
        
          with aws_ram_resource_share_accepter.test,
          on terraform_plugin_test.tf line 8, in resource "aws_ram_resource_share_accepter" "test":
           8: resource "aws_ram_resource_share_accepter" "test" {
        
--- SKIP: TestAccRAMResourceShareAccepter_basic (142.83s)
=== CONT  TestAccRAMResourceShareAccepter_disappears
--- SKIP: TestAccRAMResourceShareAccepter_resourceAssociation (146.49s)
=== NAME  TestAccRAMResourceShareAccepter_disappears
    acctest.go:1419: skipping test for aws/us-west-2: Error running apply: exit status 1
        
        Error: No RAM Resource Share (arn:aws:ram:us-west-2:123456789012:resource-share/80b8309b-8d8b-4740-a7fd-4470a92abfd8) invitation found
        
        NOTE: If both AWS accounts are in the same AWS Organization and RAM Sharing with AWS Organizations is enabled, this resource is not necessary
        
          with aws_ram_resource_share_accepter.test,
          on terraform_plugin_test.tf line 8, in resource "aws_ram_resource_share_accepter" "test":
           8: resource "aws_ram_resource_share_accepter" "test" {
        
--- SKIP: TestAccRAMResourceShareAccepter_disappears (139.14s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ram	286.846s
```