### PR TITLE
r/iot_provisioning_template: add `type` attribute

### DIFF
--- a/.changelog/33950.txt
+++ b/.changelog/33950.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_iot_provisioning_template: Add `type` attribute
+```

--- a/internal/service/iot/provisioning_template.go
+++ b/internal/service/iot/provisioning_template.go
@@ -108,6 +108,13 @@ func ResourceProvisioningTemplate() *schema.Resource {
 					validation.StringLenBetween(0, 10240),
 				),
 			},
+			"type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(iot.TemplateType_Values(), false),
+			},
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -138,6 +145,10 @@ func resourceProvisioningTemplateCreate(ctx context.Context, d *schema.ResourceD
 
 	if v, ok := d.GetOk("template_body"); ok {
 		input.TemplateBody = aws.String(v.(string))
+	}
+
+	if v, ok := d.Get("type").(string); ok && v != "" {
+		input.Type = aws.String(v)
 	}
 
 	outputRaw, err := tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout,
@@ -184,6 +195,7 @@ func resourceProvisioningTemplateRead(ctx context.Context, d *schema.ResourceDat
 	}
 	d.Set("provisioning_role_arn", output.ProvisioningRoleArn)
 	d.Set("template_body", output.TemplateBody)
+	d.Set("type", output.Type)
 
 	return nil
 }

--- a/internal/service/iot/provisioning_template_test.go
+++ b/internal/service/iot/provisioning_template_test.go
@@ -43,6 +43,7 @@ func TestAccIoTProvisioningTemplate_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "provisioning_role_arn"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttrSet(resourceName, "template_body"),
+					resource.TestCheckResourceAttr(resourceName, "type", "FLEET_PROVISIONING"),
 				),
 			},
 			{

--- a/website/docs/r/iot_provisioning_template.html.markdown
+++ b/website/docs/r/iot_provisioning_template.html.markdown
@@ -89,6 +89,7 @@ This resource supports the following arguments:
 * `provisioning_role_arn` - (Required) The role ARN for the role associated with the fleet provisioning template. This IoT role grants permission to provision a device.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `template_body` - (Required) The JSON formatted contents of the fleet provisioning template.
+* `type` - (Optional) The type you define in a provisioning template.
 
 ### pre_provisioning_hook
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #33055

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTARGS='-run=TestAccIoTProvisioningTemplate_' PKG=iot

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iot/... -v -count 1 -parallel 20  -run=TestAccIoTProvisioningTemplate_ -timeout 360m
--- PASS: TestAccIoTProvisioningTemplate_basic (162.08s)
--- PASS: TestAccIoTProvisioningTemplate_disappears (164.56s)
--- PASS: TestAccIoTProvisioningTemplate_update (249.10s)
--- PASS: TestAccIoTProvisioningTemplate_tags (330.74s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iot	334.060s
```
