### PR TITLE
t/aws-mq-update-tests-for-rabbitmq-configuration

### DIFF
--- a/.changelog/33496.txt
+++ b/.changelog/33496.txt
@@ -1,4 +1,0 @@
-```release-note:enhancement
-resource/aws_mq_broker: Update docs to include RabbitMQ as configurable
-resource/aws_mq_configuration: Update docs to include RabbitMQ as configurable
-```

--- a/.changelog/33496.txt
+++ b/.changelog/33496.txt
@@ -1,0 +1,4 @@
+```release-note:enhancement
+resource/aws_mq_broker: Update docs to include RabbitMQ as configurable
+resource/aws_mq_configuration: Update docs to include RabbitMQ as configurable
+```

--- a/internal/service/mq/broker_test.go
+++ b/internal/service/mq/broker_test.go
@@ -1102,7 +1102,55 @@ func TestAccMQBroker_RabbitMQ_basic(t *testing.T) {
 				Config: testAccBrokerConfig_rabbit(rName, testAccRabbitVersion),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, resourceName, &broker),
-					resource.TestCheckResourceAttr(resourceName, "configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "engine_type", "RabbitMQ"),
+					resource.TestCheckResourceAttr(resourceName, "engine_version", testAccRabbitVersion),
+					resource.TestCheckResourceAttr(resourceName, "host_instance_type", "mq.t3.micro"),
+					resource.TestCheckResourceAttr(resourceName, "instances.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "instances.0.endpoints.#", "1"),
+					resource.TestMatchResourceAttr(resourceName, "instances.0.endpoints.0", regexache.MustCompile(`^amqps://[0-9a-z.-]+:5671$`)),
+					resource.TestCheckResourceAttr(resourceName, "logs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logs.0.general", "false"),
+					resource.TestCheckResourceAttr(resourceName, "logs.0.audit", ""),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately", "user"},
+			},
+		},
+	})
+}
+
+func TestAccMQBroker_RabbitMQ_config(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var broker mq.DescribeBrokerResponse
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_mq_broker.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, mq.EndpointsID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, mq.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckBrokerDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBrokerConfig_rabbitConfig(rName, testAccRabbitVersion),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBrokerExists(ctx, resourceName, &broker),
+					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
+					resource.TestMatchResourceAttr(resourceName, "configuration.0.id", regexache.MustCompile(`^c-[0-9a-z-]+$`)),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.revision", "2"),
 					resource.TestCheckResourceAttr(resourceName, "engine_type", "RabbitMQ"),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", testAccRabbitVersion),
 					resource.TestCheckResourceAttr(resourceName, "host_instance_type", "mq.t3.micro"),
@@ -1148,7 +1196,7 @@ func TestAccMQBroker_RabbitMQ_logs(t *testing.T) {
 				Config: testAccBrokerConfig_rabbitLogs(rName, testAccRabbitVersion),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, resourceName, &broker),
-					resource.TestCheckResourceAttr(resourceName, "configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "engine_type", "RabbitMQ"),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", testAccRabbitVersion),
 					resource.TestCheckResourceAttr(resourceName, "host_instance_type", "mq.t3.micro"),
@@ -1964,6 +2012,49 @@ resource "aws_mq_broker" "test" {
   engine_version     = %[2]q
   host_instance_type = "mq.t3.micro"
   security_groups    = [aws_security_group.test.id]
+
+  user {
+    username = "Test"
+    password = "TestTest1234"
+  }
+}
+`, rName, version)
+}
+
+func testAccBrokerConfig_rabbitConfig(rName, version string) string {
+	return fmt.Sprintf(`
+resource "aws_security_group" "test" {
+  name = %[1]q
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_mq_configuration" "test" {
+	description             = "TfAccTest MQ Configuration"
+	name                    = %[1]q
+	engine_type             = "RabbitMQ"
+	engine_version          = %[2]q
+  
+	data = <<DATA
+  # Default RabbitMQ delivery acknowledgement timeout is 30 minutes
+  consumer_timeout = 1800000
+  
+  DATA
+}
+
+resource "aws_mq_broker" "test" {
+  broker_name        = %[1]q
+  engine_type        = "RabbitMQ"
+  engine_version     = %[2]q
+  host_instance_type = "mq.t3.micro"
+  security_groups    = [aws_security_group.test.id]
+
+  configuration {
+	id       = aws_mq_configuration.test.id
+    revision = aws_mq_configuration.test.latest_revision
+  }
 
   user {
     username = "Test"

--- a/internal/service/mq/broker_test.go
+++ b/internal/service/mq/broker_test.go
@@ -2032,12 +2032,12 @@ resource "aws_security_group" "test" {
 }
 
 resource "aws_mq_configuration" "test" {
-	description             = "TfAccTest MQ Configuration"
-	name                    = %[1]q
-	engine_type             = "RabbitMQ"
-	engine_version          = %[2]q
-  
-	data = <<DATA
+  description    = "TfAccTest MQ Configuration"
+  name           = %[1]q
+  engine_type    = "RabbitMQ"
+  engine_version = %[2]q
+
+  data = <<DATA
   # Default RabbitMQ delivery acknowledgement timeout is 30 minutes
   consumer_timeout = 1800000
   
@@ -2052,7 +2052,7 @@ resource "aws_mq_broker" "test" {
   security_groups    = [aws_security_group.test.id]
 
   configuration {
-	id       = aws_mq_configuration.test.id
+    id       = aws_mq_configuration.test.id
     revision = aws_mq_configuration.test.latest_revision
   }
 

--- a/internal/service/mq/configuration_test.go
+++ b/internal/service/mq/configuration_test.go
@@ -165,6 +165,7 @@ func TestAccMQConfiguration_withRabbitMQData(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "3.11.16"),
 					resource.TestCheckResourceAttr(resourceName, "latest_revision", "2"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "data", "consumer_timeout = 60000\n"),
 				),
 			},
 			{
@@ -351,9 +352,7 @@ resource "aws_mq_configuration" "test" {
   engine_version          = "3.11.16"
 
   data = <<DATA
-# Default RabbitMQ delivery acknowledgement timeout is 30 minutes
-consumer_timeout = 1800000
-
+consumer_timeout = 60000
 DATA
 }
 `, rName)

--- a/internal/service/mq/configuration_test.go
+++ b/internal/service/mq/configuration_test.go
@@ -346,10 +346,10 @@ DATA
 func testAccConfigurationConfig_rabbitMQData(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_mq_configuration" "test" {
-  description             = "TfAccTest MQ Configuration"
-  name                    = %[1]q
-  engine_type             = "RabbitMQ"
-  engine_version          = "3.11.16"
+  description    = "TfAccTest MQ Configuration"
+  name           = %[1]q
+  engine_type    = "RabbitMQ"
+  engine_version = "3.11.16"
 
   data = <<DATA
 consumer_timeout = 60000

--- a/internal/service/mq/configuration_test.go
+++ b/internal/service/mq/configuration_test.go
@@ -83,7 +83,7 @@ func TestAccMQConfiguration_withActiveMQData(t *testing.T) {
 		CheckDestroy:             acctest.CheckDestroyNoop,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConfigurationConfig_activeMQData(rName),
+				Config: testAccConfigurationConfig_activeData(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConfigurationExists(ctx, resourceName),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "mq", regexache.MustCompile(`configuration:+.`)),
@@ -119,7 +119,7 @@ func TestAccMQConfiguration_withActiveMQLdapData(t *testing.T) {
 		CheckDestroy:             acctest.CheckDestroyNoop,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConfigurationConfig_activeMQLdapData(rName),
+				Config: testAccConfigurationConfig_activeLdapData(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConfigurationExists(ctx, resourceName),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "mq", regexache.MustCompile(`configuration:+.`)),
@@ -156,7 +156,7 @@ func TestAccMQConfiguration_withRabbitMQData(t *testing.T) {
 		CheckDestroy:             acctest.CheckDestroyNoop,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConfigurationConfig_rabbitMQData(rName),
+				Config: testAccConfigurationConfig_rabbitData(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConfigurationExists(ctx, resourceName),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "mq", regexache.MustCompile(`configuration:+.`)),
@@ -280,7 +280,7 @@ DATA
 `, rName)
 }
 
-func testAccConfigurationConfig_activeMQData(rName string) string {
+func testAccConfigurationConfig_activeData(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_mq_configuration" "test" {
   description    = "TfAccTest MQ Configuration"
@@ -315,7 +315,7 @@ DATA
 `, rName)
 }
 
-func testAccConfigurationConfig_activeMQLdapData(rName string) string {
+func testAccConfigurationConfig_activeLdapData(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_mq_configuration" "test" {
   description             = "TfAccTest MQ Configuration"
@@ -343,7 +343,7 @@ DATA
 `, rName)
 }
 
-func testAccConfigurationConfig_rabbitMQData(rName string) string {
+func testAccConfigurationConfig_rabbitData(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_mq_configuration" "test" {
   description    = "TfAccTest MQ Configuration"

--- a/website/docs/r/mq_broker.html.markdown
+++ b/website/docs/r/mq_broker.html.markdown
@@ -12,7 +12,7 @@ Provides an Amazon MQ broker resource. This resources also manages users for the
 
 -> For more information on Amazon MQ, see [Amazon MQ documentation](https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/welcome.html).
 
-~> **NOTE:** Amazon MQ currently places limits on **RabbitMQ** brokers. For example, a RabbitMQ broker cannot have: instances with an associated IP address of an ENI attached to the broker, an associated LDAP server to authenticate and authorize broker connections, storage type `EFS`, audit logging, or `configuration` blocks. Although this resource allows you to create RabbitMQ users, RabbitMQ users cannot have console access or groups. Also, Amazon MQ does not return information about RabbitMQ users so drift detection is not possible.
+~> **NOTE:** Amazon MQ currently places limits on **RabbitMQ** brokers. For example, a RabbitMQ broker cannot have: instances with an associated IP address of an ENI attached to the broker, an associated LDAP server to authenticate and authorize broker connections, storage type `EFS`, or audit logging. Although this resource allows you to create RabbitMQ users, RabbitMQ users cannot have console access or groups. Also, Amazon MQ does not return information about RabbitMQ users so drift detection is not possible.
 
 ~> **NOTE:** Changes to an MQ Broker can occur when you change a parameter, such as `configuration` or `user`, and are reflected in the next maintenance window. Because of this, Terraform may report a difference in its planning phase because a modification has not yet taken place. You can use the `apply_immediately` flag to instruct the service to apply the change immediately (see documentation below). Using `apply_immediately` can result in a brief downtime as the broker reboots.
 
@@ -84,7 +84,7 @@ The following arguments are optional:
 * `apply_immediately` - (Optional) Specifies whether any broker modifications are applied immediately, or during the next maintenance window. Default is `false`.
 * `authentication_strategy` - (Optional) Authentication strategy used to secure the broker. Valid values are `simple` and `ldap`. `ldap` is not supported for `engine_type` `RabbitMQ`.
 * `auto_minor_version_upgrade` - (Optional) Whether to automatically upgrade to new minor versions of brokers as Amazon MQ makes releases available.
-* `configuration` - (Optional) Configuration block for broker configuration. Applies to `engine_type` of `ActiveMQ` only. Detailed below.
+* `configuration` - (Optional) Configuration block for broker configuration. Applies to `engine_type` of `ActiveMQ` and `RabbitMQ` only. Detailed below.
 * `deployment_mode` - (Optional) Deployment mode of the broker. Valid values are `SINGLE_INSTANCE`, `ACTIVE_STANDBY_MULTI_AZ`, and `CLUSTER_MULTI_AZ`. Default is `SINGLE_INSTANCE`.
 * `encryption_options` - (Optional) Configuration block containing encryption options. Detailed below.
 * `ldap_server_metadata` - (Optional) Configuration block for the LDAP server used to authenticate and authorize connections to the broker. Not supported for `engine_type` `RabbitMQ`. Detailed below. (Currently, AWS may not process changes to LDAP server metadata.)

--- a/website/docs/r/mq_configuration.html.markdown
+++ b/website/docs/r/mq_configuration.html.markdown
@@ -52,7 +52,6 @@ DATA
 }
 ```
 
-
 ## Argument Reference
 
 The following arguments are required:

--- a/website/docs/r/mq_configuration.html.markdown
+++ b/website/docs/r/mq_configuration.html.markdown
@@ -14,6 +14,8 @@ For more information on Amazon MQ, see [Amazon MQ documentation](https://docs.aw
 
 ## Example Usage
 
+### ActiveMQ
+
 ```terraform
 resource "aws_mq_configuration" "example" {
   description    = "Example Configuration"
@@ -34,11 +36,28 @@ DATA
 }
 ```
 
+### RabbitMQ
+
+```terraform
+resource "aws_mq_configuration" "example" {
+  description    = "Example Configuration"
+  name           = "example"
+  engine_type    = "RabbitMQ"
+  engine_version = "3.11.16"
+
+  data = <<DATA
+# Default RabbitMQ delivery acknowledgement timeout is 30 minutes in milliseconds
+consumer_timeout = 1800000
+DATA
+}
+```
+
+
 ## Argument Reference
 
 The following arguments are required:
 
-* `data` - (Required) Broker configuration in XML format. See [official docs](https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/amazon-mq-broker-configuration-parameters.html) for supported parameters and format of the XML.
+* `data` - (Required) Broker configuration in XML format for `ActiveMQ` or [Cuttlefish](https://github.com/Kyorai/cuttlefish) format for `RabbitMQ`. See [official docs](https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/amazon-mq-broker-configuration-parameters.html) for supported parameters and format of the XML.
 * `engine_type` - (Required) Type of broker engine. Valid values are `ActiveMQ` and `RabbitMQ`.
 * `engine_version` - (Required) Version of the broker engine.
 * `name` - (Required) Name of the configuration.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

* adds `TestAccMQConfiguration_withRabbitMQData` to test using configurations with `engine_type=RabbitMQ`
* adds `TestAccMQBroker_RabbitMQ_config` to test using configurations with a `RabbitMQ` broker
* renames some tests not assume `ActiveMQ` is the only `engine_type` that can have configurations.
* updates documentation to include `RabbitMQ` as a possible engine type for configuration

I thought I would have to update `configuration.go` or `broker.go`, but after writing the tests, it looks like it works without changes.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #30797

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

Related AWS Announcement: https://aws.amazon.com/about-aws/whats-new/2023/07/amazon-mq-managed-configuration-rabbitmq-brokers/


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
make testacc TESTS=TestAccMQConfiguration_ PKG=mq`
```
```console
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/mq/... -v -count 1 -parallel 20 -run='TestAccMQConfiguration_'  -timeout 180m
=== RUN   TestAccMQConfiguration_basic
=== PAUSE TestAccMQConfiguration_basic
=== RUN   TestAccMQConfiguration_withActiveMQData
=== PAUSE TestAccMQConfiguration_withActiveMQData
=== RUN   TestAccMQConfiguration_withActiveMQLdapData
=== PAUSE TestAccMQConfiguration_withActiveMQLdapData
=== RUN   TestAccMQConfiguration_withRabbitMQData
=== PAUSE TestAccMQConfiguration_withRabbitMQData
=== RUN   TestAccMQConfiguration_tags
=== PAUSE TestAccMQConfiguration_tags
=== CONT  TestAccMQConfiguration_basic
=== CONT  TestAccMQConfiguration_withRabbitMQData
=== CONT  TestAccMQConfiguration_withActiveMQLdapData
=== CONT  TestAccMQConfiguration_withActiveMQData
=== CONT  TestAccMQConfiguration_tags
--- PASS: TestAccMQConfiguration_withActiveMQData (20.20s)
--- PASS: TestAccMQConfiguration_withRabbitMQData (21.36s)
--- PASS: TestAccMQConfiguration_withActiveMQLdapData (23.45s)
--- PASS: TestAccMQConfiguration_basic (32.35s)
--- PASS: TestAccMQConfiguration_tags (42.11s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/mq	44.206s
```


```
make testacc TESTS=TestAccMQBroker_RabbitMQ_ PKG=mq
```
```console
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/mq/... -v -count 1 -parallel 20 -run='TestAccMQBroker_RabbitMQ_'  -timeout 180m
=== RUN   TestAccMQBroker_RabbitMQ_basic
=== PAUSE TestAccMQBroker_RabbitMQ_basic
=== RUN   TestAccMQBroker_RabbitMQ_config
=== PAUSE TestAccMQBroker_RabbitMQ_config
=== RUN   TestAccMQBroker_RabbitMQ_logs
=== PAUSE TestAccMQBroker_RabbitMQ_logs
=== RUN   TestAccMQBroker_RabbitMQ_validationAuditLog
=== PAUSE TestAccMQBroker_RabbitMQ_validationAuditLog
=== RUN   TestAccMQBroker_RabbitMQ_cluster
=== PAUSE TestAccMQBroker_RabbitMQ_cluster
=== CONT  TestAccMQBroker_RabbitMQ_basic
=== CONT  TestAccMQBroker_RabbitMQ_validationAuditLog
=== CONT  TestAccMQBroker_RabbitMQ_cluster
=== CONT  TestAccMQBroker_RabbitMQ_logs
=== CONT  TestAccMQBroker_RabbitMQ_config
--- PASS: TestAccMQBroker_RabbitMQ_config (537.66s)
--- PASS: TestAccMQBroker_RabbitMQ_validationAuditLog (550.77s)
--- PASS: TestAccMQBroker_RabbitMQ_basic (568.39s)
--- PASS: TestAccMQBroker_RabbitMQ_logs (792.73s)
--- PASS: TestAccMQBroker_RabbitMQ_cluster (982.71s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/mq	984.804s
```