### PR TITLE
r/aws_cloudformation_stack: Set computed fields correctly

### DIFF
--- a/.changelog/33969.txt
+++ b/.changelog/33969.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudformation_stack: Fix error when `computed` values are not set when there is no update
+```

--- a/internal/service/cloudformation/stack.go
+++ b/internal/service/cloudformation/stack.go
@@ -332,7 +332,7 @@ func resourceStackUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 	}, errCodeValidationError, "is invalid or cannot be assumed")
 
 	if tfawserr.ErrMessageContains(err, errCodeValidationError, "No updates are to be performed") {
-		return diags
+		return append(diags, resourceStackRead(ctx, d, meta)...)
 	}
 
 	if err != nil {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #33327

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTARGS='-run=TestAccCloudFormationStack_' PKG=cloudformation

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudformation/... -v -count 1 -parallel 20  -run=TestAccCloudFormationStack_ -timeout 360m
--- PASS: TestAccCloudFormationStack_disappears (122.15s)
--- PASS: TestAccCloudFormationStack_yaml (143.68s)
--- PASS: TestAccCloudFormationStack_onFailure (160.02s)
--- PASS: TestAccCloudFormationStack_withTransform (162.62s)
--- PASS: TestAccCloudFormationStack_basic (168.87s)
--- PASS: TestAccCloudFormationStack_updateFailure (171.24s)
--- PASS: TestAccCloudFormationStack_defaultParams (188.29s)
--- PASS: TestAccCloudFormationStack_withParams (209.04s)
--- PASS: TestAccCloudFormationStack_CreationFailure_doNothing (210.11s)
--- PASS: TestAccCloudFormationStack_CreationFailure_delete (212.13s)
--- PASS: TestAccCloudFormationStack_templateUpdate (221.74s)
--- PASS: TestAccCloudFormationStack_outputsUpdated (221.77s)
--- PASS: TestAccCloudFormationStack_CreationFailure_rollback (221.80s)
--- PASS: TestAccCloudFormationStack_allAttributes (271.92s)
--- PASS: TestAccCloudFormationStack_WithURLWithParams_withYAML (383.11s)
--- PASS: TestAccCloudFormationStack_WithURLWithParams_noUpdate (545.84s)
--- PASS: TestAccCloudFormationStack_WithURL_withParams (568.21s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudformation	571.454s
```
