### PR TITLE
Update cloudformation_stack_set.html.markdown

### DIFF
--- a/website/docs/r/cloudformation_stack_set.html.markdown
+++ b/website/docs/r/cloudformation_stack_set.html.markdown
@@ -122,7 +122,7 @@ The `operation_preferences` configuration block supports the following arguments
 This resource exports the following attributes in addition to the arguments above:
 
 * `arn` - Amazon Resource Name (ARN) of the StackSet.
-* `id` - Name of the StackSet.
+* `name` - Name of the StackSet.
 * `stack_set_id` - Unique identifier of the StackSet.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 


### PR DESCRIPTION
### Description
## Original Word
`id`

## Issues in the Original Word
(1)
The `aws_cloudformation_stack_set_instance` resource is configured to use the `name` argument from the `aws_cloudformation_stack_set` reference. This configuration is seen in two sections: "Example IAM Setup in Target Account" and "Example Deployment across Organizations Account."

In both sections, you can find the following line:

```hcl
stack_set_name = aws_cloudformation_stack_set.example.name
```

This line specifies that the `stack_set_name` for the `aws_cloudformation_stack_set_instance` resource is derived from the `name` attribute of the `aws_cloudformation_stack_set.example` resource.

(2)
The CloudFormation API documentation provides the option to use either the stackset name or ID, while the AWS CLI documentation recommends using the stack set name exclusively.

## Final Word
`name`

Using `name` instead of `id` can improve readability because the `name` attribute often carries a more descriptive and human-friendly label or identifier for a resource, making the code easier to understand. `id` may be a system-generated or less human-readable identifier, which could be cryptic and less intuitive for someone reading the code. By using `name`, the code becomes more self-explanatory and user-friendly, enhancing the overall readability and comprehension of the configuration.

### Relations
Closes #0000

### References
- https://github.com/hashicorp/terraform-provider-aws/issues/34067
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack_set_instance
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack_set
- https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_CreateStackInstances.html
- https://docs.aws.amazon.com/cli/latest/reference/cloudformation/create-stack-set.html