### PR TITLE
r/aws_s3_bucket: Migrate `FindBucket` to AWS SDK for Go v2

### DIFF
--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"time"
 
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	s3_sdkv2 "github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
@@ -22,6 +24,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	tfawserr_sdkv2 "github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -698,15 +701,15 @@ func ResourceBucket() *schema.Resource {
 func resourceBucketCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Conn(ctx)
+	connSDKv2 := meta.(*conns.AWSClient).S3Client(ctx)
 
 	bucket := create.Name(d.Get("bucket").(string), d.Get("bucket_prefix").(string))
-
 	awsRegion := meta.(*conns.AWSClient).Region
 
 	// Special case: us-east-1 does not return error if the bucket already exists and is owned by
 	// current account. It also resets the Bucket ACLs.
 	if awsRegion == endpoints.UsEast1RegionID {
-		if err := FindBucketV1(ctx, conn, bucket); err == nil {
+		if err := FindBucket(ctx, connSDKv2, bucket); err == nil {
 			return create.DiagError(names.S3, create.ErrActionCreating, resNameBucket, bucket, errors.New(ErrMessageBucketAlreadyExists))
 		}
 	}
@@ -759,7 +762,7 @@ func resourceBucketCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	d.SetId(bucket)
 
 	_, err = tfresource.RetryWhenNotFound(ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
-		return nil, FindBucketV1(ctx, conn, d.Id())
+		return nil, FindBucket(ctx, connSDKv2, d.Id())
 	})
 
 	if err != nil {
@@ -772,8 +775,9 @@ func resourceBucketCreate(ctx context.Context, d *schema.ResourceData, meta inte
 func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Conn(ctx)
+	connSDKv2 := meta.(*conns.AWSClient).S3Client(ctx)
 
-	err := FindBucketV1(ctx, conn, d.Id())
+	err := FindBucket(ctx, connSDKv2, d.Id())
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] S3 Bucket (%s) not found, removing from state", d.Id())
@@ -1365,6 +1369,7 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 
 func resourceBucketDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).S3Conn(ctx)
