### PR TITLE
aws_cloudfront_distribution: IllegalUpdate test

### DIFF
--- a/internal/service/cloudfront/continuous_deployment_policy.go
+++ b/internal/service/cloudfront/continuous_deployment_policy.go
@@ -320,11 +320,7 @@ func DeleteCDP(ctx context.Context, conn *cloudfront.CloudFront, id string) erro
 		}
 	}
 
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func disableContinuousDeploymentPolicy(ctx context.Context, conn *cloudfront.CloudFront, id string) error {
@@ -346,11 +342,7 @@ func disableContinuousDeploymentPolicy(ctx context.Context, conn *cloudfront.Clo
 	}
 
 	_, err = conn.UpdateContinuousDeploymentPolicyWithContext(ctx, in)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func cdpETag(ctx context.Context, conn *cloudfront.CloudFront, id string) (*string, error) {

--- a/internal/service/cloudfront/continuous_deployment_policy.go
+++ b/internal/service/cloudfront/continuous_deployment_policy.go
@@ -271,22 +271,95 @@ func (r *resourceContinuousDeploymentPolicy) Delete(ctx context.Context, req res
 		return
 	}
 
-	in := &cloudfront.DeleteContinuousDeploymentPolicyInput{
-		Id:      aws.String(state.ID.ValueString()),
-		IfMatch: aws.String(state.ETag.ValueString()),
-	}
+	err := DeleteCDP(ctx, conn, state.ID.ValueString())
 
-	_, err := conn.DeleteContinuousDeploymentPolicyWithContext(ctx, in)
 	if err != nil {
-		if tfawserr.ErrCodeEquals(err, cloudfront.ErrCodeNoSuchContinuousDeploymentPolicy) {
-			return
-		}
 		resp.Diagnostics.AddError(
 			create.ProblemStandardMessage(names.CloudFront, create.ErrActionDeleting, ResNameContinuousDeploymentPolicy, state.ID.String(), err),
 			err.Error(),
 		)
 		return
 	}
+}
+
+func DeleteCDP(ctx context.Context, conn *cloudfront.CloudFront, id string) error {
+	etag, err := cdpETag(ctx, conn, id)
+	if tfresource.NotFound(err) {
+		return nil
+	}
+
+	if err != nil {
+		return err
+	}
+
+	in := &cloudfront.DeleteContinuousDeploymentPolicyInput{
+		Id:      aws.String(id),
+		IfMatch: etag,
+	}
+
+	_, err = conn.DeleteContinuousDeploymentPolicyWithContext(ctx, in)
+	if tfawserr.ErrCodeEquals(err, cloudfront.ErrCodeNoSuchContinuousDeploymentPolicy) {
+		return nil
+	}
+
+	if tfawserr.ErrCodeEquals(err, cloudfront.ErrCodePreconditionFailed, cloudfront.ErrCodeInvalidIfMatchVersion) {
+		etag, err := cdpETag(ctx, conn, id)
+		if tfresource.NotFound(err) {
+			return nil
+		}
+
+		if err != nil {
+			return err
+		}
+
+		in.SetIfMatch(aws.StringValue(etag))
+
+		_, err = conn.DeleteContinuousDeploymentPolicyWithContext(ctx, in)
+		if tfawserr.ErrCodeEquals(err, cloudfront.ErrCodeNoSuchContinuousDeploymentPolicy) {
+			return nil
+		}
+	}
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func disableContinuousDeploymentPolicy(ctx context.Context, conn *cloudfront.CloudFront, id string) error {
+	out, err := FindContinuousDeploymentPolicyByID(ctx, conn, id)
+	if tfresource.NotFound(err) || out == nil || out.ContinuousDeploymentPolicy == nil || out.ContinuousDeploymentPolicy.ContinuousDeploymentPolicyConfig == nil {
+		return nil
+	}
+
+	if !aws.BoolValue(out.ContinuousDeploymentPolicy.ContinuousDeploymentPolicyConfig.Enabled) {
+		return nil
+	}
+
+	out.ContinuousDeploymentPolicy.ContinuousDeploymentPolicyConfig.SetEnabled(false)
+
+	in := &cloudfront.UpdateContinuousDeploymentPolicyInput{
+		Id:                               out.ContinuousDeploymentPolicy.Id,
+		IfMatch:                          out.ETag,
+		ContinuousDeploymentPolicyConfig: out.ContinuousDeploymentPolicy.ContinuousDeploymentPolicyConfig,
+	}
+
+	_, err = conn.UpdateContinuousDeploymentPolicyWithContext(ctx, in)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func cdpETag(ctx context.Context, conn *cloudfront.CloudFront, id string) (*string, error) {
+	output, err := FindContinuousDeploymentPolicyByID(ctx, conn, id)
+	if err != nil {
+		return nil, err
+	}
+
+	return output.ETag, nil
 }
 
 func (r *resourceContinuousDeploymentPolicy) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/internal/service/cloudfront/distribution.go
+++ b/internal/service/cloudfront/distribution.go
@@ -5,13 +5,13 @@ package cloudfront
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudfront"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -233,6 +233,7 @@ func ResourceDistribution() *schema.Resource {
 			"continuous_deployment_policy_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"comment": {
 				Type:         schema.TypeString,
@@ -871,7 +872,7 @@ func resourceDistributionCreate(ctx context.Context, d *schema.ResourceData, met
 
 	if d.Get("wait_for_deployment").(bool) {
 		log.Printf("[DEBUG] Waiting until CloudFront Distribution (%s) is deployed", d.Id())
-		if err := DistributionWaitUntilDeployed(ctx, d.Id(), meta); err != nil {
+		if err := WaitDistributionDeployed(ctx, conn, d.Id()); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting until CloudFront Distribution (%s) is deployed: %s", d.Id(), err)
 		}
 	}
@@ -930,60 +931,6 @@ func resourceDistributionUpdate(ctx context.Context, d *schema.ResourceData, met
 			IfMatch:            aws.String(d.Get("etag").(string)),
 		}
 
-		fmt.Printf("\nbefore input: %+v\n", input)
-		input.DistributionConfig.Aliases = &cloudfront.Aliases{
-			Quantity: aws.Int64(0),
-			Items:    aws.StringSlice([]string{}),
-		}
-
-		input.DistributionConfig.CacheBehaviors = &cloudfront.CacheBehaviors{
-			Quantity: aws.Int64(0),
-			Items:    []*cloudfront.CacheBehavior{},
-		}
-
-		input.DistributionConfig.OriginGroups = &cloudfront.OriginGroups{
-			Quantity: aws.Int64(0),
-			Items:    []*cloudfront.OriginGroup{},
-		}
-
-		input.DistributionConfig.ViewerCertificate = &cloudfront.ViewerCertificate{
-			MinimumProtocolVersion:       aws.String("TLSv1"),
-			CloudFrontDefaultCertificate: aws.Bool(true),
-			SSLSupportMethod:             aws.String("vip"),
-			CertificateSource:            aws.String("cloudfront"),
-		}
-
-		defaultCacheBehave := input.DistributionConfig.DefaultCacheBehavior
-		defaultCacheBehave.TrustedKeyGroups = &cloudfront.TrustedKeyGroups{
-			Quantity: aws.Int64(0),
-			Items:    aws.StringSlice([]string{}),
-			Enabled:  aws.Bool(false),
-		}
-
-		defaultCacheBehave.ResponseHeadersPolicyId = nil
-
-		defaultCacheBehave.ForwardedValues.Cookies = &cloudfront.CookiePreference{
-			Forward: aws.String("all"),
-			WhitelistedNames: &cloudfront.CookieNames{
-				Items:    aws.StringSlice([]string{}),
-				Quantity: aws.Int64(0),
-			},
-		}
-
-		defaultCacheBehave.TrustedSigners = &cloudfront.TrustedSigners{
-			Items:    aws.StringSlice([]string{}),
-			Enabled:  aws.Bool(false),
-			Quantity: aws.Int64(0),
-		}
-
-		input.DistributionConfig.DefaultCacheBehavior = defaultCacheBehave
-
-		input.DistributionConfig.Origins.Items[0].OriginShield = &cloudfront.OriginShield{
-			Enabled: aws.Bool(false),
-		}
-
-		fmt.Printf("\nafter input: %+v\n", input)
-
 		// ACM and IAM certificate eventual consistency.
 		// InvalidViewerCertificate: The specified SSL certificate doesn't exist, isn't in us-east-1 region, isn't valid, or doesn't include a valid certificate chain.
 		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 1*time.Minute, func() (interface{}, error) {
@@ -1019,7 +966,7 @@ func resourceDistributionUpdate(ctx context.Context, d *schema.ResourceData, met
 
 		if d.Get("wait_for_deployment").(bool) {
 			log.Printf("[DEBUG] Waiting until CloudFront Distribution (%s) is deployed", d.Id())
-			if err := DistributionWaitUntilDeployed(ctx, d.Id(), meta); err != nil {
+			if err := WaitDistributionDeployed(ctx, conn, d.Id()); err != nil {
 				return sdkdiag.AppendErrorf(diags, "waiting until CloudFront Distribution (%s) is deployed: %s", d.Id(), err)
 			}
 		}
@@ -1032,103 +979,51 @@ func resourceDistributionDelete(ctx context.Context, d *schema.ResourceData, met
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontConn(ctx)
 
+	if d.Get("arn").(string) == "" {
+		diags = append(diags, resourceDistributionRead(ctx, d, meta)...)
+	}
+
+	if v := d.Get("continuous_deployment_policy_id").(string); v != "" {
+		if err := disableContinuousDeploymentPolicy(ctx, conn, v); err != nil {
+			return create.DiagError(names.CloudFront, create.ErrActionDeleting, ResNameDistribution, d.Id(), err)
+		}
+
+		if err := WaitDistributionDeployed(ctx, conn, d.Id()); err != nil {
+			return diag.Errorf("waiting until CloudFront Distribution (%s) is deployed: %s", d.Id(), err)
+		}
+	}
+
+	if err := disableDistribution(ctx, conn, d.Id()); err != nil {
+		return diag.Errorf("disabling CloudFront Distribution (%s): %s", d.Id(), err)
+	}
+
 	if d.Get("retain_on_delete").(bool) {
-		// Check if we need to disable first.
-		output, err := FindDistributionByID(ctx, conn, d.Id())
-
-		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "reading CloudFront Distribution (%s): %s", d.Id(), err)
-		}
-
-		if !aws.BoolValue(output.Distribution.DistributionConfig.Enabled) {
-			log.Printf("[WARN] Removing CloudFront Distribution ID %q with `retain_on_delete` set. Please delete this distribution manually.", d.Id())
-			return diags
-		}
-
-		input := &cloudfront.UpdateDistributionInput{
-			DistributionConfig: output.Distribution.DistributionConfig,
-			Id:                 aws.String(d.Id()),
-			IfMatch:            output.ETag,
-		}
-		input.DistributionConfig.Enabled = aws.Bool(false)
-
-		_, err = conn.UpdateDistributionWithContext(ctx, input)
-
-		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "disabling CloudFront Distribution (%s): %s", d.Id(), err)
-		}
-
 		log.Printf("[WARN] Removing CloudFront Distribution ID %q with `retain_on_delete` set. Please delete this distribution manually.", d.Id())
 		return diags
 	}
 
-	deleteDistroInput := &cloudfront.DeleteDistributionInput{
-		Id:      aws.String(d.Id()),
-		IfMatch: aws.String(d.Get("etag").(string)),
-	}
-
-	log.Printf("[DEBUG] Deleting CloudFront Distribution: %s", d.Id())
-	_, err := conn.DeleteDistributionWithContext(ctx, deleteDistroInput)
-
+	err := deleteDistribution(ctx, conn, d.Id())
 	if err == nil || tfawserr.ErrCodeEquals(err, cloudfront.ErrCodeNoSuchDistribution) {
 		return diags
-	}
-
-	// Refresh our ETag if it is out of date and attempt deletion again.
-	if tfawserr.ErrCodeEquals(err, cloudfront.ErrCodeInvalidIfMatchVersion) {
-		var output *cloudfront.GetDistributionOutput
-		output, err = FindDistributionByID(ctx, conn, d.Id())
-
-		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "reading CloudFront Distribution (%s): %s", d.Id(), err)
-		}
-
-		deleteDistroInput.IfMatch = output.ETag
-
-		_, err = conn.DeleteDistributionWithContext(ctx, deleteDistroInput)
 	}
 
 	// Disable distribution if it is not yet disabled and attempt deletion again.
 	// Here we update via the deployed configuration to ensure we are not submitting an out of date
 	// configuration from the Terraform configuration, should other changes have occurred manually.
 	if tfawserr.ErrCodeEquals(err, cloudfront.ErrCodeDistributionNotDisabled) {
-		var output *cloudfront.GetDistributionOutput
-		output, err = FindDistributionByID(ctx, conn, d.Id())
-
-		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "reading CloudFront Distribution (%s): %s", d.Id(), err)
+		if err = disableDistribution(ctx, conn, d.Id()); err != nil {
+			return diag.Errorf("disabling CloudFront Distribution (%s): %s", d.Id(), err)
 		}
 
-		updateDistroInput := &cloudfront.UpdateDistributionInput{
-			DistributionConfig: output.Distribution.DistributionConfig,
-			Id:                 aws.String(d.Id()),
-			IfMatch:            output.ETag,
-		}
-		updateDistroInput.DistributionConfig.Enabled = aws.Bool(false)
-		var updateDistroOutput *cloudfront.UpdateDistributionOutput
+		_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, 1*time.Minute, func() (interface{}, error) {
+			return nil, deleteDistribution(ctx, conn, d.Id())
+		}, cloudfront.ErrCodeDistributionNotDisabled)
+	}
 
