### PR TITLE
Add `name_prefix` support for WAFv2 rule groups

### DIFF
--- a/.changelog/33206.txt
+++ b/.changelog/33206.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_wafv2_rule_group: Add `name_prefix` argument
+```

--- a/internal/service/wafv2/rule_group.go
+++ b/internal/service/wafv2/rule_group.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -79,9 +80,22 @@ func ResourceRuleGroup() *schema.Resource {
 					Computed: true,
 				},
 				"name": {
-					Type:     schema.TypeString,
-					Required: true,
-					ForceNew: true,
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{"name_prefix"},
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(1, 128),
+						validation.StringMatch(regexache.MustCompile(`^[a-zA-Z0-9-_]+$`), "must contain only alphanumeric hyphen and underscore characters"),
+					),
+				},
+				"name_prefix": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{"name"},
 					ValidateFunc: validation.All(
 						validation.StringLenBetween(1, 128),
 						validation.StringMatch(regexache.MustCompile(`^[a-zA-Z0-9-_]+$`), "must contain only alphanumeric hyphen and underscore characters"),
@@ -141,7 +155,8 @@ func ResourceRuleGroup() *schema.Resource {
 func resourceRuleGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).WAFV2Conn(ctx)
 
-	name := d.Get("name").(string)
+	name := create.Name(d.Get("name").(string), d.Get("name_prefix").(string))
+
 	input := &wafv2.CreateRuleGroupInput{
 		Capacity:         aws.Int64(int64(d.Get("capacity").(int))),
 		Name:             aws.String(name),
@@ -198,6 +213,7 @@ func resourceRuleGroupRead(ctx context.Context, d *schema.ResourceData, meta int
 	d.Set("description", ruleGroup.Description)
 	d.Set("lock_token", output.LockToken)
 	d.Set("name", ruleGroup.Name)
+	d.Set("name_prefix", create.NamePrefixFromName(aws.StringValue(ruleGroup.Name)))
 	if err := d.Set("rule", flattenRules(ruleGroup.Rules)); err != nil {
 		return diag.Errorf("setting rule: %s", err)
 	}

--- a/internal/service/wafv2/rule_group.go
+++ b/internal/service/wafv2/rule_group.go
@@ -182,9 +182,8 @@ func resourceRuleGroupCreate(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.Errorf("creating WAFv2 RuleGroup (%s): %s", name, err)
 	}
 
-	output := outputRaw.(*wafv2.CreateRuleGroupOutput)
-
-	d.SetId(aws.StringValue(output.Summary.Id))
+	d.SetId(aws.StringValue(outputRaw.(*wafv2.CreateRuleGroupOutput).Summary.Id))
+	d.Set("name", name) // Required in Read.
 
 	return resourceRuleGroupRead(ctx, d, meta)
 }

--- a/internal/service/wafv2/rule_group_test.go
+++ b/internal/service/wafv2/rule_group_test.go
@@ -61,10 +61,9 @@ func TestAccWAFV2RuleGroup_basic(t *testing.T) {
 	})
 }
 
-func TestAccWAFV2RuleGroup_Name_generated(t *testing.T) {
+func TestAccWAFV2RuleGroup_nameGenerated(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v wafv2.RuleGroup
-	ruleGroupDescription := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_wafv2_rule_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -74,14 +73,11 @@ func TestAccWAFV2RuleGroup_Name_generated(t *testing.T) {
 		CheckDestroy:             testAccCheckRuleGroupDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRuleGroupConfig_nameGenerated(ruleGroupDescription),
+				Config: testAccRuleGroupConfig_nameGenerated(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRuleGroupExists(ctx, resourceName, &v),
-					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexache.MustCompile(`regional/rulegroup/.+$`)),
-					resource.TestCheckResourceAttr(resourceName, "name", ruleGroupDescription),
-					resource.TestMatchResourceAttr(resourceName, "name", regexache.MustCompile(fmt.Sprintf("%s[[:xdigit:]]{%d}", id.UniqueIdPrefix, id.UniqueIDSuffixLength))),
+					acctest.CheckResourceAttrNameGenerated(resourceName, "name"),
 					resource.TestCheckResourceAttr(resourceName, "name_prefix", id.UniqueIdPrefix),
-					resource.TestCheckResourceAttr(resourceName, "description", ruleGroupDescription),
 				),
 			},
 			{
@@ -97,7 +93,6 @@ func TestAccWAFV2RuleGroup_Name_generated(t *testing.T) {
 func TestAccWAFV2RuleGroup_namePrefix(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v wafv2.RuleGroup
-	ruleGroupDescription := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_wafv2_rule_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -107,14 +102,11 @@ func TestAccWAFV2RuleGroup_namePrefix(t *testing.T) {
 		CheckDestroy:             testAccCheckRuleGroupDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRuleGroupConfig_nameGenerated(ruleGroupDescription),
+				Config: testAccRuleGroupConfig_namePrefix("tf-acc-test-prefix-"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRuleGroupExists(ctx, resourceName, &v),
-					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexache.MustCompile(`regional/rulegroup/.+$`)),
-					resource.TestCheckResourceAttr(resourceName, "name", ruleGroupDescription),
-					resource.TestMatchResourceAttr(resourceName, "name", regexache.MustCompile(fmt.Sprintf("%s[[:xdigit:]]{%d}", id.UniqueIdPrefix, id.UniqueIDSuffixLength))),
-					resource.TestCheckResourceAttr(resourceName, "name_prefix", id.UniqueIdPrefix),
-					resource.TestCheckResourceAttr(resourceName, "description", ruleGroupDescription),
+					acctest.CheckResourceAttrNameFromPrefix(resourceName, "name", "tf-acc-test-prefix-"),
+					resource.TestCheckResourceAttr(resourceName, "name_prefix", "tf-acc-test-prefix-"),
 				),
 			},
 			{
@@ -1896,12 +1888,11 @@ func TestAccWAFV2RuleGroup_tags(t *testing.T) {
 		CheckDestroy:             testAccCheckRuleGroupDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRuleGroupConfig_oneTag(ruleGroupName, "Tag1", "Value1"),
+				Config: testAccRuleGroupConfig_tags1(ruleGroupName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRuleGroupExists(ctx, resourceName, &v),
-					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexache.MustCompile(`regional/rulegroup/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Tag1", "Value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
 			},
 			{
@@ -1911,22 +1902,20 @@ func TestAccWAFV2RuleGroup_tags(t *testing.T) {
 				ImportStateIdFunc: testAccRuleGroupImportStateIdFunc(resourceName),
 			},
 			{
-				Config: testAccRuleGroupConfig_twoTags(ruleGroupName, "Tag1", "Value1Updated", "Tag2", "Value2"),
+				Config: testAccRuleGroupConfig_tags2(ruleGroupName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRuleGroupExists(ctx, resourceName, &v),
-					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexache.MustCompile(`regional/rulegroup/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Tag1", "Value1Updated"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Tag2", "Value2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
 			},
 			{
-				Config: testAccRuleGroupConfig_oneTag(ruleGroupName, "Tag2", "Value2"),
+				Config: testAccRuleGroupConfig_tags1(ruleGroupName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRuleGroupExists(ctx, resourceName, &v),
-					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexache.MustCompile(`regional/rulegroup/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Tag2", "Value2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
 			},
 		},
@@ -2227,10 +2216,6 @@ func testAccCheckRuleGroupExists(ctx context.Context, n string, v *wafv2.RuleGro
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No WAFv2 RuleGroup ID is set")
-		}
-
 		conn := acctest.Provider.Meta().(*conns.AWSClient).WAFV2Conn(ctx)
 
 		output, err := tfwafv2.FindRuleGroupByThreePartKey(ctx, conn, rs.Primary.ID, rs.Primary.Attributes["name"], rs.Primary.Attributes["scope"])
@@ -2245,12 +2230,23 @@ func testAccCheckRuleGroupExists(ctx context.Context, n string, v *wafv2.RuleGro
 	}
 }
 
-func testAccRuleGroupConfig_basic(name string) string {
+func testAccRuleGroupImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s/%s/%s", rs.Primary.ID, rs.Primary.Attributes["name"], rs.Primary.Attributes["scope"]), nil
+	}
+}
+
+func testAccRuleGroupConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity    = 2
-  name        = "%s"
-  description = "%s"
+  name        = %[1]q
+  description = %[1]q
   scope       = "REGIONAL"
 
   visibility_config {
@@ -2259,15 +2255,15 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name, name)
+`, rName)
 }
 
 func testAccRuleGroupConfig_namePrefix(namePrefix string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity    = 2
-  name_prefix = "%[1]s"
-  description = "%[1]s"
+  name_prefix = %[1]q
+  description = "test"
   scope       = "REGIONAL"
 
   visibility_config {
@@ -2279,11 +2275,11 @@ resource "aws_wafv2_rule_group" "test" {
 `, namePrefix)
 }
 
