### PR TITLE
Fix: Resolve issues with aws_iot_thing_type and aws_cloudwatch_event_bus_policy disappearing resources

### DIFF
--- a/.changelog/33203.txt
+++ b/.changelog/33203.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_iot_thing_type: Fix error during plan when resource is manually deleted
+```
+
+```release-note:bug
+resource/aws_cloudwatch_event_bus_policy: Fix error during plan when the associated aws_cloudwatch_event_bus resource is manually deleted
+```

--- a/internal/service/events/bus_policy.go
+++ b/internal/service/events/bus_policy.go
@@ -106,6 +106,13 @@ func resourceBusPolicyRead(ctx context.Context, d *schema.ResourceData, meta int
 		log.Printf("[DEBUG] Reading EventBridge bus: %s", input)
 		output, err = conn.DescribeEventBusWithContext(ctx, &input)
 		if err != nil {
+			if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, "ResourceNotFoundException") {
+				return &retry.RetryError{
+					Err:       &retry.NotFoundError{LastError: err, LastRequest: input},
+					Retryable: false,
+				}
+			}
+
 			return retry.NonRetryableError(fmt.Errorf("reading EventBridge permission (%s) failed: %w", d.Id(), err))
 		}
 

--- a/internal/service/events/bus_policy.go
+++ b/internal/service/events/bus_policy.go
@@ -5,14 +5,13 @@ package events
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/eventbridge"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -25,10 +24,11 @@ import (
 // @SDKResource("aws_cloudwatch_event_bus_policy")
 func ResourceBusPolicy() *schema.Resource {
 	return &schema.Resource{
-		CreateWithoutTimeout: resourceBusPolicyCreate,
+		CreateWithoutTimeout: resourceBusPolicyPut,
 		ReadWithoutTimeout:   resourceBusPolicyRead,
-		UpdateWithoutTimeout: resourceBusPolicyUpdate,
+		UpdateWithoutTimeout: resourceBusPolicyPut,
 		DeleteWithoutTimeout: resourceBusPolicyDelete,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 				d.Set("event_bus_name", d.Id())
@@ -59,95 +59,75 @@ func ResourceBusPolicy() *schema.Resource {
 	}
 }
 
-func resourceBusPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBusPolicyPut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EventsConn(ctx)
 
-	eventBusName := d.Get("event_bus_name").(string)
-
 	policy, err := structure.NormalizeJsonString(d.Get("policy").(string))
-
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "policy (%s) is invalid JSON: %s", policy, err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	input := eventbridge.PutPermissionInput{
+	var eventBusName string
+	if d.IsNewResource() {
+		eventBusName = d.Get("event_bus_name").(string)
+	} else {
+		eventBusName = d.Id()
+	}
+	input := &eventbridge.PutPermissionInput{
 		EventBusName: aws.String(eventBusName),
 		Policy:       aws.String(policy),
 	}
 
-	log.Printf("[DEBUG] Creating EventBridge policy: %s", input)
-	_, err = conn.PutPermissionWithContext(ctx, &input)
+	_, err = conn.PutPermissionWithContext(ctx, input)
+
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Creating EventBridge policy failed: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating EventBridge Event Bus (%s) Policy: %s", eventBusName, err)
 	}
 
-	d.SetId(eventBusName)
+	if d.IsNewResource() {
+		d.SetId(eventBusName)
+	}
 
 	return append(diags, resourceBusPolicyRead(ctx, d, meta)...)
 }
 
-// See also: https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_DescribeEventBus.html
 func resourceBusPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EventsConn(ctx)
 
-	eventBusName := d.Id()
-
-	input := eventbridge.DescribeEventBusInput{
-		Name: aws.String(eventBusName),
-	}
-	var output *eventbridge.DescribeEventBusOutput
-	var err error
-	var policy *string
-
-	// Especially with concurrent PutPermission calls there can be a slight delay
-	err = retry.RetryContext(ctx, propagationTimeout, func() *retry.RetryError {
-		log.Printf("[DEBUG] Reading EventBridge bus: %s", input)
-		output, err = conn.DescribeEventBusWithContext(ctx, &input)
-		if err != nil {
-			if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, "ResourceNotFoundException") {
-				return &retry.RetryError{
-					Err:       &retry.NotFoundError{LastError: err, LastRequest: input},
-					Retryable: false,
-				}
+	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
+		func() (interface{}, error) {
+			return FindEventBusPolicyByName(ctx, conn, d.Id())
+		},
+		func(err error) (bool, error) {
+			if errors.Is(err, errPolicyNotFound) {
+				return true, err
 			}
 
-			return retry.NonRetryableError(fmt.Errorf("reading EventBridge permission (%s) failed: %w", d.Id(), err))
-		}
-
-		policy, err = getEventBusPolicy(output)
-		if err != nil {
-			return retry.RetryableError(err)
-		}
-		return nil
-	})
-
-	if tfresource.TimedOut(err) {
-		output, err = conn.DescribeEventBusWithContext(ctx, &input)
-		if output != nil {
-			policy, err = getEventBusPolicy(output)
-		}
-	}
+			return false, err
+		},
+	)
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
-		log.Printf("[WARN] Policy on EventBridge Bus (%s) not found, removing from state", d.Id())
+		log.Printf("[WARN] EventBridge Event Bus (%s) Policy not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
 	}
+
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "reading policy from EventBridge Bus (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading EventBridge Event Bus (%s) Policy: %s", d.Id(), err)
 	}
 
-	busName := aws.StringValue(output.Name)
-	if busName == "" {
-		busName = DefaultEventBusName
+	eventBusName := d.Id()
+	if eventBusName == "" {
+		eventBusName = DefaultEventBusName
 	}
-	d.Set("event_bus_name", busName)
+	d.Set("event_bus_name", eventBusName)
 
-	policyToSet, err := verify.PolicyToSet(d.Get("policy").(string), aws.StringValue(policy))
+	policyToSet, err := verify.PolicyToSet(d.Get("policy").(string), aws.StringValue(outputRaw.(*string)))
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "reading policy from EventBridge Bus (%s): %s", d.Id(), err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	d.Set("policy", policyToSet)
@@ -155,62 +135,41 @@ func resourceBusPolicyRead(ctx context.Context, d *schema.ResourceData, meta int
 	return diags
 }
 
-func getEventBusPolicy(output *eventbridge.DescribeEventBusOutput) (*string, error) {
-	if output == nil || output.Policy == nil {
-		return nil, &retry.NotFoundError{
-			Message:      fmt.Sprintf("Policy for EventBridge Bus (%s) not found", *output.Name),
-			LastResponse: output,
-		}
-	}
-
-	return output.Policy, nil
-}
-
-func resourceBusPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).EventsConn(ctx)
-
-	eventBusName := d.Id()
-
-	policy, err := structure.NormalizeJsonString(d.Get("policy").(string))
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "policy (%s) is invalid JSON: %s", policy, err)
-	}
-
-	input := eventbridge.PutPermissionInput{
-		EventBusName: aws.String(eventBusName),
-		Policy:       aws.String(policy),
-	}
-
-	log.Printf("[DEBUG] Update EventBridge Bus policy: %s", input)
-	_, err = conn.PutPermissionWithContext(ctx, &input)
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "updating policy for EventBridge Bus (%s): %s", d.Id(), err)
-	}
-
-	return append(diags, resourceBusPolicyRead(ctx, d, meta)...)
-}
-
 func resourceBusPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EventsConn(ctx)
 
-	eventBusName := d.Id()
-	removeAllPermissions := true
+	log.Printf("[DEBUG] Deleting EventBridge Event Bus Policy: %s", d.Id())
+	_, err := conn.RemovePermissionWithContext(ctx, &eventbridge.RemovePermissionInput{
+		EventBusName:         aws.String(d.Id()),
+		RemoveAllPermissions: aws.Bool(true),
+	})
 
-	input := eventbridge.RemovePermissionInput{
-		EventBusName:         aws.String(eventBusName),
-		RemoveAllPermissions: &removeAllPermissions,
-	}
-
-	log.Printf("[DEBUG] Delete EventBridge Bus Policy: %s", input)
-	_, err := conn.RemovePermissionWithContext(ctx, &input)
 	if tfawserr.ErrCodeEquals(err, eventbridge.ErrCodeResourceNotFoundException) {
 		return diags
 	}
+
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "deleting policy for EventBridge Bus (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting EventBridge Event Bus (%s) Policy: %s", d.Id(), err)
 	}
+
 	return diags
+}
+
+var (
+	errPolicyNotFound = errors.New(`EventBridge policy not found`)
+)
+
+func FindEventBusPolicyByName(ctx context.Context, conn *eventbridge.EventBridge, name string) (*string, error) {
+	output, err := FindEventBusByName(ctx, conn, name)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if aws.StringValue(output.Policy) == "" {
+		return nil, errPolicyNotFound
+	}
+
+	return output.Policy, nil
 }

--- a/internal/service/events/bus_policy_test.go
+++ b/internal/service/events/bus_policy_test.go
@@ -5,6 +5,7 @@ package events_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -22,7 +23,7 @@ import (
 func TestAccEventsBusPolicy_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_event_bus_policy.test"
-	rstring := sdkacctest.RandString(5)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -31,14 +32,14 @@ func TestAccEventsBusPolicy_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckBusDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBusPolicyConfig_basic(rstring),
+				Config: testAccBusPolicyConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBusPolicyExists(ctx, resourceName),
 					testAccBusPolicyDocument(ctx, resourceName),
 				),
 			},
 			{
-				Config: testAccBusPolicyConfig_update(rstring),
+				Config: testAccBusPolicyConfig_update(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBusPolicyExists(ctx, resourceName),
 					testAccBusPolicyDocument(ctx, resourceName),
@@ -82,7 +83,7 @@ func TestAccEventsBusPolicy_ignoreEquivalent(t *testing.T) {
 func TestAccEventsBusPolicy_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_event_bus_policy.test"
-	rstring := sdkacctest.RandString(5)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -91,7 +92,7 @@ func TestAccEventsBusPolicy_disappears(t *testing.T) {
 		CheckDestroy:             testAccCheckBusDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBusPolicyConfig_basic(rstring),
+				Config: testAccBusPolicyConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBusPolicyExists(ctx, resourceName),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfevents.ResourceBusPolicy(), resourceName),
@@ -106,7 +107,7 @@ func TestAccEventsBusPolicy_disappears_EventBus(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_event_bus_policy.test"
 	parentResourceName := "aws_cloudwatch_event_bus.test"
-	rstring := sdkacctest.RandString(5)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -115,7 +116,7 @@ func TestAccEventsBusPolicy_disappears_EventBus(t *testing.T) {
 		CheckDestroy:             testAccCheckBusDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBusPolicyConfig_basic(rstring),
+				Config: testAccBusPolicyConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBusPolicyExists(ctx, resourceName),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfevents.ResourceBus(), parentResourceName),
@@ -126,73 +127,45 @@ func TestAccEventsBusPolicy_disappears_EventBus(t *testing.T) {
 	})
 }
 
-func testAccCheckBusPolicyExists(ctx context.Context, pr string) resource.TestCheckFunc {
+func testAccCheckBusPolicyExists(ctx context.Context, n string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
-		eventBusResource, ok := state.RootModule().Resources[pr]
+		rs, ok := state.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not found: %s", pr)
-		}
-
-		if eventBusResource.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		eventBusName := eventBusResource.Primary.ID
-
-		input := &eventbridge.DescribeEventBusInput{
-			Name: aws.String(eventBusName),
+			return fmt.Errorf("Not found: %s", n)
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).EventsConn(ctx)
-		describedEventBus, err := conn.DescribeEventBusWithContext(ctx, input)
+
+		_, err := tfevents.FindEventBusPolicyByName(ctx, conn, rs.Primary.ID)
+
+		return err
+	}
+}
+
+func testAccBusPolicyDocument(ctx context.Context, n string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		rs, ok := state.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).EventsConn(ctx)
+
+		policy, err := tfevents.FindEventBusPolicyByName(ctx, conn, rs.Primary.ID)
 
 		if err != nil {
-			return fmt.Errorf("Reading EventBridge bus policy for '%s' failed: %w", pr, err)
+			return err
 		}
-		if describedEventBus.Policy == nil || len(*describedEventBus.Policy) == 0 {
-			return fmt.Errorf("Not found: %s", pr)
+
+		if equivalent, err := awspolicy.PoliciesAreEquivalent(rs.Primary.Attributes["policy"], aws.StringValue(policy)); err != nil || !equivalent {
+			return errors.New(`EventBridge Event Bus Policies not equivalent`)
 		}
 
 		return nil
 	}
 }
 
-func testAccBusPolicyDocument(ctx context.Context, pr string) resource.TestCheckFunc {
-	return func(state *terraform.State) error {
-		eventBusPolicyResource, ok := state.RootModule().Resources[pr]
-		if !ok {
-			return fmt.Errorf("Not found: %s", pr)
-		}
-
-		if eventBusPolicyResource.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		eventBusName := eventBusPolicyResource.Primary.ID
-
-		input := &eventbridge.DescribeEventBusInput{
-			Name: aws.String(eventBusName),
-		}
-
-		conn := acctest.Provider.Meta().(*conns.AWSClient).EventsConn(ctx)
-		describedEventBus, err := conn.DescribeEventBusWithContext(ctx, input)
-		if err != nil {
-			return fmt.Errorf("Reading EventBridge bus policy for '%s' failed: %w", pr, err)
-		}
-
-		if describedEventBus.Policy == nil || len(*describedEventBus.Policy) == 0 {
-			return fmt.Errorf("Not found: %s", pr)
-		}
-
-		if equivalent, err := awspolicy.PoliciesAreEquivalent(eventBusPolicyResource.Primary.Attributes["policy"], aws.StringValue(describedEventBus.Policy)); err != nil || !equivalent {
-			return fmt.Errorf("EventBridge bus policy not equivalent for '%s'", pr)
-		}
-
-		return nil
-	}
-}
-
-func testAccBusPolicyConfig_basic(name string) string {
+func testAccBusPolicyConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudwatch_event_bus" "test" {
   name = %[1]q
@@ -220,10 +193,10 @@ resource "aws_cloudwatch_event_bus_policy" "test" {
   policy         = data.aws_iam_policy_document.access.json
   event_bus_name = aws_cloudwatch_event_bus.test.name
 }
-`, name)
+`, rName)
 }
 
-func testAccBusPolicyConfig_update(name string) string {
+func testAccBusPolicyConfig_update(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudwatch_event_bus" "test" {
   name = %[1]q
@@ -264,7 +237,7 @@ resource "aws_cloudwatch_event_bus_policy" "test" {
   policy         = data.aws_iam_policy_document.access.json
   event_bus_name = aws_cloudwatch_event_bus.test.name
 }
-`, name)
+`, rName)
 }
 
 func testAccBusPolicyConfig_order(rName string) string {

--- a/internal/service/events/bus_policy_test.go
+++ b/internal/service/events/bus_policy_test.go
@@ -102,6 +102,30 @@ func TestAccEventsBusPolicy_disappears(t *testing.T) {
 	})
 }
 
+func TestAccEventsBusPolicy_disappears_EventBus(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_cloudwatch_event_bus_policy.test"
+	parentResourceName := "aws_cloudwatch_event_bus.test"
+	rstring := sdkacctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, eventbridge.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckBusDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBusPolicyConfig_basic(rstring),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBusPolicyExists(ctx, resourceName),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfevents.ResourceBus(), parentResourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccCheckBusPolicyExists(ctx context.Context, pr string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 		eventBusResource, ok := state.RootModule().Resources[pr]

--- a/internal/service/iot/thing_type.go
+++ b/internal/service/iot/thing_type.go
@@ -167,16 +167,15 @@ func resourceThingTypeUpdate(ctx context.Context, d *schema.ResourceData, meta i
 	conn := meta.(*conns.AWSClient).IoTConn(ctx)
 
 	if d.HasChange("deprecated") {
-		params := &iot.DeprecateThingTypeInput{
+		input := &iot.DeprecateThingTypeInput{
 			ThingTypeName: aws.String(d.Id()),
 			UndoDeprecate: aws.Bool(!d.Get("deprecated").(bool)),
 		}
 
-		log.Printf("[DEBUG] Updating IoT Thing Type: %s", params)
-		_, err := conn.DeprecateThingTypeWithContext(ctx, params)
+		_, err := conn.DeprecateThingTypeWithContext(ctx, input)
 
 		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating IoT Thing Type (%s): deprecating Thing Type: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "deprecating IoT Thing Type (%s): %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/iot/thing_type.go
+++ b/internal/service/iot/thing_type.go
@@ -141,12 +141,14 @@ func resourceThingTypeRead(ctx context.Context, d *schema.ResourceData, meta int
 	log.Printf("[DEBUG] Reading IoT Thing Type: %s", params)
 	out, err := conn.DescribeThingTypeWithContext(ctx, params)
 
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, "ResourceNotFoundException") {
+		log.Printf("[WARN] IoT Thing Type (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return diags
+	}
+
 	if err != nil {
-		if tfawserr.ErrCodeEquals(err, iot.ErrCodeResourceNotFoundException) {
-			log.Printf("[WARN] IoT Thing Type (%s) not found, removing from state", d.Id())
-			d.SetId("")
-		}
-		return sdkdiag.AppendErrorf(diags, "reading IoT Thing Type (%s): %s", d.Id(), err)
+		return diag.Errorf("reading IoT Thing Type (%s): %s", d.Id(), err)
 	}
 
 	if out.ThingTypeMetadata != nil {

--- a/internal/service/iot/thing_type.go
+++ b/internal/service/iot/thing_type.go
@@ -39,6 +39,15 @@ func ResourceThingType() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"deprecated": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -72,17 +81,8 @@ func ResourceThingType() *schema.Resource {
 					},
 				},
 			},
-			"deprecated": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			"arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,

--- a/internal/service/iot/thing_type_test.go
+++ b/internal/service/iot/thing_type_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfiot "github.com/hashicorp/terraform-provider-aws/internal/service/iot"
 )
 
 func TestAccIoTThingType_basic(t *testing.T) {
@@ -123,6 +124,29 @@ func TestAccIoTThingType_tags(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccIoTThingType_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_iot_thing_type.foo"
+	rInt := sdkacctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, iot.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckThingTypeDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccThingTypeConfig_basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckThingTypeExists(ctx, resourceName),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfiot.ResourceThingType(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/service/iot/thing_type_test.go
+++ b/internal/service/iot/thing_type_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iot"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -16,11 +15,13 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfiot "github.com/hashicorp/terraform-provider-aws/internal/service/iot"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func TestAccIoTThingType_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	rInt := sdkacctest.RandInt()
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_iot_thing_type.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -29,78 +30,13 @@ func TestAccIoTThingType_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckThingTypeDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccThingTypeConfig_basic(rInt),
+				Config: testAccThingTypeConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckThingTypeExists(ctx, "aws_iot_thing_type.foo"),
-					resource.TestCheckResourceAttrSet("aws_iot_thing_type.foo", "arn"),
-					resource.TestCheckResourceAttr("aws_iot_thing_type.foo", "name", fmt.Sprintf("tf_acc_iot_thing_type_%d", rInt)),
-					resource.TestCheckResourceAttr("aws_iot_thing_type.foo", "tags.%", "0"),
-					resource.TestCheckResourceAttr("aws_iot_thing_type.foo", "tags_all.%", "0"),
-				),
-			},
-			{
-				ResourceName:      "aws_iot_thing_type.foo",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccIoTThingType_full(t *testing.T) {
-	ctx := acctest.Context(t)
-	rInt := sdkacctest.RandInt()
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, iot.EndpointsID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckThingTypeDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccThingTypeConfig_full(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckThingTypeExists(ctx, "aws_iot_thing_type.foo"),
-					resource.TestCheckResourceAttrSet("aws_iot_thing_type.foo", "arn"),
-					resource.TestCheckResourceAttr("aws_iot_thing_type.foo", "properties.0.description", "MyDescription"),
-					resource.TestCheckResourceAttr("aws_iot_thing_type.foo", "properties.0.searchable_attributes.#", "3"),
-					resource.TestCheckResourceAttr("aws_iot_thing_type.foo", "deprecated", "true"),
-					resource.TestCheckResourceAttr("aws_iot_thing_type.foo", "tags.%", "1"),
-					resource.TestCheckResourceAttr("aws_iot_thing_type.foo", "tags_all.%", "1"),
-				),
-			},
-			{
-				ResourceName:      "aws_iot_thing_type.foo",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccThingTypeConfig_fullUpdated(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_iot_thing_type.foo", "deprecated", "false"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccIoTThingType_tags(t *testing.T) {
-	ctx := acctest.Context(t)
-	rName := sdkacctest.RandString(5)
-	resourceName := "aws_iot_thing_type.foo"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, iot.EndpointsID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckThingTypeDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccThingTypeConfig_tags1(rName, "key1", "user@example"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckThingTypeExists(ctx, "aws_iot_thing_type.foo"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.key1", "user@example"),
+					testAccCheckThingTypeExists(ctx, resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "deprecated", "false"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
@@ -108,31 +44,14 @@ func TestAccIoTThingType_tags(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			{
-				Config: testAccThingTypeConfig_tags2(rName, "key1", "user@example", "key2", "value2"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckThingTypeExists(ctx, "aws_iot_thing_type.foo"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.key1", "user@example"),
-					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
-				),
-			},
-			{
-				Config: testAccThingTypeConfig_tags1(rName, "key2", "value2"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckThingTypeExists(ctx, "aws_iot_thing_type.foo"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
-				),
-			},
 		},
 	})
 }
 
 func TestAccIoTThingType_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	resourceName := "aws_iot_thing_type.foo"
-	rInt := sdkacctest.RandInt()
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_iot_thing_type.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -141,7 +60,7 @@ func TestAccIoTThingType_disappears(t *testing.T) {
 		CheckDestroy:             testAccCheckThingTypeDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccThingTypeConfig_basic(rInt),
+				Config: testAccThingTypeConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckThingTypeExists(ctx, resourceName),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfiot.ResourceThingType(), resourceName),
@@ -152,29 +71,102 @@ func TestAccIoTThingType_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckThingTypeExists(ctx context.Context, name string) resource.TestCheckFunc {
+func TestAccIoTThingType_full(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_iot_thing_type.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, iot.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckThingTypeDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccThingTypeConfig_full(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckThingTypeExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "deprecated", "true"),
+					resource.TestCheckResourceAttr(resourceName, "properties.0.description", "MyDescription"),
+					resource.TestCheckResourceAttr(resourceName, "properties.0.searchable_attributes.#", "3"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "properties.0.searchable_attributes.*", "foo"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "properties.0.searchable_attributes.*", "bar"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "properties.0.searchable_attributes.*", "baz"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccThingTypeConfig_full(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckThingTypeExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "deprecated", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIoTThingType_tags(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_iot_thing_type.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, iot.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckThingTypeDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccThingTypeConfig_tags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckThingTypeExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccThingTypeConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckThingTypeExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccThingTypeConfig_tags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckThingTypeExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckThingTypeExists(ctx context.Context, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", n)
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).IoTConn(ctx)
-		input := &iot.ListThingTypesInput{}
 
-		output, err := conn.ListThingTypesWithContext(ctx, input)
+		_, err := tfiot.FindThingTypeByName(ctx, conn, rs.Primary.ID)
 
-		if err != nil {
-			return err
-		}
-
-		for _, rule := range output.ThingTypes {
-			if aws.StringValue(rule.ThingTypeName) == rs.Primary.ID {
-				return nil
-			}
-		}
-
-		return fmt.Errorf("IoT Topic Rule (%s) not found", rs.Primary.ID)
+		return err
 	}
 }
 
@@ -187,68 +179,49 @@ func testAccCheckThingTypeDestroy(ctx context.Context) resource.TestCheckFunc {
 				continue
 			}
 
-			params := &iot.DescribeThingTypeInput{
-				ThingTypeName: aws.String(rs.Primary.ID),
+			_, err := tfiot.FindThingTypeByName(ctx, conn, rs.Primary.ID)
+
+			if tfresource.NotFound(err) {
+				continue
 			}
 
-			_, err := conn.DescribeThingTypeWithContext(ctx, params)
-			if err == nil {
-				return fmt.Errorf("Expected IoT Thing Type to be destroyed, %s found", rs.Primary.ID)
+			if err != nil {
+				return err
 			}
+
+			return fmt.Errorf("IoT Thing Type %s still exists", rs.Primary.ID)
 		}
 
 		return nil
 	}
 }
 
-func testAccThingTypeConfig_basic(rName int) string {
+func testAccThingTypeConfig_basic(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_iot_thing_type" "foo" {
-  name = "tf_acc_iot_thing_type_%d"
+resource "aws_iot_thing_type" "test" {
+  name = %[1]q
 }
 `, rName)
 }
 
