### PR TITLE
[New Data Source]: `aws_servicequotas_templates`

### DIFF
--- a/.changelog/33871.txt
+++ b/.changelog/33871.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_servicequotas_templates
+```

--- a/internal/service/servicequotas/service_package_gen.go
+++ b/internal/service/servicequotas/service_package_gen.go
@@ -15,7 +15,12 @@ import (
 type servicePackage struct{}
 
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.ServicePackageFrameworkDataSource {
-	return []*types.ServicePackageFrameworkDataSource{}
+	return []*types.ServicePackageFrameworkDataSource{
+		{
+			Factory: newDataSourceTemplates,
+			Name:    "Templates",
+		},
+	}
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.ServicePackageFrameworkResource {

--- a/internal/service/servicequotas/servicequotas_test.go
+++ b/internal/service/servicequotas/servicequotas_test.go
@@ -23,6 +23,9 @@ func TestAccServiceQuotas_serial(t *testing.T) {
 			"disappears":  testAccTemplateAssociation_disappears,
 			"skipDestroy": testAccTemplateAssociation_skipDestroy,
 		},
+		"TemplatesDataSource": {
+			"basic": testAccTemplatesDataSource_basic,
+		},
 	}
 
 	acctest.RunSerialTests2Levels(t, testCases, 0)

--- a/internal/service/servicequotas/templates_data_source.go
+++ b/internal/service/servicequotas/templates_data_source.go
@@ -1,0 +1,155 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package servicequotas
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/servicequotas"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/servicequotas/types"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource(name="Templates")
+func newDataSourceTemplates(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &dataSourceTemplates{}, nil
+}
+
+const (
+	DSNameTemplates = "Templates Data Source"
+)
+
+type dataSourceTemplates struct {
+	framework.DataSourceWithConfigure
+}
+
+func (d *dataSourceTemplates) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) { // nosemgrep:ci.meta-in-func-name
+	resp.TypeName = "aws_servicequotas_templates"
+}
+
+func (d *dataSourceTemplates) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": framework.IDAttribute(),
+			"region": schema.StringAttribute{
+				Required: true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"templates": schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"global_quota": schema.BoolAttribute{
+							Computed: true,
+						},
+						"quota_code": schema.StringAttribute{
+							Computed: true,
+						},
+						"quota_name": schema.StringAttribute{
+							Computed: true,
+						},
+						"region": schema.StringAttribute{
+							Computed: true,
+						},
+						"service_code": schema.StringAttribute{
+							Computed: true,
+						},
+						"service_name": schema.StringAttribute{
+							Computed: true,
+						},
+						"unit": schema.StringAttribute{
+							Computed: true,
+						},
+						"value": schema.Float64Attribute{
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *dataSourceTemplates) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	conn := d.Meta().ServiceQuotasClient(ctx)
+
+	var data dataSourceTemplatesData
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	input := servicequotas.ListServiceQuotaIncreaseRequestsInTemplateInput{
+		AwsRegion: aws.String(data.Region.ValueString()),
+	}
+	out, err := conn.ListServiceQuotaIncreaseRequestsInTemplate(ctx, &input)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.ServiceQuotas, create.ErrActionReading, DSNameTemplates, data.Region.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	data.ID = types.StringValue(data.Region.ValueString())
+
+	templates, diags := flattenTemplates(ctx, out.ServiceQuotaIncreaseRequestInTemplateList)
+	resp.Diagnostics.Append(diags...)
+	data.Templates = templates
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+var templatesSourceAttrTypes = map[string]attr.Type{
+	"global_quota": types.BoolType,
+	"quota_code":   types.StringType,
+	"quota_name":   types.StringType,
+	"region":       types.StringType,
+	"service_code": types.StringType,
+	"service_name": types.StringType,
+	"unit":         types.StringType,
+	"value":        types.Float64Type,
+}
+
+type dataSourceTemplatesData struct {
+	Region    types.String `tfsdk:"region"`
+	ID        types.String `tfsdk:"id"`
+	Templates types.List   `tfsdk:"templates"`
+}
+
+func flattenTemplates(ctx context.Context, apiObject []awstypes.ServiceQuotaIncreaseRequestInTemplate) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	elemType := types.ObjectType{AttrTypes: templatesSourceAttrTypes}
+
+	elems := []attr.Value{}
+	for _, t := range apiObject {
+		obj := map[string]attr.Value{
+			"global_quota": types.BoolValue(t.GlobalQuota),
+			"quota_code":   flex.StringToFramework(ctx, t.QuotaCode),
+			"quota_name":   flex.StringToFramework(ctx, t.QuotaName),
+			"region":       flex.StringToFramework(ctx, t.AwsRegion),
+			"service_code": flex.StringToFramework(ctx, t.ServiceCode),
+			"service_name": flex.StringToFramework(ctx, t.ServiceName),
+			"unit":         flex.StringToFramework(ctx, t.Unit),
+			"value":        flex.Float64ToFramework(ctx, t.DesiredValue),
+		}
+		objVal, d := types.ObjectValue(templatesSourceAttrTypes, obj)
+		diags.Append(d...)
+
+		elems = append(elems, objVal)
+	}
+	listVal, d := types.ListValue(elemType, elems)
+	diags.Append(d...)
+
+	return listVal, diags
+}

--- a/internal/service/servicequotas/templates_data_source_test.go
+++ b/internal/service/servicequotas/templates_data_source_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package servicequotas_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func testAccTemplatesDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_servicequotas_templates.test"
+	regionDataSourceName := "data.aws_region.current"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckRegion(t, names.USEast1RegionID)
+			acctest.PreCheckPartitionHasService(t, names.ServiceQuotasEndpointID)
+			testAccPreCheckTemplate(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceQuotasEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTemplateDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTemplatesDataSourceConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "region", regionDataSourceName, "name"),
+					resource.TestCheckResourceAttr(dataSourceName, "templates.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccTemplatesDataSourceConfig_basic() string {
+	return acctest.ConfigCompose(
+		testAccTemplateConfig_basic(lambdaStorageQuotaCode, lambdaServiceCode, lambdaStorageValue),
+		`
+data "aws_servicequotas_templates" "test" {
+  region = aws_servicequotas_template.test.region
+}
+`)
+}

--- a/website/docs/d/servicequotas_templates.html.markdown
+++ b/website/docs/d/servicequotas_templates.html.markdown
@@ -1,0 +1,44 @@
+---
+subcategory: "Service Quotas"
+layout: "aws"
+page_title: "AWS: aws_servicequotas_templates"
+description: |-
+  Terraform data source for managing an AWS Service Quotas Templates.
+---
+
+# Data Source: aws_servicequotas_templates
+
+Terraform data source for managing an AWS Service Quotas Templates.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_servicequotas_templates" "example" {
+  region = "us-east-1"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `region` - (Required) AWS Region to which the quota increases apply.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `templates` - A list of quota increase templates for specified region. See [`templates`](#templates).
+
+### `templates`
+
+* `global_quota` - Indicates whether the quota is global.
+* `quota_name` - Quota name.
+* `quota_code` - Quota identifier.
+* `region` - AWS Region to which the template applies.
+* `service_code` - (Required) Service identifier.
+* `service_name` - Service name.
+* `unit` - Unit of measurement.
+* `value` - (Required) The new, increased value for the quota.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The `aws_servicequotas_templates` data source lists all of the increase requests for a given region.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->


Relates #9119

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=servicequotas TESTS=TestAccServiceQuotas_serial/TemplatesDataSource/basic
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/servicequotas/... -v -count 1 -parallel 20 -run='TestAccServiceQuotas_serial/TemplatesDataSource/basic'  -timeout 360m

--- PASS: TestAccServiceQuotas_serial (11.02s)
    --- PASS: TestAccServiceQuotas_serial/TemplatesDataSource (11.02s)
        --- PASS: TestAccServiceQuotas_serial/TemplatesDataSource/basic (11.02s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/servicequotas      14.222s
```
