### PR TITLE
Tech debt: Migrate `redshiftdata` resources to AWS SDK for Go v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/qldb v1.16.5
 	github.com/aws/aws-sdk-go-v2/service/rbin v1.9.5
 	github.com/aws/aws-sdk-go-v2/service/rds v1.53.0
+	github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.20.5
 	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.3.5
 	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.3.5
 	github.com/aws/aws-sdk-go-v2/service/route53domains v1.17.3

--- a/go.sum
+++ b/go.sum
@@ -133,6 +133,8 @@ github.com/aws/aws-sdk-go-v2/service/rbin v1.9.5 h1:1q9FkL4ET0xAlqmfgg7fmTkelSkH
 github.com/aws/aws-sdk-go-v2/service/rbin v1.9.5/go.mod h1:edL1v6p099PQSzuByMelJQ3jXa1i59Dk/3NdAwpvcuY=
 github.com/aws/aws-sdk-go-v2/service/rds v1.53.0 h1:+PNNWmjp8VeoU6mtRkzPerlhI818uuI4hf/Td8GEjp8=
 github.com/aws/aws-sdk-go-v2/service/rds v1.53.0/go.mod h1:UNv1vk1fU1NJefzteykVpVLA88w4WxB05g3vp2kQhYM=
+github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.20.5 h1:iIRfLBX36lMn7vXdaVF1PZV/jiBXeUpiL2KHkGOjVsc=
+github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.20.5/go.mod h1:q++QEMyKK3FcyuHOuab73F3mtkmP/Xu25VkMSEgqpE0=
 github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.3.5 h1:eoLzO6Wd94zk5vFFzqkPfWah27oEnNw+SyJ19+Mhu0c=
 github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.3.5/go.mod h1:cP3b7+o+kmgjIKp9hXs+arRFIoh6lnYphtD3JsGmMeQ=
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.3.5 h1:tfmJZFDrma1cgraLRuEgfp643Gdaas2cxHnJxT7VVqk=

