### PR TITLE
tags: send all old and new tags to updateTags

### DIFF
--- a/.changelog/33226.txt
+++ b/.changelog/33226.txt
@@ -1,3 +1,7 @@
 ```release-note:bug
 resource/aws_kms_key: Fix `tag propagation: timeout while waiting for state to become 'TRUE'` errors when any tag value is empty (`""`)
 ```
+
+```release-note:bug
+provider: Correctly use old and new tag values when updating `tags` that are `computed`
+```

--- a/.changelog/33226.txt
+++ b/.changelog/33226.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_kms_key: Fix `tag propagation: timeout while waiting for state to become 'TRUE'` errors when any tag value is empty (`""`)
+```

--- a/internal/provider/tags_interceptor.go
+++ b/internal/provider/tags_interceptor.go
@@ -61,15 +61,12 @@ func tagsUpdateFunc(ctx context.Context, d schemaResourceData, sp conns.ServiceP
 		}
 	}
 
-	tagsAll := tftags.New(ctx, stateTags)
+	oldTags := tftags.New(ctx, stateTags)
 	// if tags_all was computed because not wholly known
 	// Merge the resource's configured tags with any provider configured default_tags.
-	configAll := tagsInContext.DefaultConfig.MergeTags(tftags.New(ctx, configTags))
+	newTags := tagsInContext.DefaultConfig.MergeTags(tftags.New(ctx, configTags))
 	// Remove system tags.
-	configAll = configAll.IgnoreSystem(inContext.ServicePackageName)
-
-	toAdd := configAll.Difference(tagsAll)
-	toRemove := tagsAll.Difference(configAll)
+	newTags = newTags.IgnoreSystem(inContext.ServicePackageName)
 
 	// If the service package has a generic resource update tags methods, call it.
 	var err error
@@ -77,11 +74,11 @@ func tagsUpdateFunc(ctx context.Context, d schemaResourceData, sp conns.ServiceP
 	if v, ok := sp.(interface {
 		UpdateTags(context.Context, any, string, any, any) error
 	}); ok {
-		err = v.UpdateTags(ctx, meta, identifier, toRemove, toAdd)
+		err = v.UpdateTags(ctx, meta, identifier, oldTags, newTags)
 	} else if v, ok := sp.(interface {
 		UpdateTags(context.Context, any, string, string, any, any) error
 	}); ok && spt.ResourceType != "" {
-		err = v.UpdateTags(ctx, meta, identifier, spt.ResourceType, toRemove, toAdd)
+		err = v.UpdateTags(ctx, meta, identifier, spt.ResourceType, oldTags, newTags)
 	}
 
 	// ISO partitions may not support tagging, giving error.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/33219.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/31941.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTARGS='-run=TestAccVPC_ -short' PKG=vpc

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccVPC_ -short -timeout 180m
    vpc_test.go:1021: skipping long-running test in short mode
--- SKIP: TestAccVPC_IPAMIPv4BasicNetmask (0.00s)
    vpc_test.go:1048: skipping long-running test in short mode
--- SKIP: TestAccVPC_IPAMIPv4BasicExplicitCIDR (0.00s)
    vpc_test.go:1076: skipping long-running test in short mode
--- SKIP: TestAccVPC_IPAMIPv6 (0.00s)
=== NAME  TestAccVPC_assignGeneratedIPv6CIDRBlockWithNetworkBorderGroup
    ec2_availability_zone_data_source_test.go:222: skipping since no Local Zones are available
--- SKIP: TestAccVPC_assignGeneratedIPv6CIDRBlockWithNetworkBorderGroup (1.03s)
--- PASS: TestAccVPC_DefaultTagsProviderAndResource_duplicateTag (58.74s)
--- PASS: TestAccVPC_tags_null (58.91s)
--- PASS: TestAccVPC_tags_computed (60.92s)
--- PASS: TestAccVPC_basic (70.45s)
--- PASS: TestAccVPC_bothDNSOptionsSet (79.24s)
--- PASS: TestAccVPC_enableNetworkAddressUsageMetrics (81.38s)
--- PASS: TestAccVPC_disabledDNSSupport (81.60s)
--- PASS: TestAccVPC_DynamicResourceTagsMergedWithLocals_ignoreChanges (103.09s)
--- PASS: TestAccVPC_disappears (43.84s)
--- PASS: TestAccVPC_DynamicResourceTags_ignoreChanges (105.82s)
--- PASS: TestAccVPC_DefaultTags_updateToResourceOnly (107.46s)
--- PASS: TestAccVPC_updateDNSHostnames (108.57s)
--- PASS: TestAccVPC_DefaultTags_updateToProviderOnly (108.87s)
--- PASS: TestAccVPC_ignoreTags (115.28s)
--- PASS: TestAccVPC_defaultAndIgnoreTags (116.20s)
--- PASS: TestAccVPC_DefaultTagsProviderAndResource_moveDuplicateTags (127.61s)
--- PASS: TestAccVPC_DefaultTags_zeroValue (132.03s)
--- PASS: TestAccVPC_tenancy (136.89s)
--- PASS: TestAccVPC_DefaultTagsProviderAndResource_overlappingTag (138.57s)
--- PASS: TestAccVPC_DefaultTagsProviderAndResource_nonOverlappingTag (138.57s)
--- PASS: TestAccVPC_DefaultTags_providerOnlyTestAccVPC_DefaultTags_providerOnly (138.85s)
--- PASS: TestAccVPC_tags (104.84s)
--- PASS: TestAccVPC_assignGeneratedIPv6CIDRBlock (131.55s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	195.184s
```

```console
$ make testacc TESTARGS='-run=TestAccKMSKey_tags\|TestAccKMSKey_ignoreTags' PKG=kms

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/kms/... -v -count 1 -parallel 20  -run=TestAccKMSKey_tags\|TestAccKMSKey_ignoreTags -timeout 180m
--- PASS: TestAccKMSKey_ignoreTags (74.71s)
--- PASS: TestAccKMSKey_tags (109.27s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kms	112.919s
```