### PR TITLE
r/iam: fix refreshing permission_boundary state on users and roles

### DIFF
--- a/.changelog/33963.txt
+++ b/.changelog/33963.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_iam_role: Fix refreshing `permission_boundary` when deleted outside of Terraform
+```
+
+```release-note:bug
+resource/aws_iam_user: Fix refreshing `permission_boundary` when deleted outside of Terraform
+```

--- a/internal/service/iam/role.go
+++ b/internal/service/iam/role.go
@@ -292,6 +292,8 @@ func resourceRoleRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	d.Set("path", role.Path)
 	if role.PermissionsBoundary != nil {
 		d.Set("permissions_boundary", role.PermissionsBoundary.PermissionsBoundaryArn)
+	} else {
+		d.Set("permissions_boundary", nil)
 	}
 	d.Set("unique_id", role.RoleId)
 

--- a/internal/service/iam/user.go
+++ b/internal/service/iam/user.go
@@ -161,6 +161,8 @@ func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	d.Set("path", user.Path)
 	if user.PermissionsBoundary != nil {
 		d.Set("permissions_boundary", user.PermissionsBoundary.PermissionsBoundaryArn)
+	} else {
+		d.Set("permissions_boundary", nil)
 	}
 	d.Set("unique_id", user.UserId)
 


### PR DESCRIPTION
### Relations

Closes #16534

### Output from Acceptance Testing

```console
14:21 $ make testacc PKG=iam TESTS="TestAccIAMRole_permissionsBoundary"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMRole_permissionsBoundary'  -timeout 360m
=== RUN   TestAccIAMRole_permissionsBoundary
=== PAUSE TestAccIAMRole_permissionsBoundary
=== CONT  TestAccIAMRole_permissionsBoundary
--- PASS: TestAccIAMRole_permissionsBoundary (146.16s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	149.564s
14:32 $ make testacc PKG=iam TESTS="TestAccIAMUser_permissionsBoundary"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMUser_permissionsBoundary'  -timeout 360m
=== RUN   TestAccIAMUser_permissionsBoundary
=== PAUSE TestAccIAMUser_permissionsBoundary
=== CONT  TestAccIAMUser_permissionsBoundary
--- PASS: TestAccIAMUser_permissionsBoundary (145.32s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	148.474s
...
```
