### PR TITLE
resource/aws_elasticache_replication_group: Fix error incorrectly forcing recreation when changing version from `6.x` to `6.2`

### DIFF
--- a/.changelog/33954.txt
+++ b/.changelog/33954.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_elasticache_replication_group: Fix error when swtiching `engine_version` from `6.x` to a specific `6.<digit>` version number
+```

--- a/.changelog/33954.txt
+++ b/.changelog/33954.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_elasticache_replication_group: Fix error when swtiching `engine_version` from `6.x` to a specific `6.<digit>` version number
+resource/aws_elasticache_replication_group: Fix error when switching `engine_version` from `6.x` to a specific `6.<digit>` version number
 ```

--- a/internal/service/elasticache/cluster_test.go
+++ b/internal/service/elasticache/cluster_test.go
@@ -636,7 +636,7 @@ func TestAccElastiCacheCluster_EngineVersion_redis(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	var v1, v2, v3, v4, v5, v6, v7, v8 elasticache.CacheCluster
+	var v1, v2, v3, v4, v5, v6 elasticache.CacheCluster
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
 
@@ -647,36 +647,18 @@ func TestAccElastiCacheCluster_EngineVersion_redis(t *testing.T) {
 		CheckDestroy:             testAccCheckClusterDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_engineVersionRedis(rName, "3.2.6"),
+				Config: testAccClusterConfig_engineVersionRedis(rName, "4.0.10"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v1),
-					resource.TestCheckResourceAttr(resourceName, "engine_version", "3.2.6"),
-					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "3.2.6"),
-				),
-			},
-			{
-				Config: testAccClusterConfig_engineVersionRedis(rName, "3.2.4"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &v2),
-					testAccCheckClusterRecreated(&v1, &v2),
-					resource.TestCheckResourceAttr(resourceName, "engine_version", "3.2.4"),
-					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "3.2.4"),
-				),
-			},
-			{
-				Config: testAccClusterConfig_engineVersionRedis(rName, "3.2.10"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &v3),
-					testAccCheckClusterNotRecreated(&v2, &v3),
-					resource.TestCheckResourceAttr(resourceName, "engine_version", "3.2.10"),
-					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "3.2.10"),
+					resource.TestCheckResourceAttr(resourceName, "engine_version", "4.0.10"),
+					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "4.0.10"),
 				),
 			},
 			{
 				Config: testAccClusterConfig_engineVersionRedis(rName, "6.0"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &v4),
-					testAccCheckClusterNotRecreated(&v3, &v4),
+					testAccCheckClusterExists(ctx, resourceName, &v2),
+					testAccCheckClusterNotRecreated(&v1, &v2),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "6.0"),
 					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexache.MustCompile(`^6\.0\.[[:digit:]]+$`)),
 				),
@@ -684,8 +666,8 @@ func TestAccElastiCacheCluster_EngineVersion_redis(t *testing.T) {
 			{
 				Config: testAccClusterConfig_engineVersionRedis(rName, "6.2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &v5),
-					testAccCheckClusterNotRecreated(&v4, &v5),
+					testAccCheckClusterExists(ctx, resourceName, &v3),
+					testAccCheckClusterNotRecreated(&v2, &v3),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "6.2"),
 					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexache.MustCompile(`^6\.2\.[[:digit:]]+$`)),
 				),
@@ -693,8 +675,8 @@ func TestAccElastiCacheCluster_EngineVersion_redis(t *testing.T) {
 			{
 				Config: testAccClusterConfig_engineVersionRedis(rName, "5.0.6"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &v6),
-					testAccCheckClusterRecreated(&v5, &v6),
+					testAccCheckClusterExists(ctx, resourceName, &v4),
+					testAccCheckClusterRecreated(&v3, &v4),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "5.0.6"),
 					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "5.0.6"),
 				),
@@ -702,8 +684,8 @@ func TestAccElastiCacheCluster_EngineVersion_redis(t *testing.T) {
 			{
 				Config: testAccClusterConfig_engineVersionRedis(rName, "6.x"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &v7),
-					testAccCheckClusterNotRecreated(&v6, &v7),
+					testAccCheckClusterExists(ctx, resourceName, &v5),
+					testAccCheckClusterNotRecreated(&v4, &v5),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "6.x"),
 					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexache.MustCompile(`^6\.[[:digit:]]+\.[[:digit:]]+$`)),
 				),
