### PR TITLE
Add portfolio share data source (WIP)

### DIFF
--- a/internal/service/servicecatalog/portfolio_share_data_source.go
+++ b/internal/service/servicecatalog/portfolio_share_data_source.go
@@ -1,0 +1,102 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package servicecatalog
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/servicecatalog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+)
+
+// @SDKDataSource("aws_servicecatalog_portfolio")
+func DataSourceSharePortfolio() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourcePortfolioShareRead,
+
+		// Timeouts: &schema.ResourceTimeout{
+		//	Read: schema.DefaultTimeout(ConstraintReadTimeout),
+		// },
+
+		Schema: map[string]*schema.Schema{
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"portfolio_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"accepted": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"share_principals": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"principal_ids": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourcePortfolioShareRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).ServiceCatalogConn(ctx)
+
+	PortfolioId := strings.Split(d.Get("portfolio_id").(string), ":")
+
+	input := &servicecatalog.DescribePortfolioSharesInput{
+		PortfolioId: aws.String(PortfolioId[0]),
+		Type:        aws.String(d.Get("type").(string)),
+	}
+
+	output, err := conn.DescribePortfolioShares(input)
+
+	detail := output.PortfolioShareDetails
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "getting Service Catalog Portfolio %s: %s", *detail[1].PrincipalId, err) // d.Get("portfolio_id"), err)
+	}
+
+	if output == nil { // || output.PortfolioShareDetails == nil {
+		return sdkdiag.AppendErrorf(diags, "getting Service Catalog Portfolio (%s): empty response", d.Get("portfolio_id").(string))
+	}
+
+	principalIds := []string{}
+	accepted := []string{}
+	sharePrincipals := []string{}
+	accountType := []string{}
+
+	for i := 0; i < len(detail); i++ {
+		principalIds = append(principalIds, *detail[i].PrincipalId)
+		accepted = append(accepted, strconv.FormatBool(*detail[i].Accepted))
+		sharePrincipals = append(sharePrincipals, strconv.FormatBool(*detail[i].SharePrincipals))
+		accountType = append(accountType, *detail[i].Type)
+	}
+
+	PrincipalIds := strings.Join(principalIds, ",")
+	Accepted := strings.Join(accepted, ",")
+	SharePrincipals := strings.Join(sharePrincipals, ",")
+	AccountType := strings.Join(accountType, ",")
+
+	// return sdkdiag.AppendErrorf(diags, "getting Service Catalog Portfolio %s: %s", AccountType, err) // d.Get("portfolio_id"), err)
+
+	d.SetId(PortfolioId[0])
+	d.Set("type", AccountType)
+	d.Set("accepted", Accepted)
+	d.Set("share_principals", SharePrincipals)
+	d.Set("principal_ids", PrincipalIds)
+	d.Set("wait_for_acceptance", false)
+	return diags // sdkdiag.AppendErrorf(diags, detail)
+}

--- a/internal/service/servicecatalog/service_package_gen.go
+++ b/internal/service/servicecatalog/service_package_gen.go
@@ -38,6 +38,10 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 			TypeName: "aws_servicecatalog_portfolio",
 		},
 		{
+			Factory:  DataSourceSharePortfolio,
+			TypeName: "aws_servicecatalog_portfolio_share",
+		},
+		{
 			Factory:  DataSourcePortfolioConstraints,
 			TypeName: "aws_servicecatalog_portfolio_constraints",
 		},


### PR DESCRIPTION
> ### Description
> 
> Terraform currently lacks a data source which lists all imported portfolios for which account-to-account shares were accepted by an account. There is an equivalent in Python SDK and CloudFormation but is currently not supported by Terraform AWS Provider.
> 
> Python SDK: https://boto3.amazonaws.com/v1/documentation/api/1.26.87/reference/services/servicecatalog/client/list_accepted_portfolio_shares.html
> 
> AWS CloudFormation: https://docs.aws.amazon.com/servicecatalog/latest/dg/API_ListAcceptedPortfolioShares.html
> ### Requested Resource(s) and/or Data Source(s)
> 
> aws_servicecatalog_l_portfolio_shares
> ### Potential Terraform Configuration
> 
> ```terraform
> data "aws_servicecatalog_list_accepted_portfolio_shares" "example" {
>   portfolio_share_type = "AWS_ORGANIZATIONS"
> }
> ```
> 
> ### References
> 
> https://boto3.amazonaws.com/v1/documentation/api/1.26.87/reference/services/servicecatalog/client/list_accepted_portfolio_shares.html https://docs.aws.amazon.com/servicecatalog/latest/dg/API_ListAcceptedPortfolioShares.html
> ### Would you like to implement a fix?
> 
> None

```data "aws_servicecatalog_portfolio_share" "example" {
      portfolio_id = aws_servicecatalog_portfolio_share.example.id
      type = "ACCOUNT"
}

output "shares" {
  value = data.aws_servicecatalog_portfolio_share.example
}

shares = {
  "accepted" = "false,true,false"
  "id" = "port-tl2aj12345678"
  "portfolio_id" = "port-tl2aj2qgqefca:ACCOUNT:000000000000"
  "principal_ids" = "33333333333,222222222222,111111111111111"
  "share_principals" = "false,false,false"
  "type" = "ACCOUNT,ACCOUNT,ACCOUNT"
}

```

### Relations

Closes #33673

### References

### Output from Acceptance Testing
TESTS WIP


