### PR TITLE
r/aws_elasticache_cluster: fix transit_encryption_enabled for redis

### DIFF
--- a/.changelog/33451.txt
+++ b/.changelog/33451.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_elasticache_cluster: Fix regression for `redis` engine types caused by the new `transit_encryption_enabled` argument
+```

--- a/internal/service/elasticache/cluster.go
+++ b/internal/service/elasticache/cluster.go
@@ -330,7 +330,7 @@ func ResourceCluster() *schema.Resource {
 				Type:     schema.TypeBool,
 				ForceNew: true,
 				Optional: true,
-				Default:  false,
+				Computed: true,
 			},
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
@@ -343,7 +343,6 @@ func ResourceCluster() *schema.Resource {
 			CustomizeDiffValidateClusterNumCacheNodes,
 			CustomizeDiffClusterMemcachedNodeType,
 			CustomizeDiffValidateClusterMemcachedSnapshotIdentifier,
-			CustomizeDiffValidateTransitEncryptionEnabled,
 			verify.SetTagsDiff,
 		),
 	}

--- a/internal/service/elasticache/cluster_test.go
+++ b/internal/service/elasticache/cluster_test.go
@@ -839,6 +839,37 @@ func TestAccElastiCacheCluster_ReplicationGroupID_availabilityZone(t *testing.T)
 	})
 }
 
+func TestAccElastiCacheCluster_ReplicationGroupID_transitEncryption(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var cluster elasticache.CacheCluster
+	var replicationGroup elasticache.ReplicationGroup
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	clusterResourceName := "aws_elasticache_cluster.test"
+	replicationGroupResourceName := "aws_elasticache_replication_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, elasticache.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfig_replicationGroupIDTransitEncryption(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckReplicationGroupExists(ctx, replicationGroupResourceName, &replicationGroup),
+					testAccCheckClusterExists(ctx, clusterResourceName, &cluster),
+					testAccCheckClusterReplicationGroupIDAttribute(&cluster, &replicationGroup),
+					resource.TestCheckResourceAttr(clusterResourceName, "transit_encryption_enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccElastiCacheCluster_ReplicationGroupID_singleReplica(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -1244,12 +1275,12 @@ func TestAccElastiCacheCluster_TransitEncryption(t *testing.T) {
 		CheckDestroy:             testAccCheckClusterDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccClusterConfig_transitEncryption(rName, "memcached", "1.6.11"),
-				ExpectError: regexache.MustCompile(`Transit encryption is not supported for memcached version 1.6.11`),
+				Config:      testAccClusterConfig_transitEncryption(rName, "memcached", "1.6.6"),
+				ExpectError: regexache.MustCompile(`InvalidParameterCombination: Encryption features are not supported for engine version 1.6.6. Please use engine version 1.6.12`),
 			},
 			{
 				Config:      testAccClusterConfig_transitEncryption(rName, "redis", "6.2"),
-				ExpectError: regexache.MustCompile(`aws_elasticache_cluster does not support transit encryption using the redis engine, use aws_elasticache_replication_group instead`),
+				ExpectError: regexache.MustCompile(`InvalidParameterCombination: Encryption feature is not supported for engine REDIS.`),
 			},
 			{
 				Config: testAccClusterConfig_transitEncryption(rName, "memcached", "1.6.12"),
@@ -1955,10 +1986,33 @@ resource "aws_elasticache_replication_group" "test" {
 
 resource "aws_elasticache_cluster" "test" {
   availability_zone    = data.aws_availability_zones.available.names[0]
-  cluster_id           = "%[1]s1"
+  cluster_id           = "%[1]s-1"
   replication_group_id = aws_elasticache_replication_group.test.id
 }
 `, rName))
+}
+
+func testAccClusterConfig_replicationGroupIDTransitEncryption(rName string, enabled bool) string {
+	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
+resource "aws_elasticache_replication_group" "test" {
+  description                = "Terraform Acceptance Testing"
+  replication_group_id       = %[1]q
+  node_type                  = "cache.t3.medium"
+  num_cache_clusters         = 1
+  port                       = 6379
+  transit_encryption_enabled = %[2]t
+
+  lifecycle {
+    ignore_changes = [num_cache_clusters]
+  }
+}
+
+resource "aws_elasticache_cluster" "test" {
+  availability_zone    = data.aws_availability_zones.available.names[0]
+  cluster_id           = "%[1]s-1"
+  replication_group_id = aws_elasticache_replication_group.test.id
+}
+`, rName, enabled))
 }
 
 func testAccClusterConfig_replicationGroupIDReplica(rName string, count int) string {
@@ -1977,7 +2031,7 @@ resource "aws_elasticache_replication_group" "test" {
 
 resource "aws_elasticache_cluster" "test" {
   count                = %[2]d
-  cluster_id           = "%[1]s${count.index}"
+  cluster_id           = "%[1]s-${count.index}"
   replication_group_id = aws_elasticache_replication_group.test.id
 }
 `, rName, count)

