### PR TITLE
bugfix: can't update iot topic rule with kafka destination

### DIFF
--- a/.changelog/33360.txt
+++ b/.changelog/33360.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_iot_topic_rule: Fix error when updating topic_rule with destination type kafka.
+```

--- a/internal/service/iot/topic_rule.go
+++ b/internal/service/iot/topic_rule.go
@@ -1679,28 +1679,38 @@ func expandKafkaAction(tfList []interface{}) *iot.KafkaAction {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
+	empty := true
 
 	apiObject := &iot.KafkaAction{}
 	tfMap := tfList[0].(map[string]interface{})
 
 	if v, ok := tfMap["client_properties"].(map[string]interface{}); ok && len(v) > 0 {
 		apiObject.ClientProperties = flex.ExpandStringMap(v)
+		empty = false
 	}
 
 	if v, ok := tfMap["destination_arn"].(string); ok && v != "" {
 		apiObject.DestinationArn = aws.String(v)
+		empty = false
 	}
 
 	if v, ok := tfMap["key"].(string); ok && v != "" {
 		apiObject.Key = aws.String(v)
+		empty = false
 	}
 
 	if v, ok := tfMap["partition"].(string); ok && v != "" {
 		apiObject.Partition = aws.String(v)
+		empty = false
 	}
 
 	if v, ok := tfMap["topic"].(string); ok && v != "" {
 		apiObject.Topic = aws.String(v)
+		empty = false
+	}
+
+	if empty {
+		return nil
 	}
 
 	return apiObject

--- a/internal/service/iot/topic_rule_test.go
+++ b/internal/service/iot/topic_rule_test.go
@@ -161,7 +161,7 @@ func TestAccIoTTopicRule_cloudWatchAlarm(t *testing.T) {
 		CheckDestroy:             testAccCheckTopicRuleDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTopicRuleConfig_cloudWatchAlarm(rName),
+				Config: testAccTopicRuleConfig_cloudWatchAlarm(rName, "myalarm"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTopicRuleExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cloudwatch_alarm.#", "1"),
@@ -197,6 +197,38 @@ func TestAccIoTTopicRule_cloudWatchAlarm(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccTopicRuleConfig_cloudWatchAlarm(rName, "differentName"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTopicRuleExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_alarm.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "cloudwatch_alarm.*", map[string]string{
+						"alarm_name":   "differentName",
+						"state_reason": "test",
+						"state_value":  "OK",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_metric.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Example rule"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodbv2.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "elasticsearch.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "error_action.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "firehose.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "http.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "iot_analytics.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "iot_events.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kafka.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kinesis.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "lambda.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "republish.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "s3.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "sns.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "sqs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "step_functions.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "timestream.#", "0"),
+				),
+			},
 		},
 	})
 }
@@ -213,7 +245,7 @@ func TestAccIoTTopicRule_cloudWatchLogs(t *testing.T) {
 		CheckDestroy:             testAccCheckTopicRuleDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTopicRuleConfig_cloudWatchLogs(rName),
+				Config: testAccTopicRuleConfig_cloudWatchLogs(rName, "mylogs1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTopicRuleExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cloudwatch_alarm.#", "0"),
@@ -250,6 +282,39 @@ func TestAccIoTTopicRule_cloudWatchLogs(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccTopicRuleConfig_cloudWatchLogs(rName, "updatedlogs1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTopicRuleExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_alarm.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logs.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "cloudwatch_logs.*", map[string]string{
+						"log_group_name": "updatedlogs1",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "cloudwatch_logs.*", map[string]string{
+						"log_group_name": "mylogs2",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_metric.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodbv2.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "elasticsearch.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "error_action.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "firehose.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "http.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "iot_analytics.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "iot_events.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kafka.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kinesis.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "lambda.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "republish.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "s3.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "sns.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "sqs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "step_functions.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "timestream.#", "0"),
+				),
+			},
 		},
 	})
 }
@@ -266,7 +331,7 @@ func TestAccIoTTopicRule_cloudWatchMetric(t *testing.T) {
 		CheckDestroy:             testAccCheckTopicRuleDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTopicRuleConfig_cloudWatchMetric(rName),
+				Config: testAccTopicRuleConfig_cloudWatchMetric(rName, "TestName"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTopicRuleExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cloudwatch_alarm.#", "0"),
@@ -274,6 +339,38 @@ func TestAccIoTTopicRule_cloudWatchMetric(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "cloudwatch_metric.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "cloudwatch_metric.*", map[string]string{
 						"metric_name":      "TestName",
+						"metric_namespace": "TestNS",
+						"metric_unit":      "s",
+						"metric_value":     "10",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodbv2.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "elasticsearch.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "error_action.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "firehose.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "http.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "iot_analytics.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "iot_events.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kafka.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kinesis.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "lambda.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "republish.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "s3.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "sns.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "sqs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "step_functions.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "timestream.#", "0"),
+				),
+			},
+			{
+				Config: testAccTopicRuleConfig_cloudWatchMetric(rName, "OtherName"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTopicRuleExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_alarm.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_metric.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "cloudwatch_metric.*", map[string]string{
+						"metric_name":      "OtherName",
 						"metric_namespace": "TestNS",
 						"metric_unit":      "s",
 						"metric_value":     "10",
@@ -318,7 +415,7 @@ func TestAccIoTTopicRule_dynamoDB(t *testing.T) {
 		CheckDestroy:             testAccCheckTopicRuleDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTopicRuleConfig_dynamoDB(rName),
+				Config: testAccTopicRuleConfig_dynamoDB(rName, "tn"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTopicRuleExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cloudwatch_alarm.#", "0"),
@@ -356,7 +453,7 @@ func TestAccIoTTopicRule_dynamoDB(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccTopicRuleConfig_dynamoDBRangeKey(rName),
+				Config: testAccTopicRuleConfig_dynamoDBRangeKey(rName, "tn"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTopicRuleExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cloudwatch_alarm.#", "0"),
@@ -408,7 +505,7 @@ func TestAccIoTTopicRule_dynamoDBv2(t *testing.T) {
 		CheckDestroy:             testAccCheckTopicRuleDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTopicRuleConfig_dynamoDBv2(rName),
+				Config: testAccTopicRuleConfig_dynamoDBv2(rName, "test"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTopicRuleExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cloudwatch_alarm.#", "0"),
@@ -419,6 +516,36 @@ func TestAccIoTTopicRule_dynamoDBv2(t *testing.T) {
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "dynamodbv2.*", map[string]string{
 						"put_item.#":            "1",
 						"put_item.0.table_name": "test",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "elasticsearch.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "error_action.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "firehose.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "http.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "iot_analytics.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "iot_events.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kafka.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kinesis.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "lambda.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "republish.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "s3.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "sns.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "sqs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "step_functions.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "timestream.#", "0"),
+				),
+			},
+			{
+				Config: testAccTopicRuleConfig_dynamoDBv2(rName, "updated"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTopicRuleExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_alarm.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_metric.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodbv2.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "dynamodbv2.*", map[string]string{
+						"put_item.#":            "1",
+						"put_item.0.table_name": "updated",
 					}),
 					resource.TestCheckResourceAttr(resourceName, "elasticsearch.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "error_action.#", "0"),
@@ -453,7 +580,7 @@ func TestAccIoTTopicRule_elasticSearch(t *testing.T) {
 		CheckDestroy:             testAccCheckTopicRuleDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTopicRuleConfig_elasticSearch(rName),
+				Config: testAccTopicRuleConfig_elasticSearch(rName, "myindex"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTopicRuleExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cloudwatch_alarm.#", "0"),
@@ -488,6 +615,37 @@ func TestAccIoTTopicRule_elasticSearch(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccTopicRuleConfig_elasticSearch(rName, "updatedindex"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTopicRuleExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_alarm.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_metric.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodbv2.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "elasticsearch.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "elasticsearch.*", map[string]string{
+						"id":    "myIdentifier",
+						"index": "updatedindex",
+						"type":  "mydocument",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "error_action.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "firehose.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "http.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "iot_analytics.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "iot_events.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kafka.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kinesis.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "lambda.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "republish.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "s3.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "sns.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "sqs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "step_functions.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "timestream.#", "0"),
+				),
+			},
 		},
 	})
 }
@@ -504,7 +662,7 @@ func TestAccIoTTopicRule_firehose(t *testing.T) {
 		CheckDestroy:             testAccCheckTopicRuleDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTopicRuleConfig_firehose(rName),
+				Config: testAccTopicRuleConfig_firehose(rName, "mystream1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTopicRuleExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cloudwatch_alarm.#", "0"),
@@ -542,6 +700,41 @@ func TestAccIoTTopicRule_firehose(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{
+				Config: testAccTopicRuleConfig_firehose(rName, "updatedstream1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTopicRuleExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_alarm.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_metric.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodbv2.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "elasticsearch.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "error_action.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "firehose.#", "3"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "firehose.*", map[string]string{
+						"delivery_stream_name": "updatedstream1",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "firehose.*", map[string]string{
+						"delivery_stream_name": "mystream2",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "firehose.*", map[string]string{
+						"delivery_stream_name": "mystream3",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "http.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "iot_analytics.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "iot_events.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kafka.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kinesis.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "lambda.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "republish.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "s3.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "sns.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "sqs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "step_functions.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "timestream.#", "0"),
+				),
 			},
 		},
 	})
@@ -887,7 +1080,7 @@ func TestAccIoTTopicRule_IoT_analytics(t *testing.T) {
 		CheckDestroy:             testAccCheckTopicRuleDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTopicRuleConfig_analytics(rName),
+				Config: testAccTopicRuleConfig_analytics(rName, "fakedata"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTopicRuleExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cloudwatch_alarm.#", "0"),
@@ -902,6 +1095,35 @@ func TestAccIoTTopicRule_IoT_analytics(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "iot_analytics.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "iot_analytics.*", map[string]string{
 						"channel_name": "fakedata",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "iot_events.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kafka.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kinesis.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "lambda.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "republish.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "s3.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "sns.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "sqs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "step_functions.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "timestream.#", "0"),
+				),
+			},
+			{
+				Config: testAccTopicRuleConfig_analytics(rName, "differentdata"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTopicRuleExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_alarm.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_metric.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodbv2.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "elasticsearch.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "error_action.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "firehose.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "http.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "iot_analytics.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "iot_analytics.*", map[string]string{
+						"channel_name": "differentdata",
 					}),
 					resource.TestCheckResourceAttr(resourceName, "iot_events.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "kafka.#", "0"),
@@ -931,7 +1153,7 @@ func TestAccIoTTopicRule_IoT_analytics_batch_mode(t *testing.T) {
 		CheckDestroy:             testAccCheckTopicRuleDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTopicRuleConfig_analytics(rName),
+				Config: testAccTopicRuleConfig_analytics(rName, "fakedata"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTopicRuleExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cloudwatch_alarm.#", "0"),
@@ -1167,6 +1389,40 @@ func TestAccIoTTopicRule_kafka(t *testing.T) {
 			},
 			{
 				Config: testAccTopicRuleConfig_kafka(rName, "different_topic"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTopicRuleExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_alarm.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_metric.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodbv2.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "elasticsearch.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "error_action.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "firehose.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "iot_analytics.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "iot_events.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "http.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kafka.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "kafka.*", map[string]string{
+						"client_properties.%":                     "8",
+						"client_properties.acks":                  "1",
+						"client_properties.bootstrap.servers":     "b-1.localhost:9094",
+						"client_properties.compression.type":      "none",
+						"client_properties.key.serializer":        "org.apache.kafka.common.serialization.StringSerializer",
+						"client_properties.security.protocol":     "SSL",
+						"client_properties.ssl.keystore.password": "password",
+						"client_properties.value.serializer":      "org.apache.kafka.common.serialization.ByteBufferSerializer",
+						"topic":                                   "different_topic",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "kinesis.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "lambda.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "republish.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "s3.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "sns.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "sqs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "step_functions.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "timestream.#", "0"),
+				),
 			},
 			{
 				ResourceName:      resourceName,
@@ -1193,7 +1449,7 @@ func TestAccIoTTopicRule_kinesis(t *testing.T) {
 		CheckDestroy:             testAccCheckTopicRuleDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTopicRuleConfig_kinesis(rName),
+				Config: testAccTopicRuleConfig_kinesis(rName, "mystream"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTopicRuleExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cloudwatch_alarm.#", "0"),
@@ -1211,6 +1467,35 @@ func TestAccIoTTopicRule_kinesis(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "kinesis.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "kinesis.*", map[string]string{
 						"stream_name": "mystream",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "lambda.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "republish.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "s3.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "sns.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "sqs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "step_functions.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "timestream.#", "0"),
+				),
+			},
+			{
+				Config: testAccTopicRuleConfig_kinesis(rName, "otherstream"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTopicRuleExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_alarm.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_metric.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodbv2.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "elasticsearch.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "error_action.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "firehose.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "http.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "iot_analytics.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "iot_events.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kafka.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kinesis.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "kinesis.*", map[string]string{
+						"stream_name": "otherstream",
 					}),
 					resource.TestCheckResourceAttr(resourceName, "lambda.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "republish.#", "0"),
@@ -1288,7 +1573,7 @@ func TestAccIoTTopicRule_republish(t *testing.T) {
 		CheckDestroy:             testAccCheckTopicRuleDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTopicRuleConfig_republish(rName),
+				Config: testAccTopicRuleConfig_republish(rName, "mytopic"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTopicRuleExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cloudwatch_alarm.#", "0"),
@@ -1321,6 +1606,36 @@ func TestAccIoTTopicRule_republish(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{
+				Config: testAccTopicRuleConfig_republish(rName, "othertopic"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTopicRuleExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_alarm.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_metric.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodbv2.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "elasticsearch.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "error_action.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "firehose.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "http.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "iot_analytics.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "iot_events.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kafka.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kinesis.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "lambda.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "republish.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "republish.*", map[string]string{
+						"qos":   "0",
+						"topic": "othertopic",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "s3.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "sns.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "sqs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "step_functions.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "timestream.#", "0"),
+				),
 			},
 		},
 	})
@@ -1388,7 +1703,7 @@ func TestAccIoTTopicRule_s3(t *testing.T) {
 		CheckDestroy:             testAccCheckTopicRuleDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTopicRuleConfig_s3(rName),
+				Config: testAccTopicRuleConfig_s3(rName, "mybucket"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTopicRuleExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cloudwatch_alarm.#", "0"),
@@ -1419,6 +1734,37 @@ func TestAccIoTTopicRule_s3(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccTopicRuleConfig_s3(rName, "yourbucket"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTopicRuleExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_alarm.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_metric.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodbv2.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "elasticsearch.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "error_action.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "firehose.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "http.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "iot_analytics.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "iot_events.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kafka.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kinesis.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "lambda.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "republish.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "s3.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "s3.*", map[string]string{
+						"bucket_name": "yourbucket",
+						"canned_acl":  "private",
+						"key":         "mykey",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "sns.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "sqs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "step_functions.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "timestream.#", "0"),
+				),
+			},
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -1439,7 +1785,7 @@ func TestAccIoTTopicRule_sns(t *testing.T) {
 		CheckDestroy:             testAccCheckTopicRuleDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTopicRuleConfig_sns(rName),
+				Config: testAccTopicRuleConfig_sns(rName, "RAW"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTopicRuleExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cloudwatch_alarm.#", "0"),
@@ -1459,6 +1805,38 @@ func TestAccIoTTopicRule_sns(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "republish.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "s3.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "sns.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "sns.*", map[string]string{
+						"message_format": "RAW",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "sqs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "step_functions.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "timestream.#", "0"),
+				),
+			},
+			{
+				Config: testAccTopicRuleConfig_sns(rName, "JSON"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTopicRuleExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_alarm.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_metric.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodbv2.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "elasticsearch.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "error_action.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "firehose.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "http.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "iot_analytics.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "iot_events.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kafka.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kinesis.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "lambda.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "republish.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "s3.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "sns.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "sns.*", map[string]string{
+						"message_format": "JSON",
+					}),
 					resource.TestCheckResourceAttr(resourceName, "sqs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "step_functions.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "timestream.#", "0"),
@@ -1485,7 +1863,7 @@ func TestAccIoTTopicRule_sqs(t *testing.T) {
 		CheckDestroy:             testAccCheckTopicRuleDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTopicRuleConfig_sqs(rName),
+				Config: testAccTopicRuleConfig_sqs(rName, "fakedata"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTopicRuleExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cloudwatch_alarm.#", "0"),
@@ -1515,6 +1893,36 @@ func TestAccIoTTopicRule_sqs(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccTopicRuleConfig_sqs(rName, "yourdata"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTopicRuleExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_alarm.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_metric.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodbv2.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "elasticsearch.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "error_action.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "firehose.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "http.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "iot_analytics.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "iot_events.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kafka.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kinesis.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "lambda.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "republish.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "s3.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "sns.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "sqs.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "sqs.*", map[string]string{
+						"queue_url":  "yourdata",
+						"use_base64": "false",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "step_functions.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "timestream.#", "0"),
+				),
+			},
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -1535,7 +1943,7 @@ func TestAccIoTTopicRule_Step_functions(t *testing.T) {
 		CheckDestroy:             testAccCheckTopicRuleDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTopicRuleConfig_stepFunctions(rName),
+				Config: testAccTopicRuleConfig_stepFunctions(rName, "mystatemachine"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTopicRuleExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cloudwatch_alarm.#", "0"),
@@ -1565,6 +1973,36 @@ func TestAccIoTTopicRule_Step_functions(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccTopicRuleConfig_stepFunctions(rName, "yourstatemachine"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTopicRuleExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_alarm.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_metric.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodbv2.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "elasticsearch.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "error_action.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "firehose.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "http.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "iot_analytics.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "iot_events.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kafka.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kinesis.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "lambda.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "republish.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "s3.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "sns.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "sqs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "step_functions.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "step_functions.*", map[string]string{
+						"execution_name_prefix": "myprefix",
+						"state_machine_name":    "yourstatemachine",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "timestream.#", "0"),
+				),
+			},
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -1585,7 +2023,7 @@ func TestAccIoTTopicRule_Timestream(t *testing.T) {
 		CheckDestroy:             testAccCheckTopicRuleDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTopicRuleConfig_timestream(rName),
+				Config: testAccTopicRuleConfig_timestream(rName, "dim1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTopicRuleExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cloudwatch_alarm.#", "0"),
@@ -1610,15 +2048,61 @@ func TestAccIoTTopicRule_Timestream(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "timestream.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "timestream.*", map[string]string{
 						"database_name":     "TestDB",
-						"dimension.#":       "1",
+						"dimension.#":       "2",
 						"table_name":        "test_table",
 						"timestamp.#":       "1",
 						"timestamp.0.unit":  "MILLISECONDS",
 						"timestamp.0.value": "${time}",
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "timestream.*.dimension.*", map[string]string{
-						"name":  "dim",
-						"value": "${dim}",
+						"name":  "dim1",
+						"value": "${dim1}",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "timestream.*.dimension.*", map[string]string{
+						"name":  "dim2",
+						"value": "${dim2}",
+					}),
+				),
+			},
+			{
+				Config: testAccTopicRuleConfig_timestream(rName, "dim3"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTopicRuleExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_alarm.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_metric.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodbv2.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "elasticsearch.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "error_action.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "firehose.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "http.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "iot_analytics.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "iot_events.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kafka.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kinesis.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "lambda.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "republish.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "s3.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "sns.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "sqs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "step_functions.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "timestream.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "timestream.*", map[string]string{
+						"database_name":     "TestDB",
+						"dimension.#":       "2",
+						"table_name":        "test_table",
+						"timestamp.#":       "1",
+						"timestamp.0.unit":  "MILLISECONDS",
+						"timestamp.0.value": "${time}",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "timestream.*.dimension.*", map[string]string{
+						"name":  "dim3",
+						"value": "${dim3}",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "timestream.*.dimension.*", map[string]string{
+						"name":  "dim2",
+						"value": "${dim2}",
 					}),
 				),
 			},
@@ -1643,7 +2127,7 @@ func TestAccIoTTopicRule_errorAction(t *testing.T) {
 		CheckDestroy:             testAccCheckTopicRuleDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTopicRuleConfig_errorAction(rName),
+				Config: testAccTopicRuleConfig_kinesisErrorAction(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTopicRuleExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cloudwatch_alarm.#", "0"),
@@ -1713,7 +2197,7 @@ func TestAccIoTTopicRule_updateKinesisErrorAction(t *testing.T) {
 		CheckDestroy:             testAccCheckTopicRuleDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTopicRuleConfig_kinesis(rName),
+				Config: testAccTopicRuleConfig_kinesis(rName, "mystream"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTopicRuleExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cloudwatch_alarm.#", "0"),
@@ -1742,7 +2226,7 @@ func TestAccIoTTopicRule_updateKinesisErrorAction(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTopicRuleConfig_errorAction(rName),
+				Config: testAccTopicRuleConfig_kinesisErrorAction(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTopicRuleExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cloudwatch_alarm.#", "0"),
@@ -1936,7 +2420,7 @@ resource "aws_iot_topic_rule" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccTopicRuleConfig_cloudWatchAlarm(rName string) string {
+func testAccTopicRuleConfig_cloudWatchAlarm(rName string, alarmName string) string {
 	return acctest.ConfigCompose(
 		testAccTopicRuleConfig_destinationRole(rName),
 		fmt.Sprintf(`
