### PR TITLE
skaff resource test template is missing errors stdlib import.

### DIFF
--- a/skaff/resource/resourcetest.tmpl
+++ b/skaff/resource/resourcetest.tmpl
@@ -40,6 +40,7 @@ import (
 	// types.<Type Name>.
 {{- end }}
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 


### PR DESCRIPTION
### Description
The resource test template makes use of errors in multiple places, so `errors` should be added by default in the import list.


### Relations
N/A

### References
N/A

### Output from Acceptance Testing
N/A