### PR TITLE
teamcity: add failure condition for service build

### DIFF
--- a/.teamcity/components/service_build_config.kt
+++ b/.teamcity/components/service_build_config.kt
@@ -6,6 +6,8 @@ import jetbrains.buildServer.configs.kotlin.ParameterDisplay
 import jetbrains.buildServer.configs.kotlin.buildFeatures.notifications
 import jetbrains.buildServer.configs.kotlin.buildSteps.ScriptBuildStep
 import jetbrains.buildServer.configs.kotlin.buildSteps.script
+import jetbrains.buildServer.configs.kotlin.failureConditions.failOnText
+import jetbrains.buildServer.configs.kotlin.failureConditions.BuildFailureOnText
 import java.io.File
 
 data class ServiceSpec(
@@ -69,6 +71,17 @@ class Service(name: String, spec: ServiceSpec) {
                     name = "Run Acceptance Tests"
                     workingDir = serviceDir
                     scriptContent = File("./scripts/service_tests/acceptance_tests.sh").readText()
+                }
+            }
+
+            failureConditions {
+                failOnText {
+                    conditionType = BuildFailureOnText.ConditionType.CONTAINS
+                    pattern = "build canceled"
+                    failureMessage = "build canceled when agent unregistered"
+                    reverse = false
+                    stopBuildOnFailure = true
+                    reportOnlyFirstMatch = false
                 }
             }
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Long running test can cause agent to run OOM and unregister. This causes a restart cycle. Test should fail with a failure message.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