@@ -1948,16 +2432,16 @@ resource "aws_iot_topic_rule" "test" {
   sql_version = "2015-10-08"
 
   cloudwatch_alarm {
-    alarm_name   = "myalarm"
+    alarm_name   = "%s"
     role_arn     = aws_iam_role.test.arn
     state_reason = "test"
     state_value  = "OK"
   }
 }
-`, rName))
+`, rName, alarmName))
 }
 
-func testAccTopicRuleConfig_cloudWatchLogs(rName string) string {
+func testAccTopicRuleConfig_cloudWatchLogs(rName string, logGroupName string) string {
 	return acctest.ConfigCompose(
 		testAccTopicRuleConfig_destinationRole(rName),
 		fmt.Sprintf(`
@@ -1968,7 +2452,7 @@ resource "aws_iot_topic_rule" "test" {
   sql_version = "2015-10-08"
 
   cloudwatch_logs {
-    log_group_name = "mylogs1"
+    log_group_name = "%s"
     role_arn       = aws_iam_role.test.arn
   }
 
@@ -1977,10 +2461,10 @@ resource "aws_iot_topic_rule" "test" {
     role_arn       = aws_iam_role.test.arn
   }
 }
-`, rName))
+`, rName, logGroupName))
 }
 
-func testAccTopicRuleConfig_cloudWatchMetric(rName string) string {
+func testAccTopicRuleConfig_cloudWatchMetric(rName string, metricName string) string {
 	return acctest.ConfigCompose(
 		testAccTopicRuleConfig_destinationRole(rName),
 		fmt.Sprintf(`
@@ -1991,17 +2475,17 @@ resource "aws_iot_topic_rule" "test" {
   sql_version = "2015-10-08"
 
   cloudwatch_metric {
-    metric_name      = "TestName"
+    metric_name      = "%s"
     metric_namespace = "TestNS"
     metric_value     = "10"
     metric_unit      = "s"
     role_arn         = aws_iam_role.test.arn
   }
 }
-`, rName))
+`, rName, metricName))
 }
 
