### PR TITLE
docs: add `DEPLOYMENT_STOP_ON_REQUEST` event type in auto rollback configuration for aws_codedeploy_deployment_group

### DIFF
--- a/website/docs/r/codedeploy_deployment_group.html.markdown
+++ b/website/docs/r/codedeploy_deployment_group.html.markdown
@@ -219,7 +219,7 @@ _Only one `alarm_configuration` is allowed_.
 You can configure a deployment group to automatically rollback when a deployment fails or when a monitoring threshold you specify is met. In this case, the last known good version of an application revision is deployed. `auto_rollback_configuration` supports the following:
 
 * `enabled` - (Optional) Indicates whether a defined automatic rollback configuration is currently enabled for this Deployment Group. If you enable automatic rollback, you must specify at least one event type.
-* `events` - (Optional) The event type or types that trigger a rollback. Supported types are `DEPLOYMENT_FAILURE` and `DEPLOYMENT_STOP_ON_ALARM`.
+* `events` - (Optional) The event type or types that trigger a rollback. Supported types are `DEPLOYMENT_FAILURE`, `DEPLOYMENT_STOP_ON_ALARM` and `DEPLOYMENT_STOP_ON_REQUEST`.
 
 _Only one `auto_rollback_configuration` is allowed_.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Hello. The `aws_codedeploy_deployment_group` document was missing one event value, I added it.
- The only thing missing is documentation.
- Added `DEPLOYMENT_STOP_ON_REQUEST` in auto rollback configuration in the codedeploy group property.
- This property is also available in the API and GO SDK, and requires no Terraform code changes.


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- GO Sdk Docs : https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/codedeploy/types#AutoRollbackEvent
- AWS API Docs : https://docs.aws.amazon.com/codedeploy/latest/APIReference/API_AutoRollbackConfiguration.html


### Output from Acceptance Testing
The result of running terraform apply.

```console
# aws_codedeploy_deployment_group.example will be created
  + resource "aws_codedeploy_deployment_group" "example" {
      + app_name               = "example"
...

      + auto_rollback_configuration {
          + enabled = true
          + events  = [
              + "DEPLOYMENT_STOP_ON_REQUEST",
            ]
        }

...
Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

aws_codedeploy_deployment_group.example: Creating...
  aws_codedeploy_deployment_group.example: Creation complete after 1s [id=****]

...
```
