### PR TITLE
F aws bedrock foundation models datasource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -125,6 +125,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.37 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.45 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.1.6 // indirect
+	github.com/aws/aws-sdk-go-v2/service/bedrock v1.1.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.22.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/iam v1.22.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/aws/aws-sdk-go-v2/service/appconfig v1.21.2 h1:J0OmY99LItcxPA/82K8Bqs
 github.com/aws/aws-sdk-go-v2/service/appconfig v1.21.2/go.mod h1:7bTOwXFz4+VxkDVB26d7TAhFKloGA3EtwtLAydyv1ek=
 github.com/aws/aws-sdk-go-v2/service/auditmanager v1.27.0 h1:pz81qsD+FxrrHOaNrfGSWbQ4cU6Dxj2I5tvlrLmgCUE=
 github.com/aws/aws-sdk-go-v2/service/auditmanager v1.27.0/go.mod h1:zEDWBhc3yodpWk3ZLDNPlTOZGNx0bGx90XQma07xR1Q=
+github.com/aws/aws-sdk-go-v2/service/bedrock v1.1.4 h1:lVj5Hnsw/dfxuvkYmRVLdDNcn5FI/W1IUz0Ikd5juwU=
+github.com/aws/aws-sdk-go-v2/service/bedrock v1.1.4/go.mod h1:RNwEFICbG3faiNCbWWZIjtan2KrPa0fWnCVgdZL/rxI=
 github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.4.2 h1:qt0XqbZAU+ZnaqQqvuafocTm/KPKIxf0GPRObbMvhGc=
 github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.4.2/go.mod h1:bbDwGddkt+EcDTY6PuJVKyXesjbQ61r7erTlBm+tIy4=
 github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.12.7 h1:XbzkTIZi+VwbpQHnWdSCPlnhKQo8upmObVHLBcJVx5s=

