### PR TITLE
r/aws_config_config_rule: add `evaluation_mode`

### DIFF
--- a/.changelog/34033.txt
+++ b/.changelog/34033.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_config_config_rule: Add `evaluation_mode` attribute
+```

--- a/internal/service/configservice/config_rule.go
+++ b/internal/service/configservice/config_rule.go
@@ -40,15 +40,6 @@ func ResourceConfigRule() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(0, 128),
-			},
-			"rule_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -57,6 +48,11 @@ func ResourceConfigRule() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringLenBetween(0, 256),
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(0, 128),
 			},
 			"input_parameters": {
 				Type:         schema.TypeString,
@@ -67,6 +63,10 @@ func ResourceConfigRule() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringInSlice(configservice.MaximumExecutionFrequency_Values(), false),
+			},
+			"rule_id": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"scope": {
 				Type:     schema.TypeList,

--- a/internal/service/configservice/config_rule.go
+++ b/internal/service/configservice/config_rule.go
@@ -287,6 +287,8 @@ func resourceConfigRuleRead(ctx context.Context, d *schema.ResourceData, meta in
 	d.Set("input_parameters", rule.InputParameters)
 	d.Set("maximum_execution_frequency", rule.MaximumExecutionFrequency)
 
+	d.Set("evaluation_mode", flattenRuleEvaluationMode(rule.EvaluationModes))
+
 	if rule.Scope != nil {
 		d.Set("scope", flattenRuleScope(rule.Scope))
 	}

--- a/internal/service/configservice/config_rule.go
+++ b/internal/service/configservice/config_rule.go
@@ -49,6 +49,21 @@ func ResourceConfigRule() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validation.StringLenBetween(0, 256),
 			},
+			"evaluation_mode": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"mode": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.StringInSlice(configservice.EvaluationMode_Values(), false),
+						},
+					},
+				},
+			},
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -206,9 +221,15 @@ func resourceRulePutConfig(ctx context.Context, d *schema.ResourceData, meta int
 	if v, ok := d.GetOk("description"); ok {
 		ruleInput.Description = aws.String(v.(string))
 	}
+
+	if v, ok := d.Get("evaluation_mode").(*schema.Set); ok && v.Len() > 0 {
+		ruleInput.EvaluationModes = expandRulesEvaluationModes(v.List())
+	}
+
 	if v, ok := d.GetOk("input_parameters"); ok {
 		ruleInput.InputParameters = aws.String(v.(string))
 	}
+
 	if v, ok := d.GetOk("maximum_execution_frequency"); ok {
 		ruleInput.MaximumExecutionFrequency = aws.String(v.(string))
 	}

--- a/internal/service/configservice/config_rule_test.go
+++ b/internal/service/configservice/config_rule_test.go
@@ -55,6 +55,11 @@ func testAccConfigRule_evaluationMode(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_config_config_rule.test"
 
+	evaluationMode1 := `
+  evaluation_mode {
+    mode = "DETECTIVE"
+  }
+`
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, configservice.EndpointsID),
@@ -62,7 +67,7 @@ func testAccConfigRule_evaluationMode(t *testing.T) {
 		CheckDestroy:             testAccCheckConfigRuleDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConfigRuleConfig_evaluationMode(rName, "DETECTIVE"),
+				Config: testAccConfigRuleConfig_evaluationMode(rName, evaluationMode1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConfigRuleExists(ctx, resourceName, &cr),
 					testAccCheckConfigRuleName(resourceName, rName, &cr),
@@ -72,17 +77,17 @@ func testAccConfigRule_evaluationMode(t *testing.T) {
 					}),
 				),
 			},
-			{
-				Config: testAccConfigRuleConfig_evaluationMode(rName, "PROACTIVE"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckConfigRuleExists(ctx, resourceName, &cr),
-					testAccCheckConfigRuleName(resourceName, rName, &cr),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "evaluation_mode.*", map[string]string{
-						"mode": "PROACTIVE",
-					}),
-				),
-			},
+			//{
+			//	Config: testAccConfigRuleConfig_evaluationMode(rName, "PROACTIVE"),
+			//	Check: resource.ComposeTestCheckFunc(
+			//		testAccCheckConfigRuleExists(ctx, resourceName, &cr),
+			//		testAccCheckConfigRuleName(resourceName, rName, &cr),
+			//		resource.TestCheckResourceAttr(resourceName, "name", rName),
+			//		resource.TestCheckTypeSetElemNestedAttrs(resourceName, "evaluation_mode.*", map[string]string{
+			//			"mode": "PROACTIVE",
+			//		}),
+			//	),
+			//},
 		},
 	})
 }
@@ -762,9 +767,7 @@ resource "aws_config_config_rule" "test" {
     source_identifier = "EIP_ATTACHED"
   }
 
-  evaluation_mode {
-    mode = %[2]q
-  }
+%[2]s
 
   depends_on = [aws_config_configuration_recorder.test]
 }

--- a/internal/service/configservice/config_rule_test.go
+++ b/internal/service/configservice/config_rule_test.go
@@ -40,6 +40,36 @@ func testAccConfigRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "source.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "source.0.owner", "AWS"),
 					resource.TestCheckResourceAttr(resourceName, "source.0.source_identifier", "S3_BUCKET_VERSIONING_ENABLED"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "evaluation_mode.*", map[string]string{
+						"mode": "DETECTIVE",
+					}),
+				),
+			},
+		},
+	})
+}
+
+func testAccConfigRule_evaluationMode(t *testing.T) {
+	ctx := acctest.Context(t)
+	var cr configservice.ConfigRule
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_config_config_rule.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, configservice.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckConfigRuleDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigRuleConfig_evaluationMode(rName, "DETECTIVE"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfigRuleExists(ctx, resourceName, &cr),
+					testAccCheckConfigRuleName(resourceName, rName, &cr),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "evaluation_mode.*", map[string]string{
+						"mode": "DETECTIVE",
+					}),
 				),
 			},
 		},
@@ -709,4 +739,23 @@ resource "aws_config_config_rule" "test" {
   depends_on = [aws_config_configuration_recorder.test]
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}
+
+func testAccConfigRuleConfig_evaluationMode(rName, evaluationMode string) string {
+	return testAccConfigRuleConfig_base(rName) + fmt.Sprintf(`
+resource "aws_config_config_rule" "test" {
+  name = %[1]q
+
+  source {
+    owner             = "AWS"
+    source_identifier = "S3_BUCKET_VERSIONING_ENABLED"
+  }
+
+  evaluation_mode {
+    mode = %[2]q
+  }
+
+  depends_on = [aws_config_configuration_recorder.test]
+}
+`, rName, evaluationMode)
 }

--- a/internal/service/configservice/config_rule_test.go
+++ b/internal/service/configservice/config_rule_test.go
@@ -60,6 +60,16 @@ func testAccConfigRule_evaluationMode(t *testing.T) {
     mode = "DETECTIVE"
   }
 `
