### PR TITLE
[tests] docdb test failures

### DIFF
--- a/internal/service/docdb/cluster_test.go
+++ b/internal/service/docdb/cluster_test.go
@@ -972,9 +972,9 @@ resource "aws_docdb_cluster" "default" {
     data.aws_availability_zones.available.names[2]
   ]
 
-  master_username                 = "foo"
-  master_password                 = "mustbeeightcharaters"
-  skip_final_snapshot             = true
+  master_username     = "foo"
+  master_password     = "mustbeeightcharaters"
+  skip_final_snapshot = true
 
   tags = {
     Environment = "production"
@@ -1020,9 +1020,9 @@ resource "aws_docdb_cluster" "default" {
     data.aws_availability_zones.available.names[2]
   ]
 
-  master_username                 = "foo"
-  master_password                 = "mustbeeightcharaters"
-  final_snapshot_identifier       = "tf-acctest-docdbcluster-snapshot-%[1]d"
+  master_username           = "foo"
+  master_password           = "mustbeeightcharaters"
+  final_snapshot_identifier = "tf-acctest-docdbcluster-snapshot-%[1]d"
 
   tags = {
     Environment = "production"
@@ -1082,9 +1082,9 @@ resource "aws_docdb_cluster" "default" {
     data.aws_availability_zones.available.names[2]
   ]
 
-  master_username                 = "foo"
-  master_password                 = "mustbeeightcharaters"
-  skip_final_snapshot             = true
+  master_username     = "foo"
+  master_password     = "mustbeeightcharaters"
+  skip_final_snapshot = true
 
   tags = {
     Environment = "production"
@@ -1125,11 +1125,11 @@ resource "aws_docdb_cluster" "default" {
     data.aws_availability_zones.available.names[2]
   ]
 
-  master_username                 = "foo"
-  master_password                 = "mustbeeightcharaters"
-  storage_encrypted               = true
-  kms_key_id                      = aws_kms_key.foo.arn
-  skip_final_snapshot             = true
+  master_username     = "foo"
+  master_password     = "mustbeeightcharaters"
+  storage_encrypted   = true
+  kms_key_id          = aws_kms_key.foo.arn
+  skip_final_snapshot = true
 }
 `, n))
 }
@@ -1205,12 +1205,12 @@ resource "aws_docdb_cluster" "test" {
     data.aws_availability_zones.available.names[2]
   ]
 
-  cluster_identifier              = "tf-acc-test-%d"
-  engine                          = "docdb"
-  master_password                 = "mustbeeightcharaters"
-  master_username                 = "foo"
-  port                            = %d
-  skip_final_snapshot             = true
+  cluster_identifier  = "tf-acc-test-%d"
+  engine              = "docdb"
+  master_password     = "mustbeeightcharaters"
+  master_username     = "foo"
+  port                = %d
+  skip_final_snapshot = true
 }
 `, rInt, port))
 }

