### PR TITLE
ressource/aws_budgets_budget_action : No longer waits for action to have completed running or be pending

### DIFF
--- a/.changelog/33015.txt
+++ b/.changelog/33015.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_budgets_budget_action: No longer times out when creating a non-triggered action
+```

--- a/internal/service/budgets/budget_action.go
+++ b/internal/service/budgets/budget_action.go
@@ -438,22 +438,6 @@ func FindActionByThreePartKey(ctx context.Context, conn *budgets.Budgets, accoun
 	return output.Action, nil
 }
 
-func statusAction(ctx context.Context, conn *budgets.Budgets, accountID, actionID, budgetName string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		output, err := FindActionByThreePartKey(ctx, conn, accountID, actionID, budgetName)
-
-		if tfresource.NotFound(err) {
-			return nil, "", nil
-		}
-
-		if err != nil {
-			return nil, "", err
-		}
-
-		return output, aws.StringValue(output.Status), nil
-	}
-}
-
 func expandBudgetActionActionThreshold(l []interface{}) *budgets.ActionThreshold {
 	if len(l) == 0 || l[0] == nil {
 		return nil

--- a/internal/service/budgets/budget_action_test.go
+++ b/internal/service/budgets/budget_action_test.go
@@ -149,6 +149,40 @@ func testAccCheckBudgetActionDestroy(ctx context.Context) resource.TestCheckFunc
 
 func testAccBudgetActionConfig_basic(rName string) string {
 	return fmt.Sprintf(`
+resource "aws_budgets_budget_action" "test" {
+  budget_name        = aws_budgets_budget.test.name
+  action_type        = "APPLY_IAM_POLICY"
+  approval_model     = "AUTOMATIC"
+  notification_type  = "ACTUAL"
+  execution_role_arn = aws_iam_role.test.arn
+
+  action_threshold {
+    action_threshold_type  = "ABSOLUTE_VALUE"
+    action_threshold_value = 100
+  }
+
+  definition {
+    iam_action_definition {
+      policy_arn = aws_iam_policy.test.arn
+      roles      = [aws_iam_role.test.name]
+    }
+  }
+
+  subscriber {
+    address           = "test@test.test"
+    subscription_type = "EMAIL"
+  }
+}
+
+resource "aws_budgets_budget" "test" {
+  name              = %[1]q
+  budget_type       = "USAGE"
+  limit_amount      = "1.0"
+  limit_unit        = "dollars"
+  time_period_start = "2006-01-02_15:04"
+  time_unit         = "MONTHLY"
+}
+
 resource "aws_iam_policy" "test" {
   name        = %[1]q
   description = "My test policy"

--- a/internal/service/budgets/budget_action_test.go
+++ b/internal/service/budgets/budget_action_test.go
@@ -25,6 +25,8 @@ func TestAccBudgetsBudgetAction_basic(t *testing.T) {
 	resourceName := "aws_budgets_budget_action.test"
 	var conf budgets.Action
 
+	const thresholdValue = "1000000000"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, budgets.EndpointsID) },
 		ErrorCheck:               acctest.ErrorCheck(t, budgets.EndpointsID),
