### PR TITLE
DataSync: Fix acceptance test failures

### DIFF
--- a/internal/service/datasync/find.go
+++ b/internal/service/datasync/find.go
@@ -162,3 +162,28 @@ func FindLocationObjectStorageByARN(ctx context.Context, conn *datasync.DataSync
 
 	return output, nil
 }
+
+func FindLocationNFSByARN(ctx context.Context, conn *datasync.DataSync, arn string) (*datasync.DescribeLocationNfsOutput, error) {
+	input := &datasync.DescribeLocationNfsInput{
+		LocationArn: aws.String(arn),
+	}
+
+	output, err := conn.DescribeLocationNfsWithContext(ctx, input)
+
+	if tfawserr.ErrMessageContains(err, datasync.ErrCodeInvalidRequestException, "not found") {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output, nil
+}

--- a/internal/service/datasync/location_nfs.go
+++ b/internal/service/datasync/location_nfs.go
@@ -30,6 +30,7 @@ func ResourceLocationNFS() *schema.Resource {
 		ReadWithoutTimeout:   resourceLocationNFSRead,
 		UpdateWithoutTimeout: resourceLocationNFSUpdate,
 		DeleteWithoutTimeout: resourceLocationNFSDelete,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -38,6 +39,23 @@ func ResourceLocationNFS() *schema.Resource {
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+			"mount_options": {
+				Type:             schema.TypeList,
+				Optional:         true,
+				MaxItems:         1,
+				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"version": {
+							Type:         schema.TypeString,
+							Default:      datasync.NfsVersionAutomatic,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringInSlice(datasync.NfsVersion_Values(), false),
+						},
+					},
+				},
 			},
 			"on_prem_config": {
 				Type:     schema.TypeList,
@@ -53,23 +71,6 @@ func ResourceLocationNFS() *schema.Resource {
 								Type:         schema.TypeString,
 								ValidateFunc: verify.ValidARN,
 							},
-						},
-					},
-				},
-			},
-			"mount_options": {
-				Type:             schema.TypeList,
-				Optional:         true,
-				MaxItems:         1,
-				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"version": {
-							Type:         schema.TypeString,
-							Default:      datasync.NfsVersionAutomatic,
-							Optional:     true,
-							ForceNew:     true,
-							ValidateFunc: validation.StringInSlice(datasync.NfsVersion_Values(), false),
 						},
 					},
 				},

