### PR TITLE
r/aws_quicksight: skip setting empty static_values fields

### DIFF
--- a/.changelog/33161.txt
+++ b/.changelog/33161.txt
@@ -1,0 +1,9 @@
+```release-note:bug
+resource/aws_quicksight_analysis: Skip setting `definition.*.parameter_declarations.*.*_parameter_declaration.static_values` when empty, preventing persistent differences.
+```
+```release-note:bug
+resource/aws_quicksight_dashboard: Skip setting `definition.*.parameter_declarations.*.*_parameter_declaration.static_values` when empty, preventing persistent differences.
+```
+```release-note:bug
+resource/aws_quicksight_template: Skip setting `definition.*.parameter_declarations.*.*_parameter_declaration.static_values` when empty, preventing persistent differences.
+```

--- a/internal/service/quicksight/schema/template_parameter.go
+++ b/internal/service/quicksight/schema/template_parameter.go
@@ -786,7 +786,7 @@ func flattenDateTimeDefaultValues(apiObject *quicksight.DateTimeDefaultValues) [
 	if apiObject.RollingDate != nil {
 		tfMap["rolling_date"] = flattenRollingDateConfiguration(apiObject.RollingDate)
 	}
-	if apiObject.StaticValues != nil {
+	if len(apiObject.StaticValues) > 0 {
 		tfMap["static_values"] = flex.FlattenTimeStringList(apiObject.StaticValues, time.RFC3339)
 	}
 
@@ -859,7 +859,7 @@ func flattenDecimalDefaultValues(apiObject *quicksight.DecimalDefaultValues) []i
 	if apiObject.DynamicValue != nil {
 		tfMap["dynamic_value"] = flattenDynamicDefaultValue(apiObject.DynamicValue)
 	}
-	if apiObject.StaticValues != nil {
+	if len(apiObject.StaticValues) > 0 {
 		tfMap["static_values"] = flex.FlattenFloat64List(apiObject.StaticValues)
 	}
 
@@ -913,7 +913,7 @@ func flattenIntegerDefaultValues(apiObject *quicksight.IntegerDefaultValues) []i
 	if apiObject.DynamicValue != nil {
 		tfMap["dynamic_value"] = flattenDynamicDefaultValue(apiObject.DynamicValue)
 	}
-	if apiObject.StaticValues != nil {
+	if len(apiObject.StaticValues) > 0 {
 		tfMap["static_values"] = flex.FlattenInt64List(apiObject.StaticValues)
 	}
 
@@ -967,7 +967,7 @@ func flattenStringDefaultValues(apiObject *quicksight.StringDefaultValues) []int
 	if apiObject.DynamicValue != nil {
 		tfMap["dynamic_value"] = flattenDynamicDefaultValue(apiObject.DynamicValue)
 	}
-	if apiObject.StaticValues != nil {
+	if len(apiObject.StaticValues) > 0 {
 		tfMap["static_values"] = flex.FlattenStringList(apiObject.StaticValues)
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Skips setting `definition.*.parameter_declarations.*.*_parameter_declaration.static_values` values when an empty slice is returned.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #33004

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=quicksight TESTARGS="-run TestAccQuickSightAnalysis_\|TestAccQuickSightDashboard_\|TestAccQuickSightTemplate_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/quicksight/... -v -count 1 -parallel 20  -run TestAccQuickSightAnalysis_\|TestAccQuickSightDashboard_\|TestAccQuickSightTemplate_ -timeout 180m
?       github.com/hashicorp/terraform-provider-aws/internal/service/quicksight/schema  [no test files]

--- PASS: TestAccQuickSightTemplate_disappears (84.72s)
--- PASS: TestAccQuickSightTemplate_barChart (92.30s)
--- PASS: TestAccQuickSightAnalysis_disappears (93.75s)
--- PASS: TestAccQuickSightTemplate_basic (97.60s)
--- PASS: TestAccQuickSightDashboard_disappears (99.22s)
--- PASS: TestAccQuickSightAnalysis_forceDelete (99.97s)
--- PASS: TestAccQuickSightDashboard_basic (103.99s)
--- PASS: TestAccQuickSightTemplate_sourceEntity (105.18s)
--- PASS: TestAccQuickSightAnalysis_parametersConfig (105.96s)
--- PASS: TestAccQuickSightAnalysis_basic (106.81s)
--- PASS: TestAccQuickSightDashboard_dashboardSpecificConfig (107.95s)
--- PASS: TestAccQuickSightAnalysis_Definition_calculatedFields (108.60s)
--- PASS: TestAccQuickSightAnalysis_sourceEntity (110.66s)
--- PASS: TestAccQuickSightDashboard_sourceEntity (111.19s)
--- PASS: TestAccQuickSightTemplate_table (136.82s)
--- PASS: TestAccQuickSightTemplate_update (147.37s)
--- PASS: TestAccQuickSightAnalysis_update (156.99s)
--- PASS: TestAccQuickSightDashboard_updateVersionNumber (157.20s)
--- PASS: TestAccQuickSightTemplate_tags (170.46s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/quicksight 173.902s
```
