### PR TITLE
Create user group data sources

### DIFF
--- a/internal/service/cognitoidp/service_package_gen.go
+++ b/internal/service/cognitoidp/service_package_gen.go
@@ -33,6 +33,16 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePackageSDKDataSource {
 	return []*types.ServicePackageSDKDataSource{
 		{
+			Factory:  DataSourceUserGroup,
+			TypeName: "aws_cognito_user_group",
+			Name:     "User Group",
+		},
+		{
+			Factory:  DataSourceUserGroups,
+			TypeName: "aws_cognito_user_groups",
+			Name:     "User Groups",
+		},
+		{
 			Factory:  DataSourceUserPoolClient,
 			TypeName: "aws_cognito_user_pool_client",
 		},

--- a/internal/service/cognitoidp/user_group_data_source.go
+++ b/internal/service/cognitoidp/user_group_data_source.go
@@ -1,0 +1,84 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cognitoidp
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKDataSource("aws_cognito_user_group", name="User Group")
+func DataSourceUserGroup() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceUserGroupRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validUserGroupName,
+			},
+			"user_pool_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validUserPoolID,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"precedence": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"role_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+const (
+	DSNameUserGroup = "User Group Data Source"
+)
+
+func dataSourceUserGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).CognitoIDPConn(ctx)
+
+	name := d.Get("name").(string)
+	userPoolId := d.Get("user_pool_id").(string)
+	params := &cognitoidentityprovider.GetGroupInput{
+		GroupName:  aws.String(name),
+		UserPoolId: aws.String(userPoolId),
+	}
+
+	log.Print("[DEBUG] Reading Cognito User Group")
+
+	resp, err := conn.GetGroupWithContext(ctx, params)
+	if tfresource.NotFound(err) || err != nil {
+		return append(diags, create.DiagError(names.CognitoIDP, create.ErrActionReading, DSNameUserGroup, name, err)...)
+	}
+
+	d.SetId(
+		fmt.Sprintf("%s/%s", name, userPoolId),
+	)
+
+	d.Set("description", resp.Group.Description)
+	d.Set("precedence", resp.Group.Precedence)
+	d.Set("role_arn", resp.Group.RoleArn)
+	return diags
+}

--- a/internal/service/cognitoidp/user_group_data_source_test.go
+++ b/internal/service/cognitoidp/user_group_data_source_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cognitoidp_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccCognitoIDPUserGroupDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_cognito_user_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIdentityProvider(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, cognitoidentityprovider.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserGroupDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserGroupDataSourceConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "description", "test"),
+				),
+			},
+		},
+	})
+}
+
+func testAccUserGroupDataSourceConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cognito_user_pool" "test" {
+  name = %[1]q
+}
+
+resource "aws_cognito_user_group" "test" {
+  name         = %[1]q
+  user_pool_id = aws_cognito_user_pool.test.id
+  description  = "test"
+}
+
+data "aws_cognito_user_group" "test" {
+  name         = aws_cognito_user_group.test.name
+  user_pool_id = aws_cognito_user_group.test.user_pool_id
+}
+`, rName)
+}

--- a/internal/service/cognitoidp/user_groups_data_source.go
+++ b/internal/service/cognitoidp/user_groups_data_source.go
@@ -1,0 +1,93 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cognitoidp
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKDataSource("aws_cognito_user_groups", name="User Groups")
+func DataSourceUserGroups() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceUserGroupsRead,
+		Schema: map[string]*schema.Schema{
+			"user_pool_id": {
+				Type:         schema.TypeString,
+				ValidateFunc: validUserPoolID,
+				Required:     true,
+				ForceNew:     true,
+			},
+			"groups": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"precedence": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"role_arn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+const (
+	DSNameUserGroups = "User Groups Data Source"
+)
+
+func dataSourceUserGroupsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).CognitoIDPConn(ctx)
+
+	userPoolId := d.Get("user_pool_id").(string)
+
+	params := &cognitoidentityprovider.ListGroupsInput{
+		UserPoolId: aws.String(userPoolId),
+	}
+	resp, err := conn.ListGroupsWithContext(ctx, params)
+	if err != nil {
+		return append(diags, create.DiagError(names.CognitoIDP, create.ErrActionReading, DSNameUserGroups, userPoolId, err)...)
+	}
+
+	d.SetId(userPoolId)
+	if err := d.Set("groups", flattenUserGroups(ctx, resp.Groups)); err != nil {
+		return append(diags, create.DiagError(names.CognitoIDP, create.ErrActionSetting, DSNameUserGroups, d.Id(), err)...)
+	}
+	return diags
+}
+
+func flattenUserGroups(ctx context.Context, groups []*cognitoidentityprovider.GroupType) []interface{} {
+	results := make([]interface{}, 0, len(groups))
+	for _, group := range groups {
+		results = append(results, map[string]interface{}{
+			"name":        group.GroupName,
+			"description": group.Description,
+			"precedence":  group.Precedence,
+			"role_arn":    group.RoleArn,
+		})
+	}
+	return results
+}

--- a/internal/service/cognitoidp/user_groups_data_source_test.go
+++ b/internal/service/cognitoidp/user_groups_data_source_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cognitoidp_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccCognitoIDPUserGroupsDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_cognito_user_groups.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIdentityProvider(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, cognitoidentityprovider.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserGroupDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserGroupsDataSourceConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.#"),
+					resource.TestCheckResourceAttr(dataSourceName, "groups.0.name", fmt.Sprintf("%s-1", rName)),
+					resource.TestCheckResourceAttr(dataSourceName, "groups.1.name", fmt.Sprintf("%s-2", rName)),
+				),
+			},
+		},
+	})
+}
+
+func testAccUserGroupsDataSourceConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cognito_user_pool" "test" {
+  name = %q
+}
+
+resource "aws_cognito_user_group" "test_1" {
+  name         = "%s-1"
+  user_pool_id = aws_cognito_user_pool.test.id
+  description  = "test 1"
+}
+resource "aws_cognito_user_group" "test_2" {
+  name         = "%s-2"
+  user_pool_id = aws_cognito_user_pool.test.id
+  description  = "test 2"
+}
+
+data "aws_cognito_user_groups" "test" {
+  user_pool_id = aws_cognito_user_group.test_1.user_pool_id
+}
+`, rName, rName, rName)
+}

