### PR TITLE
r/neptune_cluster: fix ignored kms key on snapshot restore #15240. 

### DIFF
--- a/.changelog/33413.txt
+++ b/.changelog/33413.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_neptune_cluster: fix ignored kms key parameter on restore from db cluster snapshot.
+```

--- a/.changelog/33413.txt
+++ b/.changelog/33413.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_neptune_cluster: fix ignored kms key parameter on restore from db cluster snapshot.
+resource/aws_neptune_cluster: Fix ignored `kms_key_arn` on restore from DB cluster snapshot
 ```

--- a/internal/service/neptune/cluster.go
+++ b/internal/service/neptune/cluster.go
@@ -396,6 +396,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 		v := v.(string)
 
 		inputC.KmsKeyId = aws.String(v)
+		inputR.KmsKeyId = aws.String(v)
 	}
 
 	if v, ok := d.GetOk("neptune_cluster_parameter_group_name"); ok {

--- a/internal/service/neptune/cluster_test.go
+++ b/internal/service/neptune/cluster_test.go
@@ -588,8 +588,8 @@ func TestAccNeptuneCluster_restoreFromSnapshot(t *testing.T) {
 					testAccCheckClusterExists(ctx, resourceName, &dbCluster),
 					resource.TestCheckResourceAttr(resourceName, "backup_retention_period", "5"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_identifier", rName),
-					resource.TestCheckResourceAttrPair(resourceName, "neptune_cluster_parameter_group_name", parameterGroupResourceName, "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "kms_key_arn", keyResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "neptune_cluster_parameter_group_name", parameterGroupResourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
 					resource.TestCheckResourceAttr(resourceName, "vpc_security_group_ids.#", "2"),
@@ -1360,8 +1360,8 @@ resource "aws_neptune_cluster" "source" {
   cluster_identifier                   = "%[1]s-src"
   neptune_cluster_parameter_group_name = "default.neptune1.2"
   skip_final_snapshot                  = true
-  storage_encrypted = true
-  kms_key_arn = aws_kms_key.test1.arn
+  storage_encrypted                    = true
+  kms_key_arn                          = aws_kms_key.test1.arn
 }
 
 resource "aws_neptune_cluster_snapshot" "test" {
@@ -1380,11 +1380,11 @@ resource "aws_neptune_cluster_parameter_group" "test" {
 }
 
 resource "aws_neptune_cluster" "test" {
-  cluster_identifier  = %[1]q
-  skip_final_snapshot = true
-  storage_encrypted = true
-  snapshot_identifier = aws_neptune_cluster_snapshot.test.id
-  kms_key_arn = aws_kms_key.test2.arn
+  cluster_identifier                   = %[1]q
+  skip_final_snapshot                  = true
+  storage_encrypted                    = true
+  snapshot_identifier                  = aws_neptune_cluster_snapshot.test.id
+  kms_key_arn                          = aws_kms_key.test2.arn
   backup_retention_period              = 5
   neptune_cluster_parameter_group_name = aws_neptune_cluster_parameter_group.test.id
   vpc_security_group_ids               = aws_security_group.test[*].id


### PR DESCRIPTION
### Description
The KMS Key parameter is presently ignored when restoring a snapshot to a new cluster.  Users will use this parameter if they want to change the KMS encryption key of the new cluster to be different than that of the key used by the snapshot.  It is also used when a user wants to create a new encrypted cluster from an unencrypted snapshot, per Issue #15240 .

This PR also modifies the existing test for restoring from a snapshot to include the KMS key parameter.

### Relations
Closes #15240.
Closes https://github.com/hashicorp/terraform-provider-aws/pull/15303.

### References
https://docs.aws.amazon.com/neptune/latest/apiref/API_RestoreDBClusterFromSnapshot.html

### Output from Acceptance Testing

```console
$ make testacc TESTS=TestAccNeptuneCluster_restoreFromSnapshot PKG=neptune
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/neptune/... -v -count 1 -parallel 20 -run='TestAccNeptuneCluster_restoreFromSnapshot'  -timeout 180m
=== RUN   TestAccNeptuneCluster_restoreFromSnapshot
=== PAUSE TestAccNeptuneCluster_restoreFromSnapshot
=== CONT  TestAccNeptuneCluster_restoreFromSnapshot
--- PASS: TestAccNeptuneCluster_restoreFromSnapshot (437.43s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/neptune    437.541s
```
