### PR TITLE
r/aws_verifiedaccess_instance_logging_configuration

### DIFF
--- a/.changelog/33864.txt
+++ b/.changelog/33864.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_verifiedaccess_instance_logging_configuration
+```

--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -7076,6 +7076,60 @@ func FindVerifiedAccessInstanceByID(ctx context.Context, conn *ec2_sdkv2.Client,
 	return output, nil
 }
 
+func FindVerifiedAccessInstanceLoggingConfiguration(ctx context.Context, conn *ec2_sdkv2.Client, input *ec2_sdkv2.DescribeVerifiedAccessInstanceLoggingConfigurationsInput) (*awstypes.VerifiedAccessInstanceLoggingConfiguration, error) {
+	output, err := FindVerifiedAccessInstanceLoggingConfigurations(ctx, conn, input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfresource.AssertSingleValueResult(output)
+}
+
+func FindVerifiedAccessInstanceLoggingConfigurations(ctx context.Context, conn *ec2_sdkv2.Client, input *ec2_sdkv2.DescribeVerifiedAccessInstanceLoggingConfigurationsInput) ([]awstypes.VerifiedAccessInstanceLoggingConfiguration, error) {
+	var output []awstypes.VerifiedAccessInstanceLoggingConfiguration
+	paginator := ec2_sdkv2.NewDescribeVerifiedAccessInstanceLoggingConfigurationsPaginator(conn, input)
+
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+
+		if tfawserr_sdkv2.ErrCodeEquals(err, errCodeInvalidVerifiedAccessInstanceIdNotFound) {
+			return nil, &retry.NotFoundError{
+				LastError:   err,
+				LastRequest: input,
+			}
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, page.LoggingConfigurations...)
+	}
+
+	return output, nil
+}
+
+func FindVerifiedAccessInstanceLoggingConfigurationByInstanceID(ctx context.Context, conn *ec2_sdkv2.Client, id string) (*awstypes.VerifiedAccessInstanceLoggingConfiguration, error) {
+	input := &ec2_sdkv2.DescribeVerifiedAccessInstanceLoggingConfigurationsInput{
+		VerifiedAccessInstanceIds: []string{id},
+	}
+	output, err := FindVerifiedAccessInstanceLoggingConfiguration(ctx, conn, input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Eventual consistency check.
+	if aws_sdkv2.ToString(output.VerifiedAccessInstanceId) != id {
+		return nil, &retry.NotFoundError{
+			LastRequest: input,
+		}
+	}
+
+	return output, nil
+}
+
 func FindVerifiedAccessInstanceTrustProviderAttachmentExists(ctx context.Context, conn *ec2_sdkv2.Client, vaiID, vatpID string) error {
 	output, err := FindVerifiedAccessInstanceByID(ctx, conn, vaiID)
 

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -952,6 +952,11 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			},
 		},
 		{
+			Factory:  ResourceVerifiedAccessInstanceLoggingConfiguration,
+			TypeName: "aws_verifiedaccess_instance_logging_configuration",
+			Name:     "Verified Access Instance Logging Configuration",
+		},
+		{
 			Factory:  ResourceVerifiedAccessInstanceTrustProviderAttachment,
 			TypeName: "aws_verifiedaccess_instance_trust_provider_attachment",
 			Name:     "Verified Access Instance Trust Provider Attachment",

--- a/internal/service/ec2/verifiedaccess_instance_logging_configuration.go
+++ b/internal/service/ec2/verifiedaccess_instance_logging_configuration.go
@@ -1,0 +1,109 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ec2
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+// @SDKResource("aws_verifiedaccess_instance_logging_configuration", name="Verified Access Instance Logging Configuration")
+func ResourceVerifiedAccessInstanceLoggingConfiguration() *schema.Resource {
+	return &schema.Resource{
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"access_logs": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cloudwatch_logs": {
+							Type:             schema.TypeList,
+							MaxItems:         1,
+							Optional:         true,
+							DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:     schema.TypeBool,
+										Required: true,
+									},
+									"log_group": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"include_trust_context": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+						},
+						"kinesis_data_firehose": {
+							Type:             schema.TypeList,
+							Optional:         true,
+							MaxItems:         1,
+							DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"delivery_stream": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"enabled": {
+										Type:     schema.TypeBool,
+										Required: true,
+									},
+								},
+							},
+						},
+						"log_version": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"s3": {
+							Type:             schema.TypeList,
+							Optional:         true,
+							MaxItems:         1,
+							DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"bucket_name": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"bucket_owner": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										Computed:     true, // Describe API returns this value if not set
+										ValidateFunc: verify.ValidAccountID,
+									},
+									"enabled": {
+										Type:     schema.TypeBool,
+										Required: true,
+									},
+									"prefix": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"verifiedaccess_instance_id": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+		},
+	}
+}

--- a/internal/service/ec2/verifiedaccess_instance_logging_configuration.go
+++ b/internal/service/ec2/verifiedaccess_instance_logging_configuration.go
@@ -4,13 +4,24 @@
 package ec2
 
 import (
+	"context"
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 // @SDKResource("aws_verifiedaccess_instance_logging_configuration", name="Verified Access Instance Logging Configuration")
 func ResourceVerifiedAccessInstanceLoggingConfiguration() *schema.Resource {
 	return &schema.Resource{
+		ReadWithoutTimeout: resourceVerifiedAccessInstanceLoggingConfigurationRead,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -106,4 +117,105 @@ func ResourceVerifiedAccessInstanceLoggingConfiguration() *schema.Resource {
 			},
 		},
 	}
+}
+
+func resourceVerifiedAccessInstanceLoggingConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).EC2Client(ctx)
+
+	vaiID := d.Id()
+
+	output, err := FindVerifiedAccessInstanceLoggingConfigurationByInstanceID(ctx, conn, vaiID)
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] EC2 Verified Access Instance Logging Configuration (%s) not found, removing from state", vaiID)
+		d.SetId("")
+		return diags
+	}
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading Verified Access Instance Logging Configuration (%s): %s", vaiID, err)
+	}
+
+	if v := output.AccessLogs; v != nil {
+		if err := d.Set("access_logs", flattenVerifiedAccessInstanceAccessLogs(v)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting verified access instance access logs: %s", err)
+		}
+	} else {
+		d.Set("access_logs", nil)
+	}
+
+	d.Set("verifiedaccess_instance_id", vaiID)
+
+	return diags
+}
+
+func flattenVerifiedAccessInstanceAccessLogs(apiObject *types.VerifiedAccessLogs) []interface{} {
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.CloudWatchLogs; v != nil {
+		tfMap["cloudwatch_logs"] = flattenVerifiedAccessLogCloudWatchLogs(v)
+	}
+
+	if v := apiObject.IncludeTrustContext; v != nil {
+		tfMap["include_trust_context"] = aws.ToBool(v)
+	}
+
+	if v := apiObject.KinesisDataFirehose; v != nil {
+		tfMap["kinesis_data_firehose"] = flattenVerifiedAccessLogKinesisDataFirehose(v)
+	}
+
+	if v := apiObject.LogVersion; v != nil {
+		tfMap["log_version"] = aws.ToString(v)
+	}
+
+	if v := apiObject.S3; v != nil {
+		tfMap["s3"] = flattenVerifiedAccessLogS3(v)
+	}
+
+	return []interface{}{tfMap}
+}
+
+func flattenVerifiedAccessLogCloudWatchLogs(apiObject *types.VerifiedAccessLogCloudWatchLogsDestination) []interface{} {
+	tfMap := map[string]interface{}{
+		"enabled": bool(*apiObject.Enabled),
+	}
+
+	if v := apiObject.LogGroup; v != nil {
+		tfMap["log_group"] = aws.ToString(v)
+	}
+
+	return []interface{}{tfMap}
+}
+
+func flattenVerifiedAccessLogKinesisDataFirehose(apiObject *types.VerifiedAccessLogKinesisDataFirehoseDestination) []interface{} {
+	tfMap := map[string]interface{}{
+		"enabled": bool(*apiObject.Enabled),
+	}
+
+	if v := apiObject.DeliveryStream; v != nil {
+		tfMap["delivery_stream"] = aws.ToString(v)
+	}
+
+	return []interface{}{tfMap}
+}
+
+func flattenVerifiedAccessLogS3(apiObject *types.VerifiedAccessLogS3Destination) []interface{} {
+	tfMap := map[string]interface{}{
+		"enabled": bool(*apiObject.Enabled),
+	}
+
+	if v := apiObject.BucketName; v != nil {
+		tfMap["bucket_name"] = aws.ToString(v)
+	}
+
+	if v := apiObject.BucketOwner; v != nil {
+		tfMap["bucket_owner"] = aws.ToString(v)
+	}
+
+	if v := apiObject.Prefix; v != nil {
+		tfMap["prefix"] = aws.ToString(v)
+	}
+
+	return []interface{}{tfMap}
 }

--- a/internal/service/ec2/verifiedaccess_instance_logging_configuration.go
+++ b/internal/service/ec2/verifiedaccess_instance_logging_configuration.go
@@ -403,7 +403,7 @@ func flattenVerifiedAccessInstanceAccessLogs(apiObject *types.VerifiedAccessLogs
 
 func flattenVerifiedAccessLogCloudWatchLogs(apiObject *types.VerifiedAccessLogCloudWatchLogsDestination) []interface{} {
 	tfMap := map[string]interface{}{
-		"enabled": bool(*apiObject.Enabled),
+		"enabled": apiObject.Enabled,
 	}
 
 	if v := apiObject.LogGroup; v != nil {
@@ -415,7 +415,7 @@ func flattenVerifiedAccessLogCloudWatchLogs(apiObject *types.VerifiedAccessLogCl
 
 func flattenVerifiedAccessLogKinesisDataFirehose(apiObject *types.VerifiedAccessLogKinesisDataFirehoseDestination) []interface{} {
 	tfMap := map[string]interface{}{
-		"enabled": bool(*apiObject.Enabled),
+		"enabled": apiObject.Enabled,
 	}
 
 	if v := apiObject.DeliveryStream; v != nil {
@@ -427,7 +427,7 @@ func flattenVerifiedAccessLogKinesisDataFirehose(apiObject *types.VerifiedAccess
 
 func flattenVerifiedAccessLogS3(apiObject *types.VerifiedAccessLogS3Destination) []interface{} {
 	tfMap := map[string]interface{}{
-		"enabled": bool(*apiObject.Enabled),
+		"enabled": apiObject.Enabled,
 	}
 
 	if v := apiObject.BucketName; v != nil {

--- a/internal/service/ec2/verifiedaccess_instance_logging_configuration_test.go
+++ b/internal/service/ec2/verifiedaccess_instance_logging_configuration_test.go
@@ -380,6 +380,35 @@ func TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsCloudWatchLogsK
 	})
 }
 
+func TestAccVerifiedAccessInstanceLoggingConfiguration_disappears(t *testing.T) {
+	// note: disappears test does not test the logging configuration since the instance is deleted
+	// the logging configuration cannot be deleted, rather, the boolean flags and logging version are reset to the default values
+	ctx := acctest.Context(t)
+
+	var v types.VerifiedAccessInstanceLoggingConfiguration
+	resourceName := "aws_verifiedaccess_instance.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheckVerifiedAccessInstanceLoggingConfiguration(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckVerifiedAccessInstanceLoggingConfigurationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoggingConfigurationConfig_basic_accessLogsIncludeTrustContext(true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVerifiedAccessInstanceLoggingConfigurationExists(ctx, resourceName, &v),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfec2.ResourceVerifiedAccessInstanceLoggingConfiguration(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccCheckVerifiedAccessInstanceLoggingConfigurationExists(ctx context.Context, n string, v *types.VerifiedAccessInstanceLoggingConfiguration) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/internal/service/ec2/verifiedaccess_instance_logging_configuration_test.go
+++ b/internal/service/ec2/verifiedaccess_instance_logging_configuration_test.go
@@ -1,0 +1,149 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ec2_test
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsIncludeTrustContext(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var v types.VerifiedAccessInstanceLoggingConfiguration
+	resourceName := "aws_verifiedaccess_instance_logging_configuration.test"
+	instanceResourceName := "aws_verifiedaccess_instance.test"
+
+	include_trust_context_original := true
+	include_trust_context_updated := false
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheckVerifiedAccessInstanceLoggingConfiguration(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckVerifiedAccessInstanceLoggingConfigurationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoggingConfigurationConfig_basic_accessLogsIncludeTrustContext(include_trust_context_original),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVerifiedAccessInstanceLoggingConfigurationExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "access_logs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "access_logs.0.include_trust_context", strconv.FormatBool(include_trust_context_original)),
+					resource.TestCheckResourceAttrPair(resourceName, "verifiedaccess_instance_id", instanceResourceName, "id"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+			{
+				Config: testAccLoggingConfigurationConfig_basic_accessLogsIncludeTrustContext(include_trust_context_updated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVerifiedAccessInstanceLoggingConfigurationExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "access_logs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "access_logs.0.include_trust_context", strconv.FormatBool(include_trust_context_updated)),
+					resource.TestCheckResourceAttrPair(resourceName, "verifiedaccess_instance_id", instanceResourceName, "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckVerifiedAccessInstanceLoggingConfigurationExists(ctx context.Context, n string, v *types.VerifiedAccessInstanceLoggingConfiguration) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Client(ctx)
+
+		output, err := tfec2.FindVerifiedAccessInstanceLoggingConfigurationByInstanceID(ctx, conn, rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		*v = *output
+
+		return nil
+	}
+}
+
+func testAccCheckVerifiedAccessInstanceLoggingConfigurationDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Client(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_verifiedaccess_instance_logging_configuration" {
+				continue
+			}
+
+			_, err := tfec2.FindVerifiedAccessInstanceLoggingConfigurationByInstanceID(ctx, conn, rs.Primary.ID)
+
+			if tfresource.NotFound(err) {
+				continue
+			}
+
+			if err != nil {
+				return err
+			}
+
+			return fmt.Errorf("Verified Access Instance Logging Configuration %s still exists", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccPreCheckVerifiedAccessInstanceLoggingConfiguration(ctx context.Context, t *testing.T) {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Client(ctx)
+
+	input := &ec2.DescribeVerifiedAccessInstanceLoggingConfigurationsInput{}
+	_, err := conn.DescribeVerifiedAccessInstanceLoggingConfigurations(ctx, input)
+
+	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func testAccVerifiedAccessInstanceLoggingConfigurationConfig_instance() string {
+	return `
+resource "aws_verifiedaccess_instance" "test" {}
+`
+}
+
+func testAccLoggingConfigurationConfig_basic_accessLogsIncludeTrustContext(includeTrustContext bool) string {
+	return acctest.ConfigCompose(
+		testAccVerifiedAccessInstanceLoggingConfigurationConfig_instance(),
+		fmt.Sprintf(`
+resource "aws_verifiedaccess_instance_logging_configuration" "test" {
+  access_logs {
+    include_trust_context = %[1]t
+  }
+
+  verifiedaccess_instance_id = aws_verifiedaccess_instance.test.id
+}
+`, includeTrustContext))
+}

--- a/website/docs/r/verifiedaccess_instance_logging_configuration.html.markdown
+++ b/website/docs/r/verifiedaccess_instance_logging_configuration.html.markdown
@@ -1,0 +1,161 @@
+---
+subcategory: "Verified Access"
+layout: "aws"
+page_title: "AWS: aws_verifiedaccess_instance_logging_configuration"
+description: |-
+  Terraform resource for managing a Verified Access Instance Logging Configuration.
+---
+
+# Resource: aws_verifiedaccess_instance_logging_configuration
+
+Terraform resource for managing a Verified Access Logging Configuration.
+
+## Example Usage
+
+### With CloudWatch Logging
+
+```terraform
+resource "aws_verifiedaccess_instance_logging_configuration" "example" {
+  access_logs {
+    cloudwatch_logs {
+      enabled   = true
+      log_group = aws_cloudwatch_log_group.example.id
+    }
+  }
+  verifiedaccess_instance_id = aws_verifiedaccess_instance.example.id
+}
+```
+
+### With Kinesis Data Firehose Logging
+
+```terraform
+resource "aws_verifiedaccess_instance_logging_configuration" "example" {
+  access_logs {
+    kinesis_data_firehose {
+      delivery_stream = aws_kinesis_firehose_delivery_stream.example.name
+      enabled         = true
+    }
+  }
+  verifiedaccess_instance_id = aws_verifiedaccess_instance.example.id
+}
+```
+
+### With S3 logging
+
+```terraform
+resource "aws_verifiedaccess_instance_logging_configuration" "example" {
+  access_logs {
+    s3 {
+      bucket_name = aws_s3_bucket.example.id
+      enabled     = true
+      prefix      = "example"
+    }
+  }
+  verifiedaccess_instance_id = aws_verifiedaccess_instance.example.id
+}
+```
+
+### With all three logging options
+
+```terraform
+resource "aws_verifiedaccess_instance_logging_configuration" "example" {
+  access_logs {
+    cloudwatch_logs {
+      enabled   = true
+      log_group = aws_cloudwatch_log_group.example.id
+    }
+    kinesis_data_firehose {
+      delivery_stream = aws_kinesis_firehose_delivery_stream.example.name
+      enabled         = true
+    }
+    s3 {
+      bucket_name = aws_s3_bucket.example.id
+      enabled     = true
+    }
+  }
+  verifiedaccess_instance_id = aws_verifiedaccess_instance.example.id
+}
+```
+
+### With `include_trust_context`
+
+```terraform
+resource "aws_verifiedaccess_instance_logging_configuration" "example" {
+  access_logs {
+    include_trust_context = true
+  }
+  verifiedaccess_instance_id = aws_verifiedaccess_instance.example.id
+}
+```
+
+### With `log_version`
+
+```terraform
+resource "aws_verifiedaccess_instance_logging_configuration" "example" {
+  access_logs {
+    log_version = "ocsf-1.0.0-rc.2"
+  }
+  verifiedaccess_instance_id = aws_verifiedaccess_instance.example.id
+}
+```
+
+## Argument Reference
+
+This resource supports the following arguments:
+
+* `access_logs` - (Required) A block that specifies the configuration options for Verified Access instances. [Detailed below](#access_logs).
+* `verifiedaccess_instance_id` - (Required - Forces New resource) The ID of the Verified Access instance.
+
+### access_logs
+
+A `access_logs` block supports the following arguments:
+
+* `cloudwatch_logs` - (Optional) A block that specifies configures sending Verified Access logs to CloudWatch Logs. [Detailed below](#cloudwatch_logs).
+* `include_trust_context` - (Optional) Include trust data sent by trust providers into the logs.
+* `kinesis_data_firehose` - (Optional) A block that specifies configures sending Verified Access logs to Kinesis. [Detailed below](#kinesis_data_firehose).
+* `log_version` - (Optional) The logging version to use. Refer to [VerifiedAccessLogOptions](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_VerifiedAccessLogOptions.html) for the allowed values.
+* `s3` - (Optional) A block that specifies configures sending Verified Access logs to S3. [Detailed below](#s3).
+
+#### cloudwatch_logs
+
+A `cloudwatch_logs` block supports the following arguments:
+
+* `enabled` - (Required) Indicates whether logging is enabled.
+* `log_group` - (Optional) The name of the CloudWatch Logs Log Group.
+
+#### kinesis_data_firehose
+
+A `kinesis_data_firehose` block supports the following arguments:
+
+* `delivery_stream` - (Optional) The name of the delivery stream.
+* `enabled` - (Required) Indicates whether logging is enabled.
+
+#### s3
+
+A `s3` block supports the following arguments:
+
+* `bucket_name` - (Optional) The name of S3 bucket.
+* `bucket_owner` - (Optional) The ID of the AWS account that owns the Amazon S3 bucket.
+* `enabled` - (Required) Indicates whether logging is enabled.
+* `prefix` - (Optional) The bucket prefix.
+
+## Attribute Reference
+
+This resource exports no additional attributes.
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Verified Access Logging Configuration using the Verified Access Instance `id`. For example:
+
+```terraform
+import {
+  to = aws_verifiedaccess_instance_logging_configuration.example
+  id = "vai-1234567890abcdef0"
+}
+```
+
+Using `terraform import`, import Verified Access Logging Configuration using the Verified Access Instance `id`. For example:
+
+```console
+% terraform import aws_verifiedaccess_instance_logging_configuration.example vai-1234567890abcdef0
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

