### PR TITLE
Fix typo in aws_sesv2_configuration_set_event_destination docs

### DIFF
--- a/website/docs/r/sesv2_configuration_set_event_destination.html.markdown
+++ b/website/docs/r/sesv2_configuration_set_event_destination.html.markdown
@@ -138,7 +138,7 @@ The following arguments are required:
 The following arguments are required:
 
 * `default_dimension_value` - (Required) The default value of the dimension that is published to Amazon CloudWatch if you don't provide the value of the dimension when you send an email.
-( `dimension_name` - (Required) The name of an Amazon CloudWatch dimension associated with an email sending metric.
+* `dimension_name` - (Required) The name of an Amazon CloudWatch dimension associated with an email sending metric.
 * `dimension_value_source` - (Required) The location where the Amazon SES API v2 finds the value of a dimension to publish to Amazon CloudWatch. Valid values: `MESSAGE_TAG`, `EMAIL_HEADER`, `LINK_TAG`.
 
 ### kinesis_firehose_destination


### PR DESCRIPTION

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Fix typo in markdown formatting that made one of the required parameters of the **aws_sesv2_configuration_set_event_destination** resource easy to overlook.
