### PR TITLE
Fix broken link to sns_topic_policy

### DIFF
--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -453,7 +453,7 @@ resource "aws_cloudwatch_event_target" "example" {
 -> **Note:** In order to be able to have your AWS Lambda function or
    SNS topic invoked by an EventBridge rule, you must set up the right permissions
    using [`aws_lambda_permission`](/docs/providers/aws/r/lambda_permission.html)
-   or [`aws_sns_topic.policy`](/docs/providers/aws/r/sns_topic.html#policy).
+   or [`aws_sns_topic_policy`](/docs/providers/aws/r/sns_topic_policy.html).
    More info [here](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-use-resource-based.html).
 
 The following arguments are required:


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The note in the documentation for the aws_cloudwatch_event_target resource had a broken link which lead to the aws_sns_topic documentation instead of aws_sns_topic_policy.

### References

There is no direct link to the note, but it is placed just below the `Argument Reference` section: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target#argument-reference

The broken link shows:

[`aws_sns_topic.policy`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic#policy)

