### PR TITLE
[Docs]: Config and example content for content tabs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,21 @@
 # Documentation
 
-- [Using the AWS Provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
-- [AWS Provider contributing guide](https://hashicorp.github.io/terraform-provider-aws/)
+This directory contains documentation for the [Terraform AWS Provider Contributor Guide](https://hashicorp.github.io/terraform-provider-aws/). Resource and data source documentation is located in the [`website`](../website/) directory and available in the [Terraform Registry](https://registry.terraform.io/providers/hashicorp/aws/latest/docs).
+
+## Local Development
+
+To serve the contributing guide locally, [`mkdocs`](https://www.mkdocs.org/user-guide/installation/) and the [`mkdocs-material`](https://github.com/squidfunk/mkdocs-material#quick-start) extension must be installed. Both require Python and `pip`.
+
+```console
+% pip3 install mkdocs
+```
+
+```console
+% pip3 install mkdocs-material
+```
+
+Once installed, the documentation can be served from the root directory:
+
+```console
+% mkdocs serve
+```

--- a/docs/add-a-new-service.md
+++ b/docs/add-a-new-service.md
@@ -51,31 +51,116 @@ If an AWS service must be created in a non-standard way, for example the service
 
 1. Add a file `internal/<service>/service_package.go` that contains an API client factory function, for example:
 
-```go
-package globalaccelerator
+=== "framework / aws-go-sdk-v2"
 
-import (
-	"context"
+    ```go
+    package globalaccelerator
+    
+    import (
+        "context"
+    
+        aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
+        endpoints_sdkv1 "github.com/aws/aws-sdk-go/aws/endpoints"
+        session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
+        globalaccelerator_sdkv1 "github.com/aws/aws-sdk-go/service/globalaccelerator"
+    )
+    
+    // NewConn returns a new AWS SDK for Go v1 client for this service package's AWS API.
+    func (p *servicePackage) NewConn(ctx context.Context) (*globalaccelerator_sdkv1.GlobalAccelerator, error) {
+        sess := p.config["session"].(*session_sdkv1.Session)
+        config := &aws_sdkv1.Config{Endpoint: aws_sdkv1.String(p.config["endpoint"].(string))}
+    
+        // Force "global" services to correct Regions.
+        if p.config["partition"].(string) == endpoints_sdkv1.AwsPartitionID {
+            config.Region = aws_sdkv1.String(endpoints_sdkv1.UsWest2RegionID)
+        }
+    
+        return globalaccelerator_sdkv1.New(sess.Copy(config)), nil
+    }
+    ```
 
-	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
-	endpoints_sdkv1 "github.com/aws/aws-sdk-go/aws/endpoints"
-	session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
-	globalaccelerator_sdkv1 "github.com/aws/aws-sdk-go/service/globalaccelerator"
-)
+=== "framework / aws-go-sdk"
 
-// NewConn returns a new AWS SDK for Go v1 client for this service package's AWS API.
-func (p *servicePackage) NewConn(ctx context.Context) (*globalaccelerator_sdkv1.GlobalAccelerator, error) {
-	sess := p.config["session"].(*session_sdkv1.Session)
-	config := &aws_sdkv1.Config{Endpoint: aws_sdkv1.String(p.config["endpoint"].(string))}
+    ```go
+    package accessanalyzer
+    
+    import (
+        "context"
+  
+        aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+        accessanalyzer_sdkv2 "github.com/aws/aws-sdk-go-v2/service/accessanalyzer"
+        "github.com/hashicorp/terraform-provider-aws/internal/conns"
+        "github.com/hashicorp/terraform-provider-aws/internal/types"
+        "github.com/hashicorp/terraform-provider-aws/names"
+    )
 
-	// Force "global" services to correct Regions.
-	if p.config["partition"].(string) == endpoints_sdkv1.AwsPartitionID {
-		config.Region = aws_sdkv1.String(endpoints_sdkv1.UsWest2RegionID)
-	}
+    // NewClient returns a new AWS SDK for Go v2 client for this service package's AWS API.
+    func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (*accessanalyzer_sdkv2.Client, error) {
+    cfg := *(config["aws_sdkv2_config"].(*aws_sdkv2.Config))
+    
+        return accessanalyzer_sdkv2.NewFromConfig(cfg, func(o *accessanalyzer_sdkv2.Options) {
+            if endpoint := config["endpoint"].(string); endpoint != "" {
+                o.EndpointResolver = accessanalyzer_sdkv2.EndpointResolverFromURL(endpoint)
+            }
+        }), nil
+    }
+    ```
 
-	return globalaccelerator_sdkv1.New(sess.Copy(config)), nil
-}
-```
+=== "sdk / aws-go-sdk-v2"
+
+    ```go
+    package globalaccelerator
+    
+    import (
+        "context"
+    
+        aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
+        endpoints_sdkv1 "github.com/aws/aws-sdk-go/aws/endpoints"
+        session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
+        globalaccelerator_sdkv1 "github.com/aws/aws-sdk-go/service/globalaccelerator"
+    )
+    
+    // NewConn returns a new AWS SDK for Go v1 client for this service package's AWS API.
+    func (p *servicePackage) NewConn(ctx context.Context) (*globalaccelerator_sdkv1.GlobalAccelerator, error) {
+        sess := p.config["session"].(*session_sdkv1.Session)
+        config := &aws_sdkv1.Config{Endpoint: aws_sdkv1.String(p.config["endpoint"].(string))}
+    
+        // Force "global" services to correct Regions.
+        if p.config["partition"].(string) == endpoints_sdkv1.AwsPartitionID {
+            config.Region = aws_sdkv1.String(endpoints_sdkv1.UsWest2RegionID)
+        }
+    
+        return globalaccelerator_sdkv1.New(sess.Copy(config)), nil
+    }
+    ```
+
+=== "sdk / aws-go-sdk"
+
+    ```go
+    package globalaccelerator
+    
+    import (
+        "context"
+    
+        aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
+        endpoints_sdkv1 "github.com/aws/aws-sdk-go/aws/endpoints"
+        session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
+        globalaccelerator_sdkv1 "github.com/aws/aws-sdk-go/service/globalaccelerator"
+    )
+    
+    // NewConn returns a new AWS SDK for Go v1 client for this service package's AWS API.
+    func (p *servicePackage) NewConn(ctx context.Context) (*globalaccelerator_sdkv1.GlobalAccelerator, error) {
+        sess := p.config["session"].(*session_sdkv1.Session)
+        config := &aws_sdkv1.Config{Endpoint: aws_sdkv1.String(p.config["endpoint"].(string))}
+    
+        // Force "global" services to correct Regions.
+        if p.config["partition"].(string) == endpoints_sdkv1.AwsPartitionID {
+            config.Region = aws_sdkv1.String(endpoints_sdkv1.UsWest2RegionID)
+        }
+    
+        return globalaccelerator_sdkv1.New(sess.Copy(config)), nil
+    }
+    ```
 
 ## Customizing a new Service Client
 

--- a/docs/add-a-new-service.md
+++ b/docs/add-a-new-service.md
@@ -51,62 +51,36 @@ If an AWS service must be created in a non-standard way, for example the service
 
 1. Add a file `internal/<service>/service_package.go` that contains an API client factory function, for example:
 
-=== "framework / aws-go-sdk-v2"
+<!-- markdownlint-disable code-block-style -->
+=== "aws-go-sdk-v2"
 
     ```go
-    package globalaccelerator
+    package route53domains
     
     import (
-        "context"
+    	"context"
     
-        aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
-        endpoints_sdkv1 "github.com/aws/aws-sdk-go/aws/endpoints"
-        session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
-        globalaccelerator_sdkv1 "github.com/aws/aws-sdk-go/service/globalaccelerator"
+    	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+    	route53domains_sdkv2 "github.com/aws/aws-sdk-go-v2/service/route53domains"
+    	endpoints_sdkv1 "github.com/aws/aws-sdk-go/aws/endpoints"
     )
     
-    // NewConn returns a new AWS SDK for Go v1 client for this service package's AWS API.
-    func (p *servicePackage) NewConn(ctx context.Context) (*globalaccelerator_sdkv1.GlobalAccelerator, error) {
-        sess := p.config["session"].(*session_sdkv1.Session)
-        config := &aws_sdkv1.Config{Endpoint: aws_sdkv1.String(p.config["endpoint"].(string))}
-    
-        // Force "global" services to correct Regions.
-        if p.config["partition"].(string) == endpoints_sdkv1.AwsPartitionID {
-            config.Region = aws_sdkv1.String(endpoints_sdkv1.UsWest2RegionID)
-        }
-    
-        return globalaccelerator_sdkv1.New(sess.Copy(config)), nil
-    }
-    ```
-
-=== "framework / aws-go-sdk"
-
-    ```go
-    package accessanalyzer
-    
-    import (
-        "context"
-  
-        aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
-        accessanalyzer_sdkv2 "github.com/aws/aws-sdk-go-v2/service/accessanalyzer"
-        "github.com/hashicorp/terraform-provider-aws/internal/conns"
-        "github.com/hashicorp/terraform-provider-aws/internal/types"
-        "github.com/hashicorp/terraform-provider-aws/names"
-    )
-
     // NewClient returns a new AWS SDK for Go v2 client for this service package's AWS API.
-    func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (*accessanalyzer_sdkv2.Client, error) {
-    cfg := *(config["aws_sdkv2_config"].(*aws_sdkv2.Config))
+    func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (*route53domains_sdkv2.Client, error) {
+    	cfg := *(config["aws_sdkv2_config"].(*aws_sdkv2.Config))
     
-        return accessanalyzer_sdkv2.NewFromConfig(cfg, func(o *accessanalyzer_sdkv2.Options) {
-            if endpoint := config["endpoint"].(string); endpoint != "" {
-                o.EndpointResolver = accessanalyzer_sdkv2.EndpointResolverFromURL(endpoint)
-            }
-        }), nil
+    	return route53domains_sdkv2.NewFromConfig(cfg, func(o *route53domains_sdkv2.Options) {
+    		if endpoint := config["endpoint"].(string); endpoint != "" {
+    			o.BaseEndpoint = aws_sdkv2.String(endpoint)
+    		} else if config["partition"].(string) == endpoints_sdkv1.AwsPartitionID {
+    			// Route 53 Domains is only available in AWS Commercial us-east-1 Region.
+    			o.Region = endpoints_sdkv1.UsEast1RegionID
+    		}
+    	}), nil
     }
     ```
 
-=== "sdk / aws-go-sdk-v2"
+=== "aws-go-sdk"
 
     ```go
     package globalaccelerator
@@ -133,34 +107,7 @@ If an AWS service must be created in a non-standard way, for example the service
         return globalaccelerator_sdkv1.New(sess.Copy(config)), nil
     }
     ```
-
-=== "sdk / aws-go-sdk"
-
-    ```go
-    package globalaccelerator
-    
-    import (
-        "context"
-    
-        aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
-        endpoints_sdkv1 "github.com/aws/aws-sdk-go/aws/endpoints"
-        session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
-        globalaccelerator_sdkv1 "github.com/aws/aws-sdk-go/service/globalaccelerator"
-    )
-    
-    // NewConn returns a new AWS SDK for Go v1 client for this service package's AWS API.
-    func (p *servicePackage) NewConn(ctx context.Context) (*globalaccelerator_sdkv1.GlobalAccelerator, error) {
-        sess := p.config["session"].(*session_sdkv1.Session)
-        config := &aws_sdkv1.Config{Endpoint: aws_sdkv1.String(p.config["endpoint"].(string))}
-    
-        // Force "global" services to correct Regions.
-        if p.config["partition"].(string) == endpoints_sdkv1.AwsPartitionID {
-            config.Region = aws_sdkv1.String(endpoints_sdkv1.UsWest2RegionID)
-        }
-    
-        return globalaccelerator_sdkv1.New(sess.Copy(config)), nil
-    }
-    ```
+<!-- markdownlint-enable code-block-style -->
 
 ## Customizing a new Service Client
 
@@ -168,30 +115,34 @@ If an AWS service must be customized after creation, for example retry handling 
 
 1. Add a file `internal/<service>/service_package.go` that contains an API client customization function, for example:
 
-```go
-package chime
+<!-- markdownlint-disable code-block-style -->
+=== "aws-go-sdk"
 
-import (
-	"context"
-
-	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
-	request_sdkv1 "github.com/aws/aws-sdk-go/aws/request"
-	chime_sdkv1 "github.com/aws/aws-sdk-go/service/chime"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
-)
-
-// CustomizeConn customizes a new AWS SDK for Go v1 client for this service package's AWS API.
-func (p *servicePackage) CustomizeConn(ctx context.Context, conn *chime_sdkv1.Chime) (*chime_sdkv1.Chime, error) {
-	conn.Handlers.Retry.PushBack(func(r *request_sdkv1.Request) {
-		// When calling CreateVoiceConnector across multiple resources,
-		// the API can randomly return a BadRequestException without explanation
-		if r.Operation.Name == "CreateVoiceConnector" {
-			if tfawserr.ErrMessageContains(r.Error, chime_sdkv1.ErrCodeBadRequestException, "Service received a bad request") {
-				r.Retryable = aws_sdkv1.Bool(true)
-			}
-		}
-	})
-
-	return conn, nil
-}
-```
+    ```go
+    package chime
+    
+    import (
+    	"context"
+    
+    	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
+    	request_sdkv1 "github.com/aws/aws-sdk-go/aws/request"
+    	chime_sdkv1 "github.com/aws/aws-sdk-go/service/chime"
+    	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+    )
+    
+    // CustomizeConn customizes a new AWS SDK for Go v1 client for this service package's AWS API.
+    func (p *servicePackage) CustomizeConn(ctx context.Context, conn *chime_sdkv1.Chime) (*chime_sdkv1.Chime, error) {
+    	conn.Handlers.Retry.PushBack(func(r *request_sdkv1.Request) {
+    		// When calling CreateVoiceConnector across multiple resources,
+    		// the API can randomly return a BadRequestException without explanation
+    		if r.Operation.Name == "CreateVoiceConnector" {
+    			if tfawserr.ErrMessageContains(r.Error, chime_sdkv1.ErrCodeBadRequestException, "Service received a bad request") {
+    				r.Retryable = aws_sdkv1.Bool(true)
+    			}
+    		}
+    	})
+    
+    	return conn, nil
+    }
+    ```
+<!-- markdownlint-enable code-block-style -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,7 @@ theme:
   features:
     - navigation.instant
     - content.tabs.link
+    - content.code.copy
 
 plugins:
   - search:
@@ -67,6 +68,8 @@ plugins:
 markdown_extensions:
   - pymdownx.highlight
   - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
   - pymdownx.inlinehilite
   - toc:
       permalink: "#"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

To help with the transition to requiring terraform-plugin-framework / aws-sdk-go-v2 all examples in the contributor documentation should lead with the preferred format. We should however preserve legacy examples to help contributors with existing resources. In order to present these various formats in a way that doesn't make the documentation hard to navigate we could use content tabs. This PR includes the mkdocs configuration to allow the use of content tabs, as well as some sample tabs.

### References

- #32917
- #32976