--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -9,6 +9,7 @@ import (
 	acm_sdkv2 "github.com/aws/aws-sdk-go-v2/service/acm"
 	appconfig_sdkv2 "github.com/aws/aws-sdk-go-v2/service/appconfig"
 	auditmanager_sdkv2 "github.com/aws/aws-sdk-go-v2/service/auditmanager"
+	bedrock_sdkv2 "github.com/aws/aws-sdk-go-v2/service/bedrock"
 	cleanrooms_sdkv2 "github.com/aws/aws-sdk-go-v2/service/cleanrooms"
 	cloudcontrol_sdkv2 "github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	cloudwatchlogs_sdkv2 "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
@@ -86,7 +87,6 @@ import (
 	autoscalingplans_sdkv1 "github.com/aws/aws-sdk-go/service/autoscalingplans"
 	backup_sdkv1 "github.com/aws/aws-sdk-go/service/backup"
 	batch_sdkv1 "github.com/aws/aws-sdk-go/service/batch"
-	bedrock_sdkv1 "github.com/aws/aws-sdk-go/service/bedrock"
 	budgets_sdkv1 "github.com/aws/aws-sdk-go/service/budgets"
 	chime_sdkv1 "github.com/aws/aws-sdk-go/service/chime"
 	chimesdkmediapipelines_sdkv1 "github.com/aws/aws-sdk-go/service/chimesdkmediapipelines"
@@ -319,8 +319,8 @@ func (c *AWSClient) BatchConn(ctx context.Context) *batch_sdkv1.Batch {
 	return errs.Must(conn[*batch_sdkv1.Batch](ctx, c, names.Batch))
 }
 
-func (c *AWSClient) BedrockConn(ctx context.Context) *bedrock_sdkv1.Bedrock {
-	return errs.Must(conn[*bedrock_sdkv1.Bedrock](ctx, c, names.Bedrock))
+func (c *AWSClient) BedrockClient(ctx context.Context) *bedrock_sdkv2.Client {
+	return errs.Must(client[*bedrock_sdkv2.Client](ctx, c, names.Bedrock))
 }
 
 func (c *AWSClient) BudgetsConn(ctx context.Context) *budgets_sdkv1.Budgets {

--- a/internal/service/bedrock/foundation_models_data_source.go
+++ b/internal/service/bedrock/foundation_models_data_source.go
@@ -138,7 +138,7 @@ type foundationModelSummary struct {
 func flattenFoundationModelSummaries(ctx context.Context, models []bedrock_types.FoundationModelSummary) types.List {
 	attributeTypes := flex.AttributeTypesMust[foundationModelSummary](ctx)
 
-	// HACK: Reflection used above to build the attributeTypes cannot determing the ElemType
+	// HACK: Reflection used above to build the attributeTypes cannot determine the ElemType
 	attributeTypes["customizations_supported"] = types.SetType{ElemType: types.StringType}
 	attributeTypes["inference_types_supported"] = types.SetType{ElemType: types.StringType}
 	attributeTypes["input_modalities"] = types.SetType{ElemType: types.StringType}

--- a/internal/service/bedrock/foundation_models_data_source.go
+++ b/internal/service/bedrock/foundation_models_data_source.go
@@ -6,12 +6,10 @@ package bedrock
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go-v2/service/bedrock"
 	bedrock_types "github.com/aws/aws-sdk-go-v2/service/bedrock/types"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
@@ -102,25 +100,14 @@ func (d *dataSourceFoundationModels) Read(ctx context.Context, request datasourc
 	}
 
 	data.ID = flex.StringToFramework(ctx, &d.Meta().Region)
-	response.Diagnostics.Append(data.refreshFromOutput(ctx, models)...)
+	data.ModelSummaries = flattenFoundationModelSummaries(ctx, models.ModelSummaries)
+
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
 
 type foundationModels struct {
 	ID             types.String `tfsdk:"id"`
 	ModelSummaries types.List   `tfsdk:"model_summaries"`
-}
-
-func (fms *foundationModels) refreshFromOutput(ctx context.Context, out *bedrock.ListFoundationModelsOutput) diag.Diagnostics {
-	var diags diag.Diagnostics
-
-	if out == nil {
-		return diags
-	}
-
-	fms.ModelSummaries = flattenFoundationModelSummaries(ctx, out.ModelSummaries)
-
-	return diags
 }
 
 type foundationModelSummary struct {

--- a/internal/service/bedrock/foundation_models_data_source.go
+++ b/internal/service/bedrock/foundation_models_data_source.go
@@ -1,0 +1,191 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package bedrock
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/bedrock"
+	bedrock_types "github.com/aws/aws-sdk-go-v2/service/bedrock/types"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+)
+
+// @FrameworkDataSource
+func newDataSourceFoundationModels(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &dataSourceFoundationModels{}, nil
+}
+
+type dataSourceFoundationModels struct {
+	framework.DataSourceWithConfigure
+}
+
+// Metadata should return the full name of the data source, such as
+// examplecloud_thing.
+func (d *dataSourceFoundationModels) Metadata(_ context.Context, request datasource.MetadataRequest, response *datasource.MetadataResponse) {
+	response.TypeName = "aws_bedrock_foundation_models"
+}
+
+// Schema returns the schema for this data source.
+func (d *dataSourceFoundationModels) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"model_summaries": schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"model_arn": schema.StringAttribute{
+							Computed: true,
+						},
+						"model_id": schema.StringAttribute{
+							Computed: true,
+						},
+						"model_name": schema.StringAttribute{
+							Computed: true,
+						},
+						"provider_name": schema.StringAttribute{
+							Computed: true,
+						},
+						"customizations_supported": schema.SetAttribute{
+							ElementType: types.StringType,
+							Computed:    true,
+						},
+						"inference_types_supported": schema.SetAttribute{
+							ElementType: types.StringType,
+							Computed:    true,
+						},
+						"input_modalities": schema.SetAttribute{
+							ElementType: types.StringType,
+							Computed:    true,
+						},
+						"output_modalities": schema.SetAttribute{
+							ElementType: types.StringType,
+							Computed:    true,
+						},
+						"response_streaming_supported": schema.BoolAttribute{
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// Read is called when the provider must read data source values in order to update state.
+// Config values should be read from the ReadRequest and new state values set on the ReadResponse.
+func (d *dataSourceFoundationModels) Read(ctx context.Context, request datasource.ReadRequest, response *datasource.ReadResponse) {
+	var data foundationModels
+
+	response.Diagnostics.Append(request.Config.Get(ctx, &data)...)
+
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := d.Meta().BedrockClient(ctx)
+
+	models, err := conn.ListFoundationModels(ctx, nil)
+	if err != nil {
+		response.Diagnostics.AddError("reading Bedrock Foundation Models", err.Error())
+		return
+	}
+
+	data.ID = flex.StringToFramework(ctx, &d.Meta().Region)
+	response.Diagnostics.Append(data.refreshFromOutput(ctx, models)...)
+	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
+}
+
+type foundationModels struct {
+	ID             types.String `tfsdk:"id"`
+	ModelSummaries types.List   `tfsdk:"model_summaries"`
+}
+
+func (fms *foundationModels) refreshFromOutput(ctx context.Context, out *bedrock.ListFoundationModelsOutput) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if out == nil {
+		return diags
+	}
+
+	fms.ModelSummaries = flattenFoundationModelSummaries(ctx, out.ModelSummaries)
+
+	return diags
+}
+
+type foundationModelSummary struct {
+	ModelID                    types.String `tfsdk:"model_id"`
+	ModelArn                   types.String `tfsdk:"model_arn"`
+	ModelName                  types.String `tfsdk:"model_name"`
+	ProviderName               types.String `tfsdk:"provider_name"`
+	CustomizationsSupported    types.Set    `tfsdk:"customizations_supported"`
+	InferenceTypesSupported    types.Set    `tfsdk:"inference_types_supported"`
+	InputModalities            types.Set    `tfsdk:"input_modalities"`
+	OutputModalities           types.Set    `tfsdk:"output_modalities"`
+	ResponseStreamingSupported types.Bool   `tfsdk:"response_streaming_supported"`
+}
+
+func flattenFoundationModelSummaries(ctx context.Context, models []bedrock_types.FoundationModelSummary) types.List {
+	attributeTypes := flex.AttributeTypesMust[foundationModelSummary](ctx)
+
+	// HACK: Reflection used above to build the attributeTypes cannot determing the ElemType
+	attributeTypes["customizations_supported"] = types.SetType{ElemType: types.StringType}
+	attributeTypes["inference_types_supported"] = types.SetType{ElemType: types.StringType}
+	attributeTypes["input_modalities"] = types.SetType{ElemType: types.StringType}
+	attributeTypes["output_modalities"] = types.SetType{ElemType: types.StringType}
+
+	elemType := types.ObjectType{AttrTypes: attributeTypes}
+
+	if models == nil {
+		return types.ListNull(elemType)
+	}
+
+	attrs := make([]attr.Value, 0, len(models))
+	for _, model := range models {
+		attr := map[string]attr.Value{}
+		attr["model_arn"] = flex.StringToFramework(ctx, model.ModelArn)
+		attr["model_id"] = flex.StringToFramework(ctx, model.ModelId)
+		attr["model_name"] = flex.StringToFramework(ctx, model.ModelName)
+		attr["provider_name"] = flex.StringToFramework(ctx, model.ProviderName)
+
+		customizationsSupported := make([]string, 0, len(model.CustomizationsSupported))
+		for _, r := range model.CustomizationsSupported {
+			customizationsSupported = append(customizationsSupported, string(r))
+		}
+		attr["customizations_supported"] = flex.FlattenFrameworkStringValueSet(ctx, customizationsSupported)
+
+		inferenceTypesSupported := make([]string, 0, len(model.InferenceTypesSupported))
+		for _, r := range model.InferenceTypesSupported {
+			inferenceTypesSupported = append(inferenceTypesSupported, string(r))
+		}
+		attr["inference_types_supported"] = flex.FlattenFrameworkStringValueSet(ctx, inferenceTypesSupported)
+
+		inputModalities := make([]string, 0, len(model.InputModalities))
+		for _, r := range model.InputModalities {
+			inputModalities = append(inputModalities, string(r))
+		}
+		attr["input_modalities"] = flex.FlattenFrameworkStringValueSet(ctx, inputModalities)
+
+		outputModalities := make([]string, 0, len(model.OutputModalities))
+		for _, r := range model.OutputModalities {
+			outputModalities = append(outputModalities, string(r))
+		}
+		attr["output_modalities"] = flex.FlattenFrameworkStringValueSet(ctx, outputModalities)
+
+		attr["response_streaming_supported"] = flex.BoolToFramework(ctx, model.ResponseStreamingSupported)
+		val := types.ObjectValueMust(attributeTypes, attr)
+		attrs = append(attrs, val)
+	}
+
+	return types.ListValueMust(elemType, attrs)
+}

--- a/internal/service/bedrock/foundation_models_data_source_test.go
+++ b/internal/service/bedrock/foundation_models_data_source_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package bedrock_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/bedrock"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccBedrockFoundationModelsDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, bedrock.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFoundationModelsDataSourceConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.aws_bedrock_foundation_models.test", "id"),
+					acctest.CheckResourceAttrGreaterThanValue("data.aws_bedrock_foundation_models.test", "model_summaries.#", 0),
+				),
+			},
+		},
+	})
+}
+
+func testAccFoundationModelsDataSourceConfig_basic() string {
+	return `
+data "aws_bedrock_foundation_models" "test" {}
+`
+}

