### PR TITLE
Add region to lakeformation table permission grant (WIP)

### DIFF
--- a/internal/service/lakeformation/permissions.go
+++ b/internal/service/lakeformation/permissions.go
@@ -293,6 +293,11 @@ func ResourcePermissions() *schema.Resource {
 								"table.0.wildcard",
 							},
 						},
+						"region": {
+							Type:     schema.TypeString,
+							ForceNew: true,
+							Optional: true,
+						},
 					},
 				},
 			},
@@ -361,6 +366,12 @@ func ResourcePermissions() *schema.Resource {
 								"table_with_columns.0.column_names",
 								"table_with_columns.0.wildcard",
 							},
+						},
+						"region": {
+							Type:     schema.TypeString,
+							ForceNew: true,
+							Optional: true,
+							Computed: true,
 						},
 					},
 				},
@@ -1017,6 +1028,10 @@ func ExpandTableResource(tfMap map[string]interface{}) *lakeformation.TableResou
 
 	if v, ok := tfMap["database_name"].(string); ok && v != "" {
 		apiObject.DatabaseName = aws.String(v)
+	}
+
+	if v, ok := tfMap["region"].(string); ok && v != "" {
+		apiObject.aws_glue_catalog_region = aws.String(v)
 	}
 
 	if v, ok := tfMap["name"].(string); ok && v != "" {

--- a/internal/service/lakeformation/permissions_test.go
+++ b/internal/service/lakeformation/permissions_test.go
@@ -352,6 +352,7 @@ func testAccPermissions_tableBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "table.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "table.0.database_name", tableName, "database_name"),
 					resource.TestCheckResourceAttrPair(resourceName, "table.0.name", tableName, "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "table.0.region", tableName, "region"),
 					resource.TestCheckResourceAttr(resourceName, "permissions.#", "3"),
 					resource.TestCheckResourceAttr(resourceName, "permissions.0", lakeformation.PermissionAlter),
 					resource.TestCheckResourceAttr(resourceName, "permissions.1", lakeformation.PermissionDelete),
@@ -383,6 +384,7 @@ func testAccPermissions_tableIAMAllowed(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "table.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "table.0.database_name", dbName, "database_name"),
 					resource.TestCheckResourceAttrPair(resourceName, "table.0.name", dbName, "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "table.0.region", dbName, "region"),
 					resource.TestCheckResourceAttr(resourceName, "permissions.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "permissions.0", lakeformation.PermissionAll),
 					resource.TestCheckResourceAttr(resourceName, "permissions_with_grant_option.#", "0"),
@@ -413,6 +415,7 @@ func testAccPermissions_tableImplicit(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "table.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "table.0.database_name", tableName, "database_name"),
 					resource.TestCheckResourceAttrPair(resourceName, "table.0.name", tableName, "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "table.0.region", tableName, "region"),
 					resource.TestCheckResourceAttr(resourceName, "permissions.#", "7"),
 					resource.TestCheckResourceAttr(resourceName, "permissions_with_grant_option.#", "7"),
 				),
@@ -453,6 +456,7 @@ func testAccPermissions_tableMultipleRoles(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName2, "table.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName2, "table.0.database_name", tableName, "database_name"),
 					resource.TestCheckResourceAttrPair(resourceName2, "table.0.name", tableName, "name"),
+					resource.TestCheckResourceAttrPair(resourceName2, "table.0.region", tableName, "region"),
 					resource.TestCheckResourceAttr(resourceName2, "permissions.#", "1"),
 					resource.TestCheckResourceAttr(resourceName2, "permissions.0", lakeformation.PermissionSelect),
 				),
@@ -482,6 +486,7 @@ func testAccPermissions_tableSelectOnly(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "table.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "table.0.database_name", tableName, "database_name"),
 					resource.TestCheckResourceAttrPair(resourceName, "table.0.name", tableName, "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "table.0.region", tableName, "region"),
 					resource.TestCheckResourceAttr(resourceName, "permissions.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "permissions.0", lakeformation.PermissionSelect),
 				),
@@ -520,6 +525,7 @@ func testAccPermissions_tableWildcardNoSelect(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lakeformation_permissions.test"
 	databaseResourceName := "aws_glue_catalog_database.test"
+	regionResourceName := "aws_glue_catalog_region.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, lakeformation.EndpointsID) },
@@ -533,6 +539,7 @@ func testAccPermissions_tableWildcardNoSelect(t *testing.T) {
 					testAccCheckPermissionsExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "table.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "table.0.database_name", databaseResourceName, "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "table.0.region", regionResourceName, "region"),
 					resource.TestCheckResourceAttr(resourceName, "table.0.wildcard", "true"),
 				),
 			},
@@ -984,6 +991,10 @@ func permissionCountForResource(ctx context.Context, conn *lakeformation.LakeFor
 
 		if v := rs.Primary.Attributes["table_with_columns.0.database_name"]; v != "" {
 			tfMap["database_name"] = v
+		}
+
+		if v := rs.Primary.Attributes["table_with_columns.0.region"]; v != "" {
+			tfMap["region"] = v
 		}
 
 		if v := rs.Primary.Attributes["table_with_columns.0.name"]; v != "" {
@@ -1618,6 +1629,7 @@ resource "aws_lakeformation_permissions" "test" {
   table {
     database_name = aws_glue_catalog_table.test.database_name
     name          = aws_glue_catalog_table.test.name
+	region        = "us-east-2"
   }
 
   # for consistency, ensure that admins are setup before testing
@@ -1673,6 +1685,7 @@ resource "aws_lakeformation_permissions" "test" {
   table {
     database_name = aws_glue_catalog_database.test.name
     name          = aws_glue_catalog_table.test.name
+    region        = "us-east-2"
   }
 }
 `, rName)
@@ -1743,6 +1756,7 @@ resource "aws_lakeformation_permissions" "test" {
   table {
     database_name = aws_glue_catalog_table.test.database_name
     name          = aws_glue_catalog_table.test.name
+	region        = "us-east-2"
   }
 
   # for consistency, ensure that admins are setup before testing
@@ -1813,6 +1827,7 @@ resource "aws_lakeformation_permissions" "test" {
   table {
     database_name = aws_glue_catalog_table.test.database_name
     name          = aws_glue_catalog_table.test.name
+    region        = "us-east-2"
   }
 
   # for consistency, ensure that admins are setup before testing
@@ -1826,6 +1841,7 @@ resource "aws_lakeformation_permissions" "test2" {
   table {
     database_name = aws_glue_catalog_table.test.database_name
     name          = aws_glue_catalog_table.test.name
+    region        = "us-east-2"
   }
 
   # for consistency, ensure that admins are setup before testing
@@ -1880,6 +1896,7 @@ resource "aws_lakeformation_permissions" "test" {
   table {
     database_name = aws_glue_catalog_table.test.database_name
     name          = aws_glue_catalog_table.test.name
+    region        = "us-east-2"
   }
 
   # for consistency, ensure that admins are setup before testing
@@ -1953,6 +1970,7 @@ resource "aws_lakeformation_permissions" "test" {
   table {
     database_name = aws_glue_catalog_table.test.database_name
     name          = aws_glue_catalog_table.test.name
+    region        = "us-east-2"
   }
 
   # for consistency, ensure that admins are setup before testing
@@ -2003,6 +2021,7 @@ resource "aws_lakeformation_permissions" "test" {
   table {
     database_name = aws_glue_catalog_database.test.name
     wildcard      = true
+	region        = "us-east-2"
   }
 
   # for consistency, ensure that admins are setup before testing
@@ -2075,6 +2094,7 @@ resource "aws_lakeformation_permissions" "test" {
   table {
     database_name = aws_glue_catalog_table.test.database_name
     wildcard      = true
+	region        = "us-east-2"
   }
 
   # for consistency, ensure that admins are setup before testing
@@ -2148,6 +2168,7 @@ resource "aws_lakeformation_permissions" "test" {
   table {
     database_name = aws_glue_catalog_table.test.database_name
     wildcard      = true
+	region        = "us-east-2"
   }
 
   # for consistency, ensure that admins are setup before testing
@@ -2220,6 +2241,7 @@ resource "aws_lakeformation_permissions" "test" {
     database_name = aws_glue_catalog_table.test.database_name
     name          = aws_glue_catalog_table.test.name
     column_names  = [%[2]s]
+	region        = "us-east-2"
   }
 
   # for consistency, ensure that admins are setup before testing
@@ -2294,6 +2316,7 @@ resource "aws_lakeformation_permissions" "test" {
     database_name = aws_glue_catalog_table.test.database_name
     name          = aws_glue_catalog_table.test.name
     wildcard      = true
+	region        = "us-east-2"
   }
 
   # for consistency, ensure that admins are setup before testing
@@ -2367,6 +2390,7 @@ resource "aws_lakeformation_permissions" "test" {
     name                  = aws_glue_catalog_table.test.name
     wildcard              = true
     excluded_column_names = ["value"]
+    region                = "us-east-2"
   }
 
   # for consistency, ensure that admins are setup before testing
@@ -2422,6 +2446,7 @@ resource "aws_lakeformation_permissions" "test" {
     database_name = aws_glue_catalog_table.test.database_name
     name          = aws_glue_catalog_table.test.name
     wildcard      = true
+	region        = "us-east-2"
   }
 
   # for consistency, ensure that admins are setup before testing
@@ -2494,6 +2519,7 @@ resource "aws_lakeformation_permissions" "test" {
     database_name = aws_glue_catalog_table.test.database_name
     name          = aws_glue_catalog_table.test.name
     wildcard      = true
+	region        = "us-east-2"
   }
 
   # for consistency, ensure that admins are setup before testing


### PR DESCRIPTION
> ### Description
> 
> Per the following issue, can region be added to the target_table argument for aws_glue_catalog_table as well? [#32099 (comment)](https://github.com/hashicorp/terraform-provider-aws/issues/32099#issue-1764919771)
> 
> The fix added it to aws_glue_catalog_database but this doesn't address the case when creating resource links to specific tables rather than whole databases.
> ### Affected Resource(s) and/or Data Source(s)
> 
> aws_glue_catalog_table
> ### Potential Terraform Configuration
> 
> ```terraform
> resource "aws_lakeformation_permissions" "lf_grant_on_target" {
> 
>   principal = local.arn
>   permissions = ["SELECT"]
> 
>   table {
>     region = "us-east-2"
>     catalog_id = local.catalog
>     database_name = local.database
>     name = local.table
>   }
> }
> ```
> 
> ### References
> 
> #33639
> ### Would you like to implement a fix?
> 
> Yes

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #33639

### References

This does not appear to be a supported identifier in the go sdk struct: https://github.com/aws/aws-sdk-go/blob/737322b8f8b54fc78d076334d1e433e2e5f2993d/service/lakeformation/api.go#L13775

When attempting to add it in I get an idempotent error where it constantly tries to force a new replacement. I'll submit what I have so far as a WIP but I'm not sure that this is, in fact, supported.


### Output from Acceptance Testing
```
    permissions_test.go:504: Step 1/1 error: After applying this test step, the plan was not empty.
        stdout:


        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
        -/+ destroy and then create replacement

        Terraform will perform the following actions:

          # aws_lakeformation_permissions.test must be replaced
        -/+ resource "aws_lakeformation_permissions" "test" {
              ~ id                            = "2476167902" -> (known after apply)
                # (4 unchanged attributes hidden)

              ~ table {
                  ~ catalog_id    = "504376484015" -> (known after apply)
                    name          = "tf-acc-test-537905478652321360"
                  + region        = "us-east-2" # forces replacement
                    # (2 unchanged attributes hidden)
                }
            }

        Plan: 1 to add, 0 to change, 1 to destroy.
```
