### PR TITLE
Add support for LakeFormation ReadOnlyAdmins

### DIFF
--- a/.changelog/33189.txt
+++ b/.changelog/33189.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_lakeformation_data_lake_settings: Add `read_only_admins` argument
+```
+
+```release-note:enhancement
+data-source/aws_lakeformation_data_lake_settings: Add `read_only_admins` attribute
+```

--- a/internal/service/lakeformation/data_lake_settings.go
+++ b/internal/service/lakeformation/data_lake_settings.go
@@ -45,6 +45,15 @@ func ResourceDataLakeSettings() *schema.Resource {
 					ValidateFunc: verify.ValidARN,
 				},
 			},
+			"read_only_admins": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: verify.ValidARN,
+				},
+			},
 			"allow_external_data_filtering": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -148,6 +157,10 @@ func resourceDataLakeSettingsCreate(ctx context.Context, d *schema.ResourceData,
 		settings.DataLakeAdmins = expandDataLakeSettingsAdmins(v.(*schema.Set))
 	}
 
+	if v, ok := d.GetOk("read_only_admins"); ok {
+		settings.ReadOnlyAdmins = expandDataLakeSettingsAdmins(v.(*schema.Set))
+	}
+
 	if v, ok := d.GetOk("allow_external_data_filtering"); ok {
 		settings.AllowExternalDataFiltering = aws.Bool(v.(bool))
 	}
@@ -237,6 +250,7 @@ func resourceDataLakeSettingsRead(ctx context.Context, d *schema.ResourceData, m
 	settings := output.DataLakeSettings
 
 	d.Set("admins", flattenDataLakeSettingsAdmins(settings.DataLakeAdmins))
+	d.Set("read_only_admins", flattenDataLakeSettingsAdmins(settings.ReadOnlyAdmins))
 	d.Set("allow_external_data_filtering", settings.AllowExternalDataFiltering)
 	d.Set("authorized_session_tag_value_list", flex.FlattenStringList(settings.AuthorizedSessionTagValueList))
 	d.Set("create_database_default_permissions", flattenDataLakeSettingsCreateDefaultPermissions(settings.CreateDatabaseDefaultPermissions))
@@ -256,6 +270,7 @@ func resourceDataLakeSettingsDelete(ctx context.Context, d *schema.ResourceData,
 			CreateDatabaseDefaultPermissions: make([]*lakeformation.PrincipalPermissions, 0),
 			CreateTableDefaultPermissions:    make([]*lakeformation.PrincipalPermissions, 0),
 			DataLakeAdmins:                   make([]*lakeformation.DataLakePrincipal, 0),
+			ReadOnlyAdmins:                   make([]*lakeformation.DataLakePrincipal, 0),
 			TrustedResourceOwners:            make([]*string, 0),
 		},
 	}

--- a/internal/service/lakeformation/data_lake_settings_data_source.go
+++ b/internal/service/lakeformation/data_lake_settings_data_source.go
@@ -30,6 +30,11 @@ func DataSourceDataLakeSettings() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"read_only_admins": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 			"allow_external_data_filtering": {
 				Type:     schema.TypeBool,
 				Computed: true,
@@ -121,6 +126,7 @@ func dataSourceDataLakeSettingsRead(ctx context.Context, d *schema.ResourceData,
 	settings := output.DataLakeSettings
 
 	d.Set("admins", flattenDataLakeSettingsAdmins(settings.DataLakeAdmins))
+	d.Set("read_only_admins", flattenDataLakeSettingsAdmins(settings.ReadOnlyAdmins))
 	d.Set("allow_external_data_filtering", settings.AllowExternalDataFiltering)
 	d.Set("authorized_session_tag_value_list", flex.FlattenStringList(settings.AuthorizedSessionTagValueList))
 	d.Set("create_database_default_permissions", flattenDataLakeSettingsCreateDefaultPermissions(settings.CreateDatabaseDefaultPermissions))

--- a/internal/service/lakeformation/data_lake_settings_data_source_test.go
+++ b/internal/service/lakeformation/data_lake_settings_data_source_test.go
@@ -36,6 +36,28 @@ func testAccDataLakeSettingsDataSource_basic(t *testing.T) {
 	})
 }
 
+func testAccDataLakeSettingsDataSource_readOnlyAdmins(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "data.aws_lakeformation_data_lake_settings.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, lakeformation.EndpointsID) },
+		ErrorCheck:               acctest.ErrorCheck(t, lakeformation.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDataLakeSettingsDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataLakeSettingsDataSourceConfig_readOnlyAdmins,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "catalog_id", "data.aws_caller_identity.current", "account_id"),
+					resource.TestCheckResourceAttr(resourceName, "read_only_admins.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "read_only_admins.0", "data.aws_iam_session_context.current", "issuer_arn"),
+				),
+			},
+		},
+	})
+}
+
 const testAccDataLakeSettingsDataSourceConfig_basic = `
 data "aws_caller_identity" "current" {}
 
