### PR TITLE
r/aws_kms_key: Fix tag propagation timeout errors when `ignore_tags` is configured

### DIFF
--- a/.changelog/#####.txt
+++ b/.changelog/#####.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_kms_key: Fix `tag propagation: timeout while waiting for state to become 'TRUE'` errors when [`ignore_tags`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#ignore_tags) has been configured
+```

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -1193,11 +1193,11 @@ func ConfigDefaultAndIgnoreTagsKeyPrefixes1(key1, value1, keyPrefix1 string) str
 provider "aws" {
   default_tags {
     tags = {
-      %q = %q
+      %[1]q = %[2]q
     }
   }
   ignore_tags {
-    key_prefixes = [%q]
+    key_prefixes = [%[3]q]
   }
 }
 `, key1, value1, keyPrefix1)
@@ -1209,7 +1209,7 @@ func ConfigDefaultAndIgnoreTagsKeys1(key1, value1 string) string {
 provider "aws" {
   default_tags {
     tags = {
-      %[1]q = %q
+      %[1]q = %[2]q
     }
   }
   ignore_tags {
@@ -1569,7 +1569,7 @@ func ConfigDefaultTags_Tags1(tag1, value1 string) string {
 provider "aws" {
   default_tags {
     tags = {
-      %q = %q
+      %[1]q = %[2]q
     }
   }
 
@@ -1588,8 +1588,8 @@ func ConfigDefaultTags_Tags2(tag1, value1, tag2, value2 string) string {
 provider "aws" {
   default_tags {
     tags = {
-      %q = %q
-      %q = %q
+      %[1]q = %[2]q
+      %[3]q = %[4]q
     }
   }
 
@@ -1609,8 +1609,8 @@ func ConfigAssumeRolePolicy(policy string) string {
 	return fmt.Sprintf(`
 provider "aws" {
   assume_role {
-    role_arn = %q
-    policy   = %q
+    role_arn = %[1]q
+    policy   = %[2]q
   }
 }
 `, os.Getenv(envvar.AccAssumeRoleARN), policy)

--- a/internal/generate/tags/main.go
+++ b/internal/generate/tags/main.go
@@ -51,6 +51,7 @@ var (
 	listTagsInIDElem        = flag.String("ListTagsInIDElem", "ResourceArn", "listTagsInIDElem")
 	listTagsInIDNeedSlice   = flag.String("ListTagsInIDNeedSlice", "", "listTagsInIDNeedSlice")
 	listTagsOp              = flag.String("ListTagsOp", "ListTagsForResource", "listTagsOp")
+	listTagsOpPaginated     = flag.Bool("ListTagsOpPaginated", false, "whether ListTagsOp is paginated")
 	listTagsOutTagsElem     = flag.String("ListTagsOutTagsElem", "Tags", "listTagsOutTagsElem")
 	setTagsOutFunc          = flag.String("SetTagsOutFunc", "setTagsOut", "setTagsOutFunc")
 	tagInCustomVal          = flag.String("TagInCustomVal", "", "tagInCustomVal")
@@ -164,6 +165,7 @@ type TemplateData struct {
 	ListTagsInIDElem        string
 	ListTagsInIDNeedSlice   string
 	ListTagsOp              string
+	ListTagsOpPaginated     bool
 	ListTagsOutTagsElem     string
 	ParentNotFoundErrCode   string
 	ParentNotFoundErrMsg    string
@@ -318,6 +320,7 @@ func main() {
 		ListTagsInIDElem:        *listTagsInIDElem,
 		ListTagsInIDNeedSlice:   *listTagsInIDNeedSlice,
 		ListTagsOp:              *listTagsOp,
+		ListTagsOpPaginated:     *listTagsOpPaginated,
 		ListTagsOutTagsElem:     *listTagsOutTagsElem,
 		ParentNotFoundErrCode:   *parentNotFoundErrCode,
 		ParentNotFoundErrMsg:    *parentNotFoundErrMsg,

--- a/internal/generate/tags/templates/v1/list_tags_body.tmpl
+++ b/internal/generate/tags/templates/v1/list_tags_body.tmpl
@@ -61,7 +61,7 @@ func {{ .ListTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier
 		return tftags.New(ctx, nil), err
 	}
 
-{{- if not .ListTagsOpPaginated }}
+{{ if not .ListTagsOpPaginated }}
 	tags := output.{{ .ListTagsOutTagsElem }}
 {{- end }}
 

--- a/internal/generate/tags/templates/v1/list_tags_body.tmpl
+++ b/internal/generate/tags/templates/v1/list_tags_body.tmpl
@@ -22,16 +22,16 @@ func {{ .ListTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier
 		{{- end }}
 	}
 {{- if .ListTagsOpPaginated }}
-	var tags []*{{ .TagPackage }}.{{ .TagType }}
+	var output []*{{ .TagPackage }}.{{ .TagType }}
 
 	err := conn.{{ .ListTagsOp }}PagesWithContext(ctx, input, func(page *{{ .TagPackage  }}.{{ .ListTagsOp }}Output, lastPage bool) bool {
 		if page == nil {
 			return !lastPage
 		}
 
-		for _, tag := range page.{{ .ListTagsOutTagsElem }} {
-			if tag != nil {
-				tags = append(tags, tag)
+		for _, v := range page.{{ .ListTagsOutTagsElem }} {
+			if v != nil {
+				output = append(output, v)
 			}
 		}
 
@@ -61,11 +61,11 @@ func {{ .ListTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier
 		return tftags.New(ctx, nil), err
 	}
 
-{{ if not .ListTagsOpPaginated }}
-	tags := output.{{ .ListTagsOutTagsElem }}
+{{- if .ListTagsOpPaginated }}
+	return {{ .KeyValueTagsFunc }}(ctx, output{{ if .TagTypeIDElem }}, identifier{{ if .TagResTypeElem }}, resourceType{{ end }}{{ end }}), nil
+{{- else }}
+	return {{ .KeyValueTagsFunc }}(ctx, output.{{ .ListTagsOutTagsElem }}{{ if .TagTypeIDElem }}, identifier{{ if .TagResTypeElem }}, resourceType{{ end }}{{ end }}), nil
 {{- end }}
-
-	return {{ .KeyValueTagsFunc }}(ctx, tags{{ if .TagTypeIDElem }}, identifier{{ if .TagResTypeElem }}, resourceType{{ end }}{{ end }}), nil
 }
 
 {{- if .IsDefaultListTags }}

--- a/internal/generate/tags/templates/v1/list_tags_body.tmpl
+++ b/internal/generate/tags/templates/v1/list_tags_body.tmpl
@@ -37,7 +37,8 @@ func {{ .ListTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier
 
 		return !lastPage
 	})
-{{- else }}
+{{ else }}
+
 	output, err := conn.{{ .ListTagsOp }}WithContext(ctx, input)
 {{- end }}
 
@@ -61,7 +62,7 @@ func {{ .ListTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier
 		return tftags.New(ctx, nil), err
 	}
 
-{{- if .ListTagsOpPaginated }}
+{{ if .ListTagsOpPaginated }}
 	return {{ .KeyValueTagsFunc }}(ctx, output{{ if .TagTypeIDElem }}, identifier{{ if .TagResTypeElem }}, resourceType{{ end }}{{ end }}), nil
 {{- else }}
 	return {{ .KeyValueTagsFunc }}(ctx, output.{{ .ListTagsOutTagsElem }}{{ if .TagTypeIDElem }}, identifier{{ if .TagResTypeElem }}, resourceType{{ end }}{{ end }}), nil

--- a/internal/generate/tags/templates/v1/list_tags_body.tmpl
+++ b/internal/generate/tags/templates/v1/list_tags_body.tmpl
@@ -21,8 +21,25 @@ func {{ .ListTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier
 		{{- end }}
 		{{- end }}
 	}
+{{- if .ListTagsOpPaginated }}
+	var tags []*{{ .TagPackage }}.{{ .TagType }}
 
+	err := conn.{{ .ListTagsOp }}PagesWithContext(ctx, input, func(page *{{ .TagPackage  }}.{{ .ListTagsOp }}Output, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, tag := range page.{{ .ListTagsOutTagsElem }} {
+			if tag != nil {
+				tags = append(tags, tag)
+			}
+		}
+
+		return !lastPage
+	})
+{{- else }}
 	output, err := conn.{{ .ListTagsOp }}WithContext(ctx, input)
+{{- end }}
 
 	{{ if and ( .ParentNotFoundErrCode ) ( .ParentNotFoundErrMsg ) }}
 			if tfawserr.ErrMessageContains(err, "{{ .ParentNotFoundErrCode }}", "{{ .ParentNotFoundErrMsg }}") {
@@ -44,7 +61,11 @@ func {{ .ListTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier
 		return tftags.New(ctx, nil), err
 	}
 
-	return {{ .KeyValueTagsFunc }}(ctx, output.{{ .ListTagsOutTagsElem }}{{ if .TagTypeIDElem }}, identifier{{ if .TagResTypeElem }}, resourceType{{ end }}{{ end }}), nil
+{{- if not .ListTagsOpPaginated }}
+	tags := output.{{ .ListTagsOutTagsElem }}
+{{- end }}
+
+	return {{ .KeyValueTagsFunc }}(ctx, tags{{ if .TagTypeIDElem }}, identifier{{ if .TagResTypeElem }}, resourceType{{ end }}{{ end }}), nil
 }
 
 {{- if .IsDefaultListTags }}

--- a/internal/generate/tags/templates/v1/wait_tags_propagated_body.tmpl
+++ b/internal/generate/tags/templates/v1/wait_tags_propagated_body.tmpl
@@ -7,7 +7,7 @@ func {{ .WaitTagsPropagatedFunc }}(ctx context.Context, conn {{ .ClientType }}, 
 	})
 
 	checkFunc := func() (bool, error) {
-		output, err := listTags(ctx, conn, id)
+		output, err := {{ .ListTagsFunc }}(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
 			return false, nil

--- a/internal/generate/tags/templates/v1/wait_tags_propagated_body.tmpl
+++ b/internal/generate/tags/templates/v1/wait_tags_propagated_body.tmpl
@@ -17,6 +17,10 @@ func {{ .WaitTagsPropagatedFunc }}(ctx context.Context, conn {{ .ClientType }}, 
 			return false, err
 		}
 
+		if inContext, ok := tftags.FromContext(ctx); ok {
+			output = output.IgnoreConfig(inContext.IgnoreConfig)
+		}
+
 		return output.Equal(tags), nil
 	}
 	opts := tfresource.WaitOpts{

--- a/internal/generate/tags/templates/v2/wait_tags_propagated_body.tmpl
+++ b/internal/generate/tags/templates/v2/wait_tags_propagated_body.tmpl
@@ -7,7 +7,7 @@ func {{ .WaitTagsPropagatedFunc }}(ctx context.Context, conn {{ .ClientType }}, 
 	})
 
 	checkFunc := func() (bool, error) {
-		output, err := listTags(ctx, conn, id)
+		output, err := {{ .ListTagsFunc }}(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
 			return false, nil

--- a/internal/generate/tags/templates/v2/wait_tags_propagated_body.tmpl
+++ b/internal/generate/tags/templates/v2/wait_tags_propagated_body.tmpl
@@ -17,6 +17,10 @@ func {{ .WaitTagsPropagatedFunc }}(ctx context.Context, conn {{ .ClientType }}, 
 			return false, err
 		}
 
+		if inContext, ok := tftags.FromContext(ctx); ok {
+			output = output.IgnoreConfig(inContext.IgnoreConfig)
+		}
+
 		return output.Equal(tags), nil
 	}
 	opts := tfresource.WaitOpts{

--- a/internal/service/kms/generate.go
+++ b/internal/service/kms/generate.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-//go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOp=ListResourceTags -ListTagsInIDElem=KeyId -ServiceTagsSlice -TagInIDElem=KeyId -TagTypeKeyElem=TagKey -TagTypeValElem=TagValue -UpdateTags -Wait -WaitContinuousOccurence 5 -WaitMinTimeout 1s -WaitTimeout 10m -ParentNotFoundErrCode=NotFoundException
+//go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOp=ListResourceTags -ListTagsOpPaginated -ListTagsInIDElem=KeyId -ServiceTagsSlice -TagInIDElem=KeyId -TagTypeKeyElem=TagKey -TagTypeValElem=TagValue -UpdateTags -Wait -WaitContinuousOccurence 5 -WaitMinTimeout 1s -WaitTimeout 10m -ParentNotFoundErrCode=NotFoundException
 //go:generate go run ../../generate/servicepackage/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/kms/key_test.go
+++ b/internal/service/kms/key_test.go
@@ -516,6 +516,48 @@ func TestAccKMSKey_tags(t *testing.T) {
 	})
 }
 
+// https://github.com/hashicorp/terraform-provider-aws/issues/26174.
+func TestAccKMSKey_ignoreTags(t *testing.T) {
+	ctx := acctest.Context(t)
+	var key kms.KeyMetadata
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_kms_key.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, kms.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckKeyDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKeyConfig_ignoreTags(rName, "key1", "value1", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeyExists(ctx, resourceName, &key),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			// Add an ignored tag.
+			{
+				Config: testAccKeyConfig_ignoreTags(rName, "key1", "value1", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeyAddTag(ctx, &key, "ignkey1", "ignvalue1"),
+				),
+			},
+			{
+				Config: testAccKeyConfig_ignoreTags(rName, "key1", "value1updated", "key3", "value3"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeyExists(ctx, resourceName, &key),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key3", "value3"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckKeyHasPolicy(ctx context.Context, name string, expectedPolicyText string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
@@ -602,6 +644,24 @@ func testAccCheckKeyExists(ctx context.Context, name string, key *kms.KeyMetadat
 		*key = *(outputRaw.(*kms.KeyMetadata))
 
 		return nil
+	}
+}
+
+func testAccCheckKeyAddTag(ctx context.Context, key *kms.KeyMetadata, tagKey, tagValue string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).KMSConn(ctx)
+
+		input := &kms.TagResourceInput{
+			KeyId: key.KeyId,
+			Tags: []*kms.Tag{{
+				TagKey:   aws.String(tagKey),
+				TagValue: aws.String(tagValue),
+			}},
+		}
+
+		_, err := conn.TagResourceWithContext(ctx, input)
+
+		return err
 	}
 }
 
@@ -1090,4 +1150,29 @@ resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
 }
 `, rName)
+}
+
+func testAccKeyConfig_ignoreTags(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+provider "aws" {
+  default_tags {
+    tags = {
+      "defkey1" = "defvalue1"
+    }
+  }
+  ignore_tags {
+    keys = ["ignkey1"]
+  }
+}
+
+resource "aws_kms_key" "test" {
+  description             = %[1]q
+  deletion_window_in_days = 7
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }

--- a/internal/service/kms/tags_gen.go
+++ b/internal/service/kms/tags_gen.go
@@ -27,16 +27,16 @@ func listTags(ctx context.Context, conn kmsiface.KMSAPI, identifier string) (tft
 	input := &kms.ListResourceTagsInput{
 		KeyId: aws.String(identifier),
 	}
-	var tags []*kms.Tag
+	var output []*kms.Tag
 
 	err := conn.ListResourceTagsPagesWithContext(ctx, input, func(page *kms.ListResourceTagsOutput, lastPage bool) bool {
 		if page == nil {
 			return !lastPage
 		}
 
-		for _, tag := range page.Tags {
-			if tag != nil {
-				tags = append(tags, tag)
+		for _, v := range page.Tags {
+			if v != nil {
+				output = append(output, v)
 			}
 		}
 
@@ -54,7 +54,7 @@ func listTags(ctx context.Context, conn kmsiface.KMSAPI, identifier string) (tft
 		return tftags.New(ctx, nil), err
 	}
 
-	return KeyValueTags(ctx, tags), nil
+	return KeyValueTags(ctx, output), nil
 }
 
 // ListTags lists kms service tags and set them in Context.

--- a/internal/service/kms/tags_gen.go
+++ b/internal/service/kms/tags_gen.go
@@ -181,6 +181,10 @@ func waitTagsPropagated(ctx context.Context, conn kmsiface.KMSAPI, id string, ta
 			return false, err
 		}
 
+		if inContext, ok := tftags.FromContext(ctx); ok {
+			output = output.IgnoreConfig(inContext.IgnoreConfig)
+		}
+
 		return output.Equal(tags), nil
 	}
 	opts := tfresource.WaitOpts{

--- a/internal/tags/key_value_tags.go
+++ b/internal/tags/key_value_tags.go
@@ -177,7 +177,7 @@ func (tags KeyValueTags) IgnoreServerlessApplicationRepository() KeyValueTags {
 	return result
 }
 
-// IgnoreAWS returns non-system tag keys.
+// IgnoreSystem returns non-system tag keys.
 // The ignored keys vary on the specified service.
 func (tags KeyValueTags) IgnoreSystem(serviceName string) KeyValueTags {
 	switch serviceName {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fixes `tag propagation: timeout while waiting for state to become 'TRUE'` errors when [`ignore_tags`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#ignore_tags) has been configured.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/26174.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/33154.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
