### PR TITLE
Support region for target_table argument in aws_glue_catalog_table

### DIFF
--- a/internal/service/glue/catalog_table.go
+++ b/internal/service/glue/catalog_table.go
@@ -342,6 +342,10 @@ func ResourceCatalogTable() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 						},
+						"region": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 					},
 				},
 			},

--- a/website/docs/r/glue_catalog_table.html.markdown
+++ b/website/docs/r/glue_catalog_table.html.markdown
@@ -190,6 +190,7 @@ To add an index to an existing table, see the [`glue_partition_index` resource](
 * `catalog_id` - (Required) ID of the Data Catalog in which the table resides.
 * `database_name` - (Required) Name of the catalog database that contains the target table.
 * `name` - (Required) Name of the target table.
+* `region` - (Optional) Region of the target table.
 
 ## Attribute Reference
 


### PR DESCRIPTION

### Description
[Enhancement]: Support region for target_table argument in aws_glue_catalog_table #[33639](https://github.com/hashicorp/terraform-provider-aws/issues/33639)

### Relations
Relates #33639