--- a/website/docs/d/cognito_user_group.html.markdown
+++ b/website/docs/d/cognito_user_group.html.markdown
@@ -1,0 +1,37 @@
+---
+subcategory: "Cognito IDP (Identity Provider)"
+layout: "aws"
+page_title: "AWS: aws_cognito_user_group"
+description: |-
+  Terraform data source for managing an AWS Cognito IDP (Identity Provider) User Group.
+---
+
+# Data Source: aws_cognito_user_group
+
+Terraform data source for managing an AWS Cognito IDP (Identity Provider) User Group.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_cognito_user_group" "example" {
+  user_pool_id = "us-west-2_aaaaaaaaa"
+  name         = "example"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `name` - (Required) Name of the user group.
+* `user_pool_id` - (Required) User pool the client belongs to.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `description` - The description of the user group.
+* `precedence` - The precedence of the user group.
+* `role_arn` - The ARN of the IAM role to be associated with the user group.

--- a/website/docs/d/cognito_user_groups.html.markdown
+++ b/website/docs/d/cognito_user_groups.html.markdown
@@ -1,0 +1,48 @@
+---
+subcategory: "Cognito IDP (Identity Provider)"
+layout: "aws"
+page_title: "AWS: aws_cognito_user_groups"
+description: |-
+  Terraform data source for managing an AWS Cognito IDP (Identity Provider) User Groups.
+---
+<!---
+TIP: A few guiding principles for writing documentation:
+1. Use simple language while avoiding jargon and figures of speech.
+2. Focus on brevity and clarity to keep a reader's attention.
+3. Use active voice and present tense whenever you can.
+4. Document your feature as it exists now; do not mention the future or past if you can help it.
+5. Use accessible and inclusive language.
+--->
+
+# Data Source: aws_cognito_user_groups
+
+Terraform data source for managing an AWS Cognito IDP (Identity Provider) User Groups.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_cognito_user_groups" "example" {
+  user_pool_id = "us-west-2_aaaaaaaaa"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `user_pool_id` - (Required) User pool the client belongs to.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `arn` - ARN of the User Groups. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+* `groups` - list of groups [Detailed below](#group).
+
+### group
+
+* `description` - The description of the user group.
+* `precedence` - The precedence of the user group.
+* `role_arn` - The ARN of the IAM role to be associated with the user group.


### PR DESCRIPTION
### Description
Creates data sources to get an individual user group or a list of the user groups.

### Relations
Closes #34024


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
# TF_ACC=1 make testacc TESTS=TestAccCognitoIDPUserGroupDataSource_basic PKG=cognitoidp 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cognitoidp/... -v -count 1 -parallel 20 -run='TestAccCognitoIDPUserGroupDataSource_basic'  -timeout 360m
=== RUN   TestAccCognitoIDPUserGroupDataSource_basic
=== PAUSE TestAccCognitoIDPUserGroupDataSource_basic
=== CONT  TestAccCognitoIDPUserGroupDataSource_basic
--- PASS: TestAccCognitoIDPUserGroupDataSource_basic (20.93s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp 23.158s

# TF_ACC=1 make testacc TESTS=TestAccCognitoIDPUserGroupsDataSource_basic PKG=cognitoidp   
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cognitoidp/... -v -count 1 -parallel 20 -run='TestAccCognitoIDPUserGroupsDataSource_basic'  -timeout 360m
=== RUN   TestAccCognitoIDPUserGroupsDataSource_basic
=== PAUSE TestAccCognitoIDPUserGroupsDataSource_basic
=== CONT  TestAccCognitoIDPUserGroupsDataSource_basic
--- PASS: TestAccCognitoIDPUserGroupsDataSource_basic (20.39s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp 22.588s

```
