### PR TITLE
[New Resource]: `aws_servicequotas_template`

### DIFF
--- a/.changelog/33688.txt
+++ b/.changelog/33688.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_servicequotas_template
+```

--- a/internal/service/servicequotas/exports_test.go
+++ b/internal/service/servicequotas/exports_test.go
@@ -1,0 +1,9 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package servicequotas
+
+// Exports for use in tests only.
+var (
+	ResourceTemplate = newResourceTemplate
+)

--- a/internal/service/servicequotas/service_package_gen.go
+++ b/internal/service/servicequotas/service_package_gen.go
@@ -19,7 +19,12 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.Serv
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.ServicePackageFrameworkResource {
-	return []*types.ServicePackageFrameworkResource{}
+	return []*types.ServicePackageFrameworkResource{
+		{
+			Factory: newResourceTemplate,
+			Name:    "Template",
+		},
+	}
 }
 
 func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePackageSDKDataSource {

--- a/internal/service/servicequotas/template.go
+++ b/internal/service/servicequotas/template.go
@@ -1,0 +1,310 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package servicequotas
+
+import (
+	"context"
+	"errors"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/servicequotas"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/servicequotas/types"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource(name="Template")
+func newResourceTemplate(_ context.Context) (resource.ResourceWithConfigure, error) {
+	return &resourceTemplate{}, nil
+}
+
+const (
+	ResNameTemplate     = "Template"
+	templateIDPartCount = 3
+)
+
+type resourceTemplate struct {
+	framework.ResourceWithConfigure
+}
+
+func (r *resourceTemplate) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "aws_servicequotas_template"
+}
+
+func (r *resourceTemplate) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"global_quota": schema.BoolAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"id": framework.IDAttribute(),
+			"quota_code": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"quota_name": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"region": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"service_code": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"service_name": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"unit": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"value": schema.Float64Attribute{
+				Required: true,
+			},
+		},
+	}
+}
+
+func (r *resourceTemplate) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().ServiceQuotasClient(ctx)
+
+	var plan resourceTemplateData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	region := plan.Region.ValueString()
+	quotaCode := plan.QuotaCode.ValueString()
+	serviceCode := plan.ServiceCode.ValueString()
+
+	parts := []string{region, quotaCode, serviceCode}
+	id, err := flex.FlattenResourceId(parts, templateIDPartCount, false)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.ServiceQuotas, create.ErrActionCreating, ResNameTemplate, id, err),
+			err.Error(),
+		)
+	}
+	plan.ID = fwflex.StringValueToFramework(ctx, id)
+
+	in := &servicequotas.PutServiceQuotaIncreaseRequestIntoTemplateInput{
+		AwsRegion:    aws.String(region),
+		DesiredValue: aws.Float64(plan.Value.ValueFloat64()),
+		QuotaCode:    aws.String(quotaCode),
+		ServiceCode:  aws.String(serviceCode),
+	}
+
+	out, err := conn.PutServiceQuotaIncreaseRequestIntoTemplate(ctx, in)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.ServiceQuotas, create.ErrActionCreating, ResNameTemplate, plan.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+	if out == nil || out.ServiceQuotaIncreaseRequestInTemplate == nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.ServiceQuotas, create.ErrActionCreating, ResNameTemplate, plan.ID.String(), nil),
+			errors.New("empty output").Error(),
+		)
+		return
+	}
+
+	templateItem := out.ServiceQuotaIncreaseRequestInTemplate
+	plan.GlobalQuota = types.BoolValue(templateItem.GlobalQuota)
+	plan.QuotaName = fwflex.StringToFramework(ctx, templateItem.QuotaName)
+	plan.ServiceName = fwflex.StringToFramework(ctx, templateItem.ServiceName)
+	plan.Unit = fwflex.StringToFramework(ctx, templateItem.Unit)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *resourceTemplate) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().ServiceQuotasClient(ctx)
+
+	var state resourceTemplateData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := FindTemplateByID(ctx, conn, state.ID.ValueString())
+	if tfresource.NotFound(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.ServiceQuotas, create.ErrActionSetting, ResNameTemplate, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	state.GlobalQuota = types.BoolValue(out.GlobalQuota)
+	state.QuotaCode = fwflex.StringToFramework(ctx, out.QuotaCode)
+	state.QuotaName = fwflex.StringToFramework(ctx, out.QuotaName)
+	state.Region = fwflex.StringToFramework(ctx, out.AwsRegion)
+	state.ServiceCode = fwflex.StringToFramework(ctx, out.ServiceCode)
+	state.ServiceName = fwflex.StringToFramework(ctx, out.ServiceName)
+	state.Unit = fwflex.StringToFramework(ctx, out.Unit)
+	state.Value = fwflex.Float64ToFramework(ctx, out.DesiredValue)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *resourceTemplate) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	conn := r.Meta().ServiceQuotasClient(ctx)
+
+	var state, plan resourceTemplateData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !plan.Value.Equal(state.Value) {
+		in := &servicequotas.PutServiceQuotaIncreaseRequestIntoTemplateInput{
+			AwsRegion:    aws.String(plan.Region.ValueString()),
+			DesiredValue: aws.Float64(plan.Value.ValueFloat64()),
+			QuotaCode:    aws.String(plan.QuotaCode.ValueString()),
+			ServiceCode:  aws.String(plan.ServiceCode.ValueString()),
+		}
+
+		out, err := conn.PutServiceQuotaIncreaseRequestIntoTemplate(ctx, in)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.ServiceQuotas, create.ErrActionUpdating, ResNameTemplate, plan.ID.String(), err),
+				err.Error(),
+			)
+			return
+		}
+		if out == nil || out.ServiceQuotaIncreaseRequestInTemplate == nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.ServiceQuotas, create.ErrActionUpdating, ResNameTemplate, plan.ID.String(), nil),
+				errors.New("empty output").Error(),
+			)
+			return
+		}
+
+		templateItem := out.ServiceQuotaIncreaseRequestInTemplate
+		plan.GlobalQuota = types.BoolValue(templateItem.GlobalQuota)
+		plan.QuotaName = fwflex.StringToFramework(ctx, templateItem.QuotaName)
+		plan.ServiceName = fwflex.StringToFramework(ctx, templateItem.ServiceName)
+		plan.Unit = fwflex.StringToFramework(ctx, templateItem.Unit)
+
+		resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+	}
+}
+
+func (r *resourceTemplate) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	conn := r.Meta().ServiceQuotasClient(ctx)
+
+	var state resourceTemplateData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := &servicequotas.DeleteServiceQuotaIncreaseRequestFromTemplateInput{
+		AwsRegion:   aws.String(state.Region.ValueString()),
+		QuotaCode:   aws.String(state.QuotaCode.ValueString()),
+		ServiceCode: aws.String(state.ServiceCode.ValueString()),
+	}
+
+	_, err := conn.DeleteServiceQuotaIncreaseRequestFromTemplate(ctx, in)
+	if err != nil {
+		if errs.IsA[*awstypes.NoSuchResourceException](err) {
+			return
+		}
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.ServiceQuotas, create.ErrActionDeleting, ResNameTemplate, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+}
+
+func (r *resourceTemplate) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func FindTemplateByID(ctx context.Context, conn *servicequotas.Client, id string) (*awstypes.ServiceQuotaIncreaseRequestInTemplate, error) {
+	parts, err := flex.ExpandResourceId(id, templateIDPartCount, false)
+	if err != nil {
+		return nil, err
+	}
+	region := parts[0]
+	quotaCode := parts[1]
+	serviceCode := parts[2]
+
+	in := &servicequotas.GetServiceQuotaIncreaseRequestFromTemplateInput{
+		AwsRegion:   aws.String(region),
+		QuotaCode:   aws.String(quotaCode),
+		ServiceCode: aws.String(serviceCode),
+	}
+
+	out, err := conn.GetServiceQuotaIncreaseRequestFromTemplate(ctx, in)
+	if err != nil {
+		if errs.IsA[*awstypes.NoSuchResourceException](err) {
+			return nil, &retry.NotFoundError{
+				LastError:   err,
+				LastRequest: in,
+			}
+		}
+
+		return nil, err
+	}
+
+	if out == nil || out.ServiceQuotaIncreaseRequestInTemplate == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return out.ServiceQuotaIncreaseRequestInTemplate, nil
+}
+
+type resourceTemplateData struct {
+	GlobalQuota types.Bool    `tfsdk:"global_quota"`
+	ID          types.String  `tfsdk:"id"`
+	QuotaCode   types.String  `tfsdk:"quota_code"`
+	QuotaName   types.String  `tfsdk:"quota_name"`
+	Region      types.String  `tfsdk:"region"`
+	ServiceCode types.String  `tfsdk:"service_code"`
+	ServiceName types.String  `tfsdk:"service_name"`
+	Unit        types.String  `tfsdk:"unit"`
+	Value       types.Float64 `tfsdk:"value"`
+}

--- a/internal/service/servicequotas/template_test.go
+++ b/internal/service/servicequotas/template_test.go
@@ -1,0 +1,227 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package servicequotas_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/servicequotas"
+	"github.com/aws/aws-sdk-go-v2/service/servicequotas/types"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	tfservicequotas "github.com/hashicorp/terraform-provider-aws/internal/service/servicequotas"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+const (
+	lambdaServiceCode = "lambda"
+
+	lambdaStorageQuotaCode = "L-2ACBD22F" // Function and layer storage
+	lambdaStorageValue     = "80"         // Default is 75 GB
+
+	lambdaConcurrentExecQuotaCode = "L-B99A9384" // Concurrent executions
+	lambdaConcurrentExecValue     = "1500"       // Default is 1000
+
+	lambdaENIQuotaCode    = "L-9FEE3D26" // Elastic network interfaces per VPC
+	lambdaENIValue        = "275"        // Default is 250
+	lambdaENIValueUpdated = "300"        // Default is 250
+)
+
+func TestAccServiceQuotasTemplate_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	var template types.ServiceQuotaIncreaseRequestInTemplate
+	resourceName := "aws_servicequotas_template.test"
+	regionDataSourceName := "data.aws_region.current"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckRegion(t, names.USEast1RegionID)
+			acctest.PreCheckPartitionHasService(t, names.ServiceQuotasEndpointID)
+			testAccPreCheckTemplate(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceQuotasEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTemplateDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				// Use a distinct quota code for each test to ensure parallel tests run safely
+				Config: testAccTemplateConfig_basic(lambdaStorageQuotaCode, lambdaServiceCode, lambdaStorageValue),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTemplateExists(ctx, resourceName, &template),
+					resource.TestCheckResourceAttrPair(resourceName, "region", regionDataSourceName, "name"),
+					resource.TestCheckResourceAttr(resourceName, "quota_code", lambdaStorageQuotaCode),
+					resource.TestCheckResourceAttr(resourceName, "service_code", lambdaServiceCode),
+					resource.TestCheckResourceAttr(resourceName, "value", lambdaStorageValue),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccServiceQuotasTemplate_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	var template types.ServiceQuotaIncreaseRequestInTemplate
+	resourceName := "aws_servicequotas_template.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckRegion(t, names.USEast1RegionID)
+			acctest.PreCheckPartitionHasService(t, names.ServiceQuotasEndpointID)
+			testAccPreCheckTemplate(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceQuotasEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTemplateDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				// Use a distinct quota code for each test to ensure parallel tests run safely
+				Config: testAccTemplateConfig_basic(lambdaConcurrentExecQuotaCode, lambdaServiceCode, lambdaConcurrentExecValue),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTemplateExists(ctx, resourceName, &template),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfservicequotas.ResourceTemplate, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccServiceQuotasTemplate_value(t *testing.T) {
+	ctx := acctest.Context(t)
+	var template types.ServiceQuotaIncreaseRequestInTemplate
+	resourceName := "aws_servicequotas_template.test"
+	regionDataSourceName := "data.aws_region.current"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckRegion(t, names.USEast1RegionID)
+			acctest.PreCheckPartitionHasService(t, names.ServiceQuotasEndpointID)
+			testAccPreCheckTemplate(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceQuotasEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTemplateDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				// Use a distinct quota code for each test to ensure parallel tests run safely
+				Config: testAccTemplateConfig_basic(lambdaENIQuotaCode, lambdaServiceCode, lambdaENIValue),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTemplateExists(ctx, resourceName, &template),
+					resource.TestCheckResourceAttrPair(resourceName, "region", regionDataSourceName, "name"),
+					resource.TestCheckResourceAttr(resourceName, "quota_code", lambdaENIQuotaCode),
+					resource.TestCheckResourceAttr(resourceName, "service_code", lambdaServiceCode),
+					resource.TestCheckResourceAttr(resourceName, "value", lambdaENIValue),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccTemplateConfig_basic(lambdaENIQuotaCode, lambdaServiceCode, lambdaENIValueUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTemplateExists(ctx, resourceName, &template),
+					resource.TestCheckResourceAttrPair(resourceName, "region", regionDataSourceName, "name"),
+					resource.TestCheckResourceAttr(resourceName, "quota_code", lambdaENIQuotaCode),
+					resource.TestCheckResourceAttr(resourceName, "service_code", lambdaServiceCode),
+					resource.TestCheckResourceAttr(resourceName, "value", lambdaENIValueUpdated),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckTemplateDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ServiceQuotasClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_servicequotas_template" {
+				continue
+			}
+
+			_, err := tfservicequotas.FindTemplateByID(ctx, conn, rs.Primary.ID)
+			if errs.IsA[*types.NoSuchResourceException](err) {
+				return nil
+			}
+			if err != nil {
+				return create.Error(names.ServiceQuotas, create.ErrActionCheckingDestroyed, tfservicequotas.ResNameTemplate, rs.Primary.ID, err)
+			}
+
+			return create.Error(names.ServiceQuotas, create.ErrActionCheckingDestroyed, tfservicequotas.ResNameTemplate, rs.Primary.ID, errors.New("not destroyed"))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckTemplateExists(ctx context.Context, name string, template *types.ServiceQuotaIncreaseRequestInTemplate) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.ServiceQuotas, create.ErrActionCheckingExistence, tfservicequotas.ResNameTemplate, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.ServiceQuotas, create.ErrActionCheckingExistence, tfservicequotas.ResNameTemplate, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ServiceQuotasClient(ctx)
+		resp, err := tfservicequotas.FindTemplateByID(ctx, conn, rs.Primary.ID)
+		if err != nil {
+			return create.Error(names.ServiceQuotas, create.ErrActionCheckingExistence, tfservicequotas.ResNameTemplate, rs.Primary.ID, err)
+		}
+
+		*template = *resp
+
+		return nil
+	}
+}
+
+func testAccPreCheckTemplate(ctx context.Context, t *testing.T) {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).ServiceQuotasClient(ctx)
+
+	input := &servicequotas.ListServiceQuotaIncreaseRequestsInTemplateInput{}
+	_, err := conn.ListServiceQuotaIncreaseRequestsInTemplate(ctx, input)
+
+	// Request must come from organization owner account
+	if errs.IsAErrorMessageContains[*types.AccessDeniedException](err, "The request was called by a member account.") {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func testAccTemplateConfig_basic(quotaCode, serviceCode, value string) string {
+	return fmt.Sprintf(`
+data "aws_region" "current" {}
+
+resource "aws_servicequotas_template" "test" {
+  region       = data.aws_region.current.name
+  quota_code   = %[1]q
+  service_code = %[2]q
+  value        = %[3]s
+}
+`, quotaCode, serviceCode, value)
+}

--- a/website/docs/r/servicequotas_template.html.markdown
+++ b/website/docs/r/servicequotas_template.html.markdown
@@ -1,0 +1,61 @@
+---
+subcategory: "Service Quotas"
+layout: "aws"
+page_title: "AWS: aws_servicequotas_template"
+description: |-
+  Terraform resource for managing an AWS Service Quotas Template.
+---
+# Resource: aws_servicequotas_template
+
+Terraform resource for managing an AWS Service Quotas Template.
+
+-> Only the management account of an organization can alter Service Quota templates, and this must be done from the `us-east-1` region.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_servicequotas_template" "example" {
+  region       = "us-east-1"
+  quota_code   = "L-2ACBD22F" # function and layer storage (default: 75 GB)
+  service_code = "lambda"
+  value        = "80"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `region` - (Required) AWS Region to which the template applies.
+* `quota_code` - (Required) Quota identifier. To find the quota code for a specific quota, use the [aws_servicequotas_service_quota](../d/servicequotas_service_quota.html.markdown) data source.
+* `service_code` - (Required) Service identifier. To find the service code value for an AWS service, use the [aws_servicequotas_service](../d/servicequotas_service.html.markdown) data source.
+* `value` - (Required) The new, increased value for the quota.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `global_quota` - Indicates whether the quota is global.
+* `id` - Unique identifier for the resource, which is a comma-delimited string separating `region`, `quota_code`, and `service_code`.
+* `quota_name` - Quota name.
+* `service_name` - Service name.
+* `unit` - Unit of measurement.
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Service Quotas Template using the `example_id_arg`. For example:
+
+```terraform
+import {
+  to = aws_servicequotas_template.example
+  id = "us-east-1,L-2ACBD22F,lambda"
+}
+```
+
+Using `terraform import`, import Service Quotas Template using the `id`. For example:
+
+```console
+% terraform import aws_servicequotas_template.example us-east-1,L-2ACBD22F,lambda
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The `aws_servicequotas_template` resource allows a management organization to add quota increases to a template to be applied across all member accounts.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #9119

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
**NOTE**: Tests must be run from the management account of an organization, and in the `us-east-1` region

