### PR TITLE
rds/instance: Fix ability to change storage IOPS, throughput

### DIFF
--- a/.changelog/33529.txt
+++ b/.changelog/33529.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_db_instance: Fix so that `storage_throughput` can be changed when `iops` and `allocated_storage` are not changed
+```

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -2179,6 +2179,14 @@ func dbInstancePopulateModify(input *rds_sdkv2.ModifyDBInstanceInput, d *schema.
 	if d.HasChange("storage_throughput") {
 		needsModify = true
 		input.StorageThroughput = aws.Int32(int32(d.Get("storage_throughput").(int)))
+
+		if input.Iops == nil {
+			input.Iops = aws.Int32(int32(d.Get("iops").(int)))
+		}
+
+		if input.AllocatedStorage == nil {
+			input.AllocatedStorage = aws.Int32(int32(d.Get("allocated_storage").(int)))
+		}
 	}
 
 	if d.HasChange("storage_type") {
@@ -2208,6 +2216,10 @@ func dbInstanceModify(ctx context.Context, conn *rds_sdkv2.Client, resourceID st
 		func(err error) (bool, error) {
 			// Retry for IAM eventual consistency.
 			if tfawserr_sdkv2.ErrMessageContains(err, errCodeInvalidParameterValue, "IAM role ARN value is invalid or does not include the required permissions") {
+				return true, err
+			}
+
+			if tfawserr_sdkv2.ErrMessageContains(err, errCodeInvalidParameterCombination, "previous storage change is being optimized") {
 				return true, err
 			}
 

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -5282,7 +5282,8 @@ func TestAccRDSInstance_gp3SQLServer(t *testing.T) {
 	})
 }
 
-func TestAccRDSInstance_storageThroughput(t *testing.T) {
+// // https://github.com/hashicorp/terraform-provider-aws/issues/33512
+func TestAccRDSInstance_storageChangeThroughput(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -5308,24 +5309,128 @@ func TestAccRDSInstance_storageThroughput(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"apply_immediately",
-					"final_snapshot_identifier",
-					"password",
-					"skip_final_snapshot",
-					"delete_automated_backups",
-					"blue_green_update",
-				},
-			},
-			{
-				Config: testAccInstanceConfig_storageThroughput(rName, 14000, 600),
+				Config: testAccInstanceConfig_storageThroughput(rName, 12000, 600),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(ctx, resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "iops", "14000"),
+					resource.TestCheckResourceAttr(resourceName, "iops", "12000"),
 					resource.TestCheckResourceAttr(resourceName, "storage_throughput", "600"),
+					resource.TestCheckResourceAttr(resourceName, "storage_type", "gp3"),
+				),
+			},
+		},
+	})
+}
+
+// https://github.com/hashicorp/terraform-provider-aws/issues/33512
+func TestAccRDSInstance_storageChangeIOPSThroughput(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var v rds.DBInstance
+	resourceName := "aws_db_instance.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, rds.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInstanceDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_storageThroughput(rName, 12000, 500),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInstanceExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "iops", "12000"),
+					resource.TestCheckResourceAttr(resourceName, "storage_throughput", "500"),
+					resource.TestCheckResourceAttr(resourceName, "storage_type", "gp3"),
+				),
+			},
+			{
+				Config: testAccInstanceConfig_storageThroughput(rName, 13000, 600),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInstanceExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "iops", "13000"),
+					resource.TestCheckResourceAttr(resourceName, "storage_throughput", "600"),
+					resource.TestCheckResourceAttr(resourceName, "storage_type", "gp3"),
+				),
+			},
+		},
+	})
+}
+
+// https://github.com/hashicorp/terraform-provider-aws/issues/33512
+func TestAccRDSInstance_storageChangeIOPS(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var v rds.DBInstance
+	resourceName := "aws_db_instance.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, rds.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInstanceDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_storageThroughput(rName, 12000, 500),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInstanceExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "iops", "12000"),
+					resource.TestCheckResourceAttr(resourceName, "storage_throughput", "500"),
+					resource.TestCheckResourceAttr(resourceName, "storage_type", "gp3"),
+				),
+			},
+			{
+				Config: testAccInstanceConfig_storageThroughput(rName, 13000, 500),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInstanceExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "iops", "13000"),
+					resource.TestCheckResourceAttr(resourceName, "storage_throughput", "500"),
+					resource.TestCheckResourceAttr(resourceName, "storage_type", "gp3"),
+				),
+			},
+		},
+	})
+}
+
+// https://github.com/hashicorp/terraform-provider-aws/issues/33512
+func TestAccRDSInstance_storageThroughputSSE(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var v rds.DBInstance
+	resourceName := "aws_db_instance.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, rds.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInstanceDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_storageThroughputSSE(rName, 4201, 125),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInstanceExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "iops", "4201"),
+					resource.TestCheckResourceAttr(resourceName, "storage_throughput", "125"),
+					resource.TestCheckResourceAttr(resourceName, "storage_type", "gp3"),
+				),
+			},
+			{
+				Config: testAccInstanceConfig_storageThroughputSSE(rName, 4201, 126),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInstanceExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "iops", "4201"),
+					resource.TestCheckResourceAttr(resourceName, "storage_throughput", "126"),
 					resource.TestCheckResourceAttr(resourceName, "storage_type", "gp3"),
 				),
 			},
@@ -10570,6 +10675,90 @@ resource "aws_db_instance" "test" {
 }
 `, rName, iops, throughput))
 }
