### PR TITLE
[New Resource] Create delegation signer association resource

### DIFF
--- a/.changelog/33596.txt
+++ b/.changelog/33596.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_route53domains_ds_association
+```

--- a/internal/service/route53domains/domain.go
+++ b/internal/service/route53domains/domain.go
@@ -1,0 +1,43 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package route53domains
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/route53domains"
+	"github.com/aws/aws-sdk-go-v2/service/route53domains/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func findDomainDetailByName(ctx context.Context, conn *route53domains.Client, name string) (*route53domains.GetDomainDetailOutput, error) {
+	input := &route53domains.GetDomainDetailInput{
+		DomainName: aws.String(name),
+	}
+
+	output, err := conn.GetDomainDetail(ctx, input)
+
+	if err != nil {
+		var invalidInput *types.InvalidInput
+
+		if errors.As(err, &invalidInput) && strings.Contains(invalidInput.ErrorMessage(), "not found") {
+			return nil, &retry.NotFoundError{
+				LastError:   err,
+				LastRequest: input,
+			}
+		}
+
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output, nil
+}

--- a/internal/service/route53domains/ds_association.go
+++ b/internal/service/route53domains/ds_association.go
@@ -1,0 +1,276 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package route53domains
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/route53domains"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/route53domains/types"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource(name="Delegation Signer Association")
+func newResourceDelegationSignerAssociation(_ context.Context) (resource.ResourceWithConfigure, error) {
+	r := &resourceDelegationSignerAssocation{}
+
+	r.SetDefaultCreateTimeout(5 * time.Minute)
+	r.SetDefaultDeleteTimeout(5 * time.Minute)
+
+	return r, nil
+}
+
+const (
+	ResNameDelegationSignerAssociation = "DelegationSignerAssociation"
+)
+
+type resourceDelegationSignerAssocation struct {
+	framework.ResourceWithConfigure
+	framework.WithTimeouts
+}
+
+func (r *resourceDelegationSignerAssocation) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "aws_route53domains_ds_association"
+}
+
+func (r *resourceDelegationSignerAssocation) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"domain_name": schema.StringAttribute{
+				Required: true,
+			},
+			"signing_algorithm_type": schema.Int64Attribute{
+				Required: true,
+			},
+			"flag": schema.Int64Attribute{
+				Required: true,
+			},
+			"public_key": schema.StringAttribute{
+				Required: true,
+			},
+			"dnssec_key_id": framework.IDAttribute(),
+		},
+		Blocks: map[string]schema.Block{
+			"timeouts": timeouts.Block(ctx, timeouts.Opts{
+				Create: true,
+				Delete: true,
+			}),
+		},
+	}
+}
+
+func (r *resourceDelegationSignerAssocation) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().Route53DomainsClient(ctx)
+
+	var plan resourceDelegationSignerAssociationData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	flag := int32(plan.Flag.ValueInt64())
+	publicKey := plan.PublicKey.ValueString()
+
+	in := &route53domains.AssociateDelegationSignerToDomainInput{
+		DomainName: plan.DomainName.ValueStringPointer(),
+		SigningAttributes: &awstypes.DnssecSigningAttributes{
+			Algorithm: aws.Int32(int32(plan.SigningAlgorithmType.ValueInt64())),
+			Flags:     aws.Int32(flag),
+			PublicKey: aws.String(publicKey),
+		},
+	}
+
+	out, err := conn.AssociateDelegationSignerToDomain(ctx, in)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.Route53Domains, create.ErrActionCreating, ResNameDelegationSignerAssociation, plan.DomainName.String(), err),
+			err.Error(),
+		)
+		return
+	}
+	if out == nil || out.OperationId == nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.Route53Domains, create.ErrActionCreating, ResNameDelegationSignerAssociation, plan.DomainName.String(), nil),
+			errors.New("empty output").Error(),
+		)
+		return
+	}
+
+	createTimeout := r.CreateTimeout(ctx, plan.Timeouts)
+
+	if _, err := waitOperationSucceeded(ctx, conn, *out.OperationId, createTimeout); err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.Route53Domains, create.ErrActionWaitingForCreation, ResNameDelegationSignerAssociation, plan.DomainName.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	domainDetail, err := findDomainDetailByName(ctx, conn, plan.DomainName.ValueString())
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.Route53Domains, create.ErrActionCheckingExistence, ResNameDelegationSignerAssociation, plan.DomainName.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	dnssecKey := getDnssecKeyWithFlagAndPublicKey(domainDetail.DnssecKeys, flag, publicKey)
+	if dnssecKey == nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.Route53Domains, create.ErrActionCheckingExistence, ResNameDelegationSignerAssociation, plan.DomainName.String(), nil),
+			errors.New("DNSSEC key not found").Error(),
+		)
+		return
+	}
+
+	plan.DNSSECKeyID = flex.StringToFramework(ctx, dnssecKey.Id)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *resourceDelegationSignerAssocation) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().Route53DomainsClient(ctx)
+
+	var state resourceDelegationSignerAssociationData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	domainDetail, err := findDomainDetailByName(ctx, conn, state.DomainName.ValueString())
+
+	if tfresource.NotFound(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.Route53Domains, create.ErrActionCheckingExistence, ResNameDelegationSignerAssociation, state.DomainName.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	dnssecKey := GetDnssecKeyWithId(domainDetail.DnssecKeys, state.DNSSECKeyID.ValueString())
+	if dnssecKey == nil {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	state.SigningAlgorithmType = flex.Int64ToFramework(ctx, aws.Int64(int64(aws.ToInt32(dnssecKey.Algorithm))))
+	state.Flag = flex.Int64ToFramework(ctx, aws.Int64(int64(aws.ToInt32(dnssecKey.Flags))))
+	state.PublicKey = flex.StringToFramework(ctx, dnssecKey.PublicKey)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+// There is no update API, so this method is a no-op
+func (r *resourceDelegationSignerAssocation) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+}
+
+func (r *resourceDelegationSignerAssocation) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	conn := r.Meta().Route53DomainsClient(ctx)
+
+	var state resourceDelegationSignerAssociationData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	domainDetail, err := findDomainDetailByName(ctx, conn, state.DomainName.ValueString())
+
+	if tfresource.NotFound(err) {
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.Route53Domains, create.ErrActionCheckingExistence, ResNameDelegationSignerAssociation, state.DomainName.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	dnssecKey := GetDnssecKeyWithId(domainDetail.DnssecKeys, state.DNSSECKeyID.ValueString())
+	if dnssecKey == nil {
+		return
+	}
+
+	in := &route53domains.DisassociateDelegationSignerFromDomainInput{
+		DomainName: aws.String(state.DomainName.ValueString()),
+		Id:         aws.String(state.DNSSECKeyID.ValueString()),
+	}
+
+	out, err := conn.DisassociateDelegationSignerFromDomain(ctx, in)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.Route53Domains, create.ErrActionDeleting, ResNameDelegationSignerAssociation, state.DomainName.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	deleteTimeout := r.DeleteTimeout(ctx, state.Timeouts)
+	_, err = waitOperationSucceeded(ctx, conn, *out.OperationId, deleteTimeout)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.Route53Domains, create.ErrActionWaitingForDeletion, ResNameDelegationSignerAssociation, state.DomainName.String(), err),
+			err.Error(),
+		)
+		return
+	}
+}
+
+func (r *resourceDelegationSignerAssocation) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	parts := strings.Split(req.ID, ":")
+	if len(parts) != 2 {
+		resp.Diagnostics.AddError("Resource Import Invalid ID", fmt.Sprintf(`Unexpected format for import ID (%s), use: "DomainName:DNSSECKeyID"`, req.ID))
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("domain_name"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("dnssec_key_id"), parts[1])...)
+}
+
+func getDnssecKeyWithFlagAndPublicKey(dnssecKeys []awstypes.DnssecKey, flag int32, publicKey string) *awstypes.DnssecKey {
+	for _, dnssecKey := range dnssecKeys {
+		if *dnssecKey.Flags == flag && *dnssecKey.PublicKey == publicKey {
+			return &dnssecKey
+		}
+	}
+	return nil
+}
+
+func GetDnssecKeyWithId(dnssecKeys []awstypes.DnssecKey, dnssec_key_id string) *awstypes.DnssecKey {
+	for _, dnssecKey := range dnssecKeys {
+		if *dnssecKey.Id == dnssec_key_id {
+			return &dnssecKey
+		}
+	}
+	return nil
+}
+
+type resourceDelegationSignerAssociationData struct {
+	DomainName           types.String   `tfsdk:"domain_name"`
+	SigningAlgorithmType types.Int64    `tfsdk:"signing_algorithm_type"`
+	Flag                 types.Int64    `tfsdk:"flag"`
+	PublicKey            types.String   `tfsdk:"public_key"`
+	DNSSECKeyID          types.String   `tfsdk:"dnssec_key_id"`
+	Timeouts             timeouts.Value `tfsdk:"timeouts"`
+}

--- a/internal/service/route53domains/ds_association_test.go
+++ b/internal/service/route53domains/ds_association_test.go
@@ -1,0 +1,221 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package route53domains_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/route53domains"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/names"
+
+	tfroute53domains "github.com/hashicorp/terraform-provider-aws/internal/service/route53domains"
+)
+
+func TestAccRoute53DomainsDelegationSignerAssocation_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	resourceName := "aws_route53domains_ds_association.test"
+
+	domainEnvironmentVariableName := "ROUTE53DOMAINS_DOMAIN_NAME"
+	domainName := os.Getenv(domainEnvironmentVariableName)
+	signingAlgorithmType := "13"
+	flag := "257"
+	publicKey := "M1jizbcdK5IBt7d4lRIiFTx+N06BJzaeScK215EOfa8efd2akkUWmxD5OhodZCIiRMvL5ZnStUP5UReIeUmBeA=="
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.Route53DomainsEndpointID)
+			testDelegationSignerAssociationAccPreCheck(ctx, domainEnvironmentVariableName, domainName, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.Route53DomainsEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDelegationSignerAssociationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDelegationSignerAssociationConfig_basic(domainName, signingAlgorithmType, flag, publicKey),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDelegationSignerAssociationExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "domain_name", domainName),
+					resource.TestCheckResourceAttr(resourceName, "signing_algorithm_type", signingAlgorithmType),
+					resource.TestCheckResourceAttr(resourceName, "flag", flag),
+					resource.TestCheckResourceAttr(resourceName, "public_key", publicKey),
+				),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateIdFunc:                    testAccDelegationSignerAssociationImportStateIDFunc(ctx, resourceName),
+				ImportStateVerifyIdentifierAttribute: "dnssec_key_id",
+			},
+		},
+	})
+}
+
+func TestAccRoute53DomainsDelegationSignerAssocation_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	resourceName := "aws_route53domains_ds_association.test"
+
+	domainEnvironmentVariableName := "ROUTE53DOMAINS_DOMAIN_NAME"
+	domainName := os.Getenv(domainEnvironmentVariableName)
+	signingAlgorithmType := "13"
+	flag := "257"
+	publicKey := "M1jizbcdK5IBt7d4lRIiFTx+N06BJzaeScK215EOfa8efd2akkUWmxD5OhodZCIiRMvL5ZnStUP5UReIeUmBeA=="
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.Route53DomainsEndpointID)
+			testDelegationSignerAssociationAccPreCheck(ctx, domainEnvironmentVariableName, domainName, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.Route53DomainsEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDelegationSignerAssociationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDelegationSignerAssociationConfig_basic(domainName, signingAlgorithmType, flag, publicKey),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDelegationSignerAssociationExists(ctx, resourceName),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfroute53domains.ResourceDelegationSignerAssociation, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckDelegationSignerAssociationDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).Route53DomainsClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_route53domains_ds_association" {
+				continue
+			}
+
+			domainName := rs.Primary.Attributes["domain_name"]
+			dnssecKeyId := rs.Primary.Attributes["dnssec_key_id"]
+
+			input := &route53domains.GetDomainDetailInput{
+				DomainName: &domainName,
+			}
+
+			out, err := conn.GetDomainDetail(ctx, input)
+
+			if err != nil {
+				return create.Error(names.Route53Domains, create.ErrActionCheckingDestroyed, tfroute53domains.ResNameDelegationSignerAssociation, rs.Primary.ID, err)
+			}
+
+			dnssecKey := tfroute53domains.GetDnssecKeyWithId(out.DnssecKeys, dnssecKeyId)
+			if dnssecKey == nil {
+				return nil
+			}
+
+			return create.Error(names.Route53Domains, create.ErrActionCheckingDestroyed, tfroute53domains.ResNameDelegationSignerAssociation, rs.Primary.ID, errors.New("not destroyed"))
+		}
+		return nil
+	}
+}
+
+func testAccCheckDelegationSignerAssociationExists(ctx context.Context, resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return create.Error(names.Route53Domains, create.ErrActionCheckingExistence, tfroute53domains.ResNameDelegationSignerAssociation, resourceName, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.Route53Domains, create.ErrActionCheckingExistence, tfroute53domains.ResNameDelegationSignerAssociation, resourceName, errors.New("not set"))
+		}
+
+		domainName := rs.Primary.Attributes["domain_name"]
+		dnssecKeyId := rs.Primary.Attributes["dnssec_key_id"]
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).Route53DomainsClient(ctx)
+
+		input := &route53domains.GetDomainDetailInput{
+			DomainName: &domainName,
+		}
+
+		out, err := conn.GetDomainDetail(ctx, input)
+
+		if err != nil {
+			return create.Error(names.Route53Domains, create.ErrActionCheckingExistence, tfroute53domains.ResNameDelegationSignerAssociation, rs.Primary.ID, err)
+		}
+
+		dnssecKey := tfroute53domains.GetDnssecKeyWithId(out.DnssecKeys, dnssecKeyId)
+
+		if dnssecKey == nil {
+			return create.Error(names.Route53Domains, create.ErrActionCheckingExistence, tfroute53domains.ResNameDelegationSignerAssociation, resourceName, errors.New("not found"))
+		}
+
+		return nil
+	}
+}
+
+func testDelegationSignerAssociationAccPreCheck(ctx context.Context, domainEnvironmentVariableName string, domainName string, t *testing.T) {
+	if domainName == "" {
+		t.Skipf("Environment variable %s is not set", domainEnvironmentVariableName)
+	}
+	conn := acctest.Provider.Meta().(*conns.AWSClient).Route53DomainsClient(ctx)
+
+	input := &route53domains.GetDomainDetailInput{
+		DomainName: &domainName,
+	}
+	_, err := conn.GetDomainDetail(ctx, input)
+
+	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func testAccDelegationSignerAssociationImportStateIDFunc(ctx context.Context, resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", create.Error(names.Route53Domains, create.ErrActionImporting, tfroute53domains.ResNameDelegationSignerAssociation, resourceName, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return "", create.Error(names.Route53Domains, create.ErrActionImporting, tfroute53domains.ResNameDelegationSignerAssociation, resourceName, errors.New("not set"))
+		}
+
+		domainName := rs.Primary.Attributes["domain_name"]
+		dnssecKeyId := rs.Primary.Attributes["dnssec_key_id"]
+
+		return fmt.Sprintf("%s:%s", domainName, dnssecKeyId), nil
+	}
+}
+
+func testAccDelegationSignerAssociationConfig_basic(domainName string, signingAlgorithmType string, flag string, publicKey string) string {
+	return fmt.Sprintf(`
+resource "aws_route53domains_ds_association" "test" {
+  domain_name            = %[1]q
+  signing_algorithm_type = %[2]q
+  flag                   = %[3]q
+  public_key             = %[4]q
+}
+`, domainName, signingAlgorithmType, flag, publicKey)
+}

--- a/internal/service/route53domains/exports_test.go
+++ b/internal/service/route53domains/exports_test.go
@@ -1,0 +1,7 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package route53domains
+
+// Exports for use in tests only.
+var ResourceDelegationSignerAssociation = newResourceDelegationSignerAssociation

--- a/internal/service/route53domains/service_package_gen.go
+++ b/internal/service/route53domains/service_package_gen.go
@@ -17,7 +17,12 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.Serv
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.ServicePackageFrameworkResource {
-	return []*types.ServicePackageFrameworkResource{}
+	return []*types.ServicePackageFrameworkResource{
+		{
+			Factory: newResourceDelegationSignerAssociation,
+			Name:    "Delegation Signer Association",
+		},
+	}
 }
 
 func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePackageSDKDataSource {

--- a/internal/service/route53domains/wait.go
+++ b/internal/service/route53domains/wait.go
@@ -1,0 +1,84 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package route53domains
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/route53domains"
+	"github.com/aws/aws-sdk-go-v2/service/route53domains/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func waitOperationSucceeded(ctx context.Context, conn *route53domains.Client, id string, timeout time.Duration) (*route53domains.GetOperationDetailOutput, error) { //nolint:unparam
+	stateConf := &retry.StateChangeConf{
+		Pending: enum.Slice(types.OperationStatusSubmitted, types.OperationStatusInProgress),
+		Target:  enum.Slice(types.OperationStatusSuccessful),
+		Timeout: timeout,
+		Refresh: statusOperation(ctx, conn, id),
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*route53domains.GetOperationDetailOutput); ok {
+		tfresource.SetLastError(err, errors.New(aws.ToString(output.Message)))
+
+		return output, err
+	}
+
+	return nil, err
+}
+
+func statusOperation(ctx context.Context, conn *route53domains.Client, id string) retry.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := findOperationDetailByID(ctx, conn, id)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, string(output.Status), nil
+	}
+}
+
+func findOperationDetailByID(ctx context.Context, conn *route53domains.Client, id string) (*route53domains.GetOperationDetailOutput, error) {
+	input := &route53domains.GetOperationDetailInput{
+		OperationId: aws.String(id),
+	}
+
+	output, err := conn.GetOperationDetail(ctx, input)
+
+	if err != nil {
+		var invalidInput *types.InvalidInput
+
+		if errors.As(err, &invalidInput) && strings.Contains(invalidInput.ErrorMessage(), "not found") {
+			return nil, &retry.NotFoundError{
+				LastError:   err,
+				LastRequest: input,
+			}
+		}
+
+		return nil, err
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output, nil
+}

--- a/website/docs/r/route53domains_ds_association.html.markdown
+++ b/website/docs/r/route53domains_ds_association.html.markdown
@@ -1,0 +1,141 @@
+---
+subcategory: "Route 53 Domains"
+layout: "aws"
+page_title: "AWS: aws_route53domains_ds_association"
+description: |-
+  Provides a resource to manage a delegation signer record in the parent DNS zone for domains registered with Route53.
+---
+
+# Resource: aws_route53domains_ds_association
+
+Provides a resource to manage a [delegation signer record](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-configuring-dnssec-enable-signing.html#dns-configuring-dnssec-enable-signing-step-1) in the parent DNS zone for domains registered with Route53.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+provider "aws" {
+  region = "us-east-1"
+}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_kms_key" "example" {
+  customer_master_key_spec = "ECC_NIST_P256"
+  deletion_window_in_days  = 7
+  key_usage                = "SIGN_VERIFY"
+  policy = jsonencode({
+    Statement = [
+      {
+        Action = [
+          "kms:DescribeKey",
+          "kms:GetPublicKey",
+          "kms:Sign",
+        ],
+        Effect = "Allow"
+        Principal = {
+          Service = "dnssec-route53.amazonaws.com"
+        }
+        Sid      = "Allow Route 53 DNSSEC Service",
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+          }
+          ArnLike = {
+            "aws:SourceArn" = "arn:aws:route53:::hostedzone/*"
+          }
+        }
+      },
+      {
+        Action = "kms:CreateGrant",
+        Effect = "Allow"
+        Principal = {
+          Service = "dnssec-route53.amazonaws.com"
+        }
+        Sid      = "Allow Route 53 DNSSEC Service to CreateGrant",
+        Resource = "*"
+        Condition = {
+          Bool = {
+            "kms:GrantIsForAWSResource" = "true"
+          }
+        }
+      },
+      {
+        Action = "kms:*"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        }
+        Resource = "*"
+        Sid      = "Enable IAM User Permissions"
+      },
+    ]
+    Version = "2012-10-17"
+  })
+}
+
+resource "aws_route53_zone" "example" {
+  name = "example.com"
+}
+
+resource "aws_route53_key_signing_key" "example" {
+  hosted_zone_id             = aws_route53_zone.test.id
+  key_management_service_arn = aws_kms_key.test.arn
+  name                       = "example"
+}
+
+resource "aws_route53_hosted_zone_dnssec" "example" {
+  depends_on = [
+    aws_route53_key_signing_key.example
+  ]
+  hosted_zone_id = aws_route53_key_signing_key.example.hosted_zone_id
+}
+
+resource "aws_route53domains_ds_association" "example" {
+  domain_name            = "example.com"
+  signing_algorithm_type = aws_route53_key_signing_key.example.signing_algorithm_type
+  flag                   = aws_route53_key_signing_key.example.flag
+  public_key             = aws_route53_key_signing_key.example.public_key
+}
+```
+
+## Argument Reference
+
+This argument supports the following arguments:
+
+* `domain_name` - (Required) The name of the domain that will have its parent DNS zone updated with the Delegation Signer record. 
+* `signing_algorithm_type` - (Required) The algorithm which was used to generate the digest from the public key.
+* `flag` - (Required) Defines the type of key. It can be either a KSK (key-signing-key, value 257) or ZSK (zone-signing-key, value 256).
+* `public_key` - (Required) The base64-encoded public key part of the key pair that is passed to the registry.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `dnssec_key_id` - An ID assigned to the created DS record.
+
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+* `create` - (Default `5m`)
+* `delete` - (Default `5m`)
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import `aws_route53domains_ds_association` using the Route 53 Domain Name and DNSSEC Key ID, separated by a colon (`:`). For example:
+
+```terraform
+import {
+  to = aws_route53domains_ds_association.example
+  id = "example.com:40DE3534F5324DBDAC598ACEDB5B1E26A5368732D9C791D1347E4FBDDF6FC343"
+}
+```
+
+Using `terraform import`, import `aws_route53domains_ds_association` using the Route 53 Domain Name and DNSSEC Key ID, separated by a colon (`:`). For example:
+
+```console
+% terraform import aws_route53domains_ds_association.example example.com:40DE3534F5324DBDAC598ACEDB5B1E26A5368732D9C791D1347E4FBDDF6FC343
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds support for creating a Delegation Signer record in the parent DNS zone for domains registered with Route53

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #28749 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
https://docs.aws.amazon.com/Route53/latest/APIReference/API_domains_AssociateDelegationSignerToDomain.html
https://docs.aws.amazon.com/Route53/latest/APIReference/API_domains_DisassociateDelegationSignerFromDomain.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccRoute53DomainsDelegationSignerAssocation_basic PKG=route53domains
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/route53domains/... -v -count 1 -parallel 20 -run='TestAccRoute53DomainsDelegationSignerAssocation_basic'  -timeout 360m
=== RUN   TestAccRoute53DomainsDelegationSignerAssocation_basic
=== PAUSE TestAccRoute53DomainsDelegationSignerAssocation_basic
=== CONT  TestAccRoute53DomainsDelegationSignerAssocation_basic
--- PASS: TestAccRoute53DomainsDelegationSignerAssocation_basic (152.19s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53domains     155.255s

% make testacc TESTS=TestAccRoute53DomainsDelegationSignerAssocation_disappears PKG=route53domains
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/route53domains/... -v -count 1 -parallel 20 -run='TestAccRoute53DomainsDelegationSignerAssocation_disappears'  -timeout 360m
=== RUN   TestAccRoute53DomainsDelegationSignerAssocation_disappears
=== PAUSE TestAccRoute53DomainsDelegationSignerAssocation_disappears
=== CONT  TestAccRoute53DomainsDelegationSignerAssocation_disappears
--- PASS: TestAccRoute53DomainsDelegationSignerAssocation_disappears (138.80s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53domains     141.989s
...
```
