### PR TITLE
fix: aws_identitystore_group update description attribute

### DIFF
--- a/.changelog/34037.txt
+++ b/.changelog/34037.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_identitystore_group: Fix updating `description` attribute when it is changed
+```

--- a/internal/service/identitystore/group.go
+++ b/internal/service/identitystore/group.go
@@ -100,7 +100,6 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	out, err := conn.CreateGroup(ctx, input)
-
 	if err != nil {
 		return create.DiagError(names.IdentityStore, create.ErrActionCreating, ResNameGroup, d.Get("identity_store_id").(string), err)
 	}
@@ -118,7 +117,6 @@ func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	conn := meta.(*conns.AWSClient).IdentityStoreClient(ctx)
 
 	identityStoreId, groupId, err := resourceGroupParseID(d.Id())
-
 	if err != nil {
 		return create.DiagError(names.IdentityStore, create.ErrActionReading, ResNameGroup, d.Id(), err)
 	}
@@ -160,6 +158,13 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		in.Operations = append(in.Operations, types.AttributeOperation{
 			AttributePath:  aws.String("displayName"),
 			AttributeValue: document.NewLazyDocument(d.Get("display_name").(string)),
+		})
+	}
+
+	if d.HasChange("description") {
+		in.Operations = append(in.Operations, types.AttributeOperation{
+			AttributePath:  aws.String("description"),
+			AttributeValue: document.NewLazyDocument(d.Get("description").(string)),
 		})
 	}
 

--- a/internal/service/identitystore/group_test.go
+++ b/internal/service/identitystore/group_test.go
@@ -83,6 +83,42 @@ func TestAccIdentityStoreGroup_disappears(t *testing.T) {
 	})
 }
 
+func TestAccIdentityStoreGroup_descriptionChange(t *testing.T) {
+	ctx := acctest.Context(t)
+	var group identitystore.DescribeGroupOutput
+	description1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	description2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_identitystore_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.IdentityStoreEndpointID)
+			testAccPreCheckSSOAdminInstances(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.IdentityStoreEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGroupDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGroupConfig_description(description1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGroupExists(ctx, resourceName, &group),
+					resource.TestCheckResourceAttr(resourceName, "description", description1),
+				),
+			},
+			{
+				Config: testAccGroupConfig_description(description2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGroupExists(ctx, resourceName, &group),
+					resource.TestCheckResourceAttr(resourceName, "description", description2),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckGroupDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).IdentityStoreClient(ctx)
@@ -122,7 +158,6 @@ func testAccCheckGroupExists(ctx context.Context, n string, v *identitystore.Des
 		conn := acctest.Provider.Meta().(*conns.AWSClient).IdentityStoreClient(ctx)
 
 		output, err := tfidentitystore.FindGroupByTwoPartKey(ctx, conn, rs.Primary.Attributes["identity_store_id"], rs.Primary.Attributes["group_id"])
-
 		if err != nil {
 			return err
 		}
@@ -142,4 +177,15 @@ resource "aws_identitystore_group" "test" {
   description       = "Example description"
 }
 `, displayName)
+}
+
+func testAccGroupConfig_description(description string) string {
+	return fmt.Sprintf(`
+data "aws_ssoadmin_instances" "test" {}
+resource "aws_identitystore_group" "test" {
+  identity_store_id = tolist(data.aws_ssoadmin_instances.test.identity_store_ids)[0]
+  display_name      = "Test display name"
+  description       = %[1]q
+}
+`, description)
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Small bugfix for updating`aws_identitystore_group` description attribute
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/28093

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
%  make testacc TESTS=TestAccIdentityStoreGroup_descriptionChange PKG=identitystore
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/identitystore/... -v -count 1 -parallel 20 -run='TestAccIdentityStoreGroup_descriptionChange'  -timeout 360m
=== RUN   TestAccIdentityStoreGroup_descriptionChange
=== PAUSE TestAccIdentityStoreGroup_descriptionChange
=== CONT  TestAccIdentityStoreGroup_descriptionChange
--- PASS: TestAccIdentityStoreGroup_descriptionChange (69.26s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/identitystore	71.409s
```
