### PR TITLE
Fix `issue_comment` workflow

### DIFF
--- a/.github/workflows/issue_comment.yml
+++ b/.github/workflows/issue_comment.yml
@@ -16,6 +16,8 @@ jobs:
     name: 'Automation Labeler'
     needs: community_check
     runs-on: ubuntu-latest
+    # Since the only step in this job requires non-maintainer, skip the job entirely if that's not met.
+    if: needs.community_check.outputs.maintainer == 'false'
     env:
       # This is a ternary that sets the variable to the assigned user's login on assigned events,
       # and otherwise sets it to the username of the pull request's author. For more information:


### PR DESCRIPTION
### Description

The `issue_comment` workflow was intended to only remove `waiting-response` and `stale` when a non-maintainer commented on issues/pull requests. Since the conditional was missing, it was running when maintainers commented too.

### Output from Acceptance Testing

N/a, workflow