+
+	evaluationMode2 := `
+  evaluation_mode {
+    mode = "DETECTIVE"
+  }
+
+  evaluation_mode {
+    mode = "PROACTIVE"
+  }
+`
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, configservice.EndpointsID),
@@ -77,17 +87,20 @@ func testAccConfigRule_evaluationMode(t *testing.T) {
 					}),
 				),
 			},
-			//{
-			//	Config: testAccConfigRuleConfig_evaluationMode(rName, "PROACTIVE"),
-			//	Check: resource.ComposeTestCheckFunc(
-			//		testAccCheckConfigRuleExists(ctx, resourceName, &cr),
-			//		testAccCheckConfigRuleName(resourceName, rName, &cr),
-			//		resource.TestCheckResourceAttr(resourceName, "name", rName),
-			//		resource.TestCheckTypeSetElemNestedAttrs(resourceName, "evaluation_mode.*", map[string]string{
-			//			"mode": "PROACTIVE",
-			//		}),
-			//	),
-			//},
+			{
+				Config: testAccConfigRuleConfig_evaluationMode(rName, evaluationMode2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfigRuleExists(ctx, resourceName, &cr),
+					testAccCheckConfigRuleName(resourceName, rName, &cr),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "evaluation_mode.*", map[string]string{
+						"mode": "DETECTIVE",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "evaluation_mode.*", map[string]string{
+						"mode": "PROACTIVE",
+					}),
+				),
+			},
 		},
 	})
 }

