### PR TITLE
aws_servicequotas: update to aws sdk v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3control v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.3.0
 	github.com/aws/aws-sdk-go-v2/service/securitylake v1.7.0
+	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.16.0
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.20.1
 	github.com/aws/aws-sdk-go-v2/service/signer v1.16.5
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.38.0

--- a/go.sum
+++ b/go.sum
@@ -156,6 +156,8 @@ github.com/aws/aws-sdk-go-v2/service/scheduler v1.3.0 h1:uzCEL2ILopsOcWvbmeMmmy3
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.3.0/go.mod h1:cdpHC7Nd4Yvtf/rhRqyqqI0fzoCb0fpo2oOFVZ0HTeQ=
 github.com/aws/aws-sdk-go-v2/service/securitylake v1.7.0 h1:Ou2rjk3siybv09bzpi5fs+9zOYZACxT1LT0KkcDAtIs=
 github.com/aws/aws-sdk-go-v2/service/securitylake v1.7.0/go.mod h1:/MCawoN8Xib5q04k2HsIQ+K2cNtC3CHamrfLZXd6KmA=
+github.com/aws/aws-sdk-go-v2/service/servicequotas v1.16.0 h1:dhp7Do5oaybdDdYGcdUNyzYFPsM4sNCvuPqph7MG5X0=
+github.com/aws/aws-sdk-go-v2/service/servicequotas v1.16.0/go.mod h1:7+H2efEiOCrUl5EEsDFhe5BeI4gHGLUlisCyAJAcSvs=
 github.com/aws/aws-sdk-go-v2/service/sesv2 v1.20.1 h1:QxzS/Hr5kixvMyPIXTfspnRUiKgFJSTPrhnglAi2YLI=
 github.com/aws/aws-sdk-go-v2/service/sesv2 v1.20.1/go.mod h1:qpAr/ear7teIUoBd1gaPbvavdICoo1XyAIHPVlyawQc=
 github.com/aws/aws-sdk-go-v2/service/signer v1.16.5 h1:nqZqDR44/ao9zQXyuCJI8L/C3QQIo4wtZyLtgwJfpEY=

