### PR TITLE
Update db_instance.html.markdown

### DIFF
--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -288,8 +288,12 @@ Cannot be specified for gp3 storage if the `allocated_storage` value is below a 
 See the [RDS User Guide](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html#gp3-storage) for details.
 * `kms_key_id` - (Optional) The ARN for the KMS encryption key. If creating an
 encrypted replica, set this to the destination KMS ARN.
-* `license_model` - (Optional, but required for some DB engines, i.e., Oracle
-SE1) License model information for this DB instance.
+* `license_model` - (Optional, but required for some DB engines, i.e., Oracle SE1) License model information for this DB instance. Valid values for this field are as follows:
+  - RDS for MariaDB: `general-public-license`
+  - RDS for Microsoft SQL Server: `license-included`
+  - RDS for MySQL: `general-public-license`
+  - RDS for Oracle: `bring-your-own-license | license-included`
+  - RDS for PostgreSQL: `postgresql-license`
 * `maintenance_window` - (Optional) The window to perform maintenance in.
 Syntax: "ddd:hh24:mi-ddd:hh24:mi". Eg: "Mon:00:00-Mon:03:00". See [RDS
 Maintenance Window

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -289,11 +289,11 @@ See the [RDS User Guide](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/
 * `kms_key_id` - (Optional) The ARN for the KMS encryption key. If creating an
 encrypted replica, set this to the destination KMS ARN.
 * `license_model` - (Optional, but required for some DB engines, i.e., Oracle SE1) License model information for this DB instance. Valid values for this field are as follows:
-  - RDS for MariaDB: `general-public-license`
-  - RDS for Microsoft SQL Server: `license-included`
-  - RDS for MySQL: `general-public-license`
-  - RDS for Oracle: `bring-your-own-license | license-included`
-  - RDS for PostgreSQL: `postgresql-license`
+    * RDS for MariaDB: `general-public-license`
+    * RDS for Microsoft SQL Server: `license-included`
+    * RDS for MySQL: `general-public-license`
+    * RDS for Oracle: `bring-your-own-license | license-included`
+    * RDS for PostgreSQL: `postgresql-license`
 * `maintenance_window` - (Optional) The window to perform maintenance in.
 Syntax: "ddd:hh24:mi-ddd:hh24:mi". Eg: "Mon:00:00-Mon:03:00". See [RDS
 Maintenance Window


### PR DESCRIPTION
### Original Sentence:
license_model - (Optional, but required for some DB engines, i.e., Oracle SE1) License model information for this DB instance.

### Issues in the Original Sentence:
- Lack of clarity regarding valid values for license_model.
- Unclear which DB engines require this information.
- No specific mention of the valid values users can select.

### Explanation of Changes:
- Add specific valid values for the license_model field.
- Clarify the requirement for certain DB engines.
- Clearly state which values correspond to which DB engines.

### Final Sentence:
license_model - (Optional, but required for some DB engines, i.e., Oracle SE1) License model information for this DB instance. To configure this field, choose from the following valid values based on your DB engine:

- RDS for MariaDB: general-public-license
- RDS for Microsoft SQL Server: license-included
- RDS for MySQL: general-public-license
- RDS for Oracle: bring-your-own-license | license-included
- RDS for PostgreSQL: postgresql-license

These changes provide a clear and informative explanation of the license_model field, including specific valid values and why it's important for users to choose the right option based on their DB engine.

### Relations
Closes #0000

### References
https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html

