### PR TITLE
tags: check that `tags_all` is not null

### DIFF
--- a/.changelog/34073.txt
+++ b/.changelog/34073.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+provider/tags: Prevent crash when `tags_all` is null
+```

--- a/internal/provider/tags_interceptor.go
+++ b/internal/provider/tags_interceptor.go
@@ -56,8 +56,12 @@ func tagsUpdateFunc(ctx context.Context, d schemaResourceData, sp conns.ServiceP
 	stateTags := make(map[string]string)
 	if state := d.GetRawState(); !state.IsNull() && state.IsKnown() {
 		s := state.GetAttr(names.AttrTagsAll)
-		for k, v := range s.AsValueMap() {
-			stateTags[k] = v.AsString()
+		if !s.IsNull() {
+			for k, v := range s.AsValueMap() {
+				if !v.IsNull() {
+					stateTags[k] = v.AsString()
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Guard against `tags_all` being `null`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #33995

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTARGS='-run=TestAccVPC_ -short' PKG=vpc

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccVPC_ -short -timeout 360m
    vpc_test.go:1021: skipping long-running test in short mode
--- SKIP: TestAccVPC_IPAMIPv4BasicNetmask (0.00s)
    vpc_test.go:1048: skipping long-running test in short mode
--- SKIP: TestAccVPC_IPAMIPv4BasicExplicitCIDR (0.00s)
    vpc_test.go:1076: skipping long-running test in short mode
--- SKIP: TestAccVPC_IPAMIPv6 (0.00s)
=== NAME  TestAccVPC_assignGeneratedIPv6CIDRBlockWithNetworkBorderGroup
    ec2_availability_zone_data_source_test.go:222: skipping since no Local Zones are available
--- SKIP: TestAccVPC_assignGeneratedIPv6CIDRBlockWithNetworkBorderGroup (1.14s)
--- PASS: TestAccVPC_disappears (117.61s)
--- PASS: TestAccVPC_tags_null (137.96s)
--- PASS: TestAccVPC_basic (145.77s)
--- PASS: TestAccVPC_disabledDNSSupport (153.87s)
--- PASS: TestAccVPC_bothDNSOptionsSet (155.52s)
--- PASS: TestAccVPC_enableNetworkAddressUsageMetrics (155.52s)
--- PASS: TestAccVPC_tags_computed (209.88s)
--- PASS: TestAccVPC_DefaultTagsProviderAndResource_duplicateTag (216.09s)
--- PASS: TestAccVPC_updateDNSHostnames (234.94s)
--- PASS: TestAccVPC_DynamicResourceTags_ignoreChanges (249.18s)
--- PASS: TestAccVPC_DefaultTags_updateToResourceOnly (274.72s)
--- PASS: TestAccVPC_DefaultTags_updateToProviderOnly (296.44s)
--- PASS: TestAccVPC_tags (298.93s)
--- PASS: TestAccVPC_tenancy (302.11s)
--- PASS: TestAccVPC_assignGeneratedIPv6CIDRBlock (316.47s)
--- PASS: TestAccVPC_DynamicResourceTagsMergedWithLocals_ignoreChanges (201.36s)
--- PASS: TestAccVPC_DefaultTagsProviderAndResource_moveDuplicateTags (320.02s)
--- PASS: TestAccVPC_defaultAndIgnoreTags (181.90s)
--- PASS: TestAccVPC_ignoreTags (190.07s)
--- PASS: TestAccVPC_DefaultTags_zeroValue (374.31s)
--- PASS: TestAccVPC_DefaultTagsProviderAndResource_nonOverlappingTag (375.70s)
--- PASS: TestAccVPC_DefaultTagsProviderAndResource_overlappingTag (377.56s)
--- PASS: TestAccVPC_DefaultTags_providerOnlyTestAccVPC_DefaultTags_providerOnly (377.89s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	381.268s
```
