### PR TITLE
aws_appflow_connector_profile: correct validation on oauth2 custom auth

### DIFF
--- a/.changelog/33192.txt
+++ b/.changelog/33192.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_appflow_connector_profile: Fix validation on `oauth2` in `custom_connector_profile`
+```

--- a/internal/service/appflow/connector_profile.go
+++ b/internal/service/appflow/connector_profile.go
@@ -192,7 +192,7 @@ func ResourceConnectorProfile() *schema.Resource {
 																Optional:  true,
 																Sensitive: true,
 																ValidateFunc: validation.All(
-																	validation.StringLenBetween(1, 2048),
+																	validation.StringLenBetween(1, 4096),
 																	validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
 																),
 															},
@@ -223,7 +223,7 @@ func ResourceConnectorProfile() *schema.Resource {
 																			Type:     schema.TypeString,
 																			Optional: true,
 																			ValidateFunc: validation.All(
-																				validation.StringLenBetween(1, 2048),
+																				validation.StringLenBetween(1, 4096),
 																				validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
 																			),
 																		},
@@ -242,7 +242,7 @@ func ResourceConnectorProfile() *schema.Resource {
 																Type:     schema.TypeString,
 																Optional: true,
 																ValidateFunc: validation.All(
-																	validation.StringLenBetween(1, 1024),
+																	validation.StringLenBetween(1, 4096),
 																	validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
 																),
 															},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fix validation errors to AWS specification.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #32660

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTARGS='-run=TestAccAppFlowConnectorProfile_' PKG=appflow

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/appflow/... -v -count 1 -parallel 20  -run=TestAccAppFlowConnectorProfile_ -timeout 180m
--- PASS: TestAccAppFlowConnectorProfile_disappears (251.51s)
--- PASS: TestAccAppFlowConnectorProfile_basic (257.14s)
--- PASS: TestAccAppFlowConnectorProfile_update (323.43s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/appflow	326.931s
```
