### PR TITLE
lightsail: Fix regex name validation

### DIFF
--- a/.changelog/33405.txt
+++ b/.changelog/33405.txt
@@ -1,0 +1,39 @@
+```release-note:bug
+resource/aws_lightsail_certificate: Fix validation of `name`
+```
+
+```release-note:bug
+resource/aws_lightsail_database: Fix validation of `name`
+```
+
+```release-note:bug
+resource/aws_lightsail_disk: Fix validation of `name`
+```
+
+```release-note:bug
+resource/aws_lightsail_instance: Fix validation of `name`
+```
+
+```release-note:bug
+resource/aws_lightsail_lb: Fix validation of `lb_name`
+```
+
+```release-note:bug
+resource/aws_lightsail_lb_attachment: Fix validation of `lb_name`
+```
+
+```release-note:bug
+resource/aws_lightsail_lb_certificate: Fix validation of `lb_name`
+```
+
+```release-note:bug
+resource/aws_lightsail_lb_certificate_attachment: Fix validation of `lb_name`
+```
+
+```release-note:bug
+resource/aws_lightsail_lb_https_redirection_policy: Fix validation of `lb_name`
+```
+
+```release-note:bug
+resource/aws_lightsail_lb_stickiness_policy: Fix validation of `lb_name`
+```

