### PR TITLE
sweeper/aws_quicksight_vpc_connection: Ignores error when account not configured for QuickSight

### DIFF
--- a/internal/service/quicksight/sweep.go
+++ b/internal/service/quicksight/sweep.go
@@ -456,6 +456,9 @@ func skipSweepError(err error) bool {
 	if tfawserr.ErrCodeEquals(err, quicksight.ErrCodeUnsupportedUserEditionException) {
 		return true
 	}
+	if tfawserr.ErrMessageContains(err, quicksight.ErrCodeResourceNotFoundException, "Directory information for account") {
+		return true
+	}
 
 	return sweep.SkipSweepError(err)
 }


### PR DESCRIPTION
### Description

The `aws_quicksight_vpc_connection` sweeper currently fails when used in an account where QuickSight isn't configured.

### Output from Acceptance Testing

Previously:

> [ERROR] Error running Sweeper (aws_quicksight_vpc_connection) in region (us-west-2): listing QuickSight VPC Connections: ResourceNotFoundException: Directory information for account 123456789012 is not found.

Now:

```console
$  make sweep SWEEPERS=aws_quicksight_vpc_connection

[WARN] Skipping QuickSight VPC Connection sweep for us-west-2: ResourceNotFoundException: Directory information for account 123456789012 is not found.
```