### PR TITLE
added segmentation_mode attribute for aws_medialive_channel hls_group…

### DIFF
--- a/.changelog/33757.txt
+++ b/.changelog/33757.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_medialive_channel: Added segmentation_mode for hls_group_settings.
+```

--- a/internal/service/medialive/channel_encoder_settings_schema.go
+++ b/internal/service/medialive/channel_encoder_settings_schema.go
@@ -1011,6 +1011,12 @@ func channelEncoderSettingsSchema() *schema.Schema {
 														Optional: true,
 														Computed: true,
 													},
+													"segmentation_mode": {
+														Type:             schema.TypeString,
+														Optional:         true,
+														Computed:         true,
+														ValidateDiagFunc: enum.Validate[types.HlsSegmentationMode](),
+													},
 													"segments_per_subdirectory": {
 														Type:     schema.TypeInt,
 														Optional: true,
@@ -3778,6 +3784,9 @@ func expandHLSGroupSettings(tfList []interface{}) *types.HlsGroupSettings {
 	if v, ok := m["segment_length"].(int); ok {
 		out.SegmentLength = int32(v)
 	}
+	if v, ok := m["segmentation_mode"].(string); ok {
+		out.SegmentationMode = types.HlsSegmentationMode(v)
+	}
 	if v, ok := m["segments_per_subdirectory"].(int); ok {
 		out.SegmentsPerSubdirectory = int32(v)
 	}
@@ -6309,6 +6318,7 @@ func flattenOutputGroupSettingsHLSGroupSettings(in *types.HlsGroupSettings) []in
 		"program_date_time_period":     int(in.ProgramDateTimePeriod),
 		"redundant_manifest":           string(in.RedundantManifest),
 		"segment_length":               int(in.SegmentLength),
+		"segmentation_mode":            string(in.SegmentationMode),
 		"segments_per_subdirectory":    int(in.SegmentsPerSubdirectory),
 		"stream_inf_resolution":        string(in.StreamInfResolution),
 		"timed_metadata_id3_frame":     string(in.TimedMetadataId3Frame),

--- a/internal/service/medialive/channel_encoder_settings_schema.go
+++ b/internal/service/medialive/channel_encoder_settings_schema.go
@@ -5027,7 +5027,7 @@ func expandChannelEncoderSettingsCaptionDescriptionsDestinationSettings(tfList [
 		out.SmpteTtDestinationSettings = &types.SmpteTtDestinationSettings{} // only unexported fields
 	}
 	if v, ok := m["teletext_destination_settings"].([]interface{}); ok && len(v) > 0 {
-		out.TeletextDestinationSettings = &types.TeletextDestinationSettings{} // only unexported fields
+		out.TeletextDestinationSettings = expandsCaptionDescriptionsDestinationSettingsTeletextDestinationSettings(v)
 	}
 	if v, ok := m["ttml_destination_settings"].([]interface{}); ok && len(v) > 0 {
 		out.TtmlDestinationSettings = expandsCaptionDescriptionsDestinationSettingsTtmlDestinationSettings(v)
@@ -5188,6 +5188,16 @@ func expandsCaptionDescriptionsDestinationSettingsEbuTtDDestinationSettings(tfLi
 	if v, ok := m["style_control"].(string); ok && len(v) > 0 {
 		out.StyleControl = types.EbuTtDDestinationStyleControl(v)
 	}
+
+	return &out
+}
+
+func expandsCaptionDescriptionsDestinationSettingsTeletextDestinationSettings(tfList []interface{}) *types.TeletextDestinationSettings {
+	if tfList == nil {
+		return nil
+	}
+
+	var out types.TeletextDestinationSettings
 
 	return &out
 }
@@ -6726,7 +6736,7 @@ func flattenCaptionDescriptionsCaptionDestinationSettings(in *types.CaptionDesti
 		"scte20_plus_embedded_destination_settings": []interface{}{}, // attribute has no exported fields
 		"scte27_destination_settings":               []interface{}{}, // attribute has no exported fields
 		"smpte_tt_destination_settings":             []interface{}{}, // attribute has no exported fields
-		"teletext_destination_settings":             []interface{}{}, // attribute has no exported fields
+		"teletext_destination_settings":             flattenCaptionDescriptionsCaptionDestinationSettingsTeletextDestinationSettings(in.TeletextDestinationSettings),
 		"ttml_destination_settings":                 flattenCaptionDescriptionsCaptionDestinationSettingsTtmlDestinationSettings(in.TtmlDestinationSettings),
 		"webvtt_destination_settings":               flattenCaptionDescriptionsCaptionDestinationSettingsWebvttDestinationSettings(in.WebvttDestinationSettings),
 	}
@@ -6801,6 +6811,16 @@ func flattenCaptionDescriptionsCaptionDestinationSettingsEbuTtDDestinationSettin
 		"font_family":      aws.ToString(in.FontFamily),
 		"style_control":    string(in.StyleControl),
 	}
+
+	return []interface{}{m}
+}
+
+func flattenCaptionDescriptionsCaptionDestinationSettingsTeletextDestinationSettings(in *types.TeletextDestinationSettings) []interface{} {
+	if in == nil {
+		return nil
+	}
+
+	m := map[string]interface{}{}
 
 	return []interface{}{m}
 }

--- a/internal/service/medialive/channel_test.go
+++ b/internal/service/medialive/channel_test.go
@@ -635,6 +635,7 @@ func TestAccMediaLiveChannel_hls(t *testing.T) {
 						"name": "test-video-name",
 					}),
 					resource.TestCheckResourceAttr(resourceName, "encoder_settings.0.output_groups.0.outputs.0.output_settings.0.hls_output_settings.0.h265_packaging_type", "HVC1"),
+					resource.TestCheckResourceAttr(resourceName, "encoder_settings.0.output_groups.0.output_group_settings.0.hls_group_settings.0.segmentation_mode", "USE_SEGMENT_DURATION"),
 				),
 			},
 		},
@@ -1774,6 +1775,7 @@ resource "aws_medialive_channel" "test" {
           destination {
             destination_ref_id = %[1]q
           }
+          segmentation_mode = "USE_SEGMENT_DURATION"
         }
       }
 


### PR DESCRIPTION
…_settings

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Added missing attribute `segmentation_mode` to `hls_group_settings`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccMediaLiveChannel_hls PKG=medialive
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/medialive/... -v -count 1 -parallel 20 -run='TestAccMediaLiveChannel_hls'  -timeout 360m
 === RUN   TestAccMediaLiveChannel_hls
=== PAUSE TestAccMediaLiveChannel_hls
=== CONT  TestAccMediaLiveChannel_hls
--- PASS: TestAccMediaLiveChannel_hls (68.48s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/medialive	70.588s
...
```
