### PR TITLE
(docs) : Updated Glue connection documentation to include custom connector

### DIFF
--- a/website/docs/r/glue_connection.html.markdown
+++ b/website/docs/r/glue_connection.html.markdown
@@ -66,6 +66,49 @@ resource "aws_glue_connection" "example" {
 }
 ```
 
+### Connection using a custom connector
+
+```terraform
+# Define the custom connector using the connection_type of `CUSTOM` with the match_criteria of `template_connection`
+# Example here being a snowflake jdbc connector with a secret having user and password as keys
+
+data "aws_secretmanager_secret" "example" {
+  name = "example-secret"
+}
+
+resource "aws_glue_connection" "example_connector" {
+  connection_type ="CUSTOM"
+
+  connection_properties = {
+    CONNECTOR_CLASS_NAME = "net.snowflake.client.jdbc.SnowflakeDriver"
+    CONNECTION_TYPE      = "Jdbc"
+    CONNECTOR_URL        = "s3://example/snowflake-jdbc.jar"  # S3 path to the snowflake jdbc jar
+    JDBC_CONNECTION_URL  = "[[\"default=jdbc:snowflake://example.com/?user=$${user}&password=$${password}\"],\",\"]"
+  }
+
+  name = "example_connector"
+
+  match_criteria = ["template-connection"]
+}
+
+# Reference the connector using match_criteria with the connector created above.
+
+resource "aws_glue_connection" "example" {
+  connection_type ="CUSTOM"
+
+  connection_properties = {
+    CONNECTOR_CLASS_NAME = "net.snowflake.client.jdbc.SnowflakeDriver"
+    CONNECTION_TYPE      = "Jdbc"
+    CONNECTOR_URL        = "s3://example/snowflake-jdbc.jar"
+    JDBC_CONNECTION_URL  = "jdbc:snowflake://example.com/?user=$${user}&password=$${password}"
+    SECRET_ID            = data.aws_secretmanager_secret.example.name
+  }
+  name = "example"
+  match_criteria = ["Connection",aws_glue_connection.example_connector.name]
+}
+
+```
+
 ## Argument Reference
 
 This resource supports the following arguments:

--- a/website/docs/r/glue_connection.html.markdown
+++ b/website/docs/r/glue_connection.html.markdown
@@ -77,12 +77,12 @@ data "aws_secretmanager_secret" "example" {
 }
 
 resource "aws_glue_connection" "example_connector" {
-  connection_type ="CUSTOM"
+  connection_type = "CUSTOM"
 
   connection_properties = {
     CONNECTOR_CLASS_NAME = "net.snowflake.client.jdbc.SnowflakeDriver"
     CONNECTION_TYPE      = "Jdbc"
-    CONNECTOR_URL        = "s3://example/snowflake-jdbc.jar"  # S3 path to the snowflake jdbc jar
+    CONNECTOR_URL        = "s3://example/snowflake-jdbc.jar" # S3 path to the snowflake jdbc jar
     JDBC_CONNECTION_URL  = "[[\"default=jdbc:snowflake://example.com/?user=$${user}&password=$${password}\"],\",\"]"
   }
 
@@ -93,8 +93,8 @@ resource "aws_glue_connection" "example_connector" {
 
 # Reference the connector using match_criteria with the connector created above.
 
-resource "aws_glue_connection" "example" {
-  connection_type ="CUSTOM"
+resource "aws_glue_connection" "example_connection" {
+  connection_type = "CUSTOM"
 
   connection_properties = {
     CONNECTOR_CLASS_NAME = "net.snowflake.client.jdbc.SnowflakeDriver"
@@ -103,8 +103,8 @@ resource "aws_glue_connection" "example" {
     JDBC_CONNECTION_URL  = "jdbc:snowflake://example.com/?user=$${user}&password=$${password}"
     SECRET_ID            = data.aws_secretmanager_secret.example.name
   }
-  name = "example"
-  match_criteria = ["Connection",aws_glue_connection.example_connector.name]
+  name           = "example"
+  match_criteria = ["Connection", aws_glue_connection.example_connector.name]
 }
 
 ```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

Updated Glue documentation to include a reference example of creating a custom Glue connector using the match_criteria `template_connection` . The example specifically uses a Snowflake JDBC connector which can be extended to any of the available custom connectors. The Glue connection resource then uses the custom connector as a baseline. 

The usage of the custom connector prevents the connector from being classified as a connection in the Glue console.





