### PR TITLE
Add `ipv6_allowed_for_dual_stack` field for lambda function

### DIFF
--- a/.changelog/34045.txt
+++ b/.changelog/34045.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_lambda_function: Added `ipv6_allowed_for_dual_stack` field to support outbound ipv6 traffic on dual-stack subnets
+```

--- a/.changelog/34045.txt
+++ b/.changelog/34045.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_lambda_function: Added `ipv6_allowed_for_dual_stack` argument
+resource/aws_lambda_function: Add `vpc_config.ipv6_allowed_for_dual_stack` argument
 ```

--- a/.changelog/34045.txt
+++ b/.changelog/34045.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_lambda_function: Added `ipv6_allowed_for_dual_stack` field to support outbound ipv6 traffic on dual-stack subnets
+resource/aws_lambda_function: Added `ipv6_allowed_for_dual_stack` argument
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ENHANCEMENTS:
 
+* resource/aws_config_config_rule: Add `evaluation_mode` attribute ([#34033](https://github.com/hashicorp/terraform-provider-aws/issues/34033))
 * resource/aws_elasticache_replication_group: Add `ip_discovery` and `network_type` arguments ([#34019](https://github.com/hashicorp/terraform-provider-aws/issues/34019))
 * resource/aws_lb: Add `dns_record_client_routing_policy` attribute to configure Availability Zonal DNS affinity on Network Load Balancer (NLB) ([#33992](https://github.com/hashicorp/terraform-provider-aws/issues/33992))
 

--- a/internal/service/lambda/flex.go
+++ b/internal/service/lambda/flex.go
@@ -45,6 +45,7 @@ func flattenVPCConfigResponse(s *types.VpcConfigResponse) []map[string]interface
 		return nil
 	}
 
+	settings["ipv6_allowed_for_dual_stack"] = aws.BoolValue(s.Ipv6AllowedForDualStack)
 	settings["subnet_ids"] = flex.FlattenStringValueSet(s.SubnetIds)
 	settings["security_group_ids"] = flex.FlattenStringValueSet(s.SecurityGroupIds)
 	if s.VpcId != nil {

--- a/internal/service/lambda/function_test.go
+++ b/internal/service/lambda/function_test.go
@@ -3937,7 +3937,7 @@ resource "aws_lambda_function" "test" {
   runtime       = "nodejs16.x"
 
   vpc_config {
-	ipv6_allowed_for_dual_stack = true
+    ipv6_allowed_for_dual_stack = true
     subnet_ids                  = [aws_subnet.subnet_for_lambda[0].id]
     security_group_ids          = [aws_security_group.sg_for_lambda.id]
   }

--- a/internal/service/lambda/function_test.go
+++ b/internal/service/lambda/function_test.go
@@ -3918,8 +3918,8 @@ resource "aws_lambda_function" "test" {
   runtime       = "nodejs16.x"
 
   vpc_config {
-    subnet_ids                  = [aws_subnet.subnet_for_lambda[0].id]
-    security_group_ids          = [aws_security_group.sg_for_lambda.id]
+    subnet_ids         = [aws_subnet.subnet_for_lambda[0].id]
+    security_group_ids = [aws_security_group.sg_for_lambda.id]
   }
 }
 `, rName))

--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -331,8 +331,9 @@ Snap start settings for low-latency startups. This feature is currently only sup
 
 For network connectivity to AWS resources in a VPC, specify a list of security groups and subnets in the VPC. When you connect a function to a VPC, it can only access resources and the internet through that VPC. See [VPC Settings][7].
 
-~> **NOTE:** If both `subnet_ids` and `security_group_ids` are empty then `vpc_config` is considered to be empty or unset.
+~> **NOTE:** If `subnet_ids`, `security_group_ids` and `ipv6_allowed_for_dual_stack` are empty then `vpc_config` is considered to be empty or unset.
 
+* `ipv6_allowed_for_dual_stack` - (Optional) Allows outbound IPv6 traffic on VPC functions that are connected to dual-stack subnets. Default is `false`.
 * `security_group_ids` - (Required) List of security group IDs associated with the Lambda function.
 * `subnet_ids` - (Required) List of subnet IDs associated with the Lambda function.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR adds support for the `ipv6_allowed_for_dual_stack` field on the `aws_lambda_function` resource.

This allows outbound IPv6 traffic on VPC functions that are connected to dual-stack subnets.

Note to the reviewer, I wasn't able to run all tests within the `TestAccLambdaFunction_` suite because of a VPC quota within my project.
 
### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/33922

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
terraform-provider-aws git:(f/add-lambda-ipv6-dual-stack-field) ✗ make testacc TESTS=TestAccLambdaFunction_ipv6AllowedForDualStack PKG=lambda
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaFunction_ipv6AllowedForDualStack'  -timeout 360m
=== RUN   TestAccLambdaFunction_ipv6AllowedForDualStack
=== PAUSE TestAccLambdaFunction_ipv6AllowedForDualStack
=== CONT  TestAccLambdaFunction_ipv6AllowedForDualStack
--- PASS: TestAccLambdaFunction_ipv6AllowedForDualStack (784.57s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     786.716s

...
```
