### PR TITLE
Change to updated endpoint

### DIFF
--- a/internal/service/chime/chime_test.go
+++ b/internal/service/chime/chime_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package chime_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccChime_serial(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]map[string]func(t *testing.T){
+		"VoiceConnector": {
+			"basic":      testAccVoiceConnector_basic,
+			"disappears": testAccVoiceConnector_disappears,
+			"update":     testAccVoiceConnector_update,
+			"tags":       testAccVoiceConnector_tags,
+		},
+		"VoiceConnectorGroup": {
+			"basic":      testAccVoiceConnectorGroup_basic,
+			"disappears": testAccVoiceConnectorGroup_disappears,
+			"update":     testAccVoiceConnectorGroup_update,
+		},
+		"VoiceConnectorLogging": {
+			"basic":      testAccVoiceConnectorLogging_basic,
+			"disappears": testAccVoiceConnectorLogging_disappears,
+			"update":     testAccVoiceConnectorLogging_update,
+		},
+		"VoiceConnectorOrigination": {
+			"basic":      testAccVoiceConnectorOrigination_basic,
+			"disappears": testAccVoiceConnectorOrigination_disappears,
+			"update":     testAccVoiceConnectorOrigination_update,
+		},
+		"VoiceConnectorTermination": {
+			"basic":      testAccVoiceConnectorTermination_basic,
+			"disappears": testAccVoiceConnectorTermination_disappears,
+			"update":     testAccVoiceConnectorTermination_update,
+		},
+		"VoiceConnectorTerminationCredentials": {
+			"basic":      testAccVoiceConnectorTerminationCredentials_basic,
+			"disappears": testAccVoiceConnectorTerminationCredentials_disappears,
+			"update":     testAccVoiceConnectorTerminationCredentials_update,
+		},
+	}
+
+	acctest.RunSerialTests2Levels(t, testCases, 0)
+}

