### PR TITLE
sweeper/aws_cloudfront_distribution: Fixes infinite loop

### DIFF
--- a/internal/service/cloudfront/sweep.go
+++ b/internal/service/cloudfront/sweep.go
@@ -160,23 +160,25 @@ func sweepCachePolicies(region string) error {
 }
 
 func sweepDistributions(region string) error {
+	var result *multierror.Error
+
 	// sweep:
 	// 1. Production Distributions
 	if err := sweepDistributionsByProductionStaging(region, false); err != nil {
-		log.Printf("[WARN] %s", err)
+		result = multierror.Append(result, err)
 	}
 
 	// 2. Continuous Deployment Policies
 	if err := sweepContinuousDeploymentPolicies(region); err != nil {
-		log.Printf("[WARN] %s", err)
+		result = multierror.Append(result, err)
 	}
 
 	// 3. Staging Distributions
 	if err := sweepDistributionsByProductionStaging(region, true); err != nil {
-		log.Printf("[WARN] %s", err)
+		result = multierror.Append(result, err)
 	}
 
-	return nil
+	return result.ErrorOrNil()
 }
 
 func sweepDistributionsByProductionStaging(region string, staging bool) error {

--- a/internal/service/cloudfront/sweep.go
+++ b/internal/service/cloudfront/sweep.go
@@ -265,7 +265,7 @@ func sweepContinuousDeploymentPolicies(region string) error {
 		}
 
 		if output == nil || output.ContinuousDeploymentPolicyList == nil || len(output.ContinuousDeploymentPolicyList.Items) == 0 {
-			continue
+			break
 		}
 
 		for _, cdp := range output.ContinuousDeploymentPolicyList.Items {


### PR DESCRIPTION
### Description

The `aws_cloudfront_distribution` sweeper has an infinite loop when there are no CloudFront Distributions