-		updateDistroOutput, err = conn.UpdateDistributionWithContext(ctx, updateDistroInput)
-
-		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "disabling CloudFront Distribution (%s): %s", d.Id(), err)
-		}
-
-		if err := DistributionWaitUntilDeployed(ctx, d.Id(), meta); err != nil {
-			return sdkdiag.AppendErrorf(diags, "waiting until CloudFront Distribution (%s) is deployed: %s", d.Id(), err)
-		}
-
-		deleteDistroInput.IfMatch = updateDistroOutput.ETag
-
-		_, err = conn.DeleteDistributionWithContext(ctx, deleteDistroInput)
-
-		// CloudFront has eventual consistency issues even for "deployed" state.
-		// Occasionally the DeleteDistribution call will return this error as well, in which retries will succeed:
-		//   * PreconditionFailed: The request failed because it didn't meet the preconditions in one or more request-header fields
-		if tfawserr.ErrCodeEquals(err, cloudfront.ErrCodeDistributionNotDisabled, cloudfront.ErrCodePreconditionFailed) {
-			_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, 5*time.Minute, func() (interface{}, error) {
-				return conn.DeleteDistributionWithContext(ctx, deleteDistroInput)
-			}, cloudfront.ErrCodeDistributionNotDisabled, cloudfront.ErrCodePreconditionFailed)
-		}
+	if tfawserr.ErrCodeEquals(err, cloudfront.ErrCodePreconditionFailed, cloudfront.ErrCodeInvalidIfMatchVersion) {
+		_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, 1*time.Minute, func() (interface{}, error) {
+			return nil, deleteDistribution(ctx, conn, d.Id())
+		}, cloudfront.ErrCodePreconditionFailed)
 	}
 
 	if tfawserr.ErrCodeEquals(err, cloudfront.ErrCodeNoSuchDistribution) {
@@ -1140,6 +1035,66 @@ func resourceDistributionDelete(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	return diags
+}
+
+func deleteDistribution(ctx context.Context, conn *cloudfront.CloudFront, id string) error {
+	etag, err := distroETag(ctx, conn, id)
+	if err != nil {
+		return err
+	}
+
+	in := &cloudfront.DeleteDistributionInput{
+		Id:      aws.String(id),
+		IfMatch: aws.String(etag),
+	}
+
+	if _, err := conn.DeleteDistributionWithContext(ctx, in); err != nil {
+		return err
+	}
+
+	if err := WaitDistributionDeleted(ctx, conn, id); err != nil && !tfawserr.ErrCodeEquals(err, cloudfront.ErrCodeNoSuchDistribution) {
+		return err
+	}
+
+	return nil
+}
+
+func distroETag(ctx context.Context, conn *cloudfront.CloudFront, id string) (string, error) {
+	output, err := FindDistributionByID(ctx, conn, id)
+	if err != nil {
+		return "", err
+	}
+
+	return aws.StringValue(output.ETag), nil
+}
+
+func disableDistribution(ctx context.Context, conn *cloudfront.CloudFront, id string) error {
+	out, err := FindDistributionByID(ctx, conn, id)
+	if err != nil {
+		return err
+	}
+
+	if !aws.BoolValue(out.Distribution.DistributionConfig.Enabled) {
+		return nil
+	}
+
+	in := &cloudfront.UpdateDistributionInput{
+		DistributionConfig: out.Distribution.DistributionConfig,
+		Id:                 aws.String(id),
+		IfMatch:            out.ETag,
+	}
+	in.DistributionConfig.Enabled = aws.Bool(false)
+
+	_, err = conn.UpdateDistributionWithContext(ctx, in)
+	if err != nil {
+		return err
+	}
+
+	if err := WaitDistributionDeployed(ctx, conn, id); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func FindDistributionByID(ctx context.Context, conn *cloudfront.CloudFront, id string) (*cloudfront.GetDistributionOutput, error) {
@@ -1167,14 +1122,104 @@ func FindDistributionByID(ctx context.Context, conn *cloudfront.CloudFront, id s
 	return output, nil
 }
 
+// ListDistributionsByContinuousDeploymentPolicyID exists in the API but not sdk v1
+func UpdateDistributionsForNoContinuousDeploymentPolicyID(ctx context.Context, conn *cloudfront.CloudFront, id string) error {
+	input := &cloudfront.ListDistributionsInput{}
+	var errs *multierror.Error
+
+	err := conn.ListDistributionsPagesWithContext(ctx, input, func(page *cloudfront.ListDistributionsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, d := range page.DistributionList.Items {
+			if d == nil {
+				continue
+			}
+
+			inGetCfg := &cloudfront.GetDistributionConfigInput{
+				Id: d.Id,
+			}
+
+			cfg, err := conn.GetDistributionConfigWithContext(ctx, inGetCfg)
+			if err != nil {
+				errs = multierror.Append(errs, err)
+			}
+
+			if cfg.DistributionConfig != nil && aws.StringValue(cfg.DistributionConfig.ContinuousDeploymentPolicyId) == id {
+				cfg.DistributionConfig.ContinuousDeploymentPolicyId = nil
+
+				updateDistroInput := &cloudfront.UpdateDistributionInput{
+					DistributionConfig: cfg.DistributionConfig,
+					Id:                 aws.String(id),
+					IfMatch:            cfg.ETag,
+				}
+
+				_, err = conn.UpdateDistributionWithContext(ctx, updateDistroInput)
+				if err != nil {
+					errs = multierror.Append(errs, err)
+				}
+			}
+		}
+
+		return !lastPage
+	})
+	if err != nil {
+		return err
+	}
+
+	return errs.ErrorOrNil()
+}
+
+func FindDistributionByDomainName(ctx context.Context, conn *cloudfront.CloudFront, name string) (*cloudfront.DistributionSummary, error) {
+	var dist *cloudfront.DistributionSummary
+
+	input := &cloudfront.ListDistributionsInput{}
+
+	err := conn.ListDistributionsPagesWithContext(ctx, input, func(page *cloudfront.ListDistributionsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, d := range page.DistributionList.Items {
+			if d == nil {
+				continue
+			}
+
+			if aws.StringValue(d.DomainName) == name {
+				dist = d
+				return false
+			}
+		}
+
+		return !lastPage
+	})
+
+	return dist, err
+}
+
 // resourceAwsCloudFrontWebDistributionWaitUntilDeployed blocks until the
 // distribution is deployed. It currently takes exactly 15 minutes to deploy
 // but that might change in the future.
-func DistributionWaitUntilDeployed(ctx context.Context, id string, meta interface{}) error {
+func WaitDistributionDeployed(ctx context.Context, conn *cloudfront.CloudFront, id string) error {
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{"InProgress"},
 		Target:     []string{"Deployed"},
-		Refresh:    resourceWebDistributionStateRefreshFunc(ctx, id, meta),
+		Refresh:    distributionRefreshFunc(ctx, conn, id),
+		Timeout:    90 * time.Minute,
+		MinTimeout: 15 * time.Second,
+		Delay:      1 * time.Minute,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func WaitDistributionDeleted(ctx context.Context, conn *cloudfront.CloudFront, id string) error {
+	stateConf := &retry.StateChangeConf{
+		Pending:    []string{"InProgress", "Deployed"},
+		Target:     []string{},
+		Refresh:    distributionRefreshFunc(ctx, conn, id),
 		Timeout:    90 * time.Minute,
 		MinTimeout: 15 * time.Second,
 		Delay:      1 * time.Minute,
@@ -1185,9 +1230,8 @@ func DistributionWaitUntilDeployed(ctx context.Context, id string, meta interfac
 }
 
 // The refresh function for resourceAwsCloudFrontWebDistributionWaitUntilDeployed.
-func resourceWebDistributionStateRefreshFunc(ctx context.Context, id string, meta interface{}) retry.StateRefreshFunc {
+func distributionRefreshFunc(ctx context.Context, conn *cloudfront.CloudFront, id string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		conn := meta.(*conns.AWSClient).CloudFrontConn(ctx)
 		params := &cloudfront.GetDistributionInput{
 			Id: aws.String(id),
 		}

--- a/internal/service/cloudfront/distribution_configuration_structure.go
+++ b/internal/service/cloudfront/distribution_configuration_structure.go
@@ -107,13 +107,9 @@ func flattenDistributionConfig(d *schema.ResourceData, distributionConfig *cloud
 	d.Set("staging", distributionConfig.Staging)
 	d.Set("web_acl_id", distributionConfig.WebACLId)
 
-	if !aws.BoolValue(distributionConfig.Staging) {
-		// Only set this for production distributions. While staging distributions do
-		// return a value when their domain name is referenced in a continuous deployment
-		// policy, this attribute is optional (not optional/computed) to correctly
-		// trigger changes when a policy is removed from a production distribution.
-		d.Set("continuous_deployment_policy_id", distributionConfig.ContinuousDeploymentPolicyId)
-	}
+	// Not having this set for staging distributions causes IllegalUpdate errors when making updates of any kind.
+	// If this absolutely must not be optional/computed, the policy ID will need to be retrieved and set for each
+	// API call for staging distributions.
 	d.Set("continuous_deployment_policy_id", distributionConfig.ContinuousDeploymentPolicyId)
 
 	if distributionConfig.CustomErrorResponses != nil {

--- a/internal/service/cloudfront/distribution_configuration_structure.go
+++ b/internal/service/cloudfront/distribution_configuration_structure.go
@@ -114,6 +114,7 @@ func flattenDistributionConfig(d *schema.ResourceData, distributionConfig *cloud
 		// trigger changes when a policy is removed from a production distribution.
 		d.Set("continuous_deployment_policy_id", distributionConfig.ContinuousDeploymentPolicyId)
 	}
+	d.Set("continuous_deployment_policy_id", distributionConfig.ContinuousDeploymentPolicyId)
 
 	if distributionConfig.CustomErrorResponses != nil {
 		err = d.Set("custom_error_response", FlattenCustomErrorResponses(distributionConfig.CustomErrorResponses))

--- a/internal/service/cloudfront/distribution_test.go
+++ b/internal/service/cloudfront/distribution_test.go
@@ -590,14 +590,6 @@ func TestAccCloudFrontDistribution_Origin_originShield(t *testing.T) {
 				ExpectError: regexache.MustCompile(`Missing required argument`),
 			},
 			{
-				Config:      testAccDistributionConfig_originItem(rName, originShieldItem(`false`, `null`)),
-				ExpectError: regexache.MustCompile(`Missing required argument`),
-			},
-			{
-				Config:      testAccDistributionConfig_originItem(rName, originShieldItem(`true`, `null`)),
-				ExpectError: regexache.MustCompile(`Missing required argument`),
-			},
-			{
 				Config:      testAccDistributionConfig_originItem(rName, originShieldItem(`false`, `""`)),
 				ExpectError: regexache.MustCompile(`.*must be a valid AWS Region Code.*`),
 			},

--- a/internal/service/cloudfront/distribution_test.go
+++ b/internal/service/cloudfront/distribution_test.go
@@ -1640,7 +1640,7 @@ func testAccCheckDistributionDisappears(ctx context.Context, distribution *cloud
 
 func testAccCheckDistributionWaitForDeployment(ctx context.Context, distribution *cloudfront.Distribution) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		return tfcloudfront.DistributionWaitUntilDeployed(ctx, aws.StringValue(distribution.Id), acctest.Provider.Meta())
+		return tfcloudfront.WaitDistributionDeployed(ctx, acctest.Provider.Meta().(*conns.AWSClient).CloudFrontConn(ctx), aws.StringValue(distribution.Id))
 	}
 }
 

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -401,7 +401,7 @@ argument should not be specified.
 ##### Origin Shield Arguments
 
 * `enabled` (Required) - Whether Origin Shield is enabled.
-* `origin_shield_region` (Required) - AWS Region for Origin Shield. To specify a region, use the region code, not the region name. For example, specify the US East (Ohio) region as us-east-2.
+* `origin_shield_region` (Optional) - AWS Region for Origin Shield. To specify a region, use the region code, not the region name. For example, specify the US East (Ohio) region as `us-east-2`.
 
 ##### S3 Origin Config Arguments
 

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -386,8 +386,8 @@ argument should not be specified.
 * `origin_access_control_id` (Optional) - Unique identifier of a [CloudFront origin access control][8] for this origin.
 * `origin_id` (Required) - Unique identifier for the origin.
 * `origin_path` (Optional) - Optional element that causes CloudFront to request your content from a directory in your Amazon S3 bucket or your custom origin.
-* `origin_shield` - The [CloudFront Origin Shield](#origin-shield-arguments) configuration information. Using Origin Shield can help reduce the load on your origin. For more information, see [Using Origin Shield](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/origin-shield.html) in the Amazon CloudFront Developer Guide.
-* `s3_origin_config` - The [CloudFront S3 origin](#s3-origin-config-arguments) configuration information. If a custom origin is required, use `custom_origin_config` instead.
+* `origin_shield` - (Optional) [CloudFront Origin Shield](#origin-shield-arguments) configuration information. Using Origin Shield can help reduce the load on your origin. For more information, see [Using Origin Shield](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/origin-shield.html) in the Amazon CloudFront Developer Guide.
+* `s3_origin_config` - (Optional) [CloudFront S3 origin](#s3-origin-config-arguments) configuration information. If a custom origin is required, use `custom_origin_config` instead.
 
 ##### Custom Origin Config Arguments
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

There is a careful delicate dance between a production `aws_cloudfront_distribution`, an `aws_clouldfront_continuous_deployment_policy`, and a staging `aws_cloudfront_distribution`. The AWS Console ("AWS Internal") does a lot for you in this regard. This fix brings in some of this functionality to allow continous deployments to be cleanly created and destroyed using Terraform.

This PR addresses two specific issues, in addition to cleanup and logic clarification:

1. The API updates a CloudFront resource's `etag` with every change to the resource. If you're doing multiple changes as part of deleting or updating, you'll get a new `etag` at each step. It's important to include the latest with each operation or you'll get `Precondition Failed` (or potentially `Invalid MatchIf Version`) errors.
2. When working with staging and production `aws_cloudfront_distribution`s, you need to include the continuous deployment policy ID with each API call or you'll get an `IllegalUpdate` trying to update.

In order to delete everything associated with a staging `aws_cloudfront_distribution` linked by an `aws_cloudfront_continuous_deployment_policy` to a production `aws_cloudfront_distribution`, you need to do everything very precisely.

The acyclic dependency graph looks something like this:
production distribution ➡️ continuous deployment policy ➡️ staging distribution.

The steps to delete the resources are roughly as follows (order is crucial):
1. Get the new continuous deployment policy etag
2. Disable the continuous deployment policy
3. Get the new production distribution etag
4. Disable the production distribution
6. Wait for deployment
7. Get the new production distribution etag
8. Delete the production distribution
9. Get the new continuous deployment policy etag
10. Delete the continous deployment policy
11. Get the new staging distribution etag
12. Disable the staging distribution
14. Wait for deployment
15. Get the new staging distribution etag
16. Delete the staging distribution

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #33338
Closes #33575 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccCloudFrontContinuousDeploymentPolicy_ K=cloudfront P=4
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudfront/... -v -count 1 -parallel 4 -run='TestAccCloudFrontContinuousDeploymentPolicy_'  -timeout 360m
=== RUN   TestAccCloudFrontContinuousDeploymentPolicy_basic
=== PAUSE TestAccCloudFrontContinuousDeploymentPolicy_basic
=== RUN   TestAccCloudFrontContinuousDeploymentPolicy_disappears
=== PAUSE TestAccCloudFrontContinuousDeploymentPolicy_disappears
=== RUN   TestAccCloudFrontContinuousDeploymentPolicy_trafficConfig
=== PAUSE TestAccCloudFrontContinuousDeploymentPolicy_trafficConfig
=== RUN   TestAccCloudFrontContinuousDeploymentPolicy_domainChange
=== PAUSE TestAccCloudFrontContinuousDeploymentPolicy_domainChange
=== CONT  TestAccCloudFrontContinuousDeploymentPolicy_basic
=== CONT  TestAccCloudFrontContinuousDeploymentPolicy_trafficConfig
=== CONT  TestAccCloudFrontContinuousDeploymentPolicy_disappears
=== CONT  TestAccCloudFrontContinuousDeploymentPolicy_domainChange
--- PASS: TestAccCloudFrontContinuousDeploymentPolicy_disappears (1297.70s)
--- PASS: TestAccCloudFrontContinuousDeploymentPolicy_basic (2596.16s)
--- PASS: TestAccCloudFrontContinuousDeploymentPolicy_trafficConfig (2639.61s)
--- PASS: TestAccCloudFrontContinuousDeploymentPolicy_domainChange (3017.79s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront	3019.747s
% make t T=TestAccCloudFrontDistribution_ K=cloudfront P=8
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudfront/... -v -count 1 -parallel 8 -run='TestAccCloudFrontDistribution_'  -timeout 360m
=== RUN   TestAccCloudFrontDistribution_basic
=== PAUSE TestAccCloudFrontDistribution_basic
=== RUN   TestAccCloudFrontDistribution_disappears
=== PAUSE TestAccCloudFrontDistribution_disappears
=== RUN   TestAccCloudFrontDistribution_tags
=== PAUSE TestAccCloudFrontDistribution_tags
=== RUN   TestAccCloudFrontDistribution_s3Origin
=== PAUSE TestAccCloudFrontDistribution_s3Origin
=== RUN   TestAccCloudFrontDistribution_customOrigin
=== PAUSE TestAccCloudFrontDistribution_customOrigin
=== RUN   TestAccCloudFrontDistribution_originPolicyDefault
=== PAUSE TestAccCloudFrontDistribution_originPolicyDefault
=== RUN   TestAccCloudFrontDistribution_originPolicyOrdered
=== PAUSE TestAccCloudFrontDistribution_originPolicyOrdered
=== RUN   TestAccCloudFrontDistribution_multiOrigin
=== PAUSE TestAccCloudFrontDistribution_multiOrigin
=== RUN   TestAccCloudFrontDistribution_orderedCacheBehavior
=== PAUSE TestAccCloudFrontDistribution_orderedCacheBehavior
=== RUN   TestAccCloudFrontDistribution_orderedCacheBehaviorCachePolicy
=== PAUSE TestAccCloudFrontDistribution_orderedCacheBehaviorCachePolicy
=== RUN   TestAccCloudFrontDistribution_orderedCacheBehaviorResponseHeadersPolicy
=== PAUSE TestAccCloudFrontDistribution_orderedCacheBehaviorResponseHeadersPolicy
=== RUN   TestAccCloudFrontDistribution_forwardedValuesToCachePolicy
=== PAUSE TestAccCloudFrontDistribution_forwardedValuesToCachePolicy
=== RUN   TestAccCloudFrontDistribution_Origin_emptyDomainName
=== PAUSE TestAccCloudFrontDistribution_Origin_emptyDomainName
=== RUN   TestAccCloudFrontDistribution_Origin_emptyOriginID
=== PAUSE TestAccCloudFrontDistribution_Origin_emptyOriginID
=== RUN   TestAccCloudFrontDistribution_Origin_connectionAttempts
=== PAUSE TestAccCloudFrontDistribution_Origin_connectionAttempts
=== RUN   TestAccCloudFrontDistribution_Origin_connectionTimeout
=== PAUSE TestAccCloudFrontDistribution_Origin_connectionTimeout
=== RUN   TestAccCloudFrontDistribution_Origin_originShield
=== PAUSE TestAccCloudFrontDistribution_Origin_originShield
=== RUN   TestAccCloudFrontDistribution_Origin_originAccessControl
=== PAUSE TestAccCloudFrontDistribution_Origin_originAccessControl
=== RUN   TestAccCloudFrontDistribution_noOptionalItems
=== PAUSE TestAccCloudFrontDistribution_noOptionalItems
=== RUN   TestAccCloudFrontDistribution_http11
=== PAUSE TestAccCloudFrontDistribution_http11
=== RUN   TestAccCloudFrontDistribution_isIPV6Enabled
=== PAUSE TestAccCloudFrontDistribution_isIPV6Enabled
=== RUN   TestAccCloudFrontDistribution_noCustomErrorResponse
=== PAUSE TestAccCloudFrontDistribution_noCustomErrorResponse
=== RUN   TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValuesCookies_whitelistedNames
=== PAUSE TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValuesCookies_whitelistedNames
=== RUN   TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValues_headers
=== PAUSE TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValues_headers
=== RUN   TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedKeyGroups
=== PAUSE TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedKeyGroups
=== RUN   TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedSigners
=== PAUSE TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedSigners
=== RUN   TestAccCloudFrontDistribution_DefaultCacheBehavior_realtimeLogARN
=== PAUSE TestAccCloudFrontDistribution_DefaultCacheBehavior_realtimeLogARN
=== RUN   TestAccCloudFrontDistribution_OrderedCacheBehavior_realtimeLogARN
=== PAUSE TestAccCloudFrontDistribution_OrderedCacheBehavior_realtimeLogARN
=== RUN   TestAccCloudFrontDistribution_enabled
=== PAUSE TestAccCloudFrontDistribution_enabled
=== RUN   TestAccCloudFrontDistribution_retainOnDelete
=== PAUSE TestAccCloudFrontDistribution_retainOnDelete
=== RUN   TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValuesCookies_whitelistedNames
=== PAUSE TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValuesCookies_whitelistedNames
=== RUN   TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValues_headers
=== PAUSE TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValues_headers
=== RUN   TestAccCloudFrontDistribution_ViewerCertificate_acmCertificateARN
=== PAUSE TestAccCloudFrontDistribution_ViewerCertificate_acmCertificateARN
=== RUN   TestAccCloudFrontDistribution_ViewerCertificateACMCertificateARN_conflictsWithCloudFrontDefaultCertificate
=== PAUSE TestAccCloudFrontDistribution_ViewerCertificateACMCertificateARN_conflictsWithCloudFrontDefaultCertificate
=== RUN   TestAccCloudFrontDistribution_waitForDeployment
=== PAUSE TestAccCloudFrontDistribution_waitForDeployment
=== RUN   TestAccCloudFrontDistribution_preconditionFailed
=== PAUSE TestAccCloudFrontDistribution_preconditionFailed
=== RUN   TestAccCloudFrontDistribution_originGroups
=== PAUSE TestAccCloudFrontDistribution_originGroups
=== CONT  TestAccCloudFrontDistribution_basic
=== CONT  TestAccCloudFrontDistribution_http11
=== CONT  TestAccCloudFrontDistribution_orderedCacheBehaviorResponseHeadersPolicy
=== CONT  TestAccCloudFrontDistribution_originPolicyDefault
=== CONT  TestAccCloudFrontDistribution_s3Origin
=== CONT  TestAccCloudFrontDistribution_enabled
=== CONT  TestAccCloudFrontDistribution_OrderedCacheBehavior_realtimeLogARN
=== CONT  TestAccCloudFrontDistribution_customOrigin
--- PASS: TestAccCloudFrontDistribution_OrderedCacheBehavior_realtimeLogARN (658.70s)
=== CONT  TestAccCloudFrontDistribution_DefaultCacheBehavior_realtimeLogARN
--- PASS: TestAccCloudFrontDistribution_basic (691.38s)
=== CONT  TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedSigners
--- PASS: TestAccCloudFrontDistribution_http11 (1253.58s)
=== CONT  TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedKeyGroups
--- PASS: TestAccCloudFrontDistribution_customOrigin (1255.49s)
=== CONT  TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValues_headers
--- PASS: TestAccCloudFrontDistribution_orderedCacheBehaviorResponseHeadersPolicy (1285.92s)
=== CONT  TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValuesCookies_whitelistedNames
--- PASS: TestAccCloudFrontDistribution_originPolicyDefault (1332.40s)
=== CONT  TestAccCloudFrontDistribution_noCustomErrorResponse
--- PASS: TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedSigners (641.53s)
=== CONT  TestAccCloudFrontDistribution_isIPV6Enabled
--- PASS: TestAccCloudFrontDistribution_s3Origin (1334.20s)
=== CONT  TestAccCloudFrontDistribution_Origin_emptyOriginID
--- PASS: TestAccCloudFrontDistribution_Origin_emptyOriginID (1.55s)
=== CONT  TestAccCloudFrontDistribution_Origin_connectionAttempts
--- PASS: TestAccCloudFrontDistribution_DefaultCacheBehavior_realtimeLogARN (684.14s)
=== CONT  TestAccCloudFrontDistribution_Origin_emptyDomainName
--- PASS: TestAccCloudFrontDistribution_Origin_emptyDomainName (1.39s)
=== CONT  TestAccCloudFrontDistribution_tags
--- PASS: TestAccCloudFrontDistribution_enabled (1827.21s)
=== CONT  TestAccCloudFrontDistribution_forwardedValuesToCachePolicy
--- PASS: TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedKeyGroups (640.86s)
=== CONT  TestAccCloudFrontDistribution_Origin_originAccessControl
--- PASS: TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValues_headers (688.92s)
=== CONT  TestAccCloudFrontDistribution_Origin_originShield
--- PASS: TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValuesCookies_whitelistedNames (667.53s)
=== CONT  TestAccCloudFrontDistribution_noOptionalItems
--- PASS: TestAccCloudFrontDistribution_tags (774.26s)
=== CONT  TestAccCloudFrontDistribution_ViewerCertificateACMCertificateARN_conflictsWithCloudFrontDefaultCertificate
--- PASS: TestAccCloudFrontDistribution_noCustomErrorResponse (1152.26s)
=== CONT  TestAccCloudFrontDistribution_Origin_connectionTimeout
--- PASS: TestAccCloudFrontDistribution_isIPV6Enabled (1154.24s)
=== CONT  TestAccCloudFrontDistribution_orderedCacheBehavior
--- PASS: TestAccCloudFrontDistribution_Origin_connectionAttempts (1209.45s)
=== CONT  TestAccCloudFrontDistribution_preconditionFailed
--- PASS: TestAccCloudFrontDistribution_ViewerCertificateACMCertificateARN_conflictsWithCloudFrontDefaultCertificate (584.73s)
=== CONT  TestAccCloudFrontDistribution_disappears
--- PASS: TestAccCloudFrontDistribution_noOptionalItems (1043.16s)
=== CONT  TestAccCloudFrontDistribution_originGroups
--- PASS: TestAccCloudFrontDistribution_Origin_originShield (1111.23s)
=== CONT  TestAccCloudFrontDistribution_waitForDeployment
--- PASS: TestAccCloudFrontDistribution_disappears (583.00s)
=== CONT  TestAccCloudFrontDistribution_orderedCacheBehaviorCachePolicy
--- PASS: TestAccCloudFrontDistribution_forwardedValuesToCachePolicy (1636.86s)
=== CONT  TestAccCloudFrontDistribution_originPolicyOrdered
--- PASS: TestAccCloudFrontDistribution_Origin_originAccessControl (1674.69s)
=== CONT  TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValues_headers
--- PASS: TestAccCloudFrontDistribution_orderedCacheBehavior (1141.04s)
=== CONT  TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValuesCookies_whitelistedNames
--- PASS: TestAccCloudFrontDistribution_Origin_connectionTimeout (1146.76s)
=== CONT  TestAccCloudFrontDistribution_ViewerCertificate_acmCertificateARN
--- PASS: TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValues_headers (668.66s)
=== CONT  TestAccCloudFrontDistribution_retainOnDelete
--- PASS: TestAccCloudFrontDistribution_waitForDeployment (1247.34s)
=== CONT  TestAccCloudFrontDistribution_multiOrigin
--- PASS: TestAccCloudFrontDistribution_originGroups (1364.38s)
--- PASS: TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValuesCookies_whitelistedNames (736.06s)
--- PASS: TestAccCloudFrontDistribution_preconditionFailed (1820.71s)
--- PASS: TestAccCloudFrontDistribution_ViewerCertificate_acmCertificateARN (739.10s)
--- PASS: TestAccCloudFrontDistribution_orderedCacheBehaviorCachePolicy (1197.15s)
--- PASS: TestAccCloudFrontDistribution_originPolicyOrdered (1203.28s)
--- PASS: TestAccCloudFrontDistribution_retainOnDelete (1220.12s)
--- PASS: TestAccCloudFrontDistribution_multiOrigin (1212.59s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront	5517.950s
```
