### PR TITLE
r/aws_route53_zone: skip disabling dnssec in unsupported partitions

### DIFF
--- a/.changelog/33103.txt
+++ b/.changelog/33103.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_route53_zone: Skip disabling DNS SEC in unsupported partitions
+```

--- a/internal/service/route53/zone.go
+++ b/internal/service/route53/zone.go
@@ -445,7 +445,8 @@ func dnsSECStatus(ctx context.Context, conn *route53.Route53, hostedZoneID strin
 		output, err = conn.GetDNSSECWithContext(ctx, input)
 	}
 
-	if tfawserr.ErrMessageContains(err, route53.ErrCodeInvalidArgument, "Operation is unsupported for private") {
+	if tfawserr.ErrMessageContains(err, route53.ErrCodeInvalidArgument, "Operation is unsupported for private") ||
+		tfawserr.ErrMessageContains(err, "AccessDenied", "The operation GetDNSSEC is not available for the current AWS account") {
 		return "NOT_SIGNING", nil
 	}
 

--- a/internal/service/route53/zone_test.go
+++ b/internal/service/route53/zone_test.go
@@ -449,6 +449,39 @@ func TestAccRoute53Zone_VPC_updates(t *testing.T) {
 	})
 }
 
+// Excercises exception handling during forced destruction in partitions
+// which do no support DNSSEC (e.g. GovCloud).
+//
+// Ref: https://github.com/hashicorp/terraform-provider-aws/issues/22334
+func TestAccRoute53Zone_VPC_single_forceDestroy(t *testing.T) {
+	ctx := acctest.Context(t)
+	var zone route53.GetHostedZoneOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_route53_zone.test"
+	vpcResourceName := "aws_vpc.test1"
+	zoneName := acctest.RandomDomainName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, route53.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckZoneDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccZoneConfig_vpcSingle_forceDestroy(rName, zoneName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckZoneExists(ctx, resourceName, &zone),
+					resource.TestCheckResourceAttr(resourceName, "vpc.#", "1"),
+					testAccCheckZoneAssociatesVPC(vpcResourceName, &zone),
+					// Add >100 records to verify pagination works ok
+					testAccCreateRandomRecordsInZoneID(ctx, &zone, 100),
+					testAccCreateRandomRecordsInZoneID(ctx, &zone, 5),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckZoneDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).Route53Conn(ctx)
@@ -702,6 +735,27 @@ resource "aws_route53_zone" "test" {
 
   vpc {
     vpc_id = aws_vpc.test2.id
+  }
+}
+`, rName, zoneName)
+}
+
+func testAccZoneConfig_vpcSingle_forceDestroy(rName, zoneName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test1" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route53_zone" "test" {
+  force_destroy = true
+  name          = "%[2]s."
+
+  vpc {
+    vpc_id = aws_vpc.test1.id
   }
 }
 `, rName, zoneName)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Ignores errors disabling DNS SEC on forced destruction of Route53 zones where the partition does not support it (ie. GovCloud).

```
        Error: while force deleting Route53 Hosted Zone (<redacted>), disabling DNSSEC: could not get DNS SEC status for hosted zone (<redacted>): AccessDenied: The operation GetDNSSEC
is not available for the current AWS account <redacted>.
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #22334

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

**GovCloud:**

```console
% make testacc PKG=route53 TESTS=TestAccRoute53Zone_VPC_single_forceDestroy
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/route53/... -v -count 1 -parallel 20 -run='TestAccRoute53Zone_VPC_single_forceDestroy'  -timeout 180m
=== RUN   TestAccRoute53Zone_VPC_single_forceDestroy
=== PAUSE TestAccRoute53Zone_VPC_single_forceDestroy
=== CONT  TestAccRoute53Zone_VPC_single_forceDestroy
--- PASS: TestAccRoute53Zone_VPC_single_forceDestroy (194.95s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53    198.018s
```

**AWS Commercial:**

```console
% make testacc PKG=route53 TESTS=TestAccRoute53Zone_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/route53/... -v -count 1 -parallel 20 -run='TestAccRoute53Zone_'  -timeout 180m

--- PASS: TestAccRoute53Zone_disappears (64.25s)
--- PASS: TestAccRoute53Zone_delegationSetID (68.68s)
--- PASS: TestAccRoute53Zone_multiple (72.10s)
--- PASS: TestAccRoute53Zone_basic (80.90s)
--- PASS: TestAccRoute53Zone_VPC_single (82.14s)
--- PASS: TestAccRoute53Zone_comment (92.47s)
--- PASS: TestAccRoute53Zone_tags (97.74s)
--- PASS: TestAccRoute53Zone_VPC_multiple (126.79s)
--- PASS: TestAccRoute53Zone_VPC_updates (204.36s)
--- PASS: TestAccRoute53Zone_VPC_single_forceDestroy (214.22s)
--- PASS: TestAccRoute53Zone_ForceDestroy_trailingPeriod (240.54s)
--- PASS: TestAccRoute53Zone_forceDestroy (261.34s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53    264.303s
```