-func testAccTopicRuleConfig_dynamoDB(rName string) string {
+func testAccTopicRuleConfig_dynamoDB(rName string, tableName string) string {
 	return acctest.ConfigCompose(
 		testAccTopicRuleConfig_destinationRole(rName),
 		fmt.Sprintf(`
@@ -2017,13 +2501,13 @@ resource "aws_iot_topic_rule" "test" {
     hash_key_value = "hkv"
     payload_field  = "pf"
     role_arn       = aws_iam_role.test.arn
-    table_name     = "tn"
+    table_name     = "%s"
   }
 }
-`, rName))
+`, rName, tableName))
 }
 
-func testAccTopicRuleConfig_dynamoDBRangeKey(rName string) string {
+func testAccTopicRuleConfig_dynamoDBRangeKey(rName string, tableName string) string {
 	return acctest.ConfigCompose(
 		testAccTopicRuleConfig_destinationRole(rName),
 		fmt.Sprintf(`
@@ -2042,14 +2526,14 @@ resource "aws_iot_topic_rule" "test" {
     range_key_value = "rkv"
     range_key_type  = "STRING"
     role_arn        = aws_iam_role.test.arn
-    table_name      = "tn"
+    table_name      = "%s"
     operation       = "INSERT"
   }
 }
-`, rName))
+`, rName, tableName))
 }
 
