### PR TITLE
Add Clean Rooms Configured Table resource

### DIFF
--- a/.changelog/33602.txt
+++ b/.changelog/33602.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_cleanrooms_configured_table
+```

--- a/examples/cleanrooms/main.tf
+++ b/examples/cleanrooms/main.tf
@@ -32,5 +32,24 @@ resource "aws_cleanrooms_collaboration" "test_collab" {
   tags = {
     Project = "Terraform"
   }
+}
 
+resource "aws_cleanrooms_configured_table" "test_configured_table" {
+  name            = "terraform-example-table"
+  description     = "I made this table with terraform!"
+  analysis_method = "DIRECT_QUERY"
+  allowed_columns = [
+    "column1",
+    "column2",
+    "column3",
+  ]
+
+  table_reference {
+    database_name = "example_database"
+    table_name    = "example_table"
+  }
+
+  tags = {
+    Project = "Terraform"
+  }
 }

--- a/internal/service/cleanrooms/configured_table.go
+++ b/internal/service/cleanrooms/configured_table.go
@@ -244,7 +244,7 @@ func expandAnalysisMethod(analysisMethod string) (types.AnalysisMethod, error) {
 	case "DIRECT_QUERY":
 		return types.AnalysisMethodDirectQuery, nil
 	default:
-		return types.AnalysisMethodDirectQuery, fmt.Errorf("Invalid analysis method type: %s. Currently the only valid value is `DIRECT_QUERY`", analysisMethod)
+		return "", fmt.Errorf("Invalid analysis method type: %s. Currently the only valid value is `DIRECT_QUERY`", analysisMethod)
 	}
 }
 

--- a/internal/service/cleanrooms/configured_table.go
+++ b/internal/service/cleanrooms/configured_table.go
@@ -159,7 +159,8 @@ func resourceConfiguredTableRead(ctx context.Context, d *schema.ResourceData, me
 	d.Set(names.AttrDescription, configuredTable.Description)
 	d.Set("allowed_columns", configuredTable.AllowedColumns)
 	d.Set("analysis_method", configuredTable.AnalysisMethod)
-	d.Set("create_time", configuredTable.CreateTime)
+	d.Set("create_time", configuredTable.CreateTime.String())
+	d.Set("update_time", configuredTable.UpdateTime.String())
 
 	if err := d.Set("table_reference", flattenTableReference(configuredTable.TableReference)); err != nil {
 		return diag.Errorf("setting table_reference: %s", err)

--- a/internal/service/cleanrooms/configured_table.go
+++ b/internal/service/cleanrooms/configured_table.go
@@ -244,7 +244,7 @@ func expandAnalysisMethod(analysisMethod string) (types.AnalysisMethod, error) {
 	case "DIRECT_QUERY":
 		return types.AnalysisMethodDirectQuery, nil
 	default:
-		return types.AnalysisMethodDirectQuery, fmt.Errorf("Invalid analysis method type: %s", analysisMethod)
+		return types.AnalysisMethodDirectQuery, fmt.Errorf("Invalid analysis method type: %s. Currently the only valid value is `DIRECT_QUERY`", analysisMethod)
 	}
 }
 

--- a/internal/service/cleanrooms/configured_table.go
+++ b/internal/service/cleanrooms/configured_table.go
@@ -1,0 +1,234 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cleanrooms
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cleanrooms"
+	"github.com/aws/aws-sdk-go-v2/service/cleanrooms/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKResource("aws_cleanrooms_configured_table")
+// @Tags(identifierAttribute="arn")
+func ResourceConfiguredTable() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceConfiguredTableCreate,
+		ReadWithoutTimeout:   resourceConfiguredTableRead,
+		UpdateWithoutTimeout: resourceConfiguredTableUpdate,
+		DeleteWithoutTimeout: resourceConfiguredTableDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(1 * time.Minute),
+			Update: schema.DefaultTimeout(1 * time.Minute),
+			Delete: schema.DefaultTimeout(1 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"allowed_columns": {
+				Type:     schema.TypeSet,
+				Required: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				MinItems: 1,
+				MaxItems: 225,
+			},
+			"analysis_method": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			names.AttrARN: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			names.AttrDescription: {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			names.AttrName: {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"table_reference": {
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"database_name": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"table_name": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			"update_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+const (
+	ResNameConfiguredTable = "Configured Table"
+)
+
+func resourceConfiguredTableCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).CleanRoomsClient(ctx)
+
+	glueTableReference := types.GlueTableReference{
+		DatabaseName: aws.String(d.Get("database_name").(string)),
+		TableName:    aws.String(d.Get("table_name").(string)),
+	}
+
+	input := &cleanrooms.CreateConfiguredTableInput{
+		Name:           aws.String(d.Get(names.AttrName).(string)),
+		AllowedColumns: flex.ExpandStringValueSet(d.Get("allowed_columns").(*schema.Set)),
+		TableReference: glueTableReference,
+		Tags:           getTagsIn(ctx),
+	}
+
+	if v, ok := d.GetOk(names.AttrDescription); ok {
+		input.Description = aws.String(v.(string))
+	}
+
+	out, err := conn.CreateConfiguredTable(ctx, input)
+	if err != nil {
+		return create.DiagError(names.CleanRooms, create.ErrActionCreating, ResNameConfiguredTable, d.Get("name").(string), err)
+	}
+
+	if out == nil || out.ConfiguredTable == nil {
+		return create.DiagError(names.CleanRooms, create.ErrActionCreating, ResNameCollaboration, d.Get("name").(string), errors.New("empty output"))
+	}
+	d.SetId(aws.ToString(out.ConfiguredTable.Id))
+
+	return resourceConfiguredTableRead(ctx, d, meta)
+}
+
+func resourceConfiguredTableRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).CleanRoomsClient(ctx)
+
+	out, err := findConfiguredTableByID(ctx, conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] Clean Rooms Configured Table (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return create.DiagError(names.CleanRooms, create.ErrActionReading, ResNameConfiguredTable, d.Id(), err)
+	}
+
+	configuredTable := out.ConfiguredTable
+	d.Set(names.AttrARN, configuredTable.Arn)
+	d.Set(names.AttrName, configuredTable.Name)
+	d.Set(names.AttrDescription, configuredTable.Description)
+	d.Set("allowed_columns", configuredTable.AllowedColumns)
+	d.Set("analysis_method", configuredTable.AnalysisMethod)
+	d.Set("create_time", configuredTable.CreateTime)
+
+	glueTable := configuredTable.TableReference.(types.TableReferenceMemberGlue).Value
+	d.Set("database_name", glueTable.DatabaseName)
+	d.Set("table_name", glueTable.TableName)
+
+	return nil
+}
+
+func resourceConfiguredTableUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).CleanRoomsClient(ctx)
+
+	if d.HasChangesExcept("tags", "tags_all") {
+		input := &cleanrooms.UpdateConfiguredTableInput{
+			ConfiguredTableIdentifier: aws.String(d.Id()),
+		}
+
+		if d.HasChanges(names.AttrDescription) {
+			input.Description = aws.String(d.Get(names.AttrDescription).(string))
+		}
+
+		if d.HasChanges(names.AttrName) {
+			input.Name = aws.String(d.Get(names.AttrName).(string))
+		}
+
+		_, err := conn.UpdateConfiguredTable(ctx, input)
+		if err != nil {
+			return create.DiagError(names.CleanRooms, create.ErrActionUpdating, ResNameConfiguredTable, d.Id(), err)
+		}
+	}
+
+	return append(diags, resourceConfiguredTableRead(ctx, d, meta)...)
+}
+
+func resourceConfiguredTableDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).CleanRoomsClient(ctx)
+
+	log.Printf("[INFO] Deleting Clean Rooms Configured Table %s", d.Id())
+	in := &cleanrooms.DeleteConfiguredTableInput{
+		ConfiguredTableIdentifier: aws.String(d.Id()),
+	}
+
+	if _, err := conn.DeleteConfiguredTable(ctx, in); err != nil {
+		return create.DiagError(names.CleanRooms, create.ErrActionDeleting, ResNameConfiguredTable, d.Id(), err)
+	}
+
+	return nil
+}
+
+func findConfiguredTableByID(ctx context.Context, conn *cleanrooms.Client, id string) (*cleanrooms.GetConfiguredTableOutput, error) {
+	in := &cleanrooms.GetConfiguredTableInput{
+		ConfiguredTableIdentifier: aws.String(id),
+	}
+
+	out, err := conn.GetConfiguredTable(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+
+	if out == nil || out.ConfiguredTable == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return out, nil
+}
+
+func expandAnalysisMethod(analysisMethod string) (types.AnalysisMethod, error) {
+	switch analysisMethod {
+	case "DIRECT_QUERY":
+		return types.AnalysisMethodDirectQuery, nil
+	default:
+		return types.AnalysisMethodDirectQuery, fmt.Errorf("Invalid analysis method. The only valid value is currently `DIRECT_QUERY`")
+	}
+}

--- a/internal/service/cleanrooms/configured_table_test.go
+++ b/internal/service/cleanrooms/configured_table_test.go
@@ -1,0 +1,487 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cleanrooms_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cleanrooms"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tfcleanrooms "github.com/hashicorp/terraform-provider-aws/internal/service/cleanrooms"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccCleanRoomsConfiguredTable_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTable cleanrooms.GetConfiguredTableOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_cleanrooms_configured_table.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckConfiguredTable(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckConfiguredTableDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableConfig_basic(TEST_NAME, TEST_DESCRIPTION, TEST_TAG, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableExists(ctx, resourceName, &configuredTable),
+					resource.TestCheckResourceAttr(resourceName, "name", TEST_NAME),
+					resource.TestCheckResourceAttr(resourceName, "description", TEST_DESCRIPTION),
+					resource.TestCheckResourceAttr(resourceName, "analysis_method", TEST_ANALYSIS_METHOD),
+					resource.TestCheckResourceAttr(resourceName, "allowed_columns.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_columns.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_columns.1", "my_column_2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "table_reference.*", map[string]string{
+						"database_name": rName,
+						"table_name":    rName,
+					}),
+					resource.TestCheckResourceAttr(resourceName, "tags.Project", TEST_TAG),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCleanRoomsConfiguredTable_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTable cleanrooms.GetConfiguredTableOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_cleanrooms_configured_table.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckConfiguredTableDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableConfig_basic(TEST_NAME, TEST_DESCRIPTION, TEST_TAG, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableExists(ctx, resourceName, &configuredTable),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfcleanrooms.ResourceConfiguredTable(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccCleanRoomsConfiguredTable_mutableProperties(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTable cleanrooms.GetConfiguredTableOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_cleanrooms_configured_table.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckConfiguredTableDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableConfig_basic(TEST_NAME, TEST_DESCRIPTION, TEST_TAG, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableExists(ctx, resourceName, &configuredTable),
+				),
+			},
+			{
+				Config: testAccConfiguredTableConfig_basic(rName, "updated description", "updated tag", rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableIsTheSame(resourceName, &configuredTable),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "updated description"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Project", "updated tag"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCleanRoomsConfiguredTable_updateAllowedColumns(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTable cleanrooms.GetConfiguredTableOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_cleanrooms_configured_table.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckConfiguredTableDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableConfig_allowedColumns(TEST_ALLOWED_COLUMNS, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableExists(ctx, resourceName, &configuredTable),
+					resource.TestCheckResourceAttr(resourceName, "allowed_columns.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_columns.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_columns.1", "my_column_2"),
+				),
+			},
+			{
+				Config: testAccConfiguredTableConfig_allowedColumns("[\"my_column_1\"]", rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableRecreated(resourceName, &configuredTable),
+					resource.TestCheckResourceAttr(resourceName, "allowed_columns.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_columns.0", "my_column_1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCleanRoomsConfiguredTable_updateTableReference(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTable cleanrooms.GetConfiguredTableOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	firstDatabaseName := rName
+	secondDatabaseName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_cleanrooms_configured_table.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckConfiguredTableDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableConfig_additionalTables(rName, firstDatabaseName, secondDatabaseName, firstDatabaseName, TEST_FIRST_ADDITIONAL_TABLE_NAME),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableExists(ctx, resourceName, &configuredTable),
+				),
+			},
+			{
+				Config: testAccConfiguredTableConfig_additionalTables(rName, firstDatabaseName, secondDatabaseName, secondDatabaseName, TEST_SECOND_ADDITIONAL_TABLE_NAME),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableRecreated(resourceName, &configuredTable),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "table_reference.*", map[string]string{
+						"database_name": secondDatabaseName,
+						"table_name":    TEST_SECOND_ADDITIONAL_TABLE_NAME,
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCleanRoomsConfiguredTable_updateTableReference_onlyDatabase(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTable cleanrooms.GetConfiguredTableOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	firstDatabaseName := rName
+	secondDatabaseName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_cleanrooms_configured_table.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckConfiguredTableDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableConfig_additionalTables(rName, firstDatabaseName, secondDatabaseName, firstDatabaseName, TEST_FIRST_ADDITIONAL_TABLE_NAME),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableExists(ctx, resourceName, &configuredTable),
+				),
+			},
+			{
+				Config: testAccConfiguredTableConfig_additionalTables(rName, firstDatabaseName, secondDatabaseName, secondDatabaseName, TEST_FIRST_ADDITIONAL_TABLE_NAME),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableRecreated(resourceName, &configuredTable),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "table_reference.*", map[string]string{
+						"database_name": secondDatabaseName,
+						"table_name":    TEST_FIRST_ADDITIONAL_TABLE_NAME,
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCleanRoomsConfiguredTable_updateTableReference_onlyTable(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTable cleanrooms.GetConfiguredTableOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	firstDatabaseName := rName
+	secondDatabaseName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_cleanrooms_configured_table.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckConfiguredTableDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableConfig_additionalTables(rName, firstDatabaseName, secondDatabaseName, firstDatabaseName, TEST_FIRST_ADDITIONAL_TABLE_NAME),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableExists(ctx, resourceName, &configuredTable),
+				),
+			},
+			{
+				Config: testAccConfiguredTableConfig_additionalTables(rName, firstDatabaseName, secondDatabaseName, firstDatabaseName, TEST_SECOND_ADDITIONAL_TABLE_NAME),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableRecreated(resourceName, &configuredTable),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "table_reference.*", map[string]string{
+						"database_name": firstDatabaseName,
+						"table_name":    TEST_SECOND_ADDITIONAL_TABLE_NAME,
+					}),
+				),
+			},
+		},
+	})
+}
+
+func testAccPreCheckConfiguredTable(ctx context.Context, t *testing.T) {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).CleanRoomsClient(ctx)
+
+	input := &cleanrooms.ListConfiguredTablesInput{}
+	_, err := conn.ListConfiguredTables(ctx, input)
+
+	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func testAccCheckConfiguredTableDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).CleanRoomsClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != tfcleanrooms.ResNameConfiguredTable {
+				continue
+			}
+
+			_, err := conn.GetConfiguredTable(ctx, &cleanrooms.GetConfiguredTableInput{
+				ConfiguredTableIdentifier: aws.String(rs.Primary.ID),
+			})
+
+			if err == nil {
+				return create.Error(names.CleanRooms, create.ErrActionCheckingExistence, tfcleanrooms.ResNameConfiguredTable, rs.Primary.ID, errors.New("not destroyed"))
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckConfiguredTableExists(ctx context.Context, name string, configuredTable *cleanrooms.GetConfiguredTableOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.CleanRooms, create.ErrActionCheckingExistence, tfcleanrooms.ResNameConfiguredTable, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.CleanRooms, create.ErrActionCheckingExistence, tfcleanrooms.ResNameConfiguredTable, name, errors.New("not set"))
+		}
+
+		client := acctest.Provider.Meta().(*conns.AWSClient).CleanRoomsClient(ctx)
+		resp, err := client.GetConfiguredTable(ctx, &cleanrooms.GetConfiguredTableInput{
+			ConfiguredTableIdentifier: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return create.Error(names.CleanRooms, create.ErrActionCheckingExistence, tfcleanrooms.ResNameConfiguredTable, rs.Primary.ID, err)
+		}
+
+		*configuredTable = *resp
+
+		return nil
+	}
+}
+
+func testAccCheckConfiguredTableIsTheSame(name string, configuredTable *cleanrooms.GetConfiguredTableOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		return checkConfiguredTableIsTheSame(name, configuredTable, s)
+	}
+}
+
+func testAccCheckConfiguredTableRecreated(name string, configuredTable *cleanrooms.GetConfiguredTableOutput) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		err := checkConfiguredTableIsTheSame(name, configuredTable, state)
+		if err == nil {
+			return fmt.Errorf("Configured Table was expected to be recreated but was updated")
+		}
+		return nil
+	}
+}
+
+func checkConfiguredTableIsTheSame(name string, configuredTable *cleanrooms.GetConfiguredTableOutput, s *terraform.State) error {
+	rs, ok := s.RootModule().Resources[name]
+	if !ok {
+		return create.Error(names.CleanRooms, create.ErrActionCheckingExistence, tfcleanrooms.ResNameConfiguredTable, name, errors.New("not found"))
+	}
+
+	if rs.Primary.ID == "" {
+		return create.Error(names.CleanRooms, create.ErrActionCheckingExistence, tfcleanrooms.ResNameConfiguredTable, name, errors.New("not set"))
+	}
+
+	if rs.Primary.ID != *configuredTable.ConfiguredTable.Id {
+		return fmt.Errorf("New configured table: %s created instead of updating: %s", rs.Primary.ID, *configuredTable.ConfiguredTable.Id)
+	}
+
+	return nil
+}
+
+const TEST_ALLOWED_COLUMNS = "[\"my_column_1\",\"my_column_2\"]"
+const TEST_ANALYSIS_METHOD = "DIRECT_QUERY"
+const TEST_DATABASE_NAME = "database"
+const TEST_TABLE_NAME = "table"
+
+func testAccConfiguredTableConfig_basic(name string, description string, tagValue string, rName string) string {
+	return testAccConfiguredTableConfig(rName, name, description, tagValue, TEST_ALLOWED_COLUMNS,
+		TEST_ANALYSIS_METHOD, rName, rName)
+}
+
+func testAccConfiguredTableConfig_allowedColumns(allowedColumns string, rName string) string {
+	return testAccConfiguredTableConfig(rName, TEST_NAME, TEST_DESCRIPTION, TEST_TAG, allowedColumns,
+		TEST_ANALYSIS_METHOD, rName, rName)
+}
+
+const TEST_FIRST_ADDITIONAL_TABLE_NAME = "table_1"
+const TEST_SECOND_ADDITIONAL_TABLE_NAME = "table_2"
+
+func testAccConfiguredTableConfig_additionalTables(rName string, firstDatabaseName string, secondDatabaseName string, databaseName string, tableName string) string {
+	storageDescriptor := `
+storage_descriptor {
+  location = "s3://${aws_s3_bucket.test.bucket}"
+
+  columns {
+    name = "my_column_1"
+    type = "string"
+  }
+}`
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_glue_catalog_database" "test_1" {
+  name = %[2]q
+}
+
+resource "aws_glue_catalog_database" "test_2" {
+  name = %[3]q
+}
+
+resource "aws_glue_catalog_table" "test_1" {
+  name          = %[7]q
+  database_name = aws_glue_catalog_database.test_1.name
+
+  %[6]s
+}
+
+resource "aws_glue_catalog_table" "test_2" {
+  name          = %[8]q
+  database_name = aws_glue_catalog_database.test_1.name
+
+  %[6]s
+}
+
+resource "aws_glue_catalog_table" "test_3" {
+  name          = %[7]q
+  database_name = aws_glue_catalog_database.test_2.name
+  
+  %[6]s
+}
+
+resource "aws_glue_catalog_table" "test_4" {
+  name          = %[8]q
+  database_name = aws_glue_catalog_database.test_2.name
+
+  %[6]s
+}
+
+resource "aws_cleanrooms_configured_table" "test" {
+  name            = "test name"
+  description     = "test description"
+  analysis_method = "DIRECT_QUERY"
+  allowed_columns = ["my_column_1"]
+
+  table_reference {
+    database_name = %[4]q
+    table_name    = %[5]q
+  }
+
+  tags = {
+    Project = "Terraform"
+  }
+
+  depends_on = [aws_glue_catalog_table.test_1, aws_glue_catalog_table.test_2, aws_glue_catalog_table.test_3, aws_glue_catalog_table.test_4]
+}
+	`, rName, firstDatabaseName, secondDatabaseName, databaseName, tableName, storageDescriptor, TEST_FIRST_ADDITIONAL_TABLE_NAME, TEST_SECOND_ADDITIONAL_TABLE_NAME)
+}
+
+func testAccConfiguredTableConfig(rName string, name string, description string, tagValue string, allowedColumns string,
+	analysisMethod string, databaseName string, tableName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+}
+
+resource "aws_glue_catalog_table" "test" {
+  name          = %[1]q
+  database_name = %[1]q
+
+  storage_descriptor {
+    location = "s3://${aws_s3_bucket.test.bucket}"
+
+    columns {
+      name = "my_column_1"
+      type = "string"
+    }
+
+    columns {
+      name = "my_column_2"
+      type = "string"
+    }
+  }
+}
+
+resource "aws_cleanrooms_configured_table" "test" {
+  name            = %[2]q
+  description     = %[3]q
+  analysis_method = %[6]q
+  allowed_columns = %[5]s
+
+  table_reference {
+    database_name = %[7]q
+    table_name    = %[8]q
+  }
+
+  tags = {
+    Project = %[4]q
+  }
+
+  depends_on = [aws_glue_catalog_table.test]
+}
+	`, rName, name, description, tagValue, allowedColumns, analysisMethod, databaseName, tableName)
+}

--- a/internal/service/cleanrooms/configured_table_test.go
+++ b/internal/service/cleanrooms/configured_table_test.go
@@ -405,7 +405,7 @@ resource "aws_glue_catalog_table" "test_2" {
 resource "aws_glue_catalog_table" "test_3" {
   name          = %[7]q
   database_name = aws_glue_catalog_database.test_2.name
-  
+
   %[6]s
 }
 

--- a/internal/service/cleanrooms/service_package_gen.go
+++ b/internal/service/cleanrooms/service_package_gen.go
@@ -35,6 +35,13 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 				IdentifierAttribute: "arn",
 			},
 		},
+		{
+			Factory:  ResourceConfiguredTable,
+			TypeName: "aws_cleanrooms_configured_table",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
+		},
 	}
 }
 

--- a/website/docs/r/cleanrooms_configured_table.html.markdown
+++ b/website/docs/r/cleanrooms_configured_table.html.markdown
@@ -8,11 +8,11 @@ description: |-
 
 # Resource: aws_cleanrooms_configured_table
 
-Provides a AWS Clean Rooms configured table. Configured tables are used to define the schema for a table which will be created in a Clean Rooms collaboration.
+Provides a AWS Clean Rooms configured table. Configured tables are used to represent references to existing tables in the AWS Glue Data Catalog.
 
 ## Example Usage
 
-### Collaboration with tags
+### Configured table with tags
 
 ```terraform
 resource "aws_cleanrooms_configured_table" "test_configured_table" {

--- a/website/docs/r/cleanrooms_configured_table.html.markdown
+++ b/website/docs/r/cleanrooms_configured_table.html.markdown
@@ -1,0 +1,84 @@
+---
+subcategory: "Clean Rooms"
+layout: "aws"
+page_title: "AWS: aws_cleanrooms_configured_table"
+description: |-
+  Provides a Clean Rooms Configured Table.
+---
+
+# Resource: aws_cleanrooms_configured_table
+
+Provides a AWS Clean Rooms configured table. Configured tables are used to define the schema for a table which will be created in a Clean Rooms collaboration.
+
+## Example Usage
+
+### Collaboration with tags
+
+```terraform
+resource "aws_cleanrooms_configured_table" "test_configured_table" {
+  name            = "terraform-example-table"
+  description     = "I made this table with terraform!"
+  analysis_method = "DIRECT_QUERY"
+  allowed_columns = [
+    "column1",
+    "column2",
+    "column3",
+  ]
+
+  table_reference {
+    database_name = "example_database"
+    table_name    = "example_table"
+  }
+
+  tags = {
+    Project = "Terraform"
+  }
+}
+```
+
+## Argument Reference
+
+This resource supports the following arguments:
+
+* `name` - (Required) - The name of the configured table.
+* `description` - (Optional) - A description for the configured table.
+* `analysis_method` - (Required) - The analysis method for the configured table. The only valid value is currently `DIRECT_QUERY`.
+* `allowed_columns` - (Required - Forces new resource) - The columns of the references table which will be included in the configured table.
+* `table_reference` - (Required - Forces new resource) - A reference to the AWS Glue table which will be used to create the configured table.
+* `table_reference.database_name` - (Required - Forces new resource) - The name of the AWS Glue database which contains the table.
+* `table_reference.table_name` - (Required - Forces new resource) - The name of the AWS Glue table which will be used to create the configured table.
+* `tags` - (Optional) - Key value pairs which tag the configured table.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `arn` - The ARN of the configured table.
+* `id` - The ID of the configured table.
+* `create_time` - The date and time the configured table was created.
+* `update_time` - The date and time the configured table was last updated.
+
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+- `create` - (Default `1m`)
+- `update` - (Default `1m`)
+- `delete` - (Default `1m`)
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import `aws_cleanrooms_configured_table` using the `id`. For example:
+
+```terraform
+import {
+  to = aws_cleanrooms_configured_table.table
+  id = "1234abcd-12ab-34cd-56ef-1234567890ab"
+}
+```
+
+Using `terraform import`, import `aws_cleanrooms_configured_table` using the `id`. For example:
+
+```console
+% terraform import aws_cleanrooms_configured_table.table 1234abcd-12ab-34cd-56ef-1234567890ab
+```


### PR DESCRIPTION
### Description
This pull request adds a new resource for AWS Clean Rooms service which is not currently fully supported by the plugin. The change adds Configured Table resource, which is used by the Collaboration to reference AWS Glue tables.

### Relations
Relates #30024 

### References
https://docs.aws.amazon.com/clean-rooms/latest/apireference/API_ConfiguredTable.html

### Output from Acceptance Testing
```console
> make testacc TESTS=TestAccCleanRoomsConfiguredTable PKG=cleanrooms
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cleanrooms/... -v -count 1 -parallel 20 -run='TestAccCleanRoomsConfiguredTable'  -timeout 360m
=== RUN   TestAccCleanRoomsConfiguredTable_basic
=== PAUSE TestAccCleanRoomsConfiguredTable_basic
=== RUN   TestAccCleanRoomsConfiguredTable_disappears
=== PAUSE TestAccCleanRoomsConfiguredTable_disappears
=== RUN   TestAccCleanRoomsConfiguredTable_mutableProperties
=== PAUSE TestAccCleanRoomsConfiguredTable_mutableProperties
=== RUN   TestAccCleanRoomsConfiguredTable_updateAllowedColumns
=== PAUSE TestAccCleanRoomsConfiguredTable_updateAllowedColumns
=== RUN   TestAccCleanRoomsConfiguredTable_updateTableReference
=== PAUSE TestAccCleanRoomsConfiguredTable_updateTableReference
=== RUN   TestAccCleanRoomsConfiguredTable_updateTableReference_onlyDatabase
=== PAUSE TestAccCleanRoomsConfiguredTable_updateTableReference_onlyDatabase
=== RUN   TestAccCleanRoomsConfiguredTable_updateTableReference_onlyTable
=== PAUSE TestAccCleanRoomsConfiguredTable_updateTableReference_onlyTable
=== CONT  TestAccCleanRoomsConfiguredTable_basic
=== CONT  TestAccCleanRoomsConfiguredTable_updateTableReference
=== CONT  TestAccCleanRoomsConfiguredTable_updateTableReference_onlyTable
=== CONT  TestAccCleanRoomsConfiguredTable_updateTableReference_onlyDatabase
=== CONT  TestAccCleanRoomsConfiguredTable_mutableProperties
=== CONT  TestAccCleanRoomsConfiguredTable_updateAllowedColumns
=== CONT  TestAccCleanRoomsConfiguredTable_disappears
--- PASS: TestAccCleanRoomsConfiguredTable_disappears (49.16s)
--- PASS: TestAccCleanRoomsConfiguredTable_basic (49.99s)
--- PASS: TestAccCleanRoomsConfiguredTable_updateTableReference (82.98s)
--- PASS: TestAccCleanRoomsConfiguredTable_mutableProperties (83.47s)
--- PASS: TestAccCleanRoomsConfiguredTable_updateAllowedColumns (84.75s)
--- PASS: TestAccCleanRoomsConfiguredTable_updateTableReference_onlyDatabase (85.81s)
--- PASS: TestAccCleanRoomsConfiguredTable_updateTableReference_onlyTable (86.25s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cleanrooms 89.995s
```