--- a/internal/service/elasticache/diff.go
+++ b/internal/service/elasticache/diff.go
@@ -6,14 +6,10 @@ package elasticache
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go/service/elasticache"
-	gversion "github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
-
-var minMemcachedTransitEncryptionVersion = gversion.Must(gversion.NewVersion("1.6.12"))
 
 // CustomizeDiffValidateClusterAZMode validates that `num_cache_nodes` is greater than 1 when `az_mode` is "cross-az"
 func CustomizeDiffValidateClusterAZMode(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
@@ -71,29 +67,5 @@ func CustomizeDiffValidateReplicationGroupAutomaticFailover(_ context.Context, d
 	if v := diff.Get("automatic_failover_enabled").(bool); !v {
 		return errors.New(`automatic_failover_enabled must be true if multi_az_enabled is true`)
 	}
-	return nil
-}
-
-// CustomizeDiffValidateTransitEncryptionEnabled validates that an appropriate engine type and version
-// are utilized when in-transit encryption is enabled
-func CustomizeDiffValidateTransitEncryptionEnabled(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
-	if v, ok := diff.GetOk("transit_encryption_enabled"); ok && v.(bool) {
-		if engine := diff.Get("engine").(string); engine == engineRedis {
-			return errors.New("aws_elasticache_cluster does not support transit encryption using the redis engine, use aws_elasticache_replication_group instead")
-		}
-
-		engineVersion, ok := diff.GetOk("engine_version")
-		if !ok {
-			return nil
-		}
-		version, err := normalizeEngineVersion(engineVersion.(string))
-		if err != nil {
-			return err
-		}
-		if version.LessThan(minMemcachedTransitEncryptionVersion) {
-			return fmt.Errorf("Transit encryption is not supported for memcached version %v", version)
-		}
-	}
-
 	return nil
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Fixes a regression for `redis` engine types caused by the new `transit_encryption_enabled` argument (added in v5.16.0). 

- Removes the default `false` value and makes the argument optional and computed. For `redis` engine types the value will effectively always be computed.
- Removes the `CustomizeDiff` function focused on the `transit_encryption_enabled` attribute, instead relying on the native AWS errors to provide the same feedback.

1. AWS error for minimum supported memcached version check:
```
Error: creating ElastiCache Cache Cluster (jb-test-memcached): InvalidParameterCombination: Encryption features are not supported for engine version 1.6.6. Please use engine version 1.6.12
```
2. AWS error when attempting to create a `redis` cluster with `transit_encryption_enabled` set (must be set on a replication group instead)
```
Error: creating ElastiCache Cache Cluster (jb-test-redis): InvalidParameterCombination: Encryption feature is not supported for engine REDIS.
```
---
Before:

```console
% make testacc PKG=elasticache TESTS=TestAccElastiCacheCluster_ReplicationGroupID_transitEncryption
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheCluster_ReplicationGroupID_transitEncryption'  -timeout 180m
=== RUN   TestAccElastiCacheCluster_ReplicationGroupID_transitEncryption
=== PAUSE TestAccElastiCacheCluster_ReplicationGroupID_transitEncryption
=== CONT  TestAccElastiCacheCluster_ReplicationGroupID_transitEncryption
    cluster_test.go:854: Step 1/1 error: After applying this test step, the plan was not empty.
        stdout:


        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
        -/+ destroy and then create replacement

        Terraform will perform the following actions:

          # aws_elasticache_cluster.test must be replaced
        -/+ resource "aws_elasticache_cluster" "test" {
              + apply_immediately          = (known after apply)
              ~ arn                        = "arn:aws:elasticache:us-west-2:727561393803:cluster:tf-acc-test-2070300389127692534-1" -> (known after 
              <snip>
              ~ transit_encryption_enabled = true -> false # forces replacement
                # (4 unchanged attributes hidden)
            }

        Plan: 1 to add, 0 to change, 1 to destroy.
--- FAIL: TestAccElastiCacheCluster_ReplicationGroupID_transitEncryption (1531.89s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        1535.078s
FAIL
make: *** [testacc] Error 1
```

After:
```console
% make testacc PKG=elasticache TESTS=TestAccElastiCacheCluster_ReplicationGroupID_transitEncryption
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheCluster_ReplicationGroupID_transitEncryption'  -timeout 180m
=== RUN   TestAccElastiCacheCluster_ReplicationGroupID_transitEncryption
=== PAUSE TestAccElastiCacheCluster_ReplicationGroupID_transitEncryption
=== CONT  TestAccElastiCacheCluster_ReplicationGroupID_transitEncryption
--- PASS: TestAccElastiCacheCluster_ReplicationGroupID_transitEncryption (1514.27s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        1517.477s
```


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #33403
Relates #26987

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=elasticache TESTS=TestAccElastiCacheCluster_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheCluster_'  -timeout 180m

=== NAME  TestAccElastiCacheCluster_outpost_memcached
    acctest.go:1102: skipping since no Outposts found
--- SKIP: TestAccElastiCacheCluster_outpost_memcached (1.19s)
=== CONT  TestAccElastiCacheCluster_outpostID_memcached
=== NAME  TestAccElastiCacheCluster_outpostID_redis
    acctest.go:1102: skipping since no Outposts found
--- SKIP: TestAccElastiCacheCluster_outpostID_redis (1.19s)
=== CONT  TestAccElastiCacheCluster_Engine_redis_v5
=== NAME  TestAccElastiCacheCluster_outpostID_memcached
    acctest.go:1102: skipping since no Outposts found
--- SKIP: TestAccElastiCacheCluster_outpostID_memcached (0.21s)
=== CONT  TestAccElastiCacheCluster_outpost_redis
    acctest.go:1102: skipping since no Outposts found
--- SKIP: TestAccElastiCacheCluster_outpost_redis (0.24s)
=== CONT  TestAccElastiCacheCluster_Engine_redis
--- PASS: TestAccElastiCacheCluster_Engine_None (5.37s)
=== CONT  TestAccElastiCacheCluster_AZMode_redis
--- PASS: TestAccElastiCacheCluster_NumCacheNodes_redis (7.26s)
=== CONT  TestAccElastiCacheCluster_NumCacheNodes_increaseWithPreferredAvailabilityZones
--- PASS: TestAccElastiCacheCluster_Memcached_finalSnapshot (8.33s)
=== CONT  TestAccElastiCacheCluster_vpc
--- PASS: TestAccElastiCacheCluster_PortRedis_default (636.76s)
=== CONT  TestAccElastiCacheCluster_NumCacheNodes_increase
--- PASS: TestAccElastiCacheCluster_ParameterGroupName_default (646.86s)
=== CONT  TestAccElastiCacheCluster_multiAZInVPC
--- PASS: TestAccElastiCacheCluster_Engine_memcached (648.00s)
=== CONT  TestAccElastiCacheCluster_tagWithOtherModification
--- PASS: TestAccElastiCacheCluster_AZMode_memcached (648.73s)
=== CONT  TestAccElastiCacheCluster_port
--- PASS: TestAccElastiCacheCluster_vpc (678.33s)
=== CONT  TestAccElastiCacheCluster_TransitEncryption
--- PASS: TestAccElastiCacheCluster_Engine_redis (688.60s)
=== CONT  TestAccElastiCacheCluster_snapshotsWithUpdates
--- PASS: TestAccElastiCacheCluster_AZMode_redis (684.99s)
=== CONT  TestAccElastiCacheCluster_ipDiscovery
--- PASS: TestAccElastiCacheCluster_Engine_redis_v5 (689.28s)
=== CONT  TestAccElastiCacheCluster_tags
--- PASS: TestAccElastiCacheCluster_Redis_autoMinorVersionUpgrade (731.40s)
=== CONT  TestAccElastiCacheCluster_Engine_Redis_LogDeliveryConfigurations
--- PASS: TestAccElastiCacheCluster_Redis_finalSnapshot (863.89s)
--- PASS: TestAccElastiCacheCluster_NumCacheNodes_decrease (1018.98s)
--- PASS: TestAccElastiCacheCluster_NumCacheNodes_increaseWithPreferredAvailabilityZones (1121.49s)
--- PASS: TestAccElastiCacheCluster_NodeTypeResize_memcached (1279.97s)
--- PASS: TestAccElastiCacheCluster_port (661.43s)
--- PASS: TestAccElastiCacheCluster_tags (655.83s)
--- PASS: TestAccElastiCacheCluster_TransitEncryption (681.01s)
--- PASS: TestAccElastiCacheCluster_ipDiscovery (690.48s)
--- PASS: TestAccElastiCacheCluster_snapshotsWithUpdates (701.79s)
--- PASS: TestAccElastiCacheCluster_EngineVersion_memcached (1415.89s)
--- PASS: TestAccElastiCacheCluster_multiAZInVPC (771.79s)
--- PASS: TestAccElastiCacheCluster_tagWithOtherModification (784.74s)
--- PASS: TestAccElastiCacheCluster_ReplicationGroupID_multipleReplica (1461.48s)
--- PASS: TestAccElastiCacheCluster_ReplicationGroupID_singleReplica (1462.17s)
--- PASS: TestAccElastiCacheCluster_ReplicationGroupID_availabilityZone (1484.05s)
--- PASS: TestAccElastiCacheCluster_NodeTypeResize_redis (1519.63s)
--- PASS: TestAccElastiCacheCluster_ReplicationGroupID_transitEncryption (1621.69s)
--- PASS: TestAccElastiCacheCluster_NumCacheNodes_increase (1138.01s)
--- PASS: TestAccElastiCacheCluster_Engine_Redis_LogDeliveryConfigurations (1169.97s)
--- PASS: TestAccElastiCacheCluster_EngineVersion_redis (3255.14s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        3258.282s
```
