### PR TITLE
feat: support databricks connectivity in quicksight data source

### DIFF
--- a/internal/service/quicksight/data_source.go
+++ b/internal/service/quicksight/data_source.go
@@ -205,6 +205,30 @@ func ResourceDataSource() *schema.Resource {
 									},
 								},
 							},
+							"databricks": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"host": {
+											Type:         schema.TypeString,
+											Required:     true,
+											ValidateFunc: validation.NoZeroValues,
+										},
+										"port": {
+											Type:         schema.TypeInt,
+											Required:     true,
+											ValidateFunc: validation.IntAtLeast(1),
+										},
+										"sql_endpoint_path": {
+											Type:         schema.TypeString,
+											Required:     true,
+											ValidateFunc: validation.NoZeroValues,
+										},
+									},
+								},
+							},
 							"jira": {
 								Type:     schema.TypeList,
 								Optional: true,
@@ -966,6 +990,26 @@ func expandDataSourceParameters(tfList []interface{}) *quicksight.DataSourcePara
 		}
 	}
 
+	if v := tfMap["databricks"].([]interface{}); ok && len(v) > 0 && v != nil {
+		m, ok := v[0].(map[string]interface{})
+
+		if ok {
+			ps := &quicksight.DatabricksParameters{}
+
+			if v, ok := m["host"].(string); ok && v != "" {
+				ps.Host = aws.String(v)
+			}
+			if v, ok := m["port"].(int); ok {
+				ps.Port = aws.Int64(int64(v))
+			}
+			if v, ok := m["sql_endpoint_path"].(string); ok && v != "" {
+				ps.SqlEndpointPath = aws.String(v)
+			}
+
+			dataSourceParams.DatabricksParameters = ps
+		}
+	}
+
 	if v := tfMap["jira"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 		m, ok := v[0].(map[string]interface{})
 
@@ -1343,6 +1387,18 @@ func flattenParameters(parameters *quicksight.DataSourceParameters) []interface{
 			"aws_iot_analytics": []interface{}{
 				map[string]interface{}{
 					"data_set_name": parameters.AwsIotAnalyticsParameters.DataSetName,
+				},
+			},
+		})
+	}
+
+	if parameters.DatabricksParameters != nil {
+		params = append(params, map[string]interface{}{
+			"databricks": []interface{}{
+				map[string]interface{}{
+					"host":              parameters.DatabricksParameters.Host,
+					"port":              parameters.DatabricksParameters.Port,
+					"sql_endpoint_path": parameters.DatabricksParameters.SqlEndpointPath,
 				},
 			},
 		})

--- a/website/docs/cdktf/python/r/quicksight_data_source.html.markdown
+++ b/website/docs/cdktf/python/r/quicksight_data_source.html.markdown
@@ -79,6 +79,7 @@ To specify data source connection parameters, exactly one of the following sub-o
 * `aurora` - (Optional) [Parameters](#aurora-argument-reference) for connecting to Aurora MySQL.
 * `aurora_postgresql` - (Optional) [Parameters](#aurora_postgresql-argument-reference) for connecting to Aurora Postgresql.
 * `aws_iot_analytics` - (Optional) [Parameters](#aws_iot_analytics-argument-reference) for connecting to AWS IOT Analytics.
+* `databricks` - (Optional) [Parameters](#databricks-fargument-reference) for connecting to Databricks.
 * `jira` - (Optional) [Parameters](#jira-fargument-reference) for connecting to Jira.
 * `maria_db` - (Optional) [Parameters](#maria_db-argument-reference) for connecting to MariaDB.
 * `mysql` - (Optional) [Parameters](#mysql-argument-reference) for connecting to MySQL.
@@ -131,6 +132,12 @@ To specify data source connection parameters, exactly one of the following sub-o
 ### aws_iot_analytics Argument Reference
 
 * `data_set_name` - (Required) The name of the data set to which to connect.
+
+### databricks Argument Reference
+
+* `host` - (Required) The host name of the Databricks data source.
+* `port` - (Required) The port for the Databricks data source.
+* `sql_endpoint_path` - (Required) The HTTP path of the Databricks data source.
 
 ### jira fArgument Reference
 

--- a/website/docs/cdktf/typescript/r/quicksight_data_source.html.markdown
+++ b/website/docs/cdktf/typescript/r/quicksight_data_source.html.markdown
@@ -82,6 +82,7 @@ To specify data source connection parameters, exactly one of the following sub-o
 * `aurora` - (Optional) [Parameters](#aurora-argument-reference) for connecting to Aurora MySQL.
 * `auroraPostgresql` - (Optional) [Parameters](#aurora_postgresql-argument-reference) for connecting to Aurora Postgresql.
 * `awsIotAnalytics` - (Optional) [Parameters](#aws_iot_analytics-argument-reference) for connecting to AWS IOT Analytics.
+* `databricks` - (Optional) [Parameters](#databricks-fargument-reference) for connecting to Databricks.
 * `jira` - (Optional) [Parameters](#jira-fargument-reference) for connecting to Jira.
 * `mariaDb` - (Optional) [Parameters](#maria_db-argument-reference) for connecting to MariaDB.
 * `mysql` - (Optional) [Parameters](#mysql-argument-reference) for connecting to MySQL.
@@ -134,6 +135,12 @@ To specify data source connection parameters, exactly one of the following sub-o
 ### aws_iot_analytics Argument Reference
 
 * `dataSetName` - (Required) The name of the data set to which to connect.
+
+### databricks Argument Reference
+
+* `host` - (Required) The host name of the Databricks data source.
+* `port` - (Required) The port for the Databricks data source.
+* `sql_endpoint_path` - (Required) The HTTP path of the Databricks data source.
 
 ### jira fArgument Reference
 

--- a/website/docs/r/quicksight_data_source.html.markdown
+++ b/website/docs/r/quicksight_data_source.html.markdown
@@ -68,6 +68,7 @@ To specify data source connection parameters, exactly one of the following sub-o
 * `aurora` - (Optional) [Parameters](#aurora-argument-reference) for connecting to Aurora MySQL.
 * `aurora_postgresql` - (Optional) [Parameters](#aurora_postgresql-argument-reference) for connecting to Aurora Postgresql.
 * `aws_iot_analytics` - (Optional) [Parameters](#aws_iot_analytics-argument-reference) for connecting to AWS IOT Analytics.
+* `databricks` - (Optional) [Parameters](#databricks-fargument-reference) for connecting to Databricks.
 * `jira` - (Optional) [Parameters](#jira-fargument-reference) for connecting to Jira.
 * `maria_db` - (Optional) [Parameters](#maria_db-argument-reference) for connecting to MariaDB.
 * `mysql` - (Optional) [Parameters](#mysql-argument-reference) for connecting to MySQL.
@@ -120,6 +121,12 @@ To specify data source connection parameters, exactly one of the following sub-o
 ### aws_iot_analytics Argument Reference
 
 * `data_set_name` - (Required) The name of the data set to which to connect.
+
+### databricks Argument Reference
+
+* `host` - (Required) The host name of the Databricks data source.
+* `port` - (Required) The port for the Databricks data source.
+* `sql_endpoint_path` - (Required) The HTTP path of the Databricks data source.
 
 ### jira fArgument Reference
 

--- a/website/docs/r/quicksight_data_source.html.markdown
+++ b/website/docs/r/quicksight_data_source.html.markdown
@@ -68,7 +68,7 @@ To specify data source connection parameters, exactly one of the following sub-o
 * `aurora` - (Optional) [Parameters](#aurora-argument-reference) for connecting to Aurora MySQL.
 * `aurora_postgresql` - (Optional) [Parameters](#aurora_postgresql-argument-reference) for connecting to Aurora Postgresql.
 * `aws_iot_analytics` - (Optional) [Parameters](#aws_iot_analytics-argument-reference) for connecting to AWS IOT Analytics.
-* `databricks` - (Optional) [Parameters](#databricks-fargument-reference) for connecting to Databricks.
+* `databricks` - (Optional) [Parameters](#databricks-argument-reference) for connecting to Databricks.
 * `jira` - (Optional) [Parameters](#jira-fargument-reference) for connecting to Jira.
 * `maria_db` - (Optional) [Parameters](#maria_db-argument-reference) for connecting to MariaDB.
 * `mysql` - (Optional) [Parameters](#mysql-argument-reference) for connecting to MySQL.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Added databricks paramter into [aws\_quicksight\_data\_source | Resources | hashicorp/aws | Terraform | Terraform Registry](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_data_source)

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #33616

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

I just followed the current code base, but please let me know if something is missing.

- [aws\_quicksight\_data\_source | Resources | hashicorp/aws | Terraform | Terraform Registry](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_data_source)
- https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/quicksight@v1.43.0/types#DatabricksParameters

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
%  make testacc PKG=quicksight TESTS=TestAccQuickSightDataSetDataSource

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/quicksight/... -v -count 1 -parallel 20 -run='TestAccQuickSightDataSetDataSource'  -timeout 180m
?   	github.com/hashicorp/terraform-provider-aws/internal/service/quicksight/schema	[no test files]
=== RUN   TestAccQuickSightDataSetDataSource_basic
=== PAUSE TestAccQuickSightDataSetDataSource_basic
=== CONT  TestAccQuickSightDataSetDataSource_basic
--- PASS: TestAccQuickSightDataSetDataSource_basic (34.88s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/quicksight	36.912s
```
