### PR TITLE
ci: Don't allow multiple sweeper, performance, or sanity builds in queue

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -445,7 +445,7 @@ object Sweeper : BuildType({
                     branchFilter = "+:refs/heads/main"
                     triggerBuild = always()
                     withPendingChangesOnly = false
-                    enableQueueOptimization = false
+                    enableQueueOptimization = true
                     enforceCleanCheckoutForDependencies = true
                 }
             }
@@ -582,7 +582,7 @@ object Sanity : BuildType({
                     branchFilter = "+:refs/heads/main"
                     triggerBuild = always()
                     withPendingChangesOnly = false
-                    enableQueueOptimization = false
+                    enableQueueOptimization = true
                     enforceCleanCheckoutForDependencies = true
                 }
             }
@@ -650,7 +650,7 @@ object Performance : BuildType({
                     branchFilter = "+:refs/heads/main"
                     triggerBuild = always()
                     withPendingChangesOnly = false
-                    enableQueueOptimization = false
+                    enableQueueOptimization = true
                     enforceCleanCheckoutForDependencies = true
                 }
             }


### PR DESCRIPTION
### Description

Because full acceptance test runs take a significant amount of time, multiple daily sweeper, performance, and sanity builds can be queued. Allow older runs to be replaced if they are queued