New resource: `aws_verifiedaccess_instance_logging_configuration`


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #29689

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

* [DescribeVerifiedAccessInstanceLoggingConfigurations](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeVerifiedAccessInstanceLoggingConfigurations.html)
* [ModifyVerifiedAccessInstanceLoggingConfiguration](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifyVerifiedAccessInstanceLoggingConfiguration.html)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccVerifiedAccessInstanceLoggingConfiguration' PKG=ec2 ACCTEST_PARALLELISM=5
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 5  -run=TestAccVerifiedAccessInstanceLoggingConfiguration -timeout 360m
=== RUN   TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsIncludeTrustContext
=== PAUSE TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsIncludeTrustContext
=== RUN   TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsLogVersion
=== PAUSE TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsLogVersion
=== RUN   TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsCloudWatchLogs
=== PAUSE TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsCloudWatchLogs
=== RUN   TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsKinesisDataFirehose
=== PAUSE TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsKinesisDataFirehose
=== RUN   TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsS3
=== PAUSE TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsS3
=== RUN   TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsCloudWatchLogsKinesisDataFirehoseS3
=== PAUSE TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsCloudWatchLogsKinesisDataFirehoseS3
=== RUN   TestAccVerifiedAccessInstanceLoggingConfiguration_disappears
=== PAUSE TestAccVerifiedAccessInstanceLoggingConfiguration_disappears
=== CONT  TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsIncludeTrustContext
=== CONT  TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsS3
=== CONT  TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsCloudWatchLogs
=== CONT  TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsKinesisDataFirehose
=== CONT  TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsLogVersion
--- PASS: TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsIncludeTrustContext (74.22s)
=== CONT  TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsCloudWatchLogsKinesisDataFirehoseS3
--- PASS: TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsLogVersion (75.46s)
=== CONT  TestAccVerifiedAccessInstanceLoggingConfiguration_disappears
--- PASS: TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsCloudWatchLogs (76.73s)
--- PASS: TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsS3 (92.69s)
--- PASS: TestAccVerifiedAccessInstanceLoggingConfiguration_disappears (33.08s)
--- PASS: TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsKinesisDataFirehose (285.04s)
--- PASS: TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsCloudWatchLogsKinesisDataFirehoseS3 (311.02s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        385.347s

...
```

### Additional information

#### Default values per Instance

When Verified Access Instances are created, they come with a logging configuration with the following default values

```json
{
    "LoggingConfigurations": [
        {
            "VerifiedAccessInstanceId": "vai-1234567890abcdef0",
            "AccessLogs": {
                "S3": {
                    "Enabled": false
                },
                "CloudWatchLogs": {
                    "Enabled": false
                },
                "KinesisDataFirehose": {
                    "Enabled": false
                },
                "LogVersion": "ocsf-1.0.0-rc.2",
                "IncludeTrustContext": false
            }
        }
    ]
}
```

Hence, when the `aws_verifiedaccess_instance_logging_configuration` resource is deleted, it should reset the logging configuration to the above

#### Value for `bucket_owner`

When S3 Logging configuration is set without a `bucket_owner`, the API will compute a value and return it. This presents issues when the S3 block is removed in Terraform. Removing it sets `enabled` to `false` but because there is still a `bucket_owner` value, the API returns an error `The parameter AccessLogs.S3.BucketOwner cannot be used when AccessLogs.S3.Enabled is false`

Hence, the expands function checks if `enabled` is first set to `true` before passing the value of `bucket_owner`. If `enabled` is `false` none of the other values matter and should not be passed to the API.

#### Value for `ClientToken`

`ClientToken` uses `uuid, err := uuid.GenerateUUID()` and `aws.String(uuid)` instead of `aws.String(id.UniqueId()),` because of Regex Validation on `ClientToken` specifically for the `ModifyVerifiedAccessInstanceLoggingConfiguration` API.