### PR TITLE
[aws_dms_s3_endpoint] Remove the default value of `false` for `add_trailing_padding_character`

### DIFF
--- a/.changelog/32698.txt
+++ b/.changelog/32698.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_dms_s3_endpoint: Remove the default value of `false` for `add_trailing_padding_character`.
+resource/aws_dms_s3_endpoint: Don't send the default value of `false` for `add_trailing_padding_character` to maintain compatability with older ((pre-3.4.7)[https://docs.aws.amazon.com/dms/latest/userguide/CHAP_ReleaseNotes.html#CHAP_ReleaseNotes.DMS347]) DMS engine versions
 ```

--- a/.changelog/32698.txt
+++ b/.changelog/32698.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dms_s3_endpoint: Remove the default value of `false` for `add_trailing_padding_character`.
+```

--- a/.changelog/32698.txt
+++ b/.changelog/32698.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_dms_s3_endpoint: Don't send the default value of `false` for `add_trailing_padding_character` to maintain compatability with older ((pre-3.4.7)[https://docs.aws.amazon.com/dms/latest/userguide/CHAP_ReleaseNotes.html#CHAP_ReleaseNotes.DMS347]) DMS engine versions
+resource/aws_dms_s3_endpoint: Don't send the default value of `false` for `add_trailing_padding_character` to maintain compatibility with older ((pre-3.4.7)[https://docs.aws.amazon.com/dms/latest/userguide/CHAP_ReleaseNotes.html#CHAP_ReleaseNotes.DMS347]) DMS engine versions
 ```

--- a/internal/service/dms/s3_endpoint.go
+++ b/internal/service/dms/s3_endpoint.go
@@ -576,8 +576,8 @@ func s3Settings(d *schema.ResourceData, target bool) *dms.S3Settings {
 		s3s.AddColumnName = aws.Bool(v)
 	}
 
-	if v, ok := d.Get("add_trailing_padding_character").(bool); ok && target { // target
-		s3s.AddTrailingPaddingCharacter = aws.Bool(v)
+	if v, ok := d.GetOk("add_trailing_padding_character"); ok && target { // target
+		s3s.AddTrailingPaddingCharacter = aws.Bool(v.(bool))
 	}
 
 	if v, ok := d.GetOk("bucket_folder"); ok {


### PR DESCRIPTION
### Description

Removes the default `add_trailing_padding_character` attribute for `aws_dms_s3_endpoint` resources. This default was previously `false`, but will now result in no value being specified (relying AWS's server-side default of `false`). 

This fixes an incompatibility with old versions of the DMS engine (<3.4.7), which raise an error when this attribute is defined. Behavior will remain unchanged for DMS versions >=3.4.7.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #32698 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

- [AWS DMS release notes](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_ReleaseNotes.html#CHAP_ReleaseNotes.DMS347), showing the addition of the `AddTrailingPaddingCharacter` option in 3.4.7.

- [AWS DMS S3Settings documentation](https://docs.aws.amazon.com/dms/latest/APIReference/API_S3Settings.html), showing the default value of `false` if no `AddTrailingPaddingCharacter` option is specified.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS='TestAccDMSS3Endpoint*' PKG=dms
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/dms/... -v -count 1 -parallel 20 -run='TestAccDMSS3Endpoint*'  -timeout 360m
=== RUN   TestAccDMSS3Endpoint_basic
=== PAUSE TestAccDMSS3Endpoint_basic
=== RUN   TestAccDMSS3Endpoint_update
=== PAUSE TestAccDMSS3Endpoint_update
=== RUN   TestAccDMSS3Endpoint_simple
=== PAUSE TestAccDMSS3Endpoint_simple
=== RUN   TestAccDMSS3Endpoint_sourceSimple
=== PAUSE TestAccDMSS3Endpoint_sourceSimple
=== RUN   TestAccDMSS3Endpoint_source
=== PAUSE TestAccDMSS3Endpoint_source
=== RUN   TestAccDMSS3Endpoint_detachTargetOnLobLookupFailureParquet
=== PAUSE TestAccDMSS3Endpoint_detachTargetOnLobLookupFailureParquet
=== CONT  TestAccDMSS3Endpoint_basic
=== CONT  TestAccDMSS3Endpoint_sourceSimple
=== CONT  TestAccDMSS3Endpoint_simple
=== CONT  TestAccDMSS3Endpoint_detachTargetOnLobLookupFailureParquet
=== CONT  TestAccDMSS3Endpoint_source
=== CONT  TestAccDMSS3Endpoint_update
--- PASS: TestAccDMSS3Endpoint_basic (338.94s)
--- PASS: TestAccDMSS3Endpoint_simple (363.90s)
--- PASS: TestAccDMSS3Endpoint_sourceSimple (371.75s)
--- PASS: TestAccDMSS3Endpoint_source (423.80s)
--- PASS: TestAccDMSS3Endpoint_update (467.55s)
--- PASS: TestAccDMSS3Endpoint_detachTargetOnLobLookupFailureParquet (539.25s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dms        541.464s

```
