### PR TITLE
added teletext destinations settings

### DIFF
--- a/.changelog/33797.txt
+++ b/.changelog/33797.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/medialive: Added missing `teletext_destination_settings`.
+```

--- a/internal/service/medialive/channel_encoder_settings_schema.go
+++ b/internal/service/medialive/channel_encoder_settings_schema.go
@@ -5018,7 +5018,7 @@ func expandChannelEncoderSettingsCaptionDescriptionsDestinationSettings(tfList [
 		out.SmpteTtDestinationSettings = &types.SmpteTtDestinationSettings{} // only unexported fields
 	}
 	if v, ok := m["teletext_destination_settings"].([]interface{}); ok && len(v) > 0 {
-		out.TeletextDestinationSettings = &types.TeletextDestinationSettings{} // only unexported fields
+		out.TeletextDestinationSettings = expandsCaptionDescriptionsDestinationSettingsTeletextDestinationSettings(v)
 	}
 	if v, ok := m["ttml_destination_settings"].([]interface{}); ok && len(v) > 0 {
 		out.TtmlDestinationSettings = expandsCaptionDescriptionsDestinationSettingsTtmlDestinationSettings(v)
@@ -5179,6 +5179,16 @@ func expandsCaptionDescriptionsDestinationSettingsEbuTtDDestinationSettings(tfLi
 	if v, ok := m["style_control"].(string); ok && len(v) > 0 {
 		out.StyleControl = types.EbuTtDDestinationStyleControl(v)
 	}
+
+	return &out
+}
+
+func expandsCaptionDescriptionsDestinationSettingsTeletextDestinationSettings(tfList []interface{}) *types.TeletextDestinationSettings {
+	if tfList == nil {
+		return nil
+	}
+
+	var out types.TeletextDestinationSettings
 
 	return &out
 }
@@ -6716,7 +6726,7 @@ func flattenCaptionDescriptionsCaptionDestinationSettings(in *types.CaptionDesti
 		"scte20_plus_embedded_destination_settings": []interface{}{}, // attribute has no exported fields
 		"scte27_destination_settings":               []interface{}{}, // attribute has no exported fields
 		"smpte_tt_destination_settings":             []interface{}{}, // attribute has no exported fields
-		"teletext_destination_settings":             []interface{}{}, // attribute has no exported fields
+		"teletext_destination_settings":             flattenCaptionDescriptionsCaptionDestinationSettingsTeletextDestinationSettings(in.TeletextDestinationSettings),
 		"ttml_destination_settings":                 flattenCaptionDescriptionsCaptionDestinationSettingsTtmlDestinationSettings(in.TtmlDestinationSettings),
 		"webvtt_destination_settings":               flattenCaptionDescriptionsCaptionDestinationSettingsWebvttDestinationSettings(in.WebvttDestinationSettings),
 	}
@@ -6791,6 +6801,16 @@ func flattenCaptionDescriptionsCaptionDestinationSettingsEbuTtDDestinationSettin
 		"font_family":      aws.ToString(in.FontFamily),
 		"style_control":    string(in.StyleControl),
 	}
+
+	return []interface{}{m}
+}
+
+func flattenCaptionDescriptionsCaptionDestinationSettingsTeletextDestinationSettings(in *types.TeletextDestinationSettings) []interface{} {
+	if in == nil {
+		return nil
+	}
+
+	m := map[string]interface{}{}
 
 	return []interface{}{m}
 }

--- a/internal/service/medialive/channel_test.go
+++ b/internal/service/medialive/channel_test.go
@@ -122,6 +122,11 @@ func TestAccMediaLiveChannel_captionDescriptions(t *testing.T) {
 						"name":                  "test-caption-name",
 						"destination_settings.0.dvb_sub_destination_settings.0.font_resolution": "100",
 					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "encoder_settings.0.caption_descriptions.*", map[string]string{
+						"caption_selector_name": "test-caption-selector-teletext",
+						"name":                  "test-caption-name-teletext",
+						"destination_settings.0.teletext_destination_settings.0": "",
+					}),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "encoder_settings.0.video_descriptions.*", map[string]string{
 						"name": "test-video-name",
 					}),
@@ -1827,6 +1832,15 @@ resource "aws_medialive_channel" "test" {
         name = %[1]q
       }
 
+      caption_selector {
+        name = "test-caption-selector-teletext"
+        selector_settings {
+          teletext_source_settings {
+            page_number = "100"
+          }
+        }
+      }
+
       audio_selector {
         name = "test-audio-selector"
       }
@@ -1871,6 +1885,15 @@ resource "aws_medialive_channel" "test" {
       }
     }
 
+    caption_descriptions {
+      name                  = "test-caption-name-teletext"
+      caption_selector_name = "test-caption-selector-teletext"
+
+      destination_settings {
+        teletext_destination_settings {}
+      }
+    }
+
     output_groups {
       output_group_settings {
         archive_group_settings {
@@ -1884,7 +1907,7 @@ resource "aws_medialive_channel" "test" {
         output_name               = "test-output-name"
         video_description_name    = "test-video-name"
         audio_description_names   = ["test-audio-name"]
-        caption_description_names = ["test-caption-name"]
+        caption_description_names = ["test-caption-name", "test-caption-name-teletext"]
         output_settings {
           archive_output_settings {
             name_modifier = "_1"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Added missing `teletext_destinations_settings` to `captions_descriptions`.

It's just an empty struct so that's what I left it at. [docs](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/medialive/types#TeletextDestinationSettings)

Even though it's just an empty struct, it's needed because of diff. In the current state where it isn't added, it'll notice it as a change every time.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccMediaLiveChannel_captionDescriptions PKG=medialive
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/medialive/... -v -count 1 -parallel 20 -run='TestAccMediaLiveChannel_captionDescriptions'  -timeout 360m
=== RUN   TestAccMediaLiveChannel_captionDescriptions
=== PAUSE TestAccMediaLiveChannel_captionDescriptions
=== CONT  TestAccMediaLiveChannel_captionDescriptions
--- PASS: TestAccMediaLiveChannel_captionDescriptions (64.19s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/medialive	66.318s
...
```
