### PR TITLE
Use default tags for ec2 root block device 

### DIFF
--- a/.changelog/33769.txt
+++ b/.changelog/33769.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_instance: Apply default tags to volumes/block devices managed through an `aws_instance`, add `ebs_block_device.*.tags_all` and `root_block_device.*.tags_all` attributes which include default tags
+```

--- a/docs/resource-tagging.md
+++ b/docs/resource-tagging.md
@@ -335,7 +335,7 @@ implement the logic to convert the configuration tags into the service tags, e.g
 === "Terraform Plugin SDK V2"
     ```go
     // Typically declared near conn := /*...*/
-    defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
+    defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
     tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
     input := &eks.CreateClusterInput{
@@ -349,7 +349,7 @@ If the service API does not allow passing an empty list, the logic can be adjust
 === "Terraform Plugin SDK V2"
     ```go
     // Typically declared near conn := /*...*/
-    defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
+    defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
     tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
     input := &eks.CreateClusterInput{
@@ -367,7 +367,7 @@ implement the logic to convert the configuration tags into the service API call 
 === "Terraform Plugin SDK V2"
     ```go
     // Typically declared near conn := /*...*/
-    defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
+    defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
     tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
     /* ... creation steps ... */
@@ -380,18 +380,18 @@ implement the logic to convert the configuration tags into the service API call 
     ```
 
 Some EC2 resources (e.g., [`aws_ec2_fleet`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_fleet)) have a `TagSpecifications` field in the `InputStruct` instead of a `Tags` field.
-In these cases the `tagSpecificationsFromKeyValueTags()` helper function should be used.
+In these cases the `tagSpecificationsFromKeyValue()` helper function should be used.
 This example shows using `TagSpecifications`:
 
 === "Terraform Plugin SDK V2"
     ```go
     // Typically declared near conn := /*...*/
-    defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
+    defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
     tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
     input := &ec2.CreateFleetInput{
         /* ... other configuration ... */
-        TagSpecifications: tagSpecificationsFromKeyValueTags(tags, ec2.ResourceTypeFleet),
+        TagSpecifications: tagSpecificationsFromKeyValue(tags, ec2.ResourceTypeFleet),
     }
     ```
 
@@ -402,8 +402,8 @@ In the resource `Read` operation, implement the logic to convert the service tag
 === "Terraform Plugin SDK V2"
     ```go
     // Typically declared near conn := /*...*/
-    defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
-    ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+    defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+    ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
     /* ... other d.Set(...) logic ... */
 
@@ -424,8 +424,8 @@ use the generated `listTags` function, e.g., with Athena Workgroups:
 === "Terraform Plugin SDK V2"
     ```go
     // Typically declared near conn := /*...*/
-    defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
-    ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+    defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+    ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
     /* ... other d.Set(...) logic ... */
 

--- a/internal/provider/intercept.go
+++ b/internal/provider/intercept.go
@@ -248,7 +248,7 @@ func (r tagsResourceInterceptor) run(ctx context.Context, d schemaResourceData, 
 				break
 			}
 
-			if d.GetRawPlan().GetAttr("tags_all").IsWhollyKnown() {
+			if d.GetRawPlan().GetAttr(names.AttrTagsAll).IsWhollyKnown() {
 				if d.HasChange(names.AttrTagsAll) {
 					if identifierAttribute := r.tags.IdentifierAttribute; identifierAttribute != "" {
 						var identifier string

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -946,7 +946,6 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	tagSpecifications = append(tagSpecifications,
 		tagSpecificationsFromKeyValue(
-			ctx,
 			defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("volume_tags").(map[string]interface{}))),
 			ec2.ResourceTypeVolume)...)
 

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -1090,9 +1090,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 				log.Printf("[ERR] Error creating tags for EBS volume %s: %s", vol, err)
 			}
 		}
-
 	}
-
 	// Update if we need to
 	return append(diags, resourceInstanceUpdate(ctx, d, meta)...)
 }
@@ -1495,7 +1493,6 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	if d.HasChange("root_block_device.0.tags") {
-
 		tagSpecifications := getTagSpecificationsIn(ctx, ec2.ResourceTypeInstance)
 
 		// Declare the map outside the loops so values aren't overwritten
@@ -2664,7 +2661,6 @@ func readBlockDeviceMappingsFromConfig(ctx context.Context, d *schema.ResourceDa
 			}
 		}
 	}
-
 	return blockDevices, nil
 }
 

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -266,6 +266,7 @@ func ResourceInstance() *schema.Resource {
 							Computed: true,
 							ForceNew: true,
 						},
+						"tags": tagsSchemaConflictsWith([]string{"volume_tags"}),
 						"throughput": {
 							Type:             schema.TypeInt,
 							Optional:         true,

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -1035,8 +1035,8 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 		// Iterate over each tag within the current tagSpecification
 		for j := 0; j < len(tagSpecifications[i].Tags); j++ {
 			// Extract the key and value from the current tag
-			key := *tagSpecifications[i].Tags[j].Key
-			value := *tagSpecifications[i].Tags[j].Value
+			key := aws.StringValue(tagSpecifications[i].Tags[j].Key)
+			value := aws.StringValue(tagSpecifications[i].Tags[j].Value)
 			// Add the key-value pair to the map
 			tagValues[key] = value //value
 		}
@@ -1501,7 +1501,6 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		return sdkdiag.AppendErrorf(diags, "reading EC2 Instance (%s): %s", d.Id(), err)
 	}
 
-	// if d.HasChange("root_block_device.0.tags") && !d.IsNewResource() {
 	tagSpecifications := getTagSpecificationsIn(ctx, ec2.ResourceTypeInstance)
 
 	// Declare the map outside the loops so values aren't overwritten
@@ -1511,8 +1510,8 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		// Iterate over each tag within the current tagSpecification
 		for j := 0; j < len(tagSpecifications[i].Tags); j++ {
 			// Extract the key and value from the current tag
-			key := *tagSpecifications[i].Tags[j].Key
-			value := *tagSpecifications[i].Tags[j].Value
+			key := aws.StringValue(tagSpecifications[i].Tags[j].Key)
+			value := aws.StringValue(tagSpecifications[i].Tags[j].Value)
 			// Add the key-value pair to the map
 			tagValues[key] = value //value
 		}

--- a/internal/service/ec2/ec2_instance_test.go
+++ b/internal/service/ec2/ec2_instance_test.go
@@ -1604,40 +1604,6 @@ func TestAccEC2Instance_BlockDeviceTags_ebsAndRoot(t *testing.T) {
 	})
 }
 
-// Random Rules of EC2 Instance tags:
-// (there is certainly a better place for this but...)
-// 1. FIVE types of tags can be in play:
-//    - instance tags
-//    - default tags
-//    - volume tags
-//    - root block device tags
-//    - ebs block device tags
-// 2. Instance tags are not applied to the block devices
-// 2. EBS/root device tags conflict with volume tags
-// 3. Default tags are applied to the instance and all block devices
-// 4. Volume tags are applied at creation time to the root block device and ebs block devices
-// 5. Root block device tags behave as expected
-// 6. EBS block device tags cannot be updated
-
-// Not all possible combinations are possible such as vol tags with ebs tags
-// tags:	def vol rbd ebs
-//			0	0	0	0	// tested elsewhere
-//			0	0	0	1	// defaultTags1:step 1
-//			0	0	1	0	// defaultTags2:step 1
-//			0	0	1	1	// defaultTags1:step 2
-//			0	1	0	0	// defaultTags2:step 2
-//			0	1	0	1	// not possible, vol conflict
-//			0	1	1	0	// not possible, vol conflict
-//			0	1	1	1	// not possible, vol conflict
-//			1	0	0	0	// defaultTags2:step 3
-//			1	0	0	1	// defaultTags1:step 3
-//			1	0	1	0	// defaultTags2:step 4
-//			1	0	1	1	// defaultTags1:step 4
-//			1	1	0	0	// defaultTags2:step 5
-//			1	1	0	1	// not possible, vol conflict
-//			1	1	1	0	// not possible, vol conflict
-//			1	1	1	1	// not possible, vol conflict
-
 func TestAccEC2Instance_BlockDeviceTags_defaultTagsVolumeTags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v ec2.Instance

--- a/internal/service/ec2/ec2_instance_test.go
+++ b/internal/service/ec2/ec2_instance_test.go
@@ -1651,7 +1651,7 @@ func TestAccEC2Instance_BlockDeviceTags_defaultTagsVolumeTags(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckInstanceDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -1728,7 +1728,7 @@ func TestAccEC2Instance_BlockDeviceTags_defaultTagsEBSRoot(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckInstanceDestroy(ctx),
 		Steps: []resource.TestStep{

--- a/internal/service/ec2/ec2_instance_test.go
+++ b/internal/service/ec2/ec2_instance_test.go
@@ -1608,7 +1608,6 @@ func TestAccEC2Instance_BlockDeviceTags_defaultTagsVolumeTags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v ec2.Instance
 	resourceName := "aws_instance.test"
-	//rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	emptyMap := map[string]string{}
 	mapWithOneKey1 := map[string]string{"brodo": "baggins"}
@@ -1684,7 +1683,6 @@ func TestAccEC2Instance_BlockDeviceTags_defaultTagsEBSRoot(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v ec2.Instance
 	resourceName := "aws_instance.test"
-	//rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	emptyMap := map[string]string{}
 	mapWithOneKey1 := map[string]string{"gigi": "kitty"}

--- a/internal/service/ec2/ec2_instance_test.go
+++ b/internal/service/ec2/ec2_instance_test.go
@@ -7021,6 +7021,7 @@ func mapToTagConfig(m map[string]string, indent int) string {
 func testAccInstanceConfig_blockDeviceTagsDefaultVolumeRBDEBS(defTg, volTg, rbdTg, ebsTg map[string]string) string {
 	defTgCfg := ""
 	if len(defTg) > 0 {
+		//lintignore:AT004
 		defTgCfg = fmt.Sprintf(`
 provider "aws" {
   default_tags {

--- a/internal/service/ec2/ec2_spot_instance_request.go
+++ b/internal/service/ec2/ec2_spot_instance_request.go
@@ -317,7 +317,7 @@ func readInstance(ctx context.Context, d *schema.ResourceData, meta interface{})
 			"host": *instance.PrivateIpAddress,
 		})
 	}
