### PR TITLE
Address AWS SDK for Go v2 `EndpointResolver is deprecated`

### DIFF
--- a/.ci/.golangci2.yml
+++ b/.ci/.golangci2.yml
@@ -80,16 +80,8 @@ issues:
       text: "SA1019: [a-zA-Z0-9.]+.CustomerMasterKeySpec is deprecated: This field has been deprecated. Instead, use the KeySpec field"
     - linters:
         - staticcheck
-      path: "internal/service/lightsail"
-      text: "SA1019: o.EndpointResolver"
-    - linters:
-        - staticcheck
       path: "internal/service/neptune"
       text: "SA1019: \\w+.(\\w+) is deprecated: (\\w+) has been deprecated"
-    - linters:
-        - staticcheck
-      path: "internal/service/route53domains"
-      text: "SA1019: o.EndpointResolver"
     - linters:
         - staticcheck
       path: "internal/service/s3"

--- a/internal/generate/servicepackage/file.tmpl
+++ b/internal/generate/servicepackage/file.tmpl
@@ -144,7 +144,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return {{ .GoV2Package }}_sdkv2.NewFromConfig(cfg, func(o *{{ .GoV2Package }}_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = {{ .GoV2Package }}_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/accessanalyzer/service_package_gen.go
+++ b/internal/service/accessanalyzer/service_package_gen.go
@@ -53,7 +53,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return accessanalyzer_sdkv2.NewFromConfig(cfg, func(o *accessanalyzer_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = accessanalyzer_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/account/service_package_gen.go
+++ b/internal/service/account/service_package_gen.go
@@ -49,7 +49,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return account_sdkv2.NewFromConfig(cfg, func(o *account_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = account_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/acm/service_package_gen.go
+++ b/internal/service/acm/service_package_gen.go
@@ -58,7 +58,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return acm_sdkv2.NewFromConfig(cfg, func(o *acm_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = acm_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/appconfig/service_package_gen.go
+++ b/internal/service/appconfig/service_package_gen.go
@@ -123,7 +123,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return appconfig_sdkv2.NewFromConfig(cfg, func(o *appconfig_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = appconfig_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/auditmanager/service_package_gen.go
+++ b/internal/service/auditmanager/service_package_gen.go
@@ -84,7 +84,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return auditmanager_sdkv2.NewFromConfig(cfg, func(o *auditmanager_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = auditmanager_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/cleanrooms/service_package_gen.go
+++ b/internal/service/cleanrooms/service_package_gen.go
@@ -48,7 +48,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return cleanrooms_sdkv2.NewFromConfig(cfg, func(o *cleanrooms_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = cleanrooms_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/cloudcontrol/service_package_gen.go
+++ b/internal/service/cloudcontrol/service_package_gen.go
@@ -50,7 +50,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return cloudcontrol_sdkv2.NewFromConfig(cfg, func(o *cloudcontrol_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = cloudcontrol_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/codecatalyst/service_package_gen.go
+++ b/internal/service/codecatalyst/service_package_gen.go
@@ -62,7 +62,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return codecatalyst_sdkv2.NewFromConfig(cfg, func(o *codecatalyst_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = codecatalyst_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/codestarconnections/service_package_gen.go
+++ b/internal/service/codestarconnections/service_package_gen.go
@@ -59,7 +59,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return codestarconnections_sdkv2.NewFromConfig(cfg, func(o *codestarconnections_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = codestarconnections_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/codestarnotifications/service_package_gen.go
+++ b/internal/service/codestarnotifications/service_package_gen.go
@@ -49,7 +49,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return codestarnotifications_sdkv2.NewFromConfig(cfg, func(o *codestarnotifications_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = codestarnotifications_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/comprehend/service_package_gen.go
+++ b/internal/service/comprehend/service_package_gen.go
@@ -57,7 +57,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return comprehend_sdkv2.NewFromConfig(cfg, func(o *comprehend_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = comprehend_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/computeoptimizer/service_package_gen.go
+++ b/internal/service/computeoptimizer/service_package_gen.go
@@ -40,7 +40,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return computeoptimizer_sdkv2.NewFromConfig(cfg, func(o *computeoptimizer_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = computeoptimizer_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/docdbelastic/service_package_gen.go
+++ b/internal/service/docdbelastic/service_package_gen.go
@@ -40,7 +40,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return docdbelastic_sdkv2.NewFromConfig(cfg, func(o *docdbelastic_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = docdbelastic_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/ds/service_package_gen.go
+++ b/internal/service/ds/service_package_gen.go
@@ -94,7 +94,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return directoryservice_sdkv2.NewFromConfig(cfg, func(o *directoryservice_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = directoryservice_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -1147,7 +1147,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return ec2_sdkv2.NewFromConfig(cfg, func(o *ec2_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = ec2_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/emrserverless/service_package_gen.go
+++ b/internal/service/emrserverless/service_package_gen.go
@@ -49,7 +49,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return emrserverless_sdkv2.NewFromConfig(cfg, func(o *emrserverless_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = emrserverless_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/finspace/service_package_gen.go
+++ b/internal/service/finspace/service_package_gen.go
@@ -73,7 +73,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return finspace_sdkv2.NewFromConfig(cfg, func(o *finspace_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = finspace_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/fis/service_package_gen.go
+++ b/internal/service/fis/service_package_gen.go
@@ -47,7 +47,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return fis_sdkv2.NewFromConfig(cfg, func(o *fis_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = fis_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/glacier/service_package_gen.go
+++ b/internal/service/glacier/service_package_gen.go
@@ -53,7 +53,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return glacier_sdkv2.NewFromConfig(cfg, func(o *glacier_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = glacier_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/healthlake/service_package_gen.go
+++ b/internal/service/healthlake/service_package_gen.go
@@ -40,7 +40,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return healthlake_sdkv2.NewFromConfig(cfg, func(o *healthlake_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = healthlake_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/identitystore/service_package_gen.go
+++ b/internal/service/identitystore/service_package_gen.go
@@ -62,7 +62,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return identitystore_sdkv2.NewFromConfig(cfg, func(o *identitystore_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = identitystore_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/inspector2/service_package_gen.go
+++ b/internal/service/inspector2/service_package_gen.go
@@ -57,7 +57,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return inspector2_sdkv2.NewFromConfig(cfg, func(o *inspector2_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = inspector2_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/internetmonitor/service_package_gen.go
+++ b/internal/service/internetmonitor/service_package_gen.go
@@ -49,7 +49,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return internetmonitor_sdkv2.NewFromConfig(cfg, func(o *internetmonitor_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = internetmonitor_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/ivschat/service_package_gen.go
+++ b/internal/service/ivschat/service_package_gen.go
@@ -57,7 +57,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return ivschat_sdkv2.NewFromConfig(cfg, func(o *ivschat_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = ivschat_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/kafka/service_package_gen.go
+++ b/internal/service/kafka/service_package_gen.go
@@ -111,7 +111,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return kafka_sdkv2.NewFromConfig(cfg, func(o *kafka_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = kafka_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/kendra/service_package_gen.go
+++ b/internal/service/kendra/service_package_gen.go
@@ -106,7 +106,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return kendra_sdkv2.NewFromConfig(cfg, func(o *kendra_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = kendra_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/keyspaces/service_package_gen.go
+++ b/internal/service/keyspaces/service_package_gen.go
@@ -57,7 +57,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return keyspaces_sdkv2.NewFromConfig(cfg, func(o *keyspaces_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = keyspaces_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/lambda/service_package_gen.go
+++ b/internal/service/lambda/service_package_gen.go
@@ -128,7 +128,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return lambda_sdkv2.NewFromConfig(cfg, func(o *lambda_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = lambda_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/lightsail/service_package.go
+++ b/internal/service/lightsail/service_package.go
@@ -19,7 +19,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return lightsail_sdkv2.NewFromConfig(cfg, func(o *lightsail_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = lightsail_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 
 		retryable := retry_sdkv2.IsErrorRetryableFunc(func(e error) aws_sdkv2.Ternary {

--- a/internal/service/logs/service_package_gen.go
+++ b/internal/service/logs/service_package_gen.go
@@ -106,7 +106,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return cloudwatchlogs_sdkv2.NewFromConfig(cfg, func(o *cloudwatchlogs_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = cloudwatchlogs_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/medialive/service_package_gen.go
+++ b/internal/service/medialive/service_package_gen.go
@@ -77,7 +77,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return medialive_sdkv2.NewFromConfig(cfg, func(o *medialive_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = medialive_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/mediapackage/service_package_gen.go
+++ b/internal/service/mediapackage/service_package_gen.go
@@ -49,7 +49,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return mediapackage_sdkv2.NewFromConfig(cfg, func(o *mediapackage_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = mediapackage_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/oam/service_package_gen.go
+++ b/internal/service/oam/service_package_gen.go
@@ -78,7 +78,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return oam_sdkv2.NewFromConfig(cfg, func(o *oam_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = oam_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/opensearchserverless/service_package_gen.go
+++ b/internal/service/opensearchserverless/service_package_gen.go
@@ -82,7 +82,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return opensearchserverless_sdkv2.NewFromConfig(cfg, func(o *opensearchserverless_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = opensearchserverless_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/pipes/service_package_gen.go
+++ b/internal/service/pipes/service_package_gen.go
@@ -49,7 +49,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return pipes_sdkv2.NewFromConfig(cfg, func(o *pipes_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = pipes_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/pricing/service_package_gen.go
+++ b/internal/service/pricing/service_package_gen.go
@@ -45,7 +45,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return pricing_sdkv2.NewFromConfig(cfg, func(o *pricing_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = pricing_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/qldb/service_package_gen.go
+++ b/internal/service/qldb/service_package_gen.go
@@ -62,7 +62,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return qldb_sdkv2.NewFromConfig(cfg, func(o *qldb_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = qldb_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/rbin/service_package_gen.go
+++ b/internal/service/rbin/service_package_gen.go
@@ -49,7 +49,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return rbin_sdkv2.NewFromConfig(cfg, func(o *rbin_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = rbin_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/rds/service_package_gen.go
+++ b/internal/service/rds/service_package_gen.go
@@ -262,7 +262,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return rds_sdkv2.NewFromConfig(cfg, func(o *rds_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = rds_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/redshiftdata/service_package_gen.go
+++ b/internal/service/redshiftdata/service_package_gen.go
@@ -45,7 +45,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return redshiftdata_sdkv2.NewFromConfig(cfg, func(o *redshiftdata_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = redshiftdata_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/resourceexplorer2/service_package_gen.go
+++ b/internal/service/resourceexplorer2/service_package_gen.go
@@ -55,7 +55,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return resourceexplorer2_sdkv2.NewFromConfig(cfg, func(o *resourceexplorer2_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = resourceexplorer2_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/rolesanywhere/service_package_gen.go
+++ b/internal/service/rolesanywhere/service_package_gen.go
@@ -57,7 +57,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return rolesanywhere_sdkv2.NewFromConfig(cfg, func(o *rolesanywhere_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = rolesanywhere_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/route53domains/service_package.go
+++ b/internal/service/route53domains/service_package.go
@@ -17,7 +17,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return route53domains_sdkv2.NewFromConfig(cfg, func(o *route53domains_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = route53domains_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		} else if config["partition"].(string) == endpoints_sdkv1.AwsPartitionID {
 			// Route 53 Domains is only available in AWS Commercial us-east-1 Region.
 			o.Region = endpoints_sdkv1.UsEast1RegionID

--- a/internal/service/s3control/service_package_gen.go
+++ b/internal/service/s3control/service_package_gen.go
@@ -108,7 +108,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return s3control_sdkv2.NewFromConfig(cfg, func(o *s3control_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = s3control_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/scheduler/service_package_gen.go
+++ b/internal/service/scheduler/service_package_gen.go
@@ -53,7 +53,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return scheduler_sdkv2.NewFromConfig(cfg, func(o *scheduler_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = scheduler_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/securitylake/service_package_gen.go
+++ b/internal/service/securitylake/service_package_gen.go
@@ -40,7 +40,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return securitylake_sdkv2.NewFromConfig(cfg, func(o *securitylake_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = securitylake_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/sesv2/service_package_gen.go
+++ b/internal/service/sesv2/service_package_gen.go
@@ -109,7 +109,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return sesv2_sdkv2.NewFromConfig(cfg, func(o *sesv2_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = sesv2_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/signer/service_package_gen.go
+++ b/internal/service/signer/service_package_gen.go
@@ -66,7 +66,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return signer_sdkv2.NewFromConfig(cfg, func(o *signer_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = signer_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/ssm/service_package_gen.go
+++ b/internal/service/ssm/service_package_gen.go
@@ -146,7 +146,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return ssm_sdkv2.NewFromConfig(cfg, func(o *ssm_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = ssm_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/ssmcontacts/service_package_gen.go
+++ b/internal/service/ssmcontacts/service_package_gen.go
@@ -72,7 +72,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return ssmcontacts_sdkv2.NewFromConfig(cfg, func(o *ssmcontacts_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = ssmcontacts_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/ssmincidents/service_package_gen.go
+++ b/internal/service/ssmincidents/service_package_gen.go
@@ -66,7 +66,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return ssmincidents_sdkv2.NewFromConfig(cfg, func(o *ssmincidents_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = ssmincidents_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/swf/service_package_gen.go
+++ b/internal/service/swf/service_package_gen.go
@@ -49,7 +49,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return swf_sdkv2.NewFromConfig(cfg, func(o *swf_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = swf_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/timestreamwrite/service_package_gen.go
+++ b/internal/service/timestreamwrite/service_package_gen.go
@@ -57,7 +57,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return timestreamwrite_sdkv2.NewFromConfig(cfg, func(o *timestreamwrite_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = timestreamwrite_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/transcribe/service_package_gen.go
+++ b/internal/service/transcribe/service_package_gen.go
@@ -73,7 +73,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return transcribe_sdkv2.NewFromConfig(cfg, func(o *transcribe_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = transcribe_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/verifiedpermissions/service_package_gen.go
+++ b/internal/service/verifiedpermissions/service_package_gen.go
@@ -40,7 +40,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return verifiedpermissions_sdkv2.NewFromConfig(cfg, func(o *verifiedpermissions_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = verifiedpermissions_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/vpclattice/service_package_gen.go
+++ b/internal/service/vpclattice/service_package_gen.go
@@ -145,7 +145,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return vpclattice_sdkv2.NewFromConfig(cfg, func(o *vpclattice_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = vpclattice_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/workspaces/service_package_gen.go
+++ b/internal/service/workspaces/service_package_gen.go
@@ -90,7 +90,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return workspaces_sdkv2.NewFromConfig(cfg, func(o *workspaces_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = workspaces_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }

--- a/internal/service/xray/service_package_gen.go
+++ b/internal/service/xray/service_package_gen.go
@@ -61,7 +61,7 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 
 	return xray_sdkv2.NewFromConfig(cfg, func(o *xray_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.EndpointResolver = xray_sdkv2.EndpointResolverFromURL(endpoint)
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
 	}), nil
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

`EndpointResolver` is deprecated, use `BaseEndpoint` instead.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/32787.