### PR TITLE
F aws workspaces directory dedicated tenancy

### DIFF
--- a/internal/service/workspaces/directory.go
+++ b/internal/service/workspaces/directory.go
@@ -61,8 +61,8 @@ func ResourceDirectory() *schema.Resource {
 			"dedicated_tenancy": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default: false,
-				Computed: true,
+				ForceNew: true,
+				Default:  false,
 			},
 			"dns_ip_addresses": {
 				Type:     schema.TypeSet,
@@ -223,7 +223,7 @@ func ResourceDirectory() *schema.Resource {
 func resourceDirectoryCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WorkSpacesClient(ctx)
-    
+
 	directoryID := d.Get("directory_id").(string)
 	directoryTenancy := types.TenancyShared
 	if d.Get("dedicated_tenancy").(bool) {

--- a/internal/service/workspaces/directory.go
+++ b/internal/service/workspaces/directory.go
@@ -58,6 +58,12 @@ func ResourceDirectory() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"dedicated_tenancy": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default: false,
+				Computed: true,
+			},
 			"dns_ip_addresses": {
 				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
@@ -217,13 +223,17 @@ func ResourceDirectory() *schema.Resource {
 func resourceDirectoryCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WorkSpacesClient(ctx)
-
+    
 	directoryID := d.Get("directory_id").(string)
+	directoryTenancy := types.TenancyShared
+	if d.Get("dedicated_tenancy").(bool) {
+		directoryTenancy = types.TenancyDedicated
+	}
 	input := &workspaces.RegisterWorkspaceDirectoryInput{
 		DirectoryId:       aws.String(directoryID),
 		EnableSelfService: aws.Bool(false), // this is handled separately below
 		EnableWorkDocs:    aws.Bool(false),
-		Tenancy:           types.TenancyShared,
+		Tenancy:           directoryTenancy,
 		Tags:              getTagsIn(ctx),
 	}
 

--- a/website/docs/r/workspaces_directory.html.markdown
+++ b/website/docs/r/workspaces_directory.html.markdown
@@ -149,6 +149,7 @@ This resource supports the following arguments:
 
 * `directory_id` - (Required) The directory identifier for registration in WorkSpaces service.
 * `subnet_ids` - (Optional) The identifiers of the subnets where the directory resides.
+* `dedicated_tenancy` - (Optional) Whether the Workspaces directory will be running in a dedicated environment (required for BYOL Workspaces). Default `false`.
 * `ip_group_ids` - The identifiers of the IP access control groups associated with the directory.
 * `tags` – (Optional) A map of tags assigned to the WorkSpaces directory. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `self_service_permissions` – (Optional) Permissions to enable or disable self-service capabilities. Defined below.


### PR DESCRIPTION
### Description
Using the current provider version, every Workspaces directory uses the "shared" tenancy which is unsuitable for
BYOL Workspaces (i.e. Workspaces created from BYOL bundles).
This PR introduces a boolean argument "dedicated_tenancy" which is optional and defaults to "false" so that
no changes need to be made to existing templates. 

### Output from Acceptance Testing
Skipped acceptance testing since it's a very small change and I don't have the resources to run these tests.

PS: This is my first PR for a public repo so please have patience. 
