### PR TITLE
r/aws_quicksight: adjust definition.*.calculated_fields.*.expression max length to 32000

### DIFF
--- a/.changelog/33012.txt
+++ b/.changelog/33012.txt
@@ -1,0 +1,15 @@
+```release-note:bug
+resource/aws_quicksight_analysis: Adjust max length of `definition.*.calculated_fields.*.expression` to 32000 characters
+```
+
+```release-note:bug
+resource/aws_quicksight_dashboard: Adjust max length of `definition.*.calculated_fields.*.expression` to 32000 characters
+```
+
+```release-note:bug
+resource/aws_quicksight_template: Adjust max length of `definition.*.calculated_fields.*.expression` to 32000 characters
+```
+
+```release-note:bug
+resource/aws_quicksight_template: Adjust max items of `definition.*.calculated_fields` to 500
+```

--- a/internal/service/quicksight/schema/analysis.go
+++ b/internal/service/quicksight/schema/analysis.go
@@ -25,19 +25,7 @@ func AnalysisDefinitionSchema() *schema.Schema {
 			Schema: map[string]*schema.Schema{
 				"data_set_identifiers_declarations": dataSetIdentifierDeclarationsSchema(), // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_DataSetIdentifierDeclaration.html
 				"analysis_defaults":                 analysisDefaultSchema(),               // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_AnalysisDefaults.html
-				"calculated_fields": { // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_CalculatedField.html
-					Type:     schema.TypeList,
-					MinItems: 1,
-					MaxItems: 500,
-					Optional: true,
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"data_set_identifier": stringSchema(true, validation.StringLenBetween(1, 2048)),
-							"expression":          stringSchema(true, validation.StringLenBetween(1, 4096)),
-							"name":                stringSchema(true, validation.StringLenBetween(1, 128)),
-						},
-					},
-				},
+				"calculated_fields":                 calculatedFieldsSchema(),              // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_CalculatedField.html
 				"column_configurations": { // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_ColumnConfiguration.html
 					Type:     schema.TypeList,
 					MinItems: 1,

--- a/internal/service/quicksight/schema/dashboard.go
+++ b/internal/service/quicksight/schema/dashboard.go
@@ -25,19 +25,7 @@ func DashboardDefinitionSchema() *schema.Schema {
 			Schema: map[string]*schema.Schema{
 				"data_set_identifiers_declarations": dataSetIdentifierDeclarationsSchema(), // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_DataSetIdentifierDeclaration.html
 				"analysis_defaults":                 analysisDefaultSchema(),               // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_AnalysisDefaults.html
-				"calculated_fields": { // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_CalculatedField.html
-					Type:     schema.TypeList,
-					MinItems: 1,
-					MaxItems: 500,
-					Optional: true,
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"data_set_identifier": stringSchema(true, validation.StringLenBetween(1, 2048)),
-							"expression":          stringSchema(true, validation.StringLenBetween(1, 4096)),
-							"name":                stringSchema(true, validation.StringLenBetween(1, 128)),
-						},
-					},
-				},
+				"calculated_fields":                 calculatedFieldsSchema(),              // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_CalculatedField.html
 				"column_configurations": { // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_ColumnConfiguration.html
 					Type:     schema.TypeList,
 					MinItems: 1,

--- a/internal/service/quicksight/schema/template.go
+++ b/internal/service/quicksight/schema/template.go
@@ -27,19 +27,7 @@ func TemplateDefinitionSchema() *schema.Schema {
 			Schema: map[string]*schema.Schema{
 				"data_set_configuration": dataSetConfigurationSchema(), // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_DataSetConfiguration.html
 				"analysis_defaults":      analysisDefaultSchema(),      // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_AnalysisDefaults.html
-				"calculated_fields": { // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_CalculatedField.html
-					Type:     schema.TypeList,
-					MinItems: 1,
-					MaxItems: 100,
-					Optional: true,
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"data_set_identifier": stringSchema(true, validation.StringLenBetween(1, 2048)),
-							"expression":          stringSchema(true, validation.StringLenBetween(1, 4096)),
-							"name":                stringSchema(true, validation.StringLenBetween(1, 128)),
-						},
-					},
-				},
+				"calculated_fields":      calculatedFieldsSchema(),     // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_CalculatedField.html
 				"column_configurations": { // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_ColumnConfiguration.html
 					Type:     schema.TypeList,
 					MinItems: 1,
@@ -172,6 +160,22 @@ func aggregationFunctionSchema(required bool) *schema.Schema {
 				"categorical_aggregation_function": stringSchema(false, validation.StringInSlice(quicksight.CategoricalAggregationFunction_Values(), false)),
 				"date_aggregation_function":        stringSchema(false, validation.StringInSlice(quicksight.DateAggregationFunction_Values(), false)),
 				"numerical_aggregation_function":   numericalAggregationFunctionSchema(false), // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_NumericalAggregationFunction.html
+			},
+		},
+	}
+}
+
+func calculatedFieldsSchema() *schema.Schema {
+	return &schema.Schema{ // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_CalculatedField.html
+		Type:     schema.TypeList,
+		MinItems: 1,
+		MaxItems: 500,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"data_set_identifier": stringSchema(true, validation.StringLenBetween(1, 2048)),
+				"expression":          stringSchema(true, validation.StringLenBetween(1, 32000)),
+				"name":                stringSchema(true, validation.StringLenBetween(1, 128)),
 			},
 		},
 	}


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
- Adjusts the max length of the nested `expression` field to 32000 characters. 
- Bumps the template `expression` list MaxItems to 500.
- Centralizes `expression` schema to a generation function since it is shared across several resources. 


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #32986

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/quicksight/latest/APIReference/API_CalculatedField.html
- https://docs.aws.amazon.com/quicksight/latest/APIReference/API_TemplateVersionDefinition.html#QS-Type-TemplateVersionDefinition-CalculatedFields (maximum of 500 items)


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
%  make testacc PKG=quicksight TESTARGS="-run TestAccQuickSightAnalysis_\|TestAccQuickSightDashboard_\|TestAccQuickSightTemplate_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/quicksight/... -v -count 1 -parallel 20  -run TestAccQuickSightAnalysis_\|TestAccQuickSightDashboard_\|TestAccQuickSightTemplate_ -timeout 180m
?       github.com/hashicorp/terraform-provider-aws/internal/service/quicksight/schema  [no test files]

