### PR TITLE
r/aws_verifiedaccess_instance

### DIFF
--- a/internal/service/ec2/errors.go
+++ b/internal/service/ec2/errors.go
@@ -100,6 +100,7 @@ const (
 	errCodeInvalidTransitGatewayPolicyTableIdNotFound        = "InvalidTransitGatewayPolicyTableId.NotFound"
 	errCodeInvalidTransitGatewayIDNotFound                   = "InvalidTransitGatewayID.NotFound"
 	errCodeInvalidTransitGatewayMulticastDomainIdNotFound    = "InvalidTransitGatewayMulticastDomainId.NotFound"
+	errCodeInvalidVerifiedAccessInstanceIdNotFound           = "InvalidVerifiedAccessInstanceId.NotFound"
 	errCodeInvalidVerifiedAccessTrustProviderIdNotFound      = "InvalidVerifiedAccessTrustProviderId.NotFound"
 	errCodeInvalidVolumeNotFound                             = "InvalidVolume.NotFound"
 	errCodeInvalidVPCCIDRBlockAssociationIDNotFound          = "InvalidVpcCidrBlockAssociationID.NotFound"

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -944,6 +944,14 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			},
 		},
 		{
+			Factory:  ResourceVerifiedAccessInstance,
+			TypeName: "aws_verifiedaccess_instance",
+			Name:     "Verified Access Instance",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
+		},
+		{
 			Factory:  ResourceVerifiedAccessTrustProvider,
 			TypeName: "aws_verifiedaccess_trust_provider",
 			Name:     "Verified Access Trust Provider",

--- a/internal/service/ec2/verifiedaccess_instance.go
+++ b/internal/service/ec2/verifiedaccess_instance.go
@@ -28,6 +28,7 @@ func ResourceVerifiedAccessInstance() *schema.Resource {
 		CreateWithoutTimeout: resourceVerifiedAccessInstanceCreate,
 		ReadWithoutTimeout:   resourceVerifiedAccessInstanceRead,
 		UpdateWithoutTimeout: resourceVerifiedAccessInstanceUpdate,
+		DeleteWithoutTimeout: resourceVerifiedAccessInstanceDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -161,6 +162,23 @@ func resourceVerifiedAccessInstanceUpdate(ctx context.Context, d *schema.Resourc
 	}
 
 	return append(diags, resourceVerifiedAccessInstanceRead(ctx, d, meta)...)
+}
+
+func resourceVerifiedAccessInstanceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).EC2Client(ctx)
+
+	log.Printf("[INFO] Deleting Verified Access Instance: %s", d.Id())
+	_, err := conn.DeleteVerifiedAccessInstance(ctx, &ec2.DeleteVerifiedAccessInstanceInput{
+		ClientToken:              aws.String(id.UniqueId()),
+		VerifiedAccessInstanceId: aws.String(d.Id()),
+	})
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "deleting Verified Access Instance (%s): %s", d.Id(), err)
+	}
+
+	return diags
 }
 
 func flattenVerifiedAccessTrustProviders(apiObjects []types.VerifiedAccessTrustProviderCondensed) []interface{} {

--- a/internal/service/ec2/verifiedaccess_instance.go
+++ b/internal/service/ec2/verifiedaccess_instance.go
@@ -1,0 +1,68 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ec2
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKResource("aws_verifiedaccess_instance", name="Verified Access Instance")
+// @Tags(identifierAttribute="id")
+func ResourceVerifiedAccessInstance() *schema.Resource {
+	return &schema.Resource{
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"creation_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"last_updated_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"verified_access_trust_providers": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"device_trust_provider_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"trust_provider_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"user_trust_provider_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"verified_access_trust_provider_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+		},
+
+		CustomizeDiff: verify.SetTagsDiff,
+	}
+}

--- a/internal/service/ec2/verifiedaccess_instance_test.go
+++ b/internal/service/ec2/verifiedaccess_instance_test.go
@@ -53,6 +53,48 @@ func TestAccVerifiedAccessInstance_basic(t *testing.T) {
 	})
 }
 
+func TestAccVerifiedAccessInstance_description(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var v types.VerifiedAccessInstance
+	resourceName := "aws_verifiedaccess_instance.test"
+
+	originalDescription := "original description"
+	updatedDescription := "updated description"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheckVerifiedAccessInstance(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckVerifiedAccessInstanceDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVerifiedAccessInstanceConfig_description(originalDescription),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVerifiedAccessInstanceExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "description", originalDescription),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+			{
+				Config: testAccVerifiedAccessInstanceConfig_description(updatedDescription),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVerifiedAccessInstanceExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "description", updatedDescription),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckVerifiedAccessInstanceExists(ctx context.Context, n string, v *types.VerifiedAccessInstance) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -118,4 +160,12 @@ func testAccVerifiedAccessInstanceConfig_basic() string {
 	return `
 resource "aws_verifiedaccess_instance" "test" {}
 `
+}
+
+func testAccVerifiedAccessInstanceConfig_description(description string) string {
+	return fmt.Sprintf(`
+resource "aws_verifiedaccess_instance" "test" {
+  description = %[1]q
+}
+`, description)
 }

--- a/internal/service/ec2/verifiedaccess_instance_test.go
+++ b/internal/service/ec2/verifiedaccess_instance_test.go
@@ -1,0 +1,121 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ec2_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccVerifiedAccessInstance_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var v types.VerifiedAccessInstance
+	resourceName := "aws_verifiedaccess_instance.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheckVerifiedAccessInstance(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckVerifiedAccessInstanceDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVerifiedAccessInstanceConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVerifiedAccessInstanceExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttrSet(resourceName, "creation_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "last_updated_time"),
+					resource.TestCheckResourceAttr(resourceName, "verified_access_trust_providers.#", "0"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+func testAccCheckVerifiedAccessInstanceExists(ctx context.Context, n string, v *types.VerifiedAccessInstance) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Client(ctx)
+
+		output, err := tfec2.FindVerifiedAccessInstanceByID(ctx, conn, rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		*v = *output
+
+		return nil
+	}
+}
+
+func testAccCheckVerifiedAccessInstanceDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Client(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_verifiedaccess_instance" {
+				continue
+			}
+
+			_, err := tfec2.FindVerifiedAccessInstanceByID(ctx, conn, rs.Primary.ID)
+
+			if tfresource.NotFound(err) {
+				continue
+			}
+
+			if err != nil {
+				return err
+			}
+
+			return fmt.Errorf("Verified Access Instance %s still exists", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccPreCheckVerifiedAccessInstance(ctx context.Context, t *testing.T) {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Client(ctx)
+
+	input := &ec2.DescribeVerifiedAccessInstancesInput{}
+	_, err := conn.DescribeVerifiedAccessInstances(ctx, input)
+
+	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func testAccVerifiedAccessInstanceConfig_basic() string {
+	return `
+resource "aws_verifiedaccess_instance" "test" {}
+`
+}

--- a/internal/service/ec2/verifiedaccess_instance_test.go
+++ b/internal/service/ec2/verifiedaccess_instance_test.go
@@ -95,6 +95,33 @@ func TestAccVerifiedAccessInstance_description(t *testing.T) {
 	})
 }
 