+
+func testAccInstanceConfig_storageThroughputSSE(rName string, iops, throughput int) string {
+	return fmt.Sprintf(`
+data "aws_rds_engine_version" "default" {
+  engine             = "sqlserver-se"
+}
+
+data "aws_rds_orderable_db_instance" "test" {
+  engine         = data.aws_rds_engine_version.default.engine
+  engine_version = data.aws_rds_engine_version.default.version
+  license_model  = "license-included"
+  storage_type   = "gp3"
+
+  preferred_instance_classes = ["db.m5.medium", "db.m5.large"]
+}
+
+resource "aws_db_instance" "test" {
+  allocated_storage    = 400
+  apply_immediately    = true
+  engine               = data.aws_rds_engine_version.default.engine
+  engine_version       = data.aws_rds_engine_version.default.version
+  identifier           = %[1]q
+  instance_class       = data.aws_rds_orderable_db_instance.test.instance_class
+  iops                 = %[2]d
+  license_model        = data.aws_rds_orderable_db_instance.test.license_model
+  parameter_group_name = "default.${data.aws_rds_engine_version.default.parameter_group_family}"
+  password             = "avoid-plaintext-passwords"
+  skip_final_snapshot  = true
+  storage_throughput   = %[3]d
+  storage_type         = data.aws_rds_orderable_db_instance.test.storage_type
+  username             = "tfacctest"
+}
+`, rName, iops, throughput)
+}
+
+/*
+resource "aws_db_instance" "mssqlrds" {
+  enabled_cloudwatch_logs_exports = [
+    "agent",
+    "error",
+  ]
+  #ca_cert_identifier         = "rds-ca-2019"
+  #db_subnet_group_name       = "br_gtodev_npd_us-east-1_rds_sbtgrp"
+  #kms_key_id                            = "arn:aws:kms:us-east-1:070213819183:key/fe677803-1f5d-4faa-934c-59861a32834d"
+  #maintenance_window                    = "sun:00:01-sun:05:00"
+  #monitoring_interval                   = 30
+  #monitoring_role_arn                   = "arn:aws:iam::070213819183:role/rds-monitoring"
+  #option_group_name                     = "br-gtodev-revdb2nva-db-sql-rds-optiongrp"
+  #parameter_group_name                  = "br-gtodev-revdb2nva-rds-db-sqlserver-se-13-0-dbparameter-group"
+  #performance_insights_enabled          = true
+  #performance_insights_kms_key_id       = "arn:aws:kms:us-east-1:070213819183:key/fe677803-1f5d-4faa-934c-59861a32834d"
+  #performance_insights_retention_period = 7
+  #storage_encrypted                     = true
+  allocated_storage          = 8001
+  apply_immediately          = true
+  auto_minor_version_upgrade = true
+  availability_zone          = "us-west-2b"
+  backup_retention_period    = 1
+  backup_window              = "21:00-23:00"
+  character_set_name         = "SQL_Latin1_General_CP1_CI_AS"
+  copy_tags_to_snapshot      = true
+  customer_owned_ip_enabled  = false
+  delete_automated_backups   = true
+  deletion_protection        = false
+  engine                                = "sqlserver-se"
+  engine_version                        = "13.00.6300.2.v1"
+  final_snapshot_identifier             = "br-gtodev-revdb2nva-rds-db-rds-def1c186d52e691066ef07396f3011d6"
+  iam_database_authentication_enabled   = false
+  instance_class                        = "db.m5.large"
+  iops                                  = 4201
+  license_model                         = "license-included"
+  max_allocated_storage                 = 8051
+  multi_az                              = false
+  network_type                          = "IPV4"
+  password                              = "foobarbazqux"
+  port                                  = 1433
+  publicly_accessible                   = false
+  skip_final_snapshot                   = true
+  storage_throughput                    = 126 #125 #-> 126
+  storage_type                          = "gp3"
+  timezone = "UTC"
+  username = "DBAdmin"
+}
+*/
 
 func testAccInstanceConfig_storageTypePostgres(rName string, storageType string, allocatedStorage int) string {
 	return fmt.Sprintf(`

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -10679,7 +10679,7 @@ resource "aws_db_instance" "test" {
 func testAccInstanceConfig_storageThroughputSSE(rName string, iops, throughput int) string {
 	return fmt.Sprintf(`
 data "aws_rds_engine_version" "default" {
-  engine             = "sqlserver-se"
+  engine = "sqlserver-se"
 }
 
 data "aws_rds_orderable_db_instance" "test" {

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -10710,56 +10710,6 @@ resource "aws_db_instance" "test" {
 `, rName, iops, throughput)
 }
 
-/*
-resource "aws_db_instance" "mssqlrds" {
-  enabled_cloudwatch_logs_exports = [
-    "agent",
-    "error",
-  ]
-  #ca_cert_identifier         = "rds-ca-2019"
-  #db_subnet_group_name       = "br_gtodev_npd_us-east-1_rds_sbtgrp"
-  #kms_key_id                            = "arn:aws:kms:us-east-1:070213819183:key/fe677803-1f5d-4faa-934c-59861a32834d"
-  #maintenance_window                    = "sun:00:01-sun:05:00"
-  #monitoring_interval                   = 30
-  #monitoring_role_arn                   = "arn:aws:iam::070213819183:role/rds-monitoring"
-  #option_group_name                     = "br-gtodev-revdb2nva-db-sql-rds-optiongrp"
-  #parameter_group_name                  = "br-gtodev-revdb2nva-rds-db-sqlserver-se-13-0-dbparameter-group"
-  #performance_insights_enabled          = true
-  #performance_insights_kms_key_id       = "arn:aws:kms:us-east-1:070213819183:key/fe677803-1f5d-4faa-934c-59861a32834d"
-  #performance_insights_retention_period = 7
-  #storage_encrypted                     = true
-  allocated_storage          = 8001
-  apply_immediately          = true
-  auto_minor_version_upgrade = true
-  availability_zone          = "us-west-2b"
-  backup_retention_period    = 1
-  backup_window              = "21:00-23:00"
-  character_set_name         = "SQL_Latin1_General_CP1_CI_AS"
-  copy_tags_to_snapshot      = true
-  customer_owned_ip_enabled  = false
-  delete_automated_backups   = true
-  deletion_protection        = false
-  engine                                = "sqlserver-se"
-  engine_version                        = "13.00.6300.2.v1"
-  final_snapshot_identifier             = "br-gtodev-revdb2nva-rds-db-rds-def1c186d52e691066ef07396f3011d6"
-  iam_database_authentication_enabled   = false
-  instance_class                        = "db.m5.large"
-  iops                                  = 4201
-  license_model                         = "license-included"
-  max_allocated_storage                 = 8051
-  multi_az                              = false
-  network_type                          = "IPV4"
-  password                              = "foobarbazqux"
-  port                                  = 1433
-  publicly_accessible                   = false
-  skip_final_snapshot                   = true
-  storage_throughput                    = 126 #125 #-> 126
-  storage_type                          = "gp3"
-  timezone = "UTC"
-  username = "DBAdmin"
-}
-*/
-
 func testAccInstanceConfig_storageTypePostgres(rName string, storageType string, allocatedStorage int) string {
 	return fmt.Sprintf(`
 data "aws_rds_engine_version" "default" {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

When changing `storage_throughput`, AWS also wants `iops` and `allocated_storage` to be passed even if these are not changing.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #33512

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccRDSInstance_storage K=rds                              
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSInstance_storage'  -timeout 180m
=== RUN   TestAccRDSInstance_storageChangeThroughput
=== PAUSE TestAccRDSInstance_storageChangeThroughput
=== RUN   TestAccRDSInstance_storageChangeIOPSThroughput
=== PAUSE TestAccRDSInstance_storageChangeIOPSThroughput
=== RUN   TestAccRDSInstance_storageChangeIOPS
=== PAUSE TestAccRDSInstance_storageChangeIOPS
=== RUN   TestAccRDSInstance_storageThroughputSSE
=== PAUSE TestAccRDSInstance_storageThroughputSSE
=== RUN   TestAccRDSInstance_storageTypePostgres
=== PAUSE TestAccRDSInstance_storageTypePostgres
=== CONT  TestAccRDSInstance_storageChangeThroughput
=== CONT  TestAccRDSInstance_storageThroughputSSE
=== CONT  TestAccRDSInstance_storageTypePostgres
=== CONT  TestAccRDSInstance_storageChangeIOPS
=== CONT  TestAccRDSInstance_storageChangeIOPSThroughput
--- PASS: TestAccRDSInstance_storageTypePostgres (708.67s)
--- PASS: TestAccRDSInstance_storageChangeIOPSThroughput (764.02s)
--- PASS: TestAccRDSInstance_storageChangeIOPS (764.22s)
--- PASS: TestAccRDSInstance_storageChangeThroughput (783.36s)
--- PASS: TestAccRDSInstance_storageThroughputSSE (990.45s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	992.225s
```
