### PR TITLE
internal/conns: switch to shared VerifyAccountIDAllowed method

### DIFF
--- a/internal/conns/config.go
+++ b/internal/conns/config.go
@@ -65,11 +65,13 @@ func (c *Config) ConfigureProvider(ctx context.Context, client *AWSClient) (*AWS
 
 	awsbaseConfig := awsbase.Config{
 		AccessKey:                     c.AccessKey,
+		AllowedAccountIds:             c.AllowedAccountIds,
 		APNInfo:                       StdUserAgentProducts(c.TerraformVersion),
 		AssumeRoleWithWebIdentity:     c.AssumeRoleWithWebIdentity,
 		CallerDocumentationURL:        "https://registry.terraform.io/providers/hashicorp/aws",
 		CallerName:                    "Terraform AWS Provider",
 		EC2MetadataServiceEnableState: c.EC2MetadataServiceEnableState,
+		ForbiddenAccountIds:           c.ForbiddenAccountIds,
 		IamEndpoint:                   c.Endpoints[names.IAM],
 		Insecure:                      c.Insecure,
 		HTTPClient:                    client.HTTPClient(),
@@ -167,24 +169,9 @@ func (c *Config) ConfigureProvider(ctx context.Context, client *AWSClient) (*AWS
 			"See https://www.terraform.io/docs/providers/aws/index.html#skip_requesting_account_id for implications."))
 	}
 
-	if len(c.ForbiddenAccountIds) > 0 {
-		for _, forbiddenAccountID := range c.ForbiddenAccountIds {
-			if accountID == forbiddenAccountID {
-				return nil, sdkdiag.AppendErrorf(diags, "AWS account ID not allowed: %s", accountID)
-			}
-		}
-	}
-	if len(c.AllowedAccountIds) > 0 {
-		found := false
-		for _, allowedAccountID := range c.AllowedAccountIds {
-			if accountID == allowedAccountID {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return nil, sdkdiag.AppendErrorf(diags, "AWS account ID not allowed: %s", accountID)
-		}
+	err := awsbaseConfig.VerifyAccountIDAllowed(accountID)
+	if err != nil {
+		return nil, sdkdiag.AppendErrorf(diags, err.Error())
 	}
 
 	DNSSuffix := "amazonaws.com"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Bumps `aws-sdk-go-base` dependency and removes custom allowed/forbidden account handling logic in favor of shared base method.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/aws-sdk-go-base/pull/638

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% go test -count=1 ./internal/conns/...
ok      github.com/hashicorp/terraform-provider-aws/internal/conns      0.266s
```

```console
% make sanity ACCTEST_PARALLELISM=10
==> Sanity Check (48 tests of Top 30 resources)
==> Like 'sane' but less output and runs all tests despite most errors
==> NOTE: NOT an exhaustive set of tests! Finds big problems only.
17 of 48 complete: 17 passed, 0 failed
33 of 48 complete: 33 passed, 0 failed
48 of 48 complete: 48 passed, 0 failed
```
