### PR TITLE
aws_dms_replication_task: allow removal of replication_task_settings

### DIFF
--- a/.changelog/33456.txt
+++ b/.changelog/33456.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dms_replication_task: Fix error when `replication_task_settings` is `nil`
+```

--- a/internal/service/dms/replication_task.go
+++ b/internal/service/dms/replication_task.go
@@ -235,8 +235,8 @@ func resourceReplicationTaskUpdate(ctx context.Context, d *schema.ResourceData, 
 		}
 
 		if d.HasChange("replication_task_settings") {
-			if v, ok := d.GetOk("replication_task_settings"); ok {
-				input.ReplicationTaskSettings = aws.String(v.(string))
+			if v, ok := d.Get("replication_task_settings").(string); ok && v != "" {
+				input.ReplicationTaskSettings = aws.String(v)
 			} else {
 				input.ReplicationTaskSettings = nil
 			}

--- a/internal/service/dms/replication_task.go
+++ b/internal/service/dms/replication_task.go
@@ -235,7 +235,11 @@ func resourceReplicationTaskUpdate(ctx context.Context, d *schema.ResourceData, 
 		}
 
 		if d.HasChange("replication_task_settings") {
-			input.ReplicationTaskSettings = aws.String(d.Get("replication_task_settings").(string))
+			if v, ok := d.GetOk("replication_task_settings"); ok {
+				input.ReplicationTaskSettings = aws.String(v.(string))
+			} else {
+				input.ReplicationTaskSettings = nil
+			}
 		}
 
 		status := d.Get("status").(string)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

When `replication_task_settings` attribute is removed the following error occurs:

``` 
Error: updating DMS Replication Task (test-dms-replication-task-tf): InvalidParameterValueException: Invalid task settings json 
│       status code: 400, request id: ab973d14-ad51-430e-9776-9cef4dce0593
│ 
│   with aws_dms_replication_task.test,
│   on main.tf line 82, in resource "aws_dms_replication_task" "test":
│   82: resource "aws_dms_replication_task" "test" {
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTARGS='-run=TestAccDMSReplicationTask_basic' PKG=dms 

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/dms/... -v -count 1 -parallel 20  -run=TestAccDMSReplicationTask_basic -timeout 180m
--- PASS: TestAccDMSReplicationTask_basic (1033.24s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dms	1036.326s
```
