### PR TITLE
typo(docs): fix typo in aoss dashboard endpoint attribute

### DIFF
--- a/website/docs/d/opensearchserverless_collection.html.markdown
+++ b/website/docs/d/opensearchserverless_collection.html.markdown
@@ -34,7 +34,7 @@ This data source exports the following attributes in addition to the arguments a
 * `arn` - Amazon Resource Name (ARN) of the collection.
 * `collection_endpoint` - Collection-specific endpoint used to submit index, search, and data upload requests to an OpenSearch Serverless collection.
 * `created_date` - Date the Collection was created.
-* `dashboard_endpont` - Collection-specific endpoint used to access OpenSearch Dashboards.
+* `dashboard_endpoint` - Collection-specific endpoint used to access OpenSearch Dashboards.
 * `description` - Description of the collection.
 * `kms_key_arn` - The ARN of the Amazon Web Services KMS key used to encrypt the collection.
 * `last_modified_date` - Date the Collection was last modified.

--- a/website/docs/r/opensearchserverless_collection.html.markdown
+++ b/website/docs/r/opensearchserverless_collection.html.markdown
@@ -60,7 +60,7 @@ This resource exports the following attributes in addition to the arguments abov
 
 * `arn` - Amazon Resource Name (ARN) of the collection.
 * `collection_endpoint` - Collection-specific endpoint used to submit index, search, and data upload requests to an OpenSearch Serverless collection.
-* `dashboard_endpont` - Collection-specific endpoint used to access OpenSearch Dashboards.
+* `dashboard_endpoint` - Collection-specific endpoint used to access OpenSearch Dashboards.
 * `kms_key_arn` - The ARN of the Amazon Web Services KMS key used to encrypt the collection.
 * `id` - Unique identifier for the collection.
 


### PR DESCRIPTION

### Description
Fixing typo in [AOSS](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/opensearchserverless_collection#dashboard_endpont) documentation


### Relations

none 
### References
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/opensearchserverless_collection#dashboard_endpont

### Output from Acceptance Testing
not sure what should be provided here, if anything for such change
```console

```