-func testAccThingTypeConfig_full(rName int) string {
+func testAccThingTypeConfig_full(rName string, deprecated bool) string {
 	return fmt.Sprintf(`
-resource "aws_iot_thing_type" "foo" {
-  name       = "tf_acc_iot_thing_type_%d"
-  deprecated = true
+resource "aws_iot_thing_type" "test" {
+  name       = %[1]q
+  deprecated = %[2]t
 
   properties {
     description           = "MyDescription"
     searchable_attributes = ["foo", "bar", "baz"]
   }
-
-  tags = {
-    testtag = "MyTagValue"
-  }
 }
-`, rName)
-}
-
-func testAccThingTypeConfig_fullUpdated(rName int) string {
-	return fmt.Sprintf(`
-resource "aws_iot_thing_type" "foo" {
-  name       = "tf_acc_iot_thing_type_%d"
-  deprecated = false
-
-  properties {
-    description           = "MyDescription"
-    searchable_attributes = ["foo", "bar", "baz"]
-  }
-
-  tags = {
-    testtag = "MyTagValue"
-  }
-}
-`, rName)
+`, rName, deprecated)
 }
 
 func testAccThingTypeConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
-resource "aws_iot_thing_type" "foo" {
-  name       = "tf_acc_iot_thing_type_%[1]s"
+resource "aws_iot_thing_type" "test" {
+  name       = %[1]q
   deprecated = false
 
   tags = {
@@ -260,8 +233,8 @@ resource "aws_iot_thing_type" "foo" {
 
 func testAccThingTypeConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
-resource "aws_iot_thing_type" "foo" {
-  name       = "tf_acc_iot_thing_type_%[1]s"
+resource "aws_iot_thing_type" "test" {
+  name       = %[1]q
   deprecated = false
 
   tags = {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
 - Fix an error while refreshing state if `aws_iot_thing_type` is manually deleted in AWS
 - Fix an error while refreshing state for `aws_cloudwatch_event_bus_policy` if the associated `aws_cloudwatch_event_bus` is manually deleted in AWS.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #31634

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
This is my first contribution, so please double check and let me know if I have missed anything.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccIoTThingType PKG=iot
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iot/... -v -count 1 -parallel 20 -run='TestAccIoTThingType'  -timeout 180m
=== RUN   TestAccIoTThingType_basic
=== PAUSE TestAccIoTThingType_basic
=== RUN   TestAccIoTThingType_full
=== PAUSE TestAccIoTThingType_full
=== RUN   TestAccIoTThingType_tags
=== PAUSE TestAccIoTThingType_tags
=== RUN   TestAccIoTThingType_disappears
=== PAUSE TestAccIoTThingType_disappears
=== CONT  TestAccIoTThingType_basic
=== CONT  TestAccIoTThingType_tags
=== CONT  TestAccIoTThingType_full
=== CONT  TestAccIoTThingType_disappears
--- PASS: TestAccIoTThingType_disappears (343.43s)
--- PASS: TestAccIoTThingType_basic (353.06s)
--- PASS: TestAccIoTThingType_full (381.52s)
--- PASS: TestAccIoTThingType_tags (414.56s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iot        417.383s

% make testacc TESTS=TestAccEventsBusPolicy PKG=events
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/events/... -v -count 1 -parallel 20 -run='TestAccEventsBusPolicy'  -timeout 180m
=== RUN   TestAccEventsBusPolicy_basic
=== PAUSE TestAccEventsBusPolicy_basic
=== RUN   TestAccEventsBusPolicy_ignoreEquivalent
=== PAUSE TestAccEventsBusPolicy_ignoreEquivalent
=== RUN   TestAccEventsBusPolicy_disappears
=== PAUSE TestAccEventsBusPolicy_disappears
=== RUN   TestAccEventsBusPolicy_disappears_EventBus
=== PAUSE TestAccEventsBusPolicy_disappears_EventBus
=== CONT  TestAccEventsBusPolicy_basic
=== CONT  TestAccEventsBusPolicy_disappears
=== CONT  TestAccEventsBusPolicy_ignoreEquivalent
=== CONT  TestAccEventsBusPolicy_disappears_EventBus
--- PASS: TestAccEventsBusPolicy_disappears_EventBus (36.38s)
--- PASS: TestAccEventsBusPolicy_ignoreEquivalent (71.66s)
--- PASS: TestAccEventsBusPolicy_basic (84.53s)
--- PASS: TestAccEventsBusPolicy_disappears (164.01s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/events     166.863s
...
```
