### PR TITLE
 [Bug] aws_iam_policy_document doesn't detect invalid SIDs

### DIFF
--- a/.changelog/33234.txt
+++ b/.changelog/33234.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_iam_policy_document: Detect invalid SIDs
+```

--- a/internal/service/iam/policy_document_data_source.go
+++ b/internal/service/iam/policy_document_data_source.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -100,8 +101,9 @@ func DataSourcePolicyDocument() *schema.Resource {
 						"principals":     dataSourcePolicyPrincipalSchema(),
 						"resources":      setOfString,
 						"sid": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[a-zA-Z0-9]+$`), "supports only ASCII uppercase letters (A-Z), lowercase letters (a-z), and numbers (0-9)"),
 						},
 					},
 				},

--- a/internal/service/iam/policy_document_data_source_test.go
+++ b/internal/service/iam/policy_document_data_source_test.go
@@ -195,6 +195,21 @@ func TestAccIAMPolicyDocumentDataSource_sourceListConflicting(t *testing.T) {
 	})
 }
 
+func TestAccIAMPolicyDocumentDataSource_sidFormatError(t *testing.T) {
+	ctx := acctest.Context(t)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, iam.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccPolicyDocumentDataSourceConfig_invalidSid,
+				ExpectError: regexache.MustCompile(`Sid must be a compose only of alphanumeric characters`),
+			},
+		},
+	})
+}
+
 func TestAccIAMPolicyDocumentDataSource_override(t *testing.T) {
 	ctx := acctest.Context(t)
 	resource.ParallelTest(t, resource.TestCase{
@@ -1063,6 +1078,17 @@ data "aws_iam_policy_document" "test_source_list_conflicting" {
     data.aws_iam_policy_document.policy_b.json,
     data.aws_iam_policy_document.policy_c.json
   ]
+}
+`
+
+var testAccPolicyDocumentDataSourceConfig_invalidSid = `
+data "aws_iam_policy_document" "policy_a" {
+  statement {
+    sid     = "invalid-sid"
+    effect  = "Allow"
+    actions   = ["*"]
+    resources = ["*"]
+  }
 }
 `
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Add a pattern check for SIDs value for aws_iam_policy_document resources

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Open Issue #33102

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
AWS Documentation : https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_sid.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
Need help to run tests..
