### PR TITLE
Correct `aws_pipes_pipe` examples

### DIFF
--- a/website/docs/r/pipes_pipe.html.markdown
+++ b/website/docs/r/pipes_pipe.html.markdown
@@ -86,7 +86,7 @@ resource "aws_sqs_queue" "target" {}
 resource "aws_pipes_pipe" "example" {
   depends_on = [aws_iam_role_policy.source, aws_iam_role_policy.target]
   name       = "example-pipe"
-  role_arn   = aws_iam_role.example.arn
+  role_arn   = aws_iam_role.test.arn
   source     = aws_sqs_queue.source.arn
   target     = aws_sqs_queue.target.arn
 }
@@ -97,23 +97,25 @@ resource "aws_pipes_pipe" "example" {
 ```terraform
 resource "aws_pipes_pipe" "example" {
   name     = "example-pipe"
-  role_arn = aws_iam_role.example.arn
+  role_arn = aws_iam_role.test.arn
   source   = aws_sqs_queue.source.arn
   target   = aws_sqs_queue.target.arn
 
   enrichment = aws_cloudwatch_event_api_destination.example.arn
 
   enrichment_parameters {
-    http_parameters = {
-      "example-header"        = "example-value"
-      "second-example-header" = "second-example-value"
-    }
+    http_parameters {
+      path_parameter_values = ["example-path-param"]
 
-    path_parameter_values = ["example-path-param"]
+      header_parameters = {
+        "example-header"        = "example-value"
+        "second-example-header" = "second-example-value"
+      }
 
-    query_string_parameters = {
-      "example-query-string"        = "example-value"
-      "second-example-query-string" = "second-example-value"
+      query_string_parameters = {
+        "example-query-string"        = "example-value"
+        "second-example-query-string" = "second-example-value"
+      }
     }
   }
 }

--- a/website/docs/r/pipes_pipe.html.markdown
+++ b/website/docs/r/pipes_pipe.html.markdown
@@ -23,7 +23,7 @@ EventBridge Pipes are very configurable, and may require IAM permissions to work
 ```terraform
 data "aws_caller_identity" "main" {}
 
-resource "aws_iam_role" "test" {
+resource "aws_iam_role" "example" {
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = {
@@ -42,7 +42,7 @@ resource "aws_iam_role" "test" {
 }
 
 resource "aws_iam_role_policy" "source" {
-  role = aws_iam_role.test.id
+  role = aws_iam_role.example.id
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -64,7 +64,7 @@ resource "aws_iam_role_policy" "source" {
 resource "aws_sqs_queue" "source" {}
 
 resource "aws_iam_role_policy" "target" {
-  role = aws_iam_role.test.id
+  role = aws_iam_role.example.id
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -86,7 +86,7 @@ resource "aws_sqs_queue" "target" {}
 resource "aws_pipes_pipe" "example" {
   depends_on = [aws_iam_role_policy.source, aws_iam_role_policy.target]
   name       = "example-pipe"
-  role_arn   = aws_iam_role.test.arn
+  role_arn   = aws_iam_role.example.arn
   source     = aws_sqs_queue.source.arn
   target     = aws_sqs_queue.target.arn
 }
@@ -97,7 +97,7 @@ resource "aws_pipes_pipe" "example" {
 ```terraform
 resource "aws_pipes_pipe" "example" {
   name     = "example-pipe"
-  role_arn = aws_iam_role.test.arn
+  role_arn = aws_iam_role.example.arn
   source   = aws_sqs_queue.source.arn
   target   = aws_sqs_queue.target.arn
 


### PR DESCRIPTION
### Description

This PR corrects the `aws_pipes_pipe` documentation's example for using `enrichment_parameters`, as it was previously non-functional. Corrected reference to `aws_iam_role` while I was at it.

### Relations

Closes #33086

### References

Docs themselves + `terraform validate`

### Output from Acceptance Testing

N/a, docs
