### PR TITLE
s3: Enable use of AWS SDK for Go v2

### DIFF
--- a/.changelog/#####.txt
+++ b/.changelog/#####.txt
@@ -5,3 +5,7 @@ data-source/aws_s3_objects: Add `request_payer` argument and `request_charged` a
 ```release-note:enhancement
 data-source/aws_s3_objects: Add plan-time validation of `encoding_type`
 ```
+
+```release-note:bug
+data-source/aws_s3_objects: Respect configured `max_keys` value if it's greater than `1000`
+```

--- a/.changelog/#####.txt
+++ b/.changelog/#####.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
 data-source/aws_s3_objects: Add `request_payer` argument and `request_charged` attribute
 ```
+
+```release-note:enhancement
+data-source/aws_s3_objects: Add plan-time validation of `encoding_type`
+```

--- a/.changelog/#####.txt
+++ b/.changelog/#####.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_s3_objects: Add `request_payer` argument and `request_charged` attribute
+```

--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.3.5
 	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.3.5
 	github.com/aws/aws-sdk-go-v2/service/route53domains v1.17.3
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.38.5
 	github.com/aws/aws-sdk-go-v2/service/s3control v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.2.5
 	github.com/aws/aws-sdk-go-v2/service/securitylake v1.7.0
@@ -117,7 +118,10 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.41 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.35 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.39 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/v4a v1.1.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/iam v1.22.5 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.14 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.1.36 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.7.35 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.35 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.15.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.35 h1:SijA0mgjV8E+8G45lt
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.35/go.mod h1:SJC1nEVVva1g3pHAIdCp7QsRIkMmLAgoDquQ9Rr8kYw=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.39 h1:fc0ukRAiP1syoSGZYu+DaE+FulSYhTiJ8WpVu5jElU4=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.39/go.mod h1:WLAW8PT7+JhjZfLSWe7WEJaJu0GNo0cKc2Zyo003RBs=
+github.com/aws/aws-sdk-go-v2/internal/v4a v1.1.4 h1:6lJvvkQ9HmbHZ4h/IEwclwv2mrTW8Uq1SOB/kXy0mfw=
+github.com/aws/aws-sdk-go-v2/internal/v4a v1.1.4/go.mod h1:1PrKYwxTM+zjpw9Y41KFtoJCQrJ34Z47Y4VgVbfndjo=
 github.com/aws/aws-sdk-go-v2/service/accessanalyzer v1.20.5 h1:1w0ELQMC3AptxEFS4A+vJuhyIuC9IoNN2YxNKK5pSYQ=
 github.com/aws/aws-sdk-go-v2/service/accessanalyzer v1.20.5/go.mod h1:zwKhX2c7u7XDz2ToVE+qunfyoy9+3AO0rZynN5TwXCc=
 github.com/aws/aws-sdk-go-v2/service/account v1.11.5 h1:UX7HDdPZwTmrr1zu1j8e9QNINZS2YSJ+DoxhnnPyJY8=
@@ -92,6 +94,10 @@ github.com/aws/aws-sdk-go-v2/service/identitystore v1.17.6 h1:1+CSnP3TCGEnv6D12I
 github.com/aws/aws-sdk-go-v2/service/identitystore v1.17.6/go.mod h1:uP4598oNnSTY5AClqIoK6QHQnwz7cuRS8CBkVMXuxOU=
 github.com/aws/aws-sdk-go-v2/service/inspector2 v1.16.6 h1:HhLDyWzcq1QAQM9/D6r49CA1NX7mSuE77XruZ/GM0tI=
 github.com/aws/aws-sdk-go-v2/service/inspector2 v1.16.6/go.mod h1:ZThso1NAB0Pt7ZHiE8QjGxZsdSq3yE3IHTO8DSsIj0Y=
+github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.14 h1:m0QTSI6pZYJTk5WSKx3fm5cNW/DCicVzULBgU/6IyD0=
+github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.14/go.mod h1:dDilntgHy9WnHXsh7dDtUPgHKEfTJIBUTHM8OWm0f/0=
+github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.1.36 h1:eev2yZX7esGRjqRbnVk1UxMLw4CyVZDpZXRCcy75oQk=
+github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.1.36/go.mod h1:lGnOkH9NJATw0XEPcAknFBj3zzNTEGRHtSw+CwC1YTg=
 github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.7.35 h1:UKjpIDLVF90RfV88XurdduMoTxPqtGHZMIDYZQM7RO4=
 github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.7.35/go.mod h1:B3dUg0V6eJesUTi+m27NUkj7n8hdDKYUpxj8f4+TqaQ=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.32/go.mod h1:4jwAWKEkCR0anWk5+1RbfSg1R5Gzld7NLiuaq5bTR/Y=
@@ -141,6 +147,8 @@ github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.3.5 h1:tfmJZFDrma1cgraLRuE
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.3.5/go.mod h1:vXPkNV5GGPdMjRRNzO45nX3qsNTgB5lP19Tk4Go30xQ=
 github.com/aws/aws-sdk-go-v2/service/route53domains v1.17.3 h1:aaHlZb06fyEQ3uqEVJiN3hLt8syCzX+tWZiz40S4c0Y=
 github.com/aws/aws-sdk-go-v2/service/route53domains v1.17.3/go.mod h1:SK+5R1cYgVgSfBGi9T/gPGNIuLInF3eIRYNruia62rg=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.38.5 h1:A42xdtStObqy7NGvzZKpnyNXvoOmm+FENobZ0/ssHWk=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.38.5/go.mod h1:rDGMZA7f4pbmTtPOk5v5UM2lmX6UAbRnMDJeDvnH7AM=
 github.com/aws/aws-sdk-go-v2/service/s3control v1.33.0 h1:f4qHghGTcns4L4F7u8AHH6pcVLwgtTMNkNZeRJZ5xlA=
 github.com/aws/aws-sdk-go-v2/service/s3control v1.33.0/go.mod h1:YSdqo9knBVm5H3JVmWDhx9Wts9828nColUJzL3OKXDk=
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.2.5 h1:AGRPn7Hef59Eb9zfXjf6MGn0xRPpO73dIV8u8pfo5Z8=

