### PR TITLE
resource/aws_applicationinsights_application: Fix acceptance test

### DIFF
--- a/internal/service/applicationinsights/wait.go
+++ b/internal/service/applicationinsights/wait.go
@@ -35,7 +35,7 @@ func waitApplicationCreated(ctx context.Context, conn *applicationinsights.Appli
 
 func waitApplicationTerminated(ctx context.Context, conn *applicationinsights.ApplicationInsights, name string) (*applicationinsights.ApplicationInfo, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending: []string{"NOT_CONFIGURED", "DELETING"},
+		Pending: []string{"ACTIVE", "NOT_CONFIGURED", "DELETING"},
 		Target:  []string{},
 		Refresh: statusApplication(ctx, conn, name),
 		Timeout: ApplicationDeletedTimeout,


### PR DESCRIPTION
### Description

The acceptance tests for `aws_applicationinsights_application` was failing with

>     testing_new.go:90: Error running post-test destroy, there may be dangling resources: exit status 1
>        2023/09/29 17:25:57 [DEBUG] Using modified User-Agent: Terraform/0.12.31 HashiCorp-terraform-exec/0.19.0
>        
>        Error: waiting for ApplicationInsights Application (tf-acc-test-8318256665595245541) delete: unexpected state 'ACTIVE', wanted target ''. last error: %!s(<nil>)

Add `ACTIVE` to expected states

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=applicationinsights TESTS=TestAccApplicationInsightsApplication_

--- PASS: TestAccApplicationInsightsApplication_disappears (29.45s)
--- PASS: TestAccApplicationInsightsApplication_autoConfig (32.35s)
--- PASS: TestAccApplicationInsightsApplication_basic (44.55s)
--- PASS: TestAccApplicationInsightsApplication_tags (55.42s)
```
