### PR TITLE
Update port description in vpclattice_target_group_attachment docs

### DIFF
--- a/website/docs/r/vpclattice_target_group_attachment.html.markdown
+++ b/website/docs/r/vpclattice_target_group_attachment.html.markdown
@@ -35,7 +35,7 @@ The following arguments are required:
 `target` supports the following:
 
 - `id` - (Required) The ID of the target. If the target type of the target group is INSTANCE, this is an instance ID. If the target type is IP , this is an IP address. If the target type is LAMBDA, this is the ARN of the Lambda function. If the target type is ALB, this is the ARN of the Application Load Balancer.
-- `port` - (Optional) The port on which the target is listening. For HTTP, the default is 80. For HTTPS, the default is 443.
+- `port` - (Optional) This port is used for routing traffic to the target, and defaults to the target group port. However, you can override the default and specify a custom port.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

- `port` doesn't use default port by `protocol`. The default port is inherited from the parent target group.