--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -44,6 +44,7 @@ import (
 	qldb_sdkv2 "github.com/aws/aws-sdk-go-v2/service/qldb"
 	rbin_sdkv2 "github.com/aws/aws-sdk-go-v2/service/rbin"
 	rds_sdkv2 "github.com/aws/aws-sdk-go-v2/service/rds"
+	redshiftdata_sdkv2 "github.com/aws/aws-sdk-go-v2/service/redshiftdata"
 	resourceexplorer2_sdkv2 "github.com/aws/aws-sdk-go-v2/service/resourceexplorer2"
 	rolesanywhere_sdkv2 "github.com/aws/aws-sdk-go-v2/service/rolesanywhere"
 	route53domains_sdkv2 "github.com/aws/aws-sdk-go-v2/service/route53domains"
@@ -182,7 +183,6 @@ import (
 	ram_sdkv1 "github.com/aws/aws-sdk-go/service/ram"
 	rds_sdkv1 "github.com/aws/aws-sdk-go/service/rds"
 	redshift_sdkv1 "github.com/aws/aws-sdk-go/service/redshift"
-	redshiftdataapiservice_sdkv1 "github.com/aws/aws-sdk-go/service/redshiftdataapiservice"
 	redshiftserverless_sdkv1 "github.com/aws/aws-sdk-go/service/redshiftserverless"
 	resourcegroups_sdkv1 "github.com/aws/aws-sdk-go/service/resourcegroups"
 	resourcegroupstaggingapi_sdkv1 "github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
@@ -861,8 +861,8 @@ func (c *AWSClient) RedshiftConn(ctx context.Context) *redshift_sdkv1.Redshift {
 	return errs.Must(conn[*redshift_sdkv1.Redshift](ctx, c, names.Redshift))
 }
 
-func (c *AWSClient) RedshiftDataConn(ctx context.Context) *redshiftdataapiservice_sdkv1.RedshiftDataAPIService {
-	return errs.Must(conn[*redshiftdataapiservice_sdkv1.RedshiftDataAPIService](ctx, c, names.RedshiftData))
+func (c *AWSClient) RedshiftDataClient(ctx context.Context) *redshiftdata_sdkv2.Client {
+	return errs.Must(client[*redshiftdata_sdkv2.Client](ctx, c, names.RedshiftData))
 }
 
 func (c *AWSClient) RedshiftServerlessConn(ctx context.Context) *redshiftserverless_sdkv1.RedshiftServerless {

--- a/internal/service/redshiftdata/service_package_gen.go
+++ b/internal/service/redshiftdata/service_package_gen.go
@@ -5,9 +5,8 @@ package redshiftdata
 import (
 	"context"
 
-	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
-	session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
-	redshiftdataapiservice_sdkv1 "github.com/aws/aws-sdk-go/service/redshiftdataapiservice"
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	redshiftdata_sdkv2 "github.com/aws/aws-sdk-go-v2/service/redshiftdata"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -40,11 +39,15 @@ func (p *servicePackage) ServicePackageName() string {
 	return names.RedshiftData
 }
 
-// NewConn returns a new AWS SDK for Go v1 client for this service package's AWS API.
-func (p *servicePackage) NewConn(ctx context.Context, config map[string]any) (*redshiftdataapiservice_sdkv1.RedshiftDataAPIService, error) {
-	sess := config["session"].(*session_sdkv1.Session)
+// NewClient returns a new AWS SDK for Go v2 client for this service package's AWS API.
+func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (*redshiftdata_sdkv2.Client, error) {
+	cfg := *(config["aws_sdkv2_config"].(*aws_sdkv2.Config))
 
-	return redshiftdataapiservice_sdkv1.New(sess.Copy(&aws_sdkv1.Config{Endpoint: aws_sdkv1.String(config["endpoint"].(string))})), nil
+	return redshiftdata_sdkv2.NewFromConfig(cfg, func(o *redshiftdata_sdkv2.Options) {
+		if endpoint := config["endpoint"].(string); endpoint != "" {
+			o.EndpointResolver = redshiftdata_sdkv2.EndpointResolverFromURL(endpoint)
+		}
+	}), nil
 }
 
 func ServicePackage(ctx context.Context) conns.ServicePackage {

--- a/internal/service/redshiftdata/service_package_gen.go
+++ b/internal/service/redshiftdata/service_package_gen.go
@@ -29,7 +29,7 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePackageSDKResource {
 	return []*types.ServicePackageSDKResource{
 		{
-			Factory:  ResourceStatement,
+			Factory:  resourceStatement,
 			TypeName: "aws_redshiftdata_statement",
 		},
 	}

--- a/internal/service/redshiftdata/statement.go
+++ b/internal/service/redshiftdata/statement.go
@@ -7,23 +7,24 @@ import (
 	"context"
 	"errors"
 	"log"
-	"strings"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/redshiftdataapiservice"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/redshiftdata"
+	"github.com/aws/aws-sdk-go-v2/service/redshiftdata/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 // @SDKResource("aws_redshiftdata_statement")
-func ResourceStatement() *schema.Resource {
+func resourceStatement() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceStatementCreate,
 		ReadWithoutTimeout:   resourceStatementRead,
@@ -105,9 +106,9 @@ func ResourceStatement() *schema.Resource {
 
 func resourceStatementCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).RedshiftDataConn(ctx)
+	conn := meta.(*conns.AWSClient).RedshiftDataClient(ctx)
 
-	input := &redshiftdataapiservice.ExecuteStatementInput{
+	input := &redshiftdata.ExecuteStatementInput{
 		Database:  aws.String(d.Get("database").(string)),
 		Sql:       aws.String(d.Get("sql").(string)),
 		WithEvent: aws.Bool(d.Get("with_event").(bool)),
@@ -137,16 +138,16 @@ func resourceStatementCreate(ctx context.Context, d *schema.ResourceData, meta i
 		input.WorkgroupName = aws.String(v.(string))
 	}
 
-	output, err := conn.ExecuteStatementWithContext(ctx, input)
+	output, err := conn.ExecuteStatement(ctx, input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "executing Redshift Data Statement: %s", err)
 	}
 
-	d.SetId(aws.StringValue(output.Id))
+	d.SetId(aws.ToString(output.Id))
 
 	if _, err := waitStatementFinished(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return sdkdiag.AppendErrorf(diags, "waiting for Redshift Data Statement (%s) to finish: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Redshift Data Statement (%s) finish: %s", d.Id(), err)
 	}
 
 	return append(diags, resourceStatementRead(ctx, d, meta)...)
@@ -154,7 +155,7 @@ func resourceStatementCreate(ctx context.Context, d *schema.ResourceData, meta i
 
 func resourceStatementRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).RedshiftDataConn(ctx)
+	conn := meta.(*conns.AWSClient).RedshiftDataClient(ctx)
 
 	sub, err := FindStatementByID(ctx, conn, d.Id())
 
@@ -169,12 +170,12 @@ func resourceStatementRead(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	d.Set("cluster_identifier", sub.ClusterIdentifier)
-	d.Set("secret_arn", sub.SecretArn)
 	d.Set("database", d.Get("database").(string))
 	d.Set("db_user", d.Get("db_user").(string))
 	if err := d.Set("parameters", flattenParameters(sub.QueryParameters)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting parameters: %s", err)
 	}
+	d.Set("secret_arn", sub.SecretArn)
 	d.Set("sql", sub.QueryString)
 	d.Set("workgroup_name", sub.WorkgroupName)
 
@@ -183,24 +184,24 @@ func resourceStatementRead(ctx context.Context, d *schema.ResourceData, meta int
 
 // FindStatementByID will only find full statement info for statements created recently.
 // For statements that AWS thinks are expired, FindStatementByID will just return a bare bones DescribeStatementOutput w/ only the Id present.
-func FindStatementByID(ctx context.Context, conn *redshiftdataapiservice.RedshiftDataAPIService, id string) (*redshiftdataapiservice.DescribeStatementOutput, error) {
-	input := &redshiftdataapiservice.DescribeStatementInput{
+func FindStatementByID(ctx context.Context, conn *redshiftdata.Client, id string) (*redshiftdata.DescribeStatementOutput, error) {
+	input := &redshiftdata.DescribeStatementInput{
 		Id: aws.String(id),
 	}
 
-	output, err := conn.DescribeStatementWithContext(ctx, input)
+	output, err := conn.DescribeStatement(ctx, input)
 
-	if tfawserr.ErrCodeEquals(err, redshiftdataapiservice.ErrCodeResourceNotFoundException) {
+	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return nil, &retry.NotFoundError{
 			LastError:   err,
 			LastRequest: input,
 		}
 	}
 
-	if tfawserr.ErrCodeEquals(err, redshiftdataapiservice.ErrCodeValidationException) && strings.Contains(err.Error(), "expired") {
-		return &redshiftdataapiservice.DescribeStatementOutput{
+	if errs.IsAErrorMessageContains[*types.ValidationException](err, "expired") {
+		return &redshiftdata.DescribeStatementOutput{
 			Id:     aws.String(id),
-			Status: aws.String("EXPIRED"),
+			Status: types.StatusString("EXPIRED"),
 		}, nil
 	}
 
@@ -215,7 +216,7 @@ func FindStatementByID(ctx context.Context, conn *redshiftdataapiservice.Redshif
 	return output, nil
 }
 
-func statusStatement(ctx context.Context, conn *redshiftdataapiservice.RedshiftDataAPIService, id string) retry.StateRefreshFunc {
+func statusStatement(ctx context.Context, conn *redshiftdata.Client, id string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		output, err := FindStatementByID(ctx, conn, id)
 
@@ -227,18 +228,18 @@ func statusStatement(ctx context.Context, conn *redshiftdataapiservice.RedshiftD
 			return nil, "", err
 		}
 
-		return output, aws.StringValue(output.Status), nil
+		return output, string(output.Status), nil
 	}
 }
 
-func waitStatementFinished(ctx context.Context, conn *redshiftdataapiservice.RedshiftDataAPIService, id string, timeout time.Duration) (*redshiftdataapiservice.DescribeStatementOutput, error) {
+func waitStatementFinished(ctx context.Context, conn *redshiftdata.Client, id string, timeout time.Duration) (*redshiftdata.DescribeStatementOutput, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending: []string{
-			redshiftdataapiservice.StatusStringPicked,
-			redshiftdataapiservice.StatusStringStarted,
-			redshiftdataapiservice.StatusStringSubmitted,
-		},
-		Target:     []string{redshiftdataapiservice.StatusStringFinished},
+		Pending: enum.Slice(
+			types.StatusStringPicked,
+			types.StatusStringStarted,
+			types.StatusStringSubmitted,
+		),
+		Target:     enum.Slice(types.StatusStringFinished),
 		Refresh:    statusStatement(ctx, conn, id),
 		Timeout:    timeout,
 		MinTimeout: 10 * time.Second,
@@ -247,9 +248,9 @@ func waitStatementFinished(ctx context.Context, conn *redshiftdataapiservice.Red
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
-	if output, ok := outputRaw.(*redshiftdataapiservice.DescribeStatementOutput); ok {
-		if status := aws.StringValue(output.Status); status == redshiftdataapiservice.StatusStringFailed {
-			tfresource.SetLastError(err, errors.New(aws.StringValue(output.Error)))
+	if output, ok := outputRaw.(*redshiftdata.DescribeStatementOutput); ok {
+		if status := output.Status; status == types.StatusStringFailed {
+			tfresource.SetLastError(err, errors.New(aws.ToString(output.Error)))
 		}
 
 		return output, err
@@ -258,12 +259,12 @@ func waitStatementFinished(ctx context.Context, conn *redshiftdataapiservice.Red
 	return nil, err
 }
 
-func expandParameter(tfMap map[string]interface{}) *redshiftdataapiservice.SqlParameter {
+func expandParameter(tfMap map[string]interface{}) *types.SqlParameter {
 	if tfMap == nil {
 		return nil
 	}
 
-	apiObject := &redshiftdataapiservice.SqlParameter{}
+	apiObject := &types.SqlParameter{}
 
 	if v, ok := tfMap["name"].(string); ok {
 		apiObject.Name = aws.String(v)
@@ -276,12 +277,12 @@ func expandParameter(tfMap map[string]interface{}) *redshiftdataapiservice.SqlPa
 	return apiObject
 }
 
-func expandParameters(tfList []interface{}) []*redshiftdataapiservice.SqlParameter {
+func expandParameters(tfList []interface{}) []types.SqlParameter {
 	if len(tfList) == 0 {
 		return nil
 	}
 
-	var apiObjects []*redshiftdataapiservice.SqlParameter
+	var apiObjects []types.SqlParameter
 
 	for _, tfMapRaw := range tfList {
 		tfMap, ok := tfMapRaw.(map[string]interface{})
@@ -296,30 +297,26 @@ func expandParameters(tfList []interface{}) []*redshiftdataapiservice.SqlParamet
 			continue
 		}
 
-		apiObjects = append(apiObjects, apiObject)
+		apiObjects = append(apiObjects, *apiObject)
 	}
 
 	return apiObjects
 }
 
-func flattenParameter(apiObject *redshiftdataapiservice.SqlParameter) map[string]interface{} {
-	if apiObject == nil {
-		return nil
-	}
-
+func flattenParameter(apiObject types.SqlParameter) map[string]interface{} {
 	tfMap := map[string]interface{}{}
 
 	if v := apiObject.Name; v != nil {
-		tfMap["name"] = aws.StringValue(v)
+		tfMap["name"] = aws.ToString(v)
 	}
 
 	if v := apiObject.Value; v != nil {
-		tfMap["value"] = aws.StringValue(v)
+		tfMap["value"] = aws.ToString(v)
 	}
 	return tfMap
 }
 
-func flattenParameters(apiObjects []*redshiftdataapiservice.SqlParameter) []interface{} {
+func flattenParameters(apiObjects []types.SqlParameter) []interface{} {
 	if len(apiObjects) == 0 {
 		return nil
 	}
@@ -327,10 +324,6 @@ func flattenParameters(apiObjects []*redshiftdataapiservice.SqlParameter) []inte
 	var tfList []interface{}
 
 	for _, apiObject := range apiObjects {
-		if apiObject == nil {
-			continue
-		}
-
 		tfList = append(tfList, flattenParameter(apiObject))
 	}
 

--- a/internal/service/redshiftdata/statement_test.go
+++ b/internal/service/redshiftdata/statement_test.go
@@ -8,24 +8,25 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/redshiftdataapiservice"
+	"github.com/aws/aws-sdk-go-v2/service/redshiftdata"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfredshiftdata "github.com/hashicorp/terraform-provider-aws/internal/service/redshiftdata"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccRedshiftDataStatement_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	var v redshiftdataapiservice.DescribeStatementOutput
+	var v redshiftdata.DescribeStatementOutput
 	resourceName := "aws_redshiftdata_statement.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, redshiftdataapiservice.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.RedshiftDataEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             acctest.CheckDestroyNoop,
 		Steps: []resource.TestStep{
@@ -51,13 +52,13 @@ func TestAccRedshiftDataStatement_basic(t *testing.T) {
 
 func TestAccRedshiftDataStatement_workgroup(t *testing.T) {
 	ctx := acctest.Context(t)
-	var v redshiftdataapiservice.DescribeStatementOutput
+	var v redshiftdata.DescribeStatementOutput
 	resourceName := "aws_redshiftdata_statement.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, redshiftdataapiservice.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.RedshiftDataEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             acctest.CheckDestroyNoop,
 		Steps: []resource.TestStep{
@@ -81,18 +82,14 @@ func TestAccRedshiftDataStatement_workgroup(t *testing.T) {
 	})
 }
 
-func testAccCheckStatementExists(ctx context.Context, n string, v *redshiftdataapiservice.DescribeStatementOutput) resource.TestCheckFunc {
+func testAccCheckStatementExists(ctx context.Context, n string, v *redshiftdata.DescribeStatementOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No Redshift Data Statement ID is set")
-		}
-
-		conn := acctest.Provider.Meta().(*conns.AWSClient).RedshiftDataConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).RedshiftDataClient(ctx)
 
 		output, err := tfredshiftdata.FindStatementByID(ctx, conn, rs.Primary.ID)
 

--- a/names/names.go
+++ b/names/names.go
@@ -51,6 +51,7 @@ const (
 	PipesEndpointID                      = "pipes"
 	PricingEndpointID                    = "pricing"
 	QLDBEndpointID                       = "qldb"
+	RedshiftDataEndpointID               = "redshift-data"
 	ResourceExplorer2EndpointID          = "resource-explorer-2"
 	RolesAnywhereEndpointID              = "rolesanywhere"
 	Route53DomainsEndpointID             = "route53domains"

--- a/names/names_data.csv
+++ b/names/names_data.csv
@@ -287,7 +287,7 @@ pi,pi,pi,pi,,pi,,,PI,PI,,1,,,aws_pi_,,pi_,RDS Performance Insights (PI),Amazon,,
 rbin,rbin,recyclebin,rbin,,rbin,,recyclebin,RBin,RecycleBin,,,2,,aws_rbin_,,rbin_,Recycle Bin (RBin),Amazon,,,,,,
 ,,,,,,,,,,,,,,,,,Red Hat OpenShift Service on AWS (ROSA),AWS,x,,,,,No SDK support
 redshift,redshift,redshift,redshift,,redshift,,,Redshift,Redshift,,1,,,aws_redshift_,,redshift_,Redshift,Amazon,,,,,,
-redshift-data,redshiftdata,redshiftdataapiservice,redshiftdata,,redshiftdata,,redshiftdataapiservice,RedshiftData,RedshiftDataAPIService,,1,,,aws_redshiftdata_,,redshiftdata_,Redshift Data,Amazon,,,,,,
+redshift-data,redshiftdata,redshiftdataapiservice,redshiftdata,,redshiftdata,,redshiftdataapiservice,RedshiftData,RedshiftDataAPIService,,,2,,aws_redshiftdata_,,redshiftdata_,Redshift Data,Amazon,,,,,,
 redshift-serverless,redshiftserverless,redshiftserverless,redshiftserverless,,redshiftserverless,,,RedshiftServerless,RedshiftServerless,,1,,,aws_redshiftserverless_,,redshiftserverless_,Redshift Serverless,Amazon,,,,,,
 rekognition,rekognition,rekognition,rekognition,,rekognition,,,Rekognition,Rekognition,,1,,,aws_rekognition_,,rekognition_,Rekognition,Amazon,,x,,,,
 resiliencehub,resiliencehub,resiliencehub,resiliencehub,,resiliencehub,,,ResilienceHub,ResilienceHub,,1,,,aws_resiliencehub_,,resiliencehub_,Resilience Hub,AWS,,x,,,,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Ibid.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccRedshiftDataStatement_' PKG=redshiftdata
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/redshiftdata/... -v -count 1 -parallel 20  -run=TestAccRedshiftDataStatement_ -timeout 180m
=== RUN   TestAccRedshiftDataStatement_basic
=== PAUSE TestAccRedshiftDataStatement_basic
=== RUN   TestAccRedshiftDataStatement_workgroup
=== PAUSE TestAccRedshiftDataStatement_workgroup
=== CONT  TestAccRedshiftDataStatement_basic
=== CONT  TestAccRedshiftDataStatement_workgroup
--- PASS: TestAccRedshiftDataStatement_basic (304.03s)
--- PASS: TestAccRedshiftDataStatement_workgroup (811.22s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/redshiftdata	817.067s
```
