### PR TITLE
cloudfront/distribution: Sweeper infinite loop

### DIFF
--- a/internal/service/cloudfront/distribution.go
+++ b/internal/service/cloudfront/distribution.go
@@ -987,7 +987,7 @@ func resourceDistributionDelete(ctx context.Context, d *schema.ResourceData, met
 			return create.DiagError(names.CloudFront, create.ErrActionDeleting, ResNameDistribution, d.Id(), err)
 		}
 
-		if err := WaitDistributionDeployed(ctx, conn, d.Id()); err != nil {
+		if err := WaitDistributionDeployed(ctx, conn, d.Id()); err != nil && !tfresource.NotFound(err) {
 			return diag.Errorf("waiting until CloudFront Distribution (%s) is deployed: %s", d.Id(), err)
 		}
 	}
@@ -1022,7 +1022,7 @@ func resourceDistributionDelete(ctx context.Context, d *schema.ResourceData, met
 	if tfawserr.ErrCodeEquals(err, cloudfront.ErrCodePreconditionFailed, cloudfront.ErrCodeInvalidIfMatchVersion) {
 		_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, 1*time.Minute, func() (interface{}, error) {
 			return nil, deleteDistribution(ctx, conn, d.Id())
-		}, cloudfront.ErrCodePreconditionFailed)
+		}, cloudfront.ErrCodePreconditionFailed, cloudfront.ErrCodeInvalidIfMatchVersion)
 	}
 
 	if tfawserr.ErrCodeEquals(err, cloudfront.ErrCodeNoSuchDistribution) {
@@ -1059,7 +1059,7 @@ func deleteDistribution(ctx context.Context, conn *cloudfront.CloudFront, id str
 		return err
 	}
 
-	if err := WaitDistributionDeleted(ctx, conn, id); err != nil && !tfawserr.ErrCodeEquals(err, cloudfront.ErrCodeNoSuchDistribution) {
+	if err := WaitDistributionDeleted(ctx, conn, id); err != nil {
 		return err
 	}
 
@@ -1076,13 +1076,20 @@ func distroETag(ctx context.Context, conn *cloudfront.CloudFront, id string) (st
 }
 
 func disableDistribution(ctx context.Context, conn *cloudfront.CloudFront, id string) error {
-	if err := WaitDistributionDeployed(ctx, conn, id); err != nil {
-		return err
-	}
-
 	out, err := FindDistributionByID(ctx, conn, id)
 	if err != nil {
 		return err
+	}
+
+	if aws.StringValue(out.Distribution.Status) == "InProgress" {
+		if err := WaitDistributionDeployed(ctx, conn, id); err != nil {
+			return err
+		}
+
+		out, err = FindDistributionByID(ctx, conn, id)
+		if err != nil {
+			return err
+		}
 	}
 
 	if !aws.BoolValue(out.Distribution.DistributionConfig.Enabled) {
@@ -1133,33 +1140,6 @@ func FindDistributionByID(ctx context.Context, conn *cloudfront.CloudFront, id s
 	return output, nil
 }
 
-func FindDistributionByDomainName(ctx context.Context, conn *cloudfront.CloudFront, name string) (*cloudfront.DistributionSummary, error) {
-	var dist *cloudfront.DistributionSummary
-
-	input := &cloudfront.ListDistributionsInput{}
-
-	err := conn.ListDistributionsPagesWithContext(ctx, input, func(page *cloudfront.ListDistributionsOutput, lastPage bool) bool {
-		if page == nil {
-			return !lastPage
-		}
-
-		for _, d := range page.DistributionList.Items {
-			if d == nil {
-				continue
-			}
-
-			if aws.StringValue(d.DomainName) == name {
-				dist = d
-				return false
-			}
-		}
-
-		return !lastPage
-	})
-
-	return dist, err
-}
-
 // resourceAwsCloudFrontWebDistributionWaitUntilDeployed blocks until the
 // distribution is deployed. It currently takes exactly 15 minutes to deploy
 // but that might change in the future.
@@ -1167,10 +1147,10 @@ func WaitDistributionDeployed(ctx context.Context, conn *cloudfront.CloudFront, 
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{"InProgress"},
 		Target:     []string{"Deployed"},
-		Refresh:    distributionRefreshFunc(ctx, conn, id),
+		Refresh:    distributionDeployRefreshFunc(ctx, conn, id),
 		Timeout:    90 * time.Minute,
 		MinTimeout: 15 * time.Second,
-		Delay:      1 * time.Minute,
+		Delay:      30 * time.Second,
 	}
 
 	_, err := stateConf.WaitForStateContext(ctx)
@@ -1181,37 +1161,46 @@ func WaitDistributionDeleted(ctx context.Context, conn *cloudfront.CloudFront, i
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{"InProgress", "Deployed"},
 		Target:     []string{},
-		Refresh:    distributionRefreshFunc(ctx, conn, id),
+		Refresh:    distributionDeleteRefreshFunc(ctx, conn, id),
 		Timeout:    90 * time.Minute,
 		MinTimeout: 15 * time.Second,
-		Delay:      1 * time.Minute,
+		Delay:      15 * time.Second,
 	}
 
 	_, err := stateConf.WaitForStateContext(ctx)
 	return err
 }
 
-// The refresh function for resourceAwsCloudFrontWebDistributionWaitUntilDeployed.
-func distributionRefreshFunc(ctx context.Context, conn *cloudfront.CloudFront, id string) retry.StateRefreshFunc {
+func distributionDeleteRefreshFunc(ctx context.Context, conn *cloudfront.CloudFront, id string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		params := &cloudfront.GetDistributionInput{
-			Id: aws.String(id),
-		}
-
-		resp, err := conn.GetDistributionWithContext(ctx, params)
-		if tfawserr.ErrCodeEquals(err, cloudfront.ErrCodeNoSuchDistribution) {
+		out, err := FindDistributionByID(ctx, conn, id)
+		if tfresource.NotFound(err) {
 			return nil, "", nil
 		}
 
 		if err != nil {
-			log.Printf("[WARN] Error retrieving CloudFront Distribution %q details: %s", id, err)
 			return nil, "", err
 		}
 
-		if resp == nil {
+		if out == nil {
 			return nil, "", nil
 		}
 
-		return resp.Distribution, *resp.Distribution.Status, nil
+		return out.Distribution, aws.StringValue(out.Distribution.Status), nil
+	}
+}
+
+func distributionDeployRefreshFunc(ctx context.Context, conn *cloudfront.CloudFront, id string) retry.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		out, err := FindDistributionByID(ctx, conn, id)
+		if err != nil {
+			return nil, "", err
+		}
+
+		if out == nil {
+			return nil, "", nil
+		}
+
+		return out.Distribution, aws.StringValue(out.Distribution.Status), nil
 	}
 }

--- a/internal/service/cloudfront/distribution.go
+++ b/internal/service/cloudfront/distribution.go
@@ -1199,6 +1199,10 @@ func distributionRefreshFunc(ctx context.Context, conn *cloudfront.CloudFront, i
 		}
 
 		resp, err := conn.GetDistributionWithContext(ctx, params)
+		if tfawserr.ErrCodeEquals(err, cloudfront.ErrCodeNoSuchDistribution) {
+			return nil, "", nil
+		}
+
 		if err != nil {
 			log.Printf("[WARN] Error retrieving CloudFront Distribution %q details: %s", id, err)
 			return nil, "", err

--- a/internal/service/cloudfront/sweep.go
+++ b/internal/service/cloudfront/sweep.go
@@ -160,23 +160,24 @@ func sweepCachePolicies(region string) error {
 }
 
 func sweepDistributions(region string) error {
-	// sweep:
+	var result *multierror.Error
+
 	// 1. Production Distributions
 	if err := sweepDistributionsByProductionStaging(region, false); err != nil {
-		log.Printf("[WARN] %s", err)
+		result = multierror.Append(result, err)
 	}
 
 	// 2. Continuous Deployment Policies
 	if err := sweepContinuousDeploymentPolicies(region); err != nil {
-		log.Printf("[WARN] %s", err)
+		result = multierror.Append(result, err)
 	}
 
 	// 3. Staging Distributions
 	if err := sweepDistributionsByProductionStaging(region, true); err != nil {
-		log.Printf("[WARN] %s", err)
+		result = multierror.Append(result, err)
 	}
 
-	return nil
+	return result.ErrorOrNil()
 }
 
 func sweepDistributionsByProductionStaging(region string, staging bool) error {
@@ -239,7 +240,6 @@ func sweepDistributionsByProductionStaging(region string, staging bool) error {
 	}
 
 	err = sweep.SweepOrchestrator(ctx, sweepResources)
-
 	if err != nil {
 		return fmt.Errorf("error sweeping CloudFront Distributions (%s): %w", region, err)
 	}
@@ -257,12 +257,14 @@ func sweepContinuousDeploymentPolicies(region string) error {
 	input := &cloudfront.ListContinuousDeploymentPoliciesInput{}
 
 	log.Printf("[INFO] Sweeping continuous deployment policies")
+	var result *multierror.Error
 
 	// ListContinuousDeploymentPolicies does not have a paginator
 	for {
 		output, err := conn.ListContinuousDeploymentPoliciesWithContext(ctx, input)
 		if err != nil {
 			log.Printf("[WARN] %s", err)
+			result = multierror.Append(result, err)
 			break
 		}
 
@@ -272,7 +274,9 @@ func sweepContinuousDeploymentPolicies(region string) error {
 		}
 
 		for _, cdp := range output.ContinuousDeploymentPolicyList.Items {
-			DeleteCDP(ctx, conn, aws.StringValue(cdp.ContinuousDeploymentPolicy.Id))
+			if err := DeleteCDP(ctx, conn, aws.StringValue(cdp.ContinuousDeploymentPolicy.Id)); err != nil {
+				result = multierror.Append(result, err)
+			}
 		}
 
 		if output.ContinuousDeploymentPolicyList.NextMarker == nil {
@@ -282,7 +286,7 @@ func sweepContinuousDeploymentPolicies(region string) error {
 		input.Marker = output.ContinuousDeploymentPolicyList.NextMarker
 	}
 
-	return nil
+	return result.ErrorOrNil()
 }
 
 func sweepFunctions(region string) error {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

![infiniteloop](https://github.com/hashicorp/terraform-provider-aws/assets/2404182/ea49e5ea-8de0-423e-8fb7-73aebcd2009f)

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/33663.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T='TestAccCloudFrontContinuousDeploymentPolicy_domainChange|TestAccCloudFrontDistribution' K=cloudfront P=8
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudfront/... -v -count 1 -parallel 8 -run='TestAccCloudFrontContinuousDeploymentPolicy_domainChange|TestAccCloudFrontDistribution'  -timeout 360m
=== RUN   TestAccCloudFrontContinuousDeploymentPolicy_domainChange
=== PAUSE TestAccCloudFrontContinuousDeploymentPolicy_domainChange
=== RUN   TestAccCloudFrontDistributionDataSource_basic
=== PAUSE TestAccCloudFrontDistributionDataSource_basic
=== RUN   TestAccCloudFrontDistribution_basic
=== PAUSE TestAccCloudFrontDistribution_basic
=== RUN   TestAccCloudFrontDistribution_disappears
=== PAUSE TestAccCloudFrontDistribution_disappears
=== RUN   TestAccCloudFrontDistribution_tags
=== PAUSE TestAccCloudFrontDistribution_tags
=== RUN   TestAccCloudFrontDistribution_s3Origin
=== PAUSE TestAccCloudFrontDistribution_s3Origin
=== RUN   TestAccCloudFrontDistribution_customOrigin
=== PAUSE TestAccCloudFrontDistribution_customOrigin
=== RUN   TestAccCloudFrontDistribution_originPolicyDefault
=== PAUSE TestAccCloudFrontDistribution_originPolicyDefault
=== RUN   TestAccCloudFrontDistribution_originPolicyOrdered
=== PAUSE TestAccCloudFrontDistribution_originPolicyOrdered
=== RUN   TestAccCloudFrontDistribution_multiOrigin
=== PAUSE TestAccCloudFrontDistribution_multiOrigin
=== RUN   TestAccCloudFrontDistribution_orderedCacheBehavior
=== PAUSE TestAccCloudFrontDistribution_orderedCacheBehavior
=== RUN   TestAccCloudFrontDistribution_orderedCacheBehaviorCachePolicy
=== PAUSE TestAccCloudFrontDistribution_orderedCacheBehaviorCachePolicy
=== RUN   TestAccCloudFrontDistribution_orderedCacheBehaviorResponseHeadersPolicy
=== PAUSE TestAccCloudFrontDistribution_orderedCacheBehaviorResponseHeadersPolicy
=== RUN   TestAccCloudFrontDistribution_forwardedValuesToCachePolicy
=== PAUSE TestAccCloudFrontDistribution_forwardedValuesToCachePolicy
=== RUN   TestAccCloudFrontDistribution_Origin_emptyDomainName
=== PAUSE TestAccCloudFrontDistribution_Origin_emptyDomainName
=== RUN   TestAccCloudFrontDistribution_Origin_emptyOriginID
=== PAUSE TestAccCloudFrontDistribution_Origin_emptyOriginID
=== RUN   TestAccCloudFrontDistribution_Origin_connectionAttempts
=== PAUSE TestAccCloudFrontDistribution_Origin_connectionAttempts
=== RUN   TestAccCloudFrontDistribution_Origin_connectionTimeout
=== PAUSE TestAccCloudFrontDistribution_Origin_connectionTimeout
=== RUN   TestAccCloudFrontDistribution_Origin_originShield
=== PAUSE TestAccCloudFrontDistribution_Origin_originShield
=== RUN   TestAccCloudFrontDistribution_Origin_originAccessControl
=== PAUSE TestAccCloudFrontDistribution_Origin_originAccessControl
=== RUN   TestAccCloudFrontDistribution_noOptionalItems
=== PAUSE TestAccCloudFrontDistribution_noOptionalItems
=== RUN   TestAccCloudFrontDistribution_http11
=== PAUSE TestAccCloudFrontDistribution_http11
=== RUN   TestAccCloudFrontDistribution_isIPV6Enabled
=== PAUSE TestAccCloudFrontDistribution_isIPV6Enabled
=== RUN   TestAccCloudFrontDistribution_noCustomErrorResponse
=== PAUSE TestAccCloudFrontDistribution_noCustomErrorResponse
=== RUN   TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValuesCookies_whitelistedNames
=== PAUSE TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValuesCookies_whitelistedNames
=== RUN   TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValues_headers
=== PAUSE TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValues_headers
=== RUN   TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedKeyGroups
=== PAUSE TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedKeyGroups
=== RUN   TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedSigners
=== PAUSE TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedSigners
=== RUN   TestAccCloudFrontDistribution_DefaultCacheBehavior_realtimeLogARN
=== PAUSE TestAccCloudFrontDistribution_DefaultCacheBehavior_realtimeLogARN
=== RUN   TestAccCloudFrontDistribution_OrderedCacheBehavior_realtimeLogARN
=== PAUSE TestAccCloudFrontDistribution_OrderedCacheBehavior_realtimeLogARN
=== RUN   TestAccCloudFrontDistribution_enabled
=== PAUSE TestAccCloudFrontDistribution_enabled
=== RUN   TestAccCloudFrontDistribution_retainOnDelete
=== PAUSE TestAccCloudFrontDistribution_retainOnDelete
=== RUN   TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValuesCookies_whitelistedNames
=== PAUSE TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValuesCookies_whitelistedNames
=== RUN   TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValues_headers
=== PAUSE TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValues_headers
=== RUN   TestAccCloudFrontDistribution_ViewerCertificate_acmCertificateARN
=== PAUSE TestAccCloudFrontDistribution_ViewerCertificate_acmCertificateARN
=== RUN   TestAccCloudFrontDistribution_ViewerCertificateACMCertificateARN_conflictsWithCloudFrontDefaultCertificate
=== PAUSE TestAccCloudFrontDistribution_ViewerCertificateACMCertificateARN_conflictsWithCloudFrontDefaultCertificate
=== RUN   TestAccCloudFrontDistribution_waitForDeployment
=== PAUSE TestAccCloudFrontDistribution_waitForDeployment
=== RUN   TestAccCloudFrontDistribution_preconditionFailed
=== PAUSE TestAccCloudFrontDistribution_preconditionFailed
=== RUN   TestAccCloudFrontDistribution_originGroups
=== PAUSE TestAccCloudFrontDistribution_originGroups
=== CONT  TestAccCloudFrontContinuousDeploymentPolicy_domainChange
=== CONT  TestAccCloudFrontDistribution_noOptionalItems
=== CONT  TestAccCloudFrontDistribution_OrderedCacheBehavior_realtimeLogARN
=== CONT  TestAccCloudFrontDistribution_enabled
=== CONT  TestAccCloudFrontDistribution_originGroups
=== CONT  TestAccCloudFrontDistribution_preconditionFailed
=== CONT  TestAccCloudFrontDistribution_waitForDeployment
=== CONT  TestAccCloudFrontDistribution_ViewerCertificateACMCertificateARN_conflictsWithCloudFrontDefaultCertificate
--- PASS: TestAccCloudFrontDistribution_OrderedCacheBehavior_realtimeLogARN (554.57s)
=== CONT  TestAccCloudFrontDistribution_ViewerCertificate_acmCertificateARN
--- PASS: TestAccCloudFrontDistribution_ViewerCertificateACMCertificateARN_conflictsWithCloudFrontDefaultCertificate (569.36s)
=== CONT  TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValues_headers
--- PASS: TestAccCloudFrontDistribution_originGroups (1099.61s)
=== CONT  TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValuesCookies_whitelistedNames
--- PASS: TestAccCloudFrontDistribution_noOptionalItems (1102.84s)
=== CONT  TestAccCloudFrontDistribution_retainOnDelete
--- PASS: TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValues_headers (590.42s)
=== CONT  TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValues_headers
--- PASS: TestAccCloudFrontDistribution_waitForDeployment (1170.81s)
=== CONT  TestAccCloudFrontDistribution_DefaultCacheBehavior_realtimeLogARN
--- PASS: TestAccCloudFrontDistribution_ViewerCertificate_acmCertificateARN (618.68s)
=== CONT  TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedSigners
--- PASS: TestAccCloudFrontDistribution_enabled (1621.33s)
=== CONT  TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedKeyGroups
--- PASS: TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValuesCookies_whitelistedNames (567.81s)
=== CONT  TestAccCloudFrontDistribution_noCustomErrorResponse
--- PASS: TestAccCloudFrontDistribution_preconditionFailed (1714.15s)
=== CONT  TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValuesCookies_whitelistedNames
--- PASS: TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedSigners (542.51s)
=== CONT  TestAccCloudFrontDistribution_orderedCacheBehavior
--- PASS: TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValues_headers (589.85s)
=== CONT  TestAccCloudFrontDistribution_isIPV6Enabled
--- PASS: TestAccCloudFrontDistribution_DefaultCacheBehavior_realtimeLogARN (587.64s)
=== CONT  TestAccCloudFrontDistribution_Origin_originAccessControl
--- PASS: TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedKeyGroups (382.06s)
=== CONT  TestAccCloudFrontDistribution_Origin_emptyOriginID
--- PASS: TestAccCloudFrontDistribution_Origin_emptyOriginID (1.47s)
=== CONT  TestAccCloudFrontDistribution_Origin_emptyDomainName
--- PASS: TestAccCloudFrontDistribution_Origin_emptyDomainName (2.08s)
=== CONT  TestAccCloudFrontDistribution_Origin_originShield
--- PASS: TestAccCloudFrontDistribution_retainOnDelete (919.10s)
=== CONT  TestAccCloudFrontDistribution_forwardedValuesToCachePolicy
--- PASS: TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValuesCookies_whitelistedNames (323.93s)
=== CONT  TestAccCloudFrontDistribution_orderedCacheBehaviorResponseHeadersPolicy
--- PASS: TestAccCloudFrontDistribution_orderedCacheBehavior (550.95s)
=== CONT  TestAccCloudFrontDistribution_orderedCacheBehaviorCachePolicy
--- PASS: TestAccCloudFrontDistribution_noCustomErrorResponse (600.73s)
=== CONT  TestAccCloudFrontDistribution_http11
--- PASS: TestAccCloudFrontDistribution_isIPV6Enabled (574.70s)
=== CONT  TestAccCloudFrontDistribution_Origin_connectionTimeout
--- PASS: TestAccCloudFrontContinuousDeploymentPolicy_domainChange (2332.77s)
=== CONT  TestAccCloudFrontDistribution_s3Origin
--- PASS: TestAccCloudFrontDistribution_orderedCacheBehaviorResponseHeadersPolicy (532.40s)
=== CONT  TestAccCloudFrontDistribution_multiOrigin
--- PASS: TestAccCloudFrontDistribution_Origin_originAccessControl (813.01s)
=== CONT  TestAccCloudFrontDistribution_originPolicyOrdered
--- PASS: TestAccCloudFrontDistribution_Origin_originShield (564.80s)
=== CONT  TestAccCloudFrontDistribution_originPolicyDefault
--- PASS: TestAccCloudFrontDistribution_orderedCacheBehaviorCachePolicy (491.71s)
=== CONT  TestAccCloudFrontDistribution_customOrigin
--- PASS: TestAccCloudFrontDistribution_forwardedValuesToCachePolicy (829.52s)
=== CONT  TestAccCloudFrontDistribution_basic
--- PASS: TestAccCloudFrontDistribution_http11 (591.28s)
=== CONT  TestAccCloudFrontDistribution_tags
--- PASS: TestAccCloudFrontDistribution_Origin_connectionTimeout (538.43s)
=== CONT  TestAccCloudFrontDistribution_disappears
--- PASS: TestAccCloudFrontDistribution_s3Origin (666.05s)
=== CONT  TestAccCloudFrontDistributionDataSource_basic
--- PASS: TestAccCloudFrontDistribution_originPolicyOrdered (611.41s)
=== CONT  TestAccCloudFrontDistribution_Origin_connectionAttempts
--- PASS: TestAccCloudFrontDistribution_disappears (321.40s)
--- PASS: TestAccCloudFrontDistribution_originPolicyDefault (615.00s)
--- PASS: TestAccCloudFrontDistribution_multiOrigin (617.00s)
--- PASS: TestAccCloudFrontDistribution_basic (343.23s)
--- PASS: TestAccCloudFrontDistribution_tags (373.87s)
--- PASS: TestAccCloudFrontDistributionDataSource_basic (275.47s)
--- PASS: TestAccCloudFrontDistribution_customOrigin (635.95s)
--- PASS: TestAccCloudFrontDistribution_Origin_connectionAttempts (544.80s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront	3730.089s
```
