### PR TITLE
r/acm_certificate: force recreation of managed certificates when expired

### DIFF
--- a/internal/service/acm/certificate.go
+++ b/internal/service/acm/certificate.go
@@ -69,6 +69,7 @@ func resourceCertificate() *schema.Resource {
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
+				ForceNew: true,
 			},
 			"certificate_authority_arn": {
 				Type:          schema.TypeString,
@@ -322,6 +323,22 @@ func resourceCertificate() *schema.Resource {
 
 				return nil
 			},
+			func(_ context.Context, diff *schema.ResourceDiff, _ any) error {
+				if diff.Id() == "" {
+					return nil
+				}
+
+				if certificateType := diff.Get("type").(string); types.CertificateType(certificateType) != types.CertificateTypeAmazonIssued {
+					return nil
+				}
+
+				if status := diff.Get("status").(string); types.CertificateStatus(status) == types.CertificateStatusExpired {
+					return diff.SetNewComputed("arn")
+				}
+
+				return nil
+			},
+
 			verify.SetTagsDiff,
 		),
 	}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Managed Amazon ACM certificates that expire cannot be re-validated. I'm not aware of a way to do so from within Terraform without a taint. This explicitly forces recreation of Amazon-managed expired certificates.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

_N/A_

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

_N/A_

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

_TBD_ I haven't created a testcase yet, but can do so if this change is acceptable.

