### PR TITLE
Feature/datasource api gateway v2 vpc link

### DIFF
--- a/.changelog/33974.txt
+++ b/.changelog/33974.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_apigatewayv2_vpc_link
+```

--- a/internal/service/apigatewayv2/service_package_gen.go
+++ b/internal/service/apigatewayv2/service_package_gen.go
@@ -37,6 +37,11 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 			Factory:  DataSourceExport,
 			TypeName: "aws_apigatewayv2_export",
 		},
+		{
+			Factory:  DataSourceVPCLink,
+			TypeName: "aws_apigatewayv2_vpc_link",
+			Name:     "VPC Link Data Source",
+		},
 	}
 }
 

--- a/internal/service/apigatewayv2/vpc_link_data_source.go
+++ b/internal/service/apigatewayv2/vpc_link_data_source.go
@@ -1,0 +1,96 @@
+package apigatewayv2
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/apigatewayv2"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKDataSource("aws_apigatewayv2_vpc_link", name="VPC Link Data Source")
+func DataSourceVPCLink() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceVPCLinkRead,
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, 128),
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"security_group_ids": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"subnet_ids": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+		},
+	}
+}
+
+func dataSourceVPCLinkRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).APIGatewayV2Conn(ctx)
+
+	id := d.Get("id").(string)
+	d.SetId(id)
+
+	outputRaw, _, err := StatusVPCLink(ctx, conn, d.Id())()
+	if tfawserr.ErrCodeEquals(err, apigatewayv2.ErrCodeNotFoundException) && !d.IsNewResource() {
+		log.Printf("[WARN] API Gateway v2 VPC Link (%s) not found", d.Id())
+		d.SetId("")
+		return diags
+	}
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading API Gateway v2 VPC Link (%s): %s", d.Id(), err)
+	}
+
+	output := outputRaw.(*apigatewayv2.GetVpcLinkOutput)
+	arn := arn.ARN{
+		Partition: meta.(*conns.AWSClient).Partition,
+		Service:   "apigateway",
+		Region:    meta.(*conns.AWSClient).Region,
+		Resource:  fmt.Sprintf("/vpclinks/%s", d.Id()),
+	}.String()
+
+	d.Set("arn", arn)
+	d.Set("name", output.Name)
+	d.Set("security_group_ids", output.SecurityGroupIds)
+	d.Set("subnet_ids", output.SubnetIds)
+
+	if err := d.Set("security_group_ids", flex.FlattenStringSet(output.SecurityGroupIds)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting security_group_ids: %s", err)
+	}
+	if err := d.Set("subnet_ids", flex.FlattenStringSet(output.SubnetIds)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting subnet_ids: %s", err)
+	}
+
+	setTagsOut(ctx, output.Tags)
+
+	return diags
+}

--- a/internal/service/apigatewayv2/vpc_link_data_source.go
+++ b/internal/service/apigatewayv2/vpc_link_data_source.go
@@ -38,12 +38,12 @@ func DataSourceVPCLink() *schema.Resource {
 				Computed: true,
 			},
 			"security_group_ids": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"subnet_ids": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
@@ -83,10 +83,10 @@ func dataSourceVPCLinkRead(ctx context.Context, d *schema.ResourceData, meta int
 	d.Set("security_group_ids", output.SecurityGroupIds)
 	d.Set("subnet_ids", output.SubnetIds)
 
-	if err := d.Set("security_group_ids", flex.FlattenStringSet(output.SecurityGroupIds)); err != nil {
+	if err := d.Set("security_group_ids", flex.FlattenStringList(output.SecurityGroupIds)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting security_group_ids: %s", err)
 	}
-	if err := d.Set("subnet_ids", flex.FlattenStringSet(output.SubnetIds)); err != nil {
+	if err := d.Set("subnet_ids", flex.FlattenStringList(output.SubnetIds)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting subnet_ids: %s", err)
 	}
 

--- a/internal/service/apigatewayv2/vpc_link_data_source_test.go
+++ b/internal/service/apigatewayv2/vpc_link_data_source_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccAPIGatewayV2VPCLinkDataSource(t *testing.T) {
+func TestAccAPIGatewayV2VPCLinkData_source(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_apigatewayv2_vpc_link.test"
 	resourceName := "aws_apigatewayv2_vpc_link.test"

--- a/internal/service/apigatewayv2/vpc_link_data_source_test.go
+++ b/internal/service/apigatewayv2/vpc_link_data_source_test.go
@@ -1,0 +1,96 @@
+package apigatewayv2_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/apigatewayv2"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccAPIGatewayV2VPCLinkDataSource(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_apigatewayv2_vpc_link.test"
+	resourceName := "aws_apigatewayv2_vpc_link.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, apigatewayv2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCLinkDataSourceConfig_base(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "Arn", resourceName, "Arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "Id", resourceName, "Id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "Name", resourceName, "Name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "SecurityGroupIds", resourceName, "SecurityGroupIds"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "SubnetIds", resourceName, "SubnetIds"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags.%", resourceName, "2"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags.Key1", resourceName, "Value1"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags.Key2", resourceName, "Value2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccVPCLinkDataSourceConfig_base(rName string) string {
+	return fmt.Sprintf(`
+	resource "aws_vpc" "test" {
+		cidr_block = "10.0.0.0/16"
+	  
+		tags = {
+		  Name = %[1]q
+		}
+	  }
+	  
+	  data "aws_availability_zones" "available" {
+		state = "available"
+	  
+		filter {
+		  name   = "opt-in-status"
+		  values = ["opt-in-not-required"]
+		}
+	  }
+	  
+	  resource "aws_subnet" "test" {
+		count = 2
+	  
+		vpc_id            = aws_vpc.test.id
+		cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 2, count.index)
+		availability_zone = data.aws_availability_zones.available.names[count.index]
+	  
+		tags = {
+		  Name = %[1]q
+		}
+	  }
+
+	  resource "aws_security_group" "test" {
+		vpc_id = aws_vpc.test.id
+	  
+		tags = {
+		  Name = %[1]q
+		}
+	  }
+
+	  resource "aws_apigatewayv2_vpc_link" "test" {
+		name               = %[1]q
+		security_group_ids = [aws_security_group.test.id]
+		subnet_ids         = aws_subnet.test[*].id
+		
+		tags = {
+			Key1 = "Value1"
+			Key2 = "Value2"
+		  }
+	  }
+
+	  data "aws_apigatewayv2_vpc_link" "test" {
+		id = aws_apigatewayv2_vpc_link.test.id
+	  }
+`, rName)
+}

--- a/website/docs/d/apigatewayv2_vpc_link.html.markdown
+++ b/website/docs/d/apigatewayv2_vpc_link.html.markdown
@@ -1,0 +1,38 @@
+---
+subcategory: "API Gateway V2"
+layout: "aws"
+page_title: "AWS: aws_apigatewayv2_vpc_link"
+description: |-
+  Terraform data source for managing an AWS API Gateway V2 VPC Link.
+---
+
+# Data Source: aws_apigatewayv2_vpc_link
+
+Terraform data source for managing an AWS API Gateway V2 VPC Link.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_apigatewayv2_vpc_link" "example" {
+  id = "abc123"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `id` - (Required) VPC Link ID
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `arn` - ARN of the VPC Link.
+* `id` - VPC Link ID.
+* `name` - VPC Link Name.
+* `security_group_ids` - List of security groups associated with the VPC Link.
+* `subnet_ids` - List of subnets attached to the VPC Link.
+* `tags` - VPC Link Tags.


### PR DESCRIPTION
### Description
Feature request: New data source for API Gateway V2 VPC Link

### Relations
Closes #12958

### References
[AWS API Gateway V2 API Documentation](https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/vpclinks-vpclinkid.html)

### Output from Acceptance Testing
```console
 % make testacc TESTS=TestAccAPIGatewayV2VPCLinkDataSource PKG=apigatewayv2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/apigatewayv2/... -v -count 1 -parallel 20 -run='TestAccAPIGatewayV2VPCLinkDataSource'  -timeout 360m
=== RUN   TestAccAPIGatewayV2VPCLinkDat### Description
Feature request: New data source for API Gateway V2 VPC Link

### Relations
Closes #12958

### References
[AWS API Gateway V2 API Documentation](https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/vpclinks-vpclinkid.html)

### Output from Acceptance Testing
```console
 % make testacc TESTS=TestAccAPIGatewayV2VPCLinkDataSource PKG=apigatewayv2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/apigatewayv2/... -v -count 1 -parallel 20 -run='TestAccAPIGatewayV2VPCLinkDataSource'  -timeout 360m
=== RUN   TestAccAPIGatewayV2VPCLinkDataSource
=== PAUSE TestAccAPIGatewayV2VPCLinkDataSource
=== CONT  TestAccAPIGatewayV2VPCLinkDataSource
--- PASS: TestAccAPIGatewayV2VPCLinkDataSource (323.91s)
PASS
...
```
Source
=== PAUSE TestAccAPIGatewayV2VPCLinkDataSource
=== CONT  TestAccAPIGatewayV2VPCLinkDataSource
--- PASS: TestAccAPIGatewayV2VPCLinkDataSource (323.91s)
PASS
...
```
