### PR TITLE
r/aws_networkmanager_core_network - base_policy_policy_document

### DIFF
--- a/internal/service/networkmanager/core_network.go
+++ b/internal/service/networkmanager/core_network.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
@@ -64,13 +65,27 @@ func ResourceCoreNetwork() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"base_policy_policy_document": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(0, 10000000),
+					validation.StringIsJSON,
+				),
+				DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
+				StateFunc: func(v interface{}) string {
+					json, _ := structure.NormalizeJsonString(v)
+					return json
+				},
+				ConflictsWith: []string{"base_policy_region", "base_policy_regions"},
+			},
 			"base_policy_region": {
 				Deprecated: "Use the base_policy_regions argument instead. " +
 					"This argument will be removed in the next major version of the provider.",
 				Type:          schema.TypeString,
 				Optional:      true,
 				ValidateFunc:  verify.ValidRegionName,
-				ConflictsWith: []string{"base_policy_regions"},
+				ConflictsWith: []string{"base_policy_policy_document", "base_policy_regions"},
 			},
 			"base_policy_regions": {
 				Type:     schema.TypeSet,
@@ -79,7 +94,7 @@ func ResourceCoreNetwork() *schema.Resource {
 					Type:         schema.TypeString,
 					ValidateFunc: verify.ValidRegionName,
 				},
-				ConflictsWith: []string{"base_policy_region"},
+				ConflictsWith: []string{"base_policy_policy_document", "base_policy_region"},
 			},
 			"create_base_policy": {
 				Type:     schema.TypeBool,
@@ -172,19 +187,25 @@ func resourceCoreNetworkCreate(ctx context.Context, d *schema.ResourceData, meta
 	// this creates the core network with a starting policy document set to LIVE
 	// this is required for the first terraform apply if there attachments to the core network
 	if _, ok := d.GetOk("create_base_policy"); ok {
-		// if user supplies a region or multiple regions use it in the base policy, otherwise use current region
-		regions := []interface{}{meta.(*conns.AWSClient).Region}
-		if v, ok := d.GetOk("base_policy_region"); ok {
-			regions = []interface{}{v.(string)}
-		} else if v, ok := d.GetOk("base_policy_regions"); ok && v.(*schema.Set).Len() > 0 {
-			regions = v.(*schema.Set).List()
-		}
+		// if user supplies a full base_policy_policy_document for maximum flexibility, use it. Otherwise, use regions list
+		// var policyDocumentTarget string
+		if v, ok := d.GetOk("base_policy_policy_document"); ok {
+			input.PolicyDocument = aws.String(v.(string))
+		} else {
+			// if user supplies a region or multiple regions use it in the base policy, otherwise use current region
+			regions := []interface{}{meta.(*conns.AWSClient).Region}
+			if v, ok := d.GetOk("base_policy_region"); ok {
+				regions = []interface{}{v.(string)}
+			} else if v, ok := d.GetOk("base_policy_regions"); ok && v.(*schema.Set).Len() > 0 {
+				regions = v.(*schema.Set).List()
+			}
 
-		policyDocumentTarget, err := buildCoreNetworkBasePolicyDocument(regions)
-		if err != nil {
-			return diag.Errorf("Formatting Core Network Base Policy: %s", err)
+			policyDocumentTarget, err := buildCoreNetworkBasePolicyDocument(regions)
+			if err != nil {
+				return diag.Errorf("Formatting Core Network Base Policy: %s", err)
+			}
+			input.PolicyDocument = aws.String(policyDocumentTarget)
 		}
-		input.PolicyDocument = aws.String(policyDocumentTarget)
 	}
 
 	output, err := conn.CreateCoreNetworkWithContext(ctx, input)

--- a/internal/service/networkmanager/core_network_test.go
+++ b/internal/service/networkmanager/core_network_test.go
@@ -276,6 +276,50 @@ func TestAccNetworkManagerCoreNetwork_createBasePolicyDocumentWithMultiRegion(t 
 	})
 }
 
+func TestAccNetworkManagerCoreNetwork_createBasePolicyDocumentWithPolicyDocument(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_networkmanager_core_network.test"
+	edgeAsn1 := "65500"
+	edgeAsn2 := "65501"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, networkmanager.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCoreNetworkDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCoreNetworkConfig_basePolicyDocumentWithPolicyDocument(edgeAsn1, edgeAsn2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCoreNetworkExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "create_base_policy", "true"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "edges.*", map[string]string{
+						"asn":                  edgeAsn1,
+						"edge_location":        acctest.AlternateRegion(),
+						"inside_cidr_blocks.#": "0",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "edges.*", map[string]string{
+						"asn":                  edgeAsn2,
+						"edge_location":        acctest.Region(),
+						"inside_cidr_blocks.#": "0",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "segments.*", map[string]string{
+						"edge_locations.#":  "2",
+						"name":              "segment",
+						"shared_segments.#": "0",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"base_policy_policy_document", "create_base_policy"},
+			},
+		},
+	})
+}
+
 func TestAccNetworkManagerCoreNetwork_withoutPolicyDocumentUpdateToCreateBasePolicyDocument(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmanager_core_network.test"
@@ -448,4 +492,36 @@ resource "aws_networkmanager_core_network" "test" {
   create_base_policy  = true
 }
 `, acctest.AlternateRegion(), acctest.Region())
+}
+
+func testAccCoreNetworkConfig_basePolicyDocumentWithPolicyDocument(edgeAsn1, edgeAsn2 string) string {
+	return fmt.Sprintf(`
+resource "aws_networkmanager_global_network" "test" {}
+
+data "aws_networkmanager_core_network_policy_document" "test" {
+  core_network_configuration {
+    asn_ranges = ["65022-65534"]
+
+    edge_locations {
+      location = %[1]q
+      asn      = %[2]q
+    }
+
+    edge_locations {
+      location = %[3]q
+      asn      = %[4]q
+    }
+  }
+
+  segments {
+    name = "segment"
+  }
+}
+
+resource "aws_networkmanager_core_network" "test" {
+  global_network_id           = aws_networkmanager_global_network.test.id
+  create_base_policy          = true
+  base_policy_policy_document = data.aws_networkmanager_core_network_policy_document.test.json
+}
+`, acctest.AlternateRegion(), edgeAsn1, acctest.Region(), edgeAsn2)
 }

--- a/website/docs/r/networkmanager_core_network.html.markdown
+++ b/website/docs/r/networkmanager_core_network.html.markdown
@@ -43,7 +43,78 @@ resource "aws_networkmanager_core_network" "example" {
 
 ### With VPC Attachment (Single Region)
 
-The example below illustrates the scenario where your policy document has static routes pointing to VPC attachments and you want to attach your VPCs to the core network before applying the desired policy document. Set the `create_base_policy` argument to `true` if your core network does not currently have any `LIVE` policies (e.g. this is the first `terraform apply` with the core network resource), since a `LIVE` policy is required before VPCs can be attached to the core network. Otherwise, if your core network already has a `LIVE` policy, you may exclude the `create_base_policy` argument.
+The example below illustrates the scenario where your policy document has static routes pointing to VPC attachments and you want to attach your VPCs to the core network before applying the desired policy document. Set the `create_base_policy` argument to `true` if your core network does not currently have any `LIVE` policies (e.g. this is the first `terraform apply` with the core network resource), since a `LIVE` policy is required before VPCs can be attached to the core network. Otherwise, if your core network already has a `LIVE` policy, you may exclude the `create_base_policy` argument. There are 2 options to implement this:
+
+- Option 1: Use the `base_policy_policy_document` argument that allows the most customizations to a base policy. Use this to customize the `edge_locations` `asn`. In the example below, `us-west-2` and ASN `65500` are used in the base policy.
+- Option 2: Use the `create_base_policy` argument only. This creates a base policy in the region specified in the `provider` block.
+
+#### Option 1 - using base_policy_policy_document
+
+If you require a custom ASN for the edge location, please use the `base_policy_policy_document` argument to pass a specific ASN. For example:
+
+```terraform
+resource "aws_networkmanager_global_network" "example" {}
+
+data "aws_networkmanager_core_network_policy_document" "base" {
+  core_network_configuration {
+    asn_ranges = ["65022-65534"]
+
+    edge_locations {
+      location = "us-west-2"
+      asn      = "65500"
+    }
+  }
+
+  segments {
+    name = "segment"
+  }
+}
+
+resource "aws_networkmanager_core_network" "example" {
+  global_network_id           = aws_networkmanager_global_network.example.id
+  base_policy_policy_document = data.aws_networkmanager_core_network_policy_document.base.json
+  create_base_policy          = true
+}
+
+data "aws_networkmanager_core_network_policy_document" "example" {
+  core_network_configuration {
+    asn_ranges = ["65022-65534"]
+
+    edge_locations {
+      location = "us-west-2"
+      asn      = "65500"
+    }
+  }
+
+  segments {
+    name = "segment"
+  }
+
+  segment_actions {
+    action  = "create-route"
+    segment = "segment"
+    destination_cidr_blocks = [
+      "0.0.0.0/0"
+    ]
+    destinations = [
+      aws_networkmanager_vpc_attachment.example.id,
+    ]
+  }
+}
+
+resource "aws_networkmanager_core_network_policy_attachment" "example" {
+  core_network_id = aws_networkmanager_core_network.example.id
+  policy_document = data.aws_networkmanager_core_network_policy_document.example.json
+}
+
+resource "aws_networkmanager_vpc_attachment" "example" {
+  core_network_id = aws_networkmanager_core_network.example.id
+  subnet_arns     = aws_subnet.example[*].arn
+  vpc_arn         = aws_vpc.example.arn
+}
+```
+
+#### Option 2 - create_base_policy only
 
 ```terraform
 resource "aws_networkmanager_global_network" "example" {}
@@ -92,7 +163,109 @@ resource "aws_networkmanager_vpc_attachment" "example" {
 
 ### With VPC Attachment (Multi-Region)
 
-The example below illustrates the scenario where your policy document has static routes pointing to VPC attachments and you want to attach your VPCs to the core network before applying the desired policy document. Set the `create_base_policy` argument of the [`aws_networkmanager_core_network` resource](/docs/providers/aws/r/networkmanager_core_network.html) to `true` if your core network does not currently have any `LIVE` policies (e.g. this is the first `terraform apply` with the core network resource), since a `LIVE` policy is required before VPCs can be attached to the core network. Otherwise, if your core network already has a `LIVE` policy, you may exclude the `create_base_policy` argument. For multi-region in a core network that does not yet have a `LIVE` policy, pass a list of regions to the `aws_networkmanager_core_network` `base_policy_regions` argument. In the example below, `us-west-2` and `us-east-1` are specified in the base policy.
+The example below illustrates the scenario where your policy document has static routes pointing to VPC attachments and you want to attach your VPCs to the core network before applying the desired policy document. Set the `create_base_policy` argument of the [`aws_networkmanager_core_network` resource](/docs/providers/aws/r/networkmanager_core_network.html) to `true` if your core network does not currently have any `LIVE` policies (e.g. this is the first `terraform apply` with the core network resource), since a `LIVE` policy is required before VPCs can be attached to the core network. Otherwise, if your core network already has a `LIVE` policy, you may exclude the `create_base_policy` argument. For multi-region in a core network that does not yet have a `LIVE` policy, there are 2 options:
+
+- Option 1: Use the `base_policy_policy_document` argument that allows the most customizations to a base policy. Use this to customize the `edge_locations` `asn`. In the example below, `us-west-2`, `us-east-1` and specific ASNs are used in the base policy.
+- Option 2: Pass a list of regions to the `aws_networkmanager_core_network` `base_policy_regions` argument. In the example below, `us-west-2` and `us-east-1` are specified in the base policy.
+
+#### Option 1 - using base_policy_policy_document
+
+```terraform
+resource "aws_networkmanager_global_network" "example" {}
+
+data "aws_networkmanager_core_network_policy_document" "base" {
+  core_network_configuration {
+    asn_ranges = ["65022-65534"]
+
+    edge_locations {
+      location = "us-west-2"
+      asn      = "65500"
+    }
+
+    edge_locations {
+      location = "us-east-1"
+      asn      = "65501"
+    }
+  }
+
+  segments {
+    name = "segment"
+  }
+}
+
+resource "aws_networkmanager_core_network" "example" {
+  global_network_id           = aws_networkmanager_global_network.example.id
+  base_policy_policy_document = data.aws_networkmanager_core_network_policy_document.base.json
+  create_base_policy          = true
+}
+
+data "aws_networkmanager_core_network_policy_document" "example" {
+  core_network_configuration {
+    asn_ranges = ["65022-65534"]
+
+    edge_locations {
+      location = "us-west-2"
+      asn      = "65500"
+    }
+
+    edge_locations {
+      location = "us-east-1"
+      asn      = "65501"
+    }
+  }
+
+  segments {
+    name = "segment"
+  }
+
+  segments {
+    name = "segment2"
+  }
+
+  segment_actions {
+    action  = "create-route"
+    segment = "segment"
+    destination_cidr_blocks = [
+      "10.0.0.0/16"
+    ]
+    destinations = [
+      aws_networkmanager_vpc_attachment.example_us_west_2.id,
+    ]
+  }
+
+  segment_actions {
+    action  = "create-route"
+    segment = "segment"
+    destination_cidr_blocks = [
+      "10.1.0.0/16"
+    ]
+    destinations = [
+      aws_networkmanager_vpc_attachment.example_us_east_1.id,
+    ]
+  }
+}
+
+resource "aws_networkmanager_core_network_policy_attachment" "example" {
+  core_network_id = aws_networkmanager_core_network.example.id
+  policy_document = data.aws_networkmanager_core_network_policy_document.example.json
+}
+
+resource "aws_networkmanager_vpc_attachment" "example_us_west_2" {
+  core_network_id = aws_networkmanager_core_network.example.id
+  subnet_arns     = aws_subnet.example_us_west_2[*].arn
+  vpc_arn         = aws_vpc.example_us_west_2.arn
+}
+
+resource "aws_networkmanager_vpc_attachment" "example_us_east_1" {
+  provider = "alternate"
+
+  core_network_id = aws_networkmanager_core_network.example.id
+  subnet_arns     = aws_subnet.example_us_east_1[*].arn
+  vpc_arn         = aws_vpc.example_us_east_1.arn
+}
+```
+
+#### Option 2 - using base_policy_regions
 
 ```terraform
 resource "aws_networkmanager_global_network" "example" {}
@@ -172,8 +345,9 @@ resource "aws_networkmanager_vpc_attachment" "example_us_east_1" {
 This resource supports the following arguments:
 
 * `description` - (Optional) Description of the Core Network.
-* `base_policy_region` - (Optional, **Deprecated** use the `base_policy_regions` argument instead) The base policy created by setting the `create_base_policy` argument to `true` requires a region to be set in the `edge-locations`, `location` key. If `base_policy_region` is not specified, the region used in the base policy defaults to the region specified in the `provider` block.
-* `base_policy_regions` - (Optional) A list of regions to add to the base policy. The base policy created by setting the `create_base_policy` argument to `true` requires one or more regions to be set in the `edge-locations`, `location` key. If `base_policy_regions` is not specified, the region used in the base policy defaults to the region specified in the `provider` block.
+* `base_policy_policy_document` - (Optional, conflicts with `base_policy_region`, `base_policy_regions`) Sets the base policy document for the core network. Refer to the [Core network policies documentation](https://docs.aws.amazon.com/network-manager/latest/cloudwan/cloudwan-policy-change-sets.html) for more information.
+* `base_policy_region` - (Optional, **Deprecated** use the `base_policy_regions` or `base_policy_policy_document` argument instead) The base policy created by setting the `create_base_policy` argument to `true` requires a region to be set in the `edge-locations`, `location` key. If `base_policy_region` is not specified, the region used in the base policy defaults to the region specified in the `provider` block.
+* `base_policy_regions` - (Optional, conflicts with `base_policy_region`, `base_policy_policy_document`) A list of regions to add to the base policy. The base policy created by setting the `create_base_policy` argument to `true` requires one or more regions to be set in the `edge-locations`, `location` key. If `base_policy_regions` is not specified, the region used in the base policy defaults to the region specified in the `provider` block.
 * `create_base_policy` - (Optional) Specifies whether to create a base policy when a core network is created or updated. A base policy is created and set to `LIVE` to allow attachments to the core network (e.g. VPC Attachments) before applying a policy document provided using the [`aws_networkmanager_core_network_policy_attachment` resource](/docs/providers/aws/r/networkmanager_core_network_policy_attachment.html). This base policy is needed if your core network does not have any `LIVE` policies and your policy document has static routes pointing to VPC attachments and you want to attach your VPCs to the core network before applying the desired policy document. Valid values are `true` or `false`. An example of this Terraform snippet can be found above [for VPC Attachment in a single region](#with-vpc-attachment-single-region) and [for VPC Attachment multi-region](#with-vpc-attachment-multi-region). An example base policy is shown below. This base policy is overridden with the policy that you specify in the [`aws_networkmanager_core_network_policy_attachment` resource](/docs/providers/aws/r/networkmanager_core_network_policy_attachment.html).
 
 ```json

--- a/website/docs/r/networkmanager_core_network_policy_attachment.html.markdown
+++ b/website/docs/r/networkmanager_core_network_policy_attachment.html.markdown
@@ -29,7 +29,76 @@ resource "aws_networkmanager_core_network_policy_attachment" "example" {
 
 ### With VPC Attachment (Single Region)
 
-The example below illustrates the scenario where your policy document has static routes pointing to VPC attachments and you want to attach your VPCs to the core network before applying the desired policy document. Set the `create_base_policy` argument of the [`aws_networkmanager_core_network` resource](/docs/providers/aws/r/networkmanager_core_network.html) to `true` if your core network does not currently have any `LIVE` policies (e.g. this is the first `terraform apply` with the core network resource), since a `LIVE` policy is required before VPCs can be attached to the core network. Otherwise, if your core network already has a `LIVE` policy, you may exclude the `create_base_policy` argument.
+The example below illustrates the scenario where your policy document has static routes pointing to VPC attachments and you want to attach your VPCs to the core network before applying the desired policy document. Set the `create_base_policy` argument of the [`aws_networkmanager_core_network` resource](/docs/providers/aws/r/networkmanager_core_network.html) to `true` if your core network does not currently have any `LIVE` policies (e.g. this is the first `terraform apply` with the core network resource), since a `LIVE` policy is required before VPCs can be attached to the core network. Otherwise, if your core network already has a `LIVE` policy, you may exclude the `create_base_policy` argument. There are 2 options to implement this:
+
+- Option 1: Use the `base_policy_policy_document` argument in the [`aws_networkmanager_core_network` resource](/docs/providers/aws/r/networkmanager_core_network.html) that allows the most customizations to a base policy. Use this to customize the `edge_locations` `asn`. In the example below, `us-west-2` and ASN `65500` are used in the base policy.
+- Option 2: Use the `create_base_policy` argument only. This creates a base policy in the region specified in the `provider` block.
+
+#### Option 1 - using base_policy_policy_document
+
+```terraform
+resource "aws_networkmanager_global_network" "example" {}
+
+data "aws_networkmanager_core_network_policy_document" "base" {
+  core_network_configuration {
+    asn_ranges = ["65022-65534"]
+
+    edge_locations {
+      location = "us-west-2"
+      asn      = "65500"
+    }
+  }
+
+  segments {
+    name = "segment"
+  }
+}
+
+resource "aws_networkmanager_core_network" "example" {
+  global_network_id           = aws_networkmanager_global_network.example.id
+  base_policy_policy_document = data.aws_networkmanager_core_network_policy_document.base.json
+  create_base_policy          = true
+}
+
+data "aws_networkmanager_core_network_policy_document" "example" {
+  core_network_configuration {
+    asn_ranges = ["65022-65534"]
+
+    edge_locations {
+      location = "us-west-2"
+      asn      = "65500"
+    }
+  }
+
+  segments {
+    name = "segment"
+  }
+
+  segment_actions {
+    action  = "create-route"
+    segment = "segment"
+    destination_cidr_blocks = [
+      "0.0.0.0/0"
+    ]
+    destinations = [
+      aws_networkmanager_vpc_attachment.example.id,
+    ]
+  }
+}
+
+resource "aws_networkmanager_core_network_policy_attachment" "example" {
+  core_network_id = aws_networkmanager_core_network.example.id
+  policy_document = data.aws_networkmanager_core_network_policy_document.example.json
+}
+
+resource "aws_networkmanager_vpc_attachment" "example" {
+  core_network_id = aws_networkmanager_core_network.example.id
+  subnet_arns     = aws_subnet.example[*].arn
+  vpc_arn         = aws_vpc.example.arn
+}
+```
+
+#### Option 2 - create_base_policy only
 
 ```terraform
 resource "aws_networkmanager_global_network" "example" {}
@@ -78,7 +147,109 @@ resource "aws_networkmanager_vpc_attachment" "example" {
 
 ### With VPC Attachment (Multi-Region)
 
-The example below illustrates the scenario where your policy document has static routes pointing to VPC attachments and you want to attach your VPCs to the core network before applying the desired policy document. Set the `create_base_policy` argument of the [`aws_networkmanager_core_network` resource](/docs/providers/aws/r/networkmanager_core_network.html) to `true` if your core network does not currently have any `LIVE` policies (e.g. this is the first `terraform apply` with the core network resource), since a `LIVE` policy is required before VPCs can be attached to the core network. Otherwise, if your core network already has a `LIVE` policy, you may exclude the `create_base_policy` argument. For multi-region in a core network that does not yet have a `LIVE` policy, pass a list of regions to the `aws_networkmanager_core_network` `base_policy_regions` argument. In the example below, `us-west-2` and `us-east-1` are specified in the base policy.
+The example below illustrates the scenario where your policy document has static routes pointing to VPC attachments and you want to attach your VPCs to the core network before applying the desired policy document. Set the `create_base_policy` argument of the [`aws_networkmanager_core_network` resource](/docs/providers/aws/r/networkmanager_core_network.html) to `true` if your core network does not currently have any `LIVE` policies (e.g. this is the first `terraform apply` with the core network resource), since a `LIVE` policy is required before VPCs can be attached to the core network. Otherwise, if your core network already has a `LIVE` policy, you may exclude the `create_base_policy` argument. For multi-region in a core network that does not yet have a `LIVE` policy, there are 2 options:
+
+- Option 1: Use the `base_policy_policy_document` argument that allows the most customizations to a base policy. Use this to customize the `edge_locations` `asn`. In the example below, `us-west-2`, `us-east-1` and specific ASNs are used in the base policy.
+- Option 2: Pass a list of regions to the [`aws_networkmanager_core_network` resource](/docs/providers/aws/r/networkmanager_core_network.html) `base_policy_regions` argument. In the example below, `us-west-2` and `us-east-1` are specified in the base policy.
+
+#### Option 1 - using base_policy_policy_document
+
+```terraform
+resource "aws_networkmanager_global_network" "example" {}
+
+data "aws_networkmanager_core_network_policy_document" "base" {
+  core_network_configuration {
+    asn_ranges = ["65022-65534"]
+
+    edge_locations {
+      location = "us-west-2"
+      asn      = "65500"
+    }
+
+    edge_locations {
+      location = "us-east-1"
+      asn      = "65501"
+    }
+  }
+
+  segments {
+    name = "segment"
+  }
+}
+
+resource "aws_networkmanager_core_network" "example" {
+  global_network_id           = aws_networkmanager_global_network.example.id
+  base_policy_policy_document = data.aws_networkmanager_core_network_policy_document.base.json
+  create_base_policy          = true
+}
+
+data "aws_networkmanager_core_network_policy_document" "example" {
+  core_network_configuration {
+    asn_ranges = ["65022-65534"]
+
+    edge_locations {
+      location = "us-west-2"
+      asn      = "65500"
+    }
+
+    edge_locations {
+      location = "us-east-1"
+      asn      = "65501"
+    }
+  }
+
+  segments {
+    name = "segment"
+  }
+
+  segments {
+    name = "segment2"
+  }
+
+  segment_actions {
+    action  = "create-route"
+    segment = "segment"
+    destination_cidr_blocks = [
+      "10.0.0.0/16"
+    ]
+    destinations = [
+      aws_networkmanager_vpc_attachment.example_us_west_2.id,
+    ]
+  }
+
+  segment_actions {
+    action  = "create-route"
+    segment = "segment"
+    destination_cidr_blocks = [
+      "10.1.0.0/16"
+    ]
+    destinations = [
+      aws_networkmanager_vpc_attachment.example_us_east_1.id,
+    ]
+  }
+}
+
+resource "aws_networkmanager_core_network_policy_attachment" "example" {
+  core_network_id = aws_networkmanager_core_network.example.id
+  policy_document = data.aws_networkmanager_core_network_policy_document.example.json
+}
+
+resource "aws_networkmanager_vpc_attachment" "example_us_west_2" {
+  core_network_id = aws_networkmanager_core_network.example.id
+  subnet_arns     = aws_subnet.example_us_west_2[*].arn
+  vpc_arn         = aws_vpc.example_us_west_2.arn
+}
+
+resource "aws_networkmanager_vpc_attachment" "example_us_east_1" {
+  provider = "alternate"
+
+  core_network_id = aws_networkmanager_core_network.example.id
+  subnet_arns     = aws_subnet.example_us_east_1[*].arn
+  vpc_arn         = aws_vpc.example_us_east_1.arn
+}
+```
+
+#### Option 2 - using base_policy_regions
 
 ```terraform
 resource "aws_networkmanager_global_network" "example" {}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

From the referenced issue, Core Network Edge Location's ASN numbers cannot be updated. There is a base policy feature in Core Network that currently allows `base_policy_regions` to be specified. These regions are propagated to a policy's Edge Location's with ASNs automatically assigned to them. This presents issues when custom ASNs should be assigned to the edge locations which cannot be done in an update.

To address this, this PR introduces the `base_policy_policy_document` argument to allow practitioners to fully customize the base policy. This allows specific values for ASN per edge location starting from the original base policy. Subsequent policies can keep the same ASN and as such the ASNs would not have to be updated.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #33709 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccNetworkManagerCoreNetwork_createBasePolicyDocumentWithPolicyDocument' PKG=networkmanager ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/networkmanager/... -v -count 1 -parallel 2  -run=TestAccNetworkManagerCoreNetwork_createBasePolicyDocumentWithPolicyDocument -timeout 360m
=== RUN   TestAccNetworkManagerCoreNetwork_createBasePolicyDocumentWithPolicyDocument
=== PAUSE TestAccNetworkManagerCoreNetwork_createBasePolicyDocumentWithPolicyDocument
=== CONT  TestAccNetworkManagerCoreNetwork_createBasePolicyDocumentWithPolicyDocument
--- PASS: TestAccNetworkManagerCoreNetwork_createBasePolicyDocumentWithPolicyDocument (1442.63s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/networkmanager     1442.741s

...
```
