### PR TITLE
Unset notify configuration as required

### DIFF
--- a/internal/service/cognitoidp/risk_configuration.go
+++ b/internal/service/cognitoidp/risk_configuration.go
@@ -121,7 +121,7 @@ func ResourceRiskConfiguration() *schema.Resource {
 						},
 						"notify_configuration": {
 							Type:     schema.TypeList,
-							Required: true,
+							Optional: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -207,7 +207,7 @@ func ResourceRiskConfiguration() *schema.Resource {
 									},
 									"source_arn": {
 										Type:         schema.TypeString,
-										Required:     true,
+										Optional:     true,
 										ValidateFunc: verify.ValidARN,
 									},
 								},

--- a/internal/service/cognitoidp/risk_configuration_test.go
+++ b/internal/service/cognitoidp/risk_configuration_test.go
@@ -137,6 +137,43 @@ func TestAccCognitoIDPRiskConfiguration_compromised(t *testing.T) {
 	})
 }
 
+func TestAccCognitoIDPRiskConfiguration_takeover_without_notification(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_cognito_risk_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIdentityProvider(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, cognitoidentityprovider.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRiskConfigurationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRiskConfigurationConfig_takeover_without_notification(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRiskConfigurationExists(ctx, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "user_pool_id", "aws_cognito_user_pool.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "account_takeover_risk_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "account_takeover_risk_configuration.actions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "account_takeover_risk_configuration.0.actions.0.medium_action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "account_takeover_risk_configuration.0.actions.0.medium_action.0.event_action", "MFA_REQUIRED"),
+					resource.TestCheckResourceAttr(resourceName, "account_takeover_risk_configuration.0.actions.0.medium_action.0.notify", "false"),
+					resource.TestCheckResourceAttr(resourceName, "account_takeover_risk_configuration.0.actions.0.high_action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "account_takeover_risk_configuration.0.actions.0.high_action.0.event_action", "BLOCK"),
+					resource.TestCheckResourceAttr(resourceName, "account_takeover_risk_configuration.0.actions.0.high_action.0.notify", "false"),
+					resource.TestCheckResourceAttr(resourceName, "compromised_credentials_risk_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "risk_exception_configuration.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccCognitoIDPRiskConfiguration_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -399,6 +436,31 @@ resource "aws_cognito_risk_configuration" "test" {
   risk_exception_configuration {
     blocked_ip_range_list = []
     skipped_ip_range_list = []
+  }
+}
+
+resource "aws_cognito_user_pool" "test" {
+  name = %[1]q
+}
+`, rName)
+}
+
+func testAccRiskConfigurationConfig_takeover_without_notification(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cognito_risk_configuration" "test" {
+  user_pool_id = aws_cognito_user_pool.test.id
+
+  account_takeover_risk_configuration {
+    actions {
+      medium_action {
+        event_action = "MFA_REQUIRED"
+        notify 	      = false
+      }
+      high_action {
+        event_action = "BLOCK"
+        notify 	      = false
+      }
+    }
   }
 }
 


### PR DESCRIPTION
### Description
In [`aws_cognito_risk_configuration`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_risk_configuration), these two arguments are requiredt
 - [`account_takeover_risk_configuration.notify_configuration`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_risk_configuration#account_takeover_risk_configuration)
 - [`account_takeover_risk_configuration.notify_configuration; source_arn`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_risk_configuration#source_arn)

whereas they are optional as per [1](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AccountTakeoverRiskConfigurationType.html) and [2](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_NotifyConfigurationType.html)

> **NotifyConfiguration**
>
> The notify configuration used to construct email notifications.
> Required: No

> **From**
>
> The email address that is sending the email. The address must be either individually verified with Amazon Simple Email Service, or from a domain that has been verified with Amazon SES.
> **Required: No**



### Relations
Closes https://github.com/hashicorp/terraform-provider-aws/issues/28784

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