```console
% make testacc PKG=servicequotas TESTS=TestAccServiceQuotasTemplate_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/servicequotas/... -v -count 1 -parallel 20 -run='TestAccServiceQuotasTemplate_'  -timeout 360m

--- PASS: TestAccServiceQuotasTemplate_disappears (11.79s)
--- PASS: TestAccServiceQuotasTemplate_basic (14.05s)
--- PASS: TestAccServiceQuotasTemplate_value (22.16s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/servicequotas      25.330s
```

In a member account or the wrong region, tests will be automatically skipped:

```console
% make testacc PKG=servicequotas TESTS=TestAccServiceQuotasTemplate_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/servicequotas/... -v -count 1 -parallel 20 -run='TestAccServiceQuotasTemplate_'  -timeout 360m

    template_test.go:152: skipping acceptance testing: operation error Service Quotas: ListServiceQuotaIncreaseRequestsInTemplate, https response error StatusCode: 400, RequestID: 8fd7d25f-c872-42f7-b472-33825df6dd79, AccessDeniedException: The request was called by a member account. To make this request, you must use the organization's master account.
--- SKIP: TestAccServiceQuotasTemplate_disappears (0.20s)
=== NAME  TestAccServiceQuotasTemplate_basic
    template_test.go:152: skipping acceptance testing: operation error Service Quotas: ListServiceQuotaIncreaseRequestsInTemplate, https response error StatusCode: 400, RequestID: 1e5f98f8-d73f-47bb-876d-5ed617d152dc, AccessDeniedException: The request was called by a member account. To make this request, you must use the organization's master account.
--- SKIP: TestAccServiceQuotasTemplate_basic (0.20s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/servicequotas      3.261s
```

```console
% make testacc PKG=servicequotas TESTS=TestAccServiceQuotasTemplate_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/servicequotas/... -v -count 1 -parallel 20 -run='TestAccServiceQuotasTemplate_'  -timeout 360m

=== NAME  TestAccServiceQuotasTemplate_basic
    acctest.go:877: skipping tests; AWS_DEFAULT_REGION (us-west-2) not supported. Supported: [us-east-1]
--- SKIP: TestAccServiceQuotasTemplate_basic (0.49s)
=== NAME  TestAccServiceQuotasTemplate_disappears
    acctest.go:877: skipping tests; AWS_DEFAULT_REGION (us-west-2) not supported. Supported: [us-east-1]
--- SKIP: TestAccServiceQuotasTemplate_disappears (0.48s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/servicequotas      3.685s
```