--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -53,6 +53,7 @@ import (
 	s3control_sdkv2 "github.com/aws/aws-sdk-go-v2/service/s3control"
 	scheduler_sdkv2 "github.com/aws/aws-sdk-go-v2/service/scheduler"
 	securitylake_sdkv2 "github.com/aws/aws-sdk-go-v2/service/securitylake"
+	servicequotas_sdkv2 "github.com/aws/aws-sdk-go-v2/service/servicequotas"
 	sesv2_sdkv2 "github.com/aws/aws-sdk-go-v2/service/sesv2"
 	signer_sdkv2 "github.com/aws/aws-sdk-go-v2/service/signer"
 	ssm_sdkv2 "github.com/aws/aws-sdk-go-v2/service/ssm"
@@ -201,7 +202,6 @@ import (
 	serverlessapplicationrepository_sdkv1 "github.com/aws/aws-sdk-go/service/serverlessapplicationrepository"
 	servicecatalog_sdkv1 "github.com/aws/aws-sdk-go/service/servicecatalog"
 	servicediscovery_sdkv1 "github.com/aws/aws-sdk-go/service/servicediscovery"
-	servicequotas_sdkv1 "github.com/aws/aws-sdk-go/service/servicequotas"
 	ses_sdkv1 "github.com/aws/aws-sdk-go/service/ses"
 	sfn_sdkv1 "github.com/aws/aws-sdk-go/service/sfn"
 	shield_sdkv1 "github.com/aws/aws-sdk-go/service/shield"
@@ -1010,8 +1010,8 @@ func (c *AWSClient) ServiceDiscoveryConn(ctx context.Context) *servicediscovery_
 	return errs.Must(conn[*servicediscovery_sdkv1.ServiceDiscovery](ctx, c, names.ServiceDiscovery))
 }
 
-func (c *AWSClient) ServiceQuotasConn(ctx context.Context) *servicequotas_sdkv1.ServiceQuotas {
-	return errs.Must(conn[*servicequotas_sdkv1.ServiceQuotas](ctx, c, names.ServiceQuotas))
+func (c *AWSClient) ServiceQuotasClient(ctx context.Context) *servicequotas_sdkv2.Client {
+	return errs.Must(client[*servicequotas_sdkv2.Client](ctx, c, names.ServiceQuotas))
 }
 
 func (c *AWSClient) ShieldConn(ctx context.Context) *shield_sdkv1.Shield {

--- a/internal/service/servicequotas/acc_test.go
+++ b/internal/service/servicequotas/acc_test.go
@@ -5,11 +5,12 @@ package servicequotas_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/servicequotas"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/servicequotas"
+	"github.com/aws/aws-sdk-go-v2/service/servicequotas/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
@@ -29,11 +30,11 @@ const (
 )
 
 func testAccPreCheck(ctx context.Context, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).ServiceQuotasConn(ctx)
+	conn := acctest.Provider.Meta().(*conns.AWSClient).ServiceQuotasClient(ctx)
 
 	input := &servicequotas.ListServicesInput{}
 
-	_, err := conn.ListServicesWithContext(ctx, input)
+	_, err := conn.ListServices(ctx, input)
 
 	if acctest.PreCheckSkipError(err) {
 		t.Skipf("skipping acceptance testing: %s", err)
@@ -46,15 +47,16 @@ func testAccPreCheck(ctx context.Context, t *testing.T) {
 
 // nosemgrep:ci.servicequotas-in-func-name
 func preCheckServiceQuotaSet(ctx context.Context, serviceCode, quotaCode string, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).ServiceQuotasConn(ctx)
+	conn := acctest.Provider.Meta().(*conns.AWSClient).ServiceQuotasClient(ctx)
 
 	input := &servicequotas.GetServiceQuotaInput{
 		QuotaCode:   aws.String(quotaCode),
 		ServiceCode: aws.String(serviceCode),
 	}
 
-	_, err := conn.GetServiceQuotaWithContext(ctx, input)
-	if tfawserr.ErrCodeEquals(err, servicequotas.ErrCodeNoSuchResourceException) {
+	_, err := conn.GetServiceQuota(ctx, input)
+	var nsr *types.NoSuchResourceException
+	if errors.As(err, &nsr) {
 		t.Fatalf("The Service Quota (%s/%s) has never been set. This test can only be run with a quota that has previously been set. Please update the test to check a new quota.", serviceCode, quotaCode)
 	}
 	if err != nil {
@@ -63,31 +65,32 @@ func preCheckServiceQuotaSet(ctx context.Context, serviceCode, quotaCode string,
 }
 
 func preCheckServiceQuotaUnset(ctx context.Context, serviceCode, quotaCode string, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).ServiceQuotasConn(ctx)
+	conn := acctest.Provider.Meta().(*conns.AWSClient).ServiceQuotasClient(ctx)
 
 	input := &servicequotas.GetServiceQuotaInput{
 		QuotaCode:   aws.String(quotaCode),
 		ServiceCode: aws.String(serviceCode),
 	}
 
-	_, err := conn.GetServiceQuotaWithContext(ctx, input)
+	_, err := conn.GetServiceQuota(ctx, input)
 	if err == nil {
 		t.Fatalf("The Service Quota (%s/%s) has been set. This test can only be run with a quota that has never been set. Please update the test to check a new quota.", serviceCode, quotaCode)
 	}
-	if !tfawserr.ErrCodeEquals(err, servicequotas.ErrCodeNoSuchResourceException) {
+	var nsr *types.NoSuchResourceException
+	if !errors.As(err, &nsr) {
 		t.Fatalf("unexpected PreCheck error getting Service Quota (%s/%s) : %s", serviceCode, quotaCode, err)
 	}
 }
 
 func preCheckServiceQuotaHasUsageMetric(ctx context.Context, serviceCode, quotaCode string, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).ServiceQuotasConn(ctx)
+	conn := acctest.Provider.Meta().(*conns.AWSClient).ServiceQuotasClient(ctx)
 
 	input := &servicequotas.GetAWSDefaultServiceQuotaInput{
 		QuotaCode:   aws.String(quotaCode),
 		ServiceCode: aws.String(serviceCode),
 	}
 
-	quota, err := conn.GetAWSDefaultServiceQuotaWithContext(ctx, input)
+	quota, err := conn.GetAWSDefaultServiceQuota(ctx, input)
 	if err != nil {
 		t.Fatalf("unexpected PreCheck error getting Service Quota (%s/%s) : %s", serviceCode, quotaCode, err)
 	}

--- a/internal/service/servicequotas/service_data_source.go
+++ b/internal/service/servicequotas/service_data_source.go
@@ -6,8 +6,9 @@ package servicequotas
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/servicequotas"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/servicequotas"
+	"github.com/aws/aws-sdk-go-v2/service/servicequotas/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -34,26 +35,31 @@ func DataSourceService() *schema.Resource {
 
 func dataSourceServiceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).ServiceQuotasConn(ctx)
+	conn := meta.(*conns.AWSClient).ServiceQuotasClient(ctx)
 
 	serviceName := d.Get("service_name").(string)
 
 	input := &servicequotas.ListServicesInput{}
 
-	var service *servicequotas.ServiceInfo
-	err := conn.ListServicesPagesWithContext(ctx, input, func(page *servicequotas.ListServicesOutput, lastPage bool) bool {
+	var service *types.ServiceInfo
+	paginator := servicequotas.NewListServicesPaginator(conn, input)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "listing Services: %s", err)
+		}
+
 		for _, s := range page.Services {
-			if aws.StringValue(s.ServiceName) == serviceName {
-				service = s
+			s := s
+			if aws.ToString(s.ServiceName) == serviceName {
+				service = &s
 				break
 			}
 		}
 
-		return !lastPage
-	})
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing Services: %s", err)
+		if service != nil {
+			break // stop paging once found
+		}
 	}
 
 	if service == nil {
@@ -62,7 +68,7 @@ func dataSourceServiceRead(ctx context.Context, d *schema.ResourceData, meta int
 
 	d.Set("service_code", service.ServiceCode)
 	d.Set("service_name", service.ServiceName)
-	d.SetId(aws.StringValue(service.ServiceCode))
+	d.SetId(aws.ToString(service.ServiceCode))
 
 	return diags
 }

--- a/internal/service/servicequotas/service_data_source_test.go
+++ b/internal/service/servicequotas/service_data_source_test.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/servicequotas"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccServiceQuotasServiceDataSource_serviceName(t *testing.T) {
@@ -17,8 +17,11 @@ func TestAccServiceQuotasServiceDataSource_serviceName(t *testing.T) {
 	dataSourceName := "data.aws_servicequotas_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, servicequotas.EndpointsID) },
-		ErrorCheck:               acctest.ErrorCheck(t, servicequotas.EndpointsID),
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.ServiceQuotasEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceQuotasEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/servicequotas/service_package_gen.go
+++ b/internal/service/servicequotas/service_package_gen.go
@@ -5,9 +5,8 @@ package servicequotas
 import (
 	"context"
 
-	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
-	session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
-	servicequotas_sdkv1 "github.com/aws/aws-sdk-go/service/servicequotas"
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	servicequotas_sdkv2 "github.com/aws/aws-sdk-go-v2/service/servicequotas"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -49,11 +48,15 @@ func (p *servicePackage) ServicePackageName() string {
 	return names.ServiceQuotas
 }
 
-// NewConn returns a new AWS SDK for Go v1 client for this service package's AWS API.
-func (p *servicePackage) NewConn(ctx context.Context, config map[string]any) (*servicequotas_sdkv1.ServiceQuotas, error) {
-	sess := config["session"].(*session_sdkv1.Session)
+// NewClient returns a new AWS SDK for Go v2 client for this service package's AWS API.
+func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (*servicequotas_sdkv2.Client, error) {
+	cfg := *(config["aws_sdkv2_config"].(*aws_sdkv2.Config))
 
-	return servicequotas_sdkv1.New(sess.Copy(&aws_sdkv1.Config{Endpoint: aws_sdkv1.String(config["endpoint"].(string))})), nil
+	return servicequotas_sdkv2.NewFromConfig(cfg, func(o *servicequotas_sdkv2.Options) {
+		if endpoint := config["endpoint"].(string); endpoint != "" {
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
+		}
+	}), nil
 }
 
 func ServicePackage(ctx context.Context) conns.ServicePackage {

--- a/internal/service/servicequotas/service_quota_data_source_test.go
+++ b/internal/service/servicequotas/service_quota_data_source_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 
 	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go/service/servicequotas"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccServiceQuotasServiceQuotaDataSource_quotaCode(t *testing.T) {
@@ -20,10 +20,10 @@ func TestAccServiceQuotasServiceQuotaDataSource_quotaCode(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, servicequotas.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.ServiceQuotasEndpointID)
 			preCheckServiceQuotaSet(ctx, setQuotaServiceCode, setQuotaQuotaCode, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, servicequotas.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceQuotasEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -52,10 +52,10 @@ func TestAccServiceQuotasServiceQuotaDataSource_quotaCode_Unset(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, servicequotas.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.ServiceQuotasEndpointID)
 			preCheckServiceQuotaUnset(ctx, unsetQuotaServiceCode, unsetQuotaQuotaCode, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, servicequotas.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceQuotasEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -85,10 +85,10 @@ func TestAccServiceQuotasServiceQuotaDataSource_quotaCode_hasUsageMetric(t *test
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, servicequotas.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.ServiceQuotasEndpointID)
 			preCheckServiceQuotaHasUsageMetric(ctx, hasUsageMetricServiceCode, hasUsageMetricQuotaCode, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, servicequotas.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceQuotasEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -126,7 +126,7 @@ func TestAccServiceQuotasServiceQuotaDataSource_PermissionError_quotaCode(t *tes
 			testAccPreCheck(ctx, t)
 			acctest.PreCheckAssumeRoleARN(t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, servicequotas.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceQuotasEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             nil,
 		Steps: []resource.TestStep{
@@ -145,10 +145,10 @@ func TestAccServiceQuotasServiceQuotaDataSource_quotaName(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, servicequotas.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.ServiceQuotasEndpointID)
 			preCheckServiceQuotaSet(ctx, setQuotaServiceCode, setQuotaQuotaCode, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, servicequotas.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceQuotasEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -177,10 +177,10 @@ func TestAccServiceQuotasServiceQuotaDataSource_quotaName_Unset(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, servicequotas.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.ServiceQuotasEndpointID)
 			preCheckServiceQuotaUnset(ctx, unsetQuotaServiceCode, unsetQuotaQuotaCode, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, servicequotas.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceQuotasEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -210,10 +210,10 @@ func TestAccServiceQuotasServiceQuotaDataSource_quotaName_hasUsageMetric(t *test
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, servicequotas.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.ServiceQuotasEndpointID)
 			preCheckServiceQuotaHasUsageMetric(ctx, hasUsageMetricServiceCode, hasUsageMetricQuotaCode, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, servicequotas.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceQuotasEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -251,7 +251,7 @@ func TestAccServiceQuotasServiceQuotaDataSource_PermissionError_quotaName(t *tes
 			testAccPreCheck(ctx, t)
 			acctest.PreCheckAssumeRoleARN(t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, servicequotas.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceQuotasEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             nil,
 		Steps: []resource.TestStep{

--- a/internal/service/servicequotas/service_quota_test.go
+++ b/internal/service/servicequotas/service_quota_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 
 	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go/service/servicequotas"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 // This resource is different than many since quotas are pre-existing
@@ -29,7 +29,7 @@ func TestAccServiceQuotasServiceQuota_basic(t *testing.T) {
 			testAccPreCheck(ctx, t)
 			preCheckServiceQuotaSet(ctx, setQuotaServiceCode, setQuotaQuotaCode, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, servicequotas.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceQuotasEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             nil,
 		Steps: []resource.TestStep{
@@ -69,7 +69,7 @@ func TestAccServiceQuotasServiceQuota_basic_Unset(t *testing.T) {
 			testAccPreCheck(ctx, t)
 			preCheckServiceQuotaUnset(ctx, unsetQuotaServiceCode, unsetQuotaQuotaCode, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, servicequotas.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceQuotasEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             nil,
 		Steps: []resource.TestStep{
@@ -109,7 +109,7 @@ func TestAccServiceQuotasServiceQuota_basic_hasUsageMetric(t *testing.T) {
 			testAccPreCheck(ctx, t)
 			preCheckServiceQuotaHasUsageMetric(ctx, hasUsageMetricServiceCode, hasUsageMetricQuotaCode, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, servicequotas.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceQuotasEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             nil,
 		Steps: []resource.TestStep{
@@ -166,7 +166,7 @@ func TestAccServiceQuotasServiceQuota_Value_increaseOnCreate(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, servicequotas.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceQuotasEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             nil,
 		Steps: []resource.TestStep{
@@ -211,7 +211,7 @@ func TestAccServiceQuotasServiceQuota_Value_increaseOnUpdate(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, servicequotas.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceQuotasEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             nil,
 		Steps: []resource.TestStep{
@@ -241,7 +241,7 @@ func TestAccServiceQuotasServiceQuota_permissionError(t *testing.T) {
 	ctx := acctest.Context(t)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t); acctest.PreCheckAssumeRoleARN(t) },
-		ErrorCheck:               acctest.ErrorCheck(t, servicequotas.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceQuotasEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             nil,
 		Steps: []resource.TestStep{

--- a/names/names.go
+++ b/names/names.go
@@ -57,6 +57,7 @@ const (
 	RolesAnywhereEndpointID              = "rolesanywhere"
 	Route53DomainsEndpointID             = "route53domains"
 	SchedulerEndpointID                  = "scheduler"
+	ServiceQuotasEndpointID              = "servicequotas"
 	S3EndpointID                         = "s3"
 	S3ControlEndpointID                  = "s3-control"
 	SESV2EndpointID                      = "sesv2"

--- a/names/names_data.csv
+++ b/names/names_data.csv
@@ -322,7 +322,7 @@ securitylake,securitylake,securitylake,securitylake,,securitylake,,,SecurityLake
 serverlessrepo,serverlessrepo,serverlessapplicationrepository,serverlessapplicationrepository,,serverlessrepo,,serverlessapprepo;serverlessapplicationrepository,ServerlessRepo,ServerlessApplicationRepository,,1,,aws_serverlessapplicationrepository_,aws_serverlessrepo_,,serverlessapplicationrepository_,Serverless Application Repository,AWS,,,,,,
 servicecatalog,servicecatalog,servicecatalog,servicecatalog,,servicecatalog,,,ServiceCatalog,ServiceCatalog,,1,,,aws_servicecatalog_,,servicecatalog_,Service Catalog,AWS,,,,,,
 servicecatalog-appregistry,servicecatalogappregistry,appregistry,servicecatalogappregistry,,servicecatalogappregistry,,appregistry,ServiceCatalogAppRegistry,AppRegistry,,1,,,aws_servicecatalogappregistry_,,servicecatalogappregistry_,Service Catalog AppRegistry,AWS,,x,,,,
-service-quotas,servicequotas,servicequotas,servicequotas,,servicequotas,,,ServiceQuotas,ServiceQuotas,,1,,,aws_servicequotas_,,servicequotas_,Service Quotas,,,,,,,
+service-quotas,servicequotas,servicequotas,servicequotas,,servicequotas,,,ServiceQuotas,ServiceQuotas,,,2,,aws_servicequotas_,,servicequotas_,Service Quotas,,,,,,,
 ses,ses,ses,ses,,ses,,,SES,SES,,1,,,aws_ses_,,ses_,SES (Simple Email),Amazon,,,,,,
 sesv2,sesv2,sesv2,sesv2,,sesv2,,,SESV2,SESV2,,,2,,aws_sesv2_,,sesv2_,SESv2 (Simple Email V2),Amazon,,,,,,
 stepfunctions,stepfunctions,sfn,sfn,,sfn,,stepfunctions,SFN,SFN,,1,,,aws_sfn_,,sfn_,SFN (Step Functions),AWS,,,,,,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Updates all `servicequotas` resources and data sources to AWS Go SDK V2. 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->
Relates #32976


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=servicequotas
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/servicequotas/... -v -count 1 -parallel 20   -timeout 360m

=== RUN   TestAccServiceQuotasServiceQuota_Value_increaseOnCreate
    service_quota_test.go:146: Environment variable SERVICEQUOTAS_INCREASE_ON_CREATE_QUOTA_CODE is not set. WARNING: This test will submit a real service quota increase!
--- SKIP: TestAccServiceQuotasServiceQuota_Value_increaseOnCreate (0.00s)
=== RUN   TestAccServiceQuotasServiceQuota_Value_increaseOnUpdate
    service_quota_test.go:190: Environment variable SERVICEQUOTAS_INCREASE_ON_UPDATE_QUOTA_CODE is not set. WARNING: This test will submit a real service quota increase!
--- SKIP: TestAccServiceQuotasServiceQuota_Value_increaseOnUpdate (0.00s)
=== NAME  TestAccServiceQuotasServiceQuotaDataSource_PermissionError_quotaCode
    acctest.go:1629: skipping test; environment variable TF_ACC_ASSUME_ROLE_ARN must be set. Usage: Amazon Resource Name (ARN) of existing IAM Role to assume for testing restricted permissions
--- SKIP: TestAccServiceQuotasServiceQuotaDataSource_PermissionError_quotaCode (0.22s)
=== NAME  TestAccServiceQuotasServiceQuotaDataSource_PermissionError_quotaName
    acctest.go:1629: skipping test; environment variable TF_ACC_ASSUME_ROLE_ARN must be set. Usage: Amazon Resource Name (ARN) of existing IAM Role to assume for testing restricted permissions
--- SKIP: TestAccServiceQuotasServiceQuotaDataSource_PermissionError_quotaName (0.23s)
=== NAME  TestAccServiceQuotasServiceQuota_permissionError
    acctest.go:1629: skipping test; environment variable TF_ACC_ASSUME_ROLE_ARN must be set. Usage: Amazon Resource Name (ARN) of existing IAM Role to assume for testing restricted permissions
--- SKIP: TestAccServiceQuotasServiceQuota_permissionError (0.23s)
--- PASS: TestAccServiceQuotasServiceQuotaDataSource_quotaCode_Unset (20.21s)
--- PASS: TestAccServiceQuotasServiceQuotaDataSource_quotaCode_hasUsageMetric (20.74s)
--- PASS: TestAccServiceQuotasServiceQuotaDataSource_quotaCode (21.07s)
--- PASS: TestAccServiceQuotasServiceQuotaDataSource_quotaName (21.29s)
--- PASS: TestAccServiceQuotasServiceQuotaDataSource_quotaName_Unset (21.29s)
--- PASS: TestAccServiceQuotasServiceQuotaDataSource_quotaName_hasUsageMetric (21.59s)
--- PASS: TestAccServiceQuotasServiceDataSource_serviceName (22.19s)
--- PASS: TestAccServiceQuotasServiceQuota_basic_Unset (24.54s)
--- PASS: TestAccServiceQuotasServiceQuota_basic (24.57s)
--- PASS: TestAccServiceQuotasServiceQuota_basic_hasUsageMetric (25.33s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/servicequotas      28.544s
```
