### PR TITLE
Lex : rejection_statement: make rejection_statement optional within follow_up_prompt block fixes #33695

### DIFF
--- a/internal/service/lexmodels/intent.go
+++ b/internal/service/lexmodels/intent.go
@@ -112,7 +112,7 @@ func ResourceIntent() *schema.Resource {
 						},
 						"rejection_statement": {
 							Type:     schema.TypeList,
-							Required: true,
+							Optional: true,
 							MinItems: 1,
 							MaxItems: 1,
 							Elem:     statementResource,

--- a/internal/service/lexmodels/intent_test.go
+++ b/internal/service/lexmodels/intent_test.go
@@ -348,6 +348,26 @@ func TestAccLexModelsIntent_followUpPrompt(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"create_version"},
 			},
+			{
+				Config: testAccIntentConfig_followUpPromptUpdateWithoutRejectionStatement(testIntentID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIntentExists(ctx, rName, &v),
+
+					resource.TestCheckResourceAttr(rName, "follow_up_prompt.0.prompt.0.max_attempts", "3"),
+					resource.TestCheckResourceAttr(rName, "follow_up_prompt.0.prompt.0.message.#", "3"),
+					resource.TestCheckResourceAttr(rName, "follow_up_prompt.0.prompt.0.message.0.content", "Would you like to order more flowers?"),
+					resource.TestCheckResourceAttr(rName, "follow_up_prompt.0.prompt.0.message.0.content_type", "PlainText"),
+					resource.TestCheckResourceAttr(rName, "follow_up_prompt.0.prompt.0.message.1.content", "Would you like to start another order?"),
+					resource.TestCheckResourceAttr(rName, "follow_up_prompt.0.prompt.0.message.1.content_type", "PlainText"),
+					resource.TestCheckResourceAttr(rName, "follow_up_prompt.0.prompt.0.response_card", "{\"version\":1,\"contentType\":\"application/vnd.amazonaws.card.generic\",\"genericAttachments\":[{\"title\":\"Would you like to start another order?\",\"buttons\":[{\"text\":\"Yes\",\"value\":\"yes\"},{\"text\":\"No\",\"value\":\"no\"}]}]}"),
+				),
+			},
+			{
+				ResourceName:            rName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"create_version"},
+			},
 		},
 	})
 }
@@ -1007,6 +1027,31 @@ resource "aws_lex_intent" "test" {
         content_type = "PlainText"
       }
       response_card = "Okay, additional flowers will be ordered."
+    }
+  }
+}
+`, rName)
+}
+
+func testAccIntentConfig_followUpPromptUpdateWithoutRejectionStatement(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_lex_intent" "test" {
+  name = "%s"
+  fulfillment_activity {
+    type = "ReturnIntent"
+  }
+  follow_up_prompt {
+    prompt {
+      max_attempts = 3
+      message {
+        content      = "Would you like to order more flowers?"
+        content_type = "PlainText"
+      }
+      message {
+        content      = "Would you like to start another order?"
+        content_type = "PlainText"
+      }
+      response_card = "{\"version\":1,\"contentType\":\"application/vnd.amazonaws.card.generic\",\"genericAttachments\":[{\"title\":\"Would you like to start another order?\",\"buttons\":[{\"text\":\"Yes\",\"value\":\"yes\"},{\"text\":\"No\",\"value\":\"no\"}]}]}"
     }
   }
 }


### PR DESCRIPTION
Lex : rejection_statement: make rejection_statement optional within follow_up_prompt block fixes #33695

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
As explained in #33695 this block is not required, but optional (provider doc actually already states this).

### Relations
Closes #33695

### References
See https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lex_intent#follow_up_prompt

### Output from Acceptance Testing
I added a test to explicitly check this. Let's wait to see test results.