### PR TITLE
fix: inspector2_enabler fails to create due to incorrect resource type

### DIFF
--- a/.changelog/33348.txt
+++ b/.changelog/33348.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_inspector2_enabler: Fix fails to create due to incorrect resource type constant
+```

--- a/internal/service/inspector2/enabler.go
+++ b/internal/service/inspector2/enabler.go
@@ -539,6 +539,9 @@ func AccountStatuses(ctx context.Context, conn *inspector2.Client, accountIDs []
 			continue
 		}
 		for k, v := range m {
+			if k == "LambdaCode" {
+				k = "LAMBDA_CODE"
+			}
 			status.ResourceStatuses[types.ResourceScanType(strings.ToUpper(k))] = v.Status
 		}
 		results[aws.ToString(a.AccountId)] = status

--- a/website/docs/r/inspector2_enabler.html.markdown
+++ b/website/docs/r/inspector2_enabler.html.markdown
@@ -41,7 +41,7 @@ The following arguments are required:
 * `account_ids` - (Required) Set of account IDs.
   Can contain one of: the Organization's Administrator Account, or one or more Member Accounts.
 * `resource_types` - (Required) Type of resources to scan.
-  Valid values are `EC2`, `ECR`, and `LAMBDA`.
+  Valid values are `EC2`, `ECR`, `LAMBDA` and `LAMBDA_CODE`.
   At least one item is required.
 
 ## Attribute Reference


### PR DESCRIPTION
### Description
This is the PR for the fix implemented by @irth in this [comment](https://github.com/hashicorp/terraform-provider-aws/issues/32334#issuecomment-1617147692)


### Relations
Closes #32334


### Output from Acceptance Testing
We have tested this locally and without the fix creating the following resource failed.
This is a similar terraform resource also used in the `testAccEnablerConfig_basic` acceptance test, but unfortunately we can currently not run the acceptance test with our current setup.

```terraform
resource "aws_inspector2_enabler" "this" {
  account_ids    = [var.aws_account_id]
  resource_types = ["EC2", "ECR"]
}
```

Output with version 5.15.0:
```console
aws_inspector2_enabler.this: Creating...
aws_inspector2_enabler.this: Still creating... [10s elapsed]
aws_inspector2_enabler.this: Still creating... [20s elapsed]
aws_inspector2_enabler.this: Still creating... [30s elapsed]
aws_inspector2_enabler.this: Still creating... [40s elapsed]
aws_inspector2_enabler.this: Still creating... [50s elapsed]
╷
│ Error: updating Amazon Inspector Enabler (535981463186-EC2:ECR): operation error Inspector2: Disable, https response error StatusCode: 400, RequestID: ****, ValidationException: 1 validation error detected: Value at 'resourceTypes' failed to satisfy constraint: Member must satisfy constraint: [Member must satisfy enum value set: [LAMBDA_CODE, LAMBDA, ECR, EC2]]
│
│   with aws_inspector2_enabler.this,
│   on main.tf line 46, in resource "aws_inspector2_enabler" "this":
│   46: resource "aws_inspector2_enabler" "this" {
│
╵
```

Output with this fix:
```console
aws_inspector2_enabler.this: Creating...
aws_inspector2_enabler.this: Still creating... [10s elapsed]
aws_inspector2_enabler.this: Still creating... [20s elapsed]
aws_inspector2_enabler.this: Still creating... [30s elapsed]
aws_inspector2_enabler.this: Still creating... [40s elapsed]
aws_inspector2_enabler.this: Still creating... [50s elapsed]
aws_inspector2_enabler.this: Still creating... [1m0s elapsed]
aws_inspector2_enabler.this: Still creating... [1m10s elapsed]
aws_inspector2_enabler.this: Creation complete after 1m14s [id=535981463186-EC2:ECR]
```