-func testAccTopicRuleConfig_dynamoDBv2(rName string) string {
+func testAccTopicRuleConfig_dynamoDBv2(rName string, tableName string) string {
 	return acctest.ConfigCompose(
 		testAccTopicRuleConfig_destinationRole(rName),
 		fmt.Sprintf(`
@@ -2061,16 +2545,16 @@ resource "aws_iot_topic_rule" "test" {
 
   dynamodbv2 {
     put_item {
-      table_name = "test"
+      table_name = "%s"
     }
 
     role_arn = aws_iam_role.test.arn
   }
 }
-`, rName))
+`, rName, tableName))
 }
 
-func testAccTopicRuleConfig_elasticSearch(rName string) string {
+func testAccTopicRuleConfig_elasticSearch(rName string, index string) string {
 	return acctest.ConfigCompose(
 		testAccTopicRuleConfig_destinationRole(rName),
 		fmt.Sprintf(`
@@ -2085,15 +2569,15 @@ resource "aws_iot_topic_rule" "test" {
   elasticsearch {
     endpoint = "https://domain.${data.aws_region.current.name}.es.${data.aws_partition.current.dns_suffix}"
     id       = "myIdentifier"
-    index    = "myindex"
+    index    = "%s"
     type     = "mydocument"
     role_arn = aws_iam_role.test.arn
   }
 }
-`, rName))
+`, rName, index))
 }
 
