### PR TITLE
r/aws_iam_user_login_profile(test): fix keybase configs

### DIFF
--- a/internal/service/iam/user_login_profile_test.go
+++ b/internal/service/iam/user_login_profile_test.go
@@ -128,13 +128,13 @@ func TestAccIAMUserLoginProfile_keybase(t *testing.T) {
 		CheckDestroy:             testAccCheckUserLoginProfileDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserLoginProfileConfig_required(rName, "keybase:terraformacctest"),
+				Config: testAccUserLoginProfileConfig_keybase(rName, "keybase:terraformacctest"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserLoginProfileExists(ctx, resourceName, &conf),
 					resource.TestCheckResourceAttrSet(resourceName, "encrypted_password"),
 					resource.TestCheckResourceAttrSet(resourceName, "key_fingerprint"),
 					resource.TestCheckResourceAttr(resourceName, "password_length", "20"),
-					resource.TestCheckResourceAttr(resourceName, "pgp_key", "keybase:terraformacctest\n"),
+					resource.TestCheckResourceAttr(resourceName, "pgp_key", "keybase:terraformacctest"),
 				),
 			},
 			{
@@ -164,7 +164,7 @@ func TestAccIAMUserLoginProfile_keybaseDoesntExist(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// We own this account but it doesn't have any key associated with it
-				Config:      testAccUserLoginProfileConfig_required(rName, "keybase:terraform_nope"),
+				Config:      testAccUserLoginProfileConfig_keybase(rName, "keybase:terraform_nope"),
 				ExpectError: regexp.MustCompile(`retrieving Public Key`),
 			},
 		},
@@ -462,6 +462,16 @@ resource "aws_iam_user_login_profile" "test" {
 EOF
 }
 `, pgpKey))
+}
+
+func testAccUserLoginProfileConfig_keybase(rName, keyname string) string {
+	return acctest.ConfigCompose(testAccUserLoginProfileConfig_base(rName), fmt.Sprintf(`
+resource "aws_iam_user_login_profile" "test" {
+  user = aws_iam_user.test.name
+
+  pgp_key = %[1]q
+}
+`, keyname))
 }
 
 func testAccUserLoginProfileConfig_noGPG(rName string) string {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Fixes acceptance tests expecting a Keybase key name for the `ppg_key` argument. The heredoc string format used in the `_required` test configuration was preventing the key name from being read properly, resulting in errors like:

```
=== CONT  TestAccIAMUserLoginProfile_keybase
    user_login_profile_test.go:124: Step 1/2 error: Error running apply: exit status 1

        Error: creating IAM User Login Profile for "tf-acc-test-6581599776859930449": encrypting Password: parsing given PGP key: EOF

          with aws_iam_user_login_profile.test,
          on terraform_plugin_test.tf line 35, in resource "aws_iam_user_login_profile" "test":
          35: resource "aws_iam_user_login_profile" "test" {
```


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=iam TESTS=TestAccIAMUserLoginProfile_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMUserLoginProfile_'  -timeout 180m

--- PASS: TestAccIAMUserLoginProfile_keybaseDoesntExist (17.25s)
--- PASS: TestAccIAMUserLoginProfile_notAKey (21.38s)
--- PASS: TestAccIAMUserLoginProfile_keybase (25.39s)
--- PASS: TestAccIAMUserLoginProfile_passwordLength (25.41s)
--- PASS: TestAccIAMUserLoginProfile_nogpg (25.41s)
--- PASS: TestAccIAMUserLoginProfile_disappears (29.38s)
--- PASS: TestAccIAMUserLoginProfile_basic (31.26s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        34.195s
```
