### PR TITLE
Add support for Availability Zonal DNS affinity on NLB

### DIFF
--- a/.changelog/33992.txt
+++ b/.changelog/33992.txt
@@ -1,0 +1,3 @@
+```release-note:{HEADER}
+resource/aws_lb: Add `dns_record_client_routing_policy` attribute to configure Availability Zonal DNS affinity on Network Load Balancer (NLB)
+```

--- a/.changelog/33992.txt
+++ b/.changelog/33992.txt
@@ -1,3 +1,3 @@
-```release-note:{HEADER}
+```release-note:enhancement
 resource/aws_lb: Add `dns_record_client_routing_policy` attribute to configure Availability Zonal DNS affinity on Network Load Balancer (NLB)
 ```

--- a/internal/service/elbv2/load_balancer.go
+++ b/internal/service/elbv2/load_balancer.go
@@ -119,15 +119,15 @@ func ResourceLoadBalancer() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			// "dns_record_client_routing_policy": {
-			// 	Type:     schema.TypeString,
-			// 	Optional: true,
-			// 	ValidateFunc: validation.StringInSlice([]string{
-			// 		"availability_zone_affinity",
-			// 		"partial_availability_zone_affinity",
-			// 		"any_availability_zone",
-			// 	}, false),
-			// },
+			"dns_record_client_routing_policy": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"availability_zone_affinity",
+					"partial_availability_zone_affinity",
+					"any_availability_zone",
+				}, false),
+			},
 			"drop_invalid_header_fields": {
 				Type:             schema.TypeBool,
 				Optional:         true,

--- a/internal/service/elbv2/load_balancer.go
+++ b/internal/service/elbv2/load_balancer.go
@@ -120,8 +120,10 @@ func ResourceLoadBalancer() *schema.Resource {
 				Computed: true,
 			},
 			"dns_record_client_routing_policy": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:             schema.TypeString,
+				Optional:         true,
+				Default:          "any_availability_zone",
+				DiffSuppressFunc: suppressIfLBTypeNot(elbv2.LoadBalancerTypeEnumNetwork),
 				ValidateFunc: validation.StringInSlice([]string{
 					"availability_zone_affinity",
 					"partial_availability_zone_affinity",

--- a/internal/service/elbv2/load_balancer.go
+++ b/internal/service/elbv2/load_balancer.go
@@ -119,6 +119,15 @@ func ResourceLoadBalancer() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			// "dns_record_client_routing_policy": {
+			// 	Type:     schema.TypeString,
+			// 	Optional: true,
+			// 	ValidateFunc: validation.StringInSlice([]string{
+			// 		"availability_zone_affinity",
+			// 		"partial_availability_zone_affinity",
+			// 		"any_availability_zone",
+			// 	}, false),
+			// },
 			"drop_invalid_header_fields": {
 				Type:             schema.TypeBool,
 				Optional:         true,
@@ -527,7 +536,21 @@ func resourceLoadBalancerUpdate(ctx context.Context, d *schema.ResourceData, met
 			})
 		}
 
-	case elbv2.LoadBalancerTypeEnumGateway, elbv2.LoadBalancerTypeEnumNetwork:
+	case elbv2.LoadBalancerTypeEnumGateway:
+		if d.HasChange("enable_cross_zone_load_balancing") || d.IsNewResource() {
+			attributes = append(attributes, &elbv2.LoadBalancerAttribute{
+				Key:   aws.String("load_balancing.cross_zone.enabled"),
+				Value: aws.String(fmt.Sprintf("%t", d.Get("enable_cross_zone_load_balancing").(bool))),
+			})
+		}
+
+	case elbv2.LoadBalancerTypeEnumNetwork:
+		if d.HasChange("dns_record_client_routing_policy") || d.IsNewResource() {
+			attributes = append(attributes, &elbv2.LoadBalancerAttribute{
+				Key:   aws.String("dns_record.client_routing_policy"),
+				Value: aws.String(d.Get("dns_record_client_routing_policy").(string)),
+			})
+		}
 		if d.HasChange("enable_cross_zone_load_balancing") || d.IsNewResource() {
 			attributes = append(attributes, &elbv2.LoadBalancerAttribute{
 				Key:   aws.String("load_balancing.cross_zone.enabled"),
@@ -955,6 +978,10 @@ func flattenResource(ctx context.Context, d *schema.ResourceData, meta interface
 			accessLogMap["bucket"] = aws.StringValue(attr.Value)
 		case "access_logs.s3.prefix":
 			accessLogMap["prefix"] = aws.StringValue(attr.Value)
+		case "dns_record.client_routing_policy":
+			dnsClientRoutingPolicy := aws.StringValue(attr.Value)
+			log.Printf("[DEBUG] Setting NLB DNS Record Client Routing Policy: %s", dnsClientRoutingPolicy)
+			d.Set("dns_record_client_routing_policy", dnsClientRoutingPolicy)
 		case "idle_timeout.timeout_seconds":
 			timeout, err := strconv.Atoi(aws.StringValue(attr.Value))
 			if err != nil {

--- a/internal/service/elbv2/load_balancer_test.go
+++ b/internal/service/elbv2/load_balancer_test.go
@@ -128,6 +128,7 @@ func TestAccELBV2LoadBalancer_NLB_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "access_logs.0.enabled", "false"),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexache.MustCompile(fmt.Sprintf("loadbalancer/net/%s/.+", rName))),
 					resource.TestCheckResourceAttrSet(resourceName, "dns_name"),
+					resource.TestCheckResourceAttr(resourceName, "dns_record_client_routing_policy", "any_availability_zone"),
 					resource.TestCheckResourceAttr(resourceName, "enable_deletion_protection", "false"),
 					resource.TestCheckResourceAttr(resourceName, "internal", "true"),
 					resource.TestCheckResourceAttr(resourceName, "ip_address_type", "ipv4"),

--- a/internal/service/elbv2/load_balancer_test.go
+++ b/internal/service/elbv2/load_balancer_test.go
@@ -2272,10 +2272,10 @@ resource "aws_subnet" "test" {
 func testAccLoadBalancerConfig_nlbDNSRecordClientRoutingPolicyAffinity(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 1), fmt.Sprintf(`
 resource "aws_lb" "test" {
-  name               = %[1]q
+  name                             = %[1]q
   dns_record_client_routing_policy = "availability_zone_affinity"
-  internal           = true
-  load_balancer_type = "network"
+  internal                         = true
+  load_balancer_type               = "network"
 
   subnet_mapping {
     subnet_id = aws_subnet.test[0].id
@@ -2291,10 +2291,10 @@ resource "aws_lb" "test" {
 func testAccLoadBalancerConfig_nlbDNSRecordClientRoutingPolicyAnyAvailabilityZone(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 1), fmt.Sprintf(`
 resource "aws_lb" "test" {
-  name               = %[1]q
+  name                             = %[1]q
   dns_record_client_routing_policy = "any_availability_zone"
-  internal           = true
-  load_balancer_type = "network"
+  internal                         = true
+  load_balancer_type               = "network"
 
   subnet_mapping {
     subnet_id = aws_subnet.test[0].id
@@ -2310,10 +2310,10 @@ resource "aws_lb" "test" {
 func testAccLoadBalancerConfig_nlbDNSRecordClientRoutingPolicyPartialAffinity(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 1), fmt.Sprintf(`
 resource "aws_lb" "test" {
-  name               = %[1]q
+  name                             = %[1]q
   dns_record_client_routing_policy = "partial_availability_zone_affinity"
-  internal           = true
-  load_balancer_type = "network"
+  internal                         = true
+  load_balancer_type               = "network"
 
   subnet_mapping {
     subnet_id = aws_subnet.test[0].id

--- a/internal/service/elbv2/load_balancer_test.go
+++ b/internal/service/elbv2/load_balancer_test.go
@@ -1304,6 +1304,48 @@ func TestAccELBV2LoadBalancer_NetworkLoadBalancer_accessLogsPrefix(t *testing.T)
 	})
 }
 
+func TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateDNSRecordClientRoutingPolicy(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf elbv2.LoadBalancer
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lb.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, elbv2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLoadBalancerDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoadBalancerConfig_nlbDNSRecordClientRoutingPolicyAffinity(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckLoadBalancerExists(ctx, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "dns_record_client_routing_policy", "availability_zone_affinity"),
+				),
+			},
+			{
+				Config: testAccLoadBalancerConfig_nlbDNSRecordClientRoutingPolicyPartialAffinity(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckLoadBalancerExists(ctx, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "dns_record_client_routing_policy", "partial_availability_zone_affinity"),
+				),
+			},
+			{
+				Config: testAccLoadBalancerConfig_nlbDNSRecordClientRoutingPolicyAnyAvailabilityZone(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckLoadBalancerExists(ctx, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "dns_record_client_routing_policy", "any_availability_zone"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateSecurityGroups(t *testing.T) {
 	ctx := acctest.Context(t)
 	var lb1, lb2, lb3, lb4 elbv2.LoadBalancer
@@ -2218,6 +2260,63 @@ resource "aws_subnet" "test" {
   cidr_block              = "10.10.0.0/21"
   map_public_ip_on_launch = true
   availability_zone       = data.aws_availability_zones.available.names[0]
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName))
+}
+
+func testAccLoadBalancerConfig_nlbDNSRecordClientRoutingPolicyAffinity(rName string) string {
+	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 1), fmt.Sprintf(`
+resource "aws_lb" "test" {
+  name               = %[1]q
+  dns_record_client_routing_policy = "availability_zone_affinity"
+  internal           = true
+  load_balancer_type = "network"
+
+  subnet_mapping {
+    subnet_id = aws_subnet.test[0].id
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName))
+}
+
+func testAccLoadBalancerConfig_nlbDNSRecordClientRoutingPolicyAnyAvailabilityZone(rName string) string {
+	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 1), fmt.Sprintf(`
+resource "aws_lb" "test" {
+  name               = %[1]q
+  dns_record_client_routing_policy = "any_availability_zone"
+  internal           = true
+  load_balancer_type = "network"
+
+  subnet_mapping {
+    subnet_id = aws_subnet.test[0].id
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName))
+}
+
+func testAccLoadBalancerConfig_nlbDNSRecordClientRoutingPolicyPartialAffinity(rName string) string {
+	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 1), fmt.Sprintf(`
+resource "aws_lb" "test" {
+  name               = %[1]q
+  dns_record_client_routing_policy = "partial_availability_zone_affinity"
+  internal           = true
+  load_balancer_type = "network"
+
+  subnet_mapping {
+    subnet_id = aws_subnet.test[0].id
+  }
 
   tags = {
     Name = %[1]q

--- a/website/docs/r/lb.html.markdown
+++ b/website/docs/r/lb.html.markdown
@@ -99,11 +99,12 @@ resource "aws_lb" "example" {
 
 ~> **NOTE:** Please note that one of either `subnets` or `subnet_mapping` is required.
 
-This argument supports the following arguments:
+This resource supports the following arguments:
 
 * `access_logs` - (Optional) An Access Logs block. Access Logs documented below.
 * `customer_owned_ipv4_pool` - (Optional) The ID of the customer owned ipv4 pool to use for this load balancer.
 * `desync_mitigation_mode` - (Optional) Determines how the load balancer handles requests that might pose a security risk to an application due to HTTP desync. Valid values are `monitor`, `defensive` (default), `strictest`.
+* `dns_record_client_routing_policy` - (Optional) Indicates how traffic is distributed among the load balancer Availability Zones. Possible values are `any_availability_zone` (default), `availability_zone_affinity`, or `partial_availability_zone_affinity`. See   [Availability Zone DNS affinity](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#zonal-dns-affinity) for additional details. Only valid for `network` type load balancers.
 * `drop_invalid_header_fields` - (Optional) Indicates whether HTTP headers with header fields that are not valid are removed by the load balancer (true) or routed to targets (false). The default is false. Elastic Load Balancing requires that message header names contain only alphanumeric characters and hyphens. Only valid for Load Balancers of type `application`.
 * `enable_cross_zone_load_balancing` - (Optional) If true, cross-zone load balancing of the load balancer will be enabled. For `network` and `gateway` type load balancers, this feature is disabled by default (`false`). For `application` load balancer this feature is always enabled (`true`) and cannot be disabled. Defaults to `false`.
 * `enable_deletion_protection` - (Optional) If true, deletion of the load balancer will be disabled via the AWS API. This will prevent Terraform from deleting the load balancer. Defaults to `false`.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
`aws_lb`: Adds a new attribute `dns_record_client_routing_policy` to enable support for Availability Zonal DNS affinity on Network Load Balancer (NLB).


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #33992 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


- Launch announcement: https://aws.amazon.com/about-aws/whats-new/2023/10/aws-nlb-availability-performance-capabilities/
- SDK: https://pkg.go.dev/github.com/aws/aws-sdk-go@v1.45.27/service/elbv2#LoadBalancerAttribute
- API reference: https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_LoadBalancerAttribute.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS='TestAccELBV2LoadBalancer' PKG=elbv2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2LoadBalancer'  -timeout 360m
=== RUN   TestAccELBV2LoadBalancerDataSource_basic
=== PAUSE TestAccELBV2LoadBalancerDataSource_basic
=== RUN   TestAccELBV2LoadBalancerDataSource_outpost
=== PAUSE TestAccELBV2LoadBalancerDataSource_outpost
=== RUN   TestAccELBV2LoadBalancerDataSource_backwardsCompatibility
=== PAUSE TestAccELBV2LoadBalancerDataSource_backwardsCompatibility
=== RUN   TestAccELBV2LoadBalancer_ALB_basic
=== PAUSE TestAccELBV2LoadBalancer_ALB_basic
=== RUN   TestAccELBV2LoadBalancer_NLB_basic
=== PAUSE TestAccELBV2LoadBalancer_NLB_basic
=== RUN   TestAccELBV2LoadBalancer_LoadBalancerType_gateway
=== PAUSE TestAccELBV2LoadBalancer_LoadBalancerType_gateway
=== RUN   TestAccELBV2LoadBalancer_disappears
=== PAUSE TestAccELBV2LoadBalancer_disappears
=== RUN   TestAccELBV2LoadBalancer_ipv6SubnetMapping
=== PAUSE TestAccELBV2LoadBalancer_ipv6SubnetMapping
=== RUN   TestAccELBV2LoadBalancer_LoadBalancerTypeGateway_enableCrossZoneLoadBalancing
=== PAUSE TestAccELBV2LoadBalancer_LoadBalancerTypeGateway_enableCrossZoneLoadBalancing
=== RUN   TestAccELBV2LoadBalancer_ALB_outpost
=== PAUSE TestAccELBV2LoadBalancer_ALB_outpost
=== RUN   TestAccELBV2LoadBalancer_networkLoadBalancerEIP
=== PAUSE TestAccELBV2LoadBalancer_networkLoadBalancerEIP
=== RUN   TestAccELBV2LoadBalancer_NLB_privateIPv4Address
=== PAUSE TestAccELBV2LoadBalancer_NLB_privateIPv4Address
=== RUN   TestAccELBV2LoadBalancer_backwardsCompatibility
=== PAUSE TestAccELBV2LoadBalancer_backwardsCompatibility
=== RUN   TestAccELBV2LoadBalancer_generatedName
=== PAUSE TestAccELBV2LoadBalancer_generatedName
=== RUN   TestAccELBV2LoadBalancer_generatesNameForZeroValue
=== PAUSE TestAccELBV2LoadBalancer_generatesNameForZeroValue
=== RUN   TestAccELBV2LoadBalancer_namePrefix
=== PAUSE TestAccELBV2LoadBalancer_namePrefix
=== RUN   TestAccELBV2LoadBalancer_duplicateName
=== PAUSE TestAccELBV2LoadBalancer_duplicateName
=== RUN   TestAccELBV2LoadBalancer_tags
=== PAUSE TestAccELBV2LoadBalancer_tags
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateCrossZone
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateCrossZone
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateHTTP2
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateHTTP2
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDropInvalidHeaderFields
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDropInvalidHeaderFields
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatePreserveHostHeader
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatePreserveHostHeader
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDeletionProtection
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDeletionProtection
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateWAFFailOpen
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateWAFFailOpen
=== RUN   TestAccELBV2LoadBalancer_updateIPAddressType
=== PAUSE TestAccELBV2LoadBalancer_updateIPAddressType
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatedSecurityGroups
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatedSecurityGroups
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateSubnets
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateSubnets
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_noSecurityGroup
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_noSecurityGroup
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_accessLogs
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_accessLogs
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_accessLogsPrefix
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_accessLogsPrefix
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_accessLogs
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_accessLogs
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_accessLogsPrefix
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_accessLogsPrefix
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateDNSRecordClientRoutingPolicy
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateDNSRecordClientRoutingPolicy
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateSecurityGroups
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateSecurityGroups
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateSubnets
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateSubnets
=== RUN   TestAccELBV2LoadBalancer_updateDesyncMitigationMode
=== PAUSE TestAccELBV2LoadBalancer_updateDesyncMitigationMode
=== RUN   TestAccELBV2LoadBalancer_ALB_updateTLSVersionAndCipherSuite
=== PAUSE TestAccELBV2LoadBalancer_ALB_updateTLSVersionAndCipherSuite
=== RUN   TestAccELBV2LoadBalancer_ALB_updateXffHeaderProcessingMode
=== PAUSE TestAccELBV2LoadBalancer_ALB_updateXffHeaderProcessingMode
=== RUN   TestAccELBV2LoadBalancer_ALB_updateXffClientPort
=== PAUSE TestAccELBV2LoadBalancer_ALB_updateXffClientPort
=== RUN   TestAccELBV2LoadBalancersDataSource_basic
=== PAUSE TestAccELBV2LoadBalancersDataSource_basic
=== CONT  TestAccELBV2LoadBalancerDataSource_basic
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDropInvalidHeaderFields
=== CONT  TestAccELBV2LoadBalancersDataSource_basic
=== CONT  TestAccELBV2LoadBalancer_ALB_updateXffClientPort
=== CONT  TestAccELBV2LoadBalancer_ALB_updateXffHeaderProcessingMode
=== CONT  TestAccELBV2LoadBalancer_ALB_updateTLSVersionAndCipherSuite
=== CONT  TestAccELBV2LoadBalancer_updateDesyncMitigationMode
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateSubnets
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateSecurityGroups
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateDNSRecordClientRoutingPolicy
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_accessLogsPrefix
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_accessLogs
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_accessLogsPrefix
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_accessLogs
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_noSecurityGroup
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateSubnets
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatedSecurityGroups
=== CONT  TestAccELBV2LoadBalancer_updateIPAddressType
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateWAFFailOpen
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDeletionProtection
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_noSecurityGroup (272.61s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatePreserveHostHeader
--- PASS: TestAccELBV2LoadBalancersDataSource_basic (284.04s)
=== CONT  TestAccELBV2LoadBalancer_networkLoadBalancerEIP
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateSubnets (315.05s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateHTTP2
--- PASS: TestAccELBV2LoadBalancerDataSource_basic (344.12s)
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateCrossZone
--- PASS: TestAccELBV2LoadBalancer_updateIPAddressType (375.52s)
=== CONT  TestAccELBV2LoadBalancer_tags
--- PASS: TestAccELBV2LoadBalancer_ALB_updateXffClientPort (406.34s)
=== CONT  TestAccELBV2LoadBalancer_duplicateName
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateDNSRecordClientRoutingPolicy (417.69s)
=== CONT  TestAccELBV2LoadBalancer_namePrefix
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatedSecurityGroups (419.13s)
=== CONT  TestAccELBV2LoadBalancer_generatesNameForZeroValue
--- PASS: TestAccELBV2LoadBalancer_ALB_updateTLSVersionAndCipherSuite (433.22s)
=== CONT  TestAccELBV2LoadBalancer_generatedName
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateWAFFailOpen (445.48s)
=== CONT  TestAccELBV2LoadBalancer_backwardsCompatibility
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_accessLogsPrefix (453.55s)
=== CONT  TestAccELBV2LoadBalancer_NLB_privateIPv4Address
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDeletionProtection (461.87s)
=== CONT  TestAccELBV2LoadBalancer_LoadBalancerType_gateway
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDropInvalidHeaderFields (464.85s)
=== CONT  TestAccELBV2LoadBalancer_ALB_outpost
    acctest.go:1103: skipping since no Outposts found
--- SKIP: TestAccELBV2LoadBalancer_ALB_outpost (0.68s)
=== CONT  TestAccELBV2LoadBalancer_LoadBalancerTypeGateway_enableCrossZoneLoadBalancing
--- PASS: TestAccELBV2LoadBalancer_ALB_updateXffHeaderProcessingMode (467.02s)
=== CONT  TestAccELBV2LoadBalancer_ipv6SubnetMapping
--- PASS: TestAccELBV2LoadBalancer_updateDesyncMitigationMode (469.35s)
=== CONT  TestAccELBV2LoadBalancer_disappears
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancer_accessLogsPrefix (481.57s)
=== CONT  TestAccELBV2LoadBalancer_ALB_basic
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancer_accessLogs (496.30s)
=== CONT  TestAccELBV2LoadBalancer_NLB_basic
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateSubnets (516.53s)
=== CONT  TestAccELBV2LoadBalancerDataSource_backwardsCompatibility
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_accessLogs (520.34s)
=== CONT  TestAccELBV2LoadBalancerDataSource_outpost
--- PASS: TestAccELBV2LoadBalancer_networkLoadBalancerEIP (236.33s)
=== NAME  TestAccELBV2LoadBalancerDataSource_outpost
    acctest.go:1103: skipping since no Outposts found
--- SKIP: TestAccELBV2LoadBalancerDataSource_outpost (0.16s)
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatePreserveHostHeader (331.98s)
--- PASS: TestAccELBV2LoadBalancer_namePrefix (208.61s)
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateHTTP2 (314.96s)
--- PASS: TestAccELBV2LoadBalancer_generatesNameForZeroValue (235.12s)
--- PASS: TestAccELBV2LoadBalancer_duplicateName (248.74s)
--- PASS: TestAccELBV2LoadBalancer_backwardsCompatibility (213.03s)
--- PASS: TestAccELBV2LoadBalancer_generatedName (230.24s)
--- PASS: TestAccELBV2LoadBalancer_LoadBalancerType_gateway (212.89s)
--- PASS: TestAccELBV2LoadBalancer_disappears (214.44s)
--- PASS: TestAccELBV2LoadBalancer_NLB_privateIPv4Address (235.56s)
--- PASS: TestAccELBV2LoadBalancer_ALB_basic (212.63s)
--- PASS: TestAccELBV2LoadBalancer_NLB_basic (202.55s)
--- PASS: TestAccELBV2LoadBalancer_ipv6SubnetMapping (238.66s)
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateCrossZone (364.38s)
--- PASS: TestAccELBV2LoadBalancer_tags (339.75s)
--- PASS: TestAccELBV2LoadBalancer_LoadBalancerTypeGateway_enableCrossZoneLoadBalancing (262.42s)
--- PASS: TestAccELBV2LoadBalancerDataSource_backwardsCompatibility (223.38s)
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateSecurityGroups (807.20s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elbv2      810.391s
```
