### PR TITLE
r/aws_redshiftserverless_workgroup: allow `require_ssl`, `use_fips_ssl` config parameters

### DIFF
--- a/.changelog/33916.txt
+++ b/.changelog/33916.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_redshiftserverless_workgroup: Allow `require_ssl` and `use_fips_ssl` `config_parameters` keys
+```

--- a/internal/service/redshiftserverless/workgroup.go
+++ b/internal/service/redshiftserverless/workgroup.go
@@ -80,6 +80,10 @@ func ResourceWorkgroup() *schema.Resource {
 								"max_query_temp_blocks_to_disk",
 								"max_join_row_count",
 								"max_nested_loop_join_row_count",
+								// default SSL parameters automatically added by AWS
+								// https://docs.aws.amazon.com/redshift/latest/mgmt/connecting-ssl-support.html
+								"require_ssl",
+								"use_fips_ssl",
 							}, false),
 							Required: true,
 						},

--- a/internal/service/redshiftserverless/workgroup_test.go
+++ b/internal/service/redshiftserverless/workgroup_test.go
@@ -101,7 +101,7 @@ func TestAccRedshiftServerlessWorkgroup_configParameters(t *testing.T) {
 				Config: testAccWorkgroupConfig_configParameters(rName, "14400"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkgroupExists(ctx, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "config_parameter.#", "7"),
+					resource.TestCheckResourceAttr(resourceName, "config_parameter.#", "9"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "config_parameter.*", map[string]string{
 						"parameter_key":   "datestyle",
 						"parameter_value": "ISO, MDY",
@@ -130,6 +130,14 @@ func TestAccRedshiftServerlessWorkgroup_configParameters(t *testing.T) {
 						"parameter_key":   "enable_case_sensitive_identifier",
 						"parameter_value": "false",
 					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "config_parameter.*", map[string]string{
+						"parameter_key":   "require_ssl",
+						"parameter_value": "false",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "config_parameter.*", map[string]string{
+						"parameter_key":   "use_fips_ssl",
+						"parameter_value": "false",
+					}),
 				),
 			},
 			{
@@ -141,7 +149,7 @@ func TestAccRedshiftServerlessWorkgroup_configParameters(t *testing.T) {
 				Config: testAccWorkgroupConfig_configParameters(rName, "28800"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkgroupExists(ctx, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "config_parameter.#", "7"),
+					resource.TestCheckResourceAttr(resourceName, "config_parameter.#", "9"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "config_parameter.*", map[string]string{
 						"parameter_key":   "datestyle",
 						"parameter_value": "ISO, MDY",
@@ -168,6 +176,14 @@ func TestAccRedshiftServerlessWorkgroup_configParameters(t *testing.T) {
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "config_parameter.*", map[string]string{
 						"parameter_key":   "enable_case_sensitive_identifier",
+						"parameter_value": "false",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "config_parameter.*", map[string]string{
+						"parameter_key":   "require_ssl",
+						"parameter_value": "false",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "config_parameter.*", map[string]string{
+						"parameter_key":   "use_fips_ssl",
 						"parameter_value": "false",
 					}),
 				),
@@ -351,6 +367,14 @@ resource "aws_redshiftserverless_workgroup" "test" {
   }
   config_parameter {
     parameter_key   = "enable_case_sensitive_identifier"
+    parameter_value = "false"
+  }
+  config_parameter {
+    parameter_key   = "require_ssl"
+    parameter_value = "false"
+  }
+  config_parameter {
+    parameter_key   = "use_fips_ssl"
     parameter_value = "false"
   }
 }

--- a/website/docs/r/redshiftserverless_workgroup.html.markdown
+++ b/website/docs/r/redshiftserverless_workgroup.html.markdown
@@ -38,7 +38,7 @@ The following arguments are optional:
 
 ### Config Parameter
 
-* `parameter_key` - (Required) The key of the parameter. The options are `auto_mv`, `datestyle`, `enable_case_sensitive_identifier`, `enable_user_activity_logging`, `query_group`, `search_path` and [query monitoring metrics](https://docs.aws.amazon.com/redshift/latest/dg/cm-c-wlm-query-monitoring-rules.html#cm-c-wlm-query-monitoring-metrics-serverless) that let you define performance boundaries: `max_query_cpu_time`, `max_query_blocks_read`, `max_scan_row_count`, `max_query_execution_time`, `max_query_queue_time`, `max_query_cpu_usage_percent`, `max_query_temp_blocks_to_disk`, `max_join_row_count` and `max_nested_loop_join_row_count`.
+* `parameter_key` - (Required) The key of the parameter. The options are `auto_mv`, `datestyle`, `enable_case_sensitive_identifier`, `enable_user_activity_logging`, `query_group`, `search_path`, `require_ssl`, `use_fips_ssl`, and [query monitoring metrics](https://docs.aws.amazon.com/redshift/latest/dg/cm-c-wlm-query-monitoring-rules.html#cm-c-wlm-query-monitoring-metrics-serverless) that let you define performance boundaries: `max_query_cpu_time`, `max_query_blocks_read`, `max_scan_row_count`, `max_query_execution_time`, `max_query_queue_time`, `max_query_cpu_usage_percent`, `max_query_temp_blocks_to_disk`, `max_join_row_count` and `max_nested_loop_join_row_count`.
 * `parameter_value` - (Required) The value of the parameter to set.
 
 ## Attribute Reference


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Allows SSL-related `config_parameters` to be specified in Terraform. Adding these can prevent persistent differences when AWS default values are returned in the `config_parameters` array.

Longer term the `config_parameters` argument could be refactored to suppress differences when keys with default values are returned from the read operation. The complexity involved with this approach warrants a deeper dive into the API. This PR aims simply to enable explicit configuration of these new keys to unblock existing configurations.


Before:

```console
% make testacc PKG=redshiftserverless TESTS=TestAccRedshiftServerlessWorkgroup_configParameters
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/redshiftserverless/... -v -count 1 -parallel 20 -run='TestAccRedshiftServerlessWorkgroup_configParameters'  -timeout 360m

    workgroup_test.go:94: Step 1/3 error: After applying this test step and performing a `terraform refresh`, the plan was not empty.
        stdout


        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place

        Terraform will perform the following actions:

          # aws_redshiftserverless_workgroup.test will be updated in-place
          ~ resource "aws_redshiftserverless_workgroup" "test" {
                id                   = "tf-acc-test-75452025310988525"
                tags                 = {}
                # (11 unchanged attributes hidden)

              - config_parameter {
                  - parameter_key   = "require_ssl" -> null
                  - parameter_value = "false" -> null
                }
              - config_parameter {
                  - parameter_key   = "use_fips_ssl" -> null
                  - parameter_value = "false" -> null
                }

                # (7 unchanged blocks hidden)
            }

        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccRedshiftServerlessWorkgroup_configParameters (628.88s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/redshiftserverless 632.144s
```

After:

```console
% make testacc PKG=redshiftserverless TESTS=TestAccRedshiftServerlessWorkgroup_configParameters
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/redshiftserverless/... -v -count 1 -parallel 20 -run='TestAccRedshiftServerlessWorkgroup_configParameters'  -timeout 360m

--- PASS: TestAccRedshiftServerlessWorkgroup_configParameters (780.42s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/redshiftserverless 783.660s
```
### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #33692

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=redshiftserverless TESTS=TestAccRedshiftServerlessWorkgroup_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/redshiftserverless/... -v -count 1 -parallel 20 -run='TestAccRedshiftServerlessWorkgroup_'  -timeout 360m

--- PASS: TestAccRedshiftServerlessWorkgroup_basic (459.50s)
--- PASS: TestAccRedshiftServerlessWorkgroup_tags (463.93s)
--- PASS: TestAccRedshiftServerlessWorkgroup_disappears (578.93s)
--- PASS: TestAccRedshiftServerlessWorkgroup_configParameters (597.36s)
--- PASS: TestAccRedshiftServerlessWorkgroup_baseCapacityAndPubliclyAccessible (695.84s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/redshiftserverless 699.211s
```
