### PR TITLE
Fix error in `lex_bot_alias` resource documentation

### DIFF
--- a/website/docs/r/lex_bot_alias.html.markdown
+++ b/website/docs/r/lex_bot_alias.html.markdown
@@ -27,7 +27,7 @@ resource "aws_lex_bot_alias" "order_flowers_prod" {
 This resource supports the following arguments:
 
 * `bot_name` - (Required) The name of the bot.
-* `bot_version` - (Required) The name of the bot.
+* `bot_version` - (Required) The version of the bot.
 * `conversation_logs` - (Optional) The settings that determine how Amazon Lex uses conversation logs for the alias. Attributes are documented under [conversation_logs](#conversation_logs).
 * `description` - (Optional) A description of the alias. Must be less than or equal to 200 characters in length.
 * `name` - (Required) The name of the alias. The name is not case sensitive. Must be less than or equal to 100 characters in length.


### PR DESCRIPTION
### Description

This PR addresses a documentation error for the `lex_bot_alias` resource, related to the `bot_version` argument. Clarified that `bot_version`  represents the version of the bot, not the name of the bot.

### Relations

N/A, docs

### References

N/A, docs

### Output from Acceptance Testing

N/A