-func testAccRuleGroupConfig_nameGenerated(description string) string {
-	return fmt.Sprintf(`
+func testAccRuleGroupConfig_nameGenerated() string {
+	return `
 resource "aws_wafv2_rule_group" "test" {
   capacity    = 2
-  description = "%[1]s"
+  description = "test"
   scope       = "REGIONAL"
 
   visibility_config {
@@ -2292,14 +2288,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, description)
+`
 }
 
-func testAccRuleGroupConfig_basicUpdate(name string) string {
+func testAccRuleGroupConfig_basicUpdate(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity    = 50
-  name        = "%s"
+  name        = %[1]q
   description = "Updated"
   scope       = "REGIONAL"
 
@@ -2330,19 +2326,19 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_updateMultiples(name string, ruleName1, ruleName2 string, priority1, priority2 int) string {
+func testAccRuleGroupConfig_updateMultiples(rName string, ruleName1, ruleName2 string, priority1, priority2 int) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity    = 50
-  name        = "%[1]s"
+  name        = %[1]q
   description = "Updated"
   scope       = "REGIONAL"
 
   rule {
-    name     = "%[2]s"
+    name     = %[2]q
     priority = %[3]d
 
     action {
@@ -2357,13 +2353,13 @@ resource "aws_wafv2_rule_group" "test" {
 
     visibility_config {
       cloudwatch_metrics_enabled = false
-      metric_name                = "%[2]s"
+      metric_name                = %[2]q
       sampled_requests_enabled   = false
     }
   }
 
   rule {
-    name     = "%[4]s"
+    name     = %[4]q
     priority = %[5]d
 
     action {
@@ -2393,7 +2389,7 @@ resource "aws_wafv2_rule_group" "test" {
 
     visibility_config {
       cloudwatch_metrics_enabled = false
-      metric_name                = "%[4]s"
+      metric_name                = %[4]q
       sampled_requests_enabled   = false
     }
   }
@@ -2404,15 +2400,15 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name, ruleName1, priority1, ruleName2, priority2)
+`, rName, ruleName1, priority1, ruleName2, priority2)
 }
 
-func testAccRuleGroupConfig_updateCapacity(name string) string {
+func testAccRuleGroupConfig_updateCapacity(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity    = 3
-  name        = "%s"
-  description = "%s"
+  name        = %[1]q
+  description = %[1]q
   scope       = "REGIONAL"
 
   visibility_config {
@@ -2421,15 +2417,15 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_updateMetricName(name string) string {
+func testAccRuleGroupConfig_updateMetricName(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity    = 2
-  name        = "%s"
-  description = "%s"
+  name        = %[1]q
+  description = %[1]q
   scope       = "REGIONAL"
 
   visibility_config {
@@ -2438,14 +2434,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_minimal(name string) string {
+func testAccRuleGroupConfig_minimal(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 2
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   visibility_config {
@@ -2454,14 +2450,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_actionAllow(name string) string {
+func testAccRuleGroupConfig_actionAllow(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 2
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -2491,14 +2487,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_actionAllowCustomRequestHandling(name string) string {
+func testAccRuleGroupConfig_actionAllowCustomRequestHandling(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 2
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -2540,14 +2536,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_actionBlock(name string) string {
+func testAccRuleGroupConfig_actionBlock(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 2
-  name     = "%s"
+  name     = "%[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -2577,14 +2573,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_actionBlockCustomResponse(name string) string {
+func testAccRuleGroupConfig_actionBlockCustomResponse(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 2
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -2627,14 +2623,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_actionBlockCustomResponseBody(name string, customBodyKey string) string {
+func testAccRuleGroupConfig_actionBlockCustomResponseBody(rName string, customBodyKey string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 2
-  name     = "%[1]s"
+  name     = %[1]q
   scope    = "REGIONAL"
   custom_response_body {
     key          = "test_body_1"
@@ -2653,7 +2649,7 @@ resource "aws_wafv2_rule_group" "test" {
       block {
         custom_response {
           response_code            = 429
-          custom_response_body_key = "%[2]s"
+          custom_response_body_key = %[2]q
         }
       }
     }
@@ -2674,14 +2670,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name, customBodyKey)
+`, rName, customBodyKey)
 }
 
-func testAccRuleGroupConfig_actionCount(name string) string {
+func testAccRuleGroupConfig_actionCount(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 2
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -2711,14 +2707,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_actionCountCustomRequestHandling(name string) string {
+func testAccRuleGroupConfig_actionCountCustomRequestHandling(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 2
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -2760,14 +2756,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_byteMatchStatement(name string) string {
+func testAccRuleGroupConfig_byteMatchStatement(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 300
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -2812,14 +2808,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_byteMatchStatementUpdate(name string) string {
+func testAccRuleGroupConfig_byteMatchStatementUpdate(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 30
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -2859,14 +2855,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_byteMatchStatementFieldToMatchAllQueryArguments(name string) string {
+func testAccRuleGroupConfig_byteMatchStatementFieldToMatchAllQueryArguments(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 30
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -2906,14 +2902,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_byteMatchStatementFieldToMatchBody(name string) string {
+func testAccRuleGroupConfig_byteMatchStatementFieldToMatchBody(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 15
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -2953,14 +2949,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_byteMatchStatementFieldToMatchJSONBody(name string) string {
+func testAccRuleGroupConfig_byteMatchStatementFieldToMatchJSONBody(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 20
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -3007,14 +3003,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_byteMatchStatementFieldToMatchHeadersInvalidConfiguration(name string) string {
+func testAccRuleGroupConfig_byteMatchStatementFieldToMatchHeadersInvalidConfiguration(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 50
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -3059,14 +3055,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_byteMatchStatementFieldToMatchHeadersMatchPatternAll(name string) string {
+func testAccRuleGroupConfig_byteMatchStatementFieldToMatchHeadersMatchPatternAll(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 50
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -3112,14 +3108,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_byteMatchStatementFieldToMatchHeadersMatchPatternIncludedHeaders(name string) string {
+func testAccRuleGroupConfig_byteMatchStatementFieldToMatchHeadersMatchPatternIncludedHeaders(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 50
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -3165,14 +3161,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_byteMatchStatementFieldToMatchHeadersMatchPatternExcludedHeaders(name string) string {
+func testAccRuleGroupConfig_byteMatchStatementFieldToMatchHeadersMatchPatternExcludedHeaders(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 50
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -3218,14 +3214,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_byteMatchStatementFieldToMatchMethod(name string) string {
+func testAccRuleGroupConfig_byteMatchStatementFieldToMatchMethod(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 15
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -3265,14 +3261,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_byteMatchStatementFieldToMatchQueryString(name string) string {
+func testAccRuleGroupConfig_byteMatchStatementFieldToMatchQueryString(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 15
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -3312,14 +3308,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_byteMatchStatementFieldToMatchCookies(name string) string {
+func testAccRuleGroupConfig_byteMatchStatementFieldToMatchCookies(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 15
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -3365,14 +3361,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_byteMatchStatementFieldToMatchSingleHeader(name string) string {
+func testAccRuleGroupConfig_byteMatchStatementFieldToMatchSingleHeader(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 15
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -3414,14 +3410,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_byteMatchStatementFieldToMatchSingleQueryArgument(name string) string {
+func testAccRuleGroupConfig_byteMatchStatementFieldToMatchSingleQueryArgument(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 30
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -3463,14 +3459,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_byteMatchStatementFieldToMatchURIPath(name string) string {
+func testAccRuleGroupConfig_byteMatchStatementFieldToMatchURIPath(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 15
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -3510,13 +3506,13 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_ipsetReferenceStatement(name string) string {
+func testAccRuleGroupConfig_ipsetReferenceStatement(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_ip_set" "test" {
-  name               = "ip-set-%s"
+  name               = "ip-set-%[1]s"
   scope              = "REGIONAL"
   ip_address_version = "IPV4"
   addresses          = ["1.1.1.1/32", "2.2.2.2/32"]
@@ -3524,7 +3520,7 @@ resource "aws_wafv2_ip_set" "test" {
 
 resource "aws_wafv2_rule_group" "test" {
   capacity = 2
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -3554,10 +3550,10 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_ipsetReferenceStatementIPSetForwardedIP(name, fallbackBehavior, headerName, position string) string {
+func testAccRuleGroupConfig_ipsetReferenceStatementIPSetForwardedIP(rName, fallbackBehavior, headerName, position string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_ip_set" "test" {
   name               = "ip-set-%[1]s"
@@ -3568,7 +3564,7 @@ resource "aws_wafv2_ip_set" "test" {
 
 resource "aws_wafv2_rule_group" "test" {
   capacity = 5
-  name     = "%[1]s"
+  name     = "%[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -3583,9 +3579,9 @@ resource "aws_wafv2_rule_group" "test" {
       ip_set_reference_statement {
         arn = aws_wafv2_ip_set.test.arn
         ip_set_forwarded_ip_config {
-          fallback_behavior = "%[2]s"
-          header_name       = "%[3]s"
-          position          = "%[4]s"
+          fallback_behavior = %[2]q
+          header_name       = %[3]q
+          position          = %[4]q
         }
       }
     }
@@ -3603,14 +3599,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name, fallbackBehavior, headerName, position)
+`, rName, fallbackBehavior, headerName, position)
 }
 
-func testAccRuleGroupConfig_geoMatchStatement(name string) string {
+func testAccRuleGroupConfig_geoMatchStatement(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 2
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -3640,14 +3636,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_geoMatchStatementForwardedIP(name, fallbackBehavior, headerName string) string {
+func testAccRuleGroupConfig_geoMatchStatementForwardedIP(rName, fallbackBehavior, headerName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 2
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -3662,8 +3658,8 @@ resource "aws_wafv2_rule_group" "test" {
       geo_match_statement {
         country_codes = ["US", "NL"]
         forwarded_ip_config {
-          fallback_behavior = "%s"
-          header_name       = "%s"
+          fallback_behavior = %[2]q
+          header_name       = %[3]q
         }
       }
     }
@@ -3681,14 +3677,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name, fallbackBehavior, headerName)
+`, rName, fallbackBehavior, headerName)
 }
 
-func testAccRuleGroupConfig_geoMatchStatementUpdate(name string) string {
+func testAccRuleGroupConfig_geoMatchStatementUpdate(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 2
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -3718,14 +3714,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_labelMatchStatement(name string, scope string, key string) string {
+func testAccRuleGroupConfig_labelMatchStatement(rName string, scope string, key string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 2
-  name     = "%[1]s"
+  name     = %[1]q
   scope    = "REGIONAL"
   rule {
     name     = "rule-1"
@@ -3735,8 +3731,8 @@ resource "aws_wafv2_rule_group" "test" {
     }
     statement {
       label_match_statement {
-        scope = "%[2]s"
-        key   = "%[3]s"
+        scope = %[2]q
+        key   = %[3]q
       }
     }
     visibility_config {
@@ -3751,14 +3747,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name, scope, key)
+`, rName, scope, key)
 }
 
-func testAccRuleGroupConfig_labels(name string) string {
+func testAccRuleGroupConfig_labels(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 2
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
   rule {
     name     = "rule-1"
@@ -3789,14 +3785,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_noLabels(name string) string {
+func testAccRuleGroupConfig_noLabels(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 2
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
   rule {
     name     = "rule-1"
@@ -3821,14 +3817,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_logicalStatementAnd(name string) string {
+func testAccRuleGroupConfig_logicalStatementAnd(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 2
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -3868,14 +3864,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_logicalStatementNotAnd(name string) string {
+func testAccRuleGroupConfig_logicalStatementNotAnd(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 2
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -3919,14 +3915,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_logicalStatementOrNotAnd(name string) string {
+func testAccRuleGroupConfig_logicalStatementOrNotAnd(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 3
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -3980,14 +3976,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_regexMatchStatement(name string) string {
+func testAccRuleGroupConfig_regexMatchStatement(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 50
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -4026,13 +4022,13 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_regexPatternSetReferenceStatement(name string) string {
+func testAccRuleGroupConfig_regexPatternSetReferenceStatement(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_regex_pattern_set" "test" {
-  name  = "regex-pattern-set-%s"
+  name  = "regex-pattern-set-%[1]s"
   scope = "REGIONAL"
 
   regular_expression {
@@ -4042,7 +4038,7 @@ resource "aws_wafv2_regex_pattern_set" "test" {
 
 resource "aws_wafv2_rule_group" "test" {
   capacity = 50
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -4081,14 +4077,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_sizeConstraintStatement(name string) string {
+func testAccRuleGroupConfig_sizeConstraintStatement(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 30
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -4128,14 +4124,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_sizeConstraintStatementUpdate(name string) string {
+func testAccRuleGroupConfig_sizeConstraintStatementUpdate(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 30
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -4180,14 +4176,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_sqliMatchStatement(name string) string {
+func testAccRuleGroupConfig_sqliMatchStatement(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 300
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -4229,14 +4225,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_sqliMatchStatementUpdate(name string) string {
+func testAccRuleGroupConfig_sqliMatchStatementUpdate(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 300
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -4283,14 +4279,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_xssMatchStatement(name string) string {
+func testAccRuleGroupConfig_xssMatchStatement(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 300
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -4327,14 +4323,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_xssMatchStatementUpdate(name string) string {
+func testAccRuleGroupConfig_xssMatchStatementUpdate(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 300
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -4371,14 +4367,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_rateBasedStatement(name string) string {
+func testAccRuleGroupConfig_rateBasedStatement(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 3
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -4408,14 +4404,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_rateBasedStatement_forwardedIPConfig(name, fallbackBehavior, headerName string) string {
+func testAccRuleGroupConfig_rateBasedStatement_forwardedIPConfig(rName, fallbackBehavior, headerName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 3
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -4450,14 +4446,14 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name, fallbackBehavior, headerName)
+`, rName, fallbackBehavior, headerName)
 }
 
-func testAccRuleGroupConfig_rateBasedStatement_update(name string) string {
+func testAccRuleGroupConfig_rateBasedStatement_update(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 3
-  name     = "%s"
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -4494,15 +4490,15 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_oneTag(name, tagKey, tagValue string) string {
+func testAccRuleGroupConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity    = 2
-  name        = "%s"
-  description = "%s"
+  name        = %[1]q
+  description = %[1]q
   scope       = "REGIONAL"
 
   visibility_config {
@@ -4512,18 +4508,18 @@ resource "aws_wafv2_rule_group" "test" {
   }
 
   tags = {
-    "%s" = "%s"
+    %[2]q = %[3]q
   }
 }
-`, name, name, tagKey, tagValue)
+`, rName, tagKey1, tagValue1)
 }
 
-func testAccRuleGroupConfig_twoTags(name, tag1Key, tag1Value, tag2Key, tag2Value string) string {
+func testAccRuleGroupConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity    = 2
-  name        = "%s"
-  description = "%s"
+  name        = %[1]q
+  description = %[1]q
   scope       = "REGIONAL"
 
   visibility_config {
@@ -4533,14 +4529,14 @@ resource "aws_wafv2_rule_group" "test" {
   }
 
   tags = {
-    "%s" = "%s"
-    "%s" = "%s"
+    %[2]q = %[3]q
+    %[4]q = %[5]q
   }
 }
-`, name, name, tag1Key, tag1Value, tag2Key, tag2Value)
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccRuleGroupConfig_multipleNestedRateBasedStatements(name string) string {
+func testAccRuleGroupConfig_multipleNestedRateBasedStatements(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_regex_pattern_set" "test" {
   name  = %[1]q
@@ -4636,10 +4632,10 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccRuleGroupConfig_multipleNestedOperatorStatements(name string) string {
+func testAccRuleGroupConfig_multipleNestedOperatorStatements(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_regex_pattern_set" "test" {
   name  = %[1]q
@@ -4738,16 +4734,5 @@ resource "aws_wafv2_rule_group" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, name)
-}
-
-func testAccRuleGroupImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
-	return func(s *terraform.State) (string, error) {
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return "", fmt.Errorf("Not found: %s", resourceName)
-		}
-
-		return fmt.Sprintf("%s/%s/%s", rs.Primary.ID, rs.Primary.Attributes["name"], rs.Primary.Attributes["scope"]), nil
-	}
+`, rName)
 }

--- a/internal/service/wafv2/rule_group_test.go
+++ b/internal/service/wafv2/rule_group_test.go
@@ -2543,7 +2543,7 @@ func testAccRuleGroupConfig_actionBlock(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 2
-  name     = "%[1]q
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {
@@ -3564,7 +3564,7 @@ resource "aws_wafv2_ip_set" "test" {
 
 resource "aws_wafv2_rule_group" "test" {
   capacity = 5
-  name     = "%[1]q
+  name     = %[1]q
   scope    = "REGIONAL"
 
   rule {

--- a/website/docs/r/waf_rule_group.html.markdown
+++ b/website/docs/r/waf_rule_group.html.markdown
@@ -37,7 +37,8 @@ resource "aws_waf_rule_group" "example" {
 
 This resource supports the following arguments:
 
-* `name` - (Required) A friendly name of the rule group
+* `name` - (Optional) Name of the rule group. If omitted, Terraform will assign a random, unique name. Conflicts with `name_prefix`.
+* `name_prefix` - (Optional) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `metric_name` - (Required) A friendly name for the metrics from the rule group
 * `activated_rule` - (Optional) A list of activated rules, see below
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.


### PR DESCRIPTION
### Description

Adds support for `name_prefix` for `aws_wafv2_rule_group`; based on following https://hashicorp.github.io/terraform-provider-aws/resource-name-generation/

### Relations

Closes #23334

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
