### PR TITLE
docs: update Go version to 1.20 in env setup

### DIFF
--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -3,7 +3,7 @@
 ## Requirements
 
 - [Terraform](https://www.terraform.io/downloads.html) 0.12.26+ (to run acceptance tests)
-- [Go](https://golang.org/doc/install) 1.19.3+ (to build the provider plugin)
+- [Go](https://golang.org/doc/install) 1.20+ (to build the provider plugin)
 
 ## Quick Start
 


### PR DESCRIPTION
Since https://github.com/hashicorp/terraform-provider-aws/pull/32108 the minimum version of Go is 1.20. Just bumped into it by accident while setting up on a machine I didn't use for some time.