--- a/internal/service/lightsail/certificate.go
+++ b/internal/service/lightsail/certificate.go
@@ -90,7 +90,7 @@ func ResourceCertificate() *schema.Resource {
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(2, 255),
 					validation.StringMatch(regexache.MustCompile(`^[A-Za-z]`), "must begin with an alphabetic character"),
-					validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]+[_.^-]$`), "must contain only alphanumeric characters, underscores, hyphens, and dots"),
+					validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]+[^_.-]$`), "must contain only alphanumeric characters, underscores, hyphens, and dots"),
 				),
 			},
 			"subject_alternative_names": {

--- a/internal/service/lightsail/database.go
+++ b/internal/service/lightsail/database.go
@@ -165,7 +165,7 @@ func ResourceDatabase() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(2, 255),
-					validation.StringMatch(regexache.MustCompile(`^[_.^-]+[0-9A-Za-z-]+[_.^-]$`), "Must contain from 2 to 255 alphanumeric characters, or hyphens. The first and last character must be a letter or number"),
+					validation.StringMatch(regexache.MustCompile(`^[^_.-]+[0-9A-Za-z-]+[^_.-]$`), "Must contain from 2 to 255 alphanumeric characters, or hyphens. The first and last character must be a letter or number"),
 				),
 			},
 			"secondary_availability_zone": {

--- a/internal/service/lightsail/disk.go
+++ b/internal/service/lightsail/disk.go
@@ -57,7 +57,7 @@ func ResourceDisk() *schema.Resource {
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(2, 255),
 					validation.StringMatch(regexache.MustCompile(`^[A-Za-z]`), "must begin with an alphabetic character"),
-					validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]+[_.^-]$`), "must contain only alphanumeric characters, underscores, hyphens, and dots"),
+					validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]+[^_.-]$`), "must contain only alphanumeric characters, underscores, hyphens, and dots"),
 				),
 			},
 			"size_in_gb": {

--- a/internal/service/lightsail/instance.go
+++ b/internal/service/lightsail/instance.go
@@ -71,7 +71,7 @@ func ResourceInstance() *schema.Resource {
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(2, 255),
 					validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z]`), "must begin with an alphanumeric character"),
-					validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]+[_.^-]$`), "must contain only alphanumeric characters, underscores, hyphens, and dots"),
+					validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]+[^_.-]$`), "must contain only alphanumeric characters, underscores, hyphens, and dots"),
 				),
 			},
 			"availability_zone": {

--- a/internal/service/lightsail/lb.go
+++ b/internal/service/lightsail/lb.go
@@ -85,7 +85,7 @@ func ResourceLoadBalancer() *schema.Resource {
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(2, 255),
 					validation.StringMatch(regexache.MustCompile(`^[A-Za-z]`), "must begin with an alphabetic character"),
-					validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]+[_.^-]$`), "must contain only alphanumeric characters, underscores, hyphens, and dots"),
+					validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]+[^_.-]$`), "must contain only alphanumeric characters, underscores, hyphens, and dots"),
 				),
 			},
 			"support_code": {

--- a/internal/service/lightsail/lb_attachment.go
+++ b/internal/service/lightsail/lb_attachment.go
@@ -41,7 +41,7 @@ func ResourceLoadBalancerAttachment() *schema.Resource {
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(2, 255),
 					validation.StringMatch(regexache.MustCompile(`^[A-Za-z]`), "must begin with an alphabetic character"),
-					validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]+[_.^-]$`), "must contain only alphanumeric characters, underscores, hyphens, and dots"),
+					validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]+[^_.-]$`), "must contain only alphanumeric characters, underscores, hyphens, and dots"),
 				),
 			},
 			"instance_name": {

--- a/internal/service/lightsail/lb_certificate.go
+++ b/internal/service/lightsail/lb_certificate.go
@@ -87,7 +87,7 @@ func ResourceLoadBalancerCertificate() *schema.Resource {
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(2, 255),
 					validation.StringMatch(regexache.MustCompile(`^[A-Za-z]`), "must begin with an alphabetic character"),
-					validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]+[_.^-]$`), "must contain only alphanumeric characters, underscores, hyphens, and dots"),
+					validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]+[^_.-]$`), "must contain only alphanumeric characters, underscores, hyphens, and dots"),
 				),
 			},
 			"name": {
@@ -97,7 +97,7 @@ func ResourceLoadBalancerCertificate() *schema.Resource {
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(2, 255),
 					validation.StringMatch(regexache.MustCompile(`^[A-Za-z]`), "must begin with an alphabetic character"),
-					validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]+[_.^-]$`), "must contain only alphanumeric characters, underscores, hyphens, and dots"),
+					validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]+[^_.-]$`), "must contain only alphanumeric characters, underscores, hyphens, and dots"),
 				),
 			},
 			"subject_alternative_names": {

--- a/internal/service/lightsail/lb_certificate_attachment.go
+++ b/internal/service/lightsail/lb_certificate_attachment.go
@@ -42,7 +42,7 @@ func ResourceLoadBalancerCertificateAttachment() *schema.Resource {
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(2, 255),
 					validation.StringMatch(regexache.MustCompile(`^[A-Za-z]`), "must begin with an alphabetic character"),
-					validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]+[_.^-]$`), "must contain only alphanumeric characters, underscores, hyphens, and dots"),
+					validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]+[^_.-]$`), "must contain only alphanumeric characters, underscores, hyphens, and dots"),
 				),
 			},
 			"certificate_name": {

--- a/internal/service/lightsail/lb_https_redirection_policy.go
+++ b/internal/service/lightsail/lb_https_redirection_policy.go
@@ -45,7 +45,7 @@ func ResourceLoadBalancerHTTPSRedirectionPolicy() *schema.Resource {
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(2, 255),
 					validation.StringMatch(regexache.MustCompile(`^[A-Za-z]`), "must begin with an alphabetic character"),
-					validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]+[_.^-]$`), "must contain only alphanumeric characters, underscores, hyphens, and dots"),
+					validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]+[^_.-]$`), "must contain only alphanumeric characters, underscores, hyphens, and dots"),
 				),
 			},
 		},

--- a/internal/service/lightsail/lb_stickiness_policy.go
+++ b/internal/service/lightsail/lb_stickiness_policy.go
@@ -50,7 +50,7 @@ func ResourceLoadBalancerStickinessPolicy() *schema.Resource {
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(2, 255),
 					validation.StringMatch(regexache.MustCompile(`^[A-Za-z]`), "must begin with an alphabetic character"),
-					validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]+[_.^-]$`), "must contain only alphanumeric characters, underscores, hyphens, and dots"),
+					validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]+[^_.-]$`), "must contain only alphanumeric characters, underscores, hyphens, and dots"),
 				),
 			},
 		},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #33386

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccLightsailCertificate_basic K=lightsail
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lightsail/... -v -count 1 -parallel 20 -run='TestAccLightsailCertificate_basic'  -timeout 180m
=== RUN   TestAccLightsailCertificate_basic
=== PAUSE TestAccLightsailCertificate_basic
=== CONT  TestAccLightsailCertificate_basic
--- PASS: TestAccLightsailCertificate_basic (58.16s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lightsail	59.917s
% make t T=TestAccLightsailDisk K=lightsail P=4
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lightsail/... -v -count 1 -parallel 4 -run='TestAccLightsailDisk'  -timeout 180m
=== RUN   TestAccLightsailDiskAttachment_basic
=== PAUSE TestAccLightsailDiskAttachment_basic
=== RUN   TestAccLightsailDiskAttachment_disappears
=== PAUSE TestAccLightsailDiskAttachment_disappears
=== RUN   TestAccLightsailDisk_basic
=== PAUSE TestAccLightsailDisk_basic
=== RUN   TestAccLightsailDisk_Tags
=== PAUSE TestAccLightsailDisk_Tags
=== RUN   TestAccLightsailDisk_disappears
=== PAUSE TestAccLightsailDisk_disappears
=== CONT  TestAccLightsailDiskAttachment_basic
=== CONT  TestAccLightsailDisk_Tags
=== CONT  TestAccLightsailDisk_basic
=== CONT  TestAccLightsailDisk_disappears
--- PASS: TestAccLightsailDisk_disappears (58.75s)
=== CONT  TestAccLightsailDiskAttachment_disappears
--- PASS: TestAccLightsailDisk_basic (64.33s)
--- PASS: TestAccLightsailDisk_Tags (104.94s)
--- PASS: TestAccLightsailDiskAttachment_basic (239.24s)
--- PASS: TestAccLightsailDiskAttachment_disappears (211.77s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lightsail	272.301s
% make t T=TestAccLightsailInstance_ K=lightsail P=4
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lightsail/... -v -count 1 -parallel 4 -run='TestAccLightsailInstance_'  -timeout 180m
=== RUN   TestAccLightsailInstance_basic
=== PAUSE TestAccLightsailInstance_basic
=== RUN   TestAccLightsailInstance_name
=== PAUSE TestAccLightsailInstance_name
=== RUN   TestAccLightsailInstance_tags
=== PAUSE TestAccLightsailInstance_tags
=== RUN   TestAccLightsailInstance_IPAddressType
=== PAUSE TestAccLightsailInstance_IPAddressType
=== RUN   TestAccLightsailInstance_addOn
=== PAUSE TestAccLightsailInstance_addOn
=== RUN   TestAccLightsailInstance_availabilityZone
    instance_test.go:283: skipping test; environment variable TF_AWS_LIGHTSAIL_AVAILABILITY_ZONE must be set. Usage: The availability zone that is outside the providers current region.
--- SKIP: TestAccLightsailInstance_availabilityZone (0.00s)
=== RUN   TestAccLightsailInstance_disappears
=== PAUSE TestAccLightsailInstance_disappears
=== CONT  TestAccLightsailInstance_basic
=== CONT  TestAccLightsailInstance_IPAddressType
=== CONT  TestAccLightsailInstance_tags
=== CONT  TestAccLightsailInstance_disappears
--- PASS: TestAccLightsailInstance_disappears (71.04s)
=== CONT  TestAccLightsailInstance_addOn
--- PASS: TestAccLightsailInstance_basic (73.07s)
=== CONT  TestAccLightsailInstance_name
--- PASS: TestAccLightsailInstance_tags (95.66s)
--- PASS: TestAccLightsailInstance_IPAddressType (105.65s)
--- PASS: TestAccLightsailInstance_name (199.41s)
--- PASS: TestAccLightsailInstance_addOn (284.76s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lightsail	357.582s
```
