### PR TITLE
add computed field for asset_id attribute

### DIFF
--- a/.changelog/33142.txt
+++ b/.changelog/33142.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ec2_host: Fixed a bug that caused resource recreation when specifying an `outpost_arn` without an `asset_id`
+```

--- a/internal/service/ec2/ec2_host.go
+++ b/internal/service/ec2/ec2_host.go
@@ -49,6 +49,7 @@ func ResourceHost() *schema.Resource {
 				Optional:     true,
 				ForceNew:     true,
 				RequiredWith: []string{"outpost_arn"},
+				Computed:     true,
 			},
 			"auto_placement": {
 				Type:         schema.TypeString,


### PR DESCRIPTION
### Description

Fixes bug in issue #33140 by setting the `asset_id` field to `Computed`

### Relations
Closes #33140

### Output from Acceptance Testing

```console
make testacc TESTS=TestAccEC2Host_outpostAssetId PKG=ec2 ACCTEST_PARALLELISM=5  
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 5 -run='TestAccEC2Host_outpostAssetId'  -timeout 180m
=== RUN   TestAccEC2Host_outpostAssetId
=== PAUSE TestAccEC2Host_outpostAssetId
=== CONT  TestAccEC2Host_outpostAssetId
--- PASS: TestAccEC2Host_outpostAssetId (23.32s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	27.031s
...
```
