### PR TITLE
r/aws_codeartifact_domain: fix error with `asset_size_bytes` size

### DIFF
--- a/.changelog/32926.txt
+++ b/.changelog/32926.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-resource/aws_codeartifact_domain: Change the type of asset_size_bytes to float (64) instead of int (32) to prevent `value out of range` panic
-```

--- a/.changelog/33220.txt
+++ b/.changelog/33220.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_codeartifact_domain: Change the type of asset_size_bytes to `TypeString` instead of `TypeInt` to prevent `value out of range` panic
+```

--- a/internal/service/codeartifact/codeartifact_test.go
+++ b/internal/service/codeartifact/codeartifact_test.go
@@ -19,10 +19,11 @@ func TestAccCodeArtifact_serial(t *testing.T) {
 			"owner":    testAccAuthorizationTokenDataSource_owner,
 		},
 		"Domain": {
-			"basic":                testAccDomain_basic,
-			"defaultEncryptionKey": testAccDomain_defaultEncryptionKey,
-			"disappears":           testAccDomain_disappears,
-			"tags":                 testAccDomain_tags,
+			"basic":                         testAccDomain_basic,
+			"defaultEncryptionKey":          testAccDomain_defaultEncryptionKey,
+			"disappears":                    testAccDomain_disappears,
+			"migrateAssetSizeBytesToString": testAccDomain_MigrateAssetSizeBytesToString,
+			"tags":                          testAccDomain_tags,
 		},
 		"DomainPermissionsPolicy": {
 			"basic":            testAccDomainPermissionsPolicy_basic,

--- a/internal/service/codeartifact/domain.go
+++ b/internal/service/codeartifact/domain.go
@@ -6,6 +6,7 @@ package codeartifact
 import (
 	"context"
 	"log"
+	"strconv"
 	"strings"
 	"time"
 
@@ -62,7 +63,7 @@ func ResourceDomain() *schema.Resource {
 				Computed: true,
 			},
 			"asset_size_bytes": {
-				Type:     schema.TypeFloat,
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"repository_count": {
@@ -131,7 +132,7 @@ func resourceDomainRead(ctx context.Context, d *schema.ResourceData, meta interf
 	d.Set("arn", arn)
 	d.Set("encryption_key", sm.Domain.EncryptionKey)
 	d.Set("owner", sm.Domain.Owner)
-	d.Set("asset_size_bytes", sm.Domain.AssetSizeBytes)
+	d.Set("asset_size_bytes", strconv.FormatInt(aws.Int64Value(sm.Domain.AssetSizeBytes), 10))
 	d.Set("repository_count", sm.Domain.RepositoryCount)
 	d.Set("created_time", sm.Domain.CreatedTime.Format(time.RFC3339))
 

--- a/internal/service/codeartifact/domain_test.go
+++ b/internal/service/codeartifact/domain_test.go
@@ -154,6 +154,39 @@ func testAccDomain_disappears(t *testing.T) {
 	})
 }
 
+func testAccDomain_MigrateAssetSizeBytesToString(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_codeartifact_domain.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, codeartifact.EndpointsID) },
+		ErrorCheck:   acctest.ErrorCheck(t, codeartifact.EndpointsID),
+		CheckDestroy: testAccCheckDomainDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "5.14.0",
+					},
+				},
+				Config: testAccDomainConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "domain", rName),
+					resource.TestCheckResourceAttr(resourceName, "asset_size_bytes", "0"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				Config:                   testAccDomainConfig_basic(rName),
+				PlanOnly:                 true,
+			},
+		},
+	})
+}
+
 func testAccCheckDomainExists(ctx context.Context, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTARGS='-run=TestAccCodeArtifact_serial/^Domain/$' PKG=codeartifact

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/codeartifact/... -v -count 1 -parallel 20  -run=TestAccCodeArtifact_serial/^Domain/ -timeout 180m
--- PASS: TestAccCodeArtifact_serial (377.54s)
    --- PASS: TestAccCodeArtifact_serial/Domain (207.51s)
        --- PASS: TestAccCodeArtifact_serial/Domain/tags (68.48s)
        --- PASS: TestAccCodeArtifact_serial/Domain/basic (29.88s)
        --- PASS: TestAccCodeArtifact_serial/Domain/defaultEncryptionKey (28.65s)
        --- PASS: TestAccCodeArtifact_serial/Domain/disappears (24.28s)
        --- PASS: TestAccCodeArtifact_serial/Domain/migrateAssetSizeBytesToString (56.21s)
    --- PASS: TestAccCodeArtifact_serial/DomainPermissionsPolicy (170.04s)
        --- PASS: TestAccCodeArtifact_serial/DomainPermissionsPolicy/disappearsDomain (25.14s)
        --- PASS: TestAccCodeArtifact_serial/DomainPermissionsPolicy/ignoreEquivalent (38.82s)
        --- PASS: TestAccCodeArtifact_serial/DomainPermissionsPolicy/basic (49.81s)
        --- PASS: TestAccCodeArtifact_serial/DomainPermissionsPolicy/disappears (26.29s)
        --- PASS: TestAccCodeArtifact_serial/DomainPermissionsPolicy/owner (29.98s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codeartifact	381.096s
```
