### PR TITLE
Add test case for appropriate error message when an account assignment fails

### DIFF
--- a/internal/service/ssoadmin/account_assignment_test.go
+++ b/internal/service/ssoadmin/account_assignment_test.go
@@ -88,6 +88,30 @@ func TestAccSSOAdminAccountAssignment_Basic_user(t *testing.T) {
 	})
 }
 
+func TestAccSSOAdminAccountAssignment_MissingPolicy(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	userName := os.Getenv("AWS_IDENTITY_STORE_USER_NAME")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheckInstances(ctx, t)
+			testAccPreCheckIdentityStoreUserName(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, ssoadmin.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAccountAssignmentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				// We assign a policy called rName on the assumption it doesn't exist due to being randomly generated, hoping to generate an error
+				Config:      testAccAccountAssignmentConfig_withCustomerPolicy(userName, "/", rName, rName),
+				ExpectError: regexp.MustCompile(fmt.Sprintf(`Received a 404 status error: Not supported policy.*%s`, rName)),
+			},
+		},
+	})
+}
+
 func TestAccSSOAdminAccountAssignment_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssoadmin_account_assignment.test"
@@ -252,4 +276,19 @@ func testAccPreCheckIdentityStoreUserName(t *testing.T) {
 		t.Skip("AWS_IDENTITY_STORE_USER_NAME env var must be set for AWS Identity Store User acceptance test. " +
 			"This is required until ListUsers API returns results without filtering by name.")
 	}
+}
+
+func testAccAccountAssignmentConfig_withCustomerPolicy(userName, policyPath, policyName, rName string) string {
+	return acctest.ConfigCompose(
+		testAccAccountAssignmentConfig_basicUser(userName, rName),
+		fmt.Sprintf(`
+resource "aws_ssoadmin_customer_managed_policy_attachment" "test" {
+  instance_arn       = aws_ssoadmin_permission_set.test.instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.test.arn
+  customer_managed_policy_reference {
+    name = %q
+    path = %q
+  }
+}
+`, policyName, policyPath))
 }


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
I was about to submit a PR for https://github.com/hashicorp/terraform-provider-aws/issues/22952 but coincidentally it got resolved yesterday in PR https://github.com/hashicorp/terraform-provider-aws/pull/33121. 

Figured you might want the test case I was using to help avoid regressions, but won't take it personally if it's not considered that useful.

Either way, https://github.com/hashicorp/terraform-provider-aws/issues/22952 can be closed after https://github.com/hashicorp/terraform-provider-aws/pull/33121

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/22952

Related PR: https://github.com/hashicorp/terraform-provider-aws/pull/33121

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
AWS_IDENTITY_STORE_USER_NAME=REDACTED AWS_IDENTITY_STORE_GROUP_NAME=REDACTED make testacc TESTS=TestAccSSOAdminAccountAssignment PKG=ssoadmin
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ssoadmin/... -v -count 1 -parallel 20 -run='TestAccSSOAdminAccountAssignment'  -timeout 180m
=== RUN   TestAccSSOAdminAccountAssignment_Basic_group
=== PAUSE TestAccSSOAdminAccountAssignment_Basic_group
=== RUN   TestAccSSOAdminAccountAssignment_Basic_user
=== PAUSE TestAccSSOAdminAccountAssignment_Basic_user
=== RUN   TestAccSSOAdminAccountAssignment_MissingPolicy
=== PAUSE TestAccSSOAdminAccountAssignment_MissingPolicy
=== RUN   TestAccSSOAdminAccountAssignment_disappears
=== PAUSE TestAccSSOAdminAccountAssignment_disappears
=== CONT  TestAccSSOAdminAccountAssignment_Basic_group
=== CONT  TestAccSSOAdminAccountAssignment_MissingPolicy
=== CONT  TestAccSSOAdminAccountAssignment_disappears
=== CONT  TestAccSSOAdminAccountAssignment_Basic_user
--- PASS: TestAccSSOAdminAccountAssignment_MissingPolicy (26.85s)
--- PASS: TestAccSSOAdminAccountAssignment_disappears (39.00s)
--- PASS: TestAccSSOAdminAccountAssignment_Basic_group (42.21s)
--- PASS: TestAccSSOAdminAccountAssignment_Basic_user (42.23s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssoadmin   44.536s
```