-func testAccTopicRuleConfig_firehose(rName string) string {
+func testAccTopicRuleConfig_firehose(rName string, streamName string) string {
 	return acctest.ConfigCompose(
 		testAccTopicRuleConfig_destinationRole(rName),
 		fmt.Sprintf(`
@@ -2104,7 +2588,7 @@ resource "aws_iot_topic_rule" "test" {
   sql_version = "2015-10-08"
 
   firehose {
-    delivery_stream_name = "mystream1"
+    delivery_stream_name = "%s"
     role_arn             = aws_iam_role.test.arn
   }
 
@@ -2118,7 +2602,7 @@ resource "aws_iot_topic_rule" "test" {
     role_arn             = aws_iam_role.test.arn
   }
 }
-`, rName))
+`, rName, streamName))
 }
 
 func testAccTopicRuleConfig_firehoseSeparator(rName, separator string) string {
@@ -2238,7 +2722,7 @@ resource "aws_iot_topic_rule" "test" {
 `, rName)
 }
 
-func testAccTopicRuleConfig_analytics(rName string) string {
+func testAccTopicRuleConfig_analytics(rName string, channelName string) string {
 	return acctest.ConfigCompose(
 		testAccTopicRuleConfig_destinationRole(rName),
 		fmt.Sprintf(`
@@ -2249,11 +2733,11 @@ resource "aws_iot_topic_rule" "test" {
   sql_version = "2015-10-08"
 
   iot_analytics {
-    channel_name = "fakedata"
+    channel_name = "%s"
     role_arn     = aws_iam_role.test.arn
   }
 }
-`, rName))
+`, rName, channelName))
 }
 
 func testAccTopicRuleConfig_analyticsBatchMode(rName string, batchMode bool) string {
@@ -2348,7 +2832,7 @@ resource "aws_iot_topic_rule" "test" {
 `, rName, topic))
 }
 
