### PR TITLE
resource/aws_s3_bucket_object_lock_configuration: fix deletion bug

### DIFF
--- a/.changelog/33966.txt
+++ b/.changelog/33966.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_s3_bucket_object_lock_configuration: Fix deletion bug
+resource/aws_s3_bucket_object_lock_configuration: Fix `found resource` errors on Delete
 ```

--- a/.changelog/33966.txt
+++ b/.changelog/33966.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_s3_bucket_object_lock_configuration: Fix deletion bug
+```

--- a/internal/service/s3/bucket_object_lock_configuration.go
+++ b/internal/service/s3/bucket_object_lock_configuration.go
@@ -244,7 +244,7 @@ func resourceBucketObjectLockConfigurationDelete(ctx context.Context, d *schema.
 		return diag.Errorf("deleting S3 Bucket Object Lock Configuration (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, s3BucketPropagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenNotFound(ctx, s3BucketPropagationTimeout, func() (interface{}, error) {
 		return findObjectLockConfiguration(ctx, conn, bucket, expectedBucketOwner)
 	})
 

--- a/internal/service/s3/bucket_object_lock_configuration.go
+++ b/internal/service/s3/bucket_object_lock_configuration.go
@@ -244,13 +244,7 @@ func resourceBucketObjectLockConfigurationDelete(ctx context.Context, d *schema.
 		return diag.Errorf("deleting S3 Bucket Object Lock Configuration (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryWhenNotFound(ctx, s3BucketPropagationTimeout, func() (interface{}, error) {
-		return findObjectLockConfiguration(ctx, conn, bucket, expectedBucketOwner)
-	})
-
-	if err != nil {
-		return diag.Errorf("waiting for S3 Bucket Object Lock Configuration (%s) delete: %s", d.Id(), err)
-	}
+	// Don't wait for the object lock configuration to disappear as may still exist.
 
 	return nil
 }


### PR DESCRIPTION
### Description
aws_s3_bucket_object_lock_configuration was used `RetryUntilNotFound` but it can not be delete.
It will cause `resource found` loop. 

I used `RetryWhenNotFound` in case object_lock_configuration cannot be get due to some error. I think this appropriate this case.

### Relations
Closes #33943

### Output from Acceptance Testing
Does not exist related test.


This is my first time PR for this org. Please point out if I've made any mistakes.