### PR TITLE
[New Resource]: `aws_servicequotas_template_association`

### DIFF
--- a/.changelog/33725.txt
+++ b/.changelog/33725.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_servicequotas_template_association
+```

--- a/internal/service/servicequotas/exports_test.go
+++ b/internal/service/servicequotas/exports_test.go
@@ -5,5 +5,6 @@ package servicequotas
 
 // Exports for use in tests only.
 var (
-	ResourceTemplate = newResourceTemplate
+	ResourceTemplate            = newResourceTemplate
+	ResourceTemplateAssociation = newResourceTemplateAssociation
 )

--- a/internal/service/servicequotas/service_package_gen.go
+++ b/internal/service/servicequotas/service_package_gen.go
@@ -24,6 +24,10 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 			Factory: newResourceTemplate,
 			Name:    "Template",
 		},
+		{
+			Factory: newResourceTemplateAssociation,
+			Name:    "Template Association",
+		},
 	}
 }
 

--- a/internal/service/servicequotas/servicequotas_test.go
+++ b/internal/service/servicequotas/servicequotas_test.go
@@ -13,6 +13,11 @@ func TestAccServiceQuotas_serial(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]map[string]func(t *testing.T){
+		"Template": {
+			"basic":      testAccTemplate_basic,
+			"disappears": testAccTemplate_disappears,
+			"value":      testAccTemplate_value,
+		},
 		"TemplateAssociation": {
 			"basic":       testAccTemplateAssociation_basic,
 			"disappears":  testAccTemplateAssociation_disappears,

--- a/internal/service/servicequotas/servicequotas_test.go
+++ b/internal/service/servicequotas/servicequotas_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package servicequotas_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccServiceQuotas_serial(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]map[string]func(t *testing.T){
+		"TemplateAssociation": {
+			"basic":       testAccTemplateAssociation_basic,
+			"disappears":  testAccTemplateAssociation_disappears,
+			"skipDestroy": testAccTemplateAssociation_skipDestroy,
+		},
+	}
+
+	acctest.RunSerialTests2Levels(t, testCases, 0)
+}

--- a/internal/service/servicequotas/template_association.go
+++ b/internal/service/servicequotas/template_association.go
@@ -1,0 +1,149 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package servicequotas
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/servicequotas"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/servicequotas/types"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource(name="Template Association")
+func newResourceTemplateAssociation(_ context.Context) (resource.ResourceWithConfigure, error) {
+	return &resourceTemplateAssociation{}, nil
+}
+
+const (
+	ResNameTemplateAssociation = "Template Association"
+)
+
+type resourceTemplateAssociation struct {
+	framework.ResourceWithConfigure
+}
+
+func (r *resourceTemplateAssociation) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "aws_servicequotas_template_association"
+}
+
+func (r *resourceTemplateAssociation) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": framework.IDAttribute(),
+			"skip_destroy": schema.BoolAttribute{
+				Optional: true,
+			},
+			"status": schema.StringAttribute{
+				Computed: true,
+			},
+		},
+	}
+}
+
+func (r *resourceTemplateAssociation) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().ServiceQuotasClient(ctx)
+
+	var plan resourceTemplateAssociationData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	plan.ID = types.StringValue(r.Meta().AccountID)
+
+	_, err := conn.AssociateServiceQuotaTemplate(ctx, &servicequotas.AssociateServiceQuotaTemplateInput{})
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.ServiceQuotas, create.ErrActionCreating, ResNameTemplateAssociation, plan.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	// Status is not returned from Associate API, so call Get to get computed value
+	out, err := conn.GetAssociationForServiceQuotaTemplate(ctx, &servicequotas.GetAssociationForServiceQuotaTemplateInput{})
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.ServiceQuotas, create.ErrActionCreating, ResNameTemplateAssociation, plan.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	plan.Status = flex.StringValueToFramework(ctx, string(out.ServiceQuotaTemplateAssociationStatus))
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *resourceTemplateAssociation) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().ServiceQuotasClient(ctx)
+
+	var state resourceTemplateAssociationData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := conn.GetAssociationForServiceQuotaTemplate(ctx, &servicequotas.GetAssociationForServiceQuotaTemplateInput{})
+	if out == nil || out.ServiceQuotaTemplateAssociationStatus == awstypes.ServiceQuotaTemplateAssociationStatusDisassociated {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.ServiceQuotas, create.ErrActionSetting, ResNameTemplateAssociation, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	state.Status = flex.StringValueToFramework(ctx, string(out.ServiceQuotaTemplateAssociationStatus))
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+// Update is a no-op
+func (r *resourceTemplateAssociation) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+}
+
+func (r *resourceTemplateAssociation) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	conn := r.Meta().ServiceQuotasClient(ctx)
+
+	var state resourceTemplateAssociationData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if state.SkipDestroy.ValueBool() {
+		return
+	}
+
+	_, err := conn.DisassociateServiceQuotaTemplate(ctx, &servicequotas.DisassociateServiceQuotaTemplateInput{})
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.ServiceQuotas, create.ErrActionDeleting, ResNameTemplateAssociation, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+}
+
+func (r *resourceTemplateAssociation) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+type resourceTemplateAssociationData struct {
+	ID          types.String `tfsdk:"id"`
+	SkipDestroy types.Bool   `tfsdk:"skip_destroy"`
+	Status      types.String `tfsdk:"status"`
+}

--- a/internal/service/servicequotas/template_association_test.go
+++ b/internal/service/servicequotas/template_association_test.go
@@ -1,0 +1,209 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package servicequotas_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/servicequotas"
+	"github.com/aws/aws-sdk-go-v2/service/servicequotas/types"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tfservicequotas "github.com/hashicorp/terraform-provider-aws/internal/service/servicequotas"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func testAccTemplateAssociation_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_servicequotas_template_association.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckRegion(t, names.USEast1RegionID)
+			acctest.PreCheckPartitionHasService(t, names.ServiceQuotasEndpointID)
+			testAccPreCheckTemplate(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceQuotasEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTemplateAssociationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTemplateAssociationConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTemplateAssociationExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "status", string(types.ServiceQuotaTemplateAssociationStatusAssociated)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccTemplateAssociation_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_servicequotas_template_association.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckRegion(t, names.USEast1RegionID)
+			acctest.PreCheckPartitionHasService(t, names.ServiceQuotasEndpointID)
+			testAccPreCheckTemplate(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceQuotasEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTemplateAssociationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTemplateAssociationConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTemplateAssociationExists(ctx, resourceName),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfservicequotas.ResourceTemplateAssociation, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccTemplateAssociation_skipDestroy(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_servicequotas_template_association.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckRegion(t, names.USEast1RegionID)
+			acctest.PreCheckPartitionHasService(t, names.ServiceQuotasEndpointID)
+			testAccPreCheckTemplate(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceQuotasEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTemplateAssociationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTemplateAssociationConfig_skipDestroy(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTemplateAssociationExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "status", string(types.ServiceQuotaTemplateAssociationStatusAssociated)),
+				),
+			},
+			{
+				// aws_servicequotas_template_association resource is removed from config
+				Config: testAccTemplateConfig_basic(lambdaENIQuotaCode, lambdaServiceCode, lambdaENIValue),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTemplateAssociationAssociated(ctx), // verify association is still live on the remote
+				),
+			},
+			{
+				// Use the basic config to remove association on destroy
+				Config: testAccTemplateAssociationConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTemplateAssociationExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "status", string(types.ServiceQuotaTemplateAssociationStatusAssociated)),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckTemplateAssociationDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ServiceQuotasClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_servicequotas_template_association" {
+				continue
+			}
+
+			out, err := conn.GetAssociationForServiceQuotaTemplate(ctx, &servicequotas.GetAssociationForServiceQuotaTemplateInput{})
+			if out != nil && out.ServiceQuotaTemplateAssociationStatus == types.ServiceQuotaTemplateAssociationStatusDisassociated {
+				return nil
+			}
+			if err != nil {
+				return create.Error(names.ServiceQuotas, create.ErrActionCheckingDestroyed, tfservicequotas.ResNameTemplateAssociation, rs.Primary.ID, err)
+			}
+
+			return create.Error(names.ServiceQuotas, create.ErrActionCheckingDestroyed, tfservicequotas.ResNameTemplateAssociation, rs.Primary.ID, errors.New("not destroyed"))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckTemplateAssociationExists(ctx context.Context, name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.ServiceQuotas, create.ErrActionCheckingExistence, tfservicequotas.ResNameTemplateAssociation, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.ServiceQuotas, create.ErrActionCheckingExistence, tfservicequotas.ResNameTemplateAssociation, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ServiceQuotasClient(ctx)
+		out, err := conn.GetAssociationForServiceQuotaTemplate(ctx, &servicequotas.GetAssociationForServiceQuotaTemplateInput{})
+		if err != nil {
+			return create.Error(names.ServiceQuotas, create.ErrActionCheckingExistence, tfservicequotas.ResNameTemplateAssociation, rs.Primary.ID, err)
+		}
+		if out != nil && out.ServiceQuotaTemplateAssociationStatus == types.ServiceQuotaTemplateAssociationStatusDisassociated {
+			return create.Error(names.ServiceQuotas, create.ErrActionCheckingExistence, tfservicequotas.ResNameTemplateAssociation, rs.Primary.ID, fmt.Errorf("unexpected status: %s", out.ServiceQuotaTemplateAssociationStatus))
+		}
+
+		return nil
+	}
+}
+
+// testAccCheckTemplateAssociationAssociated is a helper function for verifying a
+// template association remains in place when the skip_destroy argument is set to true
+// and the association resource is removed
+func testAccCheckTemplateAssociationAssociated(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ServiceQuotasClient(ctx)
+
+		out, err := conn.GetAssociationForServiceQuotaTemplate(ctx, &servicequotas.GetAssociationForServiceQuotaTemplateInput{})
+		if err != nil {
+			return create.Error(names.ServiceQuotas, create.ErrActionCheckingExistence, tfservicequotas.ResNameTemplateAssociation, "", err)
+		}
+		if out == nil || out.ServiceQuotaTemplateAssociationStatus != types.ServiceQuotaTemplateAssociationStatusAssociated {
+			return create.Error(names.ServiceQuotas, create.ErrActionCheckingExistence, tfservicequotas.ResNameTemplateAssociation, "", fmt.Errorf("unexpected status: %s", out.ServiceQuotaTemplateAssociationStatus))
+		}
+
+		return nil
+	}
+}
+
+func testAccTemplateAssociationConfig_basic() string {
+	return acctest.ConfigCompose(
+		testAccTemplateConfig_basic(lambdaENIQuotaCode, lambdaServiceCode, lambdaENIValue),
+		`
+resource "aws_servicequotas_template_association" "test" {
+  depends_on = ["aws_servicequotas_template.test"]
+}
+`)
+}
+
+func testAccTemplateAssociationConfig_skipDestroy() string {
+	return acctest.ConfigCompose(
+		testAccTemplateConfig_basic(lambdaENIQuotaCode, lambdaServiceCode, lambdaENIValue),
+		`
+resource "aws_servicequotas_template_association" "test" {
+  depends_on = ["aws_servicequotas_template.test"]
+
+  skip_destroy = true
+}
+`)
+}

--- a/internal/service/servicequotas/template_test.go
+++ b/internal/service/servicequotas/template_test.go
@@ -35,13 +35,13 @@ const (
 	lambdaENIValueUpdated = "300"        // Default is 250
 )
 
-func TestAccServiceQuotasTemplate_basic(t *testing.T) {
+func testAccTemplate_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var template types.ServiceQuotaIncreaseRequestInTemplate
 	resourceName := "aws_servicequotas_template.test"
 	regionDataSourceName := "data.aws_region.current"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckRegion(t, names.USEast1RegionID)
@@ -53,7 +53,6 @@ func TestAccServiceQuotasTemplate_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckTemplateDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				// Use a distinct quota code for each test to ensure parallel tests run safely
 				Config: testAccTemplateConfig_basic(lambdaStorageQuotaCode, lambdaServiceCode, lambdaStorageValue),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTemplateExists(ctx, resourceName, &template),
@@ -72,12 +71,12 @@ func TestAccServiceQuotasTemplate_basic(t *testing.T) {
 	})
 }
 
-func TestAccServiceQuotasTemplate_disappears(t *testing.T) {
+func testAccTemplate_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var template types.ServiceQuotaIncreaseRequestInTemplate
 	resourceName := "aws_servicequotas_template.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckRegion(t, names.USEast1RegionID)
@@ -89,7 +88,6 @@ func TestAccServiceQuotasTemplate_disappears(t *testing.T) {
 		CheckDestroy:             testAccCheckTemplateDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				// Use a distinct quota code for each test to ensure parallel tests run safely
 				Config: testAccTemplateConfig_basic(lambdaConcurrentExecQuotaCode, lambdaServiceCode, lambdaConcurrentExecValue),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTemplateExists(ctx, resourceName, &template),
@@ -101,13 +99,13 @@ func TestAccServiceQuotasTemplate_disappears(t *testing.T) {
 	})
 }
 
-func TestAccServiceQuotasTemplate_value(t *testing.T) {
+func testAccTemplate_value(t *testing.T) {
 	ctx := acctest.Context(t)
 	var template types.ServiceQuotaIncreaseRequestInTemplate
 	resourceName := "aws_servicequotas_template.test"
 	regionDataSourceName := "data.aws_region.current"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckRegion(t, names.USEast1RegionID)
@@ -119,7 +117,6 @@ func TestAccServiceQuotasTemplate_value(t *testing.T) {
 		CheckDestroy:             testAccCheckTemplateDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				// Use a distinct quota code for each test to ensure parallel tests run safely
 				Config: testAccTemplateConfig_basic(lambdaENIQuotaCode, lambdaServiceCode, lambdaENIValue),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTemplateExists(ctx, resourceName, &template),

--- a/website/docs/r/servicequotas_template_association.html.markdown
+++ b/website/docs/r/servicequotas_template_association.html.markdown
@@ -1,0 +1,50 @@
+---
+subcategory: "Service Quotas"
+layout: "aws"
+page_title: "AWS: aws_servicequotas_template_association"
+description: |-
+  Terraform resource for managing an AWS Service Quotas Template Association.
+---
+# Resource: aws_servicequotas_template_association
+
+Terraform resource for managing an AWS Service Quotas Template Association.
+
+-> Only the management account of an organization can associate Service Quota templates, and this must be done from the `us-east-1` region.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_servicequotas_template_association" "example" {}
+```
+
+## Argument Reference
+
+The following arguments are optional:
+
+* `skip_destroy` - (Optional) Skip disassociating the quota increase template upon destruction. This will remove the resource from Terraform state, but leave the remote association in place.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `id` - AWS account ID.
+* `status` - Association status. Creating this resource will result in an `ASSOCIATED` status, and quota increase requests in the template are automatically applied to new AWS accounts in the organization.
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Service Quotas Template Association using the `example_id_arg`. For example:
+
+```terraform
+import {
+  to = aws_servicequotas_template_association.example
+  id = "012345678901"
+}
+```
+
+Using `terraform import`, import Service Quotas Template Association using the `id`. For example:
+
+```console
+% terraform import aws_servicequotas_template_association.example 012345678901 
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The `aws_servicequotas_template_association` resource allows a management organization to associate (activate) a quota increases template to be applied across new member accounts.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #9119

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/servicequotas/2019-06-24/apireference/API_GetAssociationForServiceQuotaTemplate.html
- https://docs.aws.amazon.com/servicequotas/2019-06-24/apireference/API_AssociateServiceQuotaTemplate.html
- https://docs.aws.amazon.com/servicequotas/2019-06-24/apireference/API_DisassociateServiceQuotaTemplate.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=servicequotas TESTS=TestAccServiceQuotas_serial/TemplateAssociation
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/servicequotas/... -v -count 1 -parallel 20 -run='TestAccServiceQuotas_serial/TemplateAssociation'  -timeout 360m

--- PASS: TestAccServiceQuotas_serial (51.38s)
    --- PASS: TestAccServiceQuotas_serial/TemplateAssociation (51.37s)
        --- PASS: TestAccServiceQuotas_serial/TemplateAssociation/skipDestroy (28.12s)
        --- PASS: TestAccServiceQuotas_serial/TemplateAssociation/basic (12.29s)
        --- PASS: TestAccServiceQuotas_serial/TemplateAssociation/disappears (10.97s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/servicequotas      54.517s
```