```console
% make testacc TESTS=TestAccAcmCertificate_ PKG=acm

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/acm/... -v -count 1 -parallel 20 -run='TestAccACMCertificate_'  -timeout 360m
=== RUN   TestAccACMCertificate_emailValidation
    acctest.go:1743: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificate_emailValidation (0.00s)
=== RUN   TestAccACMCertificate_dnsValidation
    acctest.go:1743: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificate_dnsValidation (0.00s)
=== RUN   TestAccACMCertificate_root
    acctest.go:1743: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificate_root (0.00s)
=== RUN   TestAccACMCertificate_validationOptions
    acctest.go:1743: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificate_validationOptions (0.00s)
=== RUN   TestAccACMCertificate_privateCertificate_renewable
=== PAUSE TestAccACMCertificate_privateCertificate_renewable
=== RUN   TestAccACMCertificate_privateCertificate_noRenewalPermission
=== PAUSE TestAccACMCertificate_privateCertificate_noRenewalPermission
=== RUN   TestAccACMCertificate_privateCertificate_pendingRenewalGoDuration
=== PAUSE TestAccACMCertificate_privateCertificate_pendingRenewalGoDuration
=== RUN   TestAccACMCertificate_privateCertificate_pendingRenewalRFC3339Duration
=== PAUSE TestAccACMCertificate_privateCertificate_pendingRenewalRFC3339Duration
=== RUN   TestAccACMCertificate_privateCertificate_addEarlyRenewalPast
=== PAUSE TestAccACMCertificate_privateCertificate_addEarlyRenewalPast
=== RUN   TestAccACMCertificate_privateCertificate_addEarlyRenewalPastIneligible
=== PAUSE TestAccACMCertificate_privateCertificate_addEarlyRenewalPastIneligible
=== RUN   TestAccACMCertificate_privateCertificate_addEarlyRenewalFuture
=== PAUSE TestAccACMCertificate_privateCertificate_addEarlyRenewalFuture
=== RUN   TestAccACMCertificate_privateCertificate_updateEarlyRenewalFuture
=== PAUSE TestAccACMCertificate_privateCertificate_updateEarlyRenewalFuture
=== RUN   TestAccACMCertificate_privateCertificate_removeEarlyRenewal
=== PAUSE TestAccACMCertificate_privateCertificate_removeEarlyRenewal
=== RUN   TestAccACMCertificate_Root_trailingPeriod
    acctest.go:1743: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificate_Root_trailingPeriod (0.00s)
=== RUN   TestAccACMCertificate_rootAndWildcardSan
    acctest.go:1743: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificate_rootAndWildcardSan (0.00s)
=== RUN   TestAccACMCertificate_SubjectAlternativeNames_emptyString
    acctest.go:1743: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificate_SubjectAlternativeNames_emptyString (0.00s)
=== RUN   TestAccACMCertificate_San_single
    acctest.go:1743: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificate_San_single (0.00s)
=== RUN   TestAccACMCertificate_San_multiple
    acctest.go:1743: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificate_San_multiple (0.00s)
=== RUN   TestAccACMCertificate_San_trailingPeriod
    acctest.go:1743: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificate_San_trailingPeriod (0.00s)
=== RUN   TestAccACMCertificate_San_matches_domain
    acctest.go:1743: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificate_San_matches_domain (0.00s)
=== RUN   TestAccACMCertificate_wildcard
    acctest.go:1743: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificate_wildcard (0.00s)
=== RUN   TestAccACMCertificate_wildcardAndRootSan
    acctest.go:1743: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificate_wildcardAndRootSan (0.00s)
=== RUN   TestAccACMCertificate_keyAlgorithm
    acctest.go:1743: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificate_keyAlgorithm (0.00s)
=== RUN   TestAccACMCertificate_disableCTLogging
    acctest.go:1743: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificate_disableCTLogging (0.00s)
=== RUN   TestAccACMCertificate_disableReenableCTLogging
    acctest.go:1743: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccACMCertificate_disableReenableCTLogging (0.00s)
=== RUN   TestAccACMCertificate_Imported_domainName
=== PAUSE TestAccACMCertificate_Imported_domainName
=== RUN   TestAccACMCertificate_Imported_validityDates
=== PAUSE TestAccACMCertificate_Imported_validityDates
=== RUN   TestAccACMCertificate_Imported_ipAddress
=== PAUSE TestAccACMCertificate_Imported_ipAddress
=== RUN   TestAccACMCertificate_PrivateKey_tags
=== PAUSE TestAccACMCertificate_PrivateKey_tags
=== CONT  TestAccACMCertificate_privateCertificate_renewable
=== CONT  TestAccACMCertificate_privateCertificate_updateEarlyRenewalFuture
=== CONT  TestAccACMCertificate_privateCertificate_addEarlyRenewalPast
=== CONT  TestAccACMCertificate_privateCertificate_addEarlyRenewalFuture
=== CONT  TestAccACMCertificate_privateCertificate_pendingRenewalGoDuration
=== CONT  TestAccACMCertificate_PrivateKey_tags
=== CONT  TestAccACMCertificate_privateCertificate_pendingRenewalRFC3339Duration
=== CONT  TestAccACMCertificate_Imported_ipAddress
=== CONT  TestAccACMCertificate_Imported_validityDates
=== CONT  TestAccACMCertificate_privateCertificate_addEarlyRenewalPastIneligible
=== CONT  TestAccACMCertificate_Imported_domainName
=== CONT  TestAccACMCertificate_privateCertificate_removeEarlyRenewal
=== CONT  TestAccACMCertificate_privateCertificate_noRenewalPermission
--- PASS: TestAccACMCertificate_Imported_ipAddress (27.49s)
--- PASS: TestAccACMCertificate_Imported_validityDates (31.84s)
--- PASS: TestAccACMCertificate_Imported_domainName (64.91s)
=== NAME  TestAccACMCertificate_privateCertificate_pendingRenewalRFC3339Duration
    certificate_test.go:525: Step 3/4 error: Check failed: 6 errors occurred:
        	* Check 2/11 error: ACM Certificate not renewed: i.NotAfter="2024-11-04 21:15:37 +0000 UTC", j.NotAfter="2024-11-04 21:15:37 +0000 UTC"
        	* Check 5/11 error: aws_acm_certificate.test: Attribute 'renewal_eligibility' expected "INELIGIBLE", got "ELIGIBLE"
        	* Check 6/11 error: aws_acm_certificate.test: Attribute 'renewal_summary.#' expected "1", got "0"
        	* Check 7/11 error: aws_acm_certificate.test: Attribute 'renewal_summary.0.renewal_status' not found
        	* Check 8/11 error: aws_acm_certificate.test: Attribute 'renewal_summary.0.renewal_status_reason' not found
        	* Check 9/11 error: aws_acm_certificate.test: Attribute 'renewal_summary.0.updated_at' didn't match "^[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\\.[0-9]+)?([Zz]|([+-]([01][0-9]|2[0-3]):[0-5][0-9]))$", got ""

=== NAME  TestAccACMCertificate_privateCertificate_pendingRenewalGoDuration
    certificate_test.go:451: Step 3/4 error: Check failed: 6 errors occurred:
        	* Check 2/11 error: ACM Certificate not renewed: i.NotAfter="2024-11-04 21:15:37 +0000 UTC", j.NotAfter="2024-11-04 21:15:37 +0000 UTC"
        	* Check 5/11 error: aws_acm_certificate.test: Attribute 'renewal_eligibility' expected "INELIGIBLE", got "ELIGIBLE"
        	* Check 6/11 error: aws_acm_certificate.test: Attribute 'renewal_summary.#' expected "1", got "0"
        	* Check 7/11 error: aws_acm_certificate.test: Attribute 'renewal_summary.0.renewal_status' not found
        	* Check 8/11 error: aws_acm_certificate.test: Attribute 'renewal_summary.0.renewal_status_reason' not found
        	* Check 9/11 error: aws_acm_certificate.test: Attribute 'renewal_summary.0.updated_at' didn't match "^[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\\.[0-9]+)?([Zz]|([+-]([01][0-9]|2[0-3]):[0-5][0-9]))$", got ""

--- FAIL: TestAccACMCertificate_privateCertificate_pendingRenewalRFC3339Duration (73.13s)
--- FAIL: TestAccACMCertificate_privateCertificate_pendingRenewalGoDuration (75.57s)
--- PASS: TestAccACMCertificate_privateCertificate_addEarlyRenewalPastIneligible (88.30s)
--- PASS: TestAccACMCertificate_privateCertificate_updateEarlyRenewalFuture (89.46s)
--- PASS: TestAccACMCertificate_privateCertificate_removeEarlyRenewal (91.64s)
--- PASS: TestAccACMCertificate_PrivateKey_tags (92.31s)
--- PASS: TestAccACMCertificate_privateCertificate_addEarlyRenewalFuture (101.24s)
--- PASS: TestAccACMCertificate_privateCertificate_renewable (117.25s)
=== NAME  TestAccACMCertificate_privateCertificate_addEarlyRenewalPast
    certificate_test.go:599: Step 5/5 error: Check failed: 1 error occurred:
        	* Check 4/11 error: aws_acm_certificate.test: Attribute 'pending_renewal' expected "false", got "true"

--- FAIL: TestAccACMCertificate_privateCertificate_addEarlyRenewalPast (120.52s)
--- PASS: TestAccACMCertificate_privateCertificate_noRenewalPermission (172.38s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/acm	175.701s
FAIL
make: *** [testacc] Error 1
```
