### PR TITLE
resource/aws_db_instance: Changing `password` bypasses Blue/Green deployment

### DIFF
--- a/internal/service/rds/certificate_data_source.go
+++ b/internal/service/rds/certificate_data_source.go
@@ -5,7 +5,6 @@ package rds
 
 import (
 	"context"
-	"sort"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -14,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"golang.org/x/exp/slices"
 )
 
 // @SDKDataSource("aws_rds_certificate")
@@ -100,20 +100,18 @@ func dataSourceCertificateRead(ctx context.Context, d *schema.ResourceData, meta
 	var certificate *rds.Certificate
 
 	if d.Get("latest_valid_till").(bool) {
-		sort.Sort(rdsCertificateValidTillSort(certificates))
+		slices.SortFunc(certificates, func(a, b *rds.Certificate) int {
+			return a.ValidTill.Compare(*b.ValidTill)
+		})
 		certificate = certificates[len(certificates)-1]
-	}
-
-	if len(certificates) > 1 {
-		return sdkdiag.AppendErrorf(diags, "multiple RDS Certificates match the criteria; try changing search query")
-	}
-
-	if certificate == nil && len(certificates) == 1 {
+	} else {
+		if len(certificates) > 1 {
+			return sdkdiag.AppendErrorf(diags, "multiple RDS Certificates match the criteria; try changing search query")
+		}
+		if len(certificates) == 0 {
+			return sdkdiag.AppendErrorf(diags, "no RDS Certificates match the criteria")
+		}
 		certificate = certificates[0]
-	}
-
-	if certificate == nil {
-		return sdkdiag.AppendErrorf(diags, "no RDS Certificates match the criteria")
 	}
 
 	d.SetId(aws.StringValue(certificate.CertificateIdentifier))
@@ -137,20 +135,4 @@ func dataSourceCertificateRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	return diags
-}
-
-type rdsCertificateValidTillSort []*rds.Certificate
-
-func (s rdsCertificateValidTillSort) Len() int      { return len(s) }
-func (s rdsCertificateValidTillSort) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
-func (s rdsCertificateValidTillSort) Less(i, j int) bool {
-	if s[i] == nil || s[i].ValidTill == nil {
-		return true
-	}
-
-	if s[j] == nil || s[j].ValidTill == nil {
-		return false
-	}
-
-	return (*s[i].ValidTill).Before(*s[j].ValidTill)
 }

--- a/internal/service/rds/certificate_data_source_test.go
+++ b/internal/service/rds/certificate_data_source_test.go
@@ -26,7 +26,7 @@ func TestAccRDSCertificateDataSource_id(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCertificateDataSourceConfig_id(),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "id", "data.aws_rds_certificate.latest", "id"),
 				),
 			},