--- PASS: TestAccQuickSightTemplate_disappears (73.66s)
--- PASS: TestAccQuickSightTemplate_barChart (82.50s)
--- PASS: TestAccQuickSightTemplate_basic (86.77s)
--- PASS: TestAccQuickSightDashboard_disappears (91.75s)
--- PASS: TestAccQuickSightAnalysis_disappears (92.77s)
--- PASS: TestAccQuickSightAnalysis_forceDelete (93.40s)
--- PASS: TestAccQuickSightDashboard_dashboardSpecificConfig (97.52s)
--- PASS: TestAccQuickSightAnalysis_basic (99.66s)
--- PASS: TestAccQuickSightDashboard_basic (100.06s)
--- PASS: TestAccQuickSightAnalysis_parametersConfig (100.08s)
--- PASS: TestAccQuickSightTemplate_sourceEntity (101.66s)
--- PASS: TestAccQuickSightAnalysis_sourceEntity (103.37s)
--- PASS: TestAccQuickSightDashboard_sourceEntity (103.76s)
--- PASS: TestAccQuickSightTemplate_table (118.90s)
--- PASS: TestAccQuickSightTemplate_update (129.51s)
--- PASS: TestAccQuickSightDashboard_updateVersionNumber (142.11s)
--- PASS: TestAccQuickSightAnalysis_update (143.19s)
--- PASS: TestAccQuickSightTemplate_tags (146.86s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/quicksight 149.884s
```
