### PR TITLE
fix parameter name structured_log_destinations

### DIFF
--- a/website/docs/d/transfer_server.html.markdown
+++ b/website/docs/d/transfer_server.html.markdown
@@ -37,5 +37,5 @@ This data source exports the following attributes in addition to the arguments a
 * `logging_role` - ARN of an IAM role that allows the service to write your SFTP users’ activity to your Amazon CloudWatch logs for monitoring and auditing purposes.
 * `protocols` - File transfer protocol or protocols over which your file transfer protocol client can connect to your server's endpoint.
 * `security_policy_name` - The name of the security policy that is attached to the server.
-* `structured_logging_destinations` - A set of ARNs of destinations that will receive structured logs from the transfer server such as CloudWatch Log Group ARNs.
+* `structured_log_destinations` - A set of ARNs of destinations that will receive structured logs from the transfer server such as CloudWatch Log Group ARNs.
 * `url` - URL of the service endpoint used to authenticate users with an `identity_provider_type` of `API_GATEWAY`.

--- a/website/docs/r/transfer_server.html.markdown
+++ b/website/docs/r/transfer_server.html.markdown
@@ -146,7 +146,7 @@ This resource supports the following arguments:
 * `pre_authentication_login_banner`- (Optional) Specify a string to display when users connect to a server. This string is displayed before the user authenticates.
 * `protocol_details`- (Optional) The protocol settings that are configured for your server.
 * `security_policy_name` - (Optional) Specifies the name of the security policy that is attached to the server. Possible values are `TransferSecurityPolicy-2018-11`, `TransferSecurityPolicy-2020-06`, `TransferSecurityPolicy-FIPS-2020-06`, `TransferSecurityPolicy-2022-03` and `TransferSecurityPolicy-2023-05`. Default value is: `TransferSecurityPolicy-2018-11`.
-* `structured_logging_destinations` - (Optional) A set of ARNs of destinations that will receive structured logs from the transfer server such as CloudWatch Log Group ARNs. If provided this enables the transfer server to emit structured logs to the specified locations.
+* `structured_log_destinations` - (Optional) A set of ARNs of destinations that will receive structured logs from the transfer server such as CloudWatch Log Group ARNs. If provided this enables the transfer server to emit structured logs to the specified locations.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `workflow_details` - (Optional) Specifies the workflow details. See Workflow Details below.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!------>
The argument and attribute name in resource and data source respectively for `transfer_server` is invalid. It should be `structured_log_destinations` rather than `structured_logging_destinations`


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/33105

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
The feature was added in https://github.com/hashicorp/terraform-provider-aws/pull/32654


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
