### PR TITLE
r/aws_opensearchserverless_collection: return error on read

### DIFF
--- a/.changelog/33918.txt
+++ b/.changelog/33918.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/ws_opensearchserverless_collection: Fix crash when error is returned
+resource/aws_opensearchserverless_collection: Fix crash when error is returned
 ```

--- a/.changelog/33918.txt
+++ b/.changelog/33918.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/ws_opensearchserverless_collection: Fix crash when error is returned
+```

--- a/internal/service/opensearchserverless/collection.go
+++ b/internal/service/opensearchserverless/collection.go
@@ -208,6 +208,14 @@ func (r *resourceCollection) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionReading, ResNameCollection, state.ID.ValueString(), nil),
+			err.Error(),
+		)
+		return
+	}
+
 	state.ARN = flex.StringToFramework(ctx, out.Arn)
 	state.CollectionEndpoint = flex.StringToFramework(ctx, out.CollectionEndpoint)
 	state.DashboardEndpoint = flex.StringToFramework(ctx, out.DashboardEndpoint)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fix crash on import when Read() returns an error.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #33666

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTARGS='-run=TestAccOpenSearchServerlessCollection_' PKG=opensearchserverless

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/opensearchserverless/... -v -count 1 -parallel 20  -run=TestAccOpenSearchServerlessCollection_ -timeout 360m
--- PASS: TestAccOpenSearchServerlessCollection_disappears (450.91s)
--- PASS: TestAccOpenSearchServerlessCollection_basic (471.98s)
--- PASS: TestAccOpenSearchServerlessCollection_update (483.57s)
--- PASS: TestAccOpenSearchServerlessCollection_tags (515.02s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/opensearchserverless	518.199s
```
