### PR TITLE
r/aws_quicksight_template: table header style font_configuration schema adjustments

### DIFF
--- a/internal/service/quicksight/schema/template_control.go
+++ b/internal/service/quicksight/schema/template_control.go
@@ -1209,7 +1209,7 @@ func flattenFontConfiguration(apiObject *quicksight.FontConfiguration) []interfa
 }
 
 func flattenFontSize(apiObject *quicksight.FontSize) []interface{} {
-	if apiObject == nil {
+	if apiObject == nil || apiObject.Relative == nil {
 		return nil
 	}
 
@@ -1222,7 +1222,7 @@ func flattenFontSize(apiObject *quicksight.FontSize) []interface{} {
 }
 
 func flattenFontWeight(apiObject *quicksight.FontWeight) []interface{} {
-	if apiObject == nil {
+	if apiObject == nil || apiObject.Name == nil {
 		return nil
 	}
 

--- a/internal/service/quicksight/schema/template_format.go
+++ b/internal/service/quicksight/schema/template_format.go
@@ -232,7 +232,6 @@ func fontConfigurationSchema() *schema.Schema {
 				"font_decoration": stringSchema(false, validation.StringInSlice(quicksight.FontDecoration_Values(), false)),
 				"font_size": { // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_FontSize.html
 					Type:     schema.TypeList,
-					MinItems: 1,
 					MaxItems: 1,
 					Optional: true,
 					Elem: &schema.Resource{
@@ -244,7 +243,6 @@ func fontConfigurationSchema() *schema.Schema {
 				"font_style": stringSchema(false, validation.StringInSlice(quicksight.FontStyle_Values(), false)),
 				"font_weight": { // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_FontWeight.html
 					Type:     schema.TypeList,
-					MinItems: 1,
 					MaxItems: 1,
 					Optional: true,
 					Elem: &schema.Resource{
@@ -562,13 +560,13 @@ func expandFontConfiguration(tfList []interface{}) *quicksight.FontConfiguration
 
 	config := &quicksight.FontConfiguration{}
 
-	if v, ok := tfMap["font_color"].(string); ok {
+	if v, ok := tfMap["font_color"].(string); ok && v != "" {
 		config.FontColor = aws.String(v)
 	}
-	if v, ok := tfMap["font_decoration"].(string); ok {
+	if v, ok := tfMap["font_decoration"].(string); ok && v != "" {
 		config.FontDecoration = aws.String(v)
 	}
-	if v, ok := tfMap["font_style"].(string); ok {
+	if v, ok := tfMap["font_style"].(string); ok && v != "" {
 		config.FontStyle = aws.String(v)
 	}
 	if v, ok := tfMap["font_size"].([]interface{}); ok && len(v) > 0 {

--- a/internal/service/quicksight/template_test.go
+++ b/internal/service/quicksight/template_test.go
@@ -614,6 +614,12 @@ resource "aws_quicksight_template" "test" {
               header_style {
                 background_color = "#99CCFF"
                 height           = 20
+                font_configuration {
+                  font_color = "#212121"
+                  font_size {
+                    relative = "LARGE"
+                  }
+                }
               }
             }
             sort_configuration {


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adjustments to the table visual header style `font_configuration` schema to allow the configurable elements to be set via Terraform.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #32440

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=quicksight TESTARGS="-run TestAccQuickSightAnalysis_\|TestAccQuickSightDashboard_\|TestAccQuickSightTemplate_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/quicksight/... -v -count 1 -parallel 20  -run TestAccQuickSightAnalysis_\|TestAccQuickSightDashboard_\|TestAccQuickSightTemplate_ -timeout 180m

--- PASS: TestAccQuickSightTemplate_basic (82.70s)
--- PASS: TestAccQuickSightTemplate_barChart (85.80s)
--- PASS: TestAccQuickSightTemplate_disappears (92.14s)
--- PASS: TestAccQuickSightAnalysis_forceDelete (92.57s)
--- PASS: TestAccQuickSightDashboard_disappears (94.24s)
--- PASS: TestAccQuickSightAnalysis_disappears (95.72s)
--- PASS: TestAccQuickSightDashboard_dashboardSpecificConfig (100.99s)
--- PASS: TestAccQuickSightTemplate_sourceEntity (101.00s)
--- PASS: TestAccQuickSightAnalysis_parametersConfig (101.77s)
--- PASS: TestAccQuickSightAnalysis_basic (102.27s)
--- PASS: TestAccQuickSightDashboard_basic (102.59s)
--- PASS: TestAccQuickSightAnalysis_sourceEntity (105.25s)
--- PASS: TestAccQuickSightDashboard_sourceEntity (105.80s)
--- PASS: TestAccQuickSightTemplate_table (123.68s)
--- PASS: TestAccQuickSightTemplate_update (136.73s)
--- PASS: TestAccQuickSightAnalysis_update (143.64s)
--- PASS: TestAccQuickSightDashboard_updateVersionNumber (145.08s)
--- PASS: TestAccQuickSightTemplate_tags (151.32s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/quicksight 154.351s
```
