### PR TITLE
Fix typo in `flattenWordCloudOptions` flattener

### DIFF
--- a/.changelog/33122.txt
+++ b/.changelog/33122.txt
@@ -1,0 +1,11 @@
+```release-note:bug
+resource/aws_quicksight_analysis: Fixed a bug that caused errors related to the `word_orientation` argument when using word cloud visuals.
+```
+
+```release-note:bug
+resource/aws_quicksight_dashboard: Fixed a bug that caused errors related to the `word_orientation` argument when using word cloud visuals.
+```
+
+```release-note:bug
+resource/aws_quicksight_template: Fixed a bug that caused errors related to the `word_orientation` argument when using word cloud visuals.
+```

--- a/internal/service/quicksight/schema/visual_word_cloud.go
+++ b/internal/service/quicksight/schema/visual_word_cloud.go
@@ -360,7 +360,7 @@ func flattenWordCloudOptions(apiObject *quicksight.WordCloudOptions) []interface
 		tfMap["word_casing"] = aws.StringValue(apiObject.WordCasing)
 	}
 	if apiObject.WordOrientation != nil {
-		tfMap["work_orientation"] = aws.StringValue(apiObject.WordOrientation)
+		tfMap["word_orientation"] = aws.StringValue(apiObject.WordOrientation)
 	}
 	if apiObject.WordPadding != nil {
 		tfMap["word_padding"] = aws.StringValue(apiObject.WordPadding)


### PR DESCRIPTION
### Description

This PR fixes a typo in the `flattenWordCloudOptions` flattener that's used in `aws_quicksight_analysis`, `aws_quicksight_dashboard`, and `aws_quicksight_template`, which led to the following error:

```shell
│ Error: setting definition: Invalid address to set: []string{"definition", "0", "sheets", "9", "visuals", "17", "word_cloud_visual", "0", "chart_configuration", "0", "word_cloud_options", "0", "work_orientation"}
```

### Relations

Closes #33109

### References

- [Schema](https://github.com/hashicorp/terraform-provider-aws/blob/24b921e4566eb44d23cbae873bca8d3721a15558/internal/service/quicksight/schema/visual_word_cloud.go#L77)

### Output from Acceptance Testing

I'm unable to run tests for Quicksight.
