### PR TITLE
resource/aws_batch_job_queue: Require ARN for `compute_environments` elements

### DIFF
--- a/.changelog/33577.txt
+++ b/.changelog/33577.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_batch_job_queue: Correctly validates elements of `compute_environments` as ARNs
+```

--- a/internal/service/batch/job_queue.go
+++ b/internal/service/batch/job_queue.go
@@ -65,7 +65,7 @@ func (r *resourceJobQueue) Schema(ctx context.Context, request resource.SchemaRe
 		Attributes: map[string]schema.Attribute{
 			"arn": framework.ARNAttributeComputedOnly(),
 			"compute_environments": schema.ListAttribute{
-				ElementType: types.StringType,
+				ElementType: fwtypes.ARNType,
 				Required:    true,
 			},
 			"id": framework.IDAttribute(),
@@ -365,6 +365,7 @@ func (r *resourceJobQueueData) refreshFromOutput(ctx context.Context, out *batch
 
 	return diags
 }
+
 func expandComputeEnvironmentOrder(order []string) (envs []*batch.ComputeEnvironmentOrder) {
 	for i, env := range order {
 		envs = append(envs, &batch.ComputeEnvironmentOrder{

--- a/internal/service/batch/job_queue_test.go
+++ b/internal/service/batch/job_queue_test.go
@@ -39,6 +39,7 @@ func TestAccBatchJobQueue_basic(t *testing.T) {
 					testAccCheckJobQueueExists(ctx, resourceName, &jobQueue1),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "batch", fmt.Sprintf("job-queue/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "compute_environments.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "compute_environments.0", "aws_batch_compute_environment.test", "arn"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "priority", "1"),
 					resource.TestCheckResourceAttr(resourceName, "state", batch.JQStateEnabled),

--- a/internal/service/batch/job_queue_test.go
+++ b/internal/service/batch/job_queue_test.go
@@ -112,6 +112,52 @@ func TestAccBatchJobQueue_MigrateFromPluginSDK(t *testing.T) {
 	})
 }
 
+func TestAccBatchJobQueue_ComputeEnvironments_multiple(t *testing.T) {
+	ctx := acctest.Context(t)
+	var jobQueue1 batch.JobQueueDetail
+	resourceName := "aws_batch_job_queue.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckJobQueueDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccJobQueueConfig_ComputeEnvironments_multiple(rName, batch.JQStateEnabled),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckJobQueueExists(ctx, resourceName, &jobQueue1),
+					resource.TestCheckResourceAttr(resourceName, "compute_environments.#", "3"),
+					resource.TestCheckResourceAttrPair(resourceName, "compute_environments.0", "aws_batch_compute_environment.test", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "compute_environments.1", "aws_batch_compute_environment.more.0", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "compute_environments.2", "aws_batch_compute_environment.more.1", "arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccJobQueueConfig_ComputeEnvironments_multipleReorder(rName, batch.JQStateEnabled),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckJobQueueExists(ctx, resourceName, &jobQueue1),
+					resource.TestCheckResourceAttr(resourceName, "compute_environments.#", "3"),
+					resource.TestCheckResourceAttrPair(resourceName, "compute_environments.0", "aws_batch_compute_environment.more.0", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "compute_environments.1", "aws_batch_compute_environment.test", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "compute_environments.2", "aws_batch_compute_environment.more.1", "arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/8083
 func TestAccBatchJobQueue_ComputeEnvironments_externalOrderUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
@@ -547,6 +593,79 @@ resource "aws_batch_job_queue" "test" {
   name                 = %[1]q
   priority             = 1
   state                = %[2]q
+}
+`, rName, state))
+}
+
+func testAccJobQueueConfig_ComputeEnvironments_multiple(rName string, state string) string {
+	return acctest.ConfigCompose(
+		testAccJobQueueConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_batch_job_queue" "test" {
+  compute_environments = concat(
+    [aws_batch_compute_environment.test.arn],
+    aws_batch_compute_environment.more[*].arn,
+  )
+  name     = %[1]q
+  priority = 1
+  state    = %[2]q
+}
+
+resource "aws_batch_compute_environment" "more" {
+  count = 2
+
+  compute_environment_name = "%[1]s-${count.index + 1}"
+  service_role             = aws_iam_role.test.arn
+  type                     = "MANAGED"
+
+  compute_resources {
+    instance_role      = aws_iam_instance_profile.ecs_instance_role.arn
+    instance_type      = ["c5", "m5", "r5"]
+    max_vcpus          = 1
+    min_vcpus          = 0
+    security_group_ids = [aws_security_group.test.id]
+    subnets            = [aws_subnet.test.id]
+    type               = "EC2"
+  }
+
+  depends_on = [aws_iam_role_policy_attachment.test]
+}
+`, rName, state))
+}
+
+func testAccJobQueueConfig_ComputeEnvironments_multipleReorder(rName string, state string) string {
+	return acctest.ConfigCompose(
+		testAccJobQueueConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_batch_job_queue" "test" {
+  compute_environments = [
+    aws_batch_compute_environment.more[0].arn,
+    aws_batch_compute_environment.test.arn,
+    aws_batch_compute_environment.more[1].arn,
+  ]
+  name     = %[1]q
+  priority = 1
+  state    = %[2]q
+}
+
+resource "aws_batch_compute_environment" "more" {
+  count = 2
+
+  compute_environment_name = "%[1]s-${count.index + 1}"
+  service_role             = aws_iam_role.test.arn
+  type                     = "MANAGED"
+
+  compute_resources {
+    instance_role      = aws_iam_instance_profile.ecs_instance_role.arn
+    instance_type      = ["c5", "m5", "r5"]
+    max_vcpus          = 1
+    min_vcpus          = 0
+    security_group_ids = [aws_security_group.test.id]
+    subnets            = [aws_subnet.test.id]
+    type               = "EC2"
+  }
+
+  depends_on = [aws_iam_role_policy_attachment.test]
 }
 `, rName, state))
 }

