### PR TITLE
feat: add aws_instance_types_from_instance_requirements data source

### DIFF
--- a/internal/framework/flex/float.go
+++ b/internal/framework/flex/float.go
@@ -10,6 +10,16 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+// Float64FromFramework converts a Framework Float64 value to an float64 pointer.
+// A null Float64 is converted to a nil float64 pointer.
+func Float64FromFramework(ctx context.Context, v types.Float64) *float64 {
+	var output *float64
+
+	panicOnError(Expand(ctx, v, &output))
+
+	return output
+}
+
 // Float64ToFramework converts a float64 pointer to a Framework Float64 value.
 // A nil float64 pointer is converted to a null Float64.
 func Float64ToFramework(ctx context.Context, v *float64) types.Float64 {

--- a/internal/framework/flex/float_test.go
+++ b/internal/framework/flex/float_test.go
@@ -13,6 +13,46 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 )
 
+func TestFloat64FromFramework(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input    types.Float64
+		expected *float64
+	}
+	tests := map[string]testCase{
+		"valid float64": {
+			input:    types.Float64Value(42.1),
+			expected: aws.Float64(42.1),
+		},
+		"zero float64": {
+			input:    types.Float64Value(0.0),
+			expected: aws.Float64(0.0),
+		},
+		"null float64": {
+			input:    types.Float64Null(),
+			expected: nil,
+		},
+		"unknown float64": {
+			input:    types.Float64Unknown(),
+			expected: nil,
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := flex.Float64FromFramework(context.Background(), test.input)
+
+			if diff := cmp.Diff(got, test.expected); diff != "" {
+				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}
+
 func TestFloat64ToFramework(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/ec2/instance_types_from_instance_requirements_data_source.go
+++ b/internal/service/ec2/instance_types_from_instance_requirements_data_source.go
@@ -1,0 +1,571 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ec2
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource(name="Instance Types From Instance Requirements")
+func newDataSourceInstanceTypesFromInstanceRequirements(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &dataSourceInstanceTypesFromInstanceRequirements{}, nil
+}
+
+const (
+	DSNameInstanceTypesFromInstanceRequirements = "Instance Types From Instance Requirements Data Source"
+)
+
+type dataSourceInstanceTypesFromInstanceRequirements struct {
+	framework.DataSourceWithConfigure
+}
+
+func (d *dataSourceInstanceTypesFromInstanceRequirements) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) { // nosemgrep:ci.meta-in-func-name
+	resp.TypeName = "aws_ec2_instance_types_from_instance_requirements"
+}
+
+func (d *dataSourceInstanceTypesFromInstanceRequirements) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"architecture_types": schema.ListAttribute{
+				ElementType: types.StringType,
+				Required:    true,
+			},
+			"id": framework.IDAttribute(),
+			"instance_types": schema.ListAttribute{
+				ElementType: types.StringType,
+				Computed:    true,
+			},
+			"virtualization_types": schema.ListAttribute{
+				ElementType: types.StringType,
+				Required:    true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"instance_requirements": schema.SingleNestedBlock{
+				Attributes: map[string]schema.Attribute{
+					"accelerator_manufacturers": schema.ListAttribute{
+						ElementType: types.StringType,
+						Optional:    true,
+					},
+					"accelerator_names": schema.ListAttribute{
+						ElementType: types.StringType,
+						Optional:    true,
+					},
+					"accelerator_types": schema.ListAttribute{
+						ElementType: types.StringType,
+						Optional:    true,
+					},
+					"allowed_instance_types": schema.ListAttribute{
+						ElementType: types.StringType,
+						Optional:    true,
+					},
+					"bare_metal": schema.StringAttribute{
+						Optional: true,
+					},
+					"burstable_performance": schema.StringAttribute{
+						Optional: true,
+					},
+					"cpu_manufacturers": schema.ListAttribute{
+						ElementType: types.StringType,
+						Optional:    true,
+					},
+					"excluded_instance_types": schema.ListAttribute{
+						ElementType: types.StringType,
+						Optional:    true,
+					},
+					"instance_generations": schema.ListAttribute{
+						ElementType: types.StringType,
+						Optional:    true,
+					},
+					"local_storage": schema.StringAttribute{
+						Optional: true,
+					},
+					"local_storage_types": schema.ListAttribute{
+						ElementType: types.StringType,
+						Optional:    true,
+					},
+					"on_demand_max_price_percentage_over_lowest_price": schema.Int64Attribute{
+						Optional: true,
+					},
+					"require_hibernate_support": schema.BoolAttribute{
+						Optional: true,
+					},
+					"spot_max_price_percentage_over_lowest_price": schema.Int64Attribute{
+						Optional: true,
+					},
+				},
+				Blocks: map[string]schema.Block{
+					"memory_mib": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"min": schema.Int64Attribute{
+								Required: true,
+							},
+							"max": schema.Int64Attribute{
+								Optional: true,
+							},
+						},
+					},
+					"vcpu_count": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"min": schema.Int64Attribute{
+								Required: true,
+							},
+							"max": schema.Int64Attribute{
+								Optional: true,
+							},
+						},
+					},
+					"accelerator_count": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"min": schema.Int64Attribute{
+								Optional: true,
+							},
+							"max": schema.Int64Attribute{
+								Optional: true,
+							},
+						},
+					},
+					"accelerator_total_memory_mib": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"min": schema.Int64Attribute{
+								Optional: true,
+							},
+							"max": schema.Int64Attribute{
+								Optional: true,
+							},
+						},
+					},
+					"baseline_ebs_bandwidth_mbps": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"min": schema.Int64Attribute{
+								Optional: true,
+							},
+							"max": schema.Int64Attribute{
+								Optional: true,
+							},
+						},
+					},
+					"memory_gib_per_vcpu": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"min": schema.Float64Attribute{
+								Optional: true,
+							},
+							"max": schema.Float64Attribute{
+								Optional: true,
+							},
+						},
+					},
+					"network_bandwidth_gbps": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"min": schema.Float64Attribute{
+								Optional: true,
+							},
+							"max": schema.Float64Attribute{
+								Optional: true,
+							},
+						},
+					},
+					"network_interface_count": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"min": schema.Int64Attribute{
+								Optional: true,
+							},
+							"max": schema.Int64Attribute{
+								Optional: true,
+							},
+						},
+					},
+					"total_local_storage_gb": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"min": schema.Float64Attribute{
+								Optional: true,
+							},
+							"max": schema.Float64Attribute{
+								Optional: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+func (d *dataSourceInstanceTypesFromInstanceRequirements) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	conn := d.Meta().EC2Conn(ctx)
+
+	var data dataSourceInstanceTypesFromInstanceRequirementsData
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	input := &ec2.GetInstanceTypesFromInstanceRequirementsInput{
+		ArchitectureTypes:    flex.ExpandFrameworkStringList(ctx, data.ArchitectureTypes),
+		VirtualizationTypes:  flex.ExpandFrameworkStringList(ctx, data.VirtualizationTypes),
+		InstanceRequirements: expandInstanceRequirementsRequestOptions(ctx, data.InstanceRequirements, &resp.Diagnostics),
+	}
+
+	out, err := findInstanceTypesFromInstanceRequirements(ctx, conn, input)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.EC2, create.ErrActionReading, DSNameInstanceTypesFromInstanceRequirements, d.Meta().Region, err),
+			err.Error(),
+		)
+		return
+	}
+
+	data.ID = types.StringValue(d.Meta().Region)
+	data.InstanceTypes = flex.FlattenFrameworkStringList(ctx, out)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func expandInstanceRequirementsRequestOptions(ctx context.Context, object types.Object, diags *diag.Diagnostics) *ec2.InstanceRequirementsRequest {
+	var options instanceRequirementsData
+	diags.Append(object.As(ctx, &options, basetypes.ObjectAsOptions{})...)
+	if diags.HasError() {
+		return nil
+	}
+	return options.expand(ctx, diags)
+}
+
+func findInstanceTypesFromInstanceRequirements(ctx context.Context, conn *ec2.EC2, input *ec2.GetInstanceTypesFromInstanceRequirementsInput) ([]*string, error) {
+	var output []*string
+
+	err := conn.GetInstanceTypesFromInstanceRequirementsPagesWithContext(ctx, input, func(page *ec2.GetInstanceTypesFromInstanceRequirementsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, v := range page.InstanceTypes {
+			if v != nil {
+				output = append(output, v.InstanceType)
+			}
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return output, nil
+}
+
+type dataSourceInstanceTypesFromInstanceRequirementsData struct {
+	ArchitectureTypes    types.List   `tfsdk:"architecture_types"`
+	InstanceRequirements types.Object `tfsdk:"instance_requirements"`
+	InstanceTypes        types.List   `tfsdk:"instance_types"`
+	ID                   types.String `tfsdk:"id"`
+	VirtualizationTypes  types.List   `tfsdk:"virtualization_types"`
+}
+
+type instanceRequirementsData struct {
+	MemoryMiB                                 types.Object `tfsdk:"memory_mib"`
+	VCpuCount                                 types.Object `tfsdk:"vcpu_count"`
+	AcceleratorCount                          types.Object `tfsdk:"accelerator_count"`
+	AcceleratorManufacturers                  types.List   `tfsdk:"accelerator_manufacturers"`
+	AcceleratorNames                          types.List   `tfsdk:"accelerator_names"`
+	AcceleratorTotalMemoryMiB                 types.Object `tfsdk:"accelerator_total_memory_mib"`
+	AcceleratorTypes                          types.List   `tfsdk:"accelerator_types"`
+	AllowedInstanceTypes                      types.List   `tfsdk:"allowed_instance_types"`
+	BareMetal                                 types.String `tfsdk:"bare_metal"`
+	BaselineEbsBandwidthMbps                  types.Object `tfsdk:"baseline_ebs_bandwidth_mbps"`
+	BurstablePerformance                      types.String `tfsdk:"burstable_performance"`
+	CpuManufacturers                          types.List   `tfsdk:"cpu_manufacturers"`
+	ExcludedInstanceTypes                     types.List   `tfsdk:"excluded_instance_types"`
+	InstanceGenerations                       types.List   `tfsdk:"instance_generations"`
+	LocalStorage                              types.String `tfsdk:"local_storage"`
+	LocalStorageTypes                         types.List   `tfsdk:"local_storage_types"`
+	MemoryGiBPerVCpu                          types.Object `tfsdk:"memory_gib_per_vcpu"`
+	NetworkBandwidthGbps                      types.Object `tfsdk:"network_bandwidth_gbps"`
+	NetworkInterfaceCount                     types.Object `tfsdk:"network_interface_count"`
+	OnDemandMaxPricePercentageOverLowestPrice types.Int64  `tfsdk:"on_demand_max_price_percentage_over_lowest_price"`
+	RequireHibernateSupport                   types.Bool   `tfsdk:"require_hibernate_support"`
+	SpotMaxPricePercentageOverLowestPrice     types.Int64  `tfsdk:"spot_max_price_percentage_over_lowest_price"`
+	TotalLocalStorageGB                       types.Object `tfsdk:"total_local_storage_gb"`
+}
+
+func (ir *instanceRequirementsData) expand(ctx context.Context, diags *diag.Diagnostics) *ec2.InstanceRequirementsRequest {
+	if ir == nil {
+		return nil
+	}
+
+	result := &ec2.InstanceRequirementsRequest{
+		MemoryMiB:                expandMemoryMiBData(ctx, ir.MemoryMiB, diags),
+		VCpuCount:                expandVcpuCountData(ctx, ir.VCpuCount, diags),
+		AcceleratorManufacturers: flex.ExpandFrameworkStringList(ctx, ir.AcceleratorManufacturers),
+		AcceleratorNames:         flex.ExpandFrameworkStringList(ctx, ir.AcceleratorNames),
+		AcceleratorTypes:         flex.ExpandFrameworkStringList(ctx, ir.AcceleratorTypes),
+		AllowedInstanceTypes:     flex.ExpandFrameworkStringList(ctx, ir.AllowedInstanceTypes),
+		BareMetal:                flex.StringFromFramework(ctx, ir.BareMetal),
+		BurstablePerformance:     flex.StringFromFramework(ctx, ir.BurstablePerformance),
+		CpuManufacturers:         flex.ExpandFrameworkStringList(ctx, ir.CpuManufacturers),
+		ExcludedInstanceTypes:    flex.ExpandFrameworkStringList(ctx, ir.ExcludedInstanceTypes),
+		InstanceGenerations:      flex.ExpandFrameworkStringList(ctx, ir.InstanceGenerations),
+		LocalStorage:             flex.StringFromFramework(ctx, ir.LocalStorage),
+		LocalStorageTypes:        flex.ExpandFrameworkStringList(ctx, ir.LocalStorageTypes),
+		OnDemandMaxPricePercentageOverLowestPrice: flex.Int64FromFramework(ctx, ir.OnDemandMaxPricePercentageOverLowestPrice),
+		RequireHibernateSupport:                   flex.BoolFromFramework(ctx, ir.RequireHibernateSupport),
+		SpotMaxPricePercentageOverLowestPrice:     flex.Int64FromFramework(ctx, ir.SpotMaxPricePercentageOverLowestPrice),
+	}
+
+	if !ir.AcceleratorCount.IsNull() {
+		result.AcceleratorCount = expandAcceleratorCountData(ctx, ir.AcceleratorCount, diags)
+	}
+
+	if !ir.AcceleratorTotalMemoryMiB.IsNull() {
+		result.AcceleratorTotalMemoryMiB = expandAcceleratorTotalMemoryMiBData(ctx, ir.AcceleratorTotalMemoryMiB, diags)
+	}
+
+	if !ir.BaselineEbsBandwidthMbps.IsNull() {
+		result.BaselineEbsBandwidthMbps = expandBaselineEBSBandwidthMbpsData(ctx, ir.BaselineEbsBandwidthMbps, diags)
+	}
+
+	if !ir.MemoryGiBPerVCpu.IsNull() {
+		result.MemoryGiBPerVCpu = expandMemoryGiBPerVCpuData(ctx, ir.MemoryGiBPerVCpu, diags)
+	}
+
+	if !ir.NetworkBandwidthGbps.IsNull() {
+		result.NetworkBandwidthGbps = expandNetworkBandwidthGbpsData(ctx, ir.NetworkBandwidthGbps, diags)
+	}
+
+	if !ir.NetworkInterfaceCount.IsNull() {
+		result.NetworkInterfaceCount = expandNetworkInterfaceCountData(ctx, ir.NetworkInterfaceCount, diags)
+	}
+
+	if !ir.TotalLocalStorageGB.IsNull() {
+		result.TotalLocalStorageGB = expandTotalLocalStorageGBData(ctx, ir.TotalLocalStorageGB, diags)
+	}
+
+	return result
+}
+
+type memoryMiBData struct {
+	Min types.Int64 `tfsdk:"min"`
+	Max types.Int64 `tfsdk:"max"`
+}
+
+func (m *memoryMiBData) expand(ctx context.Context) *ec2.MemoryMiBRequest {
+	if m == nil {
+		return nil
+	}
+	return &ec2.MemoryMiBRequest{
+		Min: flex.Int64FromFramework(ctx, m.Min),
+		Max: flex.Int64FromFramework(ctx, m.Max),
+	}
+}
+
+func expandMemoryMiBData(ctx context.Context, object types.Object, diags *diag.Diagnostics) *ec2.MemoryMiBRequest {
+	var options memoryMiBData
+	diags.Append(object.As(ctx, &options, basetypes.ObjectAsOptions{})...)
+	if diags.HasError() {
+		return nil
+	}
+	return options.expand(ctx)
+}
+
+type vcpuCountData struct {
+	Min types.Int64 `tfsdk:"min"`
+	Max types.Int64 `tfsdk:"max"`
+}
+
+func (v *vcpuCountData) expand(ctx context.Context) *ec2.VCpuCountRangeRequest {
+	if v == nil {
+		return nil
+	}
+	return &ec2.VCpuCountRangeRequest{
+		Min: flex.Int64FromFramework(ctx, v.Min),
+		Max: flex.Int64FromFramework(ctx, v.Max),
+	}
+}
+
+func expandVcpuCountData(ctx context.Context, object types.Object, diags *diag.Diagnostics) *ec2.VCpuCountRangeRequest {
+	var options vcpuCountData
+	diags.Append(object.As(ctx, &options, basetypes.ObjectAsOptions{})...)
+	if diags.HasError() {
+		return nil
+	}
+	return options.expand(ctx)
+}
+
+type acceleratorCountData struct {
+	Min types.Int64 `tfsdk:"min"`
+	Max types.Int64 `tfsdk:"max"`
+}
+
+func (a *acceleratorCountData) expand(ctx context.Context) *ec2.AcceleratorCountRequest {
+	if a == nil {
+		return nil
+	}
+	return &ec2.AcceleratorCountRequest{
+		Min: flex.Int64FromFramework(ctx, a.Min),
+		Max: flex.Int64FromFramework(ctx, a.Max),
+	}
+}
+
+func expandAcceleratorCountData(ctx context.Context, object types.Object, diags *diag.Diagnostics) *ec2.AcceleratorCountRequest {
+	var options acceleratorCountData
+	diags.Append(object.As(ctx, &options, basetypes.ObjectAsOptions{})...)
+	if diags.HasError() {
+		return nil
+	}
+	return options.expand(ctx)
+}
+
+type acceleratorTotalMemoryMiBData struct {
+	Min types.Int64 `tfsdk:"min"`
+	Max types.Int64 `tfsdk:"max"`
+}
+
+func (a *acceleratorTotalMemoryMiBData) expand(ctx context.Context) *ec2.AcceleratorTotalMemoryMiBRequest {
+	if a == nil {
+		return nil
+	}
+	return &ec2.AcceleratorTotalMemoryMiBRequest{
+		Min: flex.Int64FromFramework(ctx, a.Min),
+		Max: flex.Int64FromFramework(ctx, a.Max),
+	}
+}
+
+func expandAcceleratorTotalMemoryMiBData(ctx context.Context, object types.Object, diags *diag.Diagnostics) *ec2.AcceleratorTotalMemoryMiBRequest {
+	var options acceleratorTotalMemoryMiBData
+	diags.Append(object.As(ctx, &options, basetypes.ObjectAsOptions{})...)
+	if diags.HasError() {
+		return nil
+	}
+	return options.expand(ctx)
+}
+
+type baselineEbsBandwidthMbpsData struct {
+	Min types.Int64 `tfsdk:"min"`
+	Max types.Int64 `tfsdk:"max"`
+}
+
+func (b *baselineEbsBandwidthMbpsData) expand(ctx context.Context) *ec2.BaselineEbsBandwidthMbpsRequest {
+	if b == nil {
+		return nil
+	}
+	return &ec2.BaselineEbsBandwidthMbpsRequest{
+		Min: flex.Int64FromFramework(ctx, b.Min),
+		Max: flex.Int64FromFramework(ctx, b.Max),
+	}
+}
+
+func expandBaselineEBSBandwidthMbpsData(ctx context.Context, object types.Object, diags *diag.Diagnostics) *ec2.BaselineEbsBandwidthMbpsRequest {
+	var options baselineEbsBandwidthMbpsData
+	diags.Append(object.As(ctx, &options, basetypes.ObjectAsOptions{})...)
+	if diags.HasError() {
+		return nil
+	}
+	return options.expand(ctx)
+}
+
+type memoryGiBPerVCpuData struct {
+	Min types.Float64 `tfsdk:"min"`
+	Max types.Float64 `tfsdk:"max"`
+}
+
+func (m *memoryGiBPerVCpuData) expand(ctx context.Context) *ec2.MemoryGiBPerVCpuRequest {
+	if m == nil {
+		return nil
+	}
+	return &ec2.MemoryGiBPerVCpuRequest{
+		Min: flex.Float64FromFramework(ctx, m.Min),
+		Max: flex.Float64FromFramework(ctx, m.Max),
+	}
+}
+
+func expandMemoryGiBPerVCpuData(ctx context.Context, object types.Object, diags *diag.Diagnostics) *ec2.MemoryGiBPerVCpuRequest {
+	var options memoryGiBPerVCpuData
+	diags.Append(object.As(ctx, &options, basetypes.ObjectAsOptions{})...)
+	if diags.HasError() {
+		return nil
+	}
+	return options.expand(ctx)
+}
+
+type networkBandwidthGbpsData struct {
+	Min types.Float64 `tfsdk:"min"`
+	Max types.Float64 `tfsdk:"max"`
+}
+
+func (n *networkBandwidthGbpsData) expand(ctx context.Context) *ec2.NetworkBandwidthGbpsRequest {
+	if n == nil {
+		return nil
+	}
+	return &ec2.NetworkBandwidthGbpsRequest{
+		Min: flex.Float64FromFramework(ctx, n.Min),
+		Max: flex.Float64FromFramework(ctx, n.Max),
+	}
+}
+
+func expandNetworkBandwidthGbpsData(ctx context.Context, object types.Object, diags *diag.Diagnostics) *ec2.NetworkBandwidthGbpsRequest {
+	var options networkBandwidthGbpsData
+	diags.Append(object.As(ctx, &options, basetypes.ObjectAsOptions{})...)
+	if diags.HasError() {
+		return nil
+	}
+	return options.expand(ctx)
+}
+
+type networkInterfaceCountData struct {
+	Min types.Int64 `tfsdk:"min"`
+	Max types.Int64 `tfsdk:"max"`
+}
+
+func (n *networkInterfaceCountData) expand(ctx context.Context) *ec2.NetworkInterfaceCountRequest {
+	if n == nil {
+		return nil
+	}
+	return &ec2.NetworkInterfaceCountRequest{
+		Min: flex.Int64FromFramework(ctx, n.Min),
+		Max: flex.Int64FromFramework(ctx, n.Max),
+	}
+}
+
+func expandNetworkInterfaceCountData(ctx context.Context, object types.Object, diags *diag.Diagnostics) *ec2.NetworkInterfaceCountRequest {
+	var options networkInterfaceCountData
+	diags.Append(object.As(ctx, &options, basetypes.ObjectAsOptions{})...)
+	if diags.HasError() {
+		return nil
+	}
+	return options.expand(ctx)
+}
+
+type totalLocalStorageGBData struct {
+	Min types.Float64 `tfsdk:"min"`
+	Max types.Float64 `tfsdk:"max"`
+}
+
+func (t *totalLocalStorageGBData) expand(ctx context.Context) *ec2.TotalLocalStorageGBRequest {
+	if t == nil {
+		return nil
+	}
+	return &ec2.TotalLocalStorageGBRequest{
+		Min: flex.Float64FromFramework(ctx, t.Min),
+		Max: flex.Float64FromFramework(ctx, t.Max),
+	}
+}
+
+func expandTotalLocalStorageGBData(ctx context.Context, object types.Object, diags *diag.Diagnostics) *ec2.TotalLocalStorageGBRequest {
+	var options totalLocalStorageGBData
+	diags.Append(object.As(ctx, &options, basetypes.ObjectAsOptions{})...)
+	if diags.HasError() {
+		return nil
+	}
+	return options.expand(ctx)
+}

--- a/internal/service/ec2/instance_types_from_instance_requirements_data_source_test.go
+++ b/internal/service/ec2/instance_types_from_instance_requirements_data_source_test.go
@@ -1,0 +1,1259 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ec2_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_memoryMiBAndVcpuCount(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_ec2_instance_types_from_instance_requirements.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, ec2.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					memory_mib {
+						min = 1000
+						max = 10000
+					}
+					vcpu_count {
+						min = 2
+						max = 12
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_acceleratorCount(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_ec2_instance_types_from_instance_requirements.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, ec2.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					accelerator_count {
+						min = 2
+					}
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					accelerator_count {
+						min = 1
+						max = 3
+					}
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					accelerator_count {
+						max = 0
+					}
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_acceleratorManufacturers(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_ec2_instance_types_from_instance_requirements.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, ec2.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					accelerator_manufacturers = ["amazon-web-services"]
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					accelerator_manufacturers = ["amazon-web-services", "amd", "nvidia", "xilinx"]
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_acceleratorNames(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_ec2_instance_types_from_instance_requirements.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, ec2.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					accelerator_names = ["a100"]
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					accelerator_names = ["a100", "v100", "k80", "t4", "m60", "radeon-pro-v520", "vu9p"]
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_acceleratorTotalMemoryMiB(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_ec2_instance_types_from_instance_requirements.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, ec2.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					accelerator_total_memory_mib {
+						min = 32
+					}
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					accelerator_total_memory_mib {
+						max = 12000
+					}
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					accelerator_total_memory_mib {
+						min = 32
+						max = 12000
+					}
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_acceleratorTypes(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_ec2_instance_types_from_instance_requirements.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, ec2.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					accelerator_types = ["fpga"]
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					accelerator_types = ["fpga", "gpu", "inference"]
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_allowedInstanceTypes(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_ec2_instance_types_from_instance_requirements.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, ec2.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					allowed_instance_types = ["m4.large"]
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					allowed_instance_types = ["m4.large", "m5.*", "m6*"]
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_bareMetal(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_ec2_instance_types_from_instance_requirements.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, ec2.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					bare_metal = "excluded"
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					bare_metal = "included"
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					bare_metal = "required"
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_baselineEbsBandwidthMbps(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_ec2_instance_types_from_instance_requirements.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, ec2.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					baseline_ebs_bandwidth_mbps {
+						min = 10
+					}
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					baseline_ebs_bandwidth_mbps {
+						max = 20000
+					}
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					baseline_ebs_bandwidth_mbps {
+						min = 10
+						max = 20000
+					}
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_burstablePerformance(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_ec2_instance_types_from_instance_requirements.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, ec2.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					burstable_performance = "excluded"
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					burstable_performance = "included"
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					burstable_performance = "required"
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_cpuManufacturers(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_ec2_instance_types_from_instance_requirements.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, ec2.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					cpu_manufacturers = ["amazon-web-services"]
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					cpu_manufacturers = ["amazon-web-services", "amd", "intel"]
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_excludedInstanceTypes(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_ec2_instance_types_from_instance_requirements.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, ec2.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					excluded_instance_types = ["t2.nano"]
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					excluded_instance_types = ["t2.nano", "t3*", "t4g.*"]
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_instanceGenerations(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_ec2_instance_types_from_instance_requirements.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, ec2.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					instance_generations = ["current"]
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					instance_generations = ["current", "previous"]
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_localStorage(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_ec2_instance_types_from_instance_requirements.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, ec2.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					local_storage = "excluded"
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					local_storage = "included"
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					local_storage = "required"
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_localStorageTypes(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_ec2_instance_types_from_instance_requirements.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, ec2.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					local_storage_types = ["hdd"]
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					local_storage_types = ["hdd", "ssd"]
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_memoryGiBPerVCpu(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_ec2_instance_types_from_instance_requirements.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, ec2.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					memory_gib_per_vcpu {
+						min = 0.5
+					}
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					memory_gib_per_vcpu {
+						max = 9.5
+					}
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					memory_gib_per_vcpu {
+						min = 0.5
+						max = 9.5
+					}
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_networkBandwidthGbps(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_ec2_instance_types_from_instance_requirements.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, ec2.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					network_bandwidth_gbps {
+						min = 1.5
+					}
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					network_bandwidth_gbps {
+						max = 200
+					}
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					network_bandwidth_gbps {
+						min = 2.5
+						max = 250
+					}
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_networkInterfaceCount(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_ec2_instance_types_from_instance_requirements.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, ec2.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					network_interface_count {
+						min = 1
+					}
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					network_interface_count {
+						max = 10
+					}
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					network_interface_count {
+						min = 1
+						max = 10
+					}
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_onDemandMaxPricePercentageOverLowestPrice(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_ec2_instance_types_from_instance_requirements.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, ec2.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					on_demand_max_price_percentage_over_lowest_price = 50
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_requireHibernateSupport(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_ec2_instance_types_from_instance_requirements.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, ec2.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					require_hibernate_support = false
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					require_hibernate_support = true
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_spotMaxPricePercentageOverLowestPrice(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_ec2_instance_types_from_instance_requirements.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, ec2.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					spot_max_price_percentage_over_lowest_price = 75
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_totalLocalStorageGB(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_ec2_instance_types_from_instance_requirements.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, ec2.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					total_local_storage_gb {
+						min = 0.5
+					}
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					total_local_storage_gb {
+						max = 20.5
+					}
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+			{
+				Config: testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(
+					`
+					total_local_storage_gb {
+						min = 0.5
+						max = 20.5
+					}
+					memory_mib {
+						min = 500
+					}
+					vcpu_count {
+						min = 1
+					}
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "instance_types.#", 0),
+				),
+			},
+		},
+	})
+}
+
+func testAccInstanceTypesFromInstanceRequirementsDataSourceConfig(instanceRequirements string) string {
+	return fmt.Sprintf(`
+data "aws_ec2_instance_types_from_instance_requirements" "test" {
+	architecture_types = ["x86_64"]
+	virtualization_types = ["hvm"]
+
+	instance_requirements {
+		%[1]s	
+	}
+}
+`, instanceRequirements)
+}

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -20,6 +20,10 @@ type servicePackage struct{}
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.ServicePackageFrameworkDataSource {
 	return []*types.ServicePackageFrameworkDataSource{
 		{
+			Factory: newDataSourceInstanceTypesFromInstanceRequirements,
+			Name:    "Instance Types From Instance Requirements",
+		},
+		{
 			Factory: newDataSourceSecurityGroupRule,
 		},
 		{

--- a/website/docs/d/ec2_instance_types_from_instance_requirements.html.markdown
+++ b/website/docs/d/ec2_instance_types_from_instance_requirements.html.markdown
@@ -1,0 +1,161 @@
+---
+subcategory: "EC2 (Elastic Compute Cloud)"
+layout: "aws"
+page_title: "AWS: aws_ec2_instance_types_from_instance_requirements"
+description: |-
+  EC2 Instance Types that match requirements.
+---
+
+# Data Source: aws_ec2_instance_types_from_instance_requirements
+
+Get a list of EC2 Instance Types that match requirements.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_ec2_instance_types_from_instance_requirements" "example" {
+  architecture_types = ["x86_64"]
+  virtualization_types = ["hvm"]
+
+  instance_requirements {
+    memory_mib {
+      min = 1024
+    }
+    vcpu_count {
+      min = 2
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `architecture_types` - (Required) List of architecture types allowed. Possible values are `i386`, `x86_64`, `arm64`, `x86_64_mac` and `arm64_mac`
+* `instance_requirements` - (Required) The attribute requirements for the type of instance.
+* `virtualization_types` - (Required) List of virtualization types allowed. Possible values are `hvm` and `paravirtual`
+
+### instance_requirements
+
+This configuration block supports the following:
+
+~> **NOTE:** Both `memory_mib.min` and `vcpu_count.min` must be specified.
+
+- `accelerator_count` - (Optional) Block describing the minimum and maximum number of accelerators (GPUs, FPGAs, or AWS Inferentia chips). Default is no minimum or maximum.
+    - `min` - (Optional) Minimum.
+    - `max` - (Optional) Maximum. Set to `0` to exclude instance types with accelerators.
+- `accelerator_manufacturers` - (Optional) List of accelerator manufacturer names. Default is any manufacturer.
+
+  ```
+  Valid names:
+    * amazon-web-services
+    * amd
+    * nvidia
+    * xilinx
+  ```
+
+- `accelerator_names` - (Optional) List of accelerator names. Default is any acclerator.
+
+  ```
+  Valid names:
+    * a100            - NVIDIA A100 GPUs
+    * v100            - NVIDIA V100 GPUs
+    * k80             - NVIDIA K80 GPUs
+    * t4              - NVIDIA T4 GPUs
+    * m60             - NVIDIA M60 GPUs
+    * radeon-pro-v520 - AMD Radeon Pro V520 GPUs
+    * vu9p            - Xilinx VU9P FPGAs
+  ```
+
+- `accelerator_total_memory_mib` - (Optional) Block describing the minimum and maximum total memory of the accelerators. Default is no minimum or maximum.
+
+    - `min` - (Optional) Minimum.
+    - `max` - (Optional) Maximum.
+
+- `accelerator_types` - (Optional) List of accelerator types. Default is any accelerator type.
+
+  ```
+  Valid types:
+    * fpga
+    * gpu
+    * inference
+  ```
+
+- `allowed_instance_types` - (Optional) List of instance types to apply your specified attributes against. All other instance types are ignored, even if they match your specified attributes. You can use strings with one or more wild cards, represented by an asterisk (\*), to allow an instance type, size, or generation. The following are examples: `m5.8xlarge`, `c5*.*`, `m5a.*`, `r*`, `*3*`. For example, if you specify `c5*`, you are allowing the entire C5 instance family, which includes all C5a and C5n instance types. If you specify `m5a.*`, you are allowing all the M5a instance types, but not the M5n instance types. Maximum of 400 entries in the list; each entry is limited to 30 characters. Default is all instance types.
+
+  ~> **NOTE:** If you specify `allowed_instance_types`, you can't specify `excluded_instance_types`.
+
+- `bare_metal` - (Optional) Indicate whether bare metal instace types should be `included`, `excluded`, or `required`. Default is `excluded`.
+- `baseline_ebs_bandwidth_mbps` - (Optional) Block describing the minimum and maximum baseline EBS bandwidth, in Mbps. Default is no minimum or maximum.
+    - `min` - (Optional) Minimum.
+    - `max` - (Optional) Maximum.
+- `burstable_performance` - (Optional) Indicate whether burstable performance instance types should be `included`, `excluded`, or `required`. Default is `excluded`.
+- `cpu_manufacturers` (Optional) List of CPU manufacturer names. Default is any manufacturer.
+
+  ~> **NOTE:** Don't confuse the CPU hardware manufacturer with the CPU hardware architecture. Instances will be launched with a compatible CPU architecture based on the Amazon Machine Image (AMI) that you specify in your launch template.
+
+  ```
+  Valid names:
+    * amazon-web-services
+    * amd
+    * intel
+  ```
+
+- `excluded_instance_types` - (Optional) List of instance types to exclude. You can use strings with one or more wild cards, represented by an asterisk (\*), to exclude an instance type, size, or generation. The following are examples: `m5.8xlarge`, `c5*.*`, `m5a.*`, `r*`, `*3*`. For example, if you specify `c5*`, you are excluding the entire C5 instance family, which includes all C5a and C5n instance types. If you specify `m5a.*`, you are excluding all the M5a instance types, but not the M5n instance types. Maximum of 400 entries in the list; each entry is limited to 30 characters. Default is no excluded instance types.
+
+  ~> **NOTE:** If you specify `excluded_instance_types`, you can't specify `allowed_instance_types`.
+
+- `instance_generations` - (Optional) List of instance generation names. Default is any generation.
+
+  ```
+  Valid names:
+    * current  - Recommended for best performance.
+    * previous - For existing applications optimized for older instance types.
+  ```
+
+- `local_storage` - (Optional) Indicate whether instance types with local storage volumes are `included`, `excluded`, or `required`. Default is `included`.
+- `local_storage_types` - (Optional) List of local storage type names. Default any storage type.
+
+  ```
+  Value names:
+    * hdd - hard disk drive
+    * ssd - solid state drive
+  ```
+
+- `memory_gib_per_vcpu` - (Optional) Block describing the minimum and maximum amount of memory (GiB) per vCPU. Default is no minimum or maximum.
+    - `min` - (Optional) Minimum. May be a decimal number, e.g. `0.5`.
+    - `max` - (Optional) Maximum. May be a decimal number, e.g. `0.5`.
+- `memory_mib` - (Required) Block describing the minimum and maximum amount of memory (MiB). Default is no maximum.
+    - `min` - (Required) Minimum.
+    - `max` - (Optional) Maximum.
+- `network_bandwidth_gbps` - (Optional) Block describing the minimum and maximum amount of network bandwidth, in gigabits per second (Gbps). Default is no minimum or maximum.
+    - `min` - (Optional) Minimum.
+    - `max` - (Optional) Maximum.
+- `network_interface_count` - (Optional) Block describing the minimum and maximum number of network interfaces. Default is no minimum or maximum.
+    - `min` - (Optional) Minimum.
+    - `max` - (Optional) Maximum.
+- `on_demand_max_price_percentage_over_lowest_price` - (Optional) Price protection threshold for On-Demand Instances. This is the maximum you’ll pay for an On-Demand Instance, expressed as a percentage higher than the cheapest M, C, or R instance type with your specified attributes. When Amazon EC2 Auto Scaling selects instance types with your attributes, we will exclude instance types whose price is higher than your threshold. The parameter accepts an integer, which Amazon EC2 Auto Scaling interprets as a percentage. To turn off price protection, specify a high value, such as 999999. Default is 20.
+
+  If you set DesiredCapacityType to vcpu or memory-mib, the price protection threshold is applied based on the per vCPU or per memory price instead of the per instance price.
+
+- `require_hibernate_support` - (Optional) Indicate whether instance types must support On-Demand Instance Hibernation, either `true` or `false`. Default is `false`.
+- `spot_max_price_percentage_over_lowest_price` - (Optional) Price protection threshold for Spot Instances. This is the maximum you’ll pay for a Spot Instance, expressed as a percentage higher than the cheapest M, C, or R instance type with your specified attributes. When Amazon EC2 Auto Scaling selects instance types with your attributes, we will exclude instance types whose price is higher than your threshold. The parameter accepts an integer, which Amazon EC2 Auto Scaling interprets as a percentage. To turn off price protection, specify a high value, such as 999999. Default is 100.
+
+  If you set DesiredCapacityType to vcpu or memory-mib, the price protection threshold is applied based on the per vCPU or per memory price instead of the per instance price.
+
+- `total_local_storage_gb` - (Optional) Block describing the minimum and maximum total local storage (GB). Default is no minimum or maximum.
+    - `min` - (Optional) Minimum. May be a decimal number, e.g. `0.5`.
+    - `max` - (Optional) Maximum. May be a decimal number, e.g. `0.5`.
+- `vcpu_count` - (Required) Block describing the minimum and maximum number of vCPUs. Default is no maximum.
+    - `min` - (Required) Minimum.
+    - `max` - (Optional) Maximum.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `id` - AWS Region.
+* `instance_types` - List of EC2 Instance Types.


### PR DESCRIPTION
### Description
This adds the GetInstanceTypesFromInstanceRequirements API used by Autoscaling and Spot Fleet as a generic data source. I'm planning to use this for the `instance_types` attribute in an `aws_eks_node_group` resource so I can filter instance types better than with the `aws_ec2_instance_types` data source

### References
[GetInstanceTypesFromInstanceRequirements documentation](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_GetInstanceTypesFromInstanceRequirements.html)


### Output from Acceptance Testing
```console
% make testacc TESTARGS='-run=TestAccEC2InstanceTypesFromInstanceRequirementsDataSource' PKG=ec2 ACCTEST_PARALLELISM=8
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 8  -run=TestAccEC2InstanceTypesFromInstanceRequirementsDataSource -timeout 360m
=== RUN   TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_memoryMiBAndVcpuCount
=== PAUSE TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_memoryMiBAndVcpuCount
=== RUN   TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_acceleratorCount
=== PAUSE TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_acceleratorCount
=== RUN   TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_acceleratorManufacturers
=== PAUSE TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_acceleratorManufacturers
=== RUN   TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_acceleratorNames
=== PAUSE TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_acceleratorNames
=== RUN   TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_acceleratorTotalMemoryMiB
=== PAUSE TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_acceleratorTotalMemoryMiB
=== RUN   TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_acceleratorTypes
=== PAUSE TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_acceleratorTypes
=== RUN   TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_allowedInstanceTypes
=== PAUSE TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_allowedInstanceTypes
=== RUN   TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_bareMetal
=== PAUSE TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_bareMetal
=== RUN   TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_baselineEbsBandwidthMbps
=== PAUSE TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_baselineEbsBandwidthMbps
=== RUN   TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_burstablePerformance
=== PAUSE TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_burstablePerformance
=== RUN   TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_cpuManufacturers
=== PAUSE TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_cpuManufacturers
=== RUN   TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_excludedInstanceTypes
=== PAUSE TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_excludedInstanceTypes
=== RUN   TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_instanceGenerations
=== PAUSE TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_instanceGenerations
=== RUN   TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_localStorage
=== PAUSE TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_localStorage
=== RUN   TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_localStorageTypes
=== PAUSE TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_localStorageTypes
=== RUN   TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_memoryGiBPerVCpu
=== PAUSE TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_memoryGiBPerVCpu
=== RUN   TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_networkBandwidthGbps
=== PAUSE TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_networkBandwidthGbps
=== RUN   TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_networkInterfaceCount
=== PAUSE TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_networkInterfaceCount
=== RUN   TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_onDemandMaxPricePercentageOverLowestPrice
=== PAUSE TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_onDemandMaxPricePercentageOverLowestPrice
=== RUN   TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_requireHibernateSupport
=== PAUSE TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_requireHibernateSupport
=== RUN   TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_spotMaxPricePercentageOverLowestPrice
=== PAUSE TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_spotMaxPricePercentageOverLowestPrice
=== RUN   TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_totalLocalStorageGB
=== PAUSE TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_totalLocalStorageGB
=== CONT  TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_memoryMiBAndVcpuCount
=== CONT  TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_excludedInstanceTypes
=== CONT  TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_networkInterfaceCount
=== CONT  TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_allowedInstanceTypes
=== CONT  TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_acceleratorNames
=== CONT  TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_acceleratorTypes
=== CONT  TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_acceleratorTotalMemoryMiB
=== CONT  TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_acceleratorManufacturers
--- PASS: TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_acceleratorNames (50.33s)
=== CONT  TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_spotMaxPricePercentageOverLowestPrice
--- PASS: TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_excludedInstanceTypes (53.29s)
=== CONT  TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_totalLocalStorageGB
--- PASS: TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_allowedInstanceTypes (54.44s)
=== CONT  TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_acceleratorCount
--- PASS: TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_memoryMiBAndVcpuCount (54.45s)
=== CONT  TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_burstablePerformance
--- PASS: TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_acceleratorTypes (54.61s)
=== CONT  TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_cpuManufacturers
--- PASS: TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_acceleratorManufacturers (54.65s)
=== CONT  TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_localStorageTypes
--- PASS: TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_networkInterfaceCount (75.52s)
=== CONT  TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_networkBandwidthGbps
--- PASS: TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_acceleratorTotalMemoryMiB (77.01s)
=== CONT  TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_memoryGiBPerVCpu
--- PASS: TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_spotMaxPricePercentageOverLowestPrice (26.84s)
=== CONT  TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_requireHibernateSupport
--- PASS: TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_localStorageTypes (49.26s)
=== CONT  TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_onDemandMaxPricePercentageOverLowestPrice
--- PASS: TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_cpuManufacturers (49.35s)
=== CONT  TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_localStorage
--- PASS: TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_totalLocalStorageGB (67.12s)
=== CONT  TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_instanceGenerations
--- PASS: TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_acceleratorCount (67.51s)
=== CONT  TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_baselineEbsBandwidthMbps
--- PASS: TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_requireHibernateSupport (47.84s)
=== CONT  TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_bareMetal
--- PASS: TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_burstablePerformance (71.18s)
--- PASS: TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_onDemandMaxPricePercentageOverLowestPrice (25.60s)
--- PASS: TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_networkBandwidthGbps (66.06s)
--- PASS: TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_memoryGiBPerVCpu (65.28s)
--- PASS: TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_instanceGenerations (39.81s)
--- PASS: TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_localStorage (61.51s)
--- PASS: TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_baselineEbsBandwidthMbps (56.97s)
--- PASS: TestAccEC2InstanceTypesFromInstanceRequirementsDataSource_bareMetal (55.74s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        183.171s
...
```
