### PR TITLE
sweeper/aws_ssoadmin_permission_set: Fixes panic in sweeper

### DIFF
--- a/internal/service/ssoadmin/sweep.go
+++ b/internal/service/ssoadmin/sweep.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssoadmin"
 	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/sdk"
@@ -165,7 +164,7 @@ func sweepPermissionSets(region string) error {
 		return err
 	}
 
-	instanceArn := dsData.Get("arns").(*schema.Set).List()[0].(string)
+	instanceArn := dsData.Get("arns").([]interface{})[0].(string)
 
 	input := &ssoadmin.ListPermissionSetsInput{
 		InstanceArn: aws.String(instanceArn),


### PR DESCRIPTION
### Description

Fixes panic in `aws_ssoadmin_permission_set ` sweeper

### Output from Acceptance Testing

Before:

```
[DEBUG] Running Sweeper (aws_ssoadmin_permission_set) in region (us-west-2)
panic: interface conversion: interface {} is []interface {}, not *schema.Set

goroutine 1 [running]:
github.com/hashicorp/terraform-provider-aws/internal/service/ssoadmin.sweepPermissionSets({0x16d4af2b2, 0x9})
	/Users/gdavison/developer/terraform-provider-aws/internal/service/ssoadmin/sweep.go:168 +0x6f0
github.com/hashicorp/terraform-plugin-testing/helper/resource.runSweeperWithRegion({0x16d4af2b2, 0x9}, 0x14000725d70, 0x1400099fce8?, 0x1400099fc08?, 0x0)
	/Users/gdavison/go/pkg/mod/github.com/hashicorp/terraform-plugin-testing@v1.5.1/helper/resource/testing.go:273 +0x448
github.com/hashicorp/terraform-plugin-testing/helper/resource.runSweepers({0x1400089dcc0, 0x4, 0x10d88ede8?}, 0x1?, 0x0)
	/Users/gdavison/go/pkg/mod/github.com/hashicorp/terraform-plugin-testing@v1.5.1/helper/resource/testing.go:151 +0x430
github.com/hashicorp/terraform-plugin-testing/helper/resource.TestMain({0x11069c088, 0x140007f8960})
	/Users/gdavison/go/pkg/mod/github.com/hashicorp/terraform-plugin-testing@v1.5.1/helper/resource/testing.go:129 +0xf4
github.com/hashicorp/terraform-provider-aws/internal/sweep_test.TestMain(0x140000ea688?)
	/Users/gdavison/developer/terraform-provider-aws/internal/sweep/sweep_test.go:161 +0x78
main.main()
	_testmain.go:49 +0x1ac
```

Now

```
[DEBUG] Running Sweeper (aws_ssoadmin_permission_set) in region (us-west-2)
[DEBUG] Completed Sweeper (aws_ssoadmin_permission_set) in region (us-west-2) in 247.081875ms
```
