### PR TITLE
rds/option_group: Fix bad diffs with version and port

### DIFF
--- a/.changelog/33511.txt
+++ b/.changelog/33511.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_db_option_group: Avoid erroneous differences being reported when an `option` `port` and/or `version` is not set
+```

--- a/internal/service/rds/flex.go
+++ b/internal/service/rds/flex.go
@@ -259,9 +259,15 @@ func flattenOptions(apiOptions []*rds.Option, optionConfigurations []*rds.Option
 			"db_security_group_memberships":  schema.NewSet(schema.HashString, dbSecurityGroupMemberships),
 			"option_name":                    aws.StringValue(apiOption.OptionName),
 			"option_settings":                schema.NewSet(schema.HashResource(optionSettingsResource), optionSettings),
-			"port":                           aws.Int64Value(apiOption.Port),
-			"version":                        aws.StringValue(apiOption.OptionVersion),
 			"vpc_security_group_memberships": schema.NewSet(schema.HashString, vpcSecurityGroupMemberships),
+		}
+
+		if apiOption.OptionVersion != nil && configuredOption.OptionVersion != nil {
+			r["version"] = aws.StringValue(apiOption.OptionVersion)
+		}
+
+		if apiOption.Port != nil && configuredOption.Port != nil {
+			r["port"] = aws.Int64Value(apiOption.Port)
 		}
 
 		result = append(result, r)

--- a/internal/service/rds/flex.go
+++ b/internal/service/rds/flex.go
@@ -262,11 +262,11 @@ func flattenOptions(apiOptions []*rds.Option, optionConfigurations []*rds.Option
 			"vpc_security_group_memberships": schema.NewSet(schema.HashString, vpcSecurityGroupMemberships),
 		}
 
-		if apiOption.OptionVersion != nil && configuredOption.OptionVersion != nil {
+		if apiOption.OptionVersion != nil && configuredOption != nil && configuredOption.OptionVersion != nil {
 			r["version"] = aws.StringValue(apiOption.OptionVersion)
 		}
 
-		if apiOption.Port != nil && configuredOption.Port != nil {
+		if apiOption.Port != nil && configuredOption != nil && configuredOption.Port != nil {
 			r["port"] = aws.Int64Value(apiOption.Port)
 		}
 

--- a/internal/service/rds/option_group_test.go
+++ b/internal/service/rds/option_group_test.go
@@ -1226,38 +1226,3 @@ resource "aws_db_option_group" "test" {
 }
 `, rName)
 }
-
-/*
-  option {
-    option_name = "Timezone"
-    option_settings {
-      name  = "TIME_ZONE"
-      value = "Europe/London"
-    }
-  }
-  option{
-    option_name = "UTL_MAIL"
-  }
-
-
-  option {
-    option_name = "NATIVE_NETWORK_ENCRYPTION"
-    option_settings {
-      name  = "SQLNET.ENCRYPTION_SERVER"
-      value = "REQUIRED"
-    }
-    option_settings{
-      name  = "SQLNET.ENCRYPTION_TYPES_SERVER"
-      value = "AES256,AES192,AES128,RC4_256,RC4_128,RC4_56,RC4_40"
-    }
-     option_settings{
-      name  = "SQLNET.CRYPTO_CHECKSUM_SERVER"
-      value = "ACCEPTED"
-    }
-    option_settings{
-      name  = "SQLNET.CRYPTO_CHECKSUM_TYPES_SERVER"
-      value = "SHA256,SHA384,SHA512,SHA1,MD5"
-    }
-  }
-
-*/

--- a/internal/service/rds/option_group_test.go
+++ b/internal/service/rds/option_group_test.go
@@ -521,6 +521,59 @@ func TestAccRDSOptionGroup_Tags_withOptions(t *testing.T) {
 	})
 }
 
