### PR TITLE
r/aws_fsx_ontap_volume: Set `bypass_snaplock_enterprise_retention` in sweeper

### DIFF
--- a/internal/service/fsx/sweep.go
+++ b/internal/service/fsx/sweep.go
@@ -294,6 +294,7 @@ func sweepONTAPVolumes(region string) error {
 			r := ResourceONTAPVolume()
 			d := r.Data(nil)
 			d.SetId(aws.StringValue(v.VolumeId))
+			d.Set("bypass_snaplock_enterprise_retention", true)
 			d.Set("skip_final_backup", true)
 
 			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Sets `bypass_snaplock_enterprise_retention`, bypassing errors like

```
2023/09/26 08:05:12 [ERROR] Error running Sweeper (aws_fsx_ontap_volume) in region (us-west-2): 1 error occurred:
	* error sweeping FSx ONTAP Volume for us-west-2: 2 errors occurred:
	* deleting FSx for NetApp ONTAP Volume (fsvol-034641efe8270af4c): BadRequest: Cannot delete a SnapLock Enterprise volume because it contains unexpired WORM files, it has files under legal hold, it has unexpired locked snapshots, or it is an unexpired SnapLock audit log volume. Set 'BypassSnaplockEnterpriseRetention' to true and try again.
	* deleting FSx for NetApp ONTAP Volume (fsvol-04a4dd8ba505ec225): BadRequest: Cannot delete a SnapLock Enterprise volume because it contains unexpired WORM files, it has files under legal hold, it has unexpired locked snapshots, or it is an unexpired SnapLock audit log volume. Set 'BypassSnaplockEnterpriseRetention' to true and try again.
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/32530.