-func testAccTopicRuleConfig_kinesis(rName string) string {
+func testAccTopicRuleConfig_kinesis(rName string, streamName string) string {
 	return acctest.ConfigCompose(
 		testAccTopicRuleConfig_destinationRole(rName),
 		fmt.Sprintf(`
@@ -2359,11 +2843,11 @@ resource "aws_iot_topic_rule" "test" {
   sql_version = "2015-10-08"
 
   kinesis {
-    stream_name = "mystream"
+    stream_name = "%s"
     role_arn    = aws_iam_role.test.arn
   }
 }
-`, rName))
+`, rName, streamName))
 }
 
 func testAccTopicRuleConfig_lambda(rName string) string {
@@ -2385,7 +2869,7 @@ resource "aws_iot_topic_rule" "test" {
 `, rName)
 }
 
-func testAccTopicRuleConfig_republish(rName string) string {
+func testAccTopicRuleConfig_republish(rName string, topic string) string {
 	return acctest.ConfigCompose(
 		testAccTopicRuleConfig_destinationRole(rName),
 		fmt.Sprintf(`
@@ -2397,10 +2881,10 @@ resource "aws_iot_topic_rule" "test" {
 
   republish {
     role_arn = aws_iam_role.test.arn
-    topic    = "mytopic"
+    topic    = "%s"
   }
 }
-`, rName))
+`, rName, topic))
 }
 
 func testAccTopicRuleConfig_republishQoS(rName string) string {
@@ -2422,7 +2906,7 @@ resource "aws_iot_topic_rule" "test" {
 `, rName))
 }
 
-func testAccTopicRuleConfig_s3(rName string) string {
+func testAccTopicRuleConfig_s3(rName string, bucketName string) string {
 	return acctest.ConfigCompose(
 		testAccTopicRuleConfig_destinationRole(rName),
 		fmt.Sprintf(`
@@ -2433,16 +2917,16 @@ resource "aws_iot_topic_rule" "test" {
   sql_version = "2015-10-08"
 
   s3 {
-    bucket_name = "mybucket"
+    bucket_name = "%s"
     canned_acl  = "private"
     key         = "mykey"
     role_arn    = aws_iam_role.test.arn
   }
 }
-`, rName))
+`, rName, bucketName))
 }
 
-func testAccTopicRuleConfig_sns(rName string) string {
+func testAccTopicRuleConfig_sns(rName string, messageFormat string) string {
 	return acctest.ConfigCompose(
 		testAccTopicRuleConfig_destinationRole(rName),
 		fmt.Sprintf(`
@@ -2455,14 +2939,15 @@ resource "aws_iot_topic_rule" "test" {
   sql_version = "2015-10-08"
 
   sns {
-    role_arn   = aws_iam_role.test.arn
-    target_arn = "arn:${data.aws_partition.current.partition}:sns:${data.aws_region.current.name}:123456789012:my_corporate_topic"
+	message_format = "%s"
+    role_arn       = aws_iam_role.test.arn
+    target_arn     = "arn:${data.aws_partition.current.partition}:sns:${data.aws_region.current.name}:123456789012:my_corporate_topic"
   }
 }
-`, rName))
+`, rName, messageFormat))
 }
 
