### PR TITLE
[aws_storagegateway_gateway] Allow value of 0 for `maintenance_start_time.day_of_week`

### DIFF
--- a/.changelog/34015.txt
+++ b/.changelog/34015.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_storagegateway_gateway: Support the value `0` (representing Sunday) for `maintenance_start_time.day_of_week`
+```

--- a/internal/service/storagegateway/gateway.go
+++ b/internal/service/storagegateway/gateway.go
@@ -868,7 +868,7 @@ func expandUpdateMaintenanceStartTimeInput(tfMap map[string]interface{}) *storag
 		apiObject.DayOfMonth = aws.Int64(v)
 	}
 
-	if v, null, _ := nullable.Int(tfMap["day_of_week"].(string)).Value(); !null && v > 0 {
+	if v, null, _ := nullable.Int(tfMap["day_of_week"].(string)).Value(); !null {
 		apiObject.DayOfWeek = aws.Int64(v)
 	}
 

--- a/internal/service/storagegateway/gateway_test.go
+++ b/internal/service/storagegateway/gateway_test.go
@@ -857,6 +857,16 @@ func TestAccStorageGatewayGateway_maintenanceStartTime(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "maintenance_start_time.0.day_of_month", "12"),
 				),
 			},
+			{
+				Config: testAccGatewayConfig_maintenanceStartTime(rName, 21, 10, "0", ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGatewayExists(ctx, resourceName, &gateway),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_start_time.0.hour_of_day", "21"),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_start_time.0.minute_of_hour", "10"),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_start_time.0.day_of_week", "0"),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_start_time.0.day_of_month", ""),
+				),
+			},
 		},
 	})
 }


### PR DESCRIPTION
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Allows a value of `0` (representing Sunday) for the `maintenance_start_time.day_of_week` attribute of `aws_storagegateway_gateway` resources.

Previously, a zero value in this field would be converted to null, resulting in an error from AWS when deploying.

Added an acceptance test that validates this case.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #26597


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccStorageGatewayGateway_maintenanceStartTime PKG=storagegateway
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/storagegateway/... -v -count 1 -parallel 20 -run='TestAccStorageGatewayGateway_maintenanceStartTime'  -timeout 360m
=== RUN   TestAccStorageGatewayGateway_maintenanceStartTime
=== PAUSE TestAccStorageGatewayGateway_maintenanceStartTime
=== CONT  TestAccStorageGatewayGateway_maintenanceStartTime
--- PASS: TestAccStorageGatewayGateway_maintenanceStartTime (771.62s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/storagegateway     774.616s
```
