### PR TITLE
docs: use consistent CodeCommit service name

### DIFF
--- a/website/docs/r/codecommit_repository.html.markdown
+++ b/website/docs/r/codecommit_repository.html.markdown
@@ -40,7 +40,7 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Codecommit repository using repository name. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import CodeCommit repository using repository name. For example:
 
 ```terraform
 import {
@@ -49,7 +49,7 @@ import {
 }
 ```
 
-Using `terraform import`, import Codecommit repository using repository name. For example:
+Using `terraform import`, import CodeCommit repository using repository name. For example:
 
 ```console
 % terraform import aws_codecommit_repository.imported ExistingRepo


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This change ensures the `aws_codecommit_repository` resource has consistent and correct naming for CodeCommit. Currently there is a mix between `Codecommit` and `CodeCommit` in these docs, which the latter is the [correct name](https://aws.amazon.com/codecommit/) for the service.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

N/A - doc change only in `website/`