-func testAccTopicRuleConfig_sqs(rName string) string {
+func testAccTopicRuleConfig_sqs(rName string, queueUrl string) string {
 	return acctest.ConfigCompose(
 		testAccTopicRuleConfig_destinationRole(rName),
 		fmt.Sprintf(`
@@ -2473,15 +2958,15 @@ resource "aws_iot_topic_rule" "test" {
   sql_version = "2015-10-08"
 
   sqs {
-    queue_url  = "fakedata"
+    queue_url  = "%s"
     role_arn   = aws_iam_role.test.arn
     use_base64 = false
   }
 }
-`, rName))
+`, rName, queueUrl))
 }
 
-func testAccTopicRuleConfig_stepFunctions(rName string) string {
+func testAccTopicRuleConfig_stepFunctions(rName string, smName string) string {
 	return acctest.ConfigCompose(
 		testAccTopicRuleConfig_destinationRole(rName),
 		fmt.Sprintf(`
@@ -2493,14 +2978,14 @@ resource "aws_iot_topic_rule" "test" {
 
   step_functions {
     execution_name_prefix = "myprefix"
-    state_machine_name    = "mystatemachine"
+    state_machine_name    = "%s"
     role_arn              = aws_iam_role.test.arn
   }
 }
-`, rName))
+`, rName, smName))
 }
 
