### PR TITLE
feat: added open_table_format_input attribute + tests

### DIFF
--- a/.changelog/33274.txt
+++ b/.changelog/33274.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_glue_catalog_table: Add `open_table_format_input` arguments to support open table formats such as Iceberg (https://aws.amazon.com/blogs/big-data/introducing-aws-glue-crawler-and-create-table-support-for-apache-iceberg-format/)
+```

--- a/.changelog/33274.txt
+++ b/.changelog/33274.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_glue_catalog_table: Add `open_table_format_input` arguments to support open table formats such as Iceberg (https://aws.amazon.com/blogs/big-data/introducing-aws-glue-crawler-and-create-table-support-for-apache-iceberg-format/)
+resource/aws_glue_catalog_table: Add `open_table_format_input` configuration block to support open table formats such as [Apache Iceberg](https://iceberg.apache.org/)
 ```

--- a/internal/service/glue/catalog_table.go
+++ b/internal/service/glue/catalog_table.go
@@ -1093,7 +1093,7 @@ func flattenTableTargetTable(apiObject *glue.TableIdentifier) map[string]interfa
 
 func flattenNonManagedParameters(table *glue.TableData) map[string]string {
 	allParameters := table.Parameters
-	if "ICEBERG" == aws.StringValue(allParameters["table_type"]) {
+	if aws.StringValue(allParameters["table_type"]) == "ICEBERG" {
 		delete(allParameters, "table_type")
 		delete(allParameters, "metadata_location")
 	}

--- a/internal/service/glue/catalog_table.go
+++ b/internal/service/glue/catalog_table.go
@@ -465,7 +465,7 @@ func resourceCatalogTableRead(ctx context.Context, d *schema.ResourceData, meta 
 	d.Set("view_expanded_text", table.ViewExpandedText)
 	d.Set("table_type", table.TableType)
 
-	if err := d.Set("parameters", fetchNonManagedProperties(table)); err != nil {
+	if err := d.Set("parameters", flattenNonManagedParameters(table)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting parameters: %s", err)
 	}
 
@@ -1091,9 +1091,9 @@ func flattenTableTargetTable(apiObject *glue.TableIdentifier) map[string]interfa
 	return tfMap
 }
 
-func fetchNonManagedProperties(table *glue.TableData) map[string]string {
+func flattenNonManagedParameters(table *glue.TableData) map[string]string {
 	allParameters := table.Parameters
-	if string("ICEBERG") == *table.Parameters["table_type"] {
+	if "ICEBERG" == aws.StringValue(allParameters["table_type"]) {
 		delete(allParameters, "table_type")
 		delete(allParameters, "metadata_location")
 	}

--- a/internal/service/glue/catalog_table.go
+++ b/internal/service/glue/catalog_table.go
@@ -293,6 +293,34 @@ func ResourceCatalogTable() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"open_table_format_input": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"iceberg_input": {
+							Type:     schema.TypeList,
+							Required: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"metadata_operation": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice([]string{"CREATE"}, false),
+									},
+									"version": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringLenBetween(1, 255),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			"target_table": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -371,10 +399,11 @@ func resourceCatalogTableCreate(ctx context.Context, d *schema.ResourceData, met
 	name := d.Get("name").(string)
 
 	input := &glue.CreateTableInput{
-		CatalogId:        aws.String(catalogID),
-		DatabaseName:     aws.String(dbName),
-		TableInput:       expandTableInput(d),
-		PartitionIndexes: expandTablePartitionIndexes(d.Get("partition_index").([]interface{})),
+		CatalogId:            aws.String(catalogID),
+		DatabaseName:         aws.String(dbName),
+		OpenTableFormatInput: expandOpenTableFormat(d),
+		TableInput:           expandTableInput(d),
+		PartitionIndexes:     expandTablePartitionIndexes(d.Get("partition_index").([]interface{})),
 	}
 
 	_, err := conn.CreateTableWithContext(ctx, input)
@@ -436,7 +465,7 @@ func resourceCatalogTableRead(ctx context.Context, d *schema.ResourceData, meta 
 	d.Set("view_expanded_text", table.ViewExpandedText)
 	d.Set("table_type", table.TableType)
 
-	if err := d.Set("parameters", aws.StringValueMap(table.Parameters)); err != nil {
+	if err := d.Set("parameters", fetchNonManagedProperties(table)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting parameters: %s", err)
 	}
 
@@ -536,7 +565,7 @@ func expandTableInput(d *schema.ResourceData) *glue.TableInput {
 
 	if v, ok := d.GetOk("partition_keys"); ok {
 		tableInput.PartitionKeys = expandColumns(v.([]interface{}))
-	} else {
+	} else if _, ok = d.GetOk("open_table_format_input"); !ok {
 		tableInput.PartitionKeys = []*glue.Column{}
 	}
 
@@ -561,6 +590,27 @@ func expandTableInput(d *schema.ResourceData) *glue.TableInput {
 	}
 
 	return tableInput
+}
+
+func expandOpenTableFormat(s *schema.ResourceData) *glue.OpenTableFormatInput_ {
+	if v, ok := s.GetOk("open_table_format_input"); ok {
+		openTableFormatInput := &glue.OpenTableFormatInput_{
+			IcebergInput: expandIcebergInput(v.([]interface{})[0].(map[string]interface{})),
+		}
+		return openTableFormatInput
+	}
+	return nil
+}
+
+func expandIcebergInput(s map[string]interface{}) *glue.IcebergInput_ {
+	var iceberg = s["iceberg_input"].([]interface{})[0].(map[string]interface{})
+	icebergInput := &glue.IcebergInput_{
+		MetadataOperation: aws.String(iceberg["metadata_operation"].(string)),
+	}
+	if v, ok := iceberg["version"].(string); ok && v != "" {
+		icebergInput.Version = aws.String(v)
+	}
+	return icebergInput
 }
 
 func expandTablePartitionIndexes(a []interface{}) []*glue.PartitionIndex {
@@ -1039,4 +1089,13 @@ func flattenTableTargetTable(apiObject *glue.TableIdentifier) map[string]interfa
 	}
 
 	return tfMap
+}
+
+func fetchNonManagedProperties(table *glue.TableData) map[string]string {
+	allParameters := table.Parameters
+	if string("ICEBERG") == *table.Parameters["table_type"] {
+		delete(allParameters, "table_type")
+		delete(allParameters, "metadata_location")
+	}
+	return aws.StringValueMap(allParameters)
 }

--- a/internal/service/glue/catalog_table_test.go
+++ b/internal/service/glue/catalog_table_test.go
@@ -682,6 +682,38 @@ func TestAccGlueCatalogTable_disappears(t *testing.T) {
 	})
 }
 
+func TestAccGlueCatalogTable_openTableFormat(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_glue_catalog_table.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, glue.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTableDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config:  testAccCatalogTableConfig_openTableFormat(rName),
+				Destroy: false,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCatalogTableExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "open_table_format_input.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "open_table_format_input.0.iceberg_input.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "open_table_format_input.0.iceberg_input.0.metadata_operation", "CREATE"),
+					resource.TestCheckResourceAttr(resourceName, "open_table_format_input.0.iceberg_input.0.version", "2"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"open_table_format_input"},
+			},
+		},
+	})
+}
+
 func testAccCatalogTableConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
@@ -1407,6 +1439,48 @@ resource "aws_glue_catalog_database" "test2" {
 resource "aws_glue_catalog_table" "test2" {
   name          = "%[1]s-2"
   database_name = aws_glue_catalog_database.test2.name
+}
+`, rName)
+}
+
+func testAccCatalogTableConfig_openTableFormat(rName string) string {
+	//var trimmed_name = strings.Trim(rName, "\"")
+	return fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+}
+
+resource "aws_s3_bucket" "bucket" {
+  bucket = %[1]q
+  force_destroy = true
+}
+
+resource "aws_glue_catalog_table" "test" {
+  database_name = aws_glue_catalog_database.test.name
+  name          = %[1]q
+  table_type = "EXTERNAL_TABLE"
+
+  open_table_format_input {
+      iceberg_input {
+      	metadata_operation = "CREATE"
+		version = 2
+      }
+  }
+  storage_descriptor {
+    location = "s3://%[1]s/files/"
+
+    columns {
+      name    = "my_column_1"
+      type    = "int"
+      comment = "my_column1_comment"
+    }
+
+    columns {
+      name    = "my_column_2"
+      type    = "string"
+      comment = "my_column2_comment"
+    }
+  }
 }
 `, rName)
 }

--- a/internal/service/glue/catalog_table_test.go
+++ b/internal/service/glue/catalog_table_test.go
@@ -1451,21 +1451,22 @@ resource "aws_glue_catalog_database" "test" {
 }
 
 resource "aws_s3_bucket" "bucket" {
-  bucket = %[1]q
+  bucket        = %[1]q
   force_destroy = true
 }
 
 resource "aws_glue_catalog_table" "test" {
   database_name = aws_glue_catalog_database.test.name
   name          = %[1]q
-  table_type = "EXTERNAL_TABLE"
+  table_type    = "EXTERNAL_TABLE"
 
   open_table_format_input {
-      iceberg_input {
-      	metadata_operation = "CREATE"
-		version = 2
-      }
+    iceberg_input {
+      metadata_operation = "CREATE"
+      version            = 2
+    }
   }
+
   storage_descriptor {
     location = "s3://%[1]s/files/"
 

--- a/website/docs/r/glue_catalog_table.html.markdown
+++ b/website/docs/r/glue_catalog_table.html.markdown
@@ -92,6 +92,7 @@ The follow arguments are optional:
 * `catalog_id` - (Optional) ID of the Glue Catalog and database to create the table in. If omitted, this defaults to the AWS Account ID plus the database name.
 * `description` - (Optional) Description of the table.
 * `owner` - (Optional) Owner of the table.
+* `open_table_format_input` - (Optional) Configuration block for open table formats. See [`open_table_format_input`](#open_table_format_input) below.
 * `parameters` - (Optional) Properties associated with this table, as a list of key-value pairs.
 * `partition_index` - (Optional) Configuration block for a maximum of 3 partition indexes. See [`partition_index`](#partition_index) below.
 * `partition_keys` - (Optional) Configuration block of columns by which the table is partitioned. Only primitive types are supported as partition keys. See [`partition_keys`](#partition_keys) below.
@@ -101,6 +102,21 @@ The follow arguments are optional:
 * `target_table` - (Optional) Configuration block of a target table for resource linking. See [`target_table`](#target_table) below.
 * `view_expanded_text` - (Optional) If the table is a view, the expanded text of the view; otherwise null.
 * `view_original_text` - (Optional) If the table is a view, the original text of the view; otherwise null.
+
+### open_table_format_input
+
+~> **NOTE:** A `open_table_format_input` cannot be added to an existing `glue_catalog_table`.
+This will destroy and recreate the table, possibly resulting in data loss.
+
+* `iceberg_input` - (Required) Configuration block for iceberg table config. See [`iceberg_input`](#iceberg_input) below.
+
+### iceberg_input
+
+~> **NOTE:** A `iceberg_input` cannot be added to an existing `open_table_format_input`.
+This will destroy and recreate the table, possibly resulting in data loss.
+
+* `metadata_operation` - (Required) A required metadata operation. Can only be set to CREATE.
+* `version` - (Optional) The table version for the Iceberg table. Defaults to 2.
 
 ### partition_index
 


### PR DESCRIPTION
``Description
This PR adds in support for AWS glue tables open table formats.  

Had some issues as the Open format input is not returned as part of the table read and is instead marked as updates to the table parameters, this meant changing some additional code to prevent issues with the state. 

Relations
Closes: https://github.com/hashicorp/terraform-provider-aws/issues/33157

References
Output from Acceptance Testing

`terraform-provider-aws % make testacc TESTS=TestAccGlueCatalogTable_openTableFormat PKG=glue
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/glue/... -v -count 1 -parallel 20 -run='TestAccGlueCatalogTable_openTableFormat'  -timeout 180m
=== RUN   TestAccGlueCatalogTable_openTableFormat
=== PAUSE TestAccGlueCatalogTable_openTableFormat
=== CONT  TestAccGlueCatalogTable_openTableFormat
--- PASS: TestAccGlueCatalogTable_openTableFormat (39.21s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/glue       41.707s
`