+func TestAccVerifiedAccessInstance_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var v types.VerifiedAccessInstance
+	resourceName := "aws_verifiedaccess_instance.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheckVerifiedAccessInstance(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckVerifiedAccessInstanceDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVerifiedAccessInstanceConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVerifiedAccessInstanceExists(ctx, resourceName, &v),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfec2.ResourceVerifiedAccessInstance(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccVerifiedAccessInstance_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 

--- a/website/docs/r/verifiedaccess_instance.html.markdown
+++ b/website/docs/r/verifiedaccess_instance.html.markdown
@@ -1,0 +1,66 @@
+---
+subcategory: "Verified Access"
+layout: "aws"
+page_title: "AWS: aws_verifiedaccess_instance"
+description: |-
+  Terraform resource for managing a Verified Access Instance.
+---
+
+# Resource: aws_verifiedaccess_instance
+
+Terraform resource for managing a Verified Access Instance.
+
+## Example Usage
+
+```terraform
+resource "aws_verifiedaccess_instance" "example" {
+  description = "example"
+
+  tags = {
+    Name = "example"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are optional:
+
+* `description` - (Optional) A description for the AWS Verified Access Instance.
+* `tags` - (Optional) Key-value mapping of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `creation_time` - The time that the Verified Access Instance was created.
+* `id` - The ID of the AWS Verified Access Instance.
+* `last_updated_time` - The time that the Verified Access Instance was last updated.
+* `verified_access_trust_providers` - One or more blocks of providing information about the AWS Verified Access Trust Providers. See [verified_access_trust_providers](#verified_access_trust_providers) below for details.One or more blocks
+
+### verified_access_trust_providers
+
+Each `verified_access_trust_providers` supports the following argument:
+
+* `description` - The description of trust provider.
+* `device_trust_provider_type` - The type of device-based trust provider.
+* `trust_provider_type` - The type of trust provider (user- or device-based).
+* `user_trust_provider_type` - The type of user-based trust provider.
+* `verified_access_trust_provider_id` - The ID of the trust provider.
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Transfer Workflows using the `id`. For example:
+
+```terraform
+import {
+  to = aws_verifiedaccess_instance.example
+  id = "vai-1234567890abcdef0"
+}
+```
+
+Using `terraform import`, import Transfer Workflows using the  `id`. For example:
+
+```console
+% terraform import aws_verifiedaccess_instance.example vai-1234567890abcdef0
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

New resource: `aws_verifiedaccess_instance`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #29689

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

- [CreateVerifiedAccessInstance](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateVerifiedAccessInstance.html)
- [DescribeVerifiedAccessInstances](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeVerifiedAccessInstances.html)
- [ModifyVerifiedAccessInstance](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifyVerifiedAccessInstance.html)
- [DeleteVerifiedAccessInstance](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DeleteVerifiedAccessInstance.html)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccVerifiedAccessInstance' PKG=ec2 ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 2  -run=TestAccVerifiedAccessInstance -timeout 180m
=== RUN   TestAccVerifiedAccessInstance_basic
=== PAUSE TestAccVerifiedAccessInstance_basic
=== RUN   TestAccVerifiedAccessInstance_description
=== PAUSE TestAccVerifiedAccessInstance_description
=== RUN   TestAccVerifiedAccessInstance_disappears
=== PAUSE TestAccVerifiedAccessInstance_disappears
=== RUN   TestAccVerifiedAccessInstance_tags
=== PAUSE TestAccVerifiedAccessInstance_tags
=== CONT  TestAccVerifiedAccessInstance_basic
=== CONT  TestAccVerifiedAccessInstance_disappears
--- PASS: TestAccVerifiedAccessInstance_disappears (27.66s)
=== CONT  TestAccVerifiedAccessInstance_tags
--- PASS: TestAccVerifiedAccessInstance_basic (36.32s)
=== CONT  TestAccVerifiedAccessInstance_description
--- PASS: TestAccVerifiedAccessInstance_description (57.00s)
--- PASS: TestAccVerifiedAccessInstance_tags (80.77s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        108.535s

...
```
