### PR TITLE
[feat] add arn framework validator

### DIFF
--- a/internal/framework/validators/arn.go
+++ b/internal/framework/validators/arn.go
@@ -1,0 +1,101 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validators
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/YakDriver/regexache"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+var accountIDRegexp = regexache.MustCompile(`^(aws|aws-managed|third-party|\d{12}|cw.{10})$`)
+var partitionRegexp = regexache.MustCompile(`^aws(-[a-z]+)*$`)
+var regionRegexp = regexache.MustCompile(`^[a-z]{2}(-[a-z]+)+-\d$`)
+
+type arnValidator struct{}
+
+// Description describes the validation in plain text formatting.
+func (validator arnValidator) Description(_ context.Context) string {
+	return "value must be a valid arn"
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (validator arnValidator) MarkdownDescription(ctx context.Context) string {
+	return validator.Description(ctx)
+}
+
+func (validator arnValidator) ValidateString(ctx context.Context, request validator.StringRequest, response *validator.StringResponse) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	value := request.ConfigValue.ValueString()
+	parsedARN, err := arn.Parse(value)
+
+	if err != nil {
+		response.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
+			request.Path,
+			validator.Description(ctx),
+			fmt.Sprintf("(%s) is an invalid ARN: %s", value, err),
+		))
+		return
+	}
+
+	if parsedARN.Partition == "" {
+		response.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
+			request.Path,
+			validator.Description(ctx),
+			fmt.Sprintf("(%s) is an invalid ARN: missing partition value", value),
+		))
+		return
+	} else if !partitionRegexp.MatchString(parsedARN.Partition) {
+		response.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
+			request.Path,
+			validator.Description(ctx),
+			fmt.Sprintf("(%s) is an invalid ARN: invalid partition value (expecting to match regular expression: %s)", value, partitionRegexp),
+		))
+		return
+	}
+
+	if parsedARN.Region != "" && !regionRegexp.MatchString(parsedARN.Region) {
+		response.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
+			request.Path,
+			validator.Description(ctx),
+			fmt.Sprintf("(%s) is an invalid ARN: invalid region value (expecting to match regular expression: %s)", value, regionRegexp),
+		))
+		return
+	}
+
+	if parsedARN.AccountID != "" && !accountIDRegexp.MatchString(parsedARN.AccountID) {
+		response.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
+			request.Path,
+			validator.Description(ctx),
+			fmt.Sprintf("(%s) is an invalid ARN: invalid account ID value (expecting to match regular expression: %s)", value, accountIDRegexp),
+		))
+		return
+	}
+
+	if parsedARN.Resource == "" {
+		response.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
+			request.Path,
+			validator.Description(ctx),
+			fmt.Sprintf("(%s) is an invalid ARN: missing resource value", value),
+		))
+		return
+	}
+}
+
+// ARN returns a string validator which ensures that any configured
+// attribute value:
+//
+//   - Is a string, which represents a valid ARN.
+//
+// Null (unconfigured) and unknown (known after apply) values are skipped.
+func ARN() validator.String {
+	return arnValidator{}
+}

