### PR TITLE
Added pagination support to DescribeFileSystems in EFS

### DIFF
--- a/.changelog/33336.txt
+++ b/.changelog/33336.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_efs_file_system: Fix `Search returned 0 results` errors when there are more than 101 file systems in the configured Region
+```

--- a/internal/service/efs/file_system_data_source.go
+++ b/internal/service/efs/file_system_data_source.go
@@ -14,7 +14,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 // @SDKDataSource("aws_efs_file_system")
@@ -104,56 +106,29 @@ func dataSourceFileSystemRead(ctx context.Context, d *schema.ResourceData, meta 
 	conn := meta.(*conns.AWSClient).EFSConn(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	tagsToMatch := tftags.New(ctx, d.Get("tags").(map[string]interface{})).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	describeEfsOpts := &efs.DescribeFileSystemsInput{}
+	input := &efs.DescribeFileSystemsInput{}
 
 	if v, ok := d.GetOk("creation_token"); ok {
-		describeEfsOpts.CreationToken = aws.String(v.(string))
+		input.CreationToken = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("file_system_id"); ok {
-		describeEfsOpts.FileSystemId = aws.String(v.(string))
+		input.FileSystemId = aws.String(v.(string))
 	}
 
-	var results []*efs.FileSystemDescription
-	err := conn.DescribeFileSystemsPagesWithContext(
-		ctx,
-		describeEfsOpts,
-		func(page *efs.DescribeFileSystemsOutput, lastPage bool) bool {
-			results = append(results, page.FileSystems...)
-			return true
-		})
+	filter := tfslices.PredicateTrue[*efs.FileSystemDescription]()
+
+	if tagsToMatch := tftags.New(ctx, d.Get("tags").(map[string]interface{})).IgnoreAWS().IgnoreConfig(ignoreTagsConfig); len(tagsToMatch) > 0 {
+		filter = func(v *efs.FileSystemDescription) bool {
+			return KeyValueTags(ctx, v.Tags).ContainsAll(tagsToMatch)
+		}
+	}
+
+	fs, err := findFileSystem(ctx, conn, input, filter)
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "reading EFS FileSystem: %s", err)
+		return sdkdiag.AppendFromErr(diags, tfresource.SingularDataSourceFindError("EFS file system", err))
 	}
-
-	if len(results) == 0 {
-		return sdkdiag.AppendErrorf(diags, "reading EFS FileSystem: empty output")
-	}
-
-	if len(tagsToMatch) > 0 {
-		var fileSystems []*efs.FileSystemDescription
-
-		for _, fileSystem := range results {
-			tags := KeyValueTags(ctx, fileSystem.Tags)
-
-			if !tags.ContainsAll(tagsToMatch) {
-				continue
-			}
-
-			fileSystems = append(fileSystems, fileSystem)
-		}
-
-		results = fileSystems
-	}
-
-	if count := len(results); count != 1 {
-		return sdkdiag.AppendErrorf(diags, "Search returned %d results, please revise so only one is returned", count)
-	}
-
-	fs := results[0]
 
 	d.SetId(aws.StringValue(fs.FileSystemId))
 	d.Set("arn", fs.FileSystemArn)

--- a/internal/service/efs/file_system_data_source_test.go
+++ b/internal/service/efs/file_system_data_source_test.go
@@ -146,7 +146,7 @@ func TestAccEFSFileSystemDataSource_nonExistent_tags(t *testing.T) {
 			},
 			{
 				Config:      testAccFileSystemDataSourceConfig_tagsNonExistent(rName),
-				ExpectError: regexache.MustCompile(`Search returned 0 results`),
+				ExpectError: regexache.MustCompile(`no matching EFS file system found`),
 			},
 		},
 	})


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

When an AWS account has more than 101 EFS resources, If you specify the data source of aws_efs_file_system with a tag, pagination does not work and the resource cannot be found.
This PR changes the DescribeFileSystems used at that time to use pagination.


### Steps to Reproduce

- Create 101+ EFS
  - Tag the oldest resource.
- Create a data source with the oldest resource's tag.

```
data "aws_efs_file_system" "foo" {
  tags = {
    test = "test"
  }
}
```

- terraform apply

#### Before

```
data.aws_efs_file_system.foo: Reading...
╷
│ Error: Search returned 0 results, please revise so only one is returned
│ 
│   with data.aws_efs_file_system.foo,
│   on main.tf line 14, in data "aws_efs_file_system" "foo":
│   14: data "aws_efs_file_system" "foo" {
```

#### After

```
data.aws_efs_file_system.foo: Reading...
data.aws_efs_file_system.foo: Read complete after 2s [id=fs-xxxxxxx]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #26863

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/efs_file_system
https://docs.aws.amazon.com/sdk-for-go/api/service/efs/#EFS.DescribeFileSystemsPagesWithContext

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
 % make testacc TESTS=TestAccEFSFileSystemDataSource_tags PKG=efs                                   (git)-[add-support-efs-describe-fs-pagination] 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/efs/... -v -count 1 -parallel 20 -run='TestAccEFSFileSystemDataSource_tags'  -timeout 180m
=== RUN   TestAccEFSFileSystemDataSource_tags
=== PAUSE TestAccEFSFileSystemDataSource_tags
=== CONT  TestAccEFSFileSystemDataSource_tags
--- PASS: TestAccEFSFileSystemDataSource_tags (34.87s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/efs   

...
```
