### PR TITLE
Updated aws_dms_endpoint.engine_name possible values w/ redshift-serverless

### DIFF
--- a/.changelog/33316.txt
+++ b/.changelog/33316.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_dms_endpoint: Added redshift-serverless as possible value for `engine_name`
+```

--- a/.changelog/33316.txt
+++ b/.changelog/33316.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_dms_endpoint: Added redshift-serverless as possible value for `engine_name`
+resource/aws_dms_endpoint: Add `redshift-serverless` as valid value for `engine_name`
 ```

--- a/internal/service/dms/consts.go
+++ b/internal/service/dms/consts.go
@@ -48,6 +48,7 @@ const (
 	engineNamePostgres                   = "postgres"
 	engineNameRedis                      = "redis"
 	engineNameRedshift                   = "redshift"
+	engineNameRedshiftServerless         = "redshift-serverless"
 	engineNameS3                         = "s3"
 	engineNameSQLServer                  = "sqlserver"
 	engineNameSybase                     = "sybase"
@@ -79,6 +80,7 @@ func engineName_Values() []string {
 		engineNamePostgres,
 		engineNameRedis,
 		engineNameRedshift,
+		engineNameRedshiftServerless,
 		engineNameS3,
 		engineNameSQLServer,
 		engineNameSybase,


### PR DESCRIPTION
AWS DMS currently supports creating endpoint targets for Redshift Serverless w/ the engine name `redshift-serverless` as seen below:

![image](https://github.com/hashicorp/terraform-provider-aws/assets/54035558/4c65c39a-37eb-45ea-aff8-9b0d82296949)

This pull requests enables `redshift-serverless` as an available option when creating AWS DMS endpoint resources, and the below MvP will successfully deploy an AWS DMS endpoint based on the AWS whitepaper documentation [here](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Target.Redshift.html).

```
terraform {
  required_providers {
    aws = {
      version = ">= 2.7.0"
      source  = "hashicorp/aws"
    }
  }
}

# Create a new endpoint
resource "aws_dms_endpoint" "test" {
  endpoint_id   = "test-dms-endpoint-tf"
  endpoint_type = "target"
  engine_name   = "redshift-serverless"
  username      = "<USERNAME>"
  password      = "<PASSWORD>"
  port          = 5439
  database_name = "<WORKGROUP ENDPOINT>"
  server_name   = "<WORKGROUP ENDPOINT>"
}
```

I based this implementation off of the previous one done for Aurora Serverless here: https://github.com/hashicorp/terraform-provider-aws/pull/21174

Because the Aurora Serverless implementation isn't included in the documentation or tests, I left these out to fit the convention, but please let me know if these should be included! 😄 

Closes https://github.com/hashicorp/terraform-provider-aws/issues/33075.