--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -48,6 +48,7 @@ import (
 	resourceexplorer2_sdkv2 "github.com/aws/aws-sdk-go-v2/service/resourceexplorer2"
 	rolesanywhere_sdkv2 "github.com/aws/aws-sdk-go-v2/service/rolesanywhere"
 	route53domains_sdkv2 "github.com/aws/aws-sdk-go-v2/service/route53domains"
+	s3_sdkv2 "github.com/aws/aws-sdk-go-v2/service/s3"
 	s3control_sdkv2 "github.com/aws/aws-sdk-go-v2/service/s3control"
 	scheduler_sdkv2 "github.com/aws/aws-sdk-go-v2/service/scheduler"
 	securitylake_sdkv2 "github.com/aws/aws-sdk-go-v2/service/securitylake"
@@ -907,6 +908,10 @@ func (c *AWSClient) Route53ResolverConn(ctx context.Context) *route53resolver_sd
 
 func (c *AWSClient) S3Conn(ctx context.Context) *s3_sdkv1.S3 {
 	return errs.Must(conn[*s3_sdkv1.S3](ctx, c, names.S3))
+}
+
+func (c *AWSClient) S3Client(ctx context.Context) *s3_sdkv2.Client {
+	return errs.Must(client[*s3_sdkv2.Client](ctx, c, names.S3))
 }
 
 func (c *AWSClient) S3ControlConn(ctx context.Context) *s3control_sdkv1.S3Control {

--- a/internal/service/s3/bucket_objects_data_source_test.go
+++ b/internal/service/s3/bucket_objects_data_source_test.go
@@ -34,7 +34,6 @@ func TestAccS3BucketObjectsDataSource_basic(t *testing.T) {
 			{
 				Config: testAccBucketObjectsDataSourceConfig_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckObjectsExistsDataSource("data.aws_s3_objects.yesh"),
 					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.#", "2"),
 					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.0", "arch/navajo/north_window"),
 					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.1", "arch/navajo/sand_dune"),
@@ -61,7 +60,6 @@ func TestAccS3BucketObjectsDataSource_basicViaAccessPoint(t *testing.T) {
 			{
 				Config: testAccBucketObjectsDataSourceConfig_basicViaAccessPoint(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckObjectsExistsDataSource("data.aws_s3_objects.yesh"),
 					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.#", "2"),
 					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.0", "arch/navajo/north_window"),
 					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.1", "arch/navajo/sand_dune"),
@@ -88,7 +86,6 @@ func TestAccS3BucketObjectsDataSource_all(t *testing.T) {
 			{
 				Config: testAccBucketObjectsDataSourceConfig_all(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckObjectsExistsDataSource("data.aws_s3_objects.yesh"),
 					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.#", "7"),
 					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.0", "arch/courthouse_towers/landscape"),
 					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.1", "arch/navajo/north_window"),
@@ -120,7 +117,6 @@ func TestAccS3BucketObjectsDataSource_prefixes(t *testing.T) {
 			{
 				Config: testAccBucketObjectsDataSourceConfig_prefixes(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckObjectsExistsDataSource("data.aws_s3_objects.yesh"),
 					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.#", "1"),
 					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.0", "arch/rubicon"),
 					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "common_prefixes.#", "4"),
@@ -151,7 +147,6 @@ func TestAccS3BucketObjectsDataSource_encoded(t *testing.T) {
 			{
 				Config: testAccBucketObjectsDataSourceConfig_encoded(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckObjectsExistsDataSource("data.aws_s3_objects.yesh"),
 					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.#", "2"),
 					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.0", "arch/ru+b+ic+on"),
 					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.1", "arch/rubicon"),
@@ -178,7 +173,6 @@ func TestAccS3BucketObjectsDataSource_maxKeys(t *testing.T) {
 			{
 				Config: testAccBucketObjectsDataSourceConfig_maxKeys(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckObjectsExistsDataSource("data.aws_s3_objects.yesh"),
 					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.#", "2"),
 					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.0", "arch/courthouse_towers/landscape"),
 					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.1", "arch/navajo/north_window"),
@@ -205,7 +199,6 @@ func TestAccS3BucketObjectsDataSource_startAfter(t *testing.T) {
 			{
 				Config: testAccBucketObjectsDataSourceConfig_startAfter(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckObjectsExistsDataSource("data.aws_s3_objects.yesh"),
 					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.#", "1"),
 					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.0", "arch/three_gossips/turret"),
 				),
@@ -231,7 +224,6 @@ func TestAccS3BucketObjectsDataSource_fetchOwner(t *testing.T) {
 			{
 				Config: testAccBucketObjectsDataSourceConfig_owners(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckObjectsExistsDataSource("data.aws_s3_objects.yesh"),
 					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.#", "2"),
 					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "owners.#", "2"),
 				),

--- a/internal/service/s3/canonical_user_id_data_source.go
+++ b/internal/service/s3/canonical_user_id_data_source.go
@@ -5,10 +5,9 @@ package s3
 
 import (
 	"context"
-	"log"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -16,7 +15,7 @@ import (
 )
 
 // @SDKDataSource("aws_canonical_user_id")
-func DataSourceCanonicalUserID() *schema.Resource {
+func dataSourceCanonicalUserID() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceCanonicalUserIDRead,
 
@@ -31,21 +30,20 @@ func DataSourceCanonicalUserID() *schema.Resource {
 
 func dataSourceCanonicalUserIDRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).S3Conn(ctx)
+	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
-	log.Printf("[DEBUG] Reading S3 Buckets")
+	output, err := conn.ListBuckets(ctx, &s3.ListBucketsInput{})
 
-	req := &s3.ListBucketsInput{}
-	resp, err := conn.ListBucketsWithContext(ctx, req)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "listing S3 Buckets: %s", err)
 	}
-	if resp == nil || resp.Owner == nil {
-		return sdkdiag.AppendErrorf(diags, "no canonical user ID found")
+
+	if output == nil || output.Owner == nil {
+		return sdkdiag.AppendErrorf(diags, "S3 Canonical User ID not found")
 	}
 
-	d.SetId(aws.StringValue(resp.Owner.ID))
-	d.Set("display_name", resp.Owner.DisplayName)
+	d.SetId(aws.ToString(output.Owner.ID))
+	d.Set("display_name", output.Owner.DisplayName)
 
 	return diags
 }

--- a/internal/service/s3/canonical_user_id_data_source_test.go
+++ b/internal/service/s3/canonical_user_id_data_source_test.go
@@ -4,50 +4,33 @@
 package s3_test
 
 import (
-	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccS3CanonicalUserIDDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_canonical_user_id.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, s3.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3EndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCanonicalUserIDDataSourceConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCanonicalUserIdCheckExistsDataSource("data.aws_canonical_user_id.current"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "display_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "id"),
 				),
 			},
 		},
 	})
 }
 
-func testAccCanonicalUserIdCheckExistsDataSource(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("Can't find Canonical User ID resource: %s", name)
-		}
-
-		if rs.Primary.Attributes["id"] == "" {
-			return fmt.Errorf("Missing Canonical User ID")
-		}
-		if rs.Primary.Attributes["display_name"] == "" {
-			return fmt.Errorf("Missing Display Name")
-		}
-
-		return nil
-	}
-}
-
 const testAccCanonicalUserIDDataSourceConfig_basic = `
-data "aws_canonical_user_id" "current" {}
+data "aws_canonical_user_id" "test" {}
 `

--- a/internal/service/s3/canonical_user_id_data_source_test.go
+++ b/internal/service/s3/canonical_user_id_data_source_test.go
@@ -22,7 +22,7 @@ func TestAccS3CanonicalUserIDDataSource_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCanonicalUserIDDataSourceConfig_basic,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(dataSourceName, "display_name"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "id"),
 				),

--- a/internal/service/s3/objects_data_source.go
+++ b/internal/service/s3/objects_data_source.go
@@ -26,24 +26,16 @@ func DataSourceObjects() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"prefix": {
-				Type:     schema.TypeString,
-				Optional: true,
+			"common_prefixes": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"delimiter": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
 			"encoding_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"max_keys": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  1000,
-			},
-			"start_after": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
@@ -56,15 +48,23 @@ func DataSourceObjects() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"common_prefixes": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+			"max_keys": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  1000,
 			},
 			"owners": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"prefix": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"start_after": {
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 		},
 	}

--- a/internal/service/s3/objects_data_source_test.go
+++ b/internal/service/s3/objects_data_source_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/s3"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccS3ObjectsDataSource_basic(t *testing.T) {
@@ -20,7 +20,7 @@ func TestAccS3ObjectsDataSource_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:                acctest.ErrorCheck(t, s3.EndpointsID),
+		ErrorCheck:                acctest.ErrorCheck(t, names.S3EndpointID),
 		ProtoV5ProviderFactories:  acctest.ProtoV5ProviderFactories,
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
@@ -44,7 +44,7 @@ func TestAccS3ObjectsDataSource_basicViaAccessPoint(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:                acctest.ErrorCheck(t, s3.EndpointsID),
+		ErrorCheck:                acctest.ErrorCheck(t, names.S3EndpointID),
 		ProtoV5ProviderFactories:  acctest.ProtoV5ProviderFactories,
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
@@ -67,7 +67,7 @@ func TestAccS3ObjectsDataSource_prefixes(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:                acctest.ErrorCheck(t, s3.EndpointsID),
+		ErrorCheck:                acctest.ErrorCheck(t, names.S3EndpointID),
 		ProtoV5ProviderFactories:  acctest.ProtoV5ProviderFactories,
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
@@ -90,7 +90,7 @@ func TestAccS3ObjectsDataSource_encoded(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:                acctest.ErrorCheck(t, s3.EndpointsID),
+		ErrorCheck:                acctest.ErrorCheck(t, names.S3EndpointID),
 		ProtoV5ProviderFactories:  acctest.ProtoV5ProviderFactories,
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
@@ -114,7 +114,7 @@ func TestAccS3ObjectsDataSource_maxKeys(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:                acctest.ErrorCheck(t, s3.EndpointsID),
+		ErrorCheck:                acctest.ErrorCheck(t, names.S3EndpointID),
 		ProtoV5ProviderFactories:  acctest.ProtoV5ProviderFactories,
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
@@ -145,7 +145,7 @@ func TestAccS3ObjectsDataSource_startAfter(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:                acctest.ErrorCheck(t, s3.EndpointsID),
+		ErrorCheck:                acctest.ErrorCheck(t, names.S3EndpointID),
 		ProtoV5ProviderFactories:  acctest.ProtoV5ProviderFactories,
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
@@ -168,7 +168,7 @@ func TestAccS3ObjectsDataSource_fetchOwner(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:                acctest.ErrorCheck(t, s3.EndpointsID),
+		ErrorCheck:                acctest.ErrorCheck(t, names.S3EndpointID),
 		ProtoV5ProviderFactories:  acctest.ProtoV5ProviderFactories,
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{

--- a/internal/service/s3/objects_data_source_test.go
+++ b/internal/service/s3/objects_data_source_test.go
@@ -10,13 +10,13 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
 func TestAccS3ObjectsDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	rInt := sdkacctest.RandInt()
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_s3_objects.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { acctest.PreCheck(ctx, t) },
@@ -25,16 +25,11 @@ func TestAccS3ObjectsDataSource_basic(t *testing.T) {
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccObjectsDataSourceConfig_resources(rInt), // NOTE: contains no data source
-				// Does not need Check
-			},
-			{
-				Config: testAccObjectsDataSourceConfig_basic(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckObjectsExistsDataSource("data.aws_s3_objects.yesh"),
-					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.#", "2"),
-					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.0", "arch/navajo/north_window"),
-					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.1", "arch/navajo/sand_dune"),
+				Config: testAccObjectsDataSourceConfig_basic(rName, 1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "common_prefixes.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "keys.#", "3"),
+					resource.TestCheckResourceAttr(dataSourceName, "owners.#", "0"),
 				),
 			},
 		},
@@ -43,7 +38,8 @@ func TestAccS3ObjectsDataSource_basic(t *testing.T) {
 
 func TestAccS3ObjectsDataSource_basicViaAccessPoint(t *testing.T) {
 	ctx := acctest.Context(t)
-	rInt := sdkacctest.RandInt()
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_s3_objects.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { acctest.PreCheck(ctx, t) },
@@ -52,48 +48,11 @@ func TestAccS3ObjectsDataSource_basicViaAccessPoint(t *testing.T) {
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccObjectsDataSourceConfig_resourcesPlusAccessPoint(rInt), // NOTE: contains no data source
-				// Does not need Check
-			},
-			{
-				Config: testAccObjectsDataSourceConfig_basicViaAccessPoint(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckObjectsExistsDataSource("data.aws_s3_objects.yesh"),
-					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.#", "2"),
-					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.0", "arch/navajo/north_window"),
-					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.1", "arch/navajo/sand_dune"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccS3ObjectsDataSource_all(t *testing.T) {
-	ctx := acctest.Context(t)
-	rInt := sdkacctest.RandInt()
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                  func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:                acctest.ErrorCheck(t, s3.EndpointsID),
-		ProtoV5ProviderFactories:  acctest.ProtoV5ProviderFactories,
-		PreventPostDestroyRefresh: true,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccObjectsDataSourceConfig_resources(rInt), // NOTE: contains no data source
-				// Does not need Check
-			},
-			{
-				Config: testAccObjectsDataSourceConfig_all(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckObjectsExistsDataSource("data.aws_s3_objects.yesh"),
-					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.#", "7"),
-					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.0", "arch/courthouse_towers/landscape"),
-					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.1", "arch/navajo/north_window"),
-					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.2", "arch/navajo/sand_dune"),
-					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.3", "arch/partition/park_avenue"),
-					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.4", "arch/rubicon"),
-					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.5", "arch/three_gossips/broken"),
-					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.6", "arch/three_gossips/turret"),
+				Config: testAccObjectsDataSourceConfig_basicViaAccessPoint(rName, 1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "common_prefixes.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "keys.#", "3"),
+					resource.TestCheckResourceAttr(dataSourceName, "owners.#", "0"),
 				),
 			},
 		},
@@ -102,7 +61,8 @@ func TestAccS3ObjectsDataSource_all(t *testing.T) {
 
 func TestAccS3ObjectsDataSource_prefixes(t *testing.T) {
 	ctx := acctest.Context(t)
-	rInt := sdkacctest.RandInt()
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_s3_objects.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { acctest.PreCheck(ctx, t) },
@@ -111,20 +71,11 @@ func TestAccS3ObjectsDataSource_prefixes(t *testing.T) {
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccObjectsDataSourceConfig_resources(rInt), // NOTE: contains no data source
-				// Does not need Check
-			},
-			{
-				Config: testAccObjectsDataSourceConfig_prefixes(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckObjectsExistsDataSource("data.aws_s3_objects.yesh"),
-					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.#", "1"),
-					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.0", "arch/rubicon"),
-					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "common_prefixes.#", "4"),
-					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "common_prefixes.0", "arch/courthouse_towers/"),
-					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "common_prefixes.1", "arch/navajo/"),
-					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "common_prefixes.2", "arch/partition/"),
-					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "common_prefixes.3", "arch/three_gossips/"),
+				Config: testAccObjectsDataSourceConfig_prefixes(rName, 1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "common_prefixes.#", "2"),
+					resource.TestCheckResourceAttr(dataSourceName, "keys.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "owners.#", "0"),
 				),
 			},
 		},
@@ -133,7 +84,8 @@ func TestAccS3ObjectsDataSource_prefixes(t *testing.T) {
 
 func TestAccS3ObjectsDataSource_encoded(t *testing.T) {
 	ctx := acctest.Context(t)
-	rInt := sdkacctest.RandInt()
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_s3_objects.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { acctest.PreCheck(ctx, t) },
@@ -142,16 +94,12 @@ func TestAccS3ObjectsDataSource_encoded(t *testing.T) {
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccObjectsDataSourceConfig_extraResource(rInt), // NOTE: contains no data source
-				// Does not need Check
-			},
-			{
-				Config: testAccObjectsDataSourceConfig_encoded(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckObjectsExistsDataSource("data.aws_s3_objects.yesh"),
-					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.#", "2"),
-					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.0", "arch/ru+b+ic+on"),
-					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.1", "arch/rubicon"),
+				Config: testAccObjectsDataSourceConfig_encoded(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "common_prefixes.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "keys.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "keys.0", "prefix/a+b"),
+					resource.TestCheckResourceAttr(dataSourceName, "owners.#", "0"),
 				),
 			},
 		},
@@ -160,7 +108,8 @@ func TestAccS3ObjectsDataSource_encoded(t *testing.T) {
 
 func TestAccS3ObjectsDataSource_maxKeys(t *testing.T) {
 	ctx := acctest.Context(t)
-	rInt := sdkacctest.RandInt()
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_s3_objects.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { acctest.PreCheck(ctx, t) },
@@ -169,16 +118,19 @@ func TestAccS3ObjectsDataSource_maxKeys(t *testing.T) {
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccObjectsDataSourceConfig_resources(rInt), // NOTE: contains no data source
-				// Does not need Check
+				Config: testAccObjectsDataSourceConfig_maxKeys(rName, 1, 5),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "common_prefixes.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "keys.#", "3"),
+					resource.TestCheckResourceAttr(dataSourceName, "owners.#", "0"),
+				),
 			},
 			{
-				Config: testAccObjectsDataSourceConfig_maxKeys(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckObjectsExistsDataSource("data.aws_s3_objects.yesh"),
-					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.#", "2"),
-					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.0", "arch/courthouse_towers/landscape"),
-					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.1", "arch/navajo/north_window"),
+				Config: testAccObjectsDataSourceConfig_maxKeys(rName, 2, 5),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "common_prefixes.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "keys.#", "5"),
+					resource.TestCheckResourceAttr(dataSourceName, "owners.#", "0"),
 				),
 			},
 		},
@@ -187,7 +139,8 @@ func TestAccS3ObjectsDataSource_maxKeys(t *testing.T) {
 
 func TestAccS3ObjectsDataSource_startAfter(t *testing.T) {
 	ctx := acctest.Context(t)
-	rInt := sdkacctest.RandInt()
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_s3_objects.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { acctest.PreCheck(ctx, t) },
@@ -196,15 +149,11 @@ func TestAccS3ObjectsDataSource_startAfter(t *testing.T) {
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccObjectsDataSourceConfig_resources(rInt), // NOTE: contains no data source
-				// Does not need Check
-			},
-			{
-				Config: testAccObjectsDataSourceConfig_startAfter(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckObjectsExistsDataSource("data.aws_s3_objects.yesh"),
-					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.#", "1"),
-					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.0", "arch/three_gossips/turret"),
+				Config: testAccObjectsDataSourceConfig_startAfter(rName, 1, "prefix1/sub2/0"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "common_prefixes.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "keys.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "owners.#", "0"),
 				),
 			},
 		},
@@ -213,7 +162,8 @@ func TestAccS3ObjectsDataSource_startAfter(t *testing.T) {
 
 func TestAccS3ObjectsDataSource_fetchOwner(t *testing.T) {
 	ctx := acctest.Context(t)
-	rInt := sdkacctest.RandInt()
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_s3_objects.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { acctest.PreCheck(ctx, t) },
@@ -222,193 +172,136 @@ func TestAccS3ObjectsDataSource_fetchOwner(t *testing.T) {
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccObjectsDataSourceConfig_resources(rInt), // NOTE: contains no data source
-				// Does not need Check
-			},
-			{
-				Config: testAccObjectsDataSourceConfig_owners(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckObjectsExistsDataSource("data.aws_s3_objects.yesh"),
-					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "keys.#", "2"),
-					resource.TestCheckResourceAttr("data.aws_s3_objects.yesh", "owners.#", "2"),
+				Config: testAccObjectsDataSourceConfig_owners(rName, 1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "common_prefixes.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "keys.#", "3"),
+					resource.TestCheckResourceAttr(dataSourceName, "owners.#", "3"),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckObjectsExistsDataSource(addr string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[addr]
-		if !ok {
-			return fmt.Errorf("Can't find S3 objects data source: %s", addr)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("S3 objects data source ID not set")
-		}
-
-		return nil
-	}
-}
-
-func testAccObjectsDataSourceConfig_resources(randInt int) string {
+func testAccObjectsDataSourceConfig_base(rName string, n int) string {
 	return fmt.Sprintf(`
-resource "aws_s3_bucket" "objects_bucket" {
-  bucket = "tf-acc-objects-test-bucket-%d"
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
 }
 
-resource "aws_s3_object" "object1" {
-  bucket  = aws_s3_bucket.objects_bucket.id
-  key     = "arch/three_gossips/turret"
-  content = "Delicate"
+resource "aws_s3_object" "test1" {
+  count = %[2]d
+
+  bucket  = aws_s3_bucket.test.id
+  key     = "prefix1/sub1/${count.index}"
+  content = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 }
 
-resource "aws_s3_object" "object2" {
-  bucket  = aws_s3_bucket.objects_bucket.id
-  key     = "arch/three_gossips/broken"
-  content = "Dark Angel"
+resource "aws_s3_object" "test2" {
+  count = %[2]d
+
+  bucket  = aws_s3_bucket.test.id
+  key     = "prefix1/sub2/${count.index}"
+  content = "0123456789"
 }
 
-resource "aws_s3_object" "object3" {
-  bucket  = aws_s3_bucket.objects_bucket.id
-  key     = "arch/navajo/north_window"
-  content = "Balanced Rock"
+resource "aws_s3_object" "test3" {
+  count = %[2]d
+
+  bucket  = aws_s3_bucket.test.id
+  key     = "prefix2/${count.index}"
+  content = "abcdefghijklmnopqrstuvwxyz"
+}
+`, rName, n)
 }
 
-resource "aws_s3_object" "object4" {
-  bucket  = aws_s3_bucket.objects_bucket.id
-  key     = "arch/navajo/sand_dune"
-  content = "Queen Victoria Rock"
+func testAccObjectsDataSourceConfig_basic(rName string, n int) string {
+	return acctest.ConfigCompose(testAccObjectsDataSourceConfig_base(rName, n), `
+data "aws_s3_objects" "test" {
+  bucket = aws_s3_bucket.test.id
+
+  depends_on = [aws_s3_object.test1, aws_s3_object.test2, aws_s3_object.test3]
+}
+`)
 }
 
-resource "aws_s3_object" "object5" {
-  bucket  = aws_s3_bucket.objects_bucket.id
-  key     = "arch/partition/park_avenue"
-  content = "Double-O"
-}
-
-resource "aws_s3_object" "object6" {
-  bucket  = aws_s3_bucket.objects_bucket.id
-  key     = "arch/courthouse_towers/landscape"
-  content = "Fiery Furnace"
-}
-
-resource "aws_s3_object" "object7" {
-  bucket  = aws_s3_bucket.objects_bucket.id
-  key     = "arch/rubicon"
-  content = "Devils Garden"
-}
-`, randInt)
-}
-
-func testAccObjectsDataSourceConfig_resourcesPlusAccessPoint(randInt int) string {
-	return testAccObjectsDataSourceConfig_resources(randInt) + fmt.Sprintf(`
+func testAccObjectsDataSourceConfig_basicViaAccessPoint(rName string, n int) string {
+	return acctest.ConfigCompose(testAccObjectsDataSourceConfig_base(rName, n), fmt.Sprintf(`
 resource "aws_s3_access_point" "test" {
-  bucket = aws_s3_bucket.objects_bucket.bucket
-  name   = "tf-objects-test-access-point-%[1]d"
-}
-`, randInt)
+  bucket = aws_s3_bucket.test.bucket
+  name   = "%[1]s-access-point"
 }
 
-func testAccObjectsDataSourceConfig_basic(randInt int) string {
-	return fmt.Sprintf(`
-%s
+data "aws_s3_objects" "test" {
+  bucket = aws_s3_access_point.test.arn
 
-data "aws_s3_objects" "yesh" {
-  bucket    = aws_s3_bucket.objects_bucket.id
-  prefix    = "arch/navajo/"
+  depends_on = [aws_s3_object.test1, aws_s3_object.test2, aws_s3_object.test3]
+}
+`, rName))
+}
+
+func testAccObjectsDataSourceConfig_prefixes(rName string, n int) string {
+	return acctest.ConfigCompose(testAccObjectsDataSourceConfig_base(rName, n), `
+data "aws_s3_objects" "test" {
+  bucket    = aws_s3_bucket.test.id
+  prefix    = "prefix1/"
   delimiter = "/"
+
+  depends_on = [aws_s3_object.test1, aws_s3_object.test2, aws_s3_object.test3]
 }
-`, testAccObjectsDataSourceConfig_resources(randInt))
+`)
 }
 
-func testAccObjectsDataSourceConfig_basicViaAccessPoint(randInt int) string {
-	return testAccObjectsDataSourceConfig_resourcesPlusAccessPoint(randInt) + `
-data "aws_s3_objects" "yesh" {
-  bucket    = aws_s3_access_point.test.arn
-  prefix    = "arch/navajo/"
-  delimiter = "/"
-}
-`
-}
-
-func testAccObjectsDataSourceConfig_all(randInt int) string {
+func testAccObjectsDataSourceConfig_encoded(rName string) string {
 	return fmt.Sprintf(`
-%s
-
-data "aws_s3_objects" "yesh" {
-  bucket = aws_s3_bucket.objects_bucket.id
-}
-`, testAccObjectsDataSourceConfig_resources(randInt))
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
 }
 
-func testAccObjectsDataSourceConfig_prefixes(randInt int) string {
-	return fmt.Sprintf(`
-%s
-
-data "aws_s3_objects" "yesh" {
-  bucket    = aws_s3_bucket.objects_bucket.id
-  prefix    = "arch/"
-  delimiter = "/"
-}
-`, testAccObjectsDataSourceConfig_resources(randInt))
+resource "aws_s3_object" "test" {
+  bucket  = aws_s3_bucket.test.id
+  key     = "prefix/a b"
+  content = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 }
 
-func testAccObjectsDataSourceConfig_extraResource(randInt int) string {
-	return fmt.Sprintf(`
-%s
-
-resource "aws_s3_object" "object8" {
-  bucket  = aws_s3_bucket.objects_bucket.id
-  key     = "arch/ru b ic on"
-  content = "Goose Island"
-}
-`, testAccObjectsDataSourceConfig_resources(randInt))
-}
-
-func testAccObjectsDataSourceConfig_encoded(randInt int) string {
-	return fmt.Sprintf(`
-%s
-
-data "aws_s3_objects" "yesh" {
-  bucket        = aws_s3_bucket.objects_bucket.id
+data "aws_s3_objects" "test" {
+  bucket        = aws_s3_bucket.test.id
   encoding_type = "url"
-  prefix        = "arch/ru"
-}
-`, testAccObjectsDataSourceConfig_extraResource(randInt))
-}
 
-func testAccObjectsDataSourceConfig_maxKeys(randInt int) string {
-	return fmt.Sprintf(`
-%s
-
-data "aws_s3_objects" "yesh" {
-  bucket   = aws_s3_bucket.objects_bucket.id
-  max_keys = 2
+  depends_on = [aws_s3_object.test]
 }
-`, testAccObjectsDataSourceConfig_resources(randInt))
+`, rName)
 }
 
-func testAccObjectsDataSourceConfig_startAfter(randInt int) string {
-	return fmt.Sprintf(`
-%s
+func testAccObjectsDataSourceConfig_maxKeys(rName string, n, maxKeys int) string {
+	return acctest.ConfigCompose(testAccObjectsDataSourceConfig_base(rName, n), fmt.Sprintf(`
+data "aws_s3_objects" "test" {
+  bucket   = aws_s3_bucket.test.id
+  max_keys = %[1]d
 
-data "aws_s3_objects" "yesh" {
-  bucket      = aws_s3_bucket.objects_bucket.id
-  start_after = "arch/three_gossips/broken"
+  depends_on = [aws_s3_object.test1, aws_s3_object.test2, aws_s3_object.test3]
 }
-`, testAccObjectsDataSourceConfig_resources(randInt))
+`, maxKeys))
 }
 
-func testAccObjectsDataSourceConfig_owners(randInt int) string {
-	return fmt.Sprintf(`
-%s
+func testAccObjectsDataSourceConfig_startAfter(rName string, n int, startAfter string) string {
+	return acctest.ConfigCompose(testAccObjectsDataSourceConfig_base(rName, n), fmt.Sprintf(`
+data "aws_s3_objects" "test" {
+  bucket      = aws_s3_bucket.test.id
+  start_after = %[1]q
 
-data "aws_s3_objects" "yesh" {
-  bucket      = aws_s3_bucket.objects_bucket.id
-  prefix      = "arch/three_gossips/"
+  depends_on = [aws_s3_object.test1, aws_s3_object.test2, aws_s3_object.test3]
+}
+`, startAfter))
+}
+
+func testAccObjectsDataSourceConfig_owners(rName string, n int) string {
+	return acctest.ConfigCompose(testAccObjectsDataSourceConfig_base(rName, n), `
+data "aws_s3_objects" "test" {
+  bucket      = aws_s3_bucket.test.id
   fetch_owner = true
+
+  depends_on = [aws_s3_object.test1, aws_s3_object.test2, aws_s3_object.test3]
 }
-`, testAccObjectsDataSourceConfig_resources(randInt))
+`)
 }

--- a/internal/service/s3/objects_data_source_test.go
+++ b/internal/service/s3/objects_data_source_test.go
@@ -30,6 +30,7 @@ func TestAccS3ObjectsDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "common_prefixes.#", "0"),
 					resource.TestCheckResourceAttr(dataSourceName, "keys.#", "3"),
 					resource.TestCheckResourceAttr(dataSourceName, "owners.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "request_charged", ""),
 				),
 			},
 		},

--- a/internal/service/s3/service_package.go
+++ b/internal/service/s3/service_package.go
@@ -50,5 +50,6 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 		if endpoint := config["endpoint"].(string); endpoint != "" {
 			o.BaseEndpoint = aws_sdkv2.String(endpoint)
 		}
+		o.UsePathStyle = config["s3_use_path_style"].(bool)
 	}), nil
 }

--- a/internal/service/s3/service_package.go
+++ b/internal/service/s3/service_package.go
@@ -49,6 +49,10 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 	return s3_sdkv2.NewFromConfig(cfg, func(o *s3_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
 			o.BaseEndpoint = aws_sdkv2.String(endpoint)
+		} else if o.Region == endpoints_sdkv1.UsEast1RegionID && config["s3_us_east_1_regional_endpoint"].(endpoints_sdkv1.S3UsEast1RegionalEndpoint) != endpoints_sdkv1.RegionalS3UsEast1Endpoint {
+			// Maintain the AWS SDK for Go v1 default of using the global endpoint in us-east-1.
+			// See https://github.com/hashicorp/terraform-provider-aws/issues/33028.
+			o.Region = "aws-global"
 		}
 		o.UsePathStyle = config["s3_use_path_style"].(bool)
 	}), nil

--- a/internal/service/s3/service_package.go
+++ b/internal/service/s3/service_package.go
@@ -6,6 +6,8 @@ package s3
 import (
 	"context"
 
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	s3_sdkv2 "github.com/aws/aws-sdk-go-v2/service/s3"
 	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
 	endpoints_sdkv1 "github.com/aws/aws-sdk-go/aws/endpoints"
 	request_sdkv1 "github.com/aws/aws-sdk-go/aws/request"
@@ -38,4 +40,15 @@ func (p *servicePackage) CustomizeConn(ctx context.Context, conn *s3_sdkv1.S3) (
 	})
 
 	return conn, nil
+}
+
+// NewClient returns a new AWS SDK for Go v2 client for this service package's AWS API.
+func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (*s3_sdkv2.Client, error) {
+	cfg := *(config["aws_sdkv2_config"].(*aws_sdkv2.Config))
+
+	return s3_sdkv2.NewFromConfig(cfg, func(o *s3_sdkv2.Options) {
+		if endpoint := config["endpoint"].(string); endpoint != "" {
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
+		}
+	}), nil
 }

--- a/internal/service/s3/service_package_gen.go
+++ b/internal/service/s3/service_package_gen.go
@@ -23,7 +23,7 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePackageSDKDataSource {
 	return []*types.ServicePackageSDKDataSource{
 		{
-			Factory:  DataSourceCanonicalUserID,
+			Factory:  dataSourceCanonicalUserID,
 			TypeName: "aws_canonical_user_id",
 		},
 		{

--- a/names/names.go
+++ b/names/names.go
@@ -56,6 +56,7 @@ const (
 	RolesAnywhereEndpointID              = "rolesanywhere"
 	Route53DomainsEndpointID             = "route53domains"
 	SchedulerEndpointID                  = "scheduler"
+	S3EndpointID                         = "s3"
 	SESV2EndpointID                      = "sesv2"
 	SSMEndpointID                        = "ssm"
 	SSMContactsEndpointID                = "ssm-contacts"

--- a/names/names_data.csv
+++ b/names/names_data.csv
@@ -302,7 +302,7 @@ route53-recovery-cluster,route53recoverycluster,route53recoverycluster,route53re
 route53-recovery-control-config,route53recoverycontrolconfig,route53recoverycontrolconfig,route53recoverycontrolconfig,,route53recoverycontrolconfig,,,Route53RecoveryControlConfig,Route53RecoveryControlConfig,x,1,,,aws_route53recoverycontrolconfig_,,route53recoverycontrolconfig_,Route 53 Recovery Control Config,Amazon,,,,,,
 route53-recovery-readiness,route53recoveryreadiness,route53recoveryreadiness,route53recoveryreadiness,,route53recoveryreadiness,,,Route53RecoveryReadiness,Route53RecoveryReadiness,x,1,,,aws_route53recoveryreadiness_,,route53recoveryreadiness_,Route 53 Recovery Readiness,Amazon,,,,,,
 route53resolver,route53resolver,route53resolver,route53resolver,,route53resolver,,,Route53Resolver,Route53Resolver,,1,,aws_route53_resolver_,aws_route53resolver_,,route53_resolver_,Route 53 Resolver,Amazon,,,,,,
-s3api,s3api,s3,s3,,s3,,s3api,S3,S3,x,,2,aws_(canonical_user_id|s3_bucket|s3_object),aws_s3_,,s3_bucket;s3_object;canonical_user_id,S3 (Simple Storage),Amazon,,,,AWS_S3_ENDPOINT,TF_AWS_S3_ENDPOINT,
+s3api,s3api,s3,s3,,s3,,s3api,S3,S3,x,1,2,aws_(canonical_user_id|s3_bucket|s3_object),aws_s3_,,s3_bucket;s3_object;canonical_user_id,S3 (Simple Storage),Amazon,,,,AWS_S3_ENDPOINT,TF_AWS_S3_ENDPOINT,
 s3control,s3control,s3control,s3control,,s3control,,,S3Control,S3Control,,1,2,aws_(s3_account_|s3control_|s3_access_),aws_s3control_,,s3control;s3_account_;s3_access_,S3 Control,Amazon,,,,,,
 glacier,glacier,glacier,glacier,,glacier,,,Glacier,Glacier,,,2,,aws_glacier_,,glacier_,S3 Glacier,Amazon,,,,,,
 s3outposts,s3outposts,s3outposts,s3outposts,,s3outposts,,,S3Outposts,S3Outposts,,1,,,aws_s3outposts_,,s3outposts_,S3 on Outposts,Amazon,,,,,,

--- a/names/names_data.csv
+++ b/names/names_data.csv
@@ -302,7 +302,7 @@ route53-recovery-cluster,route53recoverycluster,route53recoverycluster,route53re
 route53-recovery-control-config,route53recoverycontrolconfig,route53recoverycontrolconfig,route53recoverycontrolconfig,,route53recoverycontrolconfig,,,Route53RecoveryControlConfig,Route53RecoveryControlConfig,x,1,,,aws_route53recoverycontrolconfig_,,route53recoverycontrolconfig_,Route 53 Recovery Control Config,Amazon,,,,,,
 route53-recovery-readiness,route53recoveryreadiness,route53recoveryreadiness,route53recoveryreadiness,,route53recoveryreadiness,,,Route53RecoveryReadiness,Route53RecoveryReadiness,x,1,,,aws_route53recoveryreadiness_,,route53recoveryreadiness_,Route 53 Recovery Readiness,Amazon,,,,,,
 route53resolver,route53resolver,route53resolver,route53resolver,,route53resolver,,,Route53Resolver,Route53Resolver,,1,,aws_route53_resolver_,aws_route53resolver_,,route53_resolver_,Route 53 Resolver,Amazon,,,,,,
-s3api,s3api,s3,s3,,s3,,s3api,S3,S3,x,1,,aws_(canonical_user_id|s3_bucket|s3_object),aws_s3_,,s3_bucket;s3_object;canonical_user_id,S3 (Simple Storage),Amazon,,,,AWS_S3_ENDPOINT,TF_AWS_S3_ENDPOINT,
+s3api,s3api,s3,s3,,s3,,s3api,S3,S3,x,,2,aws_(canonical_user_id|s3_bucket|s3_object),aws_s3_,,s3_bucket;s3_object;canonical_user_id,S3 (Simple Storage),Amazon,,,,AWS_S3_ENDPOINT,TF_AWS_S3_ENDPOINT,
 s3control,s3control,s3control,s3control,,s3control,,,S3Control,S3Control,,1,2,aws_(s3_account_|s3control_|s3_access_),aws_s3control_,,s3control;s3_account_;s3_access_,S3 Control,Amazon,,,,,,
 glacier,glacier,glacier,glacier,,glacier,,,Glacier,Glacier,,,2,,aws_glacier_,,glacier_,S3 Glacier,Amazon,,,,,,
 s3outposts,s3outposts,s3outposts,s3outposts,,s3outposts,,,S3Outposts,S3Outposts,,1,,,aws_s3outposts_,,s3outposts_,S3 on Outposts,Amazon,,,,,,

--- a/website/docs/d/s3_objects.html.markdown
+++ b/website/docs/d/s3_objects.html.markdown
@@ -39,6 +39,7 @@ This data source supports the following arguments:
 * `max_keys` - (Optional) Maximum object keys to return (Default: 1000)
 * `start_after` - (Optional) Returns key names lexicographically after a specific object key in your bucket (Default: none; S3 lists object keys in UTF-8 character encoding in lexicographical order)
 * `fetch_owner` - (Optional) Boolean specifying whether to populate the owner list (Default: false)
+* `request_payer` - (Optional) Confirms that the requester knows that they will be charged for the request. Bucket owners need not specify this parameter in their requests. If included, the only valid value is `requester`.
 
 ## Attribute Reference
 
@@ -48,3 +49,4 @@ This data source exports the following attributes in addition to the arguments a
 * `common_prefixes` - List of any keys between `prefix` and the next occurrence of `delimiter` (i.e., similar to subdirectories of the `prefix` "directory"); the list is only returned when you specify `delimiter`
 * `id` - S3 Bucket.
 * `owners` - List of strings representing object owner IDs (see `fetch_owner` above)
+* `request_charged` - If present, indicates that the requester was successfully charged for the request.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Enable use of [AWS SDK for Go v2](https://github.com/aws/aws-sdk-go-v2) for S3 resources.
Migrate the `aws_canonical_user_id` and `aws_s3_objects` data sources.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/26569.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/33028.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Verified (using the `aws_canonical_user_id` data source) that the defaults for S3 API endpoints have not changed:

```
# SDK v1 us-west-2,s3_us_east_1_regional_endpoint="": http.url=https://s3.us-west-2.amazonaws.com/
# SDK v1 us-west-2,s3_us_east_1_regional_endpoint="legacy": http.url=https://s3.us-west-2.amazonaws.com/
# SDK v1 us-west-2,s3_us_east_1_regional_endpoint="regional": http.url=https://s3.us-west-2.amazonaws.com/
# SDK v1 us-east-1,s3_us_east_1_regional_endpoint="": http.url=https://s3.amazonaws.com/
# SDK v1 us-east-1,s3_us_east_1_regional_endpoint="legacy": http.url=https://s3.amazonaws.com/
# SDK v1 us-east-1,s3_us_east_1_regional_endpoint="regional": http.url=https://s3.us-east-1.amazonaws.com/


# SDK v2 us-west-2,s3_us_east_1_regional_endpoint="": http.url=https://s3.us-west-2.amazonaws.com/
# SDK v2 us-west-2,s3_us_east_1_regional_endpoint="legacy": http.url=https://s3.us-west-2.amazonaws.com/
# SDK v2 us-west-2,s3_us_east_1_regional_endpoint="regional": http.url=https://s3.us-west-2.amazonaws.com/
# SDK v2 us-east-1,s3_us_east_1_regional_endpoint="": http.url=https://s3.amazonaws.com/
# SDK v2 us-east-1,s3_us_east_1_regional_endpoint="legacy": http.url=https://s3.amazonaws.com/
# SDK v2 us-east-1,s3_us_east_1_regional_endpoint="regional": http.url=https://s3.us-east-1.amazonaws.com/
```

```console
% make testacc TESTARGS='-run=TestAccS3CanonicalUserIDDataSource_' PKG=s3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20  -run=TestAccS3CanonicalUserIDDataSource_ -timeout 180m
=== RUN   TestAccS3CanonicalUserIDDataSource_basic
=== PAUSE TestAccS3CanonicalUserIDDataSource_basic
=== CONT  TestAccS3CanonicalUserIDDataSource_basic
--- PASS: TestAccS3CanonicalUserIDDataSource_basic (31.20s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 37.281s
```
```console
% make testacc TESTARGS='-run=TestAccS3ObjectsDataSource_' PKG=s3 ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 3  -run=TestAccS3ObjectsDataSource_ -timeout 180m
=== RUN   TestAccS3ObjectsDataSource_basic
=== PAUSE TestAccS3ObjectsDataSource_basic
=== RUN   TestAccS3ObjectsDataSource_basicViaAccessPoint
=== PAUSE TestAccS3ObjectsDataSource_basicViaAccessPoint
=== RUN   TestAccS3ObjectsDataSource_prefixes
=== PAUSE TestAccS3ObjectsDataSource_prefixes
=== RUN   TestAccS3ObjectsDataSource_encoded
=== PAUSE TestAccS3ObjectsDataSource_encoded
=== RUN   TestAccS3ObjectsDataSource_maxKeys
=== PAUSE TestAccS3ObjectsDataSource_maxKeys
=== RUN   TestAccS3ObjectsDataSource_startAfter
=== PAUSE TestAccS3ObjectsDataSource_startAfter
=== RUN   TestAccS3ObjectsDataSource_fetchOwner
=== PAUSE TestAccS3ObjectsDataSource_fetchOwner
=== CONT  TestAccS3ObjectsDataSource_basic
=== CONT  TestAccS3ObjectsDataSource_maxKeys
=== CONT  TestAccS3ObjectsDataSource_fetchOwner
--- PASS: TestAccS3ObjectsDataSource_basic (48.69s)
=== CONT  TestAccS3ObjectsDataSource_startAfter
--- PASS: TestAccS3ObjectsDataSource_fetchOwner (48.82s)
=== CONT  TestAccS3ObjectsDataSource_prefixes
--- PASS: TestAccS3ObjectsDataSource_maxKeys (87.02s)
=== CONT  TestAccS3ObjectsDataSource_encoded
--- PASS: TestAccS3ObjectsDataSource_startAfter (46.36s)
=== CONT  TestAccS3ObjectsDataSource_basicViaAccessPoint
--- PASS: TestAccS3ObjectsDataSource_prefixes (46.24s)
--- PASS: TestAccS3ObjectsDataSource_encoded (43.09s)
--- PASS: TestAccS3ObjectsDataSource_basicViaAccessPoint (43.34s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	145.202s
```
```console
% make testacc TESTARGS='-run=TestAccS3ObjectsDataSource_maxKeys' PKG=s3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20  -run=TestAccS3ObjectsDataSource_maxKeys -timeout 180m
=== RUN   TestAccS3ObjectsDataSource_maxKeysSmall
=== PAUSE TestAccS3ObjectsDataSource_maxKeysSmall
=== RUN   TestAccS3ObjectsDataSource_maxKeysLarge
=== PAUSE TestAccS3ObjectsDataSource_maxKeysLarge
=== CONT  TestAccS3ObjectsDataSource_maxKeysSmall
=== CONT  TestAccS3ObjectsDataSource_maxKeysLarge
--- PASS: TestAccS3ObjectsDataSource_maxKeysSmall (76.54s)
--- PASS: TestAccS3ObjectsDataSource_maxKeysLarge (232.58s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	238.411s
```