@@ -711,8 +693,8 @@ func TestAccElastiCacheCluster_EngineVersion_redis(t *testing.T) {
 			{
 				Config: testAccClusterConfig_engineVersionRedis(rName, "6.0"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &v8),
-					testAccCheckClusterRecreated(&v7, &v8),
+					testAccCheckClusterExists(ctx, resourceName, &v6),
+					testAccCheckClusterRecreated(&v5, &v6),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "6.0"),
 					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexache.MustCompile(`^6\.0\.[[:digit:]]+$`)),
 				),

--- a/internal/service/elasticache/engine_version.go
+++ b/internal/service/elasticache/engine_version.go
@@ -23,7 +23,7 @@ const (
 
 var versionStringRegexp = regexache.MustCompile(versionStringRegexpPattern)
 
-func validMemcachedVersionString(v interface{}, k string) (ws []string, errors []error) {
+func validMemcachedVersionString(v any, k string) (ws []string, errors []error) {
 	value := v.(string)
 
 	if !versionStringRegexp.MatchString(value) {
@@ -45,7 +45,7 @@ var (
 	redisVersionPostV6Regexp = regexache.MustCompile(redisVersionPostV6RegexpPattern)
 )
 
-func validRedisVersionString(v interface{}, k string) (ws []string, errors []error) {
+func validRedisVersionString(v any, k string) (ws []string, errors []error) {
 	value := v.(string)
 
 	if !redisVersionRegexp.MatchString(value) {
@@ -56,7 +56,7 @@ func validRedisVersionString(v interface{}, k string) (ws []string, errors []err
 }
 
 // CustomizeDiffValidateClusterEngineVersion validates the correct format for `engine_version`, based on `engine`
-func CustomizeDiffValidateClusterEngineVersion(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+func CustomizeDiffValidateClusterEngineVersion(_ context.Context, diff *schema.ResourceDiff, _ any) error {
 	engineVersion, ok := diff.GetOk("engine_version")
 	if !ok {
 		return nil
@@ -84,16 +84,37 @@ func validateClusterEngineVersion(engine, engineVersion string) error {
 }
 
 // customizeDiffEngineVersionForceNewOnDowngrade causes re-creation of the resource if the version is being downgraded
-func customizeDiffEngineVersionForceNewOnDowngrade(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+func customizeDiffEngineVersionForceNewOnDowngrade(_ context.Context, diff *schema.ResourceDiff, _ any) error {
 	return engineVersionForceNewOnDowngrade(diff)
 }
 
 type getChangeDiffer interface {
-	GetChange(key string) (interface{}, interface{})
+	Get(key string) any
+	GetChange(key string) (any, any)
 }
 
 func engineVersionIsDowngrade(diff getChangeDiffer) (bool, error) {
 	o, n := diff.GetChange("engine_version")
+	if o == "6.x" {
+		actual := diff.Get("engine_version_actual")
+		aVersion, err := gversion.NewVersion(actual.(string))
+		if err != nil {
+			return false, fmt.Errorf("parsing current engine_version: %w", err)
+		}
+		nVersion, err := normalizeEngineVersion(n.(string))
+		if err != nil {
+			return false, fmt.Errorf("parsing new engine_version: %w", err)
+		}
+
+		aSegments := aVersion.Segments()
+		nSegments := nVersion.Segments()
+
+		if nSegments[0] != aSegments[0] {
+			return nSegments[0] < aSegments[0], nil
+		}
+		return nSegments[1] < aSegments[1], nil
+	}
+
 	oVersion, err := normalizeEngineVersion(o.(string))
 	if err != nil {
 		return false, fmt.Errorf("parsing old engine_version: %w", err)
@@ -108,7 +129,8 @@ func engineVersionIsDowngrade(diff getChangeDiffer) (bool, error) {
 
 type forceNewDiffer interface {
 	Id() string
-	GetChange(key string) (interface{}, interface{})
+	Get(key string) any
+	GetChange(key string) (any, any)
 	HasChange(key string) bool
 	ForceNew(key string) error
 }

--- a/internal/service/elasticache/engine_version_test.go
+++ b/internal/service/elasticache/engine_version_test.go
@@ -303,87 +303,85 @@ type mockGetChangeDiffer struct {
 	old, new string
 }
 
-func (d *mockGetChangeDiffer) GetChange(key string) (interface{}, interface{}) {
+func (d *mockGetChangeDiffer) GetChange(key string) (any, any) {
 	return d.old, d.new
+}
+
+func (d *mockGetChangeDiffer) Get(key string) any {
+	return ""
 }
 
 func TestCustomizeDiffEngineVersionIsDowngrade(t *testing.T) {
 	t.Parallel()
 
 	testcases := map[string]struct {
-		old, new string
-		expected bool
+		old, new    string
+		isDowngrade bool
 	}{
 		"no change": {
-			old:      "1.2.3",
-			new:      "1.2.3",
-			expected: false,
+			old:         "1.2.3",
+			new:         "1.2.3",
+			isDowngrade: false,
 		},
 
 		"upgrade minor versions": {
-			old:      "1.2.3",
-			new:      "1.3.5",
-			expected: false,
+			old:         "1.2.3",
+			new:         "1.3.5",
+			isDowngrade: false,
 		},
 
 		"upgrade major versions": {
-			old:      "1.2.3",
-			new:      "2.4.6",
-			expected: false,
+			old:         "1.2.3",
+			new:         "2.4.6",
+			isDowngrade: false,
 		},
 
 		"upgrade major 6.x": {
-			old:      "5.0.6",
-			new:      "6.x",
-			expected: false,
+			old:         "5.0.6",
+			new:         "6.x",
+			isDowngrade: false,
 		},
 
 		"upgrade major 6.digit": {
-			old:      "5.0.6",
-			new:      "6.0",
-			expected: false,
+			old:         "5.0.6",
+			new:         "6.0",
+			isDowngrade: false,
 		},
 
 		"downgrade minor versions": {
-			old:      "1.3.5",
-			new:      "1.2.3",
-			expected: true,
+			old:         "1.3.5",
+			new:         "1.2.3",
+			isDowngrade: true,
 		},
 
 		"downgrade major versions": {
-			old:      "2.4.6",
-			new:      "1.2.3",
-			expected: true,
-		},
-
-		"downgrade from major 6.x": {
-			old:      "6.x",
-			new:      "5.0.6",
-			expected: true,
+			old:         "2.4.6",
+			new:         "1.2.3",
+			isDowngrade: true,
 		},
 
 		"downgrade major 6.digit": {
-			old:      "6.2",
-			new:      "6.0",
-			expected: true,
+			old:         "6.2",
+			new:         "6.0",
+			isDowngrade: true,
 		},
 
 		"switch major 6.digit to 6.x": {
-			old:      "6.2",
-			new:      "6.x",
-			expected: false,
+			old:         "6.2",
+			new:         "6.x",
+			isDowngrade: false,
 		},
 
 		"downgrade from major 7.digit to 6.x": {
-			old:      "7.2",
-			new:      "6.x",
-			expected: true,
+			old:         "7.2",
+			new:         "6.x",
+			isDowngrade: true,
 		},
 
 		"downgrade from major 7.digit to 6.digit": {
-			old:      "7.2",
-			new:      "6.2",
-			expected: true,
+			old:         "7.2",
+			new:         "6.2",
+			isDowngrade: true,
 		},
 	}
 
@@ -403,8 +401,84 @@ func TestCustomizeDiffEngineVersionIsDowngrade(t *testing.T) {
 				t.Fatalf("no error expected, got %s", err)
 			}
 
-			if testcase.expected != actual {
-				t.Errorf("expected %t, got %t", testcase.expected, actual)
+			if testcase.isDowngrade != actual {
+				t.Errorf("expected %t, got %t", testcase.isDowngrade, actual)
+			}
+		})
+	}
+}
+
+func TestCustomizeDiffEngineVersionIsDowngrade_6xTo6digit(t *testing.T) {
+	t.Parallel()
+
+	// Version 6.x currently maps to v6.2. In case that changes, we need to check
+	testcases := map[string]struct {
+		versionOld       string
+		actualVersionOld string
+		versionNew       string
+		isDowngrade      bool
+	}{
+		"minor downgrade to 6.0": {
+			versionOld:       "6.x",
+			actualVersionOld: "6.2.1",
+			versionNew:       "6.0",
+			isDowngrade:      true,
+		},
+
+		"same version": {
+			versionOld:       "6.x",
+			actualVersionOld: "6.2.1",
+			versionNew:       "6.2",
+			isDowngrade:      false,
+		},
+
+		"minor upgrade": {
+			versionOld:       "6.x",
+			actualVersionOld: "6.2.1",
+			versionNew:       "6.4",
+			isDowngrade:      false,
+		},
+
+		"major downgrade from 6.x": {
+			versionOld:       "6.x",
+			actualVersionOld: "6.2.1",
+			versionNew:       "5.0.6",
+			isDowngrade:      true,
+		},
+
+		"major upgrade from 6.x": {
+			versionOld:       "6.x",
+			actualVersionOld: "6.2.1",
+			versionNew:       "7.0",
+			isDowngrade:      false,
+		},
+	}
+
+	for name, testcase := range testcases {
+		testcase := testcase
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			diff := mockChangesDiffer{
+				values: map[string]mockDiff{
+					"engine_version": {
+						old: testcase.versionOld,
+						new: testcase.versionNew,
+					},
+					"engine_version_actual": {
+						old: testcase.actualVersionOld,
+					},
+				},
+			}
+
+			actual, err := engineVersionIsDowngrade(&diff)
+
+			if err != nil {
+				t.Fatalf("no error expected, got %s", err)
+			}
+
+			if testcase.isDowngrade != actual {
+				t.Errorf("expected %t, got %t", testcase.isDowngrade, actual)
 			}
 		})
 	}
@@ -421,11 +495,15 @@ func (d *mockForceNewDiffer) Id() string {
 	return d.id
 }
 
+func (d *mockForceNewDiffer) Get(key string) any {
+	return d.old
+}
+
 func (d *mockForceNewDiffer) HasChange(key string) bool {
 	return d.hasChange || d.old != d.new
 }
 
-func (d *mockForceNewDiffer) GetChange(key string) (interface{}, interface{}) {
+func (d *mockForceNewDiffer) GetChange(key string) (any, any) {
 	return d.old, d.new
 }
 
@@ -487,7 +565,7 @@ func TestCustomizeDiffEngineVersionForceNewOnDowngrade(t *testing.T) {
 		},
 
 		"upgrade major 7.digit": {
-			old:            "6.x",
+			old:            "6.2",
 			new:            "7.0",
 			expectForceNew: false,
 		},
@@ -501,12 +579,6 @@ func TestCustomizeDiffEngineVersionForceNewOnDowngrade(t *testing.T) {
 		"downgrade major versions": {
 			old:            "2.4.6",
 			new:            "1.2.3",
-			expectForceNew: true,
-		},
-
-		"downgrade from major 6.x": {
-			old:            "6.x",
-			new:            "5.0.6",
 			expectForceNew: true,
 		},
 
@@ -678,11 +750,15 @@ type mockDiff struct {
 	hasChange bool // force HasChange() to return true
 }
 
+func (d mockDiff) Get() any {
+	return d.old
+}
+
 func (d mockDiff) HasChange() bool {
 	return d.hasChange || d.old != d.new
 }
 
-func (d mockDiff) GetChange() (interface{}, interface{}) {
+func (d mockDiff) GetChange() (any, any) {
 	return d.old, d.new
 }
 
@@ -695,11 +771,15 @@ func (d *mockChangesDiffer) Id() string {
 	return d.id
 }
 
+func (d *mockChangesDiffer) Get(key string) any {
+	return d.values[key].Get()
+}
+
 func (d *mockChangesDiffer) HasChange(key string) bool {
 	return d.values[key].HasChange()
 }
 
-func (d *mockChangesDiffer) GetChange(key string) (interface{}, interface{}) {
+func (d *mockChangesDiffer) GetChange(key string) (any, any) {
 	return d.values[key].GetChange()
 }
 

--- a/internal/service/elasticache/replication_group_test.go
+++ b/internal/service/elasticache/replication_group_test.go
@@ -179,7 +179,7 @@ func TestAccElastiCacheReplicationGroup_EngineVersion_update(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	var v1, v2, v3, v4, v5, v6, v7, v8 elasticache.ReplicationGroup
+	var v1, v2, v3, v4, v5, v6 elasticache.ReplicationGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
@@ -190,42 +190,18 @@ func TestAccElastiCacheReplicationGroup_EngineVersion_update(t *testing.T) {
 		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccReplicationGroupConfig_engineVersion(rName, "3.2.6"),
+				Config: testAccReplicationGroupConfig_engineVersion(rName, "4.0.10"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckReplicationGroupExists(ctx, resourceName, &v1),
-					resource.TestCheckResourceAttr(resourceName, "engine_version", "3.2.6"),
-					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "3.2.6"),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"apply_immediately"},
-			},
-			{
-				Config: testAccReplicationGroupConfig_engineVersion(rName, "3.2.4"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &v2),
-					testAccCheckReplicationGroupRecreated(&v1, &v2),
-					resource.TestCheckResourceAttr(resourceName, "engine_version", "3.2.4"),
-					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "3.2.4"),
-				),
-			},
-			{
-				Config: testAccReplicationGroupConfig_engineVersion(rName, "3.2.10"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &v3),
-					testAccCheckReplicationGroupNotRecreated(&v2, &v3),
-					resource.TestCheckResourceAttr(resourceName, "engine_version", "3.2.10"),
-					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "3.2.10"),
+					resource.TestCheckResourceAttr(resourceName, "engine_version", "4.0.10"),
+					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "4.0.10"),
 				),
 			},
 			{
 				Config: testAccReplicationGroupConfig_engineVersion(rName, "6.0"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &v4),
-					testAccCheckReplicationGroupNotRecreated(&v3, &v4),
+					testAccCheckReplicationGroupExists(ctx, resourceName, &v2),
+					testAccCheckReplicationGroupNotRecreated(&v1, &v2),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "6.0"),
 					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexache.MustCompile(`^6\.0\.[[:digit:]]+$`)),
 				),
@@ -233,8 +209,8 @@ func TestAccElastiCacheReplicationGroup_EngineVersion_update(t *testing.T) {
 			{
 				Config: testAccReplicationGroupConfig_engineVersion(rName, "6.2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &v5),
-					testAccCheckReplicationGroupNotRecreated(&v4, &v5),
+					testAccCheckReplicationGroupExists(ctx, resourceName, &v3),
+					testAccCheckReplicationGroupNotRecreated(&v2, &v3),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "6.2"),
 					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexache.MustCompile(`^6\.2\.[[:digit:]]+$`)),
 				),
@@ -248,8 +224,8 @@ func TestAccElastiCacheReplicationGroup_EngineVersion_update(t *testing.T) {
 			{
 				Config: testAccReplicationGroupConfig_engineVersion(rName, "5.0.6"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &v6),
-					testAccCheckReplicationGroupRecreated(&v5, &v6),
+					testAccCheckReplicationGroupExists(ctx, resourceName, &v4),
+					testAccCheckReplicationGroupRecreated(&v3, &v4),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "5.0.6"),
 					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "5.0.6"),
 				),
@@ -257,8 +233,8 @@ func TestAccElastiCacheReplicationGroup_EngineVersion_update(t *testing.T) {
 			{
 				Config: testAccReplicationGroupConfig_engineVersion(rName, "6.x"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &v7),
-					testAccCheckReplicationGroupNotRecreated(&v6, &v7),
+					testAccCheckReplicationGroupExists(ctx, resourceName, &v5),
+					testAccCheckReplicationGroupNotRecreated(&v4, &v5),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "6.x"),
 					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexache.MustCompile(`^6\.[[:digit:]]+\.[[:digit:]]+$`)),
 				),
@@ -266,8 +242,8 @@ func TestAccElastiCacheReplicationGroup_EngineVersion_update(t *testing.T) {
 			{
 				Config: testAccReplicationGroupConfig_engineVersion(rName, "6.0"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &v8),
-					testAccCheckReplicationGroupRecreated(&v7, &v8),
+					testAccCheckReplicationGroupExists(ctx, resourceName, &v6),
+					testAccCheckReplicationGroupRecreated(&v5, &v6),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "6.0"),
 					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexache.MustCompile(`^6\.0\.[[:digit:]]+$`)),
 				),
@@ -3219,8 +3195,6 @@ resource "aws_elasticache_replication_group" "test" {
   port                       = 6379
   subnet_group_name          = aws_elasticache_subnet_group.test.name
   security_group_ids         = [aws_security_group.test.id]
-  parameter_group_name       = "default.redis3.2"
-  engine_version             = "3.2.6"
   at_rest_encryption_enabled = true
   kms_key_id                 = aws_kms_key.test.arn
 }
@@ -3262,8 +3236,6 @@ resource "aws_elasticache_replication_group" "test" {
   port                       = 6379
   subnet_group_name          = aws_elasticache_subnet_group.test.name
   security_group_ids         = [aws_security_group.test.id]
-  parameter_group_name       = "default.redis3.2"
-  engine_version             = "3.2.6"
   at_rest_encryption_enabled = true
 }
 


### PR DESCRIPTION
### Description

The resource `aws_elasticache_replication_group` incorrectly identifies switching from version `6.x` to `6.2` as a downgrade, which requires a re-creation of the resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #28011
Supersedes #28877

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=elasticache TESTS=TestAccElastiCacheReplicationGroup_

--- PASS: TestAccElastiCacheReplicationGroup_clusteringAndCacheNodesCausesError (6.37s)
--- PASS: TestAccElastiCacheReplicationGroup_ValidationMultiAz_noAutomaticFailover (8.55s)
--- FAIL: TestAccElastiCacheReplicationGroup_tagWithOtherModification (928.49s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_nonClusteredParameterGroup (987.41s)
--- PASS: TestAccElastiCacheReplicationGroup_multiAzNotInVPC (1008.87s)
--- PASS: TestAccElastiCacheReplicationGroup_multiAzNotInVPC_repeated (1009.08s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterModeValidation_numNodeGroupsOnSecondary (1086.15s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_basic (1292.78s)
--- PASS: TestAccElastiCacheReplicationGroup_basic (1376.56s)
--- PASS: TestAccElastiCacheReplicationGroup_dataTiering (1382.25s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_singleNode (1396.95s)
--- PASS: TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Enabled (1937.98s)
--- PASS: TestAccElastiCacheReplicationGroup_Validation_globalReplicationGroupIdAndNodeType (967.78s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersFailover_autoFailoverEnabled (1557.85s)
--- PASS: TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Disabled (2497.64s)
--- PASS: TestAccElastiCacheReplicationGroup_deprecatedAvailabilityZones_multiAzInVPC (2499.05s)
--- PASS: TestAccElastiCacheReplicationGroup_Validation_noNodeType (5.66s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleDown (2665.87s)
--- PASS: TestAccElastiCacheReplicationGroup_tags (1701.66s)
--- PASS: TestAccElastiCacheReplicationGroup_multiAzInVPC (2815.20s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp (3097.10s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_scaleDown (2195.94s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleDown (3218.32s)
--- PASS: TestAccElastiCacheReplicationGroup_enableAuthTokenTransitEncryption (922.25s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_atTargetSize (2357.28s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_updateReplicasPerNodeGroup (3428.48s)
--- PASS: TestAccElastiCacheReplicationGroup_autoMinorVersionUpgrade (1079.48s)
--- PASS: TestAccElastiCacheReplicationGroup_finalSnapshot (1117.61s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_noChange (2448.59s)
--- PASS: TestAccElastiCacheReplicationGroup_enableSnapshotting (1007.62s)
--- PASS: TestAccElastiCacheReplicationGroup_enableAtRestEncryption (1433.57s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_addMemberCluster (2827.55s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_multiAZEnabled (2669.00s)
--- PASS: TestAccElastiCacheReplicationGroup_vpc (1157.14s)
--- PASS: TestAccElastiCacheReplicationGroup_updateAuthToken (1159.95s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersFailover_autoFailoverDisabled (1813.18s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basic (4474.75s)
--- PASS: TestAccElastiCacheReplicationGroup_updateDescription (1464.79s)
--- PASS: TestAccElastiCacheReplicationGroup_updateMaintenanceWindow (984.89s)
--- PASS: TestAccElastiCacheReplicationGroup_updateParameterGroup (1291.14s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_basic (2676.51s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_full (3324.65s)
--- PASS: TestAccElastiCacheReplicationGroup_disappears (1047.21s)
--- PASS: TestAccElastiCacheReplicationGroup_uppercase (913.20s)
--- PASS: TestAccElastiCacheReplicationGroup_EngineVersion_v7 (917.16s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears (4903.96s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic (2312.00s)
--- PASS: TestAccElastiCacheReplicationGroup_EngineVersion_6xToRealVersion (1192.38s)
--- PASS: TestAccElastiCacheReplicationGroup_useCMKKMSKeyID (885.25s)
--- PASS: TestAccElastiCacheReplicationGroup_basic_v5 (1221.40s)
--- PASS: TestAccElastiCacheReplicationGroup_updateUserGroups (2116.00s)
--- PASS: TestAccElastiCacheReplicationGroup_updateNodeSize (2329.38s)
--- PASS: TestAccElastiCacheReplicationGroup_EngineVersion_update (7435.93s)
```

`TestAccElastiCacheReplicationGroup_tagWithOtherModification` is an unrelated error