### PR TITLE
OpsWorks: Fix acceptance test failures

### DIFF
--- a/internal/service/opsworks/rds_db_instance_test.go
+++ b/internal/service/opsworks/rds_db_instance_test.go
@@ -175,8 +175,8 @@ resource "aws_opsworks_rds_db_instance" "test" {
   stack_id = aws_opsworks_stack.test.id
 
   rds_db_instance_arn = aws_db_instance.test.arn
-  db_user             = %[1]q
-  db_password         = %[2]q
+  db_user             = %[2]q
+  db_password         = %[3]q
 }
-`, userName, password))
+`, rName, userName, password))
 }

--- a/internal/service/opsworks/rds_db_instance_test.go
+++ b/internal/service/opsworks/rds_db_instance_test.go
@@ -143,9 +143,13 @@ func testAccCheckRDSDBInstanceDestroy(ctx context.Context) resource.TestCheckFun
 
 func testAccRDSDBInstanceConfig_basic(rName, userName, password string) string {
 	return acctest.ConfigCompose(testAccStackConfig_basic(rName), fmt.Sprintf(`
+data "aws_rds_engine_version" "default" {
+  engine = "mysql"
+}
+
 data "aws_rds_orderable_db_instance" "test" {
-  engine         = "mysql"
-  engine_version = "8.0.25"
+  engine         = data.aws_rds_engine_version.default.engine
+  engine_version = data.aws_rds_engine_version.default.version
   license_model  = "general-public-license"
   storage_type   = "standard"
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

In CI:

```
=== RUN   TestAccOpsWorksRDSDBInstance_basic
=== PAUSE TestAccOpsWorksRDSDBInstance_basic
=== CONT  TestAccOpsWorksRDSDBInstance_basic
    rds_db_instance_test.go:31: Step 1/3 error: Error running pre-apply refresh: exit status 1
        Error: reading RDS Orderable DB Instance Options: InvalidParameterCombination: Cannot find version 8.0.25 for mysql
          status code: 400, request id: 45e8b364-2b45-411b-bd13-d72fae3386ea
          with data.aws_rds_orderable_db_instance.test,
          on terraform_plugin_test.tf line 103, in data "aws_rds_orderable_db_instance" "test":
         103: data "aws_rds_orderable_db_instance" "test" {
--- FAIL: TestAccOpsWorksRDSDBInstance_basic (44.28s)
```

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccOpsWorksRDSDBInstance_' PKG=opsworks ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/opsworks/... -v -count 1 -parallel 2  -run=TestAccOpsWorksRDSDBInstance_ -timeout 180m
=== RUN   TestAccOpsWorksRDSDBInstance_basic
=== PAUSE TestAccOpsWorksRDSDBInstance_basic
=== RUN   TestAccOpsWorksRDSDBInstance_disappears
=== PAUSE TestAccOpsWorksRDSDBInstance_disappears
=== CONT  TestAccOpsWorksRDSDBInstance_basic
=== CONT  TestAccOpsWorksRDSDBInstance_disappears
--- PASS: TestAccOpsWorksRDSDBInstance_disappears (543.59s)
--- PASS: TestAccOpsWorksRDSDBInstance_basic (700.97s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/opsworks	705.971s
```