@@ -32,23 +34,112 @@ func TestAccBudgetsBudgetAction_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckBudgetActionDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBudgetActionConfig_basic(rName),
+				Config: testAccBudgetActionConfig_basic(rName, budgets.ApprovalModelAutomatic, thresholdValue),
 				Check: resource.ComposeTestCheckFunc(
 					testAccBudgetActionExists(ctx, resourceName, &conf),
 					acctest.MatchResourceAttrGlobalARN(resourceName, "arn", "budgets", regexp.MustCompile(fmt.Sprintf(`budget/%s/action/.+`, rName))),
 					resource.TestCheckResourceAttrPair(resourceName, "budget_name", "aws_budgets_budget.test", "name"),
 					resource.TestCheckResourceAttrPair(resourceName, "execution_role_arn", "aws_iam_role.test", "arn"),
 					resource.TestCheckResourceAttr(resourceName, "action_type", "APPLY_IAM_POLICY"),
-					resource.TestCheckResourceAttr(resourceName, "approval_model", "AUTOMATIC"),
+					resource.TestCheckResourceAttr(resourceName, "approval_model", budgets.ApprovalModelAutomatic),
 					resource.TestCheckResourceAttr(resourceName, "notification_type", "ACTUAL"),
 					resource.TestCheckResourceAttr(resourceName, "action_threshold.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "action_threshold.0.action_threshold_type", "ABSOLUTE_VALUE"),
-					resource.TestCheckResourceAttr(resourceName, "action_threshold.0.action_threshold_value", "100"),
+					resource.TestCheckResourceAttr(resourceName, "action_threshold.0.action_threshold_value", thresholdValue),
 					resource.TestCheckResourceAttr(resourceName, "definition.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "definition.0.iam_action_definition.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "definition.0.iam_action_definition.0.policy_arn", "aws_iam_policy.test", "arn"),
 					resource.TestCheckResourceAttr(resourceName, "definition.0.iam_action_definition.0.roles.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "subscriber.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "status", budgets.ActionStatusStandby),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccBudgetsBudgetAction_triggeredAutomatic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_budgets_budget_action.test"
+	var conf budgets.Action
+
+	const thresholdValue = "100"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, budgets.EndpointsID) },
+		ErrorCheck:               acctest.ErrorCheck(t, budgets.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckBudgetActionDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBudgetActionConfig_basic(rName, budgets.ApprovalModelAutomatic, thresholdValue),
+				Check: resource.ComposeTestCheckFunc(
+					testAccBudgetActionExists(ctx, resourceName, &conf),
+					acctest.MatchResourceAttrGlobalARN(resourceName, "arn", "budgets", regexp.MustCompile(fmt.Sprintf(`budget/%s/action/.+`, rName))),
+					resource.TestCheckResourceAttrPair(resourceName, "budget_name", "aws_budgets_budget.test", "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "execution_role_arn", "aws_iam_role.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "action_type", "APPLY_IAM_POLICY"),
+					resource.TestCheckResourceAttr(resourceName, "approval_model", budgets.ApprovalModelAutomatic),
+					resource.TestCheckResourceAttr(resourceName, "notification_type", "ACTUAL"),
+					resource.TestCheckResourceAttr(resourceName, "action_threshold.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "action_threshold.0.action_threshold_type", "ABSOLUTE_VALUE"),
+					resource.TestCheckResourceAttr(resourceName, "action_threshold.0.action_threshold_value", thresholdValue),
+					resource.TestCheckResourceAttr(resourceName, "definition.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "definition.0.iam_action_definition.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "definition.0.iam_action_definition.0.policy_arn", "aws_iam_policy.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "definition.0.iam_action_definition.0.roles.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "subscriber.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccBudgetsBudgetAction_triggeredManual(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_budgets_budget_action.test"
+	var conf budgets.Action
+
+	const thresholdValue = "100"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, budgets.EndpointsID) },
+		ErrorCheck:               acctest.ErrorCheck(t, budgets.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckBudgetActionDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBudgetActionConfig_basic(rName, budgets.ApprovalModelManual, thresholdValue),
+				Check: resource.ComposeTestCheckFunc(
+					testAccBudgetActionExists(ctx, resourceName, &conf),
+					acctest.MatchResourceAttrGlobalARN(resourceName, "arn", "budgets", regexp.MustCompile(fmt.Sprintf(`budget/%s/action/.+`, rName))),
+					resource.TestCheckResourceAttrPair(resourceName, "budget_name", "aws_budgets_budget.test", "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "execution_role_arn", "aws_iam_role.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "action_type", "APPLY_IAM_POLICY"),
+					resource.TestCheckResourceAttr(resourceName, "approval_model", budgets.ApprovalModelManual),
+					resource.TestCheckResourceAttr(resourceName, "notification_type", "ACTUAL"),
+					resource.TestCheckResourceAttr(resourceName, "action_threshold.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "action_threshold.0.action_threshold_type", "ABSOLUTE_VALUE"),
+					resource.TestCheckResourceAttr(resourceName, "action_threshold.0.action_threshold_value", thresholdValue),
+					resource.TestCheckResourceAttr(resourceName, "definition.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "definition.0.iam_action_definition.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "definition.0.iam_action_definition.0.policy_arn", "aws_iam_policy.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "definition.0.iam_action_definition.0.roles.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "subscriber.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "status"), // Race condition between "STANDBY" and "PENDING"
 				),
 			},
 			{
@@ -73,7 +164,7 @@ func TestAccBudgetsBudgetAction_disappears(t *testing.T) {
 		CheckDestroy:             testAccCheckBudgetActionDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBudgetActionConfig_basic(rName),
+				Config: testAccBudgetActionConfig_basic(rName, budgets.ApprovalModelAutomatic, "100"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccBudgetActionExists(ctx, resourceName, &conf),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfbudgets.ResourceBudgetAction(), resourceName),
@@ -147,18 +238,18 @@ func testAccCheckBudgetActionDestroy(ctx context.Context) resource.TestCheckFunc
 	}
 }
 
-func testAccBudgetActionConfig_basic(rName string) string {
+func testAccBudgetActionConfig_basic(rName, approvalModel, thresholdValue string) string {
 	return fmt.Sprintf(`
 resource "aws_budgets_budget_action" "test" {
   budget_name        = aws_budgets_budget.test.name
   action_type        = "APPLY_IAM_POLICY"
-  approval_model     = "AUTOMATIC"
+  approval_model     = %[2]q
   notification_type  = "ACTUAL"
   execution_role_arn = aws_iam_role.test.arn
 
   action_threshold {
     action_threshold_type  = "ABSOLUTE_VALUE"
-    action_threshold_value = 100
+    action_threshold_value = %[3]s
   }
 
   definition {
@@ -169,7 +260,7 @@ resource "aws_budgets_budget_action" "test" {
   }
 
   subscriber {
-    address           = "test@test.test"
+    address           = %[4]q
     subscription_type = "EMAIL"
   }
 }
@@ -227,39 +318,5 @@ resource "aws_iam_role" "test" {
 }
 EOF
 }
-
-resource "aws_budgets_budget" "test" {
-  name              = %[1]q
-  budget_type       = "USAGE"
-  limit_amount      = "10.0"
-  limit_unit        = "dollars"
-  time_period_start = "2006-01-02_15:04"
-  time_unit         = "MONTHLY"
-}
-
-resource "aws_budgets_budget_action" "test" {
-  budget_name        = aws_budgets_budget.test.name
-  action_type        = "APPLY_IAM_POLICY"
-  approval_model     = "AUTOMATIC"
-  notification_type  = "ACTUAL"
-  execution_role_arn = aws_iam_role.test.arn
-
-  action_threshold {
-    action_threshold_type  = "ABSOLUTE_VALUE"
-    action_threshold_value = 100
-  }
-
-  definition {
-    iam_action_definition {
-      policy_arn = aws_iam_policy.test.arn
-      roles      = [aws_iam_role.test.name]
-    }
-  }
-
-  subscriber {
-    address           = "test@test.test"
-    subscription_type = "EMAIL"
-  }
-}
-`, rName)
+`, rName, approvalModel, thresholdValue, acctest.DefaultEmailAddress)
 }


### PR DESCRIPTION
### Description

The current behaviour of `aws_budgets_budget_action` waits for the action to have completed or be in a pending state for manual approval. If a budget action is not triggered, none of these states will be valid, and the action will be in standby status.

No longer waits for any status, since creation of an action is a synchronous operation. Adds guard to deletion, since an action cannot be deleted while in progress.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #31236


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=budgets TESTS=TestAccBudgetsBudgetAction_

--- PASS: TestAccBudgetsBudgetAction_disappears (27.60s)
--- PASS: TestAccBudgetsBudgetAction_triggeredAutomatic (30.49s)
--- PASS: TestAccBudgetsBudgetAction_basic (30.62s)
--- PASS: TestAccBudgetsBudgetAction_triggeredManual (30.62s)
```
