### PR TITLE
added client_cache to expandHLSGroupSettings

### DIFF
--- a/.changelog/33798.txt
+++ b/.changelog/33798.txt
@@ -1,0 +1,4 @@
+
+```release-note:bug
+resource/aws_medialive_channel: Added `client_cache` to `expandHLSGroupSettings`.
+```

--- a/internal/service/medialive/channel_encoder_settings_schema.go
+++ b/internal/service/medialive/channel_encoder_settings_schema.go
@@ -3697,6 +3697,9 @@ func expandHLSGroupSettings(tfList []interface{}) *types.HlsGroupSettings {
 	if v, ok := m["caption_language_setting"].(string); ok && v != "" {
 		out.CaptionLanguageSetting = types.HlsCaptionLanguageSetting(v)
 	}
+	if v, ok := m["client_cache"].(string); ok && v != "" {
+		out.ClientCache = types.HlsClientCache(v)
+	}
 	if v, ok := m["codec_specification"].(string); ok && v != "" {
 		out.CodecSpecification = types.HlsCodecSpecification(v)
 	}

--- a/internal/service/medialive/channel_test.go
+++ b/internal/service/medialive/channel_test.go
@@ -635,6 +635,7 @@ func TestAccMediaLiveChannel_hls(t *testing.T) {
 						"name": "test-video-name",
 					}),
 					resource.TestCheckResourceAttr(resourceName, "encoder_settings.0.output_groups.0.outputs.0.output_settings.0.hls_output_settings.0.h265_packaging_type", "HVC1"),
+					resource.TestCheckResourceAttr(resourceName, "encoder_settings.0.output_groups.0.output_group_settings.0.hls_group_settings.0.client_cache", "ENABLED"),
 				),
 			},
 		},
@@ -1774,6 +1775,7 @@ resource "aws_medialive_channel" "test" {
           destination {
             destination_ref_id = %[1]q
           }
+          client_cache = "ENABLED"
         }
       }
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Added missing `client_cache` to `expandHLSGroupSettings`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccMediaLiveChannel_hls PKG=medialive
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/medialive/... -v -count 1 -parallel 20 -run='TestAccMediaLiveChannel_hls'  -timeout 360m
=== RUN   TestAccMediaLiveChannel_hls
=== PAUSE TestAccMediaLiveChannel_hls
=== CONT  TestAccMediaLiveChannel_hls
--- PASS: TestAccMediaLiveChannel_hls (67.40s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/medialive	69.526s
...
```
