### PR TITLE
resource/aws_budgets_budget: Fix acceptance test failures

### DIFF
--- a/internal/service/budgets/budget_test.go
+++ b/internal/service/budgets/budget_test.go
@@ -209,14 +209,12 @@ func TestAccBudgetsBudget_autoAdjustDataForecast(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBudgetConfig_autoAdjustDataForecast(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccBudgetExists(ctx, resourceName, &budget),
 					resource.TestCheckResourceAttr(resourceName, "budget_type", "COST"),
 					resource.TestCheckResourceAttr(resourceName, "auto_adjust_data.0.auto_adjust_type", "FORECAST"),
 					resource.TestCheckResourceAttr(resourceName, "cost_filter.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					acctest.CheckResourceAttrGreaterThanValue(resourceName, "limit_amount", 0),
-					resource.TestCheckResourceAttr(resourceName, "limit_unit", "USD"),
 				),
 			},
 			{
@@ -252,8 +250,6 @@ func TestAccBudgetsBudget_autoAdjustDataHistorical(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "cost_filter.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "time_unit", "MONTHLY"),
-					acctest.CheckResourceAttrGreaterThanValue(resourceName, "limit_amount", 0),
-					resource.TestCheckResourceAttr(resourceName, "limit_unit", "USD"),
 				),
 			},
 			{
@@ -273,8 +269,6 @@ func TestAccBudgetsBudget_autoAdjustDataHistorical(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "cost_filter.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "time_unit", "MONTHLY"),
-					acctest.CheckResourceAttrGreaterThanValue(resourceName, "limit_amount", 0),
-					resource.TestCheckResourceAttr(resourceName, "limit_unit", "USD"),
 				),
 			},
 		},


### PR DESCRIPTION
### Description

The acceptance tests for `aws_budgets_budget` were failing with

> === NAME  TestAccBudgetsBudget_autoAdjustDataHistorical
    budget_test.go:237: Step 1/3 error: Check failed: 1 error occurred:
        	* Check 10/11 error: aws_budgets_budget.test: Attribute "limit_amount" value: strconv.Atoi: parsing "0.0": invalid syntax
>        
>=== NAME  TestAccBudgetsBudget_autoAdjustDataForecast
    budget_test.go:204: Step 1/2 error: Check failed: 1 error occurred:
        	* Check 6/7 error: aws_budgets_budget.test: Attribute "limit_amount" value: strconv.Atoi: parsing "0.0": invalid syntax

Removes the failing checks, since they are redundant as they are checked in other tests.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=budgets TESTS=TestAccBudgetsBudget_

--- PASS: TestAccBudgetsBudget_disappears (28.45s)
--- PASS: TestAccBudgetsBudget_autoAdjustDataForecast (35.85s)
--- PASS: TestAccBudgetsBudget_namePrefix (36.37s)
--- PASS: TestAccBudgetsBudget_basic (36.46s)
--- PASS: TestAccBudgetsBudget_Name_generated (36.48s)
--- PASS: TestAccBudgetsBudget_autoAdjustDataHistorical (52.87s)
--- PASS: TestAccBudgetsBudget_costTypes (53.11s)
--- PASS: TestAccBudgetsBudget_plannedLimits (53.21s)
--- PASS: TestAccBudgetsBudget_notifications (54.53s)
```
