### PR TITLE
docs/r/lb: Support security groups for NLB

### DIFF
--- a/website/docs/r/lb.html.markdown
+++ b/website/docs/r/lb.html.markdown
@@ -119,7 +119,7 @@ This argument supports the following arguments:
 must contain only alphanumeric characters or hyphens, and must not begin or end with a hyphen. If not specified,
 Terraform will autogenerate a name beginning with `tf-lb`.
 * `name_prefix` - (Optional) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
-* `security_groups` - (Optional) A list of security group IDs to assign to the LB. Only valid for Load Balancers of type `application`.
+* `security_groups` - (Optional) A list of security group IDs to assign to the LB. Possible values for Load Balancers are either `application` or `network`.
 * `preserve_host_header` - (Optional) Indicates whether the Application Load Balancer should preserve the Host header in the HTTP request and send it to the target without any change. Defaults to `false`.
 * `subnet_mapping` - (Optional) A subnet mapping block as documented below.
 * `subnets` - (Optional) A list of subnet IDs to attach to the LB. Subnets


### PR DESCRIPTION
### Description
AWS released to support security groups for NLB. Thus updated documents.
https://aws.amazon.com/jp/about-aws/whats-new/2023/08/network-load-balancer-supports-security-groups/

No implementation updates are needed.

Closes #33009