### PR TITLE
r/aws_s3_object: Test access through a multi-region access point

### DIFF
--- a/internal/service/s3control/multi_region_access_point_test.go
+++ b/internal/service/s3control/multi_region_access_point_test.go
@@ -36,7 +36,7 @@ func TestAccS3ControlMultiRegionAccessPoint_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMultiRegionAccessPointConfig_basic(bucketName, rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMultiRegionAccessPointExists(ctx, resourceName, &v),
 					acctest.CheckResourceAttrAccountID(resourceName, "account_id"),
 					resource.TestMatchResourceAttr(resourceName, "alias", regexache.MustCompile(`^[a-z][0-9a-z]*[.]mrap$`)),
@@ -208,6 +208,29 @@ func TestAccS3ControlMultiRegionAccessPoint_threeRegions(t *testing.T) {
 	})
 }
 
+func TestAccS3ControlMultiRegionAccessPoint_putAndGetObject(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v types.MultiRegionAccessPointReport
+	resourceName := "aws_s3control_multi_region_access_point.test"
+	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionNot(t, names.USGovCloudPartitionID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3ControlEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckMultiRegionAccessPointDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMultiRegionAccessPointConfig_putAndGetObject(bucketName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMultiRegionAccessPointExists(ctx, resourceName, &v),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckMultiRegionAccessPointDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).S3ControlClient(ctx)
@@ -324,9 +347,7 @@ resource "aws_s3control_multi_region_access_point" "test" {
 }
 
 func testAccMultiRegionAccessPointConfig_three(bucketName1, bucketName2, bucketName3, multiRegionAccessPointName string) string {
-	return acctest.ConfigCompose(
-		acctest.ConfigMultipleRegionProvider(3),
-		fmt.Sprintf(`
+	return acctest.ConfigCompose(acctest.ConfigMultipleRegionProvider(3), fmt.Sprintf(`
 resource "aws_s3_bucket" "test1" {
   provider = aws
 
@@ -368,4 +389,33 @@ resource "aws_s3control_multi_region_access_point" "test" {
   }
 }
 `, bucketName1, bucketName2, bucketName3, multiRegionAccessPointName))
+}
+
+func testAccMultiRegionAccessPointConfig_putAndGetObject(bucketName, multiRegionAccessPointName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket        = %[1]q
+  force_destroy = true
+}
+
+resource "aws_s3control_multi_region_access_point" "test" {
+  details {
+    name = %[2]q
+
+    region {
+      bucket = aws_s3_bucket.test.id
+    }
+  }
+}
+
+resource "aws_s3_object" "test" {
+  bucket  = aws_s3control_multi_region_access_point.test.arn
+  key     = "%[1]s-key"
+  content = "Hello World"
+
+  tags = {
+    Name = %[2]q
+  }
+}
+`, bucketName, multiRegionAccessPointName)
 }

--- a/internal/service/s3control/multi_region_access_point_test.go
+++ b/internal/service/s3control/multi_region_access_point_test.go
@@ -418,7 +418,7 @@ resource "aws_s3_object" "test" {
   }
 }
 
-# Ensure that we can GET throught the bucket.
+# Ensure that we can GET through the bucket.
 data "aws_s3_object" "test" {
   bucket = aws_s3_bucket.test.bucket
   key    = aws_s3_object.test.key

--- a/internal/service/s3control/multi_region_access_point_test.go
+++ b/internal/service/s3control/multi_region_access_point_test.go
@@ -417,5 +417,11 @@ resource "aws_s3_object" "test" {
     Name = %[2]q
   }
 }
+
+# Ensure that we can GET throught the bucket.
+data "aws_s3_object" "test" {
+  bucket = aws_s3_bucket.test.bucket
+  key    = aws_s3_object.test.key
+}
 `, bucketName, multiRegionAccessPointName)
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Tests the `aws_s3_object` using an MRAP.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/33358.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccS3ControlMultiRegionAccessPoint_putAndGetObject' PKG=s3control
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3control/... -v -count 1 -parallel 20  -run=TestAccS3ControlMultiRegionAccessPoint_putAndGetObject -timeout 360m
=== RUN   TestAccS3ControlMultiRegionAccessPoint_putAndGetObject
=== PAUSE TestAccS3ControlMultiRegionAccessPoint_putAndGetObject
=== CONT  TestAccS3ControlMultiRegionAccessPoint_putAndGetObject
--- PASS: TestAccS3ControlMultiRegionAccessPoint_putAndGetObject (257.57s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3control	262.784s
```