--- a/internal/service/configservice/config_rule_test.go
+++ b/internal/service/configservice/config_rule_test.go
@@ -72,6 +72,17 @@ func testAccConfigRule_evaluationMode(t *testing.T) {
 					}),
 				),
 			},
+			{
+				Config: testAccConfigRuleConfig_evaluationMode(rName, "PROACTIVE"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfigRuleExists(ctx, resourceName, &cr),
+					testAccCheckConfigRuleName(resourceName, rName, &cr),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "evaluation_mode.*", map[string]string{
+						"mode": "PROACTIVE",
+					}),
+				),
+			},
 		},
 	})
 }
@@ -748,7 +759,7 @@ resource "aws_config_config_rule" "test" {
 
   source {
     owner             = "AWS"
-    source_identifier = "S3_BUCKET_VERSIONING_ENABLED"
+    source_identifier = "EIP_ATTACHED"
   }
 
   evaluation_mode {

--- a/internal/service/configservice/configservice_test.go
+++ b/internal/service/configservice/configservice_test.go
@@ -13,11 +13,12 @@ func TestAccConfigService_serial(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]map[string]func(t *testing.T){
-		"Config": {
+		"ConfigRule": {
 			"basic":            testAccConfigRule_basic,
 			"ownerAws":         testAccConfigRule_ownerAws,
 			"customlambda":     testAccConfigRule_customlambda,
 			"customPolicy":     testAccConfigRule_ownerPolicy,
+			"evaluationMode":   testAccConfigRule_evaluationMode,
 			"scopeTagKey":      testAccConfigRule_Scope_TagKey,
 			"scopeTagKeyEmpty": testAccConfigRule_Scope_TagKey_Empty,
 			"scopeTagValue":    testAccConfigRule_Scope_TagValue,

--- a/internal/service/configservice/flex.go
+++ b/internal/service/configservice/flex.go
@@ -112,7 +112,7 @@ func expandRulesEvaluationModes(in []interface{}) []*configservice.EvaluationMod
 			continue
 		}
 
-		var e *configservice.EvaluationModeConfiguration
+		e := &configservice.EvaluationModeConfiguration{}
 		if v, ok := m["mode"].(string); ok && v != "" {
 			e.Mode = aws.String(v)
 		}
@@ -270,6 +270,23 @@ func flattenExclusionByResourceTypes(exclusionByResourceTypes *configservice.Exc
 	}
 
 	return []interface{}{m}
+}
+
+func flattenRuleEvaluationMode(in []*configservice.EvaluationModeConfiguration) []interface{} {
+	if len(in) == 0 {
+		return nil
+	}
+
+	var out []interface{}
+	for _, v := range in {
+		m := map[string]interface{}{
+			"mode": aws.StringValue(v.Mode),
+		}
+
+		out = append(out, m)
+	}
+
+	return out
 }
 
 func flattenRecordingGroupRecordingStrategy(recordingStrategy *configservice.RecordingStrategy) []interface{} {

--- a/internal/service/configservice/flex.go
+++ b/internal/service/configservice/flex.go
@@ -100,6 +100,29 @@ func expandRecordingGroupRecordingStrategy(configured []interface{}) *configserv
 	return &recordingStrategy
 }
 
+func expandRulesEvaluationModes(in []interface{}) []*configservice.EvaluationModeConfiguration {
+	if len(in) == 0 {
+		return nil
+	}
+
+	var out []*configservice.EvaluationModeConfiguration
+	for _, val := range in {
+		m, ok := val.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		var e *configservice.EvaluationModeConfiguration
+		if v, ok := m["mode"].(string); ok && v != "" {
+			e.Mode = aws.String(v)
+		}
+
+		out = append(out, e)
+	}
+
+	return out
+}
+
 func expandRuleScope(l []interface{}) *configservice.Scope {
 	if len(l) == 0 || l[0] == nil {
 		return nil

--- a/website/docs/r/config_config_rule.html.markdown
+++ b/website/docs/r/config_config_rule.html.markdown
@@ -141,11 +141,16 @@ This resource supports the following arguments:
 
 * `name` - (Required) The name of the rule
 * `description` - (Optional) Description of the rule
+* `evaluation_mode` - (Optional) The modes the Config rule can be evaluated in. See [Evaluation Mode](#evaluation-mode) for more details.
 * `input_parameters` - (Optional) A string in JSON format that is passed to the AWS Config rule Lambda function.
 * `maximum_execution_frequency` - (Optional) The maximum frequency with which AWS Config runs evaluations for a rule.
 * `scope` - (Optional) Scope defines which resources can trigger an evaluation for the rule. See [Source](#source) Below.
 * `source` - (Required) Source specifies the rule owner, the rule identifier, and the notifications that cause the function to evaluate your AWS resources. See [Scope](#scope) Below.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### Evaluation Mode
+
+* `mode` - (Optional) The mode of an evaluation.
 
 ### Scope
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:
--->

Closes #33532

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc PKG=configservice TESTARGS='-run=TestAccConfigService_serial/^ConfigRule/$'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/configservice/... -v -count 1 -parallel 20  -run=TestAccConfigService_serial/^ConfigRule/ -timeout 360m
=== RUN   TestAccConfigService_serial
=== PAUSE TestAccConfigService_serial
=== CONT  TestAccConfigService_serial
=== RUN   TestAccConfigService_serial/ConfigRule
=== RUN   TestAccConfigService_serial/ConfigRule/disappears
=== RUN   TestAccConfigService_serial/ConfigRule/ownerAws
=== RUN   TestAccConfigService_serial/ConfigRule/customPolicy
=== RUN   TestAccConfigService_serial/ConfigRule/scopeTagValue
=== RUN   TestAccConfigService_serial/ConfigRule/tags
=== RUN   TestAccConfigService_serial/ConfigRule/scopeTagKeyEmpty
=== RUN   TestAccConfigService_serial/ConfigRule/basic
=== RUN   TestAccConfigService_serial/ConfigRule/customlambda
=== RUN   TestAccConfigService_serial/ConfigRule/evaluationMode
=== RUN   TestAccConfigService_serial/ConfigRule/scopeTagKey
--- PASS: TestAccConfigService_serial (2010.56s)
    --- PASS: TestAccConfigService_serial/ConfigRule (2010.56s)
        --- PASS: TestAccConfigService_serial/ConfigRule/disappears (160.43s)
        --- PASS: TestAccConfigService_serial/ConfigRule/ownerAws (161.11s)
        --- PASS: TestAccConfigService_serial/ConfigRule/customPolicy (159.02s)
        --- PASS: TestAccConfigService_serial/ConfigRule/scopeTagValue (217.73s)
        --- PASS: TestAccConfigService_serial/ConfigRule/tags (286.92s)
        --- PASS: TestAccConfigService_serial/ConfigRule/scopeTagKeyEmpty (154.99s)
        --- PASS: TestAccConfigService_serial/ConfigRule/basic (154.75s)
        --- PASS: TestAccConfigService_serial/ConfigRule/customlambda (279.08s)
        --- PASS: TestAccConfigService_serial/ConfigRule/evaluationMode (218.40s)
        --- PASS: TestAccConfigService_serial/ConfigRule/scopeTagKey (218.13s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/configservice	2013.706s
```
