### PR TITLE
Don't auto-add maintainer issues to the project board

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -94,14 +94,6 @@ jobs:
           installation_retrieval_payload: ${{ secrets.INSTALLATION_ID }}
           private_key: ${{ secrets.APP_PEM }}
 
-      - name: 'Maintainer Issues'
-        if: github.event.action == 'opened' && needs.community_check.outputs.maintainer == 'true'
-        env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
-        run: |
-          PROJECT_ITEM_ID=$(gh project item-add ${{ env.PROJECT_NUMBER }} --owner "hashicorp" --url ${{ env.ITEM_URL }} --format json | jq '.id')
-          gh project item-edit --id "$PROJECT_ITEM_ID" --project-id ${{ env.PROJECT_ID }} --field-id ${{ env.VIEW_FIELD_ID }} --single-select-option-id ${{ vars.team_project_view_working_board }}
-
       - name: 'Assigned to Maintainer'
         if: github.event.action == 'assigned' && needs.community_check.outputs.maintainer == 'true'
         env:


### PR DESCRIPTION
### Description

Removes the Action step that automatically adds all new maintainer issues to the Project Board

### Output from Acceptance Testing

N/a, workflow
