### PR TITLE
Removes incorrect environment variables from assume role documentation

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -245,27 +245,29 @@ credential_process = custom-process --username jdoe
 |Use DualStack Endpoints|`use_dualstack_endpoint`|`AWS_USE_DUALSTACK_ENDPOINT`|`use_dualstack_endpoint`|
 |Use FIPS Endpoints|`use_fips_endpoint`|`AWS_USE_FIPS_ENDPOINT`|`use_fips_endpoint`|
 
+[envvars]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
+[config]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-settings
+
 ### Assume Role Configuration Reference
 
 Configuation for assuming an IAM role can be done using provider configuration or a named profile in shared configuration files.
 In the provider, all parameters for assuming an IAM role are set in the `assume_role` block.
 
+Note that environment variables are not supported for assuming IAM roles.
+
 See the [assume role documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-role.html) for more information.
 
-|Setting|Provider|[Environment Variable][envvars]|[Shared Config][config]|
-|-------|--------|--------|-----------------------|
-|Role ARN|`role_arn`|`AWS_ROLE_ARN`|`role_arn`|
-|Duration|`duration`|N/A|`duration_seconds`|
-|External ID|`external_id`|N/A|`external_id`|
-|Policy|`policy`|N/A|N/A|
-|Policy ARNs|`policy_arns`|N/A|N/A|
-|Session Name|`session_name`|`AWS_ROLE_SESSION_NAME`|`role_session_name`|
-|Source Identity|`source_identity`|N/A|N/A|
-|Tags|`tags`|N/A|N/A|
-|Transitive Tag Keys|`transitive_tag_keys`|N/A|N/A|
-
-[envvars]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
-[config]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-settings
+|Setting|Provider|[Shared Config][config]|
+|-------|--------|-----------------------|
+|Role ARN|`role_arn`|`role_arn`|
+|Duration|`duration`|`duration_seconds`|
+|External ID|`external_id`|`external_id`|
+|Policy|`policy`|N/A|
+|Policy ARNs|`policy_arns`|N/A|
+|Session Name|`session_name`|`role_session_name`|
+|Source Identity|`source_identity`|N/A|
+|Tags|`tags`|N/A|
+|Transitive Tag Keys|`transitive_tag_keys`|N/A|
 
 ### Assume Role with Web Identity Configuration Reference
 


### PR DESCRIPTION
### Description

The main assume_role configuration does not support environment variables, since they are not supported by the AWS SDK for Go v2. However, assume_role_with_web_identity does support the environment variables.

These were incorrectly added to documentation in https://github.com/hashicorp/terraform-provider-aws/pull/28265, and reported in https://github.com/hashicorp/terraform-provider-aws/issues/27016

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #33313

### Output from Acceptance Testing

N/A