### PR TITLE
ec2_instance: Add IncorrectSpotRequestRate to wait on for EC2 instance restart

### DIFF
--- a/internal/service/ec2/errors.go
+++ b/internal/service/ec2/errors.go
@@ -88,6 +88,7 @@ const (
 	errCodeInvalidSpotFleetRequestConfig                     = "InvalidSpotFleetRequestConfig"
 	errCodeInvalidSpotFleetRequestIdNotFound                 = "InvalidSpotFleetRequestId.NotFound"
 	errCodeInvalidSpotInstanceRequestIDNotFound              = "InvalidSpotInstanceRequestID.NotFound"
+	errCodeIncorrectSpotRequestRate                          = "IncorrectSpotRequestState"
 	errCodeInvalidSubnetCIDRReservationIDNotFound            = "InvalidSubnetCidrReservationID.NotFound"
 	errCodeInvalidSubnetIDNotFound                           = "InvalidSubnetID.NotFound"
 	errCodeInvalidSubnetIdNotFound                           = "InvalidSubnetId.NotFound"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR adds onto existing logic in `modifyInstanceAttributeWithStopStart` to retry + wait for `IncorrectSpotRequestRate` until the spot request finally transitions to `disabled` state.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #33399