### PR TITLE
[enhancement]: r/aws_lightsail_bucket: add force_delete attr for lightsail s3 bucket

### DIFF
--- a/.changelog/33586.txt
+++ b/.changelog/33586.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_lightsail_bucket: Add `force_delete` attribute to allow force deleting non-empty buckets during `terraform destroy` 
+resource/aws_lightsail_bucket: Add `force_delete` argument
 ```

--- a/.changelog/33586.txt
+++ b/.changelog/33586.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_lightsail_bucket: Add `force_delete` attribute to allow force deleting non-empty buckets during `terraform destroy` 
+```

--- a/internal/service/lightsail/bucket.go
+++ b/internal/service/lightsail/bucket.go
@@ -60,6 +60,11 @@ func ResourceBucket() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"force_delete": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"support_code": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -157,8 +162,12 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 
 func resourceBucketDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
+
+	forceDelete := d.Get("force_delete").(bool)
+
 	out, err := conn.DeleteBucket(ctx, &lightsail.DeleteBucketInput{
-		BucketName: aws.String(d.Id()),
+		BucketName:  aws.String(d.Id()),
+		ForceDelete: aws.Bool(forceDelete),
 	})
 
 	if err != nil && errs.IsA[*types.NotFoundException](err) {

--- a/internal/service/lightsail/bucket_test.go
+++ b/internal/service/lightsail/bucket_test.go
@@ -322,8 +322,8 @@ resource "aws_lightsail_bucket" "test" {
 func testAccBucketConfig_forceDelete(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_lightsail_bucket" "test" {
-  name      = %[1]q
-  bundle_id = "small_1_0"
+  name         = %[1]q
+  bundle_id    = "small_1_0"
   force_delete = true
 }
 `, rName)

--- a/internal/service/lightsail/bucket_test.go
+++ b/internal/service/lightsail/bucket_test.go
@@ -51,12 +51,17 @@ func TestAccLightsailBucket_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "support_code"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttrSet(resourceName, "url"),
+					resource.TestCheckResourceAttrSet(resourceName, "force_delete"),
+					resource.TestCheckResourceAttr(resourceName, "force_delete", "false"),
 				),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_delete",
+				},
 			},
 		},
 	})
@@ -90,6 +95,9 @@ func TestAccLightsailBucket_BundleId(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_delete",
+				},
 			},
 			{
 				Config: testAccBucketConfig_bundleId(rName, bundle2),
@@ -156,6 +164,9 @@ func TestAccLightsailBucket_tags(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_delete",
+				},
 			},
 			{
 				Config: testAccBucketConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
@@ -231,6 +242,40 @@ func testAccCheckBucketDestroy(ctx context.Context) resource.TestCheckFunc {
 	}
 }
 
+func TestAccLightsailBucket_forceDelete(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lightsail_bucket.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, strings.ToLower(lightsail.ServiceID))
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, strings.ToLower(lightsail.ServiceID)),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckBucketDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketConfig_forceDelete(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "force_delete", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_delete",
+				},
+			},
+		},
+	})
+}
+
 func testAccBucketConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_lightsail_bucket" "test" {
@@ -272,4 +317,14 @@ resource "aws_lightsail_bucket" "test" {
   }
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}
+
+func testAccBucketConfig_forceDelete(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_lightsail_bucket" "test" {
+  name      = %[1]q
+  bundle_id = "small_1_0"
+  force_delete = true
+}
+`, rName)
 }