-func testAccTopicRuleConfig_timestream(rName string) string {
+func testAccTopicRuleConfig_timestream(rName string, dimName string) string {
 	return acctest.ConfigCompose(
 		testAccTopicRuleConfig_destinationRole(rName),
 		fmt.Sprintf(`
@@ -2516,8 +3001,13 @@ resource "aws_iot_topic_rule" "test" {
     table_name    = "test_table"
 
     dimension {
-      name  = "dim"
-      value = "$${dim}"
+      name  = "%s"
+      value = "$${%s}"
+    }
+
+    dimension {
+      name  = "dim2"
+      value = "$${dim2}"
     }
 
     timestamp {
@@ -2526,10 +3016,10 @@ resource "aws_iot_topic_rule" "test" {
     }
   }
 }
-`, rName))
+`, rName, dimName, dimName))
 }
 
-func testAccTopicRuleConfig_errorAction(rName string) string {
+func testAccTopicRuleConfig_kinesisErrorAction(rName string) string {
 	return acctest.ConfigCompose(
 		testAccTopicRuleConfig_destinationRole(rName),
 		fmt.Sprintf(`


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
When updating an aws_iot_topic_rule with a destination of type kafka, the `d *schema.ResourceData` passed into the `resourceTopicRuleUpdate` function contains a diff that would create a second `kafka` action, which has all zero/null/empty values for every property. This then fails schema validation, and the update fails.

I fixed it by updating the `expandKafkaAction` function to filter out this erroneous action.

I duplicated the bug with an acceptance test, which failed before my fix, and now passes. I also updated the test coverage for the other action types to include an update.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #24742 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
The source fork is owned by an organization, and as far as I can tell from the linked documentation, that means there's no way to allow maintainers to edit the PR. If I'm wrong on that, and it is possible, let me know.

### Output from Acceptance Testing


```console
% make testacc TESTS=TestAccIoTTopicRule_ PKG=iot
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iot/... -v -count 1 -parallel 20 -run='TestAccIoTTopicRule_'  -timeout 180m
=== RUN   TestAccIoTTopicRule_basic
=== PAUSE TestAccIoTTopicRule_basic
=== RUN   TestAccIoTTopicRule_disappears
=== PAUSE TestAccIoTTopicRule_disappears
=== RUN   TestAccIoTTopicRule_tags
=== PAUSE TestAccIoTTopicRule_tags
=== RUN   TestAccIoTTopicRule_cloudWatchAlarm
=== PAUSE TestAccIoTTopicRule_cloudWatchAlarm
=== RUN   TestAccIoTTopicRule_cloudWatchLogs
=== PAUSE TestAccIoTTopicRule_cloudWatchLogs
=== RUN   TestAccIoTTopicRule_cloudWatchMetric
=== PAUSE TestAccIoTTopicRule_cloudWatchMetric
=== RUN   TestAccIoTTopicRule_dynamoDB
=== PAUSE TestAccIoTTopicRule_dynamoDB
=== RUN   TestAccIoTTopicRule_dynamoDBv2
=== PAUSE TestAccIoTTopicRule_dynamoDBv2
=== RUN   TestAccIoTTopicRule_elasticSearch
=== PAUSE TestAccIoTTopicRule_elasticSearch
=== RUN   TestAccIoTTopicRule_firehose
=== PAUSE TestAccIoTTopicRule_firehose
=== RUN   TestAccIoTTopicRule_Firehose_separator
=== PAUSE TestAccIoTTopicRule_Firehose_separator
=== RUN   TestAccIoTTopicRule_Firehose_batch_mode
=== PAUSE TestAccIoTTopicRule_Firehose_batch_mode
=== RUN   TestAccIoTTopicRule_http
=== PAUSE TestAccIoTTopicRule_http
=== RUN   TestAccIoTTopicRule_IoT_analytics
=== PAUSE TestAccIoTTopicRule_IoT_analytics
=== RUN   TestAccIoTTopicRule_IoT_analytics_batch_mode
=== PAUSE TestAccIoTTopicRule_IoT_analytics_batch_mode
=== RUN   TestAccIoTTopicRule_IoT_events
=== PAUSE TestAccIoTTopicRule_IoT_events
=== RUN   TestAccIoTTopicRule_IoT_events_batch_mode
=== PAUSE TestAccIoTTopicRule_IoT_events_batch_mode
=== RUN   TestAccIoTTopicRule_kafka
=== PAUSE TestAccIoTTopicRule_kafka
=== RUN   TestAccIoTTopicRule_kinesis
=== PAUSE TestAccIoTTopicRule_kinesis
=== RUN   TestAccIoTTopicRule_lambda
=== PAUSE TestAccIoTTopicRule_lambda
=== RUN   TestAccIoTTopicRule_republish
=== PAUSE TestAccIoTTopicRule_republish
=== RUN   TestAccIoTTopicRule_republishWithQos
=== PAUSE TestAccIoTTopicRule_republishWithQos
=== RUN   TestAccIoTTopicRule_s3
=== PAUSE TestAccIoTTopicRule_s3
=== RUN   TestAccIoTTopicRule_sns
=== PAUSE TestAccIoTTopicRule_sns
=== RUN   TestAccIoTTopicRule_sqs
=== PAUSE TestAccIoTTopicRule_sqs
=== RUN   TestAccIoTTopicRule_Step_functions
=== PAUSE TestAccIoTTopicRule_Step_functions
=== RUN   TestAccIoTTopicRule_Timestream
=== PAUSE TestAccIoTTopicRule_Timestream
=== RUN   TestAccIoTTopicRule_errorAction
=== PAUSE TestAccIoTTopicRule_errorAction
=== RUN   TestAccIoTTopicRule_updateKinesisErrorAction
=== PAUSE TestAccIoTTopicRule_updateKinesisErrorAction
=== CONT  TestAccIoTTopicRule_basic
=== CONT  TestAccIoTTopicRule_IoT_events
=== CONT  TestAccIoTTopicRule_updateKinesisErrorAction
=== CONT  TestAccIoTTopicRule_errorAction
=== CONT  TestAccIoTTopicRule_republish
=== CONT  TestAccIoTTopicRule_republishWithQos
=== CONT  TestAccIoTTopicRule_Step_functions
=== CONT  TestAccIoTTopicRule_IoT_events_batch_mode
=== CONT  TestAccIoTTopicRule_sqs
=== CONT  TestAccIoTTopicRule_Timestream
=== CONT  TestAccIoTTopicRule_elasticSearch
=== CONT  TestAccIoTTopicRule_IoT_analytics_batch_mode
=== CONT  TestAccIoTTopicRule_IoT_analytics
=== CONT  TestAccIoTTopicRule_http
=== CONT  TestAccIoTTopicRule_Firehose_batch_mode
=== CONT  TestAccIoTTopicRule_Firehose_separator
=== CONT  TestAccIoTTopicRule_lambda
=== CONT  TestAccIoTTopicRule_kinesis
=== CONT  TestAccIoTTopicRule_kafka
=== CONT  TestAccIoTTopicRule_firehose
--- PASS: TestAccIoTTopicRule_lambda (38.19s)
=== CONT  TestAccIoTTopicRule_cloudWatchLogs
--- PASS: TestAccIoTTopicRule_basic (38.46s)
=== CONT  TestAccIoTTopicRule_dynamoDBv2
--- PASS: TestAccIoTTopicRule_republishWithQos (59.82s)
=== CONT  TestAccIoTTopicRule_dynamoDB
--- PASS: TestAccIoTTopicRule_IoT_events (61.24s)
=== CONT  TestAccIoTTopicRule_cloudWatchMetric
--- PASS: TestAccIoTTopicRule_errorAction (68.46s)
=== CONT  TestAccIoTTopicRule_sns
--- PASS: TestAccIoTTopicRule_IoT_analytics_batch_mode (87.58s)
=== CONT  TestAccIoTTopicRule_tags
--- PASS: TestAccIoTTopicRule_IoT_analytics (88.20s)
=== CONT  TestAccIoTTopicRule_cloudWatchAlarm
--- PASS: TestAccIoTTopicRule_elasticSearch (91.41s)
=== CONT  TestAccIoTTopicRule_s3
--- PASS: TestAccIoTTopicRule_Firehose_batch_mode (91.50s)
=== CONT  TestAccIoTTopicRule_disappears
--- PASS: TestAccIoTTopicRule_updateKinesisErrorAction (92.51s)
--- PASS: TestAccIoTTopicRule_Step_functions (93.61s)
--- PASS: TestAccIoTTopicRule_sqs (93.84s)
--- PASS: TestAccIoTTopicRule_kinesis (93.95s)
--- PASS: TestAccIoTTopicRule_Timestream (94.04s)
--- PASS: TestAccIoTTopicRule_IoT_events_batch_mode (94.22s)
--- PASS: TestAccIoTTopicRule_Firehose_separator (94.99s)
--- PASS: TestAccIoTTopicRule_republish (95.09s)
--- PASS: TestAccIoTTopicRule_firehose (95.11s)
--- PASS: TestAccIoTTopicRule_disappears (23.97s)
--- PASS: TestAccIoTTopicRule_dynamoDBv2 (77.22s)
--- PASS: TestAccIoTTopicRule_cloudWatchLogs (81.02s)
--- PASS: TestAccIoTTopicRule_http (121.75s)
--- PASS: TestAccIoTTopicRule_dynamoDB (70.89s)
--- PASS: TestAccIoTTopicRule_cloudWatchMetric (70.11s)
--- PASS: TestAccIoTTopicRule_kafka (137.49s)
--- PASS: TestAccIoTTopicRule_sns (71.98s)
--- PASS: TestAccIoTTopicRule_cloudWatchAlarm (57.63s)
--- PASS: TestAccIoTTopicRule_s3 (55.61s)
--- PASS: TestAccIoTTopicRule_tags (63.10s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iot	150.778s

...
```
