### PR TITLE
Network Manager: Fix acceptance test failures

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -1402,16 +1402,34 @@ func CheckWithNamedProviders(f TestCheckWithProviderFunc, providers map[string]*
 	}
 }
 
-// ErrorCheckSkipMessagesContaining skips tests based on error messages that indicate unsupported features
-func ErrorCheckSkipMessagesContaining(t *testing.T, messages ...string) resource.ErrorCheckFunc {
+// ErrorCheckSkipMessagesContaining skips tests based on error messages that contain one of the specified needles.
+func ErrorCheckSkipMessagesContaining(t *testing.T, needles ...string) resource.ErrorCheckFunc {
 	return func(err error) error {
 		if err == nil {
 			return nil
 		}
 
-		for _, message := range messages {
+		for _, needle := range needles {
 			errorMessage := err.Error()
-			if strings.Contains(errorMessage, message) {
+			if strings.Contains(errorMessage, needle) {
+				t.Skipf("skipping test for %s/%s: %s", Partition(), Region(), errorMessage)
+			}
+		}
+
+		return err
+	}
+}
+
+// ErrorCheckSkipMessagesMatches skips tests based on error messages that match one of the specified regular expressions.
+func ErrorCheckSkipMessagesMatches(t *testing.T, rs ...*regexp.Regexp) resource.ErrorCheckFunc {
+	return func(err error) error {
+		if err == nil {
+			return nil
+		}
+
+		for _, r := range rs {
+			errorMessage := err.Error()
+			if r.MatchString(errorMessage) {
 				t.Skipf("skipping test for %s/%s: %s", Partition(), Region(), errorMessage)
 			}
 		}

--- a/internal/service/networkmanager/connect_attachment_test.go
+++ b/internal/service/networkmanager/connect_attachment_test.go
@@ -247,11 +247,15 @@ resource "aws_networkmanager_global_network" "test" {
 
 resource "aws_networkmanager_core_network" "test" {
   global_network_id = aws_networkmanager_global_network.test.id
-  policy_document   = data.aws_networkmanager_core_network_policy_document.test.json
 
   tags = {
     Name = %[1]q
   }
+}
+
+resource "aws_networkmanager_core_network_policy_attachment" "test" {
+  core_network_id = aws_networkmanager_core_network.test.id
+  policy_document = data.aws_networkmanager_core_network_policy_document.test.json
 }
 
 data "aws_networkmanager_core_network_policy_document" "test" {
@@ -297,7 +301,7 @@ func testAccConnectAttachmentConfig_basic(rName string) string {
 	return acctest.ConfigCompose(testAccConnectAttachmentConfig_base(rName), `
 resource "aws_networkmanager_vpc_attachment" "test" {
   subnet_arns     = aws_subnet.test[*].arn
-  core_network_id = aws_networkmanager_core_network.test.id
+  core_network_id = aws_networkmanager_core_network_policy_attachment.test.core_network_id
   vpc_arn         = aws_vpc.test.arn
   tags = {
     segment = "shared"
@@ -335,7 +339,7 @@ func testAccConnectAttachmentConfig_basic_NoDependsOn(rName string) string {
 	return acctest.ConfigCompose(testAccConnectAttachmentConfig_base(rName), `
 resource "aws_networkmanager_vpc_attachment" "test" {
   subnet_arns     = aws_subnet.test[*].arn
-  core_network_id = aws_networkmanager_core_network.test.id
+  core_network_id = aws_networkmanager_core_network_policy_attachment.test.core_network_id
   vpc_arn         = aws_vpc.test.arn
   tags = {
     segment = "shared"
@@ -370,7 +374,7 @@ func testAccConnectAttachmentConfig_tags1(rName, tagKey1, tagValue1 string) stri
 	return acctest.ConfigCompose(testAccConnectAttachmentConfig_base(rName), fmt.Sprintf(`
 resource "aws_networkmanager_vpc_attachment" "test" {
   subnet_arns     = [aws_subnet.test[0].arn]
-  core_network_id = aws_networkmanager_core_network.test.id
+  core_network_id = aws_networkmanager_core_network_policy_attachment.test.core_network_id
   vpc_arn         = aws_vpc.test.arn
   tags = {
     segment = "shared"
@@ -408,7 +412,7 @@ func testAccConnectAttachmentConfig_tags2(rName, tagKey1, tagValue1, tagKey2, ta
 	return acctest.ConfigCompose(testAccConnectAttachmentConfig_base(rName), fmt.Sprintf(`
 resource "aws_networkmanager_vpc_attachment" "test" {
   subnet_arns     = [aws_subnet.test[0].arn]
-  core_network_id = aws_networkmanager_core_network.test.id
+  core_network_id = aws_networkmanager_core_network_policy_attachment.test.core_network_id
   vpc_arn         = aws_vpc.test.arn
   tags = {
     segment = "shared"

--- a/internal/service/networkmanager/connect_peer_test.go
+++ b/internal/service/networkmanager/connect_peer_test.go
@@ -238,10 +238,15 @@ resource "aws_networkmanager_global_network" "test" {
 
 resource "aws_networkmanager_core_network" "test" {
   global_network_id = aws_networkmanager_global_network.test.id
-  policy_document   = data.aws_networkmanager_core_network_policy_document.test.json
+
   tags = {
     Name = %[1]q
   }
+}
+
+resource "aws_networkmanager_core_network_policy_attachment" "test" {
+  core_network_id = aws_networkmanager_core_network.test.id
+  policy_document = data.aws_networkmanager_core_network_policy_document.test.json
 }
 
 data "aws_networkmanager_core_network_policy_document" "test" {
@@ -284,7 +289,7 @@ data "aws_networkmanager_core_network_policy_document" "test" {
 
 resource "aws_networkmanager_vpc_attachment" "test" {
   subnet_arns     = aws_subnet.test[*].arn
-  core_network_id = aws_networkmanager_core_network.test.id
+  core_network_id = aws_networkmanager_core_network_policy_attachment.test.core_network_id
   vpc_arn         = aws_vpc.test.arn
   tags = {
     segment = "shared"

--- a/internal/service/networkmanager/site_to_site_vpn_attachment_test.go
+++ b/internal/service/networkmanager/site_to_site_vpn_attachment_test.go
@@ -228,11 +228,15 @@ resource "aws_networkmanager_global_network" "test" {
 
 resource "aws_networkmanager_core_network" "test" {
   global_network_id = aws_networkmanager_global_network.test.id
-  policy_document   = data.aws_networkmanager_core_network_policy_document.test.json
 
   tags = {
     Name = %[1]q
   }
+}
+
+resource "aws_networkmanager_core_network_policy_attachment" "test" {
+  core_network_id = aws_networkmanager_core_network.test.id
+  policy_document = data.aws_networkmanager_core_network_policy_document.test.json
 }
 
 data "aws_networkmanager_core_network_policy_document" "test" {
@@ -281,7 +285,7 @@ data "aws_networkmanager_core_network_policy_document" "test" {
 func testAccSiteToSiteVPNAttachmentConfig_basic(rName string, bgpASN int, vpnIP string) string {
 	return acctest.ConfigCompose(testAccSiteToSiteVPNAttachmentConfig_base(rName, bgpASN, vpnIP), `
 resource "aws_networkmanager_site_to_site_vpn_attachment" "test" {
-  core_network_id    = aws_networkmanager_core_network.test.id
+  core_network_id    = aws_networkmanager_core_network_policy_attachment.test.core_network_id
   vpn_connection_arn = aws_vpn_connection.test.arn
 
   tags = {
@@ -299,7 +303,7 @@ resource "aws_networkmanager_attachment_accepter" "test" {
 func testAccSiteToSiteVPNAttachmentConfig_tags1(rName, vpnIP, tagKey1, tagValue1 string, bgpASN int) string {
 	return acctest.ConfigCompose(testAccSiteToSiteVPNAttachmentConfig_base(rName, bgpASN, vpnIP), fmt.Sprintf(`
 resource "aws_networkmanager_site_to_site_vpn_attachment" "test" {
-  core_network_id    = aws_networkmanager_core_network.test.id
+  core_network_id    = aws_networkmanager_core_network_policy_attachment.test.core_network_id
   vpn_connection_arn = aws_vpn_connection.test.arn
 
   tags = {
@@ -317,7 +321,7 @@ resource "aws_networkmanager_attachment_accepter" "test" {
 func testAccSiteToSiteVPNAttachmentConfig_tags2(rName, vpnIP, tagKey1, tagValue1, tagKey2, tagValue2 string, bgpASN int) string {
 	return acctest.ConfigCompose(testAccSiteToSiteVPNAttachmentConfig_base(rName, bgpASN, vpnIP), fmt.Sprintf(`
 resource "aws_networkmanager_site_to_site_vpn_attachment" "test" {
-  core_network_id    = aws_networkmanager_core_network.test.id
+  core_network_id    = aws_networkmanager_core_network_policy_attachment.test.core_network_id
   vpn_connection_arn = aws_vpn_connection.test.arn
 
   tags = {

--- a/internal/service/networkmanager/transit_gateway_peering_test.go
+++ b/internal/service/networkmanager/transit_gateway_peering_test.go
@@ -19,6 +19,16 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
+func init() {
+	acctest.RegisterServiceErrorCheckFunc(networkmanager.EndpointsID, testAccErrorCheckSkip)
+}
+
+func testAccErrorCheckSkip(t *testing.T) resource.ErrorCheckFunc {
+	return acctest.ErrorCheckSkipMessagesMatches(t,
+		regexp.MustCompile(`Core Network edge location \([a-z0-9-]+\) not available`),
+	)
+}
+
 func TestAccNetworkManagerTransitGatewayPeering_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v networkmanager.TransitGatewayPeering

--- a/internal/service/networkmanager/vpc_attachment_test.go
+++ b/internal/service/networkmanager/vpc_attachment_test.go
@@ -277,11 +277,15 @@ resource "aws_networkmanager_global_network" "test" {
 
 resource "aws_networkmanager_core_network" "test" {
   global_network_id = aws_networkmanager_global_network.test.id
-  policy_document   = data.aws_networkmanager_core_network_policy_document.test.json
 
   tags = {
     Name = %[1]q
   }
+}
+
+resource "aws_networkmanager_core_network_policy_attachment" "test" {
+  core_network_id = aws_networkmanager_core_network.test.id
+  policy_document = data.aws_networkmanager_core_network_policy_document.test.json
 }
 
 data "aws_networkmanager_core_network_policy_document" "test" {
@@ -331,7 +335,7 @@ func testAccVPCAttachmentConfig_basic(rName string) string {
 	return acctest.ConfigCompose(testAccVPCAttachmentConfig_base(rName), `
 resource "aws_networkmanager_vpc_attachment" "test" {
   subnet_arns     = aws_subnet.test[*].arn
-  core_network_id = aws_networkmanager_core_network.test.id
+  core_network_id = aws_networkmanager_core_network_policy_attachment.test.core_network_id
   vpc_arn         = aws_vpc.test.arn
 }
 
@@ -346,7 +350,7 @@ func testAccVPCAttachmentConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(testAccVPCAttachmentConfig_base(rName), fmt.Sprintf(`
 resource "aws_networkmanager_vpc_attachment" "test" {
   subnet_arns     = [aws_subnet.test[0].arn]
-  core_network_id = aws_networkmanager_core_network.test.id
+  core_network_id = aws_networkmanager_core_network_policy_attachment.test.core_network_id
   vpc_arn         = aws_vpc.test.arn
 
   tags = {
@@ -365,7 +369,7 @@ func testAccVPCAttachmentConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagVal
 	return acctest.ConfigCompose(testAccVPCAttachmentConfig_base(rName), fmt.Sprintf(`
 resource "aws_networkmanager_vpc_attachment" "test" {
   subnet_arns     = [aws_subnet.test[0].arn]
-  core_network_id = aws_networkmanager_core_network.test.id
+  core_network_id = aws_networkmanager_core_network_policy_attachment.test.core_network_id
   vpc_arn         = aws_vpc.test.arn
 
   tags = {
@@ -385,7 +389,7 @@ func testAccVPCAttachmentConfig_updates(rName string, nSubnets int, applianceMod
 	return acctest.ConfigCompose(testAccVPCAttachmentConfig_base(rName), fmt.Sprintf(`
 resource "aws_networkmanager_vpc_attachment" "test" {
   subnet_arns     = slice(aws_subnet.test[*].arn, 0, %[2]d)
-  core_network_id = aws_networkmanager_core_network.test.id
+  core_network_id = aws_networkmanager_core_network_policy_attachment.test.core_network_id
   vpc_arn         = aws_vpc.test.arn
 
   options {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

In CI:

```
=== RUN   TestAccNetworkManagerConnectAttachment_basic
=== PAUSE TestAccNetworkManagerConnectAttachment_basic
=== CONT  TestAccNetworkManagerConnectAttachment_basic
    connect_attachment_test.go:28: Step 1/2 error: Error running pre-apply refresh: exit status 1
        Error: Unsupported argument
          on terraform_plugin_test.tf line 46, in resource "aws_networkmanager_core_network" "test":
          46:   policy_document   = data.aws_networkmanager_core_network_policy_document.test.json
        An argument named "policy_document" is not expected here.
--- FAIL: TestAccNetworkManagerConnectAttachment_basic (29.62s)
```

(relates https://github.com/hashicorp/terraform-provider-aws/pull/30875), and

```
=== RUN   TestAccNetworkManagerTransitGatewayPeering_basic
=== PAUSE TestAccNetworkManagerTransitGatewayPeering_basic
=== CONT  TestAccNetworkManagerTransitGatewayPeering_basic
    transit_gateway_peering_test.go:29: Step 1/2 error: Error running apply: exit status 1
        Error: creating Network Manager Transit Gateway (arn:aws:ec2:us-west-2:123456789012:transit-gateway/tgw-0714dfbc7fc82c6ee) Peering (core-network-0b53e3008be36d2cc): ValidationException: Core Network edge location (us-west-2) not available.
        {
          RespMetadata: {
            StatusCode: 400,
            RequestID: "0cf6dd83-96f6-4ae3-9fbc-cb92ab1f9f0b"
          },
          Message_: "Core Network edge location (us-west-2) not available.",
          Reason: "Other"
        }
          with aws_networkmanager_transit_gateway_peering.test,
          on terraform_plugin_test.tf line 52, in resource "aws_networkmanager_transit_gateway_peering" "test":
          52: resource "aws_networkmanager_transit_gateway_peering" "test" {
--- FAIL: TestAccNetworkManagerTransitGatewayPeering_basic (618.96s)
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccNetworkManagerConnectAttachment_basic\|TestAccNetworkManagerConnectPeer_basic\|TestAccNetworkManagerSiteToSiteVPNAttachment_basic\|TestAccNetworkManagerTransitGatewayPeering_basic\|TestAccNetworkManagerVPCAttachment_basic' PKG=networkmanager ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/networkmanager/... -v -count 1 -parallel 3  -run=TestAccNetworkManagerConnectAttachment_basic\|TestAccNetworkManagerConnectPeer_basic\|TestAccNetworkManagerSiteToSiteVPNAttachment_basic\|TestAccNetworkManagerTransitGatewayPeering_basic\|TestAccNetworkManagerVPCAttachment_basic -timeout 180m
=== RUN   TestAccNetworkManagerConnectAttachment_basic
=== PAUSE TestAccNetworkManagerConnectAttachment_basic
=== RUN   TestAccNetworkManagerConnectAttachment_basic_NoDependsOn
=== PAUSE TestAccNetworkManagerConnectAttachment_basic_NoDependsOn
=== RUN   TestAccNetworkManagerConnectPeer_basic
=== PAUSE TestAccNetworkManagerConnectPeer_basic
=== RUN   TestAccNetworkManagerSiteToSiteVPNAttachment_basic
=== PAUSE TestAccNetworkManagerSiteToSiteVPNAttachment_basic
=== RUN   TestAccNetworkManagerTransitGatewayPeering_basic
=== PAUSE TestAccNetworkManagerTransitGatewayPeering_basic
=== RUN   TestAccNetworkManagerVPCAttachment_basic
=== PAUSE TestAccNetworkManagerVPCAttachment_basic
=== CONT  TestAccNetworkManagerConnectAttachment_basic
=== CONT  TestAccNetworkManagerSiteToSiteVPNAttachment_basic
=== CONT  TestAccNetworkManagerVPCAttachment_basic
--- PASS: TestAccNetworkManagerVPCAttachment_basic (762.24s)
=== CONT  TestAccNetworkManagerTransitGatewayPeering_basic
    acctest.go:1433: skipping test for aws/us-west-2: Error running apply: exit status 1
        
        Error: creating Network Manager Transit Gateway (arn:aws:ec2:us-west-2:123456789012:transit-gateway/tgw-0ce8b83f570a4b65e) Peering (core-network-0129267d3b713a6ba): ValidationException: Core Network edge location (us-west-2) not available.
        {
          RespMetadata: {
            StatusCode: 400,
            RequestID: "24b1d9a8-6bcd-491d-9df2-71c4eec35e31"
          },
          Message_: "Core Network edge location (us-west-2) not available.",
          Reason: "Other"
        }
        
          with aws_networkmanager_transit_gateway_peering.test,
          on terraform_plugin_test.tf line 52, in resource "aws_networkmanager_transit_gateway_peering" "test":
          52: resource "aws_networkmanager_transit_gateway_peering" "test" {
        
--- PASS: TestAccNetworkManagerConnectAttachment_basic (991.22s)
=== CONT  TestAccNetworkManagerConnectAttachment_basic_NoDependsOn
--- PASS: TestAccNetworkManagerSiteToSiteVPNAttachment_basic (1050.11s)
=== CONT  TestAccNetworkManagerConnectPeer_basic
--- SKIP: TestAccNetworkManagerTransitGatewayPeering_basic (391.57s)
--- PASS: TestAccNetworkManagerConnectAttachment_basic_NoDependsOn (1133.94s)
--- PASS: TestAccNetworkManagerConnectPeer_basic (1495.66s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/networkmanager	2550.690s
```
