### PR TITLE
Allow periods in parameter group names for RDS

### DIFF
--- a/.changelog/33704.txt
+++ b/.changelog/33704.txt
@@ -1,0 +1,6 @@
+```release-note:bug
+resource/aws_db_parameter_group: Group names containing periods (`.`) no longer fail validation
+```
+```release-note:bug
+resource/aws_rds_cluster_parameter_group: Group names containing periods (`.`) no longer fail validation
+```

--- a/internal/service/rds/validate.go
+++ b/internal/service/rds/validate.go
@@ -70,9 +70,9 @@ func validOptionGroupNamePrefix(v interface{}, k string) (ws []string, errors []
 
 func validParamGroupName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-	if !regexache.MustCompile(`^[0-9a-z-.]+$`).MatchString(value) {
+	if !regexache.MustCompile(`^[0-9a-z.-]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"only lowercase alphanumeric characters, hyphens, and periods allowed in parameter group %q", k))
+			"only lowercase alphanumeric characters, periods, and hyphens allowed in parameter group %q", k))
 	}
 	if !regexache.MustCompile(`^[a-z]`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(

--- a/internal/service/rds/validate.go
+++ b/internal/service/rds/validate.go
@@ -11,7 +11,7 @@ import (
 
 func validEventSubscriptionName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-	if !regexache.MustCompile(`^[0-9A-Za-z-.]+$`).MatchString(value) {
+	if !regexache.MustCompile(`^[0-9A-Za-z-]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
 			"only alphanumeric characters and hyphens allowed in %q", k))
 	}

--- a/internal/service/rds/validate.go
+++ b/internal/service/rds/validate.go
@@ -11,7 +11,7 @@ import (
 
 func validEventSubscriptionName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-	if !regexache.MustCompile(`^[0-9A-Za-z-]+$`).MatchString(value) {
+	if !regexache.MustCompile(`^[0-9A-Za-z-.]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
 			"only alphanumeric characters and hyphens allowed in %q", k))
 	}
@@ -70,9 +70,9 @@ func validOptionGroupNamePrefix(v interface{}, k string) (ws []string, errors []
 
 func validParamGroupName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-	if !regexache.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
+	if !regexache.MustCompile(`^[0-9a-z-.]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"only lowercase alphanumeric characters and hyphens allowed in parameter group %q", k))
+			"only lowercase alphanumeric characters, hyphens, and periods allowed in parameter group %q", k))
 	}
 	if !regexache.MustCompile(`^[a-z]`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(

--- a/internal/service/rds/validate_test.go
+++ b/internal/service/rds/validate_test.go
@@ -125,6 +125,10 @@ func TestValidParamGroupName(t *testing.T) {
 		ErrCount int
 	}{
 		{
+			Value:    "default.postgres9.6",
+			ErrCount: 0,
+		},
+		{
 			Value:    "tEsting123",
 			ErrCount: 1,
 		},


### PR DESCRIPTION
> ### Community Note
> 
>     * Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
> 
>     * Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request
> 
>     * If you are interested in working on this issue or have submitted a pull request, please leave a comment
> 
> 
> ### Terraform Version
> 
> Terraform v0.12.21 (same with 0.12.20)
> 
>     * provider.aws v2.50.0
> 
> 
> ### Affected Resource(s)
> 
>     * aws_db_parameter_group
> 
> 
> ### Terraform Configuration Files
> 
> ```terraform
> resource "aws_db_parameter_group" "default-postgres9-6" {
>     name        = "default.postgres9.6"
>     family      = "postgres9.6"
>     description = "Default parameter group for postgres9.6"
> ... rest is not relevant ...
> }
> ```
> 
> ### Debug Output
> 
> Partial output https://gist.github.com/iMartyn/09aea39aff770335ce533ca3373a27c0#file-terraform-debug-txt - too much useful information to others in the full output to make that public.
> ### Panic Output
> 
> No panic, just errors
> ### Expected Behavior
> 
> Given that this resource exists on aws, I should be able to import it into terraform.
> ### Actual Behavior
> 
> Cannot execute plan
> 
> ```
> Error: only lowercase alphanumeric characters and hyphens allowed in parameter group "name"
> 
>   on dbpg.tf line 1874, in resource "aws_db_parameter_group" "default-postgres9-6":
> 1874: resource "aws_db_parameter_group" "default-postgres9-6" {
> ```
> 
> ### Steps to Reproduce
> 
>     1. create pg database point and click and then use something like terraforming to create terraform to import resources into.  or just create a db parameter group name with something like the hcl above.
> 
>     2. `terraform plan`
> 
> 
> ### Important Factoids
> 
> The DB was pre-existing, I'm trying to import everything into terraform that has been created by point-and-click.
> ### References
> 
> I'm not the only one facing this problem : https://stackoverflow.com/questions/57386371/terraform-rds-instance-errors-with-lowercase-alphanumeric-characters-and-hypens


### Relations

Closes #12144 

### Output from Acceptance Testing
```
terraform-provider-aws % make testacc TESTS=TestValidParamGroupName PKG=rds
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestValidParamGroupName'  -timeout 360m
=== RUN   TestValidParamGroupName
=== PAUSE TestValidParamGroupName
=== CONT  TestValidParamGroupName
--- PASS: TestValidParamGroupName (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	3.720s

terraform import aws_db_parameter_group.default-mysql default.aurora-mysql8.0

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.
```
