### PR TITLE
sweeper/aws_servicecatalog_provisioning_artifact: Fix sweeper

### DIFF
--- a/internal/service/servicecatalog/sweep.go
+++ b/internal/service/servicecatalog/sweep.go
@@ -575,9 +575,7 @@ func sweepProvisioningArtifacts(region string) error {
 				output, err := conn.ListProvisioningArtifactsWithContext(ctx, artInput)
 
 				if err != nil {
-					err := fmt.Errorf("error listing Service Catalog Provisioning Artifacts for product (%s): %w", productID, err)
-					log.Printf("[ERROR] %s", err)
-					errs = multierror.Append(errs, err)
+					errs = multierror.Append(errs, fmt.Errorf("error listing Service Catalog Provisioning Artifacts for product (%s): %w", productID, err))
 					break
 				}
 
@@ -585,8 +583,7 @@ func sweepProvisioningArtifacts(region string) error {
 					r := ResourceProvisioningArtifact()
 					d := r.Data(nil)
 
-					d.SetId(aws.StringValue(pad.Id))
-					d.Set("product_id", productID)
+					d.SetId(ProvisioningArtifactID(aws.StringValue(pad.Id), productID))
 
 					sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 				}


### PR DESCRIPTION
### Description

The sweeper fails with an error such as

> parsing Service Catalog Provisioning Artifact ID (pa-d3wdwwz5teu74): unexpected format of ID (pa-d3wdwwz5teu74), expected artifactID:productID
