### PR TITLE
r/aws_quicksight_vpc_connection: Fix sweeper in US GovCloud

### DIFF
--- a/internal/service/quicksight/sweep.go
+++ b/internal/service/quicksight/sweep.go
@@ -459,6 +459,9 @@ func skipSweepError(err error) bool {
 	if tfawserr.ErrMessageContains(err, quicksight.ErrCodeResourceNotFoundException, "Directory information for account") {
 		return true
 	}
+	if tfawserr.ErrMessageContains(err, quicksight.ErrCodeResourceNotFoundException, "Account information for account") {
+		return true
+	}
 
 	return sweep.SkipSweepError(err)
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Ignore errors like

```
2023/09/27 14:30:09 [ERROR] Error running Sweeper (aws_quicksight_vpc_connection) in region (us-gov-east-1): listing QuickSight VPC Connections: ResourceNotFoundException: Account information for account 123456789012 is not found.
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/33615.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/33612.