### PR TITLE
Ensure AWS SDK for Go v2 HTTP requests and responses are logged

### DIFF
--- a/internal/conns/awsclient.go
+++ b/internal/conns/awsclient.go
@@ -15,6 +15,7 @@ import (
 	session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
 	apigatewayv2_sdkv1 "github.com/aws/aws-sdk-go/service/apigatewayv2"
 	mediaconvert_sdkv1 "github.com/aws/aws-sdk-go/service/mediaconvert"
+	baselogging "github.com/hashicorp/aws-sdk-go-base/v2/logging"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -38,6 +39,7 @@ type AWSClient struct {
 	endpoints                 map[string]string // From provider configuration.
 	httpClient                *http.Client
 	lock                      sync.Mutex
+	logger                    baselogging.Logger
 	s3UsePathStyle            bool                                      // From provider configuration.
 	s3UsEast1RegionalEndpoint endpoints_sdkv1.S3UsEast1RegionalEndpoint // From provider configuration.
 	stsRegion                 string                                    // From provider configuration.
@@ -81,6 +83,11 @@ func (client *AWSClient) SetHTTPClient(httpClient *http.Client) {
 // HTTPClient returns the http.Client used for AWS API calls.
 func (client *AWSClient) HTTPClient() *http.Client {
 	return client.httpClient
+}
+
+// RegisterLogger places the configured logger into Context so it can be used via `tflog`.
+func (client *AWSClient) RegisterLogger(ctx context.Context) context.Context {
+	return baselogging.RegisterLogger(ctx, client.logger)
 }
 
 // APIGatewayInvokeURL returns the Amazon API Gateway (REST APIs) invoke URL for the configured AWS Region.

--- a/internal/conns/config.go
+++ b/internal/conns/config.go
@@ -117,6 +117,11 @@ func (c *Config) ConfigureProvider(ctx context.Context, client *AWSClient) (*AWS
 		awsbaseConfig.StsRegion = c.STSRegion
 	}
 
+	// Avoid duplicate calls to STS by enabling SkipCredsValidation for the call to GetAwsConfig
+	// and then restoring the configured value for the call to GetAwsAccountIDAndPartition.
+	skipCredsValidation := awsbaseConfig.SkipCredsValidation
+	awsbaseConfig.SkipCredsValidation = true
+
 	tflog.Debug(ctx, "Configuring Terraform AWS Provider")
 	ctx, cfg, awsDiags := awsbase.GetAwsConfig(ctx, &awsbaseConfig)
 
@@ -138,6 +143,8 @@ func (c *Config) ConfigureProvider(ctx context.Context, client *AWSClient) (*AWS
 		}
 	}
 	c.Region = cfg.Region
+
+	awsbaseConfig.SkipCredsValidation = skipCredsValidation
 
 	tflog.Debug(ctx, "Creating AWS SDK v1 session")
 	sess, awsDiags := awsbasev1.GetSession(ctx, &cfg, &awsbaseConfig)

--- a/internal/conns/config.go
+++ b/internal/conns/config.go
@@ -203,6 +203,7 @@ func (c *Config) ConfigureProvider(ctx context.Context, client *AWSClient) (*AWS
 	client.clients = make(map[string]any, 0)
 	client.conns = make(map[string]any, 0)
 	client.endpoints = c.Endpoints
+	client.logger = logger
 	client.s3UsePathStyle = c.S3UsePathStyle
 	client.s3UsEast1RegionalEndpoint = c.S3UsEast1RegionalEndpoint
 	client.stsRegion = c.STSRegion

--- a/internal/provider/fwprovider/intercept.go
+++ b/internal/provider/fwprovider/intercept.go
@@ -173,6 +173,9 @@ func (w *wrappedDataSource) Read(ctx context.Context, request datasource.ReadReq
 }
 
 func (w *wrappedDataSource) Configure(ctx context.Context, request datasource.ConfigureRequest, response *datasource.ConfigureResponse) {
+	if v, ok := request.ProviderData.(*conns.AWSClient); ok {
+		w.meta = v
+	}
 	ctx = w.bootstrapContext(ctx, w.meta)
 	w.inner.Configure(ctx, request, response)
 }

--- a/internal/provider/fwprovider/provider.go
+++ b/internal/provider/fwprovider/provider.go
@@ -319,6 +319,7 @@ func (p *fwprovider) DataSources(ctx context.Context) []func() datasource.DataSo
 				ctx = conns.NewDataSourceContext(ctx, servicePackageName, v.Name)
 				if meta != nil {
 					ctx = tftags.NewContext(ctx, meta.DefaultTagsConfig, meta.IgnoreTagsConfig)
+					ctx = meta.RegisterLogger(ctx)
 				}
 
 				return ctx
@@ -389,6 +390,7 @@ func (p *fwprovider) Resources(ctx context.Context) []func() resource.Resource {
 				ctx = conns.NewResourceContext(ctx, servicePackageName, v.Name)
 				if meta != nil {
 					ctx = tftags.NewContext(ctx, meta.DefaultTagsConfig, meta.IgnoreTagsConfig)
+					ctx = meta.RegisterLogger(ctx)
 				}
 
 				return ctx

--- a/internal/provider/fwprovider/provider.go
+++ b/internal/provider/fwprovider/provider.go
@@ -5,9 +5,9 @@ package fwprovider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
-	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
@@ -291,7 +291,7 @@ func (p *fwprovider) Configure(ctx context.Context, request provider.ConfigureRe
 // The data source type name is determined by the DataSource implementing
 // the Metadata method. All data sources must have unique names.
 func (p *fwprovider) DataSources(ctx context.Context) []func() datasource.DataSource {
-	var errs *multierror.Error
+	var errs []error
 	var dataSources []func() datasource.DataSource
 
 	for n, sp := range p.Primary.Meta().(*conns.AWSClient).ServicePackages {
@@ -333,11 +333,11 @@ func (p *fwprovider) DataSources(ctx context.Context) []func() datasource.DataSo
 
 				if v, ok := schemaResponse.Schema.Attributes[names.AttrTags]; ok {
 					if !v.IsComputed() {
-						errs = multierror.Append(errs, fmt.Errorf("`%s` attribute must be Computed: %s", names.AttrTags, typeName))
+						errs = append(errs, fmt.Errorf("`%s` attribute must be Computed: %s", names.AttrTags, typeName))
 						continue
 					}
 				} else {
-					errs = multierror.Append(errs, fmt.Errorf("no `%s` attribute defined in schema: %s", names.AttrTags, typeName))
+					errs = append(errs, fmt.Errorf("no `%s` attribute defined in schema: %s", names.AttrTags, typeName))
 					continue
 				}
 
@@ -350,7 +350,7 @@ func (p *fwprovider) DataSources(ctx context.Context) []func() datasource.DataSo
 		}
 	}
 
-	if err := errs.ErrorOrNil(); err != nil {
+	if err := errors.Join(errs...); err != nil {
 		tflog.Warn(ctx, "registering data sources", map[string]interface{}{
 			"error": err.Error(),
 		})
@@ -365,7 +365,7 @@ func (p *fwprovider) DataSources(ctx context.Context) []func() datasource.DataSo
 // The resource type name is determined by the Resource implementing
 // the Metadata method. All resources must have unique names.
 func (p *fwprovider) Resources(ctx context.Context) []func() resource.Resource {
-	var errs *multierror.Error
+	var errs []error
 	var resources []func() resource.Resource
 
 	for _, sp := range p.Primary.Meta().(*conns.AWSClient).ServicePackages {
@@ -376,7 +376,7 @@ func (p *fwprovider) Resources(ctx context.Context) []func() resource.Resource {
 			inner, err := v.Factory(ctx)
 
 			if err != nil {
-				errs = multierror.Append(errs, fmt.Errorf("creating resource: %w", err))
+				errs = append(errs, fmt.Errorf("creating resource: %w", err))
 				continue
 			}
 
@@ -403,20 +403,20 @@ func (p *fwprovider) Resources(ctx context.Context) []func() resource.Resource {
 
 				if v, ok := schemaResponse.Schema.Attributes[names.AttrTags]; ok {
 					if v.IsComputed() {
-						errs = multierror.Append(errs, fmt.Errorf("`%s` attribute cannot be Computed: %s", names.AttrTags, typeName))
+						errs = append(errs, fmt.Errorf("`%s` attribute cannot be Computed: %s", names.AttrTags, typeName))
 						continue
 					}
 				} else {
-					errs = multierror.Append(errs, fmt.Errorf("no `%s` attribute defined in schema: %s", names.AttrTags, typeName))
+					errs = append(errs, fmt.Errorf("no `%s` attribute defined in schema: %s", names.AttrTags, typeName))
 					continue
 				}
 				if v, ok := schemaResponse.Schema.Attributes[names.AttrTagsAll]; ok {
 					if !v.IsComputed() {
-						errs = multierror.Append(errs, fmt.Errorf("`%s` attribute must be Computed: %s", names.AttrTagsAll, typeName))
+						errs = append(errs, fmt.Errorf("`%s` attribute must be Computed: %s", names.AttrTagsAll, typeName))
 						continue
 					}
 				} else {
-					errs = multierror.Append(errs, fmt.Errorf("no `%s` attribute defined in schema: %s", names.AttrTagsAll, typeName))
+					errs = append(errs, fmt.Errorf("no `%s` attribute defined in schema: %s", names.AttrTagsAll, typeName))
 					continue
 				}
 
@@ -429,7 +429,7 @@ func (p *fwprovider) Resources(ctx context.Context) []func() resource.Resource {
 		}
 	}
 
-	if err := errs.ErrorOrNil(); err != nil {
+	if err := errors.Join(errs...); err != nil {
 		tflog.Warn(ctx, "registering resources", map[string]interface{}{
 			"error": err.Error(),
 		})

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -273,6 +273,7 @@ func New(ctx context.Context) (*schema.Provider, error) {
 				ctx = conns.NewDataSourceContext(ctx, servicePackageName, v.Name)
 				if v, ok := meta.(*conns.AWSClient); ok {
 					ctx = tftags.NewContext(ctx, v.DefaultTagsConfig, v.IgnoreTagsConfig)
+					ctx = v.RegisterLogger(ctx)
 				}
 
 				return ctx
@@ -349,6 +350,7 @@ func New(ctx context.Context) (*schema.Provider, error) {
 				ctx = conns.NewResourceContext(ctx, servicePackageName, v.Name)
 				if v, ok := meta.(*conns.AWSClient); ok {
 					ctx = tftags.NewContext(ctx, v.DefaultTagsConfig, v.IgnoreTagsConfig)
+					ctx = v.RegisterLogger(ctx)
 				}
 
 				return ctx

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -15,7 +16,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	awsbase "github.com/hashicorp/aws-sdk-go-base/v2"
-	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -244,7 +244,7 @@ func New(ctx context.Context) (*schema.Provider, error) {
 		return configure(ctx, provider, d)
 	}
 
-	var errs *multierror.Error
+	var errs []error
 	servicePackageMap := make(map[string]conns.ServicePackage)
 
 	for _, sp := range servicePackages(ctx) {
@@ -256,7 +256,7 @@ func New(ctx context.Context) (*schema.Provider, error) {
 			typeName := v.TypeName
 
 			if _, ok := provider.DataSourcesMap[typeName]; ok {
-				errs = multierror.Append(errs, fmt.Errorf("duplicate data source: %s", typeName))
+				errs = append(errs, fmt.Errorf("duplicate data source: %s", typeName))
 				continue
 			}
 
@@ -264,7 +264,7 @@ func New(ctx context.Context) (*schema.Provider, error) {
 
 			// Ensure that the correct CRUD handler variants are used.
 			if r.Read != nil || r.ReadContext != nil {
-				errs = multierror.Append(errs, fmt.Errorf("incorrect Read handler variant: %s", typeName))
+				errs = append(errs, fmt.Errorf("incorrect Read handler variant: %s", typeName))
 				continue
 			}
 
@@ -286,11 +286,11 @@ func New(ctx context.Context) (*schema.Provider, error) {
 				// Ensure that the schema look OK.
 				if v, ok := schema[names.AttrTags]; ok {
 					if !v.Computed {
-						errs = multierror.Append(errs, fmt.Errorf("`%s` attribute must be Computed: %s", names.AttrTags, typeName))
+						errs = append(errs, fmt.Errorf("`%s` attribute must be Computed: %s", names.AttrTags, typeName))
 						continue
 					}
 				} else {
-					errs = multierror.Append(errs, fmt.Errorf("no `%s` attribute defined in schema: %s", names.AttrTags, typeName))
+					errs = append(errs, fmt.Errorf("no `%s` attribute defined in schema: %s", names.AttrTags, typeName))
 					continue
 				}
 
@@ -320,7 +320,7 @@ func New(ctx context.Context) (*schema.Provider, error) {
 			typeName := v.TypeName
 
 			if _, ok := provider.ResourcesMap[typeName]; ok {
-				errs = multierror.Append(errs, fmt.Errorf("duplicate resource: %s", typeName))
+				errs = append(errs, fmt.Errorf("duplicate resource: %s", typeName))
 				continue
 			}
 
@@ -328,19 +328,19 @@ func New(ctx context.Context) (*schema.Provider, error) {
 
 			// Ensure that the correct CRUD handler variants are used.
 			if r.Create != nil || r.CreateContext != nil {
-				errs = multierror.Append(errs, fmt.Errorf("incorrect Create handler variant: %s", typeName))
+				errs = append(errs, fmt.Errorf("incorrect Create handler variant: %s", typeName))
 				continue
 			}
 			if r.Read != nil || r.ReadContext != nil {
-				errs = multierror.Append(errs, fmt.Errorf("incorrect Read handler variant: %s", typeName))
+				errs = append(errs, fmt.Errorf("incorrect Read handler variant: %s", typeName))
 				continue
 			}
 			if r.Update != nil || r.UpdateContext != nil {
-				errs = multierror.Append(errs, fmt.Errorf("incorrect Update handler variant: %s", typeName))
+				errs = append(errs, fmt.Errorf("incorrect Update handler variant: %s", typeName))
 				continue
 			}
 			if r.Delete != nil || r.DeleteContext != nil {
-				errs = multierror.Append(errs, fmt.Errorf("incorrect Delete handler variant: %s", typeName))
+				errs = append(errs, fmt.Errorf("incorrect Delete handler variant: %s", typeName))
 				continue
 			}
 
@@ -362,20 +362,20 @@ func New(ctx context.Context) (*schema.Provider, error) {
 				// Ensure that the schema look OK.
 				if v, ok := schema[names.AttrTags]; ok {
 					if v.Computed {
-						errs = multierror.Append(errs, fmt.Errorf("`%s` attribute cannot be Computed: %s", names.AttrTags, typeName))
+						errs = append(errs, fmt.Errorf("`%s` attribute cannot be Computed: %s", names.AttrTags, typeName))
 						continue
 					}
 				} else {
-					errs = multierror.Append(errs, fmt.Errorf("no `%s` attribute defined in schema: %s", names.AttrTags, typeName))
+					errs = append(errs, fmt.Errorf("no `%s` attribute defined in schema: %s", names.AttrTags, typeName))
 					continue
 				}
 				if v, ok := schema[names.AttrTagsAll]; ok {
 					if !v.Computed {
-						errs = multierror.Append(errs, fmt.Errorf("`%s` attribute must be Computed: %s", names.AttrTags, typeName))
+						errs = append(errs, fmt.Errorf("`%s` attribute must be Computed: %s", names.AttrTags, typeName))
 						continue
 					}
 				} else {
-					errs = multierror.Append(errs, fmt.Errorf("no `%s` attribute defined in schema: %s", names.AttrTagsAll, typeName))
+					errs = append(errs, fmt.Errorf("no `%s` attribute defined in schema: %s", names.AttrTagsAll, typeName))
 					continue
 				}
 
@@ -425,7 +425,7 @@ func New(ctx context.Context) (*schema.Provider, error) {
 		}
 	}
 
-	if err := errs.ErrorOrNil(); err != nil {
+	if err := errors.Join(errs...); err != nil {
 		return nil, err
 	}
 

--- a/internal/service/meta/regions_data_source.go
+++ b/internal/service/meta/regions_data_source.go
@@ -16,7 +16,7 @@ import (
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 )
 
-// @FrameworkDataSource
+// @FrameworkDataSource(name=Regions)
 func newDataSourceRegions(context.Context) (datasource.DataSourceWithConfigure, error) {
 	d := &dataSourceRegions{}
 	d.SetMigratedFromPluginSDK(true)

--- a/internal/service/meta/service_package_gen.go
+++ b/internal/service/meta/service_package_gen.go
@@ -33,6 +33,7 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.Serv
 		},
 		{
 			Factory: newDataSourceRegions,
+			Name:    "Regions",
 		},
 		{
 			Factory: newDataSourceService,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

AWS SDK for Go v2 HTTP requests and responses were missing when `TF_LOG=debug` was defined.
The configured logger is only being used during provider configuration and needs to be added to each call's `Context` -- done via the `bootstrapContext` function called from wrapped resources and data sources.
Also, wrapped Framework data sources were never initializing a local copy of `meta` and so weren't setting much in `Context`.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccProvider_' PKG_NAME=internal/provider
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/provider/... -v -count 1 -parallel 20  -run=TestAccProvider_ -timeout 360m
?   	github.com/hashicorp/terraform-provider-aws/internal/provider/fwprovider	[no test files]
=== RUN   TestAccProvider_DefaultTags_emptyBlock
=== PAUSE TestAccProvider_DefaultTags_emptyBlock
=== RUN   TestAccProvider_DefaultTagsTags_none
=== PAUSE TestAccProvider_DefaultTagsTags_none
=== RUN   TestAccProvider_DefaultTagsTags_one
=== PAUSE TestAccProvider_DefaultTagsTags_one
=== RUN   TestAccProvider_DefaultTagsTags_multiple
=== PAUSE TestAccProvider_DefaultTagsTags_multiple
=== RUN   TestAccProvider_DefaultAndIgnoreTags_emptyBlocks
=== PAUSE TestAccProvider_DefaultAndIgnoreTags_emptyBlocks
=== RUN   TestAccProvider_endpoints
=== PAUSE TestAccProvider_endpoints
=== RUN   TestAccProvider_fipsEndpoint
=== PAUSE TestAccProvider_fipsEndpoint
=== RUN   TestAccProvider_unusualEndpoints
=== PAUSE TestAccProvider_unusualEndpoints
=== RUN   TestAccProvider_IgnoreTags_emptyBlock
=== PAUSE TestAccProvider_IgnoreTags_emptyBlock
=== RUN   TestAccProvider_IgnoreTagsKeyPrefixes_none
=== PAUSE TestAccProvider_IgnoreTagsKeyPrefixes_none
=== RUN   TestAccProvider_IgnoreTagsKeyPrefixes_one
=== PAUSE TestAccProvider_IgnoreTagsKeyPrefixes_one
=== RUN   TestAccProvider_IgnoreTagsKeyPrefixes_multiple
=== PAUSE TestAccProvider_IgnoreTagsKeyPrefixes_multiple
=== RUN   TestAccProvider_IgnoreTagsKeys_none
=== PAUSE TestAccProvider_IgnoreTagsKeys_none
=== RUN   TestAccProvider_IgnoreTagsKeys_one
=== PAUSE TestAccProvider_IgnoreTagsKeys_one
=== RUN   TestAccProvider_IgnoreTagsKeys_multiple
=== PAUSE TestAccProvider_IgnoreTagsKeys_multiple
=== RUN   TestAccProvider_Region_c2s
=== PAUSE TestAccProvider_Region_c2s
=== RUN   TestAccProvider_Region_china
=== PAUSE TestAccProvider_Region_china
=== RUN   TestAccProvider_Region_commercial
=== PAUSE TestAccProvider_Region_commercial
=== RUN   TestAccProvider_Region_govCloud
=== PAUSE TestAccProvider_Region_govCloud
=== RUN   TestAccProvider_Region_sc2s
=== PAUSE TestAccProvider_Region_sc2s
=== RUN   TestAccProvider_Region_stsRegion
=== PAUSE TestAccProvider_Region_stsRegion
=== RUN   TestAccProvider_AssumeRole_empty
=== PAUSE TestAccProvider_AssumeRole_empty
=== CONT  TestAccProvider_DefaultTags_emptyBlock
=== CONT  TestAccProvider_Region_govCloud
=== CONT  TestAccProvider_Region_stsRegion
=== CONT  TestAccProvider_Region_sc2s
=== CONT  TestAccProvider_IgnoreTagsKeyPrefixes_none
=== CONT  TestAccProvider_IgnoreTagsKeys_multiple
=== CONT  TestAccProvider_AssumeRole_empty
=== CONT  TestAccProvider_IgnoreTagsKeys_none
=== CONT  TestAccProvider_Region_commercial
=== CONT  TestAccProvider_IgnoreTagsKeyPrefixes_multiple
=== CONT  TestAccProvider_Region_china
=== CONT  TestAccProvider_Region_c2s
=== CONT  TestAccProvider_IgnoreTagsKeyPrefixes_one
=== CONT  TestAccProvider_IgnoreTagsKeys_one
=== CONT  TestAccProvider_endpoints
=== CONT  TestAccProvider_IgnoreTags_emptyBlock
=== CONT  TestAccProvider_fipsEndpoint
=== CONT  TestAccProvider_DefaultTagsTags_multiple
=== CONT  TestAccProvider_unusualEndpoints
=== CONT  TestAccProvider_DefaultAndIgnoreTags_emptyBlocks
--- PASS: TestAccProvider_Region_stsRegion (76.56s)
=== CONT  TestAccProvider_DefaultTagsTags_one
--- PASS: TestAccProvider_Region_govCloud (76.99s)
=== CONT  TestAccProvider_DefaultTagsTags_none
--- PASS: TestAccProvider_Region_sc2s (79.67s)
--- PASS: TestAccProvider_Region_commercial (79.71s)
--- PASS: TestAccProvider_Region_c2s (79.70s)
--- PASS: TestAccProvider_Region_china (79.71s)
--- PASS: TestAccProvider_IgnoreTagsKeyPrefixes_none (99.47s)
--- PASS: TestAccProvider_DefaultAndIgnoreTags_emptyBlocks (99.64s)
--- PASS: TestAccProvider_IgnoreTagsKeys_multiple (99.66s)
--- PASS: TestAccProvider_IgnoreTagsKeys_none (99.76s)
--- PASS: TestAccProvider_DefaultTags_emptyBlock (99.84s)
--- PASS: TestAccProvider_IgnoreTagsKeys_one (99.88s)
--- PASS: TestAccProvider_IgnoreTagsKeyPrefixes_multiple (99.89s)
--- PASS: TestAccProvider_IgnoreTagsKeyPrefixes_one (99.92s)
--- PASS: TestAccProvider_IgnoreTags_emptyBlock (99.92s)
--- PASS: TestAccProvider_DefaultTagsTags_multiple (100.00s)
--- PASS: TestAccProvider_AssumeRole_empty (103.48s)
--- PASS: TestAccProvider_DefaultTagsTags_none (40.35s)
--- PASS: TestAccProvider_DefaultTagsTags_one (40.83s)
--- PASS: TestAccProvider_unusualEndpoints (126.10s)
--- PASS: TestAccProvider_endpoints (126.80s)
--- PASS: TestAccProvider_fipsEndpoint (136.96s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider	143.530s
```