--- a/internal/service/chime/voice_connector.go
+++ b/internal/service/chime/voice_connector.go
@@ -8,7 +8,9 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/chime"
+	// "github.com/aws/aws-sdk-go/service/chime"
+
+	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -42,8 +44,8 @@ func ResourceVoiceConnector() *schema.Resource {
 				Type:         schema.TypeString,
 				ForceNew:     true,
 				Optional:     true,
-				Default:      chime.VoiceConnectorAwsRegionUsEast1,
-				ValidateFunc: validation.StringInSlice([]string{chime.VoiceConnectorAwsRegionUsEast1, chime.VoiceConnectorAwsRegionUsWest2}, false),
+				Default:      chimesdkvoice.VoiceConnectorAwsRegionUsEast1,
+				ValidateFunc: validation.StringInSlice([]string{chimesdkvoice.VoiceConnectorAwsRegionUsEast1, chimesdkvoice.VoiceConnectorAwsRegionUsWest2}, false),
 			},
 			"name": {
 				Type:         schema.TypeString,
@@ -68,9 +70,9 @@ func ResourceVoiceConnector() *schema.Resource {
 
 func resourceVoiceConnectorCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).ChimeConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
 
-	createInput := &chime.CreateVoiceConnectorInput{
+	createInput := &chimesdkvoice.CreateVoiceConnectorInput{
 		Name:              aws.String(d.Get("name").(string)),
 		RequireEncryption: aws.Bool(d.Get("require_encryption").(bool)),
 	}
@@ -96,14 +98,14 @@ func resourceVoiceConnectorCreate(ctx context.Context, d *schema.ResourceData, m
 
 func resourceVoiceConnectorRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).ChimeConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
 
-	getInput := &chime.GetVoiceConnectorInput{
+	getInput := &chimesdkvoice.GetVoiceConnectorInput{
 		VoiceConnectorId: aws.String(d.Id()),
 	}
 
 	resp, err := conn.GetVoiceConnectorWithContext(ctx, getInput)
-	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, chime.ErrCodeNotFoundException) {
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, chimesdkvoice.ErrCodeNotFoundException) {
 		log.Printf("[WARN] Chime Voice connector %s not found", d.Id())
 		d.SetId("")
 		return diags
@@ -124,10 +126,10 @@ func resourceVoiceConnectorRead(ctx context.Context, d *schema.ResourceData, met
 
 func resourceVoiceConnectorUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).ChimeConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
 
 	if d.HasChanges("name", "require_encryption") {
-		updateInput := &chime.UpdateVoiceConnectorInput{
+		updateInput := &chimesdkvoice.UpdateVoiceConnectorInput{
 			VoiceConnectorId:  aws.String(d.Id()),
 			Name:              aws.String(d.Get("name").(string)),
 			RequireEncryption: aws.Bool(d.Get("require_encryption").(bool)),
@@ -143,14 +145,14 @@ func resourceVoiceConnectorUpdate(ctx context.Context, d *schema.ResourceData, m
 
 func resourceVoiceConnectorDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).ChimeConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
 
-	input := &chime.DeleteVoiceConnectorInput{
+	input := &chimesdkvoice.DeleteVoiceConnectorInput{
 		VoiceConnectorId: aws.String(d.Id()),
 	}
 
 	if _, err := conn.DeleteVoiceConnectorWithContext(ctx, input); err != nil {
-		if tfawserr.ErrCodeEquals(err, chime.ErrCodeNotFoundException) {
+		if tfawserr.ErrCodeEquals(err, chimesdkvoice.ErrCodeNotFoundException) {
 			log.Printf("[WARN] Chime Voice connector %s not found", d.Id())
 			return diags
 		}

--- a/internal/service/chime/voice_connector.go
+++ b/internal/service/chime/voice_connector.go
@@ -8,8 +8,6 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
-	// "github.com/aws/aws-sdk-go/service/chime"
-
 	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/internal/service/chime/voice_connector_group.go
+++ b/internal/service/chime/voice_connector_group.go
@@ -8,7 +8,7 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/chime"
+	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -58,9 +58,9 @@ func ResourceVoiceConnectorGroup() *schema.Resource {
 }
 
 func resourceVoiceConnectorGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ChimeConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
 
-	input := &chime.CreateVoiceConnectorGroupInput{
+	input := &chimesdkvoice.CreateVoiceConnectorGroupInput{
 		Name: aws.String(d.Get("name").(string)),
 	}
 
@@ -79,14 +79,14 @@ func resourceVoiceConnectorGroupCreate(ctx context.Context, d *schema.ResourceDa
 }
 
 func resourceVoiceConnectorGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ChimeConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
 
-	getInput := &chime.GetVoiceConnectorGroupInput{
+	getInput := &chimesdkvoice.GetVoiceConnectorGroupInput{
 		VoiceConnectorGroupId: aws.String(d.Id()),
 	}
 
 	resp, err := conn.GetVoiceConnectorGroupWithContext(ctx, getInput)
-	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, chime.ErrCodeNotFoundException) {
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, chimesdkvoice.ErrCodeNotFoundException) {
 		log.Printf("[WARN] Chime Voice conector group %s not found", d.Id())
 		d.SetId("")
 		return nil
@@ -104,9 +104,9 @@ func resourceVoiceConnectorGroupRead(ctx context.Context, d *schema.ResourceData
 }
 
 func resourceVoiceConnectorGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ChimeConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
 
-	input := &chime.UpdateVoiceConnectorGroupInput{
+	input := &chimesdkvoice.UpdateVoiceConnectorGroupInput{
 		Name:                  aws.String(d.Get("name").(string)),
 		VoiceConnectorGroupId: aws.String(d.Id()),
 	}
@@ -116,7 +116,7 @@ func resourceVoiceConnectorGroupUpdate(ctx context.Context, d *schema.ResourceDa
 			input.VoiceConnectorItems = expandVoiceConnectorItems(v.(*schema.Set).List())
 		}
 	} else if !d.IsNewResource() {
-		input.VoiceConnectorItems = make([]*chime.VoiceConnectorItem, 0)
+		input.VoiceConnectorItems = make([]*chimesdkvoice.VoiceConnectorItem, 0)
 	}
 
 	if _, err := conn.UpdateVoiceConnectorGroupWithContext(ctx, input); err != nil {
@@ -127,7 +127,7 @@ func resourceVoiceConnectorGroupUpdate(ctx context.Context, d *schema.ResourceDa
 }
 
 func resourceVoiceConnectorGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ChimeConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
 
 	if v, ok := d.GetOk("connector"); ok && v.(*schema.Set).Len() > 0 {
 		if err := resourceVoiceConnectorGroupUpdate(ctx, d, meta); err != nil {
@@ -135,12 +135,12 @@ func resourceVoiceConnectorGroupDelete(ctx context.Context, d *schema.ResourceDa
 		}
 	}
 
-	input := &chime.DeleteVoiceConnectorGroupInput{
+	input := &chimesdkvoice.DeleteVoiceConnectorGroupInput{
 		VoiceConnectorGroupId: aws.String(d.Id()),
 	}
 
 	if _, err := conn.DeleteVoiceConnectorGroupWithContext(ctx, input); err != nil {
-		if tfawserr.ErrCodeEquals(err, chime.ErrCodeNotFoundException) {
+		if tfawserr.ErrCodeEquals(err, chimesdkvoice.ErrCodeNotFoundException) {
 			log.Printf("[WARN] Chime Voice conector group %s not found", d.Id())
 			return nil
 		}
@@ -150,12 +150,12 @@ func resourceVoiceConnectorGroupDelete(ctx context.Context, d *schema.ResourceDa
 	return nil
 }
 
-func expandVoiceConnectorItems(data []interface{}) []*chime.VoiceConnectorItem {
-	var connectorsItems []*chime.VoiceConnectorItem
+func expandVoiceConnectorItems(data []interface{}) []*chimesdkvoice.VoiceConnectorItem {
+	var connectorsItems []*chimesdkvoice.VoiceConnectorItem
 
 	for _, rItem := range data {
 		item := rItem.(map[string]interface{})
-		connectorsItems = append(connectorsItems, &chime.VoiceConnectorItem{
+		connectorsItems = append(connectorsItems, &chimesdkvoice.VoiceConnectorItem{
 			VoiceConnectorId: aws.String(item["voice_connector_id"].(string)),
 			Priority:         aws.Int64(int64(item["priority"].(int))),
 		})
@@ -164,7 +164,7 @@ func expandVoiceConnectorItems(data []interface{}) []*chime.VoiceConnectorItem {
 	return connectorsItems
 }
 
-func flattenVoiceConnectorItems(connectors []*chime.VoiceConnectorItem) []interface{} {
+func flattenVoiceConnectorItems(connectors []*chimesdkvoice.VoiceConnectorItem) []interface{} {
 	var rawConnectors []interface{}
 
 	for _, c := range connectors {

--- a/internal/service/chime/voice_connector_group_test.go
+++ b/internal/service/chime/voice_connector_group_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -28,6 +29,7 @@ func testAccVoiceConnectorGroup_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
+			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
@@ -62,6 +64,7 @@ func testAccVoiceConnectorGroup_disappears(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
+			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
@@ -90,6 +93,7 @@ func testAccVoiceConnectorGroup_update(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
+			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),

--- a/internal/service/chime/voice_connector_group_test.go
+++ b/internal/service/chime/voice_connector_group_test.go
@@ -18,7 +18,19 @@ import (
 	tfchime "github.com/hashicorp/terraform-provider-aws/internal/service/chime"
 )
 
-func TestAccChimeVoiceConnectorGroup_basic(t *testing.T) {
+func TestAccChimeVoiceConnectorGroup_serial(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]func(t *testing.T){
+		"basic":      testAccVoiceConnectorGroup_basic,
+		"disappears": testAccVoiceConnectorGroup_disappears,
+		"update":     testAccVoiceConnectorGroup_update,
+	}
+
+	acctest.RunSerialTests1Level(t, testCases, 0)
+}
+
+func testAccVoiceConnectorGroup_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var voiceConnectorGroup *chimesdkvoice.VoiceConnectorGroup
 
@@ -52,7 +64,7 @@ func TestAccChimeVoiceConnectorGroup_basic(t *testing.T) {
 	})
 }
 
-func TestAccChimeVoiceConnectorGroup_disappears(t *testing.T) {
+func testAccVoiceConnectorGroup_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var voiceConnectorGroup *chimesdkvoice.VoiceConnectorGroup
 
@@ -80,7 +92,7 @@ func TestAccChimeVoiceConnectorGroup_disappears(t *testing.T) {
 	})
 }
 
-func TestAccChimeVoiceConnectorGroup_update(t *testing.T) {
+func testAccVoiceConnectorGroup_update(t *testing.T) {
 	ctx := acctest.Context(t)
 	var voiceConnectorGroup *chimesdkvoice.VoiceConnectorGroup
 

--- a/internal/service/chime/voice_connector_group_test.go
+++ b/internal/service/chime/voice_connector_group_test.go
@@ -18,18 +18,6 @@ import (
 	tfchime "github.com/hashicorp/terraform-provider-aws/internal/service/chime"
 )
 
-func TestAccChimeVoiceConnectorGroup_serial(t *testing.T) {
-	t.Parallel()
-
-	testCases := map[string]func(t *testing.T){
-		"basic":      testAccVoiceConnectorGroup_basic,
-		"disappears": testAccVoiceConnectorGroup_disappears,
-		"update":     testAccVoiceConnectorGroup_update,
-	}
-
-	acctest.RunSerialTests1Level(t, testCases, 0)
-}
-
 func testAccVoiceConnectorGroup_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var voiceConnectorGroup *chimesdkvoice.VoiceConnectorGroup

--- a/internal/service/chime/voice_connector_group_test.go
+++ b/internal/service/chime/voice_connector_group_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/chime"
+	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -20,17 +20,17 @@ import (
 
 func TestAccChimeVoiceConnectorGroup_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	var voiceConnectorGroup *chime.VoiceConnectorGroup
+	var voiceConnectorGroup *chimesdkvoice.VoiceConnectorGroup
 
 	vcgName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chime.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorGroupDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -54,17 +54,17 @@ func TestAccChimeVoiceConnectorGroup_basic(t *testing.T) {
 
 func TestAccChimeVoiceConnectorGroup_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	var voiceConnectorGroup *chime.VoiceConnectorGroup
+	var voiceConnectorGroup *chimesdkvoice.VoiceConnectorGroup
 
 	vcgName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chime.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorGroupDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -82,17 +82,17 @@ func TestAccChimeVoiceConnectorGroup_disappears(t *testing.T) {
 
 func TestAccChimeVoiceConnectorGroup_update(t *testing.T) {
 	ctx := acctest.Context(t)
-	var voiceConnectorGroup *chime.VoiceConnectorGroup
+	var voiceConnectorGroup *chimesdkvoice.VoiceConnectorGroup
 
 	vcgName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chime.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorGroupDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -108,7 +108,7 @@ func TestAccChimeVoiceConnectorGroup_update(t *testing.T) {
 				Config: testAccVoiceConnectorGroupConfig_updated(vcgName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("vcg-updated-%s", vcgName)),
-					resource.TestCheckResourceAttr(resourceName, "connector.0.priority", "10"),
+					resource.TestCheckResourceAttr(resourceName, "connector.0.priority", "3"),
 				),
 			},
 			{
@@ -150,13 +150,13 @@ resource "aws_chime_voice_connector_group" "test" {
 
   connector {
     voice_connector_id = aws_chime_voice_connector.chime.id
-    priority           = 10
+    priority           = 3
   }
 }
 `, name)
 }
 
-func testAccCheckVoiceConnectorGroupExists(ctx context.Context, name string, vc *chime.VoiceConnectorGroup) resource.TestCheckFunc {
+func testAccCheckVoiceConnectorGroupExists(ctx context.Context, name string, vc *chimesdkvoice.VoiceConnectorGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -167,8 +167,8 @@ func testAccCheckVoiceConnectorGroupExists(ctx context.Context, name string, vc 
 			return fmt.Errorf("no Chime voice connector group ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeConn(ctx)
-		input := &chime.GetVoiceConnectorGroupInput{
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+		input := &chimesdkvoice.GetVoiceConnectorGroupInput{
 			VoiceConnectorGroupId: aws.String(rs.Primary.ID),
 		}
 
@@ -188,8 +188,8 @@ func testAccCheckVoiceConnectorGroupDestroy(ctx context.Context) resource.TestCh
 			if rs.Type != "aws_chime_voice_connector" {
 				continue
 			}
-			conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeConn(ctx)
-			input := &chime.GetVoiceConnectorGroupInput{
+			conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+			input := &chimesdkvoice.GetVoiceConnectorGroupInput{
 				VoiceConnectorGroupId: aws.String(rs.Primary.ID),
 			}
 			resp, err := conn.GetVoiceConnectorGroupWithContext(ctx, input)

--- a/internal/service/chime/voice_connector_logging.go
+++ b/internal/service/chime/voice_connector_logging.go
@@ -8,7 +8,7 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/chime"
+	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -48,12 +48,12 @@ func ResourceVoiceConnectorLogging() *schema.Resource {
 }
 
 func resourceVoiceConnectorLoggingCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ChimeConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
 
 	vcId := d.Get("voice_connector_id").(string)
-	input := &chime.PutVoiceConnectorLoggingConfigurationInput{
+	input := &chimesdkvoice.PutVoiceConnectorLoggingConfigurationInput{
 		VoiceConnectorId: aws.String(vcId),
-		LoggingConfiguration: &chime.LoggingConfiguration{
+		LoggingConfiguration: &chimesdkvoice.LoggingConfiguration{
 			EnableMediaMetricLogs: aws.Bool(d.Get("enable_media_metric_logs").(bool)),
 			EnableSIPLogs:         aws.Bool(d.Get("enable_sip_logs").(bool)),
 		},
@@ -68,14 +68,14 @@ func resourceVoiceConnectorLoggingCreate(ctx context.Context, d *schema.Resource
 }
 
 func resourceVoiceConnectorLoggingRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ChimeConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
 
-	input := &chime.GetVoiceConnectorLoggingConfigurationInput{
+	input := &chimesdkvoice.GetVoiceConnectorLoggingConfigurationInput{
 		VoiceConnectorId: aws.String(d.Id()),
 	}
 
 	resp, err := conn.GetVoiceConnectorLoggingConfigurationWithContext(ctx, input)
-	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, chime.ErrCodeNotFoundException) {
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, chimesdkvoice.ErrCodeNotFoundException) {
 		log.Printf("[WARN] Chime Voice Connector logging configuration %s not found", d.Id())
 		d.SetId("")
 		return nil
@@ -92,12 +92,12 @@ func resourceVoiceConnectorLoggingRead(ctx context.Context, d *schema.ResourceDa
 }
 
 func resourceVoiceConnectorLoggingUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ChimeConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
 
 	if d.HasChanges("enable_sip_logs", "enable_media_metric_logs") {
-		input := &chime.PutVoiceConnectorLoggingConfigurationInput{
+		input := &chimesdkvoice.PutVoiceConnectorLoggingConfigurationInput{
 			VoiceConnectorId: aws.String(d.Id()),
-			LoggingConfiguration: &chime.LoggingConfiguration{
+			LoggingConfiguration: &chimesdkvoice.LoggingConfiguration{
 				EnableMediaMetricLogs: aws.Bool(d.Get("enable_media_metric_logs").(bool)),
 				EnableSIPLogs:         aws.Bool(d.Get("enable_sip_logs").(bool)),
 			},
@@ -112,11 +112,11 @@ func resourceVoiceConnectorLoggingUpdate(ctx context.Context, d *schema.Resource
 }
 
 func resourceVoiceConnectorLoggingDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ChimeConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
 
-	input := &chime.PutVoiceConnectorLoggingConfigurationInput{
+	input := &chimesdkvoice.PutVoiceConnectorLoggingConfigurationInput{
 		VoiceConnectorId: aws.String(d.Id()),
-		LoggingConfiguration: &chime.LoggingConfiguration{
+		LoggingConfiguration: &chimesdkvoice.LoggingConfiguration{
 			EnableSIPLogs:         aws.Bool(false),
 			EnableMediaMetricLogs: aws.Bool(false),
 		},
@@ -124,7 +124,7 @@ func resourceVoiceConnectorLoggingDelete(ctx context.Context, d *schema.Resource
 
 	_, err := conn.PutVoiceConnectorLoggingConfigurationWithContext(ctx, input)
 
-	if tfawserr.ErrCodeEquals(err, chime.ErrCodeNotFoundException) {
+	if tfawserr.ErrCodeEquals(err, chimesdkvoice.ErrCodeNotFoundException) {
 		return nil
 	}
 

--- a/internal/service/chime/voice_connector_logging_test.go
+++ b/internal/service/chime/voice_connector_logging_test.go
@@ -18,7 +18,19 @@ import (
 	tfchime "github.com/hashicorp/terraform-provider-aws/internal/service/chime"
 )
 
-func TestAccChimeVoiceConnectorLogging_basic(t *testing.T) {
+func TestAccChimeVoiceConnectorLogging_serial(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]func(t *testing.T){
+		"basic":      testAccVoiceConnectorLogging_basic,
+		"disappears": testAccVoiceConnectorLogging_disappears,
+		"update":     testAccVoiceConnectorLogging_update,
+	}
+
+	acctest.RunSerialTests1Level(t, testCases, 0)
+}
+
+func testAccVoiceConnectorLogging_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector_logging.test"
@@ -49,7 +61,7 @@ func TestAccChimeVoiceConnectorLogging_basic(t *testing.T) {
 	})
 }
 
-func TestAccChimeVoiceConnectorLogging_disappears(t *testing.T) {
+func testAccVoiceConnectorLogging_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector_logging.test"
@@ -75,7 +87,7 @@ func TestAccChimeVoiceConnectorLogging_disappears(t *testing.T) {
 	})
 }
 
-func TestAccChimeVoiceConnectorLogging_update(t *testing.T) {
+func testAccVoiceConnectorLogging_update(t *testing.T) {
 	ctx := acctest.Context(t)
 	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector_logging.test"

--- a/internal/service/chime/voice_connector_logging_test.go
+++ b/internal/service/chime/voice_connector_logging_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/chime"
+	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -23,12 +23,12 @@ func TestAccChimeVoiceConnectorLogging_basic(t *testing.T) {
 	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector_logging.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chime.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -54,12 +54,12 @@ func TestAccChimeVoiceConnectorLogging_disappears(t *testing.T) {
 	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector_logging.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chime.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -80,12 +80,12 @@ func TestAccChimeVoiceConnectorLogging_update(t *testing.T) {
 	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector_logging.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chime.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -153,8 +153,8 @@ func testAccCheckVoiceConnectorLoggingExists(ctx context.Context, name string) r
 			return fmt.Errorf("no Chime Voice Connector logging ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeConn(ctx)
-		input := &chime.GetVoiceConnectorLoggingConfigurationInput{
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+		input := &chimesdkvoice.GetVoiceConnectorLoggingConfigurationInput{
 			VoiceConnectorId: aws.String(rs.Primary.ID),
 		}
 

--- a/internal/service/chime/voice_connector_logging_test.go
+++ b/internal/service/chime/voice_connector_logging_test.go
@@ -18,18 +18,6 @@ import (
 	tfchime "github.com/hashicorp/terraform-provider-aws/internal/service/chime"
 )
 
-func TestAccChimeVoiceConnectorLogging_serial(t *testing.T) {
-	t.Parallel()
-
-	testCases := map[string]func(t *testing.T){
-		"basic":      testAccVoiceConnectorLogging_basic,
-		"disappears": testAccVoiceConnectorLogging_disappears,
-		"update":     testAccVoiceConnectorLogging_update,
-	}
-
-	acctest.RunSerialTests1Level(t, testCases, 0)
-}
-
 func testAccVoiceConnectorLogging_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/chime/voice_connector_logging_test.go
+++ b/internal/service/chime/voice_connector_logging_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -26,6 +27,7 @@ func testAccVoiceConnectorLogging_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
+			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
@@ -57,6 +59,7 @@ func testAccVoiceConnectorLogging_disappears(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
+			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
@@ -83,6 +86,7 @@ func testAccVoiceConnectorLogging_update(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
+			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),

--- a/internal/service/chime/voice_connector_origination.go
+++ b/internal/service/chime/voice_connector_origination.go
@@ -8,7 +8,7 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/chime"
+	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -59,7 +59,7 @@ func ResourceVoiceConnectorOrigination() *schema.Resource {
 						"protocol": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: validation.StringInSlice(chime.OriginationRouteProtocol_Values(), false),
+							ValidateFunc: validation.StringInSlice(chimesdkvoice.OriginationRouteProtocol_Values(), false),
 						},
 						"weight": {
 							Type:         schema.TypeInt,
@@ -79,13 +79,13 @@ func ResourceVoiceConnectorOrigination() *schema.Resource {
 }
 
 func resourceVoiceConnectorOriginationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ChimeConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
 
 	vcId := d.Get("voice_connector_id").(string)
 
-	input := &chime.PutVoiceConnectorOriginationInput{
+	input := &chimesdkvoice.PutVoiceConnectorOriginationInput{
 		VoiceConnectorId: aws.String(vcId),
-		Origination: &chime.Origination{
+		Origination: &chimesdkvoice.Origination{
 			Routes: expandOriginationRoutes(d.Get("route").(*schema.Set).List()),
 		},
 	}
@@ -104,15 +104,15 @@ func resourceVoiceConnectorOriginationCreate(ctx context.Context, d *schema.Reso
 }
 
 func resourceVoiceConnectorOriginationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ChimeConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
 
-	input := &chime.GetVoiceConnectorOriginationInput{
+	input := &chimesdkvoice.GetVoiceConnectorOriginationInput{
 		VoiceConnectorId: aws.String(d.Id()),
 	}
 
 	resp, err := conn.GetVoiceConnectorOriginationWithContext(ctx, input)
 
-	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, chime.ErrCodeNotFoundException) {
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, chimesdkvoice.ErrCodeNotFoundException) {
 		log.Printf("[WARN] Chime Voice Connector (%s) origination not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
@@ -137,12 +137,12 @@ func resourceVoiceConnectorOriginationRead(ctx context.Context, d *schema.Resour
 }
 
 func resourceVoiceConnectorOriginationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ChimeConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
 
 	if d.HasChanges("route", "disabled") {
-		input := &chime.PutVoiceConnectorOriginationInput{
+		input := &chimesdkvoice.PutVoiceConnectorOriginationInput{
 			VoiceConnectorId: aws.String(d.Id()),
-			Origination: &chime.Origination{
+			Origination: &chimesdkvoice.Origination{
 				Routes: expandOriginationRoutes(d.Get("route").(*schema.Set).List()),
 			},
 		}
@@ -162,15 +162,15 @@ func resourceVoiceConnectorOriginationUpdate(ctx context.Context, d *schema.Reso
 }
 
 func resourceVoiceConnectorOriginationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ChimeConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
 
-	input := &chime.DeleteVoiceConnectorOriginationInput{
+	input := &chimesdkvoice.DeleteVoiceConnectorOriginationInput{
 		VoiceConnectorId: aws.String(d.Id()),
 	}
 
 	_, err := conn.DeleteVoiceConnectorOriginationWithContext(ctx, input)
 
-	if tfawserr.ErrCodeEquals(err, chime.ErrCodeNotFoundException) {
+	if tfawserr.ErrCodeEquals(err, chimesdkvoice.ErrCodeNotFoundException) {
 		return nil
 	}
 
@@ -181,12 +181,12 @@ func resourceVoiceConnectorOriginationDelete(ctx context.Context, d *schema.Reso
 	return nil
 }
 
-func expandOriginationRoutes(data []interface{}) []*chime.OriginationRoute {
-	var originationRoutes []*chime.OriginationRoute
+func expandOriginationRoutes(data []interface{}) []*chimesdkvoice.OriginationRoute {
+	var originationRoutes []*chimesdkvoice.OriginationRoute
 
 	for _, rItem := range data {
 		item := rItem.(map[string]interface{})
-		originationRoutes = append(originationRoutes, &chime.OriginationRoute{
+		originationRoutes = append(originationRoutes, &chimesdkvoice.OriginationRoute{
 			Host:     aws.String(item["host"].(string)),
 			Port:     aws.Int64(int64(item["port"].(int))),
 			Priority: aws.Int64(int64(item["priority"].(int))),
@@ -198,7 +198,7 @@ func expandOriginationRoutes(data []interface{}) []*chime.OriginationRoute {
 	return originationRoutes
 }
 
-func flattenOriginationRoutes(routes []*chime.OriginationRoute) []interface{} {
+func flattenOriginationRoutes(routes []*chimesdkvoice.OriginationRoute) []interface{} {
 	var rawRoutes []interface{}
 
 	for _, route := range routes {

--- a/internal/service/chime/voice_connector_origination_test.go
+++ b/internal/service/chime/voice_connector_origination_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -27,6 +28,7 @@ func testAccVoiceConnectorOrigination_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
+			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
@@ -61,6 +63,7 @@ func testAccVoiceConnectorOrigination_disappears(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
+			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
@@ -87,6 +90,7 @@ func testAccVoiceConnectorOrigination_update(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
+			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),

--- a/internal/service/chime/voice_connector_origination_test.go
+++ b/internal/service/chime/voice_connector_origination_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/chime"
+	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -24,12 +24,12 @@ func TestAccChimeVoiceConnectorOrigination_basic(t *testing.T) {
 	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector_origination.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chime.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorOriginationDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -58,12 +58,12 @@ func TestAccChimeVoiceConnectorOrigination_disappears(t *testing.T) {
 	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector_origination.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chime.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorOriginationDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -84,12 +84,12 @@ func TestAccChimeVoiceConnectorOrigination_update(t *testing.T) {
 	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector_origination.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chime.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorOriginationDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -136,8 +136,8 @@ func testAccCheckVoiceConnectorOriginationExists(ctx context.Context, name strin
 			return fmt.Errorf("no Chime voice connector origination ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeConn(ctx)
-		input := &chime.GetVoiceConnectorOriginationInput{
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+		input := &chimesdkvoice.GetVoiceConnectorOriginationInput{
 			VoiceConnectorId: aws.String(rs.Primary.ID),
 		}
 
@@ -160,14 +160,14 @@ func testAccCheckVoiceConnectorOriginationDestroy(ctx context.Context) resource.
 			if rs.Type != "aws_chime_voice_connector_origination" {
 				continue
 			}
-			conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeConn(ctx)
-			input := &chime.GetVoiceConnectorOriginationInput{
+			conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+			input := &chimesdkvoice.GetVoiceConnectorOriginationInput{
 				VoiceConnectorId: aws.String(rs.Primary.ID),
 			}
 
 			resp, err := conn.GetVoiceConnectorOriginationWithContext(ctx, input)
 
-			if tfawserr.ErrCodeEquals(err, chime.ErrCodeNotFoundException) {
+			if tfawserr.ErrCodeEquals(err, chimesdkvoice.ErrCodeNotFoundException) {
 				continue
 			}
 

--- a/internal/service/chime/voice_connector_origination_test.go
+++ b/internal/service/chime/voice_connector_origination_test.go
@@ -19,7 +19,19 @@ import (
 	tfchime "github.com/hashicorp/terraform-provider-aws/internal/service/chime"
 )
 
-func TestAccChimeVoiceConnectorOrigination_basic(t *testing.T) {
+func TestAccChimeVoiceConnectorOrigination_serial(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]func(t *testing.T){
+		"basic":      testAccVoiceConnectorOrigination_basic,
+		"disappears": testAccVoiceConnectorOrigination_disappears,
+		"update":     testAccVoiceConnectorOrigination_update,
+	}
+
+	acctest.RunSerialTests1Level(t, testCases, 0)
+}
+
+func testAccVoiceConnectorOrigination_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector_origination.test"
@@ -53,7 +65,7 @@ func TestAccChimeVoiceConnectorOrigination_basic(t *testing.T) {
 	})
 }
 
-func TestAccChimeVoiceConnectorOrigination_disappears(t *testing.T) {
+func testAccVoiceConnectorOrigination_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector_origination.test"
@@ -79,7 +91,7 @@ func TestAccChimeVoiceConnectorOrigination_disappears(t *testing.T) {
 	})
 }
 
-func TestAccChimeVoiceConnectorOrigination_update(t *testing.T) {
+func testAccVoiceConnectorOrigination_update(t *testing.T) {
 	ctx := acctest.Context(t)
 	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector_origination.test"

--- a/internal/service/chime/voice_connector_origination_test.go
+++ b/internal/service/chime/voice_connector_origination_test.go
@@ -19,18 +19,6 @@ import (
 	tfchime "github.com/hashicorp/terraform-provider-aws/internal/service/chime"
 )
 
-func TestAccChimeVoiceConnectorOrigination_serial(t *testing.T) {
-	t.Parallel()
-
-	testCases := map[string]func(t *testing.T){
-		"basic":      testAccVoiceConnectorOrigination_basic,
-		"disappears": testAccVoiceConnectorOrigination_disappears,
-		"update":     testAccVoiceConnectorOrigination_update,
-	}
-
-	acctest.RunSerialTests1Level(t, testCases, 0)
-}
-
 func testAccVoiceConnectorOrigination_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/chime/voice_connector_termination.go
+++ b/internal/service/chime/voice_connector_termination.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/chime"
+	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -74,15 +74,15 @@ func ResourceVoiceConnectorTermination() *schema.Resource {
 }
 
 func resourceVoiceConnectorTerminationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ChimeConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
 
 	vcId := d.Get("voice_connector_id").(string)
 
-	input := &chime.PutVoiceConnectorTerminationInput{
+	input := &chimesdkvoice.PutVoiceConnectorTerminationInput{
 		VoiceConnectorId: aws.String(vcId),
 	}
 
-	termination := &chime.Termination{
+	termination := &chimesdkvoice.Termination{
 		CidrAllowedList: flex.ExpandStringSet(d.Get("cidr_allow_list").(*schema.Set)),
 		CallingRegions:  flex.ExpandStringSet(d.Get("calling_regions").(*schema.Set)),
 	}
@@ -111,15 +111,15 @@ func resourceVoiceConnectorTerminationCreate(ctx context.Context, d *schema.Reso
 }
 
 func resourceVoiceConnectorTerminationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ChimeConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
 
-	input := &chime.GetVoiceConnectorTerminationInput{
+	input := &chimesdkvoice.GetVoiceConnectorTerminationInput{
 		VoiceConnectorId: aws.String(d.Id()),
 	}
 
 	resp, err := conn.GetVoiceConnectorTerminationWithContext(ctx, input)
 
-	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, chime.ErrCodeNotFoundException) {
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, chimesdkvoice.ErrCodeNotFoundException) {
 		log.Printf("[WARN] Chime Voice Connector (%s) termination not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
@@ -150,10 +150,10 @@ func resourceVoiceConnectorTerminationRead(ctx context.Context, d *schema.Resour
 }
 
 func resourceVoiceConnectorTerminationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ChimeConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
 
 	if d.HasChanges("calling_regions", "cidr_allow_list", "disabled", "cps_limit", "default_phone_number") {
-		termination := &chime.Termination{
+		termination := &chimesdkvoice.Termination{
 			CallingRegions:  flex.ExpandStringSet(d.Get("calling_regions").(*schema.Set)),
 			CidrAllowedList: flex.ExpandStringSet(d.Get("cidr_allow_list").(*schema.Set)),
 			CpsLimit:        aws.Int64(int64(d.Get("cps_limit").(int))),
@@ -167,7 +167,7 @@ func resourceVoiceConnectorTerminationUpdate(ctx context.Context, d *schema.Reso
 			termination.Disabled = aws.Bool(v.(bool))
 		}
 
-		input := &chime.PutVoiceConnectorTerminationInput{
+		input := &chimesdkvoice.PutVoiceConnectorTerminationInput{
 			VoiceConnectorId: aws.String(d.Id()),
 			Termination:      termination,
 		}
@@ -183,15 +183,15 @@ func resourceVoiceConnectorTerminationUpdate(ctx context.Context, d *schema.Reso
 }
 
 func resourceVoiceConnectorTerminationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ChimeConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
 
-	input := &chime.DeleteVoiceConnectorTerminationInput{
+	input := &chimesdkvoice.DeleteVoiceConnectorTerminationInput{
 		VoiceConnectorId: aws.String(d.Id()),
 	}
 
 	_, err := conn.DeleteVoiceConnectorTerminationWithContext(ctx, input)
 
-	if tfawserr.ErrCodeEquals(err, chime.ErrCodeNotFoundException) {
+	if tfawserr.ErrCodeEquals(err, chimesdkvoice.ErrCodeNotFoundException) {
 		return nil
 	}
 

--- a/internal/service/chime/voice_connector_termination_credentials.go
+++ b/internal/service/chime/voice_connector_termination_credentials.go
@@ -8,7 +8,7 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/chime"
+	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -60,11 +60,11 @@ func ResourceVoiceConnectorTerminationCredentials() *schema.Resource {
 }
 
 func resourceVoiceConnectorTerminationCredentialsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ChimeConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
 
 	vcId := d.Get("voice_connector_id").(string)
 
-	input := &chime.PutVoiceConnectorTerminationCredentialsInput{
+	input := &chimesdkvoice.PutVoiceConnectorTerminationCredentialsInput{
 		VoiceConnectorId: aws.String(vcId),
 		Credentials:      expandCredentials(d.Get("credentials").(*schema.Set).List()),
 	}
@@ -79,14 +79,14 @@ func resourceVoiceConnectorTerminationCredentialsCreate(ctx context.Context, d *
 }
 
 func resourceVoiceConnectorTerminationCredentialsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ChimeConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
 
-	input := &chime.ListVoiceConnectorTerminationCredentialsInput{
+	input := &chimesdkvoice.ListVoiceConnectorTerminationCredentialsInput{
 		VoiceConnectorId: aws.String(d.Id()),
 	}
 
 	_, err := conn.ListVoiceConnectorTerminationCredentialsWithContext(ctx, input)
-	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, chime.ErrCodeNotFoundException) {
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, chimesdkvoice.ErrCodeNotFoundException) {
 		log.Printf("[WARN] Chime Voice Connector (%s) termination credentials not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
@@ -102,10 +102,10 @@ func resourceVoiceConnectorTerminationCredentialsRead(ctx context.Context, d *sc
 }
 
 func resourceVoiceConnectorTerminationCredentialsUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ChimeConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
 
 	if d.HasChanges("credentials") {
-		input := &chime.PutVoiceConnectorTerminationCredentialsInput{
+		input := &chimesdkvoice.PutVoiceConnectorTerminationCredentialsInput{
 			VoiceConnectorId: aws.String(d.Id()),
 			Credentials:      expandCredentials(d.Get("credentials").(*schema.Set).List()),
 		}
@@ -121,16 +121,16 @@ func resourceVoiceConnectorTerminationCredentialsUpdate(ctx context.Context, d *
 }
 
 func resourceVoiceConnectorTerminationCredentialsDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ChimeConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
 
-	input := &chime.DeleteVoiceConnectorTerminationCredentialsInput{
+	input := &chimesdkvoice.DeleteVoiceConnectorTerminationCredentialsInput{
 		VoiceConnectorId: aws.String(d.Id()),
 		Usernames:        expandCredentialsUsernames(d.Get("credentials").(*schema.Set).List()),
 	}
 
 	_, err := conn.DeleteVoiceConnectorTerminationCredentialsWithContext(ctx, input)
 
-	if tfawserr.ErrCodeEquals(err, chime.ErrCodeNotFoundException) {
+	if tfawserr.ErrCodeEquals(err, chimesdkvoice.ErrCodeNotFoundException) {
 		return nil
 	}
 
@@ -152,12 +152,12 @@ func expandCredentialsUsernames(data []interface{}) []*string {
 	return rawNames
 }
 
-func expandCredentials(data []interface{}) []*chime.Credential {
-	var credentials []*chime.Credential
+func expandCredentials(data []interface{}) []*chimesdkvoice.Credential {
+	var credentials []*chimesdkvoice.Credential
 
 	for _, rItem := range data {
 		item := rItem.(map[string]interface{})
-		credentials = append(credentials, &chime.Credential{
+		credentials = append(credentials, &chimesdkvoice.Credential{
 			Username: aws.String(item["username"].(string)),
 			Password: aws.String(item["password"].(string)),
 		})

--- a/internal/service/chime/voice_connector_termination_credentials_test.go
+++ b/internal/service/chime/voice_connector_termination_credentials_test.go
@@ -19,7 +19,19 @@ import (
 	tfchime "github.com/hashicorp/terraform-provider-aws/internal/service/chime"
 )
 
-func TestAccChimeVoiceConnectorTerminationCredentials_basic(t *testing.T) {
+func TestAccChimeVoiceConnectorTerminationCredentials_serial(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]func(t *testing.T){
+		"basic":      testAccVoiceConnectorTerminationCredentials_basic,
+		"disappears": testAccVoiceConnectorTerminationCredentials_disappears,
+		"update":     testAccVoiceConnectorTerminationCredentials_update,
+	}
+
+	acctest.RunSerialTests1Level(t, testCases, 0)
+}
+
+func testAccVoiceConnectorTerminationCredentials_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector_termination_credentials.test"
@@ -50,7 +62,7 @@ func TestAccChimeVoiceConnectorTerminationCredentials_basic(t *testing.T) {
 	})
 }
 
-func TestAccChimeVoiceConnectorTerminationCredentials_disappears(t *testing.T) {
+func testAccVoiceConnectorTerminationCredentials_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector_termination_credentials.test"
@@ -76,7 +88,7 @@ func TestAccChimeVoiceConnectorTerminationCredentials_disappears(t *testing.T) {
 	})
 }
 
-func TestAccChimeVoiceConnectorTerminationCredentials_update(t *testing.T) {
+func testAccVoiceConnectorTerminationCredentials_update(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector_termination_credentials.test"

--- a/internal/service/chime/voice_connector_termination_credentials_test.go
+++ b/internal/service/chime/voice_connector_termination_credentials_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/chime"
+	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -24,12 +24,12 @@ func TestAccChimeVoiceConnectorTerminationCredentials_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector_termination_credentials.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chime.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorTerminationCredentialsDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -55,12 +55,12 @@ func TestAccChimeVoiceConnectorTerminationCredentials_disappears(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector_termination_credentials.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chime.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorTerminationCredentialsDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -81,12 +81,12 @@ func TestAccChimeVoiceConnectorTerminationCredentials_update(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector_termination_credentials.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chime.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorTerminationCredentialsDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -119,8 +119,8 @@ func testAccCheckVoiceConnectorTerminationCredentialsExists(ctx context.Context,
 			return fmt.Errorf("no Chime Voice Connector termination credentials ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeConn(ctx)
-		input := &chime.ListVoiceConnectorTerminationCredentialsInput{
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+		input := &chimesdkvoice.ListVoiceConnectorTerminationCredentialsInput{
 			VoiceConnectorId: aws.String(rs.Primary.ID),
 		}
 
@@ -143,13 +143,13 @@ func testAccCheckVoiceConnectorTerminationCredentialsDestroy(ctx context.Context
 			if rs.Type != "aws_chime_voice_connector_termination_credentials" {
 				continue
 			}
-			conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeConn(ctx)
-			input := &chime.ListVoiceConnectorTerminationCredentialsInput{
+			conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+			input := &chimesdkvoice.ListVoiceConnectorTerminationCredentialsInput{
 				VoiceConnectorId: aws.String(rs.Primary.ID),
 			}
 			resp, err := conn.ListVoiceConnectorTerminationCredentialsWithContext(ctx, input)
 
-			if tfawserr.ErrCodeEquals(err, chime.ErrCodeNotFoundException) {
+			if tfawserr.ErrCodeEquals(err, chimesdkvoice.ErrCodeNotFoundException) {
 				continue
 			}
 

--- a/internal/service/chime/voice_connector_termination_credentials_test.go
+++ b/internal/service/chime/voice_connector_termination_credentials_test.go
@@ -19,18 +19,6 @@ import (
 	tfchime "github.com/hashicorp/terraform-provider-aws/internal/service/chime"
 )
 
-func TestAccChimeVoiceConnectorTerminationCredentials_serial(t *testing.T) {
-	t.Parallel()
-
-	testCases := map[string]func(t *testing.T){
-		"basic":      testAccVoiceConnectorTerminationCredentials_basic,
-		"disappears": testAccVoiceConnectorTerminationCredentials_disappears,
-		"update":     testAccVoiceConnectorTerminationCredentials_update,
-	}
-
-	acctest.RunSerialTests1Level(t, testCases, 0)
-}
-
 func testAccVoiceConnectorTerminationCredentials_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/chime/voice_connector_termination_credentials_test.go
+++ b/internal/service/chime/voice_connector_termination_credentials_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -27,6 +28,7 @@ func testAccVoiceConnectorTerminationCredentials_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
+			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
@@ -58,6 +60,7 @@ func testAccVoiceConnectorTerminationCredentials_disappears(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
+			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
@@ -84,6 +87,7 @@ func testAccVoiceConnectorTerminationCredentials_update(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
+			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),

--- a/internal/service/chime/voice_connector_termination_test.go
+++ b/internal/service/chime/voice_connector_termination_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/chime"
+	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -24,12 +24,12 @@ func TestAccChimeVoiceConnectorTermination_basic(t *testing.T) {
 	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector_termination.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chime.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorTerminationDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -57,12 +57,12 @@ func TestAccChimeVoiceConnectorTermination_disappears(t *testing.T) {
 	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector_termination.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chime.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorTerminationDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -83,12 +83,12 @@ func TestAccChimeVoiceConnectorTermination_update(t *testing.T) {
 	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector_termination.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chime.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorTerminationDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -161,8 +161,8 @@ func testAccCheckVoiceConnectorTerminationExists(ctx context.Context, name strin
 			return fmt.Errorf("no Chime Voice Connector termination ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeConn(ctx)
-		input := &chime.GetVoiceConnectorTerminationInput{
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+		input := &chimesdkvoice.GetVoiceConnectorTerminationInput{
 			VoiceConnectorId: aws.String(rs.Primary.ID),
 		}
 
@@ -185,13 +185,13 @@ func testAccCheckVoiceConnectorTerminationDestroy(ctx context.Context) resource.
 			if rs.Type != "aws_chime_voice_connector_termination" {
 				continue
 			}
-			conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeConn(ctx)
-			input := &chime.GetVoiceConnectorTerminationInput{
+			conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+			input := &chimesdkvoice.GetVoiceConnectorTerminationInput{
 				VoiceConnectorId: aws.String(rs.Primary.ID),
 			}
 			resp, err := conn.GetVoiceConnectorTerminationWithContext(ctx, input)
 
-			if tfawserr.ErrCodeEquals(err, chime.ErrCodeNotFoundException) {
+			if tfawserr.ErrCodeEquals(err, chimesdkvoice.ErrCodeNotFoundException) {
 				continue
 			}
 

--- a/internal/service/chime/voice_connector_termination_test.go
+++ b/internal/service/chime/voice_connector_termination_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -27,6 +28,7 @@ func testAccVoiceConnectorTermination_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
+			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
@@ -60,6 +62,7 @@ func testAccVoiceConnectorTermination_disappears(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
+			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
@@ -86,6 +89,7 @@ func testAccVoiceConnectorTermination_update(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
+			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),

--- a/internal/service/chime/voice_connector_termination_test.go
+++ b/internal/service/chime/voice_connector_termination_test.go
@@ -19,7 +19,19 @@ import (
 	tfchime "github.com/hashicorp/terraform-provider-aws/internal/service/chime"
 )
 
-func TestAccChimeVoiceConnectorTermination_basic(t *testing.T) {
+func TestAccChimeVoiceConnectorTermination_serial(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]func(t *testing.T){
+		"basic":      testAccVoiceConnectorTermination_basic,
+		"disappears": testAccVoiceConnectorTermination_disappears,
+		"update":     testAccVoiceConnectorTermination_update,
+	}
+
+	acctest.RunSerialTests1Level(t, testCases, 0)
+}
+
+func testAccVoiceConnectorTermination_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector_termination.test"
@@ -52,7 +64,7 @@ func TestAccChimeVoiceConnectorTermination_basic(t *testing.T) {
 	})
 }
 
-func TestAccChimeVoiceConnectorTermination_disappears(t *testing.T) {
+func testAccVoiceConnectorTermination_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector_termination.test"
@@ -78,7 +90,7 @@ func TestAccChimeVoiceConnectorTermination_disappears(t *testing.T) {
 	})
 }
 
-func TestAccChimeVoiceConnectorTermination_update(t *testing.T) {
+func testAccVoiceConnectorTermination_update(t *testing.T) {
 	ctx := acctest.Context(t)
 	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector_termination.test"

--- a/internal/service/chime/voice_connector_termination_test.go
+++ b/internal/service/chime/voice_connector_termination_test.go
@@ -19,18 +19,6 @@ import (
 	tfchime "github.com/hashicorp/terraform-provider-aws/internal/service/chime"
 )
 
-func TestAccChimeVoiceConnectorTermination_serial(t *testing.T) {
-	t.Parallel()
-
-	testCases := map[string]func(t *testing.T){
-		"basic":      testAccVoiceConnectorTermination_basic,
-		"disappears": testAccVoiceConnectorTermination_disappears,
-		"update":     testAccVoiceConnectorTermination_update,
-	}
-
-	acctest.RunSerialTests1Level(t, testCases, 0)
-}
-
 func testAccVoiceConnectorTermination_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/chime/voice_connector_test.go
+++ b/internal/service/chime/voice_connector_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/chime"
+	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -21,7 +22,7 @@ import (
 
 func TestAccChimeVoiceConnector_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	var voiceConnector *chime.VoiceConnector
+	var voiceConnector *chimesdkvoice.VoiceConnector
 
 	vcName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector.test"
@@ -32,7 +33,7 @@ func TestAccChimeVoiceConnector_basic(t *testing.T) {
 			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chime.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -41,7 +42,7 @@ func TestAccChimeVoiceConnector_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVoiceConnectorExists(ctx, resourceName, voiceConnector),
 					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("vc-%s", vcName)),
-					resource.TestCheckResourceAttr(resourceName, "aws_region", chime.VoiceConnectorAwsRegionUsEast1),
+					resource.TestCheckResourceAttr(resourceName, "aws_region", chimesdkvoice.VoiceConnectorAwsRegionUsEast1),
 					resource.TestCheckResourceAttr(resourceName, "require_encryption", "true"),
 				),
 			},
@@ -56,7 +57,7 @@ func TestAccChimeVoiceConnector_basic(t *testing.T) {
 
 func TestAccChimeVoiceConnector_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	var voiceConnector *chime.VoiceConnector
+	var voiceConnector *chimesdkvoice.VoiceConnector
 
 	vcName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector.test"
@@ -67,7 +68,7 @@ func TestAccChimeVoiceConnector_disappears(t *testing.T) {
 			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chime.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -85,7 +86,7 @@ func TestAccChimeVoiceConnector_disappears(t *testing.T) {
 
 func TestAccChimeVoiceConnector_update(t *testing.T) {
 	ctx := acctest.Context(t)
-	var voiceConnector *chime.VoiceConnector
+	var voiceConnector *chimesdkvoice.VoiceConnector
 
 	vcName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector.test"
@@ -96,7 +97,7 @@ func TestAccChimeVoiceConnector_update(t *testing.T) {
 			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chime.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -105,7 +106,7 @@ func TestAccChimeVoiceConnector_update(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVoiceConnectorExists(ctx, resourceName, voiceConnector),
 					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("vc-%s", vcName)),
-					resource.TestCheckResourceAttr(resourceName, "aws_region", chime.VoiceConnectorAwsRegionUsEast1),
+					resource.TestCheckResourceAttr(resourceName, "aws_region", chimesdkvoice.VoiceConnectorAwsRegionUsEast1),
 					resource.TestCheckResourceAttr(resourceName, "require_encryption", "true"),
 				),
 			},
@@ -126,7 +127,7 @@ func TestAccChimeVoiceConnector_update(t *testing.T) {
 
 func TestAccChimeVoiceConnector_tags(t *testing.T) {
 	ctx := acctest.Context(t)
-	var voiceConnector *chime.VoiceConnector
+	var voiceConnector *chimesdkvoice.VoiceConnector
 
 	vcName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector.test"
@@ -139,7 +140,7 @@ func TestAccChimeVoiceConnector_tags(t *testing.T) {
 			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chime.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -225,7 +226,7 @@ resource "aws_chime_voice_connector" "test" {
 `, name, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccCheckVoiceConnectorExists(ctx context.Context, name string, vc *chime.VoiceConnector) resource.TestCheckFunc {
+func testAccCheckVoiceConnectorExists(ctx context.Context, name string, vc *chimesdkvoice.VoiceConnector) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -236,8 +237,8 @@ func testAccCheckVoiceConnectorExists(ctx context.Context, name string, vc *chim
 			return fmt.Errorf("no Chime voice connector ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeConn(ctx)
-		input := &chime.GetVoiceConnectorInput{
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+		input := &chimesdkvoice.GetVoiceConnectorInput{
 			VoiceConnectorId: aws.String(rs.Primary.ID),
 		}
 		resp, err := conn.GetVoiceConnectorWithContext(ctx, input)

--- a/internal/service/chime/voice_connector_test.go
+++ b/internal/service/chime/voice_connector_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
-	"github.com/aws/aws-sdk-go/service/chime"
 	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -27,7 +26,7 @@ func TestAccChimeVoiceConnector_basic(t *testing.T) {
 	vcName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
@@ -62,7 +61,7 @@ func TestAccChimeVoiceConnector_disappears(t *testing.T) {
 	vcName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
@@ -91,7 +90,7 @@ func TestAccChimeVoiceConnector_update(t *testing.T) {
 	vcName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
@@ -132,7 +131,7 @@ func TestAccChimeVoiceConnector_tags(t *testing.T) {
 	vcName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			// Legacy chime resources are always created in us-east-1, and the ListTags operation
@@ -258,8 +257,8 @@ func testAccCheckVoiceConnectorDestroy(ctx context.Context) resource.TestCheckFu
 			if rs.Type != "aws_chime_voice_connector" {
 				continue
 			}
-			conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeConn(ctx)
-			input := &chime.GetVoiceConnectorInput{
+			conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+			input := &chimesdkvoice.GetVoiceConnectorInput{
 				VoiceConnectorId: aws.String(rs.Primary.ID),
 			}
 			resp, err := conn.GetVoiceConnectorWithContext(ctx, input)
@@ -275,9 +274,9 @@ func testAccCheckVoiceConnectorDestroy(ctx context.Context) resource.TestCheckFu
 }
 
 func testAccPreCheck(ctx context.Context, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeConn(ctx)
+	conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
 
-	input := &chime.ListVoiceConnectorsInput{}
+	input := &chimesdkvoice.ListVoiceConnectorsInput{}
 
 	_, err := conn.ListVoiceConnectorsWithContext(ctx, input)
 

--- a/internal/service/chime/voice_connector_test.go
+++ b/internal/service/chime/voice_connector_test.go
@@ -19,19 +19,6 @@ import (
 	tfchime "github.com/hashicorp/terraform-provider-aws/internal/service/chime"
 )
 
-func TestAccChimeVoiceConnector_serial(t *testing.T) {
-	t.Parallel()
-
-	testCases := map[string]func(t *testing.T){
-		"basic":      testAccVoiceConnector_basic,
-		"disappears": testAccVoiceConnector_disappears,
-		"update":     testAccVoiceConnector_update,
-		"tags":       testAccVoiceConnector_tags,
-	}
-
-	acctest.RunSerialTests1Level(t, testCases, 0)
-}
-
 func testAccVoiceConnector_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var voiceConnector *chimesdkvoice.VoiceConnector

--- a/internal/service/chime/voice_connector_test.go
+++ b/internal/service/chime/voice_connector_test.go
@@ -19,7 +19,20 @@ import (
 	tfchime "github.com/hashicorp/terraform-provider-aws/internal/service/chime"
 )
 
-func TestAccChimeVoiceConnector_basic(t *testing.T) {
+func TestAccChimeVoiceConnector_serial(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]func(t *testing.T){
+		"basic":      testAccVoiceConnector_basic,
+		"disappears": testAccVoiceConnector_disappears,
+		"update":     testAccVoiceConnector_update,
+		"tags":       testAccVoiceConnector_tags,
+	}
+
+	acctest.RunSerialTests1Level(t, testCases, 0)
+}
+
+func testAccVoiceConnector_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var voiceConnector *chimesdkvoice.VoiceConnector
 
@@ -54,7 +67,7 @@ func TestAccChimeVoiceConnector_basic(t *testing.T) {
 	})
 }
 
-func TestAccChimeVoiceConnector_disappears(t *testing.T) {
+func testAccVoiceConnector_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var voiceConnector *chimesdkvoice.VoiceConnector
 
@@ -83,7 +96,7 @@ func TestAccChimeVoiceConnector_disappears(t *testing.T) {
 	})
 }
 
-func TestAccChimeVoiceConnector_update(t *testing.T) {
+func testAccVoiceConnector_update(t *testing.T) {
 	ctx := acctest.Context(t)
 	var voiceConnector *chimesdkvoice.VoiceConnector
 
@@ -124,7 +137,7 @@ func TestAccChimeVoiceConnector_update(t *testing.T) {
 	})
 }
 
-func TestAccChimeVoiceConnector_tags(t *testing.T) {
+func testAccVoiceConnector_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var voiceConnector *chimesdkvoice.VoiceConnector
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Updates the deprecated chime endpoints

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #2697
Closes #33633
--->

Relates #2697
Closes #33633

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
> make testacc TESTS=TestAccChimeVoiceConnector_ PKG=chime
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/chime/... -v -count 1 -parallel 20 -run='TestAccChimeVoiceConnector_'  -timeout 360m
=== RUN   TestAccChimeVoiceConnector_basic
--- PASS: TestAccChimeVoiceConnector_basic (19.40s)
=== RUN   TestAccChimeVoiceConnector_disappears
--- PASS: TestAccChimeVoiceConnector_disappears (13.30s)
=== RUN   TestAccChimeVoiceConnector_update
--- PASS: TestAccChimeVoiceConnector_update (30.13s)
=== RUN   TestAccChimeVoiceConnector_tags
--- PASS: TestAccChimeVoiceConnector_tags (42.86s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/chime      108.768s

> make testacc TESTS=TestAccChimeVoiceConnectorGroup_ PKG=chime
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/chime/... -v -count 1 -parallel 20 -run='TestAccChimeVoiceConnectorGroup_'  -timeout 360m
=== RUN   TestAccChimeVoiceConnectorGroup_basic
--- PASS: TestAccChimeVoiceConnectorGroup_basic (19.55s)
=== RUN   TestAccChimeVoiceConnectorGroup_disappears
--- PASS: TestAccChimeVoiceConnectorGroup_disappears (16.78s)
=== RUN   TestAccChimeVoiceConnectorGroup_update
--- PASS: TestAccChimeVoiceConnectorGroup_update (31.20s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/chime      70.796s

> make testacc TESTS=TestAccChimeVoiceConnectorLogging_ PKG=chime
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/chime/... -v -count 1 -parallel 20 -run='TestAccChimeVoiceConnectorLogging_'  -timeout 360m
=== RUN   TestAccChimeVoiceConnectorLogging_basic
--- PASS: TestAccChimeVoiceConnectorLogging_basic (20.27s)
=== RUN   TestAccChimeVoiceConnectorLogging_disappears
--- PASS: TestAccChimeVoiceConnectorLogging_disappears (17.04s)
=== RUN   TestAccChimeVoiceConnectorLogging_update
--- PASS: TestAccChimeVoiceConnectorLogging_update (31.25s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/chime      71.635s

> make testacc TESTS=TestAccChimeVoiceConnectorOrigination_ PKG=chime
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/chime/... -v -count 1 -parallel 20 -run='TestAccChimeVoiceConnectorOrigination_'  -timeout 360m
=== RUN   TestAccChimeVoiceConnectorOrigination_basic
--- PASS: TestAccChimeVoiceConnectorOrigination_basic (19.45s)
=== RUN   TestAccChimeVoiceConnectorOrigination_disappears
--- PASS: TestAccChimeVoiceConnectorOrigination_disappears (16.30s)
=== RUN   TestAccChimeVoiceConnectorOrigination_update
--- PASS: TestAccChimeVoiceConnectorOrigination_update (30.79s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/chime      69.592s

> make testacc TESTS=TestAccChimeVoiceConnectorTermination_ PKG=chime
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/chime/... -v -count 1 -parallel 20 -run='TestAccChimeVoiceConnectorTermination_'  -timeout 360m
=== RUN   TestAccChimeVoiceConnectorTermination_basic
--- PASS: TestAccChimeVoiceConnectorTermination_basic (19.63s)
=== RUN   TestAccChimeVoiceConnectorTermination_disappears
=== PAUSE TestAccChimeVoiceConnectorTermination_disappears
=== RUN   TestAccChimeVoiceConnectorTermination_update
=== PAUSE TestAccChimeVoiceConnectorTermination_update
=== CONT  TestAccChimeVoiceConnectorTermination_disappears
=== CONT  TestAccChimeVoiceConnectorTermination_update
--- PASS: TestAccChimeVoiceConnectorTermination_disappears (17.18s)
--- PASS: TestAccChimeVoiceConnectorTermination_update (32.78s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/chime      55.491s

> make testacc TESTS=TestAccChimeVoiceConnectorTerminationCredentials_ PKG=chime
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/chime/... -v -count 1 -parallel 20 -run='TestAccChimeVoiceConnectorTerminationCredentials_'  -timeout 360m
=== RUN   TestAccChimeVoiceConnectorTerminationCredentials_basic
--- PASS: TestAccChimeVoiceConnectorTerminationCredentials_basic (20.35s)
=== RUN   TestAccChimeVoiceConnectorTerminationCredentials_disappears
--- PASS: TestAccChimeVoiceConnectorTerminationCredentials_disappears (16.70s)
=== RUN   TestAccChimeVoiceConnectorTerminationCredentials_update
--- PASS: TestAccChimeVoiceConnectorTerminationCredentials_update (29.43s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/chime      69.601s
...
```