--- a/website/docs/r/batch_job_queue.html.markdown
+++ b/website/docs/r/batch_job_queue.html.markdown
@@ -62,9 +62,8 @@ resource "aws_batch_job_queue" "example" {
 This resource supports the following arguments:
 
 * `name` - (Required) Specifies the name of the job queue.
-* `compute_environments` - (Required) Specifies the set of compute environments
-    mapped to a job queue and their order.  The position of the compute environments
-    in the list will dictate the order.
+* `compute_environments` - (Required) List of compute environment ARNs mapped to a job queue.
+  The position of the compute environments in the list will dictate the order.
 * `priority` - (Required) The priority of the job queue. Job queues with a higher priority
     are evaluated first when associated with the same compute environment.
 * `scheduling_policy_arn` - (Optional) The ARN of the fair share scheduling policy. If this parameter is specified, the job queue uses a fair share scheduling policy. If this parameter isn't specified, the job queue uses a first in, first out (FIFO) scheduling policy. After a job queue is created, you can replace but can't remove the fair share scheduling policy.


### PR DESCRIPTION
### Description

The AWS API is documented to take ARNs for the list of compute environments. Add validator to `compute_environments`.

Also adds test for multiple compute environments for a job queue.

### Relations

Closes #33376

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=batch TESTS=TestAccBatchJobQueue_

--- PASS: TestAccBatchJobQueue_disappears (141.55s)
--- PASS: TestAccBatchJobQueue_ComputeEnvironments_externalOrderUpdate (142.84s)
--- PASS: TestAccBatchJobQueue_basic (150.52s)
--- PASS: TestAccBatchJobQueue_MigrateFromPluginSDK (156.94s)
--- PASS: TestAccBatchJobQueue_tags (191.81s)
--- PASS: TestAccBatchJobQueue_schedulingPolicy (196.51s)
--- PASS: TestAccBatchJobQueue_ComputeEnvironments_multiple (206.25s)
--- PASS: TestAccBatchJobQueue_state (210.15s)
--- PASS: TestAccBatchJobQueue_priority (210.15s)
```
