### PR TITLE
fix: add additional tgw route filter 🌽

### DIFF
--- a/.changelog/33765.txt
+++ b/.changelog/33765.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ec2_transit_gateway_route : Fix TGW route search filter to avoid routes being missed when more than 1,000 static routes are in a TGW route table
+```

--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -4601,7 +4601,7 @@ func FindTransitGatewayStaticRoute(ctx context.Context, conn *ec2.EC2, transitGa
 	input := &ec2.SearchTransitGatewayRoutesInput{
 		Filters: BuildAttributeFilterList(map[string]string{
 			"type": ec2.TransitGatewayRouteTypeStatic,
-			"route-search.exact-match": *aws.String(destination),
+			"route-search.exact-match": destination,
 		}),
 		TransitGatewayRouteTableId: aws.String(transitGatewayRouteTableID),
 	}

--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -4601,6 +4601,7 @@ func FindTransitGatewayStaticRoute(ctx context.Context, conn *ec2.EC2, transitGa
 	input := &ec2.SearchTransitGatewayRoutesInput{
 		Filters: BuildAttributeFilterList(map[string]string{
 			"type": ec2.TransitGatewayRouteTypeStatic,
+			"route-search.exact-match": aws.String(destination),
 		}),
 		TransitGatewayRouteTableId: aws.String(transitGatewayRouteTableID),
 	}

--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -4600,7 +4600,7 @@ func FindTransitGatewayPrefixListReferenceByTwoPartKey(ctx context.Context, conn
 func FindTransitGatewayStaticRoute(ctx context.Context, conn *ec2.EC2, transitGatewayRouteTableID, destination string) (*ec2.TransitGatewayRoute, error) {
 	input := &ec2.SearchTransitGatewayRoutesInput{
 		Filters: BuildAttributeFilterList(map[string]string{
-			"type": ec2.TransitGatewayRouteTypeStatic,
+			"type":                     ec2.TransitGatewayRouteTypeStatic,
 			"route-search.exact-match": destination,
 		}),
 		TransitGatewayRouteTableId: aws.String(transitGatewayRouteTableID),

--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -4601,7 +4601,7 @@ func FindTransitGatewayStaticRoute(ctx context.Context, conn *ec2.EC2, transitGa
 	input := &ec2.SearchTransitGatewayRoutesInput{
 		Filters: BuildAttributeFilterList(map[string]string{
 			"type": ec2.TransitGatewayRouteTypeStatic,
-			"route-search.exact-match": destination,
+			"route-search.exact-match": *aws.String(destination),
 		}),
 		TransitGatewayRouteTableId: aws.String(transitGatewayRouteTableID),
 	}

--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -4601,7 +4601,7 @@ func FindTransitGatewayStaticRoute(ctx context.Context, conn *ec2.EC2, transitGa
 	input := &ec2.SearchTransitGatewayRoutesInput{
 		Filters: BuildAttributeFilterList(map[string]string{
 			"type": ec2.TransitGatewayRouteTypeStatic,
-			"route-search.exact-match": aws.String(destination),
+			"route-search.exact-match": destination,
 		}),
 		TransitGatewayRouteTableId: aws.String(transitGatewayRouteTableID),
 	}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
fixing the transit gateway route search function by adding an additional filter.  when more than 1,000 routes are present in a route table and the filter matches ore than 1,000 routes, the list is truncated.  as noted in the linked issue, terraform will try to start recreating routes if they aren't returned


### Relations
closes #33762 


### References
https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_SearchTransitGatewayRoutes.html
https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/ec2/find.go#L4600


### Output from Acceptance Testing
NOTE: I need help with testing this from the admins/maintainers.  I validated the filter works as desired via the AWS CLI