### PR TITLE
Replace the values' data type from string to number in the document

### DIFF
--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -109,7 +109,7 @@ resource "aws_iam_role_policy" "example" {
 resource "aws_codebuild_project" "example" {
   name          = "test-project"
   description   = "test_codebuild_project"
-  build_timeout = "5"
+  build_timeout = 5
   service_role  = aws_iam_role.example.arn
 
   artifacts {
@@ -185,8 +185,8 @@ resource "aws_codebuild_project" "example" {
 resource "aws_codebuild_project" "project-with-cache" {
   name           = "test-project-cache"
   description    = "test_codebuild_project_cache"
-  build_timeout  = "5"
-  queued_timeout = "5"
+  build_timeout  = 5
+  queued_timeout = 5
 
   service_role = aws_iam_role.example.arn
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Replaced the `build_timeout` and `queued_timeout` values' data type from a string to a number in the document because it is expected to be a Int in the [code](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/codebuild/project.go#L627-L632).
While it is not illegal to use a string value, it should be of the number data type.