-	if err := readBlockDevices(ctx, d, instance, conn); err != nil {
+	if err := readBlockDevices(ctx, d, meta, instance); err != nil {
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 

--- a/internal/service/ec2/tags.go
+++ b/internal/service/ec2/tags.go
@@ -51,8 +51,8 @@ func tagSpecificationsFromMap(ctx context.Context, m map[string]interface{}, t s
 	}
 }
 
-// tagSpecificationsFromMap returns the tag specifications for the given tag key/value map and resource type.
-func tagSpecificationsFromKeyValue(ctx context.Context, tags tftags.KeyValueTags, resourceType string) []*ec2.TagSpecification {
+// tagSpecificationsFromKeyValue returns the tag specifications for the given tag key/value tags and resource type.
+func tagSpecificationsFromKeyValue(tags tftags.KeyValueTags, resourceType string) []*ec2.TagSpecification {
 	if len(tags) == 0 {
 		return nil
 	}
@@ -105,18 +105,4 @@ func tagsSchemaConflictsWith(conflictsWith []string) *schema.Schema {
 	v.ConflictsWith = conflictsWith
 
 	return v
-}
-
-// tagSpecificationsFromMap returns the tag specifications for the given tag key/value map and resource type.
-func resolveDuplicate(ctx context.Context, m map[string]interface{}, t string) []*ec2.TagSpecification {
-	if len(m) == 0 {
-		return nil
-	}
-
-	return []*ec2.TagSpecification{
-		{
-			ResourceType: aws.String(t),
-			Tags:         Tags(tftags.New(ctx, m).IgnoreAWS()),
-		},
-	}
 }

--- a/internal/service/ec2/tags.go
+++ b/internal/service/ec2/tags.go
@@ -51,6 +51,20 @@ func tagSpecificationsFromMap(ctx context.Context, m map[string]interface{}, t s
 	}
 }
 
+// tagSpecificationsFromMap returns the tag specifications for the given tag key/value map and resource type.
+func tagSpecificationsFromKeyValue(ctx context.Context, tags tftags.KeyValueTags, resourceType string) []*ec2.TagSpecification {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	return []*ec2.TagSpecification{
+		{
+			ResourceType: aws.String(resourceType),
+			Tags:         Tags(tags.IgnoreAWS()),
+		},
+	}
+}
+
 // getTagSpecificationsIn returns AWS SDK for Go v1 EC2 service tags from Context.
 // nil is returned if there are no input tags.
 func getTagSpecificationsIn(ctx context.Context, resourceType string) []*ec2.TagSpecification {
@@ -91,4 +105,18 @@ func tagsSchemaConflictsWith(conflictsWith []string) *schema.Schema {
 	v.ConflictsWith = conflictsWith
 
 	return v
+}
+
+// tagSpecificationsFromMap returns the tag specifications for the given tag key/value map and resource type.
+func resolveDuplicate(ctx context.Context, m map[string]interface{}, t string) []*ec2.TagSpecification {
+	if len(m) == 0 {
+		return nil
+	}
+
+	return []*ec2.TagSpecification{
+		{
+			ResourceType: aws.String(t),
+			Tags:         Tags(tftags.New(ctx, m).IgnoreAWS()),
+		},
+	}
 }

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -180,7 +180,7 @@ resource "aws_instance" "this" {
 
 ## Tag Guide
 
-Here's a breakdown of the five types of tags you might encounter relative to an `aws_instance`:
+These are the five types of tags you might encounter relative to an `aws_instance`:
 
 1. **Instance tags**: Applied to instances but not to `ebs_block_device` and `root_block_device` volumes.
 2. **Default tags**: Applied to the instance and to `ebs_block_device` and `root_block_device` volumes.

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -178,6 +178,18 @@ resource "aws_instance" "this" {
 }
 ```
 
+## Tag Guide
+
+Here's a breakdown of the five types of tags you might encounter relative to an `aws_instance`:
+
+1. **Instance tags**: Applied to instances but not to `ebs_block_device` and `root_block_device` volumes.
+2. **Default tags**: Applied to the instance and to `ebs_block_device` and `root_block_device` volumes.
+3. **Volume tags**: Applied during creation to `ebs_block_device` and `root_block_device` volumes.
+4. **Root block device tags**: Applied only to the `root_block_device` volume. These conflict with `volume_tags`.
+5. **EBS block device tags**: Applied only to the specific `ebs_block_device` volume you configure them for and cannot be updated. These conflict with `volume_tags`.
+
+Do not use `volume_tags` if you plan to manage block device tags outside the `aws_instance` configuration, such as using `tags` in an [`aws_ebs_volume`](/docs/providers/aws/r/ebs_volume.html) resource attached via [`aws_volume_attachment`](/docs/providers/aws/r/volume_attachment.html). Doing so will result in resource cycling and inconsistent behavior.
+
 ## Argument Reference
 
 This resource supports the following arguments:
@@ -424,11 +436,13 @@ This resource exports the following attributes in addition to the arguments abov
 For `ebs_block_device`, in addition to the arguments above, the following attribute is exported:
 
 * `volume_id` - ID of the volume. For example, the ID can be accessed like this, `aws_instance.web.ebs_block_device.2.volume_id`.
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 For `root_block_device`, in addition to the arguments above, the following attributes are exported:
 
 * `volume_id` - ID of the volume. For example, the ID can be accessed like this, `aws_instance.web.root_block_device.0.volume_id`.
 * `device_name` - Device name, e.g., `/dev/sdh` or `xvdh`.
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 For `instance_market_options`, in addition to the arguments above, the following attributes are exported:
 


### PR DESCRIPTION
### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

### Terraform CLI and Terraform AWS Provider Version

```
$ terraform -v
Terraform v0.14.6
+ provider registry.terraform.io/hashicorp/aws v3.46.0
```

### Affected Resource(s)

* `aws_instance`

### Terraform Configuration Files

Please include all Terraform configurations required to reproduce the bug. Bug reports without a functional reproduction may be closed without investigation.

```terraform
provider "aws" {
  region = "us-west-2"

  default_tags {
    tags = {
      wooo = "yeah"
    }
  }
}

data "aws_ami" "debian_buster" {
  most_recent = true
  owners      = ["136693071363"]

  filter {
    name   = "name"
    values = ["debian-10-amd64-*"]
  }
}

resource "aws_instance" "example" {
  ami           = data.aws_ami.debian_buster.id
  instance_type = "t3.micro"

  tags = {
    Name = "heyy"
  }
}
```

### Expected Behavior

ec2 instance root volumes should have default tags applied.
### Actual Behavior

The ebs device created for the root volume did not get the default tags:

```
$ terraform state show aws_instance.example
resource "aws_instance" "example" {
    ...
    root_block_device {
        delete_on_termination = true
        device_name           = "/dev/xvda"
        encrypted             = true
        iops                  = 100
        kms_key_id            = "arn:aws:kms:us-west-2:012345678901:key/1e99b441-f5a0-4bfa-b772-eb0b5ae926cc"
        tags                  = {}
        throughput            = 0
        volume_id             = "vol-00646f0d935e22e7d"
        volume_size           = 8
        volume_type           = "gp2"
    }
$ aws ec2 describe-tags --filters Name=resource-id,Values=vol-00646f0d935e22e7d
{
    "Tags": []
}
```

### Steps to Reproduce

    1. `terraform apply`
    2. check the resulting ebs volume tags


### Relations
Closes #19890 
Closes #19188

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=testAccInstanceConfig_blockDeviceTagsEBSTags PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='testAccInstanceConfig_blockDeviceTagsEBSTags'  -timeout 360m
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	2.317s [no tests to run]

...
```
