### PR TITLE
Add `ja3_fingerprint` matching support to WAFv2

### DIFF
--- a/.changelog/33933.txt
+++ b/.changelog/33933.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_wafv2_web_acl: Add `ja3_fingerprint` to `field_to_match` configuration blocks
+```

--- a/internal/service/wafv2/flex.go
+++ b/internal/service/wafv2/flex.go
@@ -525,6 +525,10 @@ func expandFieldToMatch(l []interface{}) *wafv2.FieldToMatch {
 		f.SingleHeader = expandSingleHeader(m["single_header"].([]interface{}))
 	}
 
+	if v, ok := m["ja3_fingerprint"]; ok && len(v.([]interface{})) > 0 {
+		f.JA3Fingerprint = expandJA3Fingerprint(v.([]interface{}))
+	}
+
 	if v, ok := m["single_query_argument"]; ok && len(v.([]interface{})) > 0 {
 		f.SingleQueryArgument = expandSingleQueryArgument(m["single_query_argument"].([]interface{}))
 	}
@@ -639,6 +643,20 @@ func expandBody(l []interface{}) *wafv2.Body {
 	}
 
 	return body
+}
+
+func expandJA3Fingerprint(l []interface{}) *wafv2.JA3Fingerprint {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	ja3fingerprint := &wafv2.JA3Fingerprint{
+		FallbackBehavior: aws.String(m["fallback_behavior"].(string)),
+	}
+
+	return ja3fingerprint
 }
 
 func expandJSONMatchPattern(l []interface{}) *wafv2.JsonMatchPattern {
@@ -1901,6 +1919,10 @@ func flattenFieldToMatch(f *wafv2.FieldToMatch) interface{} {
 		m["headers"] = flattenHeaders(f.Headers)
 	}
 
+	if f.JA3Fingerprint != nil {
+		m["ja3_fingerprint"] = flattenJA3Fingerprint(f.JA3Fingerprint)
+	}
+
 	if f.JsonBody != nil {
 		m["json_body"] = flattenJSONBody(f.JsonBody)
 	}
@@ -1981,6 +2003,18 @@ func flattenCookiesMatchPattern(c *wafv2.CookieMatchPattern) interface{} {
 
 	if c.All != nil {
 		m["all"] = make([]map[string]interface{}, 1)
+	}
+
+	return []interface{}{m}
+}
+
+func flattenJA3Fingerprint(j *wafv2.JA3Fingerprint) interface{} {
+	if j == nil {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"fallback_behavior": aws.StringValue(j.FallbackBehavior),
 	}
 
 	return []interface{}{m}

--- a/internal/service/wafv2/schemas.go
+++ b/internal/service/wafv2/schemas.go
@@ -343,6 +343,7 @@ func fieldToMatchBaseSchema() *schema.Resource {
 			"body":                bodySchema(),
 			"cookies":             cookiesSchema(),
 			"headers":             headersSchema(),
+			"ja3_fingerprint":     ja3fingerprintSchema(),
 			"json_body":           jsonBodySchema(),
 			"method":              emptySchema(),
 			"query_string":        emptySchema(),
@@ -783,6 +784,23 @@ func cookiesMatchPatternSchema() *schema.Schema {
 					Type:     schema.TypeList,
 					Optional: true,
 					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+			},
+		},
+	}
+}
+
+func ja3fingerprintSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"fallback_behavior": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice(wafv2.FallbackBehavior_Values(), false),
 				},
 			},
 		},

--- a/website/docs/r/wafv2_web_acl.html.markdown
+++ b/website/docs/r/wafv2_web_acl.html.markdown
@@ -814,12 +814,13 @@ The part of a web request that you want AWS WAF to inspect. Include the single `
 
 The `field_to_match` block supports the following arguments:
 
-~> **Note** Only one of `all_query_arguments`, `body`, `cookies`, `headers`, `json_body`, `method`, `query_string`, `single_header`, `single_query_argument`, or `uri_path` can be specified. An empty configuration block `{}` should be used when specifying `all_query_arguments`, `method`, or `query_string` attributes.
+~> **Note** Only one of `all_query_arguments`, `body`, `cookies`, `headers`, `ja3_fingerprint`, `json_body`, `method`, `query_string`, `single_header`, `single_query_argument`, or `uri_path` can be specified. An empty configuration block `{}` should be used when specifying `all_query_arguments`, `method`, or `query_string` attributes.
 
 * `all_query_arguments` - (Optional) Inspect all query arguments.
 * `body` - (Optional) Inspect the request body, which immediately follows the request headers. See [`body`](#body-block) below for details.
 * `cookies` - (Optional) Inspect the cookies in the web request. See [`cookies`](#cookies-block) below for details.
 * `headers` - (Optional) Inspect the request headers. See [`headers`](#headers-block) below for details.
+* `ja3_fingerprint` - (Optional) Inspect the JA3 fingerprint. See [`ja3_fingerprint`](#ja3_fingerprint-block) below for details.
 * `json_body` - (Optional) Inspect the request body as JSON. See [`json_body`](#json_body-block) for details.
 * `method` - (Optional) Inspect the HTTP method. The method indicates the type of operation that the request is asking the origin to perform.
 * `query_string` - (Optional) Inspect the query string. This is the part of a URL that appears after a `?` character, if any.
@@ -858,6 +859,12 @@ The `headers` block supports the following arguments:
     * `excluded_headers` - An array of strings that will be used for inspecting headers that do not have a key that matches one of the provided values.
 * `match_scope` - (Required) The parts of the headers to inspect with the rule inspection criteria. If you specify `All`, AWS WAF inspects both keys and values. Valid values include the following: `ALL`, `Key`, `Value`.
 * `oversize_handling` - (Required) Oversize handling tells AWS WAF what to do with a web request when the request component that the rule inspects is over the limits. Valid values include the following: `CONTINUE`, `MATCH`, `NO_MATCH`. See the AWS [documentation](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html) for more information.
+
+### `ja3_fingerprint` Block
+
+The `ja3_fingerprint` block supports the following arguments:
+
+* `fallback_behavior` - (Required) The match status to assign to the web request if the request doesn't have a JA3 fingerprint. Valid values include: `MATCH` or `NO_MATCH`.
 
 ### `json_body` Block
 


### PR DESCRIPTION
### Description

AWS recently released JA3 fingerprints into WAFv2.

This PR adds Terraform support for `ja3_fingerprint` as a `field_to_match` in a `byte_match_statement`.

### Relations

Closes #33671

### References

* https://docs.aws.amazon.com/waf/latest/APIReference/API_JA3Fingerprint.html
* https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-fields-list.html#waf-rule-statement-request-component-ja3-fingerprint
* https://aws.amazon.com/about-aws/whats-new/2023/09/aws-waf-ja3-fingerprint-match/

### Output from Acceptance Testing
```console
% make testacc TESTS=TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint PKG=wafv2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/wafv2/... -v -count 1 -parallel 20 -run='TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint'  -timeout 360m
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint (96.31s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/wafv2      96.385s
```
