### PR TITLE
Fix `aws_docdb_global_cluster` example

### DIFF
--- a/website/docs/r/docdb_global_cluster.html.markdown
+++ b/website/docs/r/docdb_global_cluster.html.markdown
@@ -59,6 +59,10 @@ resource "aws_docdb_cluster" "secondary" {
   cluster_identifier        = "test-secondary-cluster"
   global_cluster_identifier = aws_docdb_global_cluster.example.id
   db_subnet_group_name      = "default"
+
+  depends_on = [
+    aws_docdb_cluster.primary
+  ]
 }
 
 resource "aws_docdb_cluster_instance" "secondary" {


### PR DESCRIPTION
### Description

This PR updates the `aws_docdb_global_cluster` documentation to fix the example by declaring an explicit dependency between `aws_docdb_cluster.primary` and `aws_docdb_cluster.secondary`. This prevents the errors described in the linked issue by ensuring `aws_docdb_cluster.primary` is created before `aws_docdb_cluster.secondary`.

### Relations

Closes #32293

### Output from Acceptance Testing

N/a, docs (though the example was run locally to test/verify)
