### PR TITLE
Disable module cache for `actions/setup-go` with `golangci/golangci-lint-action`

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           go-version-file: go.mod
+          cache: false
       - id: golangci-lint-version
         working-directory: .ci/tools
         run: >-
@@ -47,6 +48,7 @@ jobs:
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           go-version-file: go.mod
+          cache: false
       - id: golangci-lint-version
         working-directory: .ci/tools
         run: >-


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Disables the module cache for `setup-go` GitHub Actions when used with `golangci/golangci-lint-action`.
This _should_ speedup this workflow.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/33239.