### PR TITLE
Neptune slow query logs cloudwatch export

### DIFF
--- a/.changelog/34053.txt
+++ b/.changelog/34053.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_neptune_cluster: Add `slowquery` as a valid `enable_cloudwatch_logs_exports` value
+```

--- a/internal/service/neptune/cluster.go
+++ b/internal/service/neptune/cluster.go
@@ -33,7 +33,8 @@ const (
 	// A constant for the supported CloudwatchLogsExports types
 	// is not currently available in the AWS sdk-for-go
 	// https://docs.aws.amazon.com/sdk-for-go/api/service/neptune/#pkg-constants
-	cloudWatchLogsExportsAudit = "audit"
+	cloudWatchLogsExportsAudit     = "audit"
+	cloudWatchLogsExportsSlowQuery = "slowquery"
 
 	DefaultPort = 8182
 
@@ -129,6 +130,7 @@ func ResourceCluster() *schema.Resource {
 					Type: schema.TypeString,
 					ValidateFunc: validation.StringInSlice([]string{
 						cloudWatchLogsExportsAudit,
+						cloudWatchLogsExportsSlowQuery,
 					}, false),
 				},
 			},

--- a/internal/service/neptune/cluster_test.go
+++ b/internal/service/neptune/cluster_test.go
@@ -469,6 +469,14 @@ func TestAccNeptuneCluster_updateCloudWatchLogsExports(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccClusterConfig_cloudWatchLogsExports(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(ctx, resourceName, &dbCluster),
+					resource.TestCheckResourceAttr(resourceName, "enable_cloudwatch_logs_exports.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "enable_cloudwatch_logs_exports.*", "slowquery"),
+				),
+			},
+			{
 				Config: testAccClusterConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &dbCluster),

--- a/internal/service/neptune/cluster_test.go
+++ b/internal/service/neptune/cluster_test.go
@@ -464,15 +464,8 @@ func TestAccNeptuneCluster_updateCloudWatchLogsExports(t *testing.T) {
 				Config: testAccClusterConfig_cloudWatchLogsExports(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &dbCluster),
-					resource.TestCheckResourceAttr(resourceName, "enable_cloudwatch_logs_exports.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "enable_cloudwatch_logs_exports.#", "2"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "enable_cloudwatch_logs_exports.*", "audit"),
-				),
-			},
-			{
-				Config: testAccClusterConfig_cloudWatchLogsExports(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &dbCluster),
-					resource.TestCheckResourceAttr(resourceName, "enable_cloudwatch_logs_exports.#", "1"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "enable_cloudwatch_logs_exports.*", "slowquery"),
 				),
 			},
@@ -1212,7 +1205,7 @@ resource "aws_neptune_cluster" "test" {
   cluster_identifier             = %[1]q
   availability_zones             = local.availability_zone_names
   skip_final_snapshot            = true
-  enable_cloudwatch_logs_exports = ["audit"]
+  enable_cloudwatch_logs_exports = ["audit", "slowquery"]
 
   neptune_cluster_parameter_group_name = "default.neptune1.2"
 }

--- a/website/docs/cdktf/python/r/neptune_cluster.html.markdown
+++ b/website/docs/cdktf/python/r/neptune_cluster.html.markdown
@@ -59,7 +59,7 @@ This resource supports the following arguments:
 * `cluster_identifier` - (Optional, Forces new resources) The cluster identifier. If omitted, Terraform will assign a random, unique identifier.
 * `cluster_identifier_prefix` - (Optional, Forces new resource) Creates a unique cluster identifier beginning with the specified prefix. Conflicts with `cluster_identifier`.
 * `copy_tags_to_snapshot` - (Optional) If set to true, tags are copied to any snapshot of the DB cluster that is created.
-* `enable_cloudwatch_logs_exports` - (Optional) A list of the log types this DB cluster is configured to export to Cloudwatch Logs. Currently only supports `audit`.
+* `enable_cloudwatch_logs_exports` - (Optional) A list of the log types this DB cluster is configured to export to Cloudwatch Logs. Currently only supports `audit` and `slowquery`.
 * `engine` - (Optional) The name of the database engine to be used for this Neptune cluster. Defaults to `neptune`.
 * `engine_version` - (Optional) The database engine version.
 * `final_snapshot_identifier` - (Optional) The name of your final Neptune snapshot when this Neptune cluster is deleted. If omitted, no final snapshot will be made.

--- a/website/docs/r/neptune_cluster.html.markdown
+++ b/website/docs/r/neptune_cluster.html.markdown
@@ -46,7 +46,7 @@ This resource supports the following arguments:
 * `cluster_identifier` - (Optional, Forces new resources) The cluster identifier. If omitted, Terraform will assign a random, unique identifier.
 * `cluster_identifier_prefix` - (Optional, Forces new resource) Creates a unique cluster identifier beginning with the specified prefix. Conflicts with `cluster_identifier`.
 * `copy_tags_to_snapshot` - (Optional) If set to true, tags are copied to any snapshot of the DB cluster that is created.
-* `enable_cloudwatch_logs_exports` - (Optional) A list of the log types this DB cluster is configured to export to Cloudwatch Logs. Currently only supports `audit`.
+* `enable_cloudwatch_logs_exports` - (Optional) A list of the log types this DB cluster is configured to export to Cloudwatch Logs. Currently only supports `audit` and `slowquery`.
 * `engine` - (Optional) The name of the database engine to be used for this Neptune cluster. Defaults to `neptune`.
 * `engine_version` - (Optional) The database engine version.
 * `final_snapshot_identifier` - (Optional) The name of your final Neptune snapshot when this Neptune cluster is deleted. If omitted, no final snapshot will be made.


### PR DESCRIPTION
### Description
Add the ability to export Neptune slow query logs to CloudWatch.
This can be done using the AWS CLI and Console, but fails validation when you try to set it using the module, which causes drifts.

### Relations
Non known relations

### References
AWS CLI instructions for setting this log export - https://docs.aws.amazon.com/neptune/latest/userguide/cloudwatch-logs.html#cloudwatch-slow-query-logs-cli


### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccNeptuneCluster_updateCloudWatchLogsExports PKG=neptune
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/neptune/... -v -count 1 -parallel 20 -run='TestAccNeptuneCluster_updateCloudWatchLogsExports'  -timeout 360m
=== RUN   TestAccNeptuneCluster_updateCloudWatchLogsExports
=== PAUSE TestAccNeptuneCluster_updateCloudWatchLogsExports
=== CONT  TestAccNeptuneCluster_updateCloudWatchLogsExports
--- PASS: TestAccNeptuneCluster_updateCloudWatchLogsExports (298.83s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/neptune    302.265s
...
```
