### PR TITLE
r/aws_verifiedaccess_instance - fips_enabled

### DIFF
--- a/.changelog/33880.txt
+++ b/.changelog/33880.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_verifiedaccess_instance: Add `fips_enabled` argument.
+resource/aws_verifiedaccess_instance: Add `fips_enabled` argument
 ```

--- a/.changelog/33880.txt
+++ b/.changelog/33880.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_verifiedaccess_instance: Add `fips_enabled` argument.
+```

--- a/internal/service/ec2/verifiedaccess_instance.go
+++ b/internal/service/ec2/verifiedaccess_instance.go
@@ -44,6 +44,11 @@ func ResourceVerifiedAccessInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"fips_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
 			"last_updated_time": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -97,6 +102,10 @@ func resourceVerifiedAccessInstanceCreate(ctx context.Context, d *schema.Resourc
 		input.Description = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("fips_enabled"); ok {
+		input.FIPSEnabled = aws.Bool(v.(bool))
+	}
+
 	output, err := conn.CreateVerifiedAccessInstance(ctx, input)
 
 	if err != nil {
@@ -126,6 +135,7 @@ func resourceVerifiedAccessInstanceRead(ctx context.Context, d *schema.ResourceD
 
 	d.Set("creation_time", output.CreationTime)
 	d.Set("description", output.Description)
+	d.Set("fips_enabled", output.FipsEnabled)
 	d.Set("last_updated_time", output.LastUpdatedTime)
 
 	if v := output.VerifiedAccessTrustProviders; v != nil {

--- a/internal/service/ec2/verifiedaccess_instance_test.go
+++ b/internal/service/ec2/verifiedaccess_instance_test.go
@@ -9,9 +9,9 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
@@ -217,7 +217,7 @@ func TestAccVerifiedAccessInstance_tags(t *testing.T) {
 
 func testAccCheckVerifiedAccessInstanceNotRecreated(before, after *types.VerifiedAccessInstance) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if before, after := aws.StringValue(before.VerifiedAccessInstanceId), aws.StringValue(after.VerifiedAccessInstanceId); before != after {
+		if before, after := aws.ToString(before.VerifiedAccessInstanceId), aws.ToString(after.VerifiedAccessInstanceId); before != after {
 			return fmt.Errorf("Verified Access Instance (%s/%s) recreated", before, after)
 		}
 
@@ -227,7 +227,7 @@ func testAccCheckVerifiedAccessInstanceNotRecreated(before, after *types.Verifie
 
 func testAccCheckVerifiedAccessInstanceRecreated(before, after *types.VerifiedAccessInstance) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if before, after := aws.StringValue(before.VerifiedAccessInstanceId), aws.StringValue(after.VerifiedAccessInstanceId); before == after {
+		if before, after := aws.ToString(before.VerifiedAccessInstanceId), aws.ToString(after.VerifiedAccessInstanceId); before == after {
 			return fmt.Errorf("Verified Access Instance (%s) not recreated", before)
 		}
 

--- a/website/docs/r/verifiedaccess_instance.html.markdown
+++ b/website/docs/r/verifiedaccess_instance.html.markdown
@@ -61,7 +61,7 @@ Each `verified_access_trust_providers` supports the following argument:
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Transfer Workflows using the `id`. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Verified Access Instances using the `id`. For example:
 
 ```terraform
 import {
@@ -70,7 +70,7 @@ import {
 }
 ```
 
-Using `terraform import`, import Transfer Workflows using the  `id`. For example:
+Using `terraform import`, import Verified Access Instances using the  `id`. For example:
 
 ```console
 % terraform import aws_verifiedaccess_instance.example vai-1234567890abcdef0

--- a/website/docs/r/verifiedaccess_instance.html.markdown
+++ b/website/docs/r/verifiedaccess_instance.html.markdown
@@ -12,6 +12,8 @@ Terraform resource for managing a Verified Access Instance.
 
 ## Example Usage
 
+### Basic
+
 ```terraform
 resource "aws_verifiedaccess_instance" "example" {
   description = "example"
@@ -22,11 +24,20 @@ resource "aws_verifiedaccess_instance" "example" {
 }
 ```
 
+### With `fips_enabled`
+
+```terraform
+resource "aws_verifiedaccess_instance" "example" {
+  fips_enabled = true
+}
+```
+
 ## Argument Reference
 
 The following arguments are optional:
 
 * `description` - (Optional) A description for the AWS Verified Access Instance.
+* `fips_enabled` - (Optional, Forces new resource) Enable or disable support for Federal Information Processing Standards (FIPS) on the AWS Verified Access Instance.
 * `tags` - (Optional) Key-value mapping of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attribute Reference


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds the `fips_enabled` (optional, forces new) argument to `aws_verifiedaccess_instance`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #29689

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

Announcement: [AWS Verified Access supports FIPS 140-2 compliant endpoints in US and Canada Regions](https://aws.amazon.com/about-aws/whats-new/2023/09/aws-verified-access-fips-140-2-compliant-endpoints-us-canada/)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccVerifiedAccessInstance_' PKG=ec2 ACCTEST_PARALLELISM=5
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 5  -run=TestAccVerifiedAccessInstance_ -timeout 360m
=== RUN   TestAccVerifiedAccessInstance_basic
=== PAUSE TestAccVerifiedAccessInstance_basic
=== RUN   TestAccVerifiedAccessInstance_description
=== PAUSE TestAccVerifiedAccessInstance_description
=== RUN   TestAccVerifiedAccessInstance_fipsEnabled
=== PAUSE TestAccVerifiedAccessInstance_fipsEnabled
=== RUN   TestAccVerifiedAccessInstance_disappears
=== PAUSE TestAccVerifiedAccessInstance_disappears
=== RUN   TestAccVerifiedAccessInstance_tags
=== PAUSE TestAccVerifiedAccessInstance_tags
=== CONT  TestAccVerifiedAccessInstance_basic
=== CONT  TestAccVerifiedAccessInstance_fipsEnabled
=== CONT  TestAccVerifiedAccessInstance_disappears
=== CONT  TestAccVerifiedAccessInstance_description
=== CONT  TestAccVerifiedAccessInstance_tags
--- PASS: TestAccVerifiedAccessInstance_disappears (38.37s)
--- PASS: TestAccVerifiedAccessInstance_basic (49.18s)
--- PASS: TestAccVerifiedAccessInstance_fipsEnabled (74.65s)
--- PASS: TestAccVerifiedAccessInstance_description (74.82s)
--- PASS: TestAccVerifiedAccessInstance_tags (96.15s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        96.269s

...
```
