### PR TITLE
resource/aws_cloudformation_stack: Sets `outputs` as `Computed` when other fields change

### DIFF
--- a/.changelog/33059.txt
+++ b/.changelog/33059.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudformation_stack: Marks `outputs` as Computed when there are potential changes.
+```

--- a/internal/service/cloudformation/stack.go
+++ b/internal/service/cloudformation/stack.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -132,7 +133,10 @@ func ResourceStack() *schema.Resource {
 			},
 		},
 
-		CustomizeDiff: verify.SetTagsDiff,
+		CustomizeDiff: customdiff.All(
+			verify.SetTagsDiff,
+			customdiff.ComputedIf("outputs", stackHasActualChanges),
+		),
 	}
 }
 
@@ -689,4 +693,32 @@ func isStackDeletionEvent(event *cloudformation.StackEvent) bool {
 
 func reasonFromEvent(event *cloudformation.StackEvent) string {
 	return aws.StringValue(event.ResourceStatusReason)
+}
+
+func stackHasActualChanges(ctx context.Context, d *schema.ResourceDiff, meta any) bool {
+	if d.Id() == "" {
+		return false
+	}
+
+	for k, attr := range ResourceStack().Schema {
+		if attr.ForceNew {
+			continue
+		}
+		if attr.Computed && !attr.Optional {
+			continue
+		}
+
+		if d.HasChange(k) {
+			if attr.StateFunc == nil {
+				return true
+			}
+			o, n := d.GetChange(k)
+			on := attr.StateFunc(o)
+			nn := attr.StateFunc(n)
+			if on != nn {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/internal/service/cloudformation/stack_test.go
+++ b/internal/service/cloudformation/stack_test.go
@@ -12,7 +12,9 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfcloudformation "github.com/hashicorp/terraform-provider-aws/internal/service/cloudformation"
@@ -499,6 +501,12 @@ func TestAccCloudFormationStack_outputsUpdated(t *testing.T) {
 			},
 			{
 				Config: testAccStackConfig_parametersAndOutputs(rName, "in2"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("outputs")),
+					},
+				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStackExists(ctx, resourceName, &stack),
 					resource.TestCheckResourceAttr(resourceName, "parameters.%", "1"),
@@ -541,6 +549,12 @@ func TestAccCloudFormationStack_templateUpdate(t *testing.T) {
 			},
 			{
 				Config: testAccStackConfig_templateUpdate(rName, "out2", "value2"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("outputs")),
+					},
+				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStackExists(ctx, resourceName, &stack),
 					resource.TestCheckResourceAttr(resourceName, "outputs.%", "1"),

--- a/internal/service/cloudformation/stack_test.go
+++ b/internal/service/cloudformation/stack_test.go
@@ -33,7 +33,7 @@ func TestAccCloudFormationStack_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStackConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStackExists(ctx, resourceName, &stack),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckNoResourceAttr(resourceName, "on_failure"),
@@ -119,7 +119,7 @@ func TestAccCloudFormationStack_updateFailure(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStackConfig_params(rName, vpcCidrInitial),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStackExists(ctx, resourceName, &stack),
 				),
 			},
@@ -145,7 +145,7 @@ func TestAccCloudFormationStack_disappears(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStackConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStackExists(ctx, resourceName, &stack),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfcloudformation.ResourceStack(), resourceName),
 				),
@@ -169,7 +169,7 @@ func TestAccCloudFormationStack_yaml(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStackConfig_yaml(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStackExists(ctx, resourceName, &stack),
 				),
 			},
@@ -196,7 +196,7 @@ func TestAccCloudFormationStack_defaultParams(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStackConfig_defaultParams(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStackExists(ctx, resourceName, &stack),
 				),
 			},
@@ -225,7 +225,7 @@ func TestAccCloudFormationStack_allAttributes(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStackConfig_allAttributesBodies(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStackExists(ctx, resourceName, &stack),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "capabilities.#", "1"),
@@ -249,7 +249,7 @@ func TestAccCloudFormationStack_allAttributes(t *testing.T) {
 			},
 			{
 				Config: testAccStackConfig_allAttributesBodiesModified(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStackExists(ctx, resourceName, &stack),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "capabilities.#", "1"),
@@ -287,7 +287,7 @@ func TestAccCloudFormationStack_withParams(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStackConfig_params(rName, vpcCidrInitial),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStackExists(ctx, resourceName, &stack),
 					resource.TestCheckResourceAttr(resourceName, "parameters.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.VpcCIDR", vpcCidrInitial),
@@ -301,7 +301,7 @@ func TestAccCloudFormationStack_withParams(t *testing.T) {
 			},
 			{
 				Config: testAccStackConfig_params(rName, vpcCidrUpdated),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStackExists(ctx, resourceName, &stack),
 					resource.TestCheckResourceAttr(resourceName, "parameters.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.VpcCIDR", vpcCidrUpdated),
@@ -326,7 +326,7 @@ func TestAccCloudFormationStack_WithURL_withParams(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStackConfig_templateURLParams(rName, "tf-cf-stack.json", "11.0.0.0/16"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStackExists(ctx, resourceName, &stack),
 				),
 			},
@@ -338,7 +338,7 @@ func TestAccCloudFormationStack_WithURL_withParams(t *testing.T) {
 			},
 			{
 				Config: testAccStackConfig_templateURLParams(rName, "tf-cf-stack.json", "13.0.0.0/16"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStackExists(ctx, resourceName, &stack),
 				),
 			},
@@ -360,7 +360,7 @@ func TestAccCloudFormationStack_WithURLWithParams_withYAML(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStackConfig_templateURLParamsYAML(rName, "tf-cf-stack.test", "13.0.0.0/16"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStackExists(ctx, resourceName, &stack),
 				),
 			},
@@ -389,7 +389,7 @@ func TestAccCloudFormationStack_WithURLWithParams_noUpdate(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStackConfig_templateURLParams(rName, "tf-cf-stack-1.json", "11.0.0.0/16"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStackExists(ctx, resourceName, &stack),
 				),
 			},
@@ -401,7 +401,7 @@ func TestAccCloudFormationStack_WithURLWithParams_noUpdate(t *testing.T) {
 			},
 			{
 				Config: testAccStackConfig_templateURLParams(rName, "tf-cf-stack-2.json", "11.0.0.0/16"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStackExists(ctx, resourceName, &stack),
 				),
 			},
@@ -423,14 +423,14 @@ func TestAccCloudFormationStack_withTransform(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStackConfig_transform(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStackExists(ctx, resourceName, &stack),
 				),
 			},
 			{
 				PlanOnly: true,
 				Config:   testAccStackConfig_transform(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStackExists(ctx, resourceName, &stack),
 				),
 			},
@@ -453,7 +453,7 @@ func TestAccCloudFormationStack_onFailure(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStackConfig_onFailure(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStackExists(ctx, resourceName, &stack),
 					resource.TestCheckResourceAttr(resourceName, "disable_rollback", "false"),
 					resource.TestCheckResourceAttr(resourceName, "on_failure", cloudformation.OnFailureDoNothing),
@@ -477,7 +477,7 @@ func TestAccCloudFormationStack_outputsUpdated(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStackConfig_parametersAndOutputs(rName, "in1"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStackExists(ctx, resourceName, &stack),
 					resource.TestCheckResourceAttr(resourceName, "parameters.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.DataIn", "in1"),
@@ -487,7 +487,7 @@ func TestAccCloudFormationStack_outputsUpdated(t *testing.T) {
 			},
 			{
 				Config: testAccStackConfig_parametersAndOutputs(rName, "in2"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStackExists(ctx, resourceName, &stack),
 					resource.TestCheckResourceAttr(resourceName, "parameters.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.DataIn", "in2"),

--- a/internal/service/cloudformation/stack_test.go
+++ b/internal/service/cloudformation/stack_test.go
@@ -37,6 +37,11 @@ func TestAccCloudFormationStack_basic(t *testing.T) {
 					testAccCheckStackExists(ctx, resourceName, &stack),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckNoResourceAttr(resourceName, "on_failure"),
+					resource.TestCheckResourceAttr(resourceName, "outputs.%", "2"),
+					resource.TestCheckResourceAttrSet(resourceName, "outputs.DefaultSgId"),
+					resource.TestCheckResourceAttrSet(resourceName, "outputs.VpcID"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "template_url"),
 				),
 			},
 			{


### PR DESCRIPTION
### Description

When the output values of an `aws_cloudformation_stack` change, the `outputs` attribute is not correctly marked as `Computed`, so changes are not picked up by dependent resources or Terraform output values. The values in state are correctly updated.

When any configurable, non-`ForceNew` parameters are changed, now marks the `outputs` attribute as `Computed`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #32744

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=cloudformation TESTS=TestAccCloudFormationStack_

--- PASS: TestAccCloudFormationStack_disappears (69.58s)
--- PASS: TestAccCloudFormationStack_yaml (78.66s)
--- PASS: TestAccCloudFormationStack_onFailure (83.11s)
--- PASS: TestAccCloudFormationStack_WithURLWithParams_withYAML (85.38s)
--- PASS: TestAccCloudFormationStack_withTransform (87.62s)
--- PASS: TestAccCloudFormationStack_basic (92.09s)
--- PASS: TestAccCloudFormationStack_updateFailure (93.19s)
--- PASS: TestAccCloudFormationStack_outputsUpdated (93.77s)
--- PASS: TestAccCloudFormationStack_templateUpdate (94.36s)
--- PASS: TestAccCloudFormationStack_allAttributes (101.44s)
--- PASS: TestAccCloudFormationStack_WithURLWithParams_noUpdate (103.51s)
--- PASS: TestAccCloudFormationStack_withParams (119.98s)
--- PASS: TestAccCloudFormationStack_defaultParams (125.39s)
--- PASS: TestAccCloudFormationStack_WithURL_withParams (127.70s)
--- PASS: TestAccCloudFormationStack_CreationFailure_doNothing (194.04s)
--- PASS: TestAccCloudFormationStack_CreationFailure_delete (197.94s)
--- PASS: TestAccCloudFormationStack_CreationFailure_rollback (198.03s)
```
