### PR TITLE
Extend use of generic Plugin Framework flattener/expander functions

### DIFF
--- a/internal/errs/fwdiag/diags.go
+++ b/internal/errs/fwdiag/diags.go
@@ -7,21 +7,18 @@ import (
 	"errors"
 	"fmt"
 
-	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 )
 
 // DiagnosticsError returns an error containing all Diagnostic with SeverityError
-func DiagnosticsError(diags diag.Diagnostics) (errs error) {
-	if !diags.HasError() {
-		return
-	}
+func DiagnosticsError(diags diag.Diagnostics) error {
+	var errs []error
 
 	for _, d := range diags.Errors() {
-		errs = multierror.Append(errs, errors.New(DiagnosticString(d)))
+		errs = append(errs, errors.New(DiagnosticString(d)))
 	}
 
-	return
+	return errors.Join(errs...)
 }
 
 // DiagnosticString formats a Diagnostic

--- a/internal/errs/fwdiag/diags_test.go
+++ b/internal/errs/fwdiag/diags_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package fwdiag_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+)
+
+func TestDiagnosticsError(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		testName string
+		diags    diag.Diagnostics
+		wantErr  bool
+	}{
+		{
+			testName: "nil Diagnostics",
+		},
+		{
+			testName: "single warning Diagnostics",
+			diags:    diag.Diagnostics{diag.NewWarningDiagnostic("summary", "detail")},
+		},
+		{
+			testName: "single error Diagnostics",
+			diags:    diag.Diagnostics{diag.NewErrorDiagnostic("summary", "detail")},
+			wantErr:  true,
+		},
+		{
+			testName: "mixed warning and error Diagnostics",
+			diags: diag.Diagnostics{
+				diag.NewWarningDiagnostic("summary1", "detail1"),
+				diag.NewErrorDiagnostic("summary2", "detail2"),
+			},
+			wantErr: true,
+		},
+		{
+			testName: "multiple error Diagnostics",
+			diags: diag.Diagnostics{
+				diag.NewErrorDiagnostic("summary1", "detail1"),
+				diag.NewErrorDiagnostic("summary2", "detail2"),
+			},
+			wantErr: true,
+		},
+		{
+			testName: "multiple warning Diagnostics",
+			diags: diag.Diagnostics{
+				diag.NewWarningDiagnostic("summary1", "detail1"),
+				diag.NewWarningDiagnostic("summary2", "detail2"),
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.testName, func(t *testing.T) {
+			t.Parallel()
+
+			err := fwdiag.DiagnosticsError(testCase.diags)
+			gotErr := err != nil
+
+			if gotErr != testCase.wantErr {
+				t.Errorf("gotErr = %v, wantErr = %v", gotErr, testCase.wantErr)
+			}
+		})
+	}
+}

