### PR TITLE
docs: Add exclusion_by_resource_types block object details for aws_config_configuration_recorder

### DIFF
--- a/website/docs/r/config_configuration_recorder.html.markdown
+++ b/website/docs/r/config_configuration_recorder.html.markdown
@@ -14,6 +14,8 @@ Provides an AWS Config Configuration Recorder. Please note that this resource **
 
 ## Example Usage
 
+### Basic Usage
+
 ```terraform
 resource "aws_config_configuration_recorder" "foo" {
   name     = "example"
@@ -39,6 +41,27 @@ resource "aws_iam_role" "r" {
 }
 ```
 
+### Exclude Resources Types Usage
+
+```terraform
+resource "aws_config_configuration_recorder" "foo" {
+  name     = "example"
+  role_arn = aws_iam_role.r.arn
+
+  recording_group {
+    all_supported = false
+
+    exclusion_by_resource_types {
+      resource_types = ["AWS::EC2::Instance"]
+    }
+
+    recording_strategy {
+      use_only = "EXCLUSION_BY_RESOURCE_TYPES"
+    }
+  }
+}
+```
+
 ## Argument Reference
 
 This resource supports the following arguments:
@@ -47,15 +70,19 @@ This resource supports the following arguments:
 * `role_arn` - (Required) Amazon Resource Name (ARN) of the IAM role. Used to make read or write requests to the delivery channel and to describe the AWS resources associated with the account. See [AWS Docs](http://docs.aws.amazon.com/config/latest/developerguide/iamrole-permissions.html) for more details.
 * `recording_group` - (Optional) Recording group - see below.
 
-### `recording_group`
+### recording_group Configuration Block
 
 * `all_supported` - (Optional) Specifies whether AWS Config records configuration changes for every supported type of regional resource (which includes any new type that will become supported in the future). Conflicts with `resource_types`. Defaults to `true`.
 * `exclusion_by_resource_types` - (Optional) An object that specifies how AWS Config excludes resource types from being recorded by the configuration recorder.To use this option, you must set the useOnly field of RecordingStrategy to `EXCLUSION_BY_RESOURCE_TYPES` Requires `all_supported = false`. Conflicts with `resource_types`.
 * `include_global_resource_types` - (Optional) Specifies whether AWS Config includes all supported types of _global resources_ with the resources that it records. Requires `all_supported = true`. Conflicts with `resource_types`.
-* `recording_strategy` - (Optional) Recording Strategy - see below..
+* `recording_strategy` - (Optional) Recording Strategy. Detailed below.
 * `resource_types` - (Optional) A list that specifies the types of AWS resources for which AWS Config records configuration changes (for example, `AWS::EC2::Instance` or `AWS::CloudTrail::Trail`). See [relevant part of AWS Docs](http://docs.aws.amazon.com/config/latest/APIReference/API_ResourceIdentifier.html#config-Type-ResourceIdentifier-resourceType) for available types. In order to use this attribute, `all_supported` must be set to false.
 
-#### `recording_strategy`
+#### exclusion_by_resource_types Configuration Block
+
+* `resource_types` - (Optional) A list that specifies the types of AWS resources for which AWS Config excludes records configuration changes. See [relevant part of AWS Docs](http://docs.aws.amazon.com/config/latest/APIReference/API_ResourceIdentifier.html#config-Type-ResourceIdentifier-resourceType) for available types.
+
+#### recording_strategy Configuration Block
 
 * ` use_only` - (Optional) The recording strategy for the configuration recorder.See [relevant part of AWS Docs](https://docs.aws.amazon.com/config/latest/APIReference/API_RecordingStrategy.html)
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
* Clarify the documentation for the `aws_config_configuration_recorder` resource on configuration block `exclusion_by_resource_types` object by adding `resource_types` attribute.
* Add an example to `show recording_group` configuration to exclude specific resources types.