--- a/internal/framework/validators/arn_test.go
+++ b/internal/framework/validators/arn_test.go
@@ -1,0 +1,158 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validators_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	fwvalidators "github.com/hashicorp/terraform-provider-aws/internal/framework/validators"
+)
+
+func TestARNValidator(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		val                 types.String
+		expectedDiagnostics diag.Diagnostics
+	}
+	tests := map[string]testCase{
+		"unknown String": {
+			val: types.StringUnknown(),
+		},
+		"null String": {
+			val: types.StringNull(),
+		},
+		"Beanstalk": {
+			val: types.StringValue("arn:aws:elasticbeanstalk:us-east-1:123456789012:environment/My App/MyEnvironment"),
+		},
+		"IAM User": {
+			val: types.StringValue("arn:aws:iam::123456789012:user/David"),
+		},
+		"Managed IAM policy": {
+			val: types.StringValue("arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess"),
+		},
+		"ImageBuilder": {
+			val: types.StringValue("arn:aws:imagebuilder:us-east-1:third-party:component/my-component"),
+		},
+		"RDS": {
+			val: types.StringValue("arn:aws:rds:eu-west-1:123456789012:db:mysql-db"),
+		},
+		"S3 object": {
+			val: types.StringValue("arn:aws:s3:::my_corporate_bucket/exampleobject.png"),
+		},
+		"CloudWatch Rule": {
+			val: types.StringValue("arn:aws:events:us-east-1:319201112229:rule/rule_name"),
+		},
+		"Lambda function": {
+			val: types.StringValue("arn:aws:lambda:eu-west-1:319201112229:function:myCustomFunction"),
+		},
+		"Lambda func qualifier": {
+			val: types.StringValue("arn:aws:lambda:eu-west-1:319201112229:function:myCustomFunction:Qualifier"),
+		},
+		"China EC2 ARN": {
+			val: types.StringValue("arn:aws-cn:ec2:cn-north-1:123456789012:instance/i-12345678"),
+		},
+		"China S3 ARN": {
+			val: types.StringValue("arn:aws-cn:s3:::bucket/object"),
+		},
+		"C2S EC2 ARN": {
+			val: types.StringValue("arn:aws-iso:ec2:us-iso-east-1:123456789012:instance/i-12345678"),
+		},
+		"C2S S3 ARN": {
+			val: types.StringValue("arn:aws-iso:s3:::bucket/object"),
+		},
+		"SC2S EC2 ARN": {
+			val: types.StringValue("arn:aws-iso-b:ec2:us-isob-east-1:123456789012:instance/i-12345678"),
+		},
+		"SC2S S3 ARN": {
+			val: types.StringValue("arn:aws-iso-b:s3:::bucket/object"),
+		},
+		"GovCloud EC2 ARN": {
+			val: types.StringValue("arn:aws-us-gov:ec2:us-gov-west-1:123456789012:instance/i-12345678"),
+		},
+		"GovCloud S3 ARN": {
+			val: types.StringValue("arn:aws-us-gov:s3:::bucket/object"),
+		},
+		"Cloudwatch Alarm": {
+			val: types.StringValue("arn:aws:cloudwatch::cw0000000000:alarm:my-alarm"),
+		},
+		"Invalid prefix 1": {
+			val: types.StringValue("arn"),
+			expectedDiagnostics: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test"),
+					"Invalid Attribute Value",
+					`Attribute test value must be a valid arn, got: (arn) is an invalid ARN: arn: invalid prefix`,
+				),
+			},
+		},
+		"Invalid prefix 2": {
+			val: types.StringValue("123456789012"),
+			expectedDiagnostics: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test"),
+					"Invalid Attribute Value",
+					`Attribute test value must be a valid arn, got: (123456789012) is an invalid ARN: arn: invalid prefix`,
+				),
+			},
+		},
+		"Not enough sections 1": {
+			val: types.StringValue("arn:aws"),
+			expectedDiagnostics: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test"),
+					"Invalid Attribute Value",
+					`Attribute test value must be a valid arn, got: (arn:aws) is an invalid ARN: arn: not enough sections`,
+				),
+			},
+		},
+		"Not enough sections 2": {
+			val: types.StringValue("arn:aws:logs"),
+			expectedDiagnostics: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test"),
+					"Invalid Attribute Value",
+					`Attribute test value must be a valid arn, got: (arn:aws:logs) is an invalid ARN: arn: not enough sections`,
+				),
+			},
+		},
+		"Invalid region value": {
+			val: types.StringValue("arn:aws:logs:region:*:*"),
+			expectedDiagnostics: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test"),
+					"Invalid Attribute Value",
+					`Attribute test value must be a valid arn, got: (arn:aws:logs:region:*:*) is an invalid ARN: invalid region value (expecting to match regular expression: ^[a-z]{2}(-[a-z]+)+-\d$)`,
+				),
+			},
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			request := validator.StringRequest{
+				Path:           path.Root("test"),
+				PathExpression: path.MatchRoot("test"),
+				ConfigValue:    test.val,
+			}
+			response := validator.StringResponse{}
+			fwvalidators.ARN().ValidateString(ctx, request, &response)
+
+			if diff := cmp.Diff(response.Diagnostics, test.expectedDiagnostics); diff != "" {
+				t.Errorf("unexpected diagnostics difference: %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description
Part 1 of trying to upgrade `aws_iam_role` to terraform plugin framework to resolve issues related inline policies and plans being unreadable for end users and recreate policies on every change. To make overall change smaller, making a bunch of smaller PRs like this to add core functionality for upgrade like an arn string validtor for the terraform plugin framework. If there is a better way I should be splitting up this work please let me know. 

This is based off [this file](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/verify/validate.go#L67-L125) in provider and it's [tests here](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/verify/validate_test.go#L176-L225)


### Relations
Relates #22336

### Output from Acceptance Testing
```zsh
╰─ go test ./internal/framework/validators/... -v -count 1 -parallel 20 -run='TestARNValidator' -short -timeout 180m

=== RUN   TestArnValidator
=== PAUSE TestArnValidator
=== CONT  TestArnValidator
=== RUN   TestArnValidator/SC2S_EC2_ARN
=== PAUSE TestArnValidator/SC2S_EC2_ARN
=== RUN   TestArnValidator/Not_enough_sections_1
=== PAUSE TestArnValidator/Not_enough_sections_1
=== RUN   TestArnValidator/Not_enough_sections_2
=== PAUSE TestArnValidator/Not_enough_sections_2
=== RUN   TestArnValidator/Beanstalk
=== PAUSE TestArnValidator/Beanstalk
=== RUN   TestArnValidator/RDS
=== PAUSE TestArnValidator/RDS
=== RUN   TestArnValidator/S3_object
=== PAUSE TestArnValidator/S3_object
=== RUN   TestArnValidator/China_S3_ARN
=== PAUSE TestArnValidator/China_S3_ARN
=== RUN   TestArnValidator/C2S_EC2_ARN
=== PAUSE TestArnValidator/C2S_EC2_ARN
=== RUN   TestArnValidator/GovCloud_EC2_ARN
=== PAUSE TestArnValidator/GovCloud_EC2_ARN
=== RUN   TestArnValidator/Invalid_prefix_2
=== PAUSE TestArnValidator/Invalid_prefix_2
=== RUN   TestArnValidator/Lambda_function
=== PAUSE TestArnValidator/Lambda_function
=== RUN   TestArnValidator/Lambda_func_qualifier
=== PAUSE TestArnValidator/Lambda_func_qualifier
=== RUN   TestArnValidator/China_EC2_ARN
=== PAUSE TestArnValidator/China_EC2_ARN
=== RUN   TestArnValidator/unknown_String
=== PAUSE TestArnValidator/unknown_String
=== RUN   TestArnValidator/null_String
=== PAUSE TestArnValidator/null_String
=== RUN   TestArnValidator/IAM_User
=== PAUSE TestArnValidator/IAM_User
=== RUN   TestArnValidator/ImageBuilder
=== PAUSE TestArnValidator/ImageBuilder
=== RUN   TestArnValidator/CloudWatch_Rule
=== PAUSE TestArnValidator/CloudWatch_Rule
=== RUN   TestArnValidator/SC2S_S3_ARN
=== PAUSE TestArnValidator/SC2S_S3_ARN
=== RUN   TestArnValidator/GovCloud_S3_ARN
=== PAUSE TestArnValidator/GovCloud_S3_ARN
=== RUN   TestArnValidator/Cloudwatch_Alarm
=== PAUSE TestArnValidator/Cloudwatch_Alarm
=== RUN   TestArnValidator/Managed_IAM_policy
=== PAUSE TestArnValidator/Managed_IAM_policy
=== RUN   TestArnValidator/C2S_S3_ARN
=== PAUSE TestArnValidator/C2S_S3_ARN
=== RUN   TestArnValidator/Invalid_prefix_1
=== PAUSE TestArnValidator/Invalid_prefix_1
=== RUN   TestArnValidator/Invalid_region_value
=== PAUSE TestArnValidator/Invalid_region_value
=== CONT  TestArnValidator/SC2S_EC2_ARN
=== CONT  TestArnValidator/unknown_String
=== CONT  TestArnValidator/GovCloud_EC2_ARN
=== CONT  TestArnValidator/C2S_EC2_ARN
=== CONT  TestArnValidator/China_EC2_ARN
=== CONT  TestArnValidator/Lambda_func_qualifier
=== CONT  TestArnValidator/Lambda_function
=== CONT  TestArnValidator/Invalid_prefix_2
=== CONT  TestArnValidator/RDS
=== CONT  TestArnValidator/SC2S_S3_ARN
=== CONT  TestArnValidator/CloudWatch_Rule
=== CONT  TestArnValidator/IAM_User
=== CONT  TestArnValidator/null_String
=== CONT  TestArnValidator/Not_enough_sections_1
=== CONT  TestArnValidator/China_S3_ARN
=== CONT  TestArnValidator/S3_object
=== CONT  TestArnValidator/C2S_S3_ARN
=== CONT  TestArnValidator/Invalid_region_value
=== CONT  TestArnValidator/GovCloud_S3_ARN
=== CONT  TestArnValidator/Managed_IAM_policy
=== CONT  TestArnValidator/Invalid_prefix_1
=== CONT  TestArnValidator/Beanstalk
=== CONT  TestArnValidator/ImageBuilder
=== CONT  TestArnValidator/Cloudwatch_Alarm
=== CONT  TestArnValidator/Not_enough_sections_2
--- PASS: TestArnValidator (0.00s)
    --- PASS: TestArnValidator/unknown_String (0.00s)
    --- PASS: TestArnValidator/C2S_EC2_ARN (0.00s)
    --- PASS: TestArnValidator/China_EC2_ARN (0.00s)
    --- PASS: TestArnValidator/SC2S_S3_ARN (0.00s)
    --- PASS: TestArnValidator/Invalid_prefix_2 (0.00s)
    --- PASS: TestArnValidator/IAM_User (0.00s)
    --- PASS: TestArnValidator/null_String (0.00s)
    --- PASS: TestArnValidator/GovCloud_EC2_ARN (0.00s)
    --- PASS: TestArnValidator/China_S3_ARN (0.00s)
    --- PASS: TestArnValidator/CloudWatch_Rule (0.00s)
    --- PASS: TestArnValidator/Not_enough_sections_1 (0.00s)
    --- PASS: TestArnValidator/RDS (0.00s)
    --- PASS: TestArnValidator/Lambda_function (0.00s)
    --- PASS: TestArnValidator/SC2S_EC2_ARN (0.00s)
    --- PASS: TestArnValidator/C2S_S3_ARN (0.00s)
    --- PASS: TestArnValidator/Lambda_func_qualifier (0.00s)
    --- PASS: TestArnValidator/S3_object (0.00s)
    --- PASS: TestArnValidator/Invalid_region_value (0.00s)
    --- PASS: TestArnValidator/GovCloud_S3_ARN (0.00s)
    --- PASS: TestArnValidator/Managed_IAM_policy (0.00s)
    --- PASS: TestArnValidator/Invalid_prefix_1 (0.00s)
    --- PASS: TestArnValidator/Beanstalk (0.00s)
    --- PASS: TestArnValidator/ImageBuilder (0.00s)
    --- PASS: TestArnValidator/Cloudwatch_Alarm (0.00s)
    --- PASS: TestArnValidator/Not_enough_sections_2 (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/framework/validators       0.320s
```