--- a/internal/service/datasync/location_nfs_test.go
+++ b/internal/service/datasync/location_nfs_test.go
@@ -334,13 +334,11 @@ func testAccLocationNFSConfig_agentARNsMultiple(rName string) string {
 resource "aws_instance" "test2" {
   depends_on = [aws_internet_gateway.test]
 
-  ami                         = data.aws_ssm_parameter.aws_service_datasync_ami.value
+  ami                         = aws_instance.test.ami
   associate_public_ip_address = true
-
-  # Default instance type from sync.sh
-  instance_type          = "c5.2xlarge"
-  vpc_security_group_ids = [aws_security_group.test.id]
-  subnet_id              = aws_subnet.test[0].id
+  instance_type               = aws_instance.test.instance_type
+  vpc_security_group_ids      = [aws_security_group.test.id]
+  subnet_id                   = aws_subnet.test[0].id
 
   tags = {
     Name = %[1]q

--- a/internal/service/datasync/location_nfs_test.go
+++ b/internal/service/datasync/location_nfs_test.go
@@ -312,7 +312,7 @@ func testAccCheckLocationNFSNotRecreated(i, j *datasync.DescribeLocationNfsOutpu
 	}
 }
 
-func testAccLocationNFSBaseConfig(rName string) string {
+func testAccLocationNFSConfig_base(rName string) string {
 	return fmt.Sprintf(`
 data "aws_ami" "aws-thinstaller" {
   most_recent = true
@@ -407,13 +407,13 @@ resource "aws_instance" "test" {
 
 resource "aws_datasync_agent" "test" {
   ip_address = aws_instance.test.public_ip
-  name       = %q
+  name       = %[1]q
 }
 `, rName)
 }
 
 func testAccLocationNFSConfig_basic(rName string) string {
-	return testAccLocationNFSBaseConfig(rName) + `
+	return acctest.ConfigCompose(testAccLocationNFSConfig_base(rName), `
 resource "aws_datasync_location_nfs" "test" {
   server_hostname = "example.com"
   subdirectory    = "/"
@@ -422,11 +422,11 @@ resource "aws_datasync_location_nfs" "test" {
     agent_arns = [aws_datasync_agent.test.arn]
   }
 }
-`
+`)
 }
 
 func testAccLocationNFSConfig_mountOptions(rName, option string) string {
-	return testAccLocationNFSBaseConfig(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccLocationNFSConfig_base(rName), fmt.Sprintf(`
 resource "aws_datasync_location_nfs" "test" {
   server_hostname = "example.com"
   subdirectory    = "/"
@@ -439,11 +439,11 @@ resource "aws_datasync_location_nfs" "test" {
     version = %[1]q
   }
 }
-`, option)
+`, option))
 }
 
 func testAccLocationNFSConfig_agentARNsMultiple(rName string) string {
-	return testAccLocationNFSBaseConfig(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccLocationNFSConfig_base(rName), fmt.Sprintf(`
 resource "aws_instance" "test2" {
   depends_on = [aws_internet_gateway.test]
 
@@ -462,7 +462,7 @@ resource "aws_instance" "test2" {
 
 resource "aws_datasync_agent" "test2" {
   ip_address = aws_instance.test2.public_ip
-  name       = "%s2"
+  name       = "%[1]s2"
 }
 
 resource "aws_datasync_location_nfs" "test" {
@@ -476,24 +476,24 @@ resource "aws_datasync_location_nfs" "test" {
     ]
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccLocationNFSConfig_subdirectory(rName, subdirectory string) string {
-	return testAccLocationNFSBaseConfig(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccLocationNFSConfig_base(rName), fmt.Sprintf(`
 resource "aws_datasync_location_nfs" "test" {
   server_hostname = "example.com"
-  subdirectory    = %q
+  subdirectory    = %[1]q
 
   on_prem_config {
     agent_arns = [aws_datasync_agent.test.arn]
   }
 }
-`, subdirectory)
+`, subdirectory))
 }
 
 func testAccLocationNFSConfig_tags1(rName, key1, value1 string) string {
-	return testAccLocationNFSBaseConfig(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccLocationNFSConfig_base(rName), fmt.Sprintf(`
 resource "aws_datasync_location_nfs" "test" {
   server_hostname = "example.com"
   subdirectory    = "/"
@@ -503,14 +503,14 @@ resource "aws_datasync_location_nfs" "test" {
   }
 
   tags = {
-    %q = %q
+    %[1]q = %[2]q
   }
 }
-`, key1, value1)
+`, key1, value1))
 }
 
 func testAccLocationNFSConfig_tags2(rName, key1, value1, key2, value2 string) string {
-	return testAccLocationNFSBaseConfig(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccLocationNFSConfig_base(rName), fmt.Sprintf(`
 resource "aws_datasync_location_nfs" "test" {
   server_hostname = "example.com"
   subdirectory    = "/"
@@ -520,9 +520,9 @@ resource "aws_datasync_location_nfs" "test" {
   }
 
   tags = {
-    %q = %q
-    %q = %q
+    %[1]q = %[2]q
+    %[3]q = %[4]q
   }
 }
-`, key1, value1, key2, value2)
+`, key1, value1, key2, value2))
 }

--- a/internal/service/datasync/location_nfs_test.go
+++ b/internal/service/datasync/location_nfs_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfdatasync "github.com/hashicorp/terraform-provider-aws/internal/service/datasync"
 )
 
 func TestAccDataSyncLocationNFS_basic(t *testing.T) {
@@ -109,7 +110,7 @@ func TestAccDataSyncLocationNFS_disappears(t *testing.T) {
 				Config: testAccLocationNFSConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLocationNFSExists(ctx, resourceName, &locationNfs1),
-					testAccCheckLocationNFSDisappears(ctx, &locationNfs1),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfdatasync.ResourceLocationNFS(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -288,24 +289,10 @@ func testAccCheckLocationNFSExists(ctx context.Context, resourceName string, loc
 	}
 }
 
-func testAccCheckLocationNFSDisappears(ctx context.Context, location *datasync.DescribeLocationNfsOutput) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).DataSyncConn(ctx)
-
-		input := &datasync.DeleteLocationInput{
-			LocationArn: location.LocationArn,
-		}
-
-		_, err := conn.DeleteLocationWithContext(ctx, input)
-
-		return err
-	}
-}
-
 func testAccCheckLocationNFSNotRecreated(i, j *datasync.DescribeLocationNfsOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if !aws.TimeValue(i.CreationTime).Equal(aws.TimeValue(j.CreationTime)) {
-			return errors.New("DataSync Location Nfs was recreated")
+			return errors.New("DataSync Location NFS was recreated")
 		}
 
 		return nil


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

In CI:

```
=== RUN   TestAccDataSyncLocationNFS_basic
=== PAUSE TestAccDataSyncLocationNFS_basic
=== CONT  TestAccDataSyncLocationNFS_basic
    location_nfs_test.go:29: Step 1/2 error: Error running pre-apply refresh: exit status 1
        Error: Your query returned no results. Please change your search criteria and try again.
          with data.aws_ami.aws-thinstaller,
          on terraform_plugin_test.tf line 2, in data "aws_ami" "aws-thinstaller":
           2: data "aws_ami" "aws-thinstaller" {
--- FAIL: TestAccDataSyncLocationNFS_basic (18.60s)
```

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccDataSyncLocationNFS_' PKG=datasync ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/datasync/... -v -count 1 -parallel 2  -run=TestAccDataSyncLocationNFS_ -timeout 180m
=== RUN   TestAccDataSyncLocationNFS_basic
=== PAUSE TestAccDataSyncLocationNFS_basic
=== RUN   TestAccDataSyncLocationNFS_mountOptions
=== PAUSE TestAccDataSyncLocationNFS_mountOptions
=== RUN   TestAccDataSyncLocationNFS_disappears
=== PAUSE TestAccDataSyncLocationNFS_disappears
=== RUN   TestAccDataSyncLocationNFS_AgentARNs_multiple
=== PAUSE TestAccDataSyncLocationNFS_AgentARNs_multiple
=== RUN   TestAccDataSyncLocationNFS_subdirectory
=== PAUSE TestAccDataSyncLocationNFS_subdirectory
=== RUN   TestAccDataSyncLocationNFS_tags
=== PAUSE TestAccDataSyncLocationNFS_tags
=== CONT  TestAccDataSyncLocationNFS_basic
=== CONT  TestAccDataSyncLocationNFS_AgentARNs_multiple
--- PASS: TestAccDataSyncLocationNFS_basic (127.35s)
=== CONT  TestAccDataSyncLocationNFS_tags
--- PASS: TestAccDataSyncLocationNFS_AgentARNs_multiple (192.66s)
=== CONT  TestAccDataSyncLocationNFS_subdirectory
--- PASS: TestAccDataSyncLocationNFS_tags (163.30s)
=== CONT  TestAccDataSyncLocationNFS_disappears
--- PASS: TestAccDataSyncLocationNFS_subdirectory (178.93s)
=== CONT  TestAccDataSyncLocationNFS_mountOptions
--- PASS: TestAccDataSyncLocationNFS_disappears (111.57s)
--- PASS: TestAccDataSyncLocationNFS_mountOptions (163.68s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/datasync	540.455s
```