+// https://github.com/hashicorp/terraform-provider-aws/issues/21367
+func TestAccRDSOptionGroup_badDiffs(t *testing.T) {
+	ctx := acctest.Context(t)
+	var optionGroup1 rds.OptionGroup
+	resourceName := "aws_db_option_group.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, rds.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckOptionGroupDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOptionGroupConfig_badDiffs1(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOptionGroupExists(ctx, resourceName, &optionGroup1),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "option.*", map[string]string{
+						"port": "3872",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "option.*", map[string]string{
+						"option_name": "SQLT",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "option.*", map[string]string{
+						"option_name": "S3_INTEGRATION",
+					}),
+				),
+			},
+			{
+				Config:   testAccOptionGroupConfig_badDiffs1(rName),
+				PlanOnly: true,
+			},
+			{
+				Config: testAccOptionGroupConfig_badDiffs2(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOptionGroupExists(ctx, resourceName, &optionGroup1),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "option.*", map[string]string{
+						"port": "3873",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "option.*", map[string]string{
+						"option_name": "SQLT",
+						"version":     "2018-07-25.v1",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "option.*", map[string]string{
+						"option_name": "S3_INTEGRATION",
+						"version":     "1.0",
+					}),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckOptionGroupOptionSettingsIAMRole(optionGroup *rds.OptionGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if optionGroup == nil {
@@ -1053,3 +1106,158 @@ resource "aws_db_option_group" "test" {
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
+
+func testAccOptionGroupConfig_badDiffs1(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_security_group" "test" {
+  name = %[1]q
+}
+
+data "aws_rds_engine_version" "default" {
+  engine = "oracle-ee"
+}
+
+resource "aws_db_option_group" "test" {
+  name                     = %[1]q
+  option_group_description = "Option Group for Numagove"
+  engine_name              = data.aws_rds_engine_version.default.engine
+  major_engine_version     = regex("^\\d+", data.aws_rds_engine_version.default.version)
+
+  option{
+    option_name = "S3_INTEGRATION"
+  }
+
+  option {
+    option_name = "SQLT"
+    option_settings {
+      name  = "LICENSE_PACK"
+      value = "T"
+    }
+  }
+
+  option {
+    option_name                    = "OEM_AGENT"
+    version                        = "13.5.0.0.v1"
+    port                           = 3872
+    vpc_security_group_memberships = [aws_security_group.test.id]
+
+    option_settings {
+      name  = "AGENT_REGISTRATION_PASSWORD"
+      value = "TESTPASSWORDBGY"
+    }
+    option_settings {
+      name  = "MINIMUM_TLS_VERSION"
+      value = "TLSv1.2"
+    }
+    option_settings {
+      name  = "TLS_CIPHER_SUITE"
+      value = "TLS_RSA_WITH_AES_128_CBC_SHA"
+    }
+    option_settings {
+      name  = "OMS_HOST"
+      value = "BGY-TEST"
+    }
+    option_settings {
+      name  = "OMS_PORT"
+      value = "1159"
+    }
+  }
+}
+`, rName)
+}
+
+func testAccOptionGroupConfig_badDiffs2(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_security_group" "test" {
+  name = %[1]q
+}
+
+data "aws_rds_engine_version" "default" {
+  engine = "oracle-ee"
+}
+
+resource "aws_db_option_group" "test" {
+  name                     = %[1]q
+  option_group_description = "Option Group for Numagove"
+  engine_name              = data.aws_rds_engine_version.default.engine
+  major_engine_version     = regex("^\\d+", data.aws_rds_engine_version.default.version)
+
+  option{
+    option_name = "S3_INTEGRATION"
+    version     = "1.0"
+  }
+
+  option {
+    option_name = "SQLT"
+    option_settings {
+      name  = "LICENSE_PACK"
+      value = "T"
+    }
+    version = "2018-07-25.v1"
+  }
+
+  option {
+    option_name                    = "OEM_AGENT"
+    version                        = "13.5.0.0.v1"
+    port                           = 3873
+    vpc_security_group_memberships = [aws_security_group.test.id]
+
+    option_settings {
+      name  = "AGENT_REGISTRATION_PASSWORD"
+      value = "TESTPASSWORDBGY"
+    }
+    option_settings {
+      name  = "MINIMUM_TLS_VERSION"
+      value = "TLSv1.2"
+    }
+    option_settings {
+      name  = "TLS_CIPHER_SUITE"
+      value = "TLS_RSA_WITH_AES_128_CBC_SHA"
+    }
+    option_settings {
+      name  = "OMS_HOST"
+      value = "BGY-TEST"
+    }
+    option_settings {
+      name  = "OMS_PORT"
+      value = "1159"
+    }
+  }
+}
+`, rName)
+}
+
+/*
+  option {
+    option_name = "Timezone"
+    option_settings {
+      name  = "TIME_ZONE"
+      value = "Europe/London"
+    }
+  }
+  option{
+    option_name = "UTL_MAIL"
+  }
+
+
+  option {
+    option_name = "NATIVE_NETWORK_ENCRYPTION"
+    option_settings {
+      name  = "SQLNET.ENCRYPTION_SERVER"
+      value = "REQUIRED"
+    }
+    option_settings{
+      name  = "SQLNET.ENCRYPTION_TYPES_SERVER"
+      value = "AES256,AES192,AES128,RC4_256,RC4_128,RC4_56,RC4_40"
+    }
+     option_settings{
+      name  = "SQLNET.CRYPTO_CHECKSUM_SERVER"
+      value = "ACCEPTED"
+    }
+    option_settings{
+      name  = "SQLNET.CRYPTO_CHECKSUM_TYPES_SERVER"
+      value = "SHA256,SHA384,SHA512,SHA1,MD5"
+    }
+  }
+
+*/

--- a/internal/service/rds/option_group_test.go
+++ b/internal/service/rds/option_group_test.go
@@ -1123,7 +1123,7 @@ resource "aws_db_option_group" "test" {
   engine_name              = data.aws_rds_engine_version.default.engine
   major_engine_version     = regex("^\\d+", data.aws_rds_engine_version.default.version)
 
-  option{
+  option {
     option_name = "S3_INTEGRATION"
   }
 
@@ -1182,7 +1182,7 @@ resource "aws_db_option_group" "test" {
   engine_name              = data.aws_rds_engine_version.default.engine
   major_engine_version     = regex("^\\d+", data.aws_rds_engine_version.default.version)
 
-  option{
+  option {
     option_name = "S3_INTEGRATION"
     version     = "1.0"
   }

--- a/website/docs/r/db_option_group.html.markdown
+++ b/website/docs/r/db_option_group.html.markdown
@@ -62,35 +62,35 @@ More information about this can be found [here](https://docs.aws.amazon.com/Amaz
 
 This resource supports the following arguments:
 
-* `name` - (Optional, Forces new resource) The name of the option group. If omitted, Terraform will assign a random, unique name. Must be lowercase, to match as it is stored in AWS.
+* `name` - (Optional, Forces new resource) Name of the option group. If omitted, Terraform will assign a random, unique name. Must be lowercase, to match as it is stored in AWS.
 * `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`. Must be lowercase, to match as it is stored in AWS.
-* `option_group_description` - (Optional) The description of the option group. Defaults to "Managed by Terraform".
+* `option_group_description` - (Optional) Description of the option group. Defaults to "Managed by Terraform".
 * `engine_name` - (Required) Specifies the name of the engine that this option group should be associated with.
 * `major_engine_version` - (Required) Specifies the major version of the engine that this option group should be associated with.
-* `option` - (Optional) A list of Options to apply.
-* `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `option` - (Optional) List of options to apply.
+* `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
-Option blocks support the following:
+`option` blocks support the following:
 
-* `option_name` - (Required) The Name of the Option (e.g., MEMCACHED).
-* `option_settings` - (Optional) A list of option settings to apply.
-* `port` - (Optional) The Port number when connecting to the Option (e.g., 11211).
-* `version` - (Optional) The version of the option (e.g., 13.1.0.0).
-* `db_security_group_memberships` - (Optional) A list of DB Security Groups for which the option is enabled.
-* `vpc_security_group_memberships` - (Optional) A list of VPC Security Groups for which the option is enabled.
+* `option_name` - (Required) Name of the option (e.g., MEMCACHED).
+* `option_settings` - (Optional) List of option settings to apply.
+* `port` - (Optional) Port number when connecting to the option (e.g., 11211). Leaving out or removing `port` from your configuration does not remove or clear a port from the option in AWS. AWS may assign a default port. Not including `port` in your configuration means that the AWS provider will ignore a previously set value, a value set by AWS, and any port changes.
+* `version` - (Optional) Version of the option (e.g., 13.1.0.0). Leaving out or removing `version` from your configuration does not remove or clear a version from the option in AWS. AWS may assign a default version. Not including `version` in your configuration means that the AWS provider will ignore a previously set value, a value set by AWS, and any version changes.
+* `db_security_group_memberships` - (Optional) List of DB Security Groups for which the option is enabled.
+* `vpc_security_group_memberships` - (Optional) List of VPC Security Groups for which the option is enabled.
 
-Option Settings blocks support the following:
+`option_settings` blocks support the following:
 
-* `name` - (Optional) The Name of the setting.
-* `value` - (Optional) The Value of the setting.
+* `name` - (Optional) Name of the setting.
+* `value` - (Optional) Value of the setting.
 
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `id` - The db option group name.
-* `arn` - The ARN of the db option group.
-* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
+* `id` - DB option group name.
+* `arn` - ARN of the db option group.
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Timeouts
 
@@ -100,7 +100,7 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import DB Option groups using the `name`. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import DB option groups using the `name`. For example:
 
 ```terraform
 import {
@@ -109,7 +109,7 @@ import {
 }
 ```
 
-Using `terraform import`, import DB Option groups using the `name`. For example:
+Using `terraform import`, import DB option groups using the `name`. For example:
 
 ```console
 % terraform import aws_db_option_group.example mysql-option-group

--- a/website/docs/r/db_option_group.html.markdown
+++ b/website/docs/r/db_option_group.html.markdown
@@ -89,7 +89,7 @@ This resource supports the following arguments:
 This resource exports the following attributes in addition to the arguments above:
 
 * `id` - DB option group name.
-* `arn` - ARN of the db option group.
+* `arn` - ARN of the DB option group.
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Timeouts


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Previously, on reading options back from AWS, `version` and `port` would be set even if they weren't configured. This PR changes that to check first if `version` and/or `port` is set in the configuration before setting the value from AWS.

This approach can be misleading in this scenario: a) `version` is set and applied, b) `version` is removed from the configuration. Diffs in `version` will not be checked. (The same would be true of `port`.) A practitioner may assume that removing the value will clear or remove the value from the AWS infrastructure. However, removing the value from configuration will instead just mean that Terraform will not detect diffs for `version` in the future.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #21367

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccRDSOptionGroup_ K=rds P=4
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 4 -run='TestAccRDSOptionGroup_'  -timeout 180m
=== RUN   TestAccRDSOptionGroup_basic
=== PAUSE TestAccRDSOptionGroup_basic
=== RUN   TestAccRDSOptionGroup_timeoutBlock
=== PAUSE TestAccRDSOptionGroup_timeoutBlock
=== RUN   TestAccRDSOptionGroup_namePrefix
=== PAUSE TestAccRDSOptionGroup_namePrefix
=== RUN   TestAccRDSOptionGroup_generatedName
=== PAUSE TestAccRDSOptionGroup_generatedName
=== RUN   TestAccRDSOptionGroup_optionGroupDescription
=== PAUSE TestAccRDSOptionGroup_optionGroupDescription
=== RUN   TestAccRDSOptionGroup_basicDestroyWithInstance
=== PAUSE TestAccRDSOptionGroup_basicDestroyWithInstance
=== RUN   TestAccRDSOptionGroup_Option_optionSettings
=== PAUSE TestAccRDSOptionGroup_Option_optionSettings
=== RUN   TestAccRDSOptionGroup_OptionOptionSettings_iamRole
=== PAUSE TestAccRDSOptionGroup_OptionOptionSettings_iamRole
=== RUN   TestAccRDSOptionGroup_sqlServerOptionsUpdate
=== PAUSE TestAccRDSOptionGroup_sqlServerOptionsUpdate
=== RUN   TestAccRDSOptionGroup_oracleOptionsUpdate
=== PAUSE TestAccRDSOptionGroup_oracleOptionsUpdate
=== RUN   TestAccRDSOptionGroup_OptionOptionSettings_multipleNonDefault
=== PAUSE TestAccRDSOptionGroup_OptionOptionSettings_multipleNonDefault
=== RUN   TestAccRDSOptionGroup_multipleOptions
=== PAUSE TestAccRDSOptionGroup_multipleOptions
=== RUN   TestAccRDSOptionGroup_tags
=== PAUSE TestAccRDSOptionGroup_tags
=== RUN   TestAccRDSOptionGroup_Tags_withOptions
=== PAUSE TestAccRDSOptionGroup_Tags_withOptions
=== RUN   TestAccRDSOptionGroup_badDiffs
=== PAUSE TestAccRDSOptionGroup_badDiffs
=== CONT  TestAccRDSOptionGroup_basic
=== CONT  TestAccRDSOptionGroup_sqlServerOptionsUpdate
=== CONT  TestAccRDSOptionGroup_tags
=== CONT  TestAccRDSOptionGroup_badDiffs
--- PASS: TestAccRDSOptionGroup_basic (31.33s)
=== CONT  TestAccRDSOptionGroup_OptionOptionSettings_multipleNonDefault
--- PASS: TestAccRDSOptionGroup_sqlServerOptionsUpdate (53.36s)
=== CONT  TestAccRDSOptionGroup_multipleOptions
--- PASS: TestAccRDSOptionGroup_badDiffs (64.79s)
=== CONT  TestAccRDSOptionGroup_Tags_withOptions
--- PASS: TestAccRDSOptionGroup_tags (72.11s)
=== CONT  TestAccRDSOptionGroup_optionGroupDescription
--- PASS: TestAccRDSOptionGroup_OptionOptionSettings_multipleNonDefault (50.33s)
=== CONT  TestAccRDSOptionGroup_OptionOptionSettings_iamRole
--- PASS: TestAccRDSOptionGroup_multipleOptions (29.61s)
=== CONT  TestAccRDSOptionGroup_Option_optionSettings
--- PASS: TestAccRDSOptionGroup_optionGroupDescription (29.39s)
=== CONT  TestAccRDSOptionGroup_basicDestroyWithInstance
--- PASS: TestAccRDSOptionGroup_OptionOptionSettings_iamRole (39.78s)
=== CONT  TestAccRDSOptionGroup_oracleOptionsUpdate
--- PASS: TestAccRDSOptionGroup_Tags_withOptions (70.10s)
=== CONT  TestAccRDSOptionGroup_namePrefix
--- PASS: TestAccRDSOptionGroup_Option_optionSettings (53.10s)
=== CONT  TestAccRDSOptionGroup_generatedName
--- PASS: TestAccRDSOptionGroup_namePrefix (28.31s)
=== CONT  TestAccRDSOptionGroup_timeoutBlock
--- PASS: TestAccRDSOptionGroup_generatedName (27.88s)
--- PASS: TestAccRDSOptionGroup_oracleOptionsUpdate (52.41s)
--- PASS: TestAccRDSOptionGroup_timeoutBlock (26.21s)
--- PASS: TestAccRDSOptionGroup_basicDestroyWithInstance (637.95s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	741.179s
```