--- a/internal/errs/sdkdiag/diags.go
+++ b/internal/errs/sdkdiag/diags.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 
-	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 )
@@ -32,26 +31,13 @@ func severityFilter(s diag.Severity) tfslices.Predicate[diag.Diagnostic] {
 
 // DiagnosticsError returns an error containing all Diagnostic with SeverityError
 func DiagnosticsError(diags diag.Diagnostics) error {
-	if !diags.HasError() {
-		return nil
+	var errs []error
+
+	for _, d := range Errors(diags) {
+		errs = append(errs, errors.New(DiagnosticString(d)))
 	}
 
-	errDiags := Errors(diags)
-
-	if len(errDiags) == 1 {
-		return diagnosticError(errDiags[0])
-	}
-
-	var errs error
-	for _, d := range errDiags {
-		errs = multierror.Append(errs, diagnosticError(d))
-	}
-
-	return errs
-}
-
-func diagnosticError(diag diag.Diagnostic) error {
-	return errors.New(DiagnosticString(diag))
+	return errors.Join(errs...)
 }
 
 // DiagnosticString formats a Diagnostic

--- a/internal/errs/sdkdiag/diags_test.go
+++ b/internal/errs/sdkdiag/diags_test.go
@@ -1,0 +1,189 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package sdkdiag_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+)
+
+func TestErrors(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		testName string
+		diags    diag.Diagnostics
+		want     int
+	}{
+		{
+			testName: "nil Diagnostics",
+		},
+		{
+			testName: "single warning Diagnostics",
+			diags:    diag.Diagnostics{diag.Diagnostic{Severity: diag.Warning, Summary: "summary", Detail: "detail"}},
+		},
+		{
+			testName: "single error Diagnostics",
+			diags:    diag.Diagnostics{diag.Diagnostic{Severity: diag.Error, Summary: "summary", Detail: "detail"}},
+			want:     1,
+		},
+		{
+			testName: "mixed warning and error Diagnostics",
+			diags: diag.Diagnostics{
+				diag.Diagnostic{Severity: diag.Warning, Summary: "summary1", Detail: "detail1"},
+				diag.Diagnostic{Severity: diag.Error, Summary: "summary2", Detail: "detail2"},
+			},
+			want: 1,
+		},
+		{
+			testName: "multiple error Diagnostics",
+			diags: diag.Diagnostics{
+				diag.Diagnostic{Severity: diag.Error, Summary: "summary1", Detail: "detail1"},
+				diag.Diagnostic{Severity: diag.Error, Summary: "summary2", Detail: "detail2"},
+			},
+			want: 2,
+		},
+		{
+			testName: "multiple warning Diagnostics",
+			diags: diag.Diagnostics{
+				diag.Diagnostic{Severity: diag.Warning, Summary: "summary1", Detail: "detail1"},
+				diag.Diagnostic{Severity: diag.Warning, Summary: "summary2", Detail: "detail2"},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.testName, func(t *testing.T) {
+			t.Parallel()
+
+			output := sdkdiag.Errors(testCase.diags)
+
+			if got, want := len(output), testCase.want; got != want {
+				t.Errorf("Errors = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestWarnings(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		testName string
+		diags    diag.Diagnostics
+		want     int
+	}{
+		{
+			testName: "nil Diagnostics",
+		},
+		{
+			testName: "single warning Diagnostics",
+			diags:    diag.Diagnostics{diag.Diagnostic{Severity: diag.Warning, Summary: "summary", Detail: "detail"}},
+			want:     1,
+		},
+		{
+			testName: "single error Diagnostics",
+			diags:    diag.Diagnostics{diag.Diagnostic{Severity: diag.Error, Summary: "summary", Detail: "detail"}},
+		},
+		{
+			testName: "mixed warning and error Diagnostics",
+			diags: diag.Diagnostics{
+				diag.Diagnostic{Severity: diag.Warning, Summary: "summary1", Detail: "detail1"},
+				diag.Diagnostic{Severity: diag.Error, Summary: "summary2", Detail: "detail2"},
+			},
+			want: 1,
+		},
+		{
+			testName: "multiple error Diagnostics",
+			diags: diag.Diagnostics{
+				diag.Diagnostic{Severity: diag.Error, Summary: "summary1", Detail: "detail1"},
+				diag.Diagnostic{Severity: diag.Error, Summary: "summary2", Detail: "detail2"},
+			},
+		},
+		{
+			testName: "multiple warning Diagnostics",
+			diags: diag.Diagnostics{
+				diag.Diagnostic{Severity: diag.Warning, Summary: "summary1", Detail: "detail1"},
+				diag.Diagnostic{Severity: diag.Warning, Summary: "summary2", Detail: "detail2"},
+			},
+			want: 2,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.testName, func(t *testing.T) {
+			t.Parallel()
+
+			output := sdkdiag.Warnings(testCase.diags)
+
+			if got, want := len(output), testCase.want; got != want {
+				t.Errorf("Warnings = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestDiagnosticsError(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		testName string
+		diags    diag.Diagnostics
+		wantErr  bool
+	}{
+		{
+			testName: "nil Diagnostics",
+		},
+		{
+			testName: "single warning Diagnostics",
+			diags:    diag.Diagnostics{diag.Diagnostic{Severity: diag.Warning, Summary: "summary", Detail: "detail"}},
+		},
+		{
+			testName: "single error Diagnostics",
+			diags:    diag.Diagnostics{diag.Diagnostic{Severity: diag.Error, Summary: "summary", Detail: "detail"}},
+			wantErr:  true,
+		},
+		{
+			testName: "mixed warning and error Diagnostics",
+			diags: diag.Diagnostics{
+				diag.Diagnostic{Severity: diag.Warning, Summary: "summary1", Detail: "detail1"},
+				diag.Diagnostic{Severity: diag.Error, Summary: "summary2", Detail: "detail2"},
+			},
+			wantErr: true,
+		},
+		{
+			testName: "multiple error Diagnostics",
+			diags: diag.Diagnostics{
+				diag.Diagnostic{Severity: diag.Error, Summary: "summary1", Detail: "detail1"},
+				diag.Diagnostic{Severity: diag.Error, Summary: "summary2", Detail: "detail2"},
+			},
+			wantErr: true,
+		},
+		{
+			testName: "multiple warning Diagnostics",
+			diags: diag.Diagnostics{
+				diag.Diagnostic{Severity: diag.Warning, Summary: "summary1", Detail: "detail1"},
+				diag.Diagnostic{Severity: diag.Warning, Summary: "summary2", Detail: "detail2"},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.testName, func(t *testing.T) {
+			t.Parallel()
+
+			err := sdkdiag.DiagnosticsError(testCase.diags)
+			gotErr := err != nil
+
+			if gotErr != testCase.wantErr {
+				t.Errorf("gotErr = %v, wantErr = %v", gotErr, testCase.wantErr)
+			}
+		})
+	}
+}

--- a/internal/framework/flex/autoflex.go
+++ b/internal/framework/flex/autoflex.go
@@ -85,9 +85,11 @@ func autoFlexConvert(ctx context.Context, from, to any, flexer autoFlexer) diag.
 	}
 
 	// Top-level struct to struct conversion.
-	if typFrom, typTo := valFrom.Type(), valTo.Type(); typFrom.Kind() == reflect.Struct && typTo.Kind() == reflect.Struct {
-		diags.Append(autoFlexConvertStruct(ctx, from, to, flexer)...)
-		return diags
+	if valFrom.IsValid() && valTo.IsValid() {
+		if typFrom, typTo := valFrom.Type(), valTo.Type(); typFrom.Kind() == reflect.Struct && typTo.Kind() == reflect.Struct {
+			diags.Append(autoFlexConvertStruct(ctx, from, to, flexer)...)
+			return diags
+		}
 	}
 
 	// Anything else.

--- a/internal/framework/flex/bool.go
+++ b/internal/framework/flex/bool.go
@@ -7,31 +7,39 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 )
 
 // BoolFromFramework converts a Framework Bool value to a bool pointer.
 // A null Bool is converted to a nil bool pointer.
-func BoolFromFramework(_ context.Context, v types.Bool) *bool {
-	if v.IsNull() || v.IsUnknown() {
-		return nil
-	}
+func BoolFromFramework(ctx context.Context, v types.Bool) *bool {
+	var output *bool
 
-	return aws.Bool(v.ValueBool())
+	panicOnError(Expand(ctx, v, &output))
+
+	return output
 }
 
 // BoolToFramework converts a bool pointer to a Framework Bool value.
 // A nil bool pointer is converted to a null Bool.
-func BoolToFramework(_ context.Context, v *bool) types.Bool {
-	if v == nil {
-		return types.BoolNull()
-	}
+func BoolToFramework(ctx context.Context, v *bool) types.Bool {
+	var output types.Bool
 
-	return types.BoolValue(aws.ToBool(v))
+	panicOnError(Flatten(ctx, v, &output))
+
+	return output
 }
 
 // BoolToFrameworkLegacy converts a bool pointer to a Framework Bool value.
 // A nil bool pointer is converted to a false Bool.
 func BoolToFrameworkLegacy(_ context.Context, v *bool) types.Bool {
 	return types.BoolValue(aws.ToBool(v))
+}
+
+func panicOnError(diags diag.Diagnostics) {
+	if err := fwdiag.DiagnosticsError(diags); err != nil {
+		panic(err)
+	}
 }

--- a/internal/framework/flex/float.go
+++ b/internal/framework/flex/float.go
@@ -12,12 +12,12 @@ import (
 
 // Float64ToFramework converts a float64 pointer to a Framework Float64 value.
 // A nil float64 pointer is converted to a null Float64.
-func Float64ToFramework(_ context.Context, v *float64) types.Float64 {
-	if v == nil {
-		return types.Float64Null()
-	}
+func Float64ToFramework(ctx context.Context, v *float64) types.Float64 {
+	var output types.Float64
 
-	return types.Float64Value(aws.ToFloat64(v))
+	panicOnError(Flatten(ctx, v, &output))
+
+	return output
 }
 
 // Float64ToFrameworkLegacy converts a float64 pointer to a Framework Float64 value.

--- a/internal/framework/flex/int.go
+++ b/internal/framework/flex/int.go
@@ -12,22 +12,22 @@ import (
 
 // Int64FromFramework converts a Framework Int64 value to an int64 pointer.
 // A null Int64 is converted to a nil int64 pointer.
-func Int64FromFramework(_ context.Context, v types.Int64) *int64 {
-	if v.IsNull() || v.IsUnknown() {
-		return nil
-	}
+func Int64FromFramework(ctx context.Context, v types.Int64) *int64 {
+	var output *int64
 
-	return aws.Int64(v.ValueInt64())
+	panicOnError(Expand(ctx, v, &output))
+
+	return output
 }
 
 // Int64ToFramework converts an int64 pointer to a Framework Int64 value.
 // A nil int64 pointer is converted to a null Int64.
-func Int64ToFramework(_ context.Context, v *int64) types.Int64 {
-	if v == nil {
-		return types.Int64Null()
-	}
+func Int64ToFramework(ctx context.Context, v *int64) types.Int64 {
+	var output types.Int64
 
-	return types.Int64Value(aws.ToInt64(v))
+	panicOnError(Flatten(ctx, v, &output))
+
+	return output
 }
 
 // Int64ToFrameworkLegacy converts an int64 pointer to a Framework Int64 value.

--- a/internal/framework/flex/list.go
+++ b/internal/framework/flex/list.go
@@ -13,50 +13,36 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/slices"
 )
 
-func ExpandFrameworkStringList(ctx context.Context, list types.List) []*string {
-	if list.IsNull() || list.IsUnknown() {
-		return nil
-	}
+func ExpandFrameworkStringList(ctx context.Context, v types.List) []*string {
+	var output []*string
 
-	var vl []*string
+	panicOnError(Expand(ctx, v, &output))
 
-	if list.ElementsAs(ctx, &vl, false).HasError() {
-		return nil
-	}
-
-	return vl
+	return output
 }
 
-func ExpandFrameworkStringValueList(ctx context.Context, list types.List) []string {
-	if list.IsNull() || list.IsUnknown() {
-		return nil
-	}
+func ExpandFrameworkStringValueList(ctx context.Context, v types.List) []string {
+	var output []string
 
-	var vl []string
+	panicOnError(Expand(ctx, v, &output))
 
-	if list.ElementsAs(ctx, &vl, false).HasError() {
-		return nil
-	}
-
-	return vl
+	return output
 }
 
 // FlattenFrameworkStringList converts a slice of string pointers to a framework List value.
 //
 // A nil slice is converted to a null List.
 // An empty slice is converted to a null List.
-func FlattenFrameworkStringList(_ context.Context, vs []*string) types.List {
-	if len(vs) == 0 {
+func FlattenFrameworkStringList(ctx context.Context, v []*string) types.List {
+	if len(v) == 0 {
 		return types.ListNull(types.StringType)
 	}
 
-	elems := make([]attr.Value, len(vs))
+	var output types.List
 
-	for i, v := range vs {
-		elems[i] = types.StringValue(aws.ToString(v))
-	}
+	panicOnError(Flatten(ctx, v, &output))
 
-	return types.ListValueMust(types.StringType, elems)
+	return output
 }
 
 // FlattenFrameworkStringListLegacy is the Plugin Framework variant of FlattenStringList.
@@ -75,18 +61,16 @@ func FlattenFrameworkStringListLegacy(_ context.Context, vs []*string) types.Lis
 //
 // A nil slice is converted to a null List.
 // An empty slice is converted to a null List.
-func FlattenFrameworkStringValueList(_ context.Context, vs []string) types.List {
-	if len(vs) == 0 {
+func FlattenFrameworkStringValueList(ctx context.Context, v []string) types.List {
+	if len(v) == 0 {
 		return types.ListNull(types.StringType)
 	}
 
-	elems := make([]attr.Value, len(vs))
+	var output types.List
 
-	for i, v := range vs {
-		elems[i] = types.StringValue(v)
-	}
+	panicOnError(Flatten(ctx, v, &output))
 
-	return types.ListValueMust(types.StringType, elems)
+	return output
 }
 
 // FlattenFrameworkStringValueListLegacy is the Plugin Framework variant of FlattenStringValueList.

--- a/internal/framework/flex/map.go
+++ b/internal/framework/flex/map.go
@@ -6,73 +6,56 @@ package flex
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-func ExpandFrameworkStringMap(ctx context.Context, set types.Map) map[string]*string {
-	if set.IsNull() || set.IsUnknown() {
-		return nil
-	}
+func ExpandFrameworkStringMap(ctx context.Context, v types.Map) map[string]*string {
+	var output map[string]*string
 
-	var m map[string]*string
+	panicOnError(Expand(ctx, v, &output))
 
-	if set.ElementsAs(ctx, &m, false).HasError() {
-		return nil
-	}
-
-	return m
+	return output
 }
 
-func ExpandFrameworkStringValueMap(ctx context.Context, set types.Map) map[string]string {
-	if set.IsNull() || set.IsUnknown() {
-		return nil
-	}
+func ExpandFrameworkStringValueMap(ctx context.Context, v types.Map) map[string]string {
+	var output map[string]string
 
-	var m map[string]string
+	panicOnError(Expand(ctx, v, &output))
 
-	if set.ElementsAs(ctx, &m, false).HasError() {
-		return nil
-	}
-
-	return m
+	return output
 }
 
 // FlattenFrameworkStringMap converts a map of string pointers to a framework Map value.
 //
 // A nil map is converted to a null Map.
 // An empty map is converted to a null Map.
-func FlattenFrameworkStringMap(_ context.Context, m map[string]*string) types.Map {
-	if len(m) == 0 {
+func FlattenFrameworkStringMap(ctx context.Context, v map[string]*string) types.Map {
+	if len(v) == 0 {
 		return types.MapNull(types.StringType)
 	}
 
-	elems := make(map[string]attr.Value, len(m))
+	var output types.Map
 
-	for k, v := range m {
-		elems[k] = types.StringValue(aws.ToString(v))
-	}
+	panicOnError(Flatten(ctx, v, &output))
 
-	return types.MapValueMust(types.StringType, elems)
+	return output
 }
 
 // FlattenFrameworkStringValueMap converts a map of strings to a framework Map value.
 //
 // A nil map is converted to a null Map.
 // An empty map is converted to a null Map.
-func FlattenFrameworkStringValueMap(_ context.Context, m map[string]string) types.Map {
-	if len(m) == 0 {
+func FlattenFrameworkStringValueMap(ctx context.Context, v map[string]string) types.Map {
+	if len(v) == 0 {
 		return types.MapNull(types.StringType)
 	}
 
-	elems := make(map[string]attr.Value, len(m))
+	var output types.Map
 
-	for k, v := range m {
-		elems[k] = types.StringValue(v)
-	}
+	panicOnError(Flatten(ctx, v, &output))
 
-	return types.MapValueMust(types.StringType, elems)
+	return output
 }
 
 // FlattenFrameworkStringValueMapLegacy has no Plugin SDK equivalent as schema.ResourceData.Set can be passed string value maps directly.

--- a/internal/framework/flex/set.go
+++ b/internal/framework/flex/set.go
@@ -11,50 +11,36 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-func ExpandFrameworkStringSet(ctx context.Context, set types.Set) []*string {
-	if set.IsNull() || set.IsUnknown() {
-		return nil
-	}
+func ExpandFrameworkStringSet(ctx context.Context, v types.Set) []*string {
+	var output []*string
 
-	var vs []*string
+	panicOnError(Expand(ctx, v, &output))
 
-	if set.ElementsAs(ctx, &vs, false).HasError() {
-		return nil
-	}
-
-	return vs
+	return output
 }
 
-func ExpandFrameworkStringValueSet(ctx context.Context, set types.Set) Set[string] {
-	if set.IsNull() || set.IsUnknown() {
-		return nil
-	}
+func ExpandFrameworkStringValueSet(ctx context.Context, v types.Set) Set[string] {
+	var output []string
 
-	var vs []string
+	panicOnError(Expand(ctx, v, &output))
 
-	if set.ElementsAs(ctx, &vs, false).HasError() {
-		return nil
-	}
-
-	return vs
+	return output
 }
 
 // FlattenFrameworkStringSet converts a slice of string pointers to a framework Set value.
 //
 // A nil slice is converted to a null Set.
 // An empty slice is converted to a null Set.
-func FlattenFrameworkStringSet(_ context.Context, vs []*string) types.Set {
-	if len(vs) == 0 {
+func FlattenFrameworkStringSet(ctx context.Context, v []*string) types.Set {
+	if len(v) == 0 {
 		return types.SetNull(types.StringType)
 	}
 
-	elems := make([]attr.Value, len(vs))
+	var output types.Set
 
-	for i, v := range vs {
-		elems[i] = types.StringValue(aws.ToString(v))
-	}
+	panicOnError(Flatten(ctx, v, &output))
 
-	return types.SetValueMust(types.StringType, elems)
+	return output
 }
 
 // FlattenFrameworkStringSetLegacy converts a slice of string pointers to a framework Set value.
@@ -74,18 +60,16 @@ func FlattenFrameworkStringSetLegacy(_ context.Context, vs []*string) types.Set 
 //
 // A nil slice is converted to a null Set.
 // An empty slice is converted to a null Set.
-func FlattenFrameworkStringValueSet(_ context.Context, vs []string) types.Set {
-	if len(vs) == 0 {
+func FlattenFrameworkStringValueSet(ctx context.Context, v []string) types.Set {
+	if len(v) == 0 {
 		return types.SetNull(types.StringType)
 	}
 
-	elems := make([]attr.Value, len(vs))
+	var output types.Set
 
-	for i, v := range vs {
-		elems[i] = types.StringValue(v)
-	}
+	panicOnError(Flatten(ctx, v, &output))
 
-	return types.SetValueMust(types.StringType, elems)
+	return output
 }
 
 // FlattenFrameworkStringValueSetLegacy is the Plugin Framework variant of FlattenStringValueSet.

--- a/internal/framework/flex/string_test.go
+++ b/internal/framework/flex/string_test.go
@@ -5,7 +5,6 @@ package flex_test
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -123,42 +122,6 @@ func TestStringToFrameworkLegacy(t *testing.T) {
 			t.Parallel()
 
 			got := flex.StringToFrameworkLegacy(context.Background(), test.input)
-
-			if diff := cmp.Diff(got, test.expected); diff != "" {
-				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
-			}
-		})
-	}
-}
-
-func TestStringToFrameworkWithTransform(t *testing.T) {
-	t.Parallel()
-
-	type testCase struct {
-		input    *string
-		expected types.String
-	}
-	tests := map[string]testCase{
-		"valid string": {
-			input:    aws.String("TEST"),
-			expected: types.StringValue("test"),
-		},
-		"empty string": {
-			input:    aws.String(""),
-			expected: types.StringValue(""),
-		},
-		"nil string": {
-			input:    nil,
-			expected: types.StringNull(),
-		},
-	}
-
-	for name, test := range tests {
-		name, test := name, test
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
-			got := flex.StringToFrameworkWithTransform(context.Background(), test.input, strings.ToLower)
 
 			if diff := cmp.Diff(got, test.expected); diff != "" {
 				t.Errorf("unexpected diff (+wanted, -got): %s", diff)

--- a/internal/framework/flex/string_test.go
+++ b/internal/framework/flex/string_test.go
@@ -9,9 +9,14 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 )
 
 func TestStringFromFramework(t *testing.T) {
@@ -226,6 +231,77 @@ func TestStringValueToFrameworkLegacy(t *testing.T) {
 			got := flex.StringValueToFrameworkLegacy(context.Background(), test.input)
 
 			if diff := cmp.Diff(got, test.expected); diff != "" {
+				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}
+
+func TestARNStringFromFramework(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input    fwtypes.ARN
+		expected *string
+	}
+	tests := map[string]testCase{
+		"valid ARN": {
+			input:    fwtypes.ARNValue(errs.Must(arn.Parse("arn:aws:iam::123456789012:user/David"))),
+			expected: aws.String("arn:aws:iam::123456789012:user/David"),
+		},
+		"null ARN": {
+			input:    fwtypes.ARNNull(),
+			expected: nil,
+		},
+		"unknown ARN": {
+			input:    fwtypes.ARNUnknown(),
+			expected: nil,
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := flex.ARNStringFromFramework(context.Background(), test.input)
+
+			if diff := cmp.Diff(got, test.expected); diff != "" {
+				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}
+
+func TestStringToFrameworkARN(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input    *string
+		expected fwtypes.ARN
+	}
+	tests := map[string]testCase{
+		"valid ARN": {
+			input:    aws.String("arn:aws:iam::123456789012:user/David"),
+			expected: fwtypes.ARNValue(errs.Must(arn.Parse("arn:aws:iam::123456789012:user/David"))),
+		},
+		"null ARN": {
+			input:    nil,
+			expected: fwtypes.ARNNull(),
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var diags diag.Diagnostics
+			got := flex.StringToFrameworkARN(context.Background(), test.input, &diags)
+
+			if err := fwdiag.DiagnosticsError(diags); err != nil {
+				t.Errorf("err %q", err)
+			} else if diff := cmp.Diff(got, test.expected); diff != "" {
 				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
 			}
 		})


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Use the generic Plugin Framework flattener/expander functions `flex.Expand` and `flex.Flatten` in the type-specific helpers.
This PR does not address "legacy-mode" -- `nil` pointers are converted to zero values.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/32356.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% go test ./internal/framework/flex                             
ok  	github.com/hashicorp/terraform-provider-aws/internal/framework/flex	0.253s
% go test ./internal/errs/...                         
ok  	github.com/hashicorp/terraform-provider-aws/internal/errs	0.428s
ok  	github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag	0.670s
ok  	github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag	0.287s
```
