### PR TITLE
r/aws_quicksight: convert calculated_fields to set type

### DIFF
--- a/.changelog/33040.txt
+++ b/.changelog/33040.txt
@@ -1,0 +1,9 @@
+```release-note:bug
+resource/aws_quicksight_analysis: Convert `definition.*.calculated_fields` to a set type, preventing persistent differences
+```
+```release-note:bug
+resource/aws_quicksight_dashboard: Convert `definition.*.calculated_fields` to a set type, preventing persistent differences
+```
+```release-note:bug
+resource/aws_quicksight_template: Convert `definition.*.calculated_fields` to a set type, preventing persistent differences
+```

--- a/internal/service/quicksight/analysis_test.go
+++ b/internal/service/quicksight/analysis_test.go
@@ -225,6 +225,52 @@ func TestAccQuickSightAnalysis_forceDelete(t *testing.T) {
 	})
 }
 
+func TestAccQuickSightAnalysis_Definition_calculatedFields(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var analysis quicksight.Analysis
+	resourceName := "aws_quicksight_analysis.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, quicksight.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAnalysisDestroy(ctx, false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAnalysisConfig_Definition_calculatedFields(rId, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAnalysisExists(ctx, resourceName, &analysis),
+					resource.TestCheckResourceAttr(resourceName, "analysis_id", rId),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "status", quicksight.ResourceStatusCreationSuccessful),
+					resource.TestCheckResourceAttr(resourceName, "definition.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "definition.0.calculated_fields.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "definition.0.calculated_fields.*", map[string]string{
+						"data_set_identifier": "1",
+						"expression":          "1",
+						"name":                "test1",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "definition.0.calculated_fields.*", map[string]string{
+						"data_set_identifier": "1",
+						"expression":          "2",
+						"name":                "test2",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAnalysisDestroy(ctx context.Context, forceDelete bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).QuickSightConn(ctx)
@@ -578,6 +624,83 @@ resource "aws_quicksight_analysis" "test" {
           title {
             format_text {
               plain_text = "Line Chart Example"
+            }
+          }
+          chart_configuration {
+            field_wells {
+              line_chart_aggregated_field_wells {
+                category {
+                  categorical_dimension_field {
+                    field_id = "1"
+                    column {
+                      data_set_identifier = "1"
+                      column_name         = "Column1"
+                    }
+                  }
+                }
+                values {
+                  categorical_measure_field {
+                    field_id = "2"
+                    column {
+                      data_set_identifier = "1"
+                      column_name         = "Column1"
+                    }
+                    aggregation_function = "COUNT"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`, rId, rName))
+}
+
+func testAccAnalysisConfig_Definition_calculatedFields(rId, rName string) string {
+	return acctest.ConfigCompose(
+		testAccAnalysisConfigBase(rId, rName),
+		fmt.Sprintf(`
+resource "aws_quicksight_analysis" "test" {
+  analysis_id = %[1]q
+  name        = %[2]q
+  definition {
+    data_set_identifiers_declarations {
+      data_set_arn = aws_quicksight_data_set.test.arn
+      identifier   = "1"
+    }
+    calculated_fields {
+      data_set_identifier = "1"
+      expression          = "1"
+      name                = "test1"
+    }
+    calculated_fields {
+      data_set_identifier = "1"
+      expression          = "2"
+      name                = "test2"
+    }
+    sheets {
+      title    = "Test"
+      sheet_id = "Test1"
+      visuals {
+        custom_content_visual {
+          data_set_identifier = "1"
+          title {
+            format_text {
+              plain_text = "Test"
+            }
+          }
+          visual_id = "Test1"
+        }
+      }
+      visuals {
+        line_chart_visual {
+          visual_id = "LineChart"
+          title {
+            format_text {
+              plain_text = "Line Chart Test"
             }
           }
           chart_configuration {

--- a/internal/service/quicksight/dashboard.go
+++ b/internal/service/quicksight/dashboard.go
@@ -15,7 +15,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/quicksight"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -134,10 +133,7 @@ func ResourceDashboard() *schema.Resource {
 			}
 		},
 
-		CustomizeDiff: customdiff.All(
-			refreshOutputsDiff,
-			verify.SetTagsDiff,
-		),
+		CustomizeDiff: verify.SetTagsDiff,
 	}
 }
 
@@ -417,14 +413,4 @@ func createDashboardId(awsAccountID, dashboardId string) string {
 func extractVersionFromARN(arn string) *int64 {
 	version, _ := strconv.Atoi(arn[strings.LastIndex(arn, "/")+1:])
 	return aws.Int64(int64(version))
-}
-
-func refreshOutputsDiff(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
-	if diff.HasChanges("name", "definition", "source_entity", "theme_arn", "version_description", "parameters", "dashboard_publish_options") {
-		if err := diff.SetNewComputed("version_number"); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }

--- a/internal/service/quicksight/schema/analysis.go
+++ b/internal/service/quicksight/schema/analysis.go
@@ -191,8 +191,8 @@ func ExpandAnalysisDefinition(tfList []interface{}) *quicksight.AnalysisDefiniti
 	if v, ok := tfMap["analysis_defaults"].([]interface{}); ok && len(v) > 0 {
 		definition.AnalysisDefaults = expandAnalysisDefaults(v)
 	}
-	if v, ok := tfMap["calculated_fields"].([]interface{}); ok && len(v) > 0 {
-		definition.CalculatedFields = expandCalculatedFields(v)
+	if v, ok := tfMap["calculated_fields"].(*schema.Set); ok && v.Len() > 0 {
+		definition.CalculatedFields = expandCalculatedFields(v.List())
 	}
 	if v, ok := tfMap["column_configurations"].([]interface{}); ok && len(v) > 0 {
 		definition.ColumnConfigurations = expandColumnConfigurations(v)

--- a/internal/service/quicksight/schema/dashboard.go
+++ b/internal/service/quicksight/schema/dashboard.go
@@ -346,8 +346,8 @@ func ExpandDashboardDefinition(tfList []interface{}) *quicksight.DashboardVersio
 	if v, ok := tfMap["analysis_defaults"].([]interface{}); ok && len(v) > 0 {
 		definition.AnalysisDefaults = expandAnalysisDefaults(v)
 	}
-	if v, ok := tfMap["calculated_fields"].([]interface{}); ok && len(v) > 0 {
-		definition.CalculatedFields = expandCalculatedFields(v)
+	if v, ok := tfMap["calculated_fields"].(*schema.Set); ok && v.Len() > 0 {
+		definition.CalculatedFields = expandCalculatedFields(v.List())
 	}
 	if v, ok := tfMap["column_configurations"].([]interface{}); ok && len(v) > 0 {
 		definition.ColumnConfigurations = expandColumnConfigurations(v)

--- a/internal/service/quicksight/schema/template.go
+++ b/internal/service/quicksight/schema/template.go
@@ -167,7 +167,7 @@ func aggregationFunctionSchema(required bool) *schema.Schema {
 
 func calculatedFieldsSchema() *schema.Schema {
 	return &schema.Schema{ // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_CalculatedField.html
-		Type:     schema.TypeList,
+		Type:     schema.TypeSet,
 		MinItems: 1,
 		MaxItems: 500,
 		Optional: true,
@@ -479,8 +479,8 @@ func ExpandTemplateDefinition(tfList []interface{}) *quicksight.TemplateVersionD
 	if v, ok := tfMap["analysis_defaults"].([]interface{}); ok && len(v) > 0 {
 		definition.AnalysisDefaults = expandAnalysisDefaults(v)
 	}
-	if v, ok := tfMap["calculated_fields"].([]interface{}); ok && len(v) > 0 {
-		definition.CalculatedFields = expandCalculatedFields(v)
+	if v, ok := tfMap["calculated_fields"].(*schema.Set); ok && v.Len() > 0 {
+		definition.CalculatedFields = expandCalculatedFields(v.List())
 	}
 	if v, ok := tfMap["column_configurations"].([]interface{}); ok && len(v) > 0 {
 		definition.ColumnConfigurations = expandColumnConfigurations(v)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Converts the `definition.0.calculated_fields` argument in the Analysis, Dashboard, and Template resources to a set type.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #32997

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=quicksight TESTARGS="-run TestAccQuickSightAnalysis_\|TestAccQuickSightDashboard_\|TestAccQuickSightTemplate_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/quicksight/... -v -count 1 -parallel 20  -run TestAccQuickSightAnalysis_\|TestAccQuickSightDashboard_\|TestAccQuickSightTemplate_ -timeout 180m
?       github.com/hashicorp/terraform-provider-aws/internal/service/quicksight/schema  [no test files]

--- PASS: TestAccQuickSightTemplate_basic (84.83s)
--- PASS: TestAccQuickSightDashboard_disappears (93.99s)
--- PASS: TestAccQuickSightAnalysis_disappears (94.02s)
--- PASS: TestAccQuickSightAnalysis_forceDelete (94.21s)
--- PASS: TestAccQuickSightTemplate_disappears (94.62s)
--- PASS: TestAccQuickSightTemplate_sourceEntity (97.54s)
--- PASS: TestAccQuickSightTemplate_barChart (99.17s)
--- PASS: TestAccQuickSightAnalysis_parametersConfig (103.25s)
--- PASS: TestAccQuickSightDashboard_dashboardSpecificConfig (104.28s)
--- PASS: TestAccQuickSightAnalysis_basic (104.35s)
--- PASS: TestAccQuickSightDashboard_basic (104.76s)
--- PASS: TestAccQuickSightAnalysis_Definition_calculatedFields (104.89s)
--- PASS: TestAccQuickSightAnalysis_sourceEntity (107.74s)
--- PASS: TestAccQuickSightDashboard_sourceEntity (110.11s)
--- PASS: TestAccQuickSightTemplate_table (123.68s)
--- PASS: TestAccQuickSightTemplate_update (138.46s)
--- PASS: TestAccQuickSightDashboard_updateVersionNumber (145.02s)
--- PASS: TestAccQuickSightAnalysis_update (146.36s)
--- PASS: TestAccQuickSightTemplate_tags (158.01s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/quicksight 161.125s
```