--- a/internal/service/docdb/cluster_test.go
+++ b/internal/service/docdb/cluster_test.go
@@ -529,10 +529,7 @@ func TestAccDocDBCluster_encrypted(t *testing.T) {
 				Config: testAccClusterConfig_encrypted(sdkacctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(ctx, "aws_docdb_cluster.default", &v),
-					resource.TestCheckResourceAttr(
-						"aws_docdb_cluster.default", "storage_encrypted", "true"),
-					resource.TestCheckResourceAttr(
-						"aws_docdb_cluster.default", "db_cluster_parameter_group_name", "default.docdb4.0"),
+					resource.TestCheckResourceAttr("aws_docdb_cluster.default", "storage_encrypted", "true"),
 				),
 			},
 			{
@@ -977,7 +974,6 @@ resource "aws_docdb_cluster" "default" {
 
   master_username                 = "foo"
   master_password                 = "mustbeeightcharaters"
-  db_cluster_parameter_group_name = "default.docdb4.0"
   skip_final_snapshot             = true
 
   tags = {
@@ -1026,7 +1022,6 @@ resource "aws_docdb_cluster" "default" {
 
   master_username                 = "foo"
   master_password                 = "mustbeeightcharaters"
-  db_cluster_parameter_group_name = "default.docdb4.0"
   final_snapshot_identifier       = "tf-acctest-docdbcluster-snapshot-%[1]d"
 
   tags = {
@@ -1089,7 +1084,6 @@ resource "aws_docdb_cluster" "default" {
 
   master_username                 = "foo"
   master_password                 = "mustbeeightcharaters"
-  db_cluster_parameter_group_name = "default.docdb4.0"
   skip_final_snapshot             = true
 
   tags = {
@@ -1133,7 +1127,6 @@ resource "aws_docdb_cluster" "default" {
 
   master_username                 = "foo"
   master_password                 = "mustbeeightcharaters"
-  db_cluster_parameter_group_name = "default.docdb4.0"
   storage_encrypted               = true
   kms_key_id                      = aws_kms_key.foo.arn
   skip_final_snapshot             = true
@@ -1213,7 +1206,6 @@ resource "aws_docdb_cluster" "test" {
   ]
 
   cluster_identifier              = "tf-acc-test-%d"
-  db_cluster_parameter_group_name = "default.docdb4.0"
   engine                          = "docdb"
   master_password                 = "mustbeeightcharaters"
   master_username                 = "foo"

--- a/internal/service/docdb/cluster_test.go
+++ b/internal/service/docdb/cluster_test.go
@@ -50,7 +50,7 @@ func TestAccDocDBCluster_basic(t *testing.T) {
 					testAccCheckClusterExists(ctx, resourceName, &dbCluster),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "rds", regexache.MustCompile(`cluster:.+`)),
 					resource.TestCheckResourceAttr(resourceName, "storage_encrypted", "false"),
-					resource.TestCheckResourceAttr(resourceName, "db_cluster_parameter_group_name", "default.docdb4.0"),
+					resource.TestCheckResourceAttrSet(resourceName, "db_cluster_parameter_group_name"),
 					resource.TestCheckResourceAttrSet(resourceName, "reader_endpoint"),
 					resource.TestCheckResourceAttrSet(resourceName, "cluster_resource_id"),
 					resource.TestCheckResourceAttr(resourceName, "engine", "docdb"),
@@ -1060,7 +1060,6 @@ resource "aws_docdb_cluster" "default" {
 
   master_username                 = "foo"
   master_password                 = "mustbeeightcharaters"
-  db_cluster_parameter_group_name = "default.docdb4.0"
   skip_final_snapshot             = true
 
   tags = {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

```
------- Stdout: -------
=== RUN   TestAccDocDBCluster_basic
=== PAUSE TestAccDocDBCluster_basic
=== CONT  TestAccDocDBCluster_basic
    cluster_test.go:41: Step 1/2 error: Error running apply: exit status 1
        Error: creating DocumentDB cluster: InvalidParameterCombination: The Parameter Group default.docdb4.0 with DBParameterGroupFamily docdb4.0 cannot be used for this instance. Please use a Parameter Group with DBParameterGroupFamily docdb5.0
          status code: 400, request id: b3e1beb6-2d58-4659-b074-ccbd06c04205
          with aws_docdb_cluster.default,
          on terraform_plugin_test.tf line 11, in resource "aws_docdb_cluster" "default":
          11: resource "aws_docdb_cluster" "default" {
--- FAIL: TestAccDocDBCluster_basic (1103.71s)
FAIL
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTARGS='-run=TestAccDocDBCluster_ -short' PKG=docdb

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/docdb/... -v -count 1 -parallel 20  -run=TestAccDocDBCluster_ -short -timeout 360m
    cluster_test.go:319: skipping long-running test in short mode
--- SKIP: TestAccDocDBCluster_GlobalClusterIdentifier_PrimarySecondaryClusters (0.00s)
--- PASS: TestAccDocDBCluster_missingUserNameCausesError (116.69s)
--- PASS: TestAccDocDBCluster_namePrefix (206.86s)
--- PASS: TestAccDocDBCluster_generatedName (207.00s)
--- PASS: TestAccDocDBCluster_GlobalClusterIdentifier (332.04s)
--- PASS: TestAccDocDBCluster_basic (351.62s)
--- PASS: TestAccDocDBCluster_GlobalClusterIdentifier_Add (352.98s)
--- PASS: TestAccDocDBCluster_encrypted (353.37s)
--- PASS: TestAccDocDBCluster_GlobalClusterIdentifier_Remove (367.78s)
--- PASS: TestAccDocDBCluster_kmsKey (396.66s)
--- PASS: TestAccDocDBCluster_GlobalClusterIdentifier_Update (426.42s)
--- PASS: TestAccDocDBCluster_deleteProtection (435.78s)
--- PASS: TestAccDocDBCluster_takeFinalSnapshot (436.00s)
--- PASS: TestAccDocDBCluster_updateTags (457.09s)
--- PASS: TestAccDocDBCluster_updateCloudWatchLogsExports (458.92s)
--- PASS: TestAccDocDBCluster_backupsUpdate (459.97s)
--- PASS: TestAccDocDBCluster_port (576.59s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/docdb	579.734s
```
