### PR TITLE
aws_servicecatalog_product: import latest `provisioning_artifact_parameters`

### DIFF
--- a/.changelog/33448.txt
+++ b/.changelog/33448.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_servicecatalog_product: Allow import on `provisioning_artifact_parameters` attribute
+```

--- a/internal/service/servicecatalog/find.go
+++ b/internal/service/servicecatalog/find.go
@@ -149,3 +149,24 @@ func FindTagOptionResourceAssociation(ctx context.Context, conn *servicecatalog.
 
 	return result, err
 }
+
+func findProductByID(ctx context.Context, conn *servicecatalog.ServiceCatalog, productID string) (*servicecatalog.DescribeProductAsAdminOutput, error) {
+	in := &servicecatalog.DescribeProductAsAdminInput{
+		Id: aws.String(productID),
+	}
+
+	out, err := conn.DescribeProductAsAdminWithContext(ctx, in)
+
+	if tfawserr.ErrCodeEquals(err, servicecatalog.ErrCodeResourceNotFoundException) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: in,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}

--- a/internal/service/servicecatalog/product.go
+++ b/internal/service/servicecatalog/product.go
@@ -178,7 +178,7 @@ func resourceProductImport(ctx context.Context, d *schema.ResourceData, meta int
 		sort.Slice(productData.ProvisioningArtifactSummaries, func(i, j int) bool {
 			return aws.TimeValue(productData.ProvisioningArtifactSummaries[i].CreatedTime).Before(aws.TimeValue(productData.ProvisioningArtifactSummaries[j].CreatedTime))
 		})
-		
+
 		provisioningArtifact := productData.ProvisioningArtifactSummaries[len(productData.ProvisioningArtifactSummaries)-1]
 		in := &servicecatalog.DescribeProvisioningArtifactInput{
 			ProductId:              aws.String(d.Id()),

--- a/internal/service/servicecatalog/product.go
+++ b/internal/service/servicecatalog/product.go
@@ -474,7 +474,7 @@ func flattenProvisioningArtifactParameters(apiObject *servicecatalog.DescribePro
 
 	m := map[string]interface{}{
 		"description":                 aws.StringValue(apiObject.ProvisioningArtifactDetail.Description),
-		"disable_template_validation": false,
+		"disable_template_validation": false, // set default because it cannot be read
 		"name":                        aws.StringValue(apiObject.ProvisioningArtifactDetail.Name),
 		"type":                        aws.StringValue(apiObject.ProvisioningArtifactDetail.Type),
 	}

--- a/internal/service/servicecatalog/product.go
+++ b/internal/service/servicecatalog/product.go
@@ -6,6 +6,7 @@ package servicecatalog
 import (
 	"context"
 	"log"
+	"sort"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -34,7 +35,7 @@ func ResourceProduct() *schema.Resource {
 		DeleteWithoutTimeout: resourceProductDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceProductImport,
 		},
 
 		Timeouts: &schema.ResourceTimeout{
@@ -161,6 +162,38 @@ func ResourceProduct() *schema.Resource {
 
 		CustomizeDiff: verify.SetTagsDiff,
 	}
+}
+
+func resourceProductImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	conn := meta.(*conns.AWSClient).ServiceCatalogConn(ctx)
+
+	productData, err := findProductByID(ctx, conn, d.Id())
+
+	if err != nil {
+		return []*schema.ResourceData{d}, err
+	}
+
+	sort.Slice(productData.ProvisioningArtifactSummaries, func(i, j int) bool {
+		return aws.TimeValue(productData.ProvisioningArtifactSummaries[i].CreatedTime).Before(aws.TimeValue(productData.ProvisioningArtifactSummaries[j].CreatedTime))
+	})
+
+	// import the last entry in the summary
+	provisioningArtifact := productData.ProvisioningArtifactSummaries[len(productData.ProvisioningArtifactSummaries)-1]
+	in := &servicecatalog.DescribeProvisioningArtifactInput{
+		ProductId:              aws.String(d.Id()),
+		ProvisioningArtifactId: provisioningArtifact.Id,
+	}
+
+	// Find additional artifact details.
+	artifactData, err := conn.DescribeProvisioningArtifactWithContext(ctx, in)
+
+	if err != nil {
+		return []*schema.ResourceData{d}, err
+	}
+
+	d.Set("provisioning_artifact_parameters", flattenProvisioningArtifactParameters(artifactData))
+
+	return []*schema.ResourceData{d}, nil
 }
 
 func resourceProductCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -432,4 +465,29 @@ func expandProvisioningArtifactParameters(tfMap map[string]interface{}) *service
 	}
 
 	return apiObject
+}
+
+func flattenProvisioningArtifactParameters(apiObject *servicecatalog.DescribeProvisioningArtifactOutput) []interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	m := map[string]interface{}{
+		"description":                 aws.StringValue(apiObject.ProvisioningArtifactDetail.Description),
+		"disable_template_validation": false,
+		"name":                        aws.StringValue(apiObject.ProvisioningArtifactDetail.Name),
+		"type":                        aws.StringValue(apiObject.ProvisioningArtifactDetail.Type),
+	}
+
+	if apiObject.Info != nil {
+		if v, ok := apiObject.Info["TemplateUrl"]; ok {
+			m["template_url"] = aws.StringValue(v)
+		}
+
+		if v, ok := apiObject.Info["PhysicalId"]; ok {
+			m["template_physical_id"] = aws.StringValue(v)
+		}
+	}
+
+	return []interface{}{m}
 }

--- a/internal/service/servicecatalog/product_test.go
+++ b/internal/service/servicecatalog/product_test.go
@@ -68,7 +68,7 @@ func TestAccServiceCatalogProduct_basic(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"accept_language",
-					"provisioning_artifact_parameters",
+					"provisioning_artifact_parameters.0.disable_template_validation",
 				},
 			},
 		},
@@ -208,7 +208,7 @@ func TestAccServiceCatalogProduct_physicalID(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"accept_language",
-					"provisioning_artifact_parameters",
+					"provisioning_artifact_parameters.0.disable_template_validation",
 				},
 			},
 		},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Relates #33253

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTARGS='-run=TestAccServiceCatalogProduct_' PKG=servicecatalog

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/servicecatalog/... -v -count 1 -parallel 20  -run=TestAccServiceCatalogProduct_ -timeout 180m
--- PASS: TestAccServiceCatalogProduct_disappears (33.31s)
--- PASS: TestAccServiceCatalogProduct_basic (42.26s)
--- PASS: TestAccServiceCatalogProduct_update (62.14s)
--- PASS: TestAccServiceCatalogProduct_updateTags (63.19s)
--- PASS: TestAccServiceCatalogProduct_physicalID (64.23s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/servicecatalog	67.455s
```