--- a/website/docs/r/lightsail_bucket.html.markdown
+++ b/website/docs/r/lightsail_bucket.html.markdown
@@ -25,7 +25,7 @@ This resource supports the following arguments:
 
 * `name` - (Required) The name for the bucket.
 * `bundle_id` - (Required) - The ID of the bundle to use for the bucket. A bucket bundle specifies the monthly cost, storage space, and data transfer quota for a bucket. Use the [get-bucket-bundles](https://docs.aws.amazon.com/cli/latest/reference/lightsail/get-bucket-bundles.html) cli command to get a list of bundle IDs that you can specify.
-* `force_delete` - (Optional) - Force Delete non-empty buckets using `terraform destroy`. AWS by defualt will not delete an s3 bucket which is not empty, to prevent losing bucket data and affecting other resources in lightsail. If `force_delete` is set to `true` the bucket will be deleted even when not empty. 
+* `force_delete` - (Optional) - Force Delete non-empty buckets using `terraform destroy`. AWS by default will not delete an s3 bucket which is not empty, to prevent losing bucket data and affecting other resources in lightsail. If `force_delete` is set to `true` the bucket will be deleted even when not empty. 
 * `tags` - (Optional) A map of tags to assign to the resource. To create a key-only tag, use an empty string as the value. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attribute Reference

--- a/website/docs/r/lightsail_bucket.html.markdown
+++ b/website/docs/r/lightsail_bucket.html.markdown
@@ -25,7 +25,7 @@ This resource supports the following arguments:
 
 * `name` - (Required) The name for the bucket.
 * `bundle_id` - (Required) - The ID of the bundle to use for the bucket. A bucket bundle specifies the monthly cost, storage space, and data transfer quota for a bucket. Use the [get-bucket-bundles](https://docs.aws.amazon.com/cli/latest/reference/lightsail/get-bucket-bundles.html) cli command to get a list of bundle IDs that you can specify.
-* `force_delete` - (Optional) - Force Delete non-empty buckets using `terraform destroy`. AWS by default will not delete an s3 bucket which is not empty, to prevent losing bucket data and affecting other resources in lightsail. If `force_delete` is set to `true` the bucket will be deleted even when not empty. 
+* `force_delete` - (Optional) - Force Delete non-empty buckets using `terraform destroy`. AWS by default will not delete an s3 bucket which is not empty, to prevent losing bucket data and affecting other resources in lightsail. If `force_delete` is set to `true` the bucket will be deleted even when not empty.
 * `tags` - (Optional) A map of tags to assign to the resource. To create a key-only tag, use an empty string as the value. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attribute Reference

--- a/website/docs/r/lightsail_bucket.html.markdown
+++ b/website/docs/r/lightsail_bucket.html.markdown
@@ -25,6 +25,7 @@ This resource supports the following arguments:
 
 * `name` - (Required) The name for the bucket.
 * `bundle_id` - (Required) - The ID of the bundle to use for the bucket. A bucket bundle specifies the monthly cost, storage space, and data transfer quota for a bucket. Use the [get-bucket-bundles](https://docs.aws.amazon.com/cli/latest/reference/lightsail/get-bucket-bundles.html) cli command to get a list of bundle IDs that you can specify.
+* `force_delete` - (Optional) - Force Delete non-empty buckets using `terraform destroy`. AWS by defualt will not delete an s3 bucket which is not empty, to prevent losing bucket data and affecting other resources in lightsail. If `force_delete` is set to `true` the bucket will be deleted even when not empty. 
 * `tags` - (Optional) A map of tags to assign to the resource. To create a key-only tag, use an empty string as the value. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attribute Reference


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
adds `force_delete` attribute to Lightsail Bucket which allows to force delete a non-empty bucket during `terraform destroy`

I have amended the `testAccLightsailBucket_basic` to check for default `force_delete` value and added `testAccLightsailBucket_forceDelete` to check for `force_delete=true`. Happy to amend/add more acceptance tests if required.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #33585

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
AWS Go SDK: https://docs.aws.amazon.com/sdk-for-go/api/service/lightsail/#Lightsail.DeleteBucket

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

**TestAccLightsailBucket_basic**
```console
% make testacc TESTS=TestAccLightsailBucket_basic PKG=lightsail
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lightsail/... -v -count 1 -parallel 20 -run='TestAccLightsailBucket_basic'  -timeout 360m
=== RUN   TestAccLightsailBucket_basic
=== PAUSE TestAccLightsailBucket_basic
=== CONT  TestAccLightsailBucket_basic
--- PASS: TestAccLightsailBucket_basic (40.43s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lightsail  42.477s
...
```

**TestAccLightsailBucket_forceDelete**
```console
% make testacc TESTS=TestAccLightsailBucket_basic PKG=lightsail

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lightsail/... -v -count 1 -parallel 20 -run='TestAccLightsailBucket_forceDelete'  -timeout 360m
=== RUN   TestAccLightsailBucket_forceDelete
=== PAUSE TestAccLightsailBucket_forceDelete
=== CONT  TestAccLightsailBucket_forceDelete
--- PASS: TestAccLightsailBucket_forceDelete (40.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lightsail  42.063s
...
```