@@ -46,6 +68,23 @@ data "aws_iam_session_context" "current" {
 resource "aws_lakeformation_data_lake_settings" "test" {
   catalog_id = data.aws_caller_identity.current.account_id
   admins     = [data.aws_iam_session_context.current.issuer_arn]
+}
+
+data "aws_lakeformation_data_lake_settings" "test" {
+  catalog_id = aws_lakeformation_data_lake_settings.test.catalog_id
+}
+`
+
+const testAccDataLakeSettingsDataSourceConfig_readOnlyAdmins = `
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_session_context" "current" {
+  arn = data.aws_caller_identity.current.arn
+}
+
+resource "aws_lakeformation_data_lake_settings" "test" {
+  catalog_id       = data.aws_caller_identity.current.account_id
+  read_only_admins = [data.aws_iam_session_context.current.issuer_arn]
 }
 
 data "aws_lakeformation_data_lake_settings" "test" {

--- a/internal/service/lakeformation/lakeformation_test.go
+++ b/internal/service/lakeformation/lakeformation_test.go
@@ -15,9 +15,13 @@ func TestAccLakeFormation_serial(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){
 		"DataLakeSettings": {
 			"basic":            testAccDataLakeSettings_basic,
-			"dataSource":       testAccDataLakeSettingsDataSource_basic,
 			"disappears":       testAccDataLakeSettings_disappears,
 			"withoutCatalogId": testAccDataLakeSettings_withoutCatalogID,
+			"readOnlyAdmins":   testAccDataLakeSettings_readOnlyAdmins,
+		},
+		"DataLakeSettingsDataSource": {
+			"basic":          testAccDataLakeSettingsDataSource_basic,
+			"readOnlyAdmins": testAccDataLakeSettingsDataSource_readOnlyAdmins,
 		},
 		"PermissionsBasic": {
 			"basic":               testAccPermissions_basic,

--- a/website/docs/d/lakeformation_data_lake_settings.html.markdown
+++ b/website/docs/d/lakeformation_data_lake_settings.html.markdown
@@ -29,6 +29,7 @@ The following arguments are optional:
 This data source exports the following attributes in addition to the arguments above:
 
 * `admins` – List of ARNs of AWS Lake Formation principals (IAM users or roles).
+* `read_only_admins` – List of ARNs of AWS Lake Formation principals (IAM users or roles) with only view access to the resources.
 * `create_database_default_permissions` - Up to three configuration blocks of principal permissions for default create database permissions. Detailed below.
 * `create_table_default_permissions` - Up to three configuration blocks of principal permissions for default create table permissions. Detailed below.
 * `trusted_resource_owners` – List of the resource-owning account IDs that the caller's account can use to share their user access details (user ARNs).

--- a/website/docs/r/lakeformation_data_lake_settings.html.markdown
+++ b/website/docs/r/lakeformation_data_lake_settings.html.markdown
@@ -67,6 +67,7 @@ resource "aws_lakeformation_data_lake_settings" "example" {
 The following arguments are optional:
 
 * `admins` – (Optional) Set of ARNs of AWS Lake Formation principals (IAM users or roles).
+* `read_only_admins` – (Optional) Set of ARNs of AWS Lake Formation principals (IAM users or roles) with only view access to the resources.
 * `catalog_id` – (Optional) Identifier for the Data Catalog. By default, the account ID.
 * `create_database_default_permissions` - (Optional) Up to three configuration blocks of principal permissions for default create database permissions. Detailed below.
 * `create_table_default_permissions` - (Optional) Up to three configuration blocks of principal permissions for default create table permissions. Detailed below.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Add support for [ReadOnlyAdmins](https://docs.aws.amazon.com/lake-formation/latest/APIReference/API_DataLakeSettings.html#lakeformation-Type-DataLakeSettings-ReadOnlyAdmins) in the aws_lakeformation_data_lake_settings (data) resources


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #33143

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->


```console
% make testacc PKG=lakeformation TESTS=TestAccLakeFormation_serial/DataLakeSettings/readOnlyAdmins
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lakeformation/... -v -count 1 -parallel 20 -run='TestAccLakeFormation_serial/DataLakeSettings/readOnlyAdmins'  -timeout 180m
=== RUN   TestAccLakeFormation_serial
=== PAUSE TestAccLakeFormation_serial
=== CONT  TestAccLakeFormation_serial
=== RUN   TestAccLakeFormation_serial/DataLakeSettings
=== RUN   TestAccLakeFormation_serial/DataLakeSettings/readOnlyAdmins
=== RUN   TestAccLakeFormation_serial/DataLakeSettingsDataSource
=== RUN   TestAccLakeFormation_serial/DataLakeSettingsDataSource/readOnlyAdmins
--- PASS: TestAccLakeFormation_serial (106.77s)
    --- PASS: TestAccLakeFormation_serial/DataLakeSettings (53.75s)
        --- PASS: TestAccLakeFormation_serial/DataLakeSettings/readOnlyAdmins (53.75s)
    --- PASS: TestAccLakeFormation_serial/DataLakeSettingsDataSource (53.02s)
        --- PASS: TestAccLakeFormation_serial/DataLakeSettingsDataSource/readOnlyAdmins (53.02s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lakeformation	110.600s
```

```console
% make testacc PKG=lakeformation TESTS=TestAccLakeFormation_serial/DataLakeSettingsDataSource/readOnlyAdmins
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lakeformation/... -v -count 1 -parallel 20 -run='TestAccLakeFormation_serial/DataLakeSettingsDataSource/readOnlyAdmins'  -timeout 180m
=== RUN   TestAccLakeFormation_serial
=== PAUSE TestAccLakeFormation_serial
=== CONT  TestAccLakeFormation_serial
=== RUN   TestAccLakeFormation_serial/DataLakeSettingsDataSource
=== RUN   TestAccLakeFormation_serial/DataLakeSettingsDataSource/readOnlyAdmins
--- PASS: TestAccLakeFormation_serial (57.30s)
    --- PASS: TestAccLakeFormation_serial/DataLakeSettingsDataSource (57.30s)
        --- PASS: TestAccLakeFormation_serial/DataLakeSettingsDataSource/readOnlyAdmins (57.30s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lakeformation	61.118s
```