--- a/internal/service/bedrock/service_package_gen.go
+++ b/internal/service/bedrock/service_package_gen.go
@@ -15,7 +15,11 @@ import (
 type servicePackage struct{}
 
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.ServicePackageFrameworkDataSource {
-	return []*types.ServicePackageFrameworkDataSource{}
+	return []*types.ServicePackageFrameworkDataSource{
+		{
+			Factory: newDataSourceFoundationModels,
+		},
+	}
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.ServicePackageFrameworkResource {

--- a/internal/service/bedrock/service_package_gen.go
+++ b/internal/service/bedrock/service_package_gen.go
@@ -5,9 +5,8 @@ package bedrock
 import (
 	"context"
 
-	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
-	session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
-	bedrock_sdkv1 "github.com/aws/aws-sdk-go/service/bedrock"
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	bedrock_sdkv2 "github.com/aws/aws-sdk-go-v2/service/bedrock"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -35,11 +34,15 @@ func (p *servicePackage) ServicePackageName() string {
 	return names.Bedrock
 }
 
-// NewConn returns a new AWS SDK for Go v1 client for this service package's AWS API.
-func (p *servicePackage) NewConn(ctx context.Context, config map[string]any) (*bedrock_sdkv1.Bedrock, error) {
-	sess := config["session"].(*session_sdkv1.Session)
+// NewClient returns a new AWS SDK for Go v2 client for this service package's AWS API.
+func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (*bedrock_sdkv2.Client, error) {
+	cfg := *(config["aws_sdkv2_config"].(*aws_sdkv2.Config))
 
-	return bedrock_sdkv1.New(sess.Copy(&aws_sdkv1.Config{Endpoint: aws_sdkv1.String(config["endpoint"].(string))})), nil
+	return bedrock_sdkv2.NewFromConfig(cfg, func(o *bedrock_sdkv2.Options) {
+		if endpoint := config["endpoint"].(string); endpoint != "" {
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
+		}
+	}), nil
 }
 
 func ServicePackage(ctx context.Context) conns.ServicePackage {

--- a/names/names_data.csv
+++ b/names/names_data.csv
@@ -34,7 +34,7 @@ autoscaling-plans,autoscalingplans,autoscalingplans,autoscalingplans,,autoscalin
 backup,backup,backup,backup,,backup,,,Backup,Backup,,1,,,aws_backup_,,backup_,Backup,AWS,,,,,,
 backup-gateway,backupgateway,backupgateway,backupgateway,,backupgateway,,,BackupGateway,BackupGateway,,1,,,aws_backupgateway_,,backupgateway_,Backup Gateway,AWS,,x,,,,
 batch,batch,batch,batch,,batch,,,Batch,Batch,,1,,,aws_batch_,,batch_,Batch,AWS,,,,,,
-bedrock,bedrock,bedrock,,,bedrock,,,Bedrock,Bedrock,,1,,,aws_bedrock_,,bedrock_,Amazon Bedrock,Amazon,,,,,,
+bedrock,bedrock,bedrock,bedrock,,bedrock,,,Bedrock,Bedrock,,,2,,aws_bedrock_,,bedrock_,Amazon Bedrock,Amazon,,,,,,
 billingconductor,billingconductor,billingconductor,,,billingconductor,,,BillingConductor,BillingConductor,,1,,,aws_billingconductor_,,billingconductor_,Billing Conductor,AWS,,x,,,,
 braket,braket,braket,braket,,braket,,,Braket,Braket,,1,,,aws_braket_,,braket_,Braket,Amazon,,x,,,,
 ce,ce,costexplorer,costexplorer,,ce,,costexplorer,CE,CostExplorer,,1,,,aws_ce_,,ce_,CE (Cost Explorer),AWS,,,,,,

--- a/website/docs/d/bedrock_foundation_models.html.markdown
+++ b/website/docs/d/bedrock_foundation_models.html.markdown
@@ -1,0 +1,41 @@
+---
+subcategory: "Amazon Bedrock"
+layout: "aws"
+page_title: "AWS: aws_bedrock_foundation_models"
+description: |-
+  List of Bedrock foundation models that you can use.
+---
+
+# Data Source: aws_bedrock_foundation_models
+
+List of Bedrock foundation models that you can use.
+
+## Example Usage
+
+```terraform
+data "aws_bedrock_foundation_models" "test" {}
+```
+
+## Argument Reference
+
+NONE
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `model_summaries` - array of FoundationModelSummary objects
+
+### FoundationModelSummary
+
+Attributes of the FoundationModelSummary object.
+
+* `model_arn` - The ARN of the foundation model.
+* `model_id` - The model Id of the foundation model.
+* `customizations_supported` - Whether the model supports fine-tuning or continual pre-training.
+* `inference_types_supported` - he inference types that the model supports.
+* `input_modalities` - The input modalities that the model supports.
+* `model_name` - The model name.
+* `output_modalities` - The output modalities that the model supports.
+* `provider_name` - The model's provider name.
+* `response_streaming_supported` - Indicates whether the model supports streaming.


### PR DESCRIPTION
### Description

New datasource for Bedrock service: `aws_bedrock_foundation_models`

### Relations

Relates #33809
Relates #33738
Relates #33737
Relates #33718
Relates #33816

### References

https://docs.aws.amazon.com/bedrock/latest/APIReference/API_ListFoundationModels.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc  PKG=bedrock                                            
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/bedrock/... -v -count 1 -parallel 20   -timeout 360m
=== RUN   TestAccBedrockFoundationModelsDataSource_basic
=== PAUSE TestAccBedrockFoundationModelsDataSource_basic
=== CONT  TestAccBedrockFoundationModelsDataSource_basic
--- PASS: TestAccBedrockFoundationModelsDataSource_basic (19.02s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/bedrock    22.119s
```