@@ -46,13 +46,13 @@ func TestAccRDSCertificateDataSource_latestValidTill(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCertificateDataSourceConfig_latestValidTill(),
-				Check: resource.ComposeTestCheckFunc(
-					acctest.MatchResourceAttrRegionalARNNoAccount(dataSourceName, "arn", "rds", regexache.MustCompile(`cert:rds-ca-[0-9]{4}`)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.MatchResourceAttrRegionalARNNoAccount(dataSourceName, "arn", "rds", regexache.MustCompile(`cert:rds-ca-[-0-9a-z]+$`)),
 					resource.TestCheckResourceAttr(dataSourceName, "certificate_type", "CA"),
 					resource.TestCheckResourceAttr(dataSourceName, "customer_override", "false"),
 					resource.TestCheckNoResourceAttr(dataSourceName, "customer_override_valid_till"),
-					resource.TestMatchResourceAttr(dataSourceName, "id", regexache.MustCompile(`rds-ca-[0-9]{4}`)),
-					resource.TestMatchResourceAttr(dataSourceName, "thumbprint", regexache.MustCompile(`[0-9a-f]+`)),
+					resource.TestMatchResourceAttr(dataSourceName, "id", regexache.MustCompile(`^rds-ca-[-0-9a-z]+$`)),
+					resource.TestMatchResourceAttr(dataSourceName, "thumbprint", regexache.MustCompile(`^[0-9a-f]+$`)),
 					resource.TestMatchResourceAttr(dataSourceName, "valid_from", regexache.MustCompile(acctest.RFC3339RegexPattern)),
 					resource.TestMatchResourceAttr(dataSourceName, "valid_till", regexache.MustCompile(acctest.RFC3339RegexPattern)),
 				),

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -1799,7 +1799,17 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		"skip_final_snapshot",
 		"tags", "tags_all",
 	) {
-		if d.Get("blue_green_update.0.enabled").(bool) {
+		if d.Get("blue_green_update.0.enabled").(bool) && d.HasChangesExcept(
+			"allow_major_version_upgrade",
+			"blue_green_update",
+			"delete_automated_backups",
+			"final_snapshot_identifier",
+			"replicate_source_db",
+			"skip_final_snapshot",
+			"tags", "tags_all",
+			"deletion_protection",
+			"password",
+		) {
 			orchestrator := newBlueGreenOrchestrator(conn)
 			handler := newInstanceHandler(conn)
 			var cleaupWaiters []func(optFns ...tfresource.OptionsFunc)

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -919,7 +919,7 @@ func TestAccRDSInstance_password(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	var v rds.DBInstance
+	var v1, v2 rds.DBInstance
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_db_instance.test"
 
@@ -937,7 +937,7 @@ func TestAccRDSInstance_password(t *testing.T) {
 			{
 				Config: testAccInstanceConfig_password(rName, "valid-password-1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceExists(ctx, resourceName, &v),
+					testAccCheckInstanceExists(ctx, resourceName, &v1),
 					resource.TestCheckResourceAttr(resourceName, "password", "valid-password-1"),
 				),
 			},
@@ -955,7 +955,8 @@ func TestAccRDSInstance_password(t *testing.T) {
 			{
 				Config: testAccInstanceConfig_password(rName, "valid-password-2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInstanceExists(ctx, resourceName, &v),
+					testAccCheckInstanceExists(ctx, resourceName, &v2),
+					testAccCheckDBInstanceNotRecreated(&v1, &v2),
 					resource.TestCheckResourceAttr(resourceName, "password", "valid-password-2"),
 				),
 			},
@@ -4718,6 +4719,7 @@ func TestAccRDSInstance_BlueGreenDeployment_updateEngineVersion(t *testing.T) {
 					"skip_final_snapshot",
 					"delete_automated_backups",
 					"blue_green_update",
+					"latest_restorable_time",
 				},
 			},
 		},
@@ -4823,6 +4825,7 @@ func TestAccRDSInstance_BlueGreenDeployment_tags(t *testing.T) {
 					"skip_final_snapshot",
 					"delete_automated_backups",
 					"blue_green_update",
+					"latest_restorable_time",
 				},
 			},
 		},
@@ -4873,6 +4876,7 @@ func TestAccRDSInstance_BlueGreenDeployment_updateInstanceClass(t *testing.T) {
 					"skip_final_snapshot",
 					"delete_automated_backups",
 					"blue_green_update",
+					"latest_restorable_time",
 				},
 			},
 		},
@@ -4977,14 +4981,14 @@ func TestAccRDSInstance_BlueGreenDeployment_updateAndEnableBackups(t *testing.T)
 					"skip_final_snapshot",
 					"delete_automated_backups",
 					"blue_green_update",
+					"latest_restorable_time",
 				},
 			},
 		},
 	})
 }
 
-// TODO: When the only change is to disable deletion_protection, bypass Blue/Green
-func TestAccRDSInstance_BlueGreenDeployment_deletionProtection(t *testing.T) {
+func TestAccRDSInstance_BlueGreenDeployment_deletionProtectionBypassesBlueGreen(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -5019,14 +5023,14 @@ func TestAccRDSInstance_BlueGreenDeployment_deletionProtection(t *testing.T) {
 					"skip_final_snapshot",
 					"delete_automated_backups",
 					"blue_green_update",
+					"latest_restorable_time",
 				},
 			},
 			{
 				Config: testAccInstanceConfig_BlueGreenDeployment_deletionProtection(rName, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(ctx, resourceName, &v2),
-					// TODO: This should bypass Blue/Green Deployment
-					// testAccCheckDBInstanceNotRecreated(&v2, &v3),
+					testAccCheckDBInstanceNotRecreated(&v1, &v2),
 					resource.TestCheckResourceAttr(resourceName, "deletion_protection", "false"),
 					resource.TestCheckResourceAttr(resourceName, "blue_green_update.0.enabled", "true"),
 				),
@@ -5042,7 +5046,43 @@ func TestAccRDSInstance_BlueGreenDeployment_deletionProtection(t *testing.T) {
 					"skip_final_snapshot",
 					"delete_automated_backups",
 					"blue_green_update",
+					"latest_restorable_time",
 				},
+			},
+		},
+	})
+}
+
+func TestAccRDSInstance_BlueGreenDeployment_passwordBypassesBlueGreen(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var v1, v2 rds.DBInstance
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_db_instance.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, rds.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInstanceDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_BlueGreenDeployment_password(rName, "valid-password-1"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInstanceExists(ctx, resourceName, &v1),
+					resource.TestCheckResourceAttr(resourceName, "password", "valid-password-1"),
+				),
+			},
+			{
+				Config: testAccInstanceConfig_BlueGreenDeployment_password(rName, "valid-password-2"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInstanceExists(ctx, resourceName, &v2),
+					testAccCheckDBInstanceNotRecreated(&v1, &v2),
+					resource.TestCheckResourceAttr(resourceName, "password", "valid-password-2"),
+				),
 			},
 		},
 	})
@@ -5084,6 +5124,7 @@ func TestAccRDSInstance_BlueGreenDeployment_updateWithDeletionProtection(t *test
 					"skip_final_snapshot",
 					"delete_automated_backups",
 					"blue_green_update",
+					"latest_restorable_time",
 				},
 			},
 			{
@@ -5107,14 +5148,14 @@ func TestAccRDSInstance_BlueGreenDeployment_updateWithDeletionProtection(t *test
 					"skip_final_snapshot",
 					"delete_automated_backups",
 					"blue_green_update",
+					"latest_restorable_time",
 				},
 			},
 			{
 				Config: testAccInstanceConfig_BlueGreenDeployment_updateInstanceClassWithDeletionProtection(rName, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(ctx, resourceName, &v3),
-					// TODO: This should bypass Blue/Green Deployment
-					// testAccCheckDBInstanceNotRecreated(&v2, &v3),
+					testAccCheckDBInstanceNotRecreated(&v2, &v3),
 					resource.TestCheckResourceAttr(resourceName, "deletion_protection", "false"),
 					resource.TestCheckResourceAttr(resourceName, "blue_green_update.0.enabled", "true"),
 				),
@@ -7527,7 +7568,9 @@ resource "aws_db_instance" "test" {
 }
 
 func testAccInstanceConfig_password(rName, password string) string {
-	return acctest.ConfigCompose(testAccInstanceConfig_orderableClassMySQL(), fmt.Sprintf(`
+	return acctest.ConfigCompose(
+		testAccInstanceConfig_orderableClassMySQL(),
+		fmt.Sprintf(`
 resource "aws_db_instance" "test" {
   allocated_storage   = 5
   engine              = data.aws_rds_orderable_db_instance.test.engine
@@ -9074,7 +9117,7 @@ func testAccInstanceConfig_SnapshotID_allowMajorVersionUpgrade(rName string, all
 	return fmt.Sprintf(`
 data "aws_rds_orderable_db_instance" "postgres13" {
   engine         = "postgres"
-  engine_version = "13.5"
+  engine_version = "13.12"
   license_model  = "postgresql-license"
   storage_type   = "standard"
 
@@ -9099,7 +9142,7 @@ resource "aws_db_snapshot" "test" {
 
 data "aws_rds_orderable_db_instance" "postgres14" {
   engine         = "postgres"
-  engine_version = "14.1"
+  engine_version = "14.9"
   license_model  = "postgresql-license"
   storage_type   = "standard"
 
@@ -10625,6 +10668,30 @@ data "aws_rds_orderable_db_instance" "updated" {
   preferred_instance_classes = ["db.t4g.micro", "db.t4g.small"]
 }
 `, rName, deletionProtection))
+}
+
+func testAccInstanceConfig_BlueGreenDeployment_password(rName, password string) string {
+	return acctest.ConfigCompose(
+		testAccInstanceConfig_orderableClassMySQL(),
+		fmt.Sprintf(`
+resource "aws_db_instance" "test" {
+  identifier              = %[1]q
+  allocated_storage       = 10
+  backup_retention_period = 1
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
+  engine_version          = data.aws_rds_orderable_db_instance.test.engine_version
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
+  db_name                 = "test"
+  parameter_group_name    = "default.${data.aws_rds_engine_version.default.parameter_group_family}"
+  skip_final_snapshot     = true
+  password                = %[2]q
+  username                = "tfacctest"
+
+  blue_green_update {
+    enabled = true
+  }
+}
+`, rName, password))
 }
 
 func testAccInstanceConfig_gp3(rName string, orderableClassConfig func() string, allocatedStorage int) string {


### PR DESCRIPTION
### Description

Since changing `password` does not require downtime, if it is the only change, bypass Blue/Green deployment

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #32024

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=rds TESTS=TestAccRDSInstance_

--- PASS: TestAccRDSInstance_basic (849.87s)
--- PASS: TestAccRDSInstance_storageTypePostgres (1225.28s)
--- PASS: TestAccRDSInstance_noDeleteAutomatedBackups (1394.53s)
--- PASS: TestAccRDSInstance_PerformanceInsightsEnabled_disabledToEnabled (1396.08s)
--- PASS: TestAccRDSInstance_storageChangeIOPSThroughput (1549.41s)
--- PASS: TestAccRDSInstance_gp3MySQL (1732.90s)
--- PASS: TestAccRDSInstance_storageChangeIOPS (1786.49s)
--- PASS: TestAccRDSInstance_newIdentifier (1840.43s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_deletionProtectionBypassesBlueGreen (1842.25s)
--- PASS: TestAccRDSInstance_gp3Postgres (1890.11s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_passwordBypassesBlueGreen (2046.70s)
--- PASS: TestAccRDSInstance_license (2093.01s)
--- PASS: TestAccRDSInstance_EnabledCloudWatchLogsExports_postgresql (1257.91s)
--- PASS: TestAccRDSInstance_storageThroughputSSE (2131.59s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_availabilityZone (2181.69s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupName (2250.90s)
--- PASS: TestAccRDSInstance_performanceInsightsKMSKeyID (2311.41s)
--- PASS: TestAccRDSInstance_performanceInsightsRetentionPeriod (2325.57s)
--- PASS: TestAccRDSInstance_minorVersion (544.40s)
--- PASS: TestAccRDSInstance_EnabledCloudWatchLogsExports_oracle (1096.78s)
--- PASS: TestAccRDSInstance_EnabledCloudWatchLogsExports_msSQL (1084.60s)
--- PASS: TestAccRDSInstance_cloudWatchLogsExport (891.56s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateParameterGroup (2926.50s)
--- PASS: TestAccRDSInstance_NoNationalCharacterSet_oracle (976.90s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateEngineVersion (3256.26s)
--- PASS: TestAccRDSInstance_NationalCharacterSet_oracle (974.28s)
--- PASS: TestAccRDSInstance_separateIopsUpdate (1052.09s)
--- PASS: TestAccRDSInstance_EnabledCloudWatchLogsExports_mySQL (1695.89s)
--- PASS: TestAccRDSInstance_MonitoringRoleARN_removedToEnabled (943.20s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_port (1653.80s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateWithDeletionProtection (3527.11s)
--- PASS: TestAccRDSInstance_MySQL_snapshotRestoreWithEngineVersion (1760.24s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_backupWindow (1616.56s)
--- PASS: TestAccRDSInstance_MonitoringRoleARN_enabledToRemoved (1226.76s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodUnset (1898.57s)
--- PASS: TestAccRDSInstance_MSSQL_tz (2080.86s)
--- PASS: TestAccRDSInstance_RestoreToPointInTime_monitoring (1604.47s)
--- PASS: TestAccRDSInstance_RestoreToPointInTime_sourceResourceID (1424.79s)
--- PASS: TestAccRDSInstance_MonitoringRoleARN_enabledToDisabled (1141.18s)
--- PASS: TestAccRDSInstance_RestoreToPointInTime_sourceIdentifier (1422.16s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_vpcSecurityGroupIDs (1555.41s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_autoMinorVersionUpgrade (1429.56s)
--- PASS: TestAccRDSInstance_ManagedMasterPassword_managedSpecificKMSKey (571.72s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_namePrefix (1588.61s)
--- PASS: TestAccRDSInstance_ManagedMasterPassword_convertToManaged (858.35s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_caCertificateIdentifier (1973.61s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_performanceInsightsEnabled (1635.35s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateAndPromoteReplica (4073.91s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_allowMajorVersionUpgrade (1775.87s)
--- PASS: TestAccRDSInstance_ManagedMasterPassword_managed (529.99s)
--- PASS: TestAccRDSInstance_monitoringInterval (1933.51s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_replicaMode (3090.87s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_monitoring (1752.28s)
--- PASS: TestAccRDSInstance_MSSQL_domainSnapshotRestore (3568.88s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_deletionProtection (1525.08s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_maxAllocatedStorage (1725.57s)
--- PASS: TestAccRDSInstance_password (894.68s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_basic (1840.70s)
--- PASS: TestAccRDSInstance_storageChangeThroughput (962.94s)
--- PASS: TestAccRDSInstance_MSSQL_domain (4236.56s)
--- PASS: TestAccRDSInstance_isAlreadyBeingDeleted (713.11s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_availabilityZone (1424.85s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_AssociationRemoved (1563.24s)
--- PASS: TestAccRDSInstance_FinalSnapshotIdentifier_skipFinalSnapshot (757.44s)
--- PASS: TestAccRDSInstance_maxAllocatedStorage (1136.70s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_autoMinorVersionUpgrade (1436.85s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_basic (1368.41s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodOverride (1834.56s)
--- PASS: TestAccRDSInstance_dbSubnetGroupName (697.14s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_nameGenerated (1444.28s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_allowMajorVersionUpgrade (1709.78s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_io1Storage (1762.00s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_allocatedStorage (1819.49s)
--- PASS: TestAccRDSInstance_deletionProtection (823.88s)
--- PASS: TestAccRDSInstance_DBSubnetGroupName_vpcSecurityGroupIDs (811.20s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDsTags (1482.10s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_tags (1596.43s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDs (1476.56s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_port (1574.76s)
--- PASS: TestAccRDSInstance_PerformanceInsightsEnabled_enabledToDisabled (1085.20s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_parameterGroupName (1705.82s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_monitoring (1770.80s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_tags (906.84s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_backupWindow (1786.38s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSetOnReplica (1783.29s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameReplicaCopiesValue (1816.19s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupTwoStep (3399.21s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSameSetOnBoth (1837.91s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_multiAZSQLServer (4873.43s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_backupRetentionPeriod (2004.58s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_networkType (1670.11s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameDifferentSetOnBoth (2023.23s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_monitoring_sourceAlreadyExists (1718.80s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName (2264.58s)
--- PASS: TestAccRDSInstance_gp3SQLServer (1332.58s)
--- PASS: TestAccRDSInstance_portUpdate (920.32s)
--- PASS: TestAccRDSInstance_allowMajorVersionUpgrade (677.02s)
--- PASS: TestAccRDSInstance_finalSnapshotIdentifier (1040.24s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_multiAZ (2175.01s)
--- PASS: TestAccRDSInstance_caCertificateIdentifier (735.35s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_multiAZ (2070.97s)
--- PASS: TestAccRDSInstance_kmsKey (688.86s)
--- PASS: TestAccRDSInstance_onlyMajorVersion (690.83s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_namePrefix (1319.90s)
--- PASS: TestAccRDSInstance_optionGroup (765.11s)
--- PASS: TestAccRDSInstance_tags (906.61s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_iamDatabaseAuthenticationEnabled (1559.08s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateInstanceClass (2420.26s)
--- PASS: TestAccRDSInstance_iamAuth (652.69s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_maintenanceWindow (1695.42s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_maxAllocatedStorage (1859.95s)
--- PASS: TestAccRDSInstance_identifierPrefix (480.48s)
--- PASS: TestAccRDSInstance_identifierGenerated (643.24s)
--- PASS: TestAccRDSInstance_disappears (646.56s)
--- PASS: TestAccRDSInstance_manage_password (615.33s)
--- PASS: TestAccRDSInstance_networkType (1141.56s)
--- PASS: TestAccRDSInstance_ReplicateSourceDBDBSubnetGroupName_vpcSecurityGroupIDs (2198.63s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_iamDatabaseAuthenticationEnabled (1562.36s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_performanceInsightsEnabled (1893.75s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_allocatedStorage (1738.57s)
--- PASS: TestAccRDSInstance_subnetGroup (1312.73s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_maintenanceWindow (1332.85s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameVPCSecurityGroupIDs (1603.43s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_nameGenerated (1832.37s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_addLater (1898.31s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_allocatedStorageAndIops (1688.54s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_iops (1800.70s)
--- PASS: TestAccRDSInstance_customIAMInstanceProfile (3044.19s)
```
