### PR TITLE
r/[Enhancement]: aws_transfer_server support for increased length login banners

### DIFF
--- a/.changelog/33937.txt
+++ b/.changelog/33937.txt
@@ -1,4 +1,4 @@
 ```release-note:enhancement
-resource/aws_transfer_server: Change pre/post login header limit to 4096
+resource/aws_transfer_server: Change `pre_authentication_login_banner` and `post_authentication_login_banner` length limits to 4096
 ```
 

--- a/.changelog/33937.txt
+++ b/.changelog/33937.txt
@@ -1,0 +1,4 @@
+```release-note:enhancement
+resource/aws_transfer_server: Change pre/post login header limit to 4096
+```
+

--- a/internal/service/transfer/server.go
+++ b/internal/service/transfer/server.go
@@ -165,13 +165,13 @@ func ResourceServer() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Sensitive:    true,
-				ValidateFunc: validation.StringLenBetween(0, 512),
+				ValidateFunc: validation.StringLenBetween(0, 4096),
 			},
 			"pre_authentication_login_banner": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Sensitive:    true,
-				ValidateFunc: validation.StringLenBetween(0, 512),
+				ValidateFunc: validation.StringLenBetween(0, 4096),
 			},
 			"protocol_details": {
 				Type:     schema.TypeList,


### PR DESCRIPTION
### Description

The previous limit of 512 characters is now increased to 4096.

### Relations

Closes #33889

### References

https://docs.aws.amazon.com/transfer/latest/userguide/API_CreateServer.html#TransferFamily-CreateServer-request-PreAuthenticationLoginBanner

### Output from Acceptance Testing
The current acceptance tests are not performing limit validation. As such this does not have a test to verify that 4096 is indeed the limit. I can probably make a negative test and positive test pair proving 4096 is in fact the limit.
