### PR TITLE
SG ids should allow computed values

### DIFF
--- a/internal/service/opensearch/domain.go
+++ b/internal/service/opensearch/domain.go
@@ -593,6 +593,7 @@ func ResourceDomain() *schema.Resource {
 						"security_group_ids": {
 							Type:     schema.TypeSet,
 							Optional: true,
+							Computed: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 							Set:      schema.HashString,
 						},


### PR DESCRIPTION
### Description

Added `computed` behavior to the `security_group_ids`  argument. 
This will stop terraform from resetting `security_group_ids` argument each time it runs when a value is not specified and a default SG is created for the OpenSearch Domain.

### Relations
Closes #33621 

### References

[Computed behavior](https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-behaviors#computed)
[security_group_ids argument](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/opensearch_domain#security_group_ids)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