+	connSDKv2 := meta.(*conns.AWSClient).S3Client(ctx)
 
 	log.Printf("[INFO] Deleting S3 Bucket: %s", d.Id())
 	_, err := conn.DeleteBucketWithContext(ctx, &s3.DeleteBucketInput{
@@ -1409,7 +1414,7 @@ func resourceBucketDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	_, err = tfresource.RetryUntilNotFound(ctx, 1*time.Minute, func() (interface{}, error) {
-		return nil, FindBucketV1(ctx, conn, d.Id())
+		return nil, FindBucket(ctx, connSDKv2, d.Id())
 	})
 
 	if err != nil {
@@ -1419,14 +1424,14 @@ func resourceBucketDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	return nil
 }
 
-func FindBucketV1(ctx context.Context, conn *s3.S3, bucket string) error {
-	input := &s3.HeadBucketInput{
-		Bucket: aws.String(bucket),
+func FindBucket(ctx context.Context, conn *s3_sdkv2.Client, bucket string) error {
+	input := &s3_sdkv2.HeadBucketInput{
+		Bucket: aws_sdkv2.String(bucket),
 	}
 
-	_, err := conn.HeadBucketWithContext(ctx, input)
+	_, err := conn.HeadBucket(ctx, input)
 
-	if tfawserr.ErrStatusCodeEquals(err, http.StatusNotFound) || tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket) {
+	if tfawserr_sdkv2.ErrHTTPStatusCodeEquals(err, http.StatusNotFound) || tfawserr_sdkv2.ErrCodeEquals(err, errCodeNoSuchBucket) {
 		return &retry.NotFoundError{
 			LastError:   err,
 			LastRequest: input,

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -709,7 +709,7 @@ func resourceBucketCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	// Special case: us-east-1 does not return error if the bucket already exists and is owned by
 	// current account. It also resets the Bucket ACLs.
 	if awsRegion == endpoints.UsEast1RegionID {
-		if err := FindBucket(ctx, connSDKv2, bucket); err == nil {
+		if err := findBucket(ctx, connSDKv2, bucket); err == nil {
 			return create.DiagError(names.S3, create.ErrActionCreating, resNameBucket, bucket, errors.New(ErrMessageBucketAlreadyExists))
 		}
 	}
@@ -762,7 +762,7 @@ func resourceBucketCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	d.SetId(bucket)
 
 	_, err = tfresource.RetryWhenNotFound(ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
-		return nil, FindBucket(ctx, connSDKv2, d.Id())
+		return nil, findBucket(ctx, connSDKv2, d.Id())
 	})
 
 	if err != nil {
@@ -777,7 +777,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 	conn := meta.(*conns.AWSClient).S3Conn(ctx)
 	connSDKv2 := meta.(*conns.AWSClient).S3Client(ctx)
 
-	err := FindBucket(ctx, connSDKv2, d.Id())
+	err := findBucket(ctx, connSDKv2, d.Id())
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] S3 Bucket (%s) not found, removing from state", d.Id())
@@ -1414,7 +1414,7 @@ func resourceBucketDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	_, err = tfresource.RetryUntilNotFound(ctx, 1*time.Minute, func() (interface{}, error) {
-		return nil, FindBucket(ctx, connSDKv2, d.Id())
+		return nil, findBucket(ctx, connSDKv2, d.Id())
 	})
 
 	if err != nil {
@@ -1424,7 +1424,7 @@ func resourceBucketDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	return nil
 }
 
-func FindBucket(ctx context.Context, conn *s3_sdkv2.Client, bucket string) error {
+func findBucket(ctx context.Context, conn *s3_sdkv2.Client, bucket string) error {
 	input := &s3_sdkv2.HeadBucketInput{
 		Bucket: aws_sdkv2.String(bucket),
 	}

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -706,7 +706,7 @@ func resourceBucketCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	// Special case: us-east-1 does not return error if the bucket already exists and is owned by
 	// current account. It also resets the Bucket ACLs.
 	if awsRegion == endpoints.UsEast1RegionID {
-		if err := FindBucket(ctx, conn, bucket); err == nil {
+		if err := FindBucketV1(ctx, conn, bucket); err == nil {
 			return create.DiagError(names.S3, create.ErrActionCreating, resNameBucket, bucket, errors.New(ErrMessageBucketAlreadyExists))
 		}
 	}
@@ -759,7 +759,7 @@ func resourceBucketCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	d.SetId(bucket)
 
 	_, err = tfresource.RetryWhenNotFound(ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
-		return nil, FindBucket(ctx, conn, d.Id())
+		return nil, FindBucketV1(ctx, conn, d.Id())
 	})
 
 	if err != nil {
@@ -773,7 +773,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Conn(ctx)
 
-	err := FindBucket(ctx, conn, d.Id())
+	err := FindBucketV1(ctx, conn, d.Id())
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] S3 Bucket (%s) not found, removing from state", d.Id())
@@ -1409,7 +1409,7 @@ func resourceBucketDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	_, err = tfresource.RetryUntilNotFound(ctx, 1*time.Minute, func() (interface{}, error) {
-		return nil, FindBucket(ctx, conn, d.Id())
+		return nil, FindBucketV1(ctx, conn, d.Id())
 	})
 
 	if err != nil {
@@ -1419,7 +1419,7 @@ func resourceBucketDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	return nil
 }
 
-func FindBucket(ctx context.Context, conn *s3.S3, bucket string) error {
+func FindBucketV1(ctx context.Context, conn *s3.S3, bucket string) error {
 	input := &s3.HeadBucketInput{
 		Bucket: aws.String(bucket),
 	}

--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -2559,7 +2559,7 @@ func testAccCheckBucketDestroyWithProvider(ctx context.Context) acctest.TestChec
 				continue
 			}
 
-			err := tfs3.FindBucket(ctx, conn, rs.Primary.ID)
+			err := tfs3.FindBucketV1(ctx, conn, rs.Primary.ID)
 
 			if tfresource.NotFound(err) {
 				continue
@@ -2593,7 +2593,7 @@ func testAccCheckBucketExistsWithProvider(ctx context.Context, n string, provide
 
 		conn := providerF().Meta().(*conns.AWSClient).S3Conn(ctx)
 
-		return tfs3.FindBucket(ctx, conn, rs.Primary.ID)
+		return tfs3.FindBucketV1(ctx, conn, rs.Primary.ID)
 	}
 }
 

--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -2552,14 +2552,14 @@ func testAccCheckBucketDestroy(ctx context.Context) resource.TestCheckFunc {
 
 func testAccCheckBucketDestroyWithProvider(ctx context.Context) acctest.TestCheckWithProviderFunc {
 	return func(s *terraform.State, provider *schema.Provider) error {
-		conn := provider.Meta().(*conns.AWSClient).S3Conn(ctx)
+		conn := provider.Meta().(*conns.AWSClient).S3Client(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_s3_bucket" {
 				continue
 			}
 
-			err := tfs3.FindBucketV1(ctx, conn, rs.Primary.ID)
+			err := tfs3.FindBucket(ctx, conn, rs.Primary.ID)
 
 			if tfresource.NotFound(err) {
 				continue
@@ -2591,9 +2591,9 @@ func testAccCheckBucketExistsWithProvider(ctx context.Context, n string, provide
 			return fmt.Errorf("No S3 Bucket ID is set")
 		}
 
-		conn := providerF().Meta().(*conns.AWSClient).S3Conn(ctx)
+		conn := providerF().Meta().(*conns.AWSClient).S3Client(ctx)
 
-		return tfs3.FindBucketV1(ctx, conn, rs.Primary.ID)
+		return tfs3.FindBucket(ctx, conn, rs.Primary.ID)
 	}
 }
 

--- a/internal/service/s3/exports_test.go
+++ b/internal/service/s3/exports_test.go
@@ -7,6 +7,7 @@ package s3
 var (
 	DeleteAllObjectVersions           = deleteAllObjectVersions
 	EmptyBucket                       = emptyBucket
+	FindBucket                        = findBucket
 	FindBucketAccelerateConfiguration = findBucketAccelerateConfiguration
 	FindBucketPolicy                  = findBucketPolicy
 	FindBucketVersioning              = findBucketVersioning


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Migrates the `FindBucket` helper function used by the `aws_s3_bucket` resource to AWS SDK for Go v2.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/33431.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/33358.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/33330.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/33304.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccS3Bucket_' PKG=s3 ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 2  -run=TestAccS3Bucket_ -timeout 180m
=== RUN   TestAccS3Bucket_Basic_basic
=== PAUSE TestAccS3Bucket_Basic_basic
=== RUN   TestAccS3Bucket_Basic_emptyString
=== PAUSE TestAccS3Bucket_Basic_emptyString
=== RUN   TestAccS3Bucket_Basic_generatedName
=== PAUSE TestAccS3Bucket_Basic_generatedName
=== RUN   TestAccS3Bucket_Basic_namePrefix
=== PAUSE TestAccS3Bucket_Basic_namePrefix
=== RUN   TestAccS3Bucket_Basic_forceDestroy
=== PAUSE TestAccS3Bucket_Basic_forceDestroy
=== RUN   TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes
=== PAUSE TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes
=== RUN   TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled
=== PAUSE TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled
=== RUN   TestAccS3Bucket_Basic_acceleration
=== PAUSE TestAccS3Bucket_Basic_acceleration
=== RUN   TestAccS3Bucket_Basic_keyEnabled
=== PAUSE TestAccS3Bucket_Basic_keyEnabled
=== RUN   TestAccS3Bucket_Basic_requestPayer
=== PAUSE TestAccS3Bucket_Basic_requestPayer
=== RUN   TestAccS3Bucket_disappears
=== PAUSE TestAccS3Bucket_disappears
=== RUN   TestAccS3Bucket_Duplicate_basic
=== PAUSE TestAccS3Bucket_Duplicate_basic
=== RUN   TestAccS3Bucket_Duplicate_UsEast1
=== PAUSE TestAccS3Bucket_Duplicate_UsEast1
=== RUN   TestAccS3Bucket_Duplicate_UsEast1AltAccount
=== PAUSE TestAccS3Bucket_Duplicate_UsEast1AltAccount
=== RUN   TestAccS3Bucket_Tags_basic
=== PAUSE TestAccS3Bucket_Tags_basic
=== RUN   TestAccS3Bucket_Tags_withNoSystemTags
=== PAUSE TestAccS3Bucket_Tags_withNoSystemTags
=== RUN   TestAccS3Bucket_Tags_withSystemTags
=== PAUSE TestAccS3Bucket_Tags_withSystemTags
=== RUN   TestAccS3Bucket_Tags_ignoreTags
=== PAUSE TestAccS3Bucket_Tags_ignoreTags
=== RUN   TestAccS3Bucket_Manage_lifecycleBasic
=== PAUSE TestAccS3Bucket_Manage_lifecycleBasic
=== RUN   TestAccS3Bucket_Manage_lifecycleExpireMarkerOnly
=== PAUSE TestAccS3Bucket_Manage_lifecycleExpireMarkerOnly
=== RUN   TestAccS3Bucket_Manage_lifecycleRuleExpirationEmptyBlock
=== PAUSE TestAccS3Bucket_Manage_lifecycleRuleExpirationEmptyBlock
=== RUN   TestAccS3Bucket_Manage_lifecycleRuleAbortIncompleteMultipartUploadDaysNoExpiration
=== PAUSE TestAccS3Bucket_Manage_lifecycleRuleAbortIncompleteMultipartUploadDaysNoExpiration
=== RUN   TestAccS3Bucket_Manage_lifecycleRemove
=== PAUSE TestAccS3Bucket_Manage_lifecycleRemove
=== RUN   TestAccS3Bucket_Manage_objectLock
=== PAUSE TestAccS3Bucket_Manage_objectLock
=== RUN   TestAccS3Bucket_Manage_objectLock_deprecatedEnabled
=== PAUSE TestAccS3Bucket_Manage_objectLock_deprecatedEnabled
=== RUN   TestAccS3Bucket_Manage_objectLock_migrate
=== PAUSE TestAccS3Bucket_Manage_objectLock_migrate
=== RUN   TestAccS3Bucket_Manage_objectLockWithVersioning
=== PAUSE TestAccS3Bucket_Manage_objectLockWithVersioning
=== RUN   TestAccS3Bucket_Manage_objectLockWithVersioning_deprecatedEnabled
=== PAUSE TestAccS3Bucket_Manage_objectLockWithVersioning_deprecatedEnabled
=== RUN   TestAccS3Bucket_Manage_versioning
=== PAUSE TestAccS3Bucket_Manage_versioning
=== RUN   TestAccS3Bucket_Manage_versioningDisabled
=== PAUSE TestAccS3Bucket_Manage_versioningDisabled
=== RUN   TestAccS3Bucket_Manage_MFADeleteDisabled
=== PAUSE TestAccS3Bucket_Manage_MFADeleteDisabled
=== RUN   TestAccS3Bucket_Manage_versioningAndMFADeleteDisabled
=== PAUSE TestAccS3Bucket_Manage_versioningAndMFADeleteDisabled
=== RUN   TestAccS3Bucket_Replication_basic
=== PAUSE TestAccS3Bucket_Replication_basic
=== RUN   TestAccS3Bucket_Replication_multipleDestinationsEmptyFilter
=== PAUSE TestAccS3Bucket_Replication_multipleDestinationsEmptyFilter
=== RUN   TestAccS3Bucket_Replication_multipleDestinationsNonEmptyFilter
=== PAUSE TestAccS3Bucket_Replication_multipleDestinationsNonEmptyFilter
=== RUN   TestAccS3Bucket_Replication_twoDestination
=== PAUSE TestAccS3Bucket_Replication_twoDestination
=== RUN   TestAccS3Bucket_Replication_ruleDestinationAccessControlTranslation
=== PAUSE TestAccS3Bucket_Replication_ruleDestinationAccessControlTranslation
=== RUN   TestAccS3Bucket_Replication_ruleDestinationAddAccessControlTranslation
=== PAUSE TestAccS3Bucket_Replication_ruleDestinationAddAccessControlTranslation
=== RUN   TestAccS3Bucket_Replication_withoutStorageClass
=== PAUSE TestAccS3Bucket_Replication_withoutStorageClass
=== RUN   TestAccS3Bucket_Replication_expectVersioningValidationError
=== PAUSE TestAccS3Bucket_Replication_expectVersioningValidationError
=== RUN   TestAccS3Bucket_Replication_withoutPrefix
=== PAUSE TestAccS3Bucket_Replication_withoutPrefix
=== RUN   TestAccS3Bucket_Replication_schemaV2
=== PAUSE TestAccS3Bucket_Replication_schemaV2
=== RUN   TestAccS3Bucket_Replication_schemaV2SameRegion
=== PAUSE TestAccS3Bucket_Replication_schemaV2SameRegion
=== RUN   TestAccS3Bucket_Replication_RTC_valid
=== PAUSE TestAccS3Bucket_Replication_RTC_valid
=== RUN   TestAccS3Bucket_Security_corsUpdate
=== PAUSE TestAccS3Bucket_Security_corsUpdate
=== RUN   TestAccS3Bucket_Security_corsDelete
=== PAUSE TestAccS3Bucket_Security_corsDelete
=== RUN   TestAccS3Bucket_Security_corsEmptyOrigin
=== PAUSE TestAccS3Bucket_Security_corsEmptyOrigin
=== RUN   TestAccS3Bucket_Security_corsSingleMethodAndEmptyOrigin
=== PAUSE TestAccS3Bucket_Security_corsSingleMethodAndEmptyOrigin
=== RUN   TestAccS3Bucket_Security_logging
=== PAUSE TestAccS3Bucket_Security_logging
=== RUN   TestAccS3Bucket_Security_enableDefaultEncryptionWhenTypical
=== PAUSE TestAccS3Bucket_Security_enableDefaultEncryptionWhenTypical
=== RUN   TestAccS3Bucket_Security_enableDefaultEncryptionWhenAES256IsUsed
=== PAUSE TestAccS3Bucket_Security_enableDefaultEncryptionWhenAES256IsUsed
=== RUN   TestAccS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled
=== PAUSE TestAccS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled
=== RUN   TestAccS3Bucket_Web_simple
=== PAUSE TestAccS3Bucket_Web_simple
=== RUN   TestAccS3Bucket_Web_redirect
=== PAUSE TestAccS3Bucket_Web_redirect
=== RUN   TestAccS3Bucket_Web_routingRules
=== PAUSE TestAccS3Bucket_Web_routingRules
=== CONT  TestAccS3Bucket_Basic_basic
=== CONT  TestAccS3Bucket_Manage_versioning
--- PASS: TestAccS3Bucket_Basic_basic (31.70s)
=== CONT  TestAccS3Bucket_Web_routingRules
--- PASS: TestAccS3Bucket_Manage_versioning (58.19s)
=== CONT  TestAccS3Bucket_Web_redirect
--- PASS: TestAccS3Bucket_Web_routingRules (52.33s)
=== CONT  TestAccS3Bucket_Web_simple
--- PASS: TestAccS3Bucket_Web_redirect (79.28s)
=== CONT  TestAccS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled
--- PASS: TestAccS3Bucket_Web_simple (75.52s)
=== CONT  TestAccS3Bucket_Security_enableDefaultEncryptionWhenAES256IsUsed
--- PASS: TestAccS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled (49.68s)
=== CONT  TestAccS3Bucket_Security_enableDefaultEncryptionWhenTypical
--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenAES256IsUsed (31.42s)
=== CONT  TestAccS3Bucket_Security_logging
--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenTypical (32.94s)
=== CONT  TestAccS3Bucket_Security_corsSingleMethodAndEmptyOrigin
--- PASS: TestAccS3Bucket_Security_logging (37.18s)
=== CONT  TestAccS3Bucket_Security_corsEmptyOrigin
--- PASS: TestAccS3Bucket_Security_corsSingleMethodAndEmptyOrigin (31.88s)
=== CONT  TestAccS3Bucket_Security_corsDelete
--- PASS: TestAccS3Bucket_Security_corsEmptyOrigin (31.77s)
=== CONT  TestAccS3Bucket_Security_corsUpdate
--- PASS: TestAccS3Bucket_Security_corsDelete (27.03s)
=== CONT  TestAccS3Bucket_Replication_RTC_valid
--- PASS: TestAccS3Bucket_Security_corsUpdate (54.58s)
=== CONT  TestAccS3Bucket_Replication_schemaV2SameRegion
--- PASS: TestAccS3Bucket_Replication_schemaV2SameRegion (38.03s)
=== CONT  TestAccS3Bucket_Replication_schemaV2
--- PASS: TestAccS3Bucket_Replication_RTC_valid (110.36s)
=== CONT  TestAccS3Bucket_Replication_withoutPrefix
--- PASS: TestAccS3Bucket_Replication_withoutPrefix (40.95s)
=== CONT  TestAccS3Bucket_Replication_expectVersioningValidationError
--- PASS: TestAccS3Bucket_Replication_expectVersioningValidationError (18.21s)
=== CONT  TestAccS3Bucket_Replication_withoutStorageClass
--- PASS: TestAccS3Bucket_Replication_withoutStorageClass (40.27s)
=== CONT  TestAccS3Bucket_Replication_ruleDestinationAddAccessControlTranslation
--- PASS: TestAccS3Bucket_Replication_schemaV2 (150.71s)
=== CONT  TestAccS3Bucket_Replication_ruleDestinationAccessControlTranslation
--- PASS: TestAccS3Bucket_Replication_ruleDestinationAddAccessControlTranslation (69.81s)
=== CONT  TestAccS3Bucket_Replication_twoDestination
--- PASS: TestAccS3Bucket_Replication_ruleDestinationAccessControlTranslation (71.38s)
=== CONT  TestAccS3Bucket_Replication_multipleDestinationsNonEmptyFilter
--- PASS: TestAccS3Bucket_Replication_twoDestination (42.49s)
=== CONT  TestAccS3Bucket_Replication_multipleDestinationsEmptyFilter
--- PASS: TestAccS3Bucket_Replication_multipleDestinationsNonEmptyFilter (45.62s)
=== CONT  TestAccS3Bucket_Replication_basic
--- PASS: TestAccS3Bucket_Replication_multipleDestinationsEmptyFilter (52.94s)
=== CONT  TestAccS3Bucket_Manage_versioningAndMFADeleteDisabled
--- PASS: TestAccS3Bucket_Manage_versioningAndMFADeleteDisabled (43.06s)
=== CONT  TestAccS3Bucket_Manage_MFADeleteDisabled
--- PASS: TestAccS3Bucket_Replication_basic (108.40s)
=== CONT  TestAccS3Bucket_Manage_versioningDisabled
--- PASS: TestAccS3Bucket_Manage_MFADeleteDisabled (32.23s)
=== CONT  TestAccS3Bucket_Manage_lifecycleRuleAbortIncompleteMultipartUploadDaysNoExpiration
--- PASS: TestAccS3Bucket_Manage_versioningDisabled (31.30s)
=== CONT  TestAccS3Bucket_Manage_objectLockWithVersioning_deprecatedEnabled
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleAbortIncompleteMultipartUploadDaysNoExpiration (31.12s)
=== CONT  TestAccS3Bucket_Manage_objectLockWithVersioning
--- PASS: TestAccS3Bucket_Manage_objectLockWithVersioning (50.48s)
=== CONT  TestAccS3Bucket_Manage_objectLock_migrate
--- PASS: TestAccS3Bucket_Manage_objectLockWithVersioning_deprecatedEnabled (50.65s)
=== CONT  TestAccS3Bucket_Manage_objectLock_deprecatedEnabled
--- PASS: TestAccS3Bucket_Manage_objectLock_deprecatedEnabled (31.49s)
=== CONT  TestAccS3Bucket_Manage_objectLock
--- PASS: TestAccS3Bucket_Manage_objectLock_migrate (40.48s)
=== CONT  TestAccS3Bucket_Manage_lifecycleRemove
--- PASS: TestAccS3Bucket_Manage_objectLock (55.11s)
=== CONT  TestAccS3Bucket_Manage_lifecycleBasic
--- PASS: TestAccS3Bucket_Manage_lifecycleRemove (46.40s)
=== CONT  TestAccS3Bucket_Manage_lifecycleRuleExpirationEmptyBlock
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleExpirationEmptyBlock (26.82s)
=== CONT  TestAccS3Bucket_Manage_lifecycleExpireMarkerOnly
--- PASS: TestAccS3Bucket_Manage_lifecycleBasic (51.61s)
=== CONT  TestAccS3Bucket_Basic_acceleration
--- PASS: TestAccS3Bucket_Manage_lifecycleExpireMarkerOnly (50.28s)
=== CONT  TestAccS3Bucket_Duplicate_UsEast1AltAccount
    acctest.go:806: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccS3Bucket_Duplicate_UsEast1AltAccount (0.00s)
=== CONT  TestAccS3Bucket_Duplicate_UsEast1
--- PASS: TestAccS3Bucket_Duplicate_UsEast1 (26.84s)
=== CONT  TestAccS3Bucket_Duplicate_basic
--- PASS: TestAccS3Bucket_Basic_acceleration (55.31s)
=== CONT  TestAccS3Bucket_disappears
--- PASS: TestAccS3Bucket_Duplicate_basic (15.50s)
=== CONT  TestAccS3Bucket_Basic_requestPayer
--- PASS: TestAccS3Bucket_disappears (37.91s)
=== CONT  TestAccS3Bucket_Basic_keyEnabled
--- PASS: TestAccS3Bucket_Basic_requestPayer (55.90s)
=== CONT  TestAccS3Bucket_Basic_forceDestroy
--- PASS: TestAccS3Bucket_Basic_keyEnabled (36.64s)
=== CONT  TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled
--- PASS: TestAccS3Bucket_Basic_forceDestroy (43.16s)
=== CONT  TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled (47.12s)
=== CONT  TestAccS3Bucket_Basic_generatedName
--- PASS: TestAccS3Bucket_Basic_generatedName (33.82s)
=== CONT  TestAccS3Bucket_Basic_namePrefix
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes (45.52s)
=== CONT  TestAccS3Bucket_Tags_withSystemTags
--- PASS: TestAccS3Bucket_Basic_namePrefix (28.73s)
=== CONT  TestAccS3Bucket_Tags_ignoreTags
--- PASS: TestAccS3Bucket_Tags_ignoreTags (47.38s)
=== CONT  TestAccS3Bucket_Basic_emptyString
--- PASS: TestAccS3Bucket_Basic_emptyString (29.39s)
=== CONT  TestAccS3Bucket_Tags_withNoSystemTags
--- PASS: TestAccS3Bucket_Tags_withSystemTags (150.83s)
=== CONT  TestAccS3Bucket_Tags_basic
--- PASS: TestAccS3Bucket_Tags_basic (34.91s)
--- PASS: TestAccS3Bucket_Tags_withNoSystemTags (97.88s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	1368.958s
```
