### PR TITLE
r/aws_quicksight_{analysis,dashboard}: flatten/expand `theme_arn`.

### DIFF
--- a/.changelog/33582.txt
+++ b/.changelog/33582.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_quicksight_analysis: add support for `theme_arn`.
+```
+
+```release-note:enhancement
+resource/aws_quicksight_dashboard: add support for `theme_arn`.
+```

--- a/internal/service/quicksight/analysis.go
+++ b/internal/service/quicksight/analysis.go
@@ -178,6 +178,10 @@ func resourceAnalysisCreate(ctx context.Context, d *schema.ResourceData, meta in
 		input.Permissions = expandResourcePermissions(v.List())
 	}
 
+	if v, ok := d.Get("theme_arn").(string); ok && v != "" {
+		input.ThemeArn = aws.String(v)
+	}
+
 	_, err := conn.CreateAnalysisWithContext(ctx, input)
 	if err != nil {
 		return create.DiagError(names.QuickSight, create.ErrActionCreating, ResNameAnalysis, d.Get("name").(string), err)
@@ -224,6 +228,7 @@ func resourceAnalysisRead(ctx context.Context, d *schema.ResourceData, meta inte
 	d.Set("name", out.Name)
 	d.Set("status", out.Status)
 	d.Set("analysis_id", out.AnalysisId)
+	d.Set("theme_arn", out.ThemeArn)
 
 	descResp, err := conn.DescribeAnalysisDefinitionWithContext(ctx, &quicksight.DescribeAnalysisDefinitionInput{
 		AwsAccountId: aws.String(awsAccountId),
@@ -278,6 +283,10 @@ func resourceAnalysisUpdate(ctx context.Context, d *schema.ResourceData, meta in
 
 		if v, ok := d.GetOk("parameters"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 			in.Parameters = quicksightschema.ExpandParameters(d.Get("parameters").([]interface{}))
+		}
+
+		if v, ok := d.Get("theme_arn").(string); ok && v != "" {
+			in.ThemeArn = aws.String(v)
 		}
 
 		log.Printf("[DEBUG] Updating QuickSight Analysis (%s): %#v", d.Id(), in)

--- a/internal/service/quicksight/dashboard.go
+++ b/internal/service/quicksight/dashboard.go
@@ -183,6 +183,10 @@ func resourceDashboardCreate(ctx context.Context, d *schema.ResourceData, meta i
 		input.Permissions = expandResourcePermissions(v.List())
 	}
 
+	if v, ok := d.Get("theme_arn").(string); ok && v != "" {
+		input.ThemeArn = aws.String(v)
+	}
+
 	_, err := conn.CreateDashboardWithContext(ctx, input)
 	if err != nil {
 		return create.DiagError(names.QuickSight, create.ErrActionCreating, ResNameDashboard, d.Get("name").(string), err)
@@ -223,6 +227,7 @@ func resourceDashboardRead(ctx context.Context, d *schema.ResourceData, meta int
 	d.Set("status", out.Version.Status)
 	d.Set("source_entity_arn", out.Version.SourceEntityArn)
 	d.Set("dashboard_id", out.DashboardId)
+	d.Set("theme_arn", out.Version.ThemeArn)
 	d.Set("version_description", out.Version.Description)
 	d.Set("version_number", out.Version.VersionNumber)
 
@@ -289,6 +294,10 @@ func resourceDashboardUpdate(ctx context.Context, d *schema.ResourceData, meta i
 
 		if v, ok := d.GetOk("dashboard_publish_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 			in.DashboardPublishOptions = quicksightschema.ExpandDashboardPublishOptions(d.Get("dashboard_publish_options").([]interface{}))
+		}
+
+		if v, ok := d.Get("theme_arn").(string); ok && v != "" {
+			in.ThemeArn = aws.String(v)
 		}
 
 		log.Printf("[DEBUG] Updating QuickSight Dashboard (%s): %#v", d.Id(), in)


### PR DESCRIPTION
### Description
Adds flatten/expand for `theme_arn` for resources `aws_quicksight_analysis`, `aws_quicksight_dashboard`.

### Relations
Closes #33524

### References
[QuickSight Documentation](https://docs.aws.amazon.com/sdk-for-go/api/service/quicksight/#Analysis)


### Output from Acceptance Testing
I lack permissions to test this.