### PR TITLE
Add Ubuntu 22.04 to Cloud9 ec2 options

### DIFF
--- a/.changelog/33662.txt
+++ b/.changelog/33662.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cloud9_environment_ec2: Add `ubuntu-22.04-x86_64` and `resolve:ssm:/aws/service/cloud9/amis/ubuntu-22.04-x86_64` as valid values for `image_id`
+```

--- a/internal/service/cloud9/environment_ec2.go
+++ b/internal/service/cloud9/environment_ec2.go
@@ -67,9 +67,11 @@ func ResourceEnvironmentEC2() *schema.Resource {
 					"amazonlinux-1-x86_64",
 					"amazonlinux-2-x86_64",
 					"ubuntu-18.04-x86_64",
+					"ubuntu-22.04-x86_64",
 					"resolve:ssm:/aws/service/cloud9/amis/amazonlinux-1-x86_64",
 					"resolve:ssm:/aws/service/cloud9/amis/amazonlinux-2-x86_64",
 					"resolve:ssm:/aws/service/cloud9/amis/ubuntu-18.04-x86_64",
+					"resolve:ssm:/aws/service/cloud9/amis/ubuntu-22.04-x86_64",
 				}, false),
 			},
 			"instance_type": {

--- a/website/docs/r/cloud9_environment_ec2.html.markdown
+++ b/website/docs/r/cloud9_environment_ec2.html.markdown
@@ -79,9 +79,12 @@ This resource supports the following arguments:
     * `amazonlinux-1-x86_64`
     * `amazonlinux-2-x86_64`
     * `ubuntu-18.04-x86_64`
+    * `ubuntu-22.04-x86_64`
     * `resolve:ssm:/aws/service/cloud9/amis/amazonlinux-1-x86_64`
     * `resolve:ssm:/aws/service/cloud9/amis/amazonlinux-2-x86_64`
     * `resolve:ssm:/aws/service/cloud9/amis/ubuntu-18.04-x86_64`
+    * `resolve:ssm:/aws/service/cloud9/amis/ubuntu-22.04-x86_64`
+
 * `owner_arn` - (Optional) The ARN of the environment owner. This can be ARN of any AWS IAM principal. Defaults to the environment's creator.
 * `subnet_id` - (Optional) The ID of the subnet in Amazon VPC that AWS Cloud9 will use to communicate with the Amazon EC2 instance.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.


### PR DESCRIPTION
> ### Description
> 
> Since a few weeks AWS offers Ubuntu 22.04 LTS as image for Cloud9 Environments next to Amazon Linux 2, but currently only Ubuntu 18.04 is available via the Terraform Provider. ![image](https://user-images.githubusercontent.com/120108972/270642607-07a12d59-f98b-49ce-90ed-d7f461706629.png)
> 
> When trying to use Ubuntu 22.04 as image this is the error response: `| Error: expected image_id to be one of [amazonlinux-1-x86_64 amazonlinux-2-x86_64 ubuntu-18.04-x86_64 resolve:ssm:/aws/service/cloud9/amis/amazonlinux-1-x86_64 resolve:ssm:/aws/service/cloud9/amis/amazonlinux-2-x86_64 resolve:ssm:/aws/service/cloud9/amis/ubuntu-18.04-x86_64], got ubuntu-22.04-x86_64 │ │ with aws_cloud9_environment_ec2.this["test"], │ on main.tf line 39, in resource "aws_cloud9_environment_ec2" "this": │ 39: image_id = each.value.image_id`
> 
> Despite Ubuntu 18.04 is not available anymore in the AWS console (see Screenshot), it still part of the CLI/API and can be used in Terraform to deploy a Ubuntu 18.04 Environment that can be manually upgraded to 22.04.
> ### Affected Resource(s) and/or Data Source(s)
> 
> aws_cloud9_environment_ec2
> ### Potential Terraform Configuration
> 
> ```terraform
> resource "aws_cloud9_environment_ec2" "this" {
>   name            = "Cloud9-Ubuntu22.04"
>   instance_type   = "t3a.medium"
>   connection_type = "CONNECT_SSM"
>   image_id        = "ubuntu-22.04-x86_64"
>   subnet_id       = "subnet-12345abcdef"
> }
> ```
> 
> ### References
> 
> https://docs.aws.amazon.com/cli/latest/reference/cloud9/create-environment-ec2.html
> ### Would you like to implement a fix?
> 
> YES



### Relations

Closes #33625

### Output from Acceptance Testing
```brianadams@Brians-MacBook-Pro-2 terraform-provider-aws % make testacc TESTS=testAccEnvironmentEC2Config_allFields PKG=cloud9
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloud9/... -v -count 1 -parallel 20 -run='testAccEnvironmentEC2Config_allFields'  -timeout 360m

testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloud9

```