### PR TITLE
medialive/channel: fix typos audio_selectors and caption_selectors.

### DIFF
--- a/.changelog/33128.txt
+++ b/.changelog/33128.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_medialive_channel: fix documentation `audio_selector` and `caption_selector`.
+```

--- a/website/docs/r/medialive_channel.html.markdown
+++ b/website/docs/r/medialive_channel.html.markdown
@@ -142,8 +142,8 @@ The following arguments are optional:
 
 ### Input Settings
 
-* `audio_selectors` - (Optional) Used to select the audio stream to decode for inputs that have multiple. See [Audio Selectors](#audio-selectors) for more details.
-* `caption_selectors` - (Optional) Used to select the caption input to use for inputs that have multiple available. See [Caption Selectors](#caption-selectors) for more details.
+* `audio_selector` - (Optional) Used to select the audio stream to decode for inputs that have multiple. See [Audio Selectors](#audio-selectors) for more details.
+* `caption_selector` - (Optional) Used to select the caption input to use for inputs that have multiple available. See [Caption Selectors](#caption-selectors) for more details.
 * `deblock_filter` - (Optional) Enable or disable the deblock filter when filtering.
 * `denoise_filter` - (Optional) Enable or disable the denoise filter when filtering.
 * `filter_strength` - (Optional) Adjusts the magnitude of filtering from 1 (minimal) to 5 (strongest).


### PR DESCRIPTION
### Description
This PR fixes typos `audio_selectors` and `caption_selectors` to be singular in the documentation.


### Relations
N/A

### References
[audio_selectors documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/medialive_channel#audio_selectors)
[caption_selctors documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/medialive_channel#caption_selectors)


### Output from Acceptance Testing
N/A