### PR TITLE
Correct typo in d/aws_lambda_function_url

### DIFF
--- a/website/docs/d/lambda_function_url.html.markdown
+++ b/website/docs/d/lambda_function_url.html.markdown
@@ -26,7 +26,7 @@ data "aws_lambda_function_url" "existing" {
 
 This data source supports the following arguments:
 
-* `function_name` - (Required) he name (or ARN) of the Lambda function.
+* `function_name` - (Required) The name (or ARN) of the Lambda function.
 * `qualifier` - (Optional) Alias name or `"$LATEST"`.
 
 ## Attribute Reference


### PR DESCRIPTION
### Description

Quick typo fix `he` -> `The`


### Relations

Closes #33326

### References

N/a

### Output from Acceptance Testing

N/a, docs