### PR TITLE
[Breaking Change] Update id on `r/aws_cognito_user_in_group` to support import

### DIFF
--- a/internal/service/cognitoidp/user_in_group.go
+++ b/internal/service/cognitoidp/user_in_group.go
@@ -5,11 +5,12 @@ package cognitoidp
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -22,6 +23,9 @@ func ResourceUserInGroup() *schema.Resource {
 		CreateWithoutTimeout: resourceUserInGroupCreate,
 		ReadWithoutTimeout:   resourceUserInGroupRead,
 		DeleteWithoutTimeout: resourceUserInGroupDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 		Schema: map[string]*schema.Schema{
 			"group_name": {
 				Type:         schema.TypeString,
@@ -49,18 +53,14 @@ func resourceUserInGroupCreate(ctx context.Context, d *schema.ResourceData, meta
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPConn(ctx)
 
-	input := &cognitoidentityprovider.AdminAddUserToGroupInput{}
+	groupName := d.Get("group_name").(string)
+	userPoolId := d.Get("user_pool_id").(string)
+	username := d.Get("username").(string)
 
-	if v, ok := d.GetOk("group_name"); ok {
-		input.GroupName = aws.String(v.(string))
-	}
-
-	if v, ok := d.GetOk("user_pool_id"); ok {
-		input.UserPoolId = aws.String(v.(string))
-	}
-
-	if v, ok := d.GetOk("username"); ok {
-		input.Username = aws.String(v.(string))
+	input := &cognitoidentityprovider.AdminAddUserToGroupInput{
+		GroupName:  aws.String(groupName),
+		UserPoolId: aws.String(userPoolId),
+		Username:   aws.String(username),
 	}
 
 	_, err := conn.AdminAddUserToGroupWithContext(ctx, input)
@@ -69,8 +69,9 @@ func resourceUserInGroupCreate(ctx context.Context, d *schema.ResourceData, meta
 		return sdkdiag.AppendErrorf(diags, "adding user to group: %s", err)
 	}
 
-	//lintignore:R015 // Allow legacy unstable ID usage in managed resource
-	d.SetId(id.UniqueId())
+	d.SetId(
+		fmt.Sprintf("%s/%s/%s", userPoolId, groupName, username),
+	)
 
 	return append(diags, resourceUserInGroupRead(ctx, d, meta)...)
 }
@@ -79,9 +80,10 @@ func resourceUserInGroupRead(ctx context.Context, d *schema.ResourceData, meta i
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPConn(ctx)
 
-	groupName := d.Get("group_name").(string)
-	userPoolId := d.Get("user_pool_id").(string)
-	username := d.Get("username").(string)
+	id := strings.Split(d.Id(), "/")
+	userPoolId := id[0]
+	groupName := id[1]
+	username := id[2]
 
 	found, err := FindCognitoUserInGroup(ctx, conn, groupName, userPoolId, username)
 
@@ -92,6 +94,9 @@ func resourceUserInGroupRead(ctx context.Context, d *schema.ResourceData, meta i
 	if !found {
 		d.SetId("")
 	}
+	d.Set("group_name", groupName)
+	d.Set("user_pool_id", userPoolId)
+	d.Set("username", username)
 
 	return diags
 }

--- a/internal/service/cognitoidp/user_in_group_test.go
+++ b/internal/service/cognitoidp/user_in_group_test.go
@@ -46,6 +46,32 @@ func TestAccCognitoIDPUserInGroup_basic(t *testing.T) {
 	})
 }
 
+func TestAccCognitoIDPUserInGroup_import(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_cognito_user_in_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, cognitoidentityprovider.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserInGroupDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserInGroupConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserInGroupExists(ctx, resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccCognitoIDPUserInGroup_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/website/docs/r/cognito_user_in_group.html.markdown
+++ b/website/docs/r/cognito_user_in_group.html.markdown
@@ -53,3 +53,9 @@ The following arguments are required:
 ## Attribute Reference
 
 This resource exports no additional attributes.
+
+## Import
+
+```console
+% terraform import aws_cognito_user_in_group.example <user pool>/<group name>/<user name>
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Currently the `aws_cognito_user_in_group` doesn't support import because it is using the unique id. This PR modifies the id to use the required fields. This will allow import.

### Relations
Closes #31404

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% TF_ACC=1 make testacc TESTS=TestAccCognitoIDPUserInGroup_import PKG=cognitoidp
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cognitoidp/... -v -count 1 -parallel 20 -run='TestAccCognitoIDPUserInGroup_import'  -timeout 360m
=== RUN   TestAccCognitoIDPUserInGroup_import
=== PAUSE TestAccCognitoIDPUserInGroup_import
=== CONT  TestAccCognitoIDPUserInGroup_import
--- PASS: TestAccCognitoIDPUserInGroup_import (34.32s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp 36.531s
```
