### PR TITLE
ci: library version check github action

### DIFF
--- a/.github/workflows/library_versions.yml
+++ b/.github/workflows/library_versions.yml
@@ -1,0 +1,63 @@
+name: Preferred Library Version Check
+
+# This check verifies that preferred library versions are used in development
+# of net-new resources. This is done by inspecting the pull request diff for any
+# occurrence of a non-preferred library name, typically seen in an import block.
+# At this time the only check is for AWS SDK for Go V1, but it may be extended
+# in the future. This check will not fail if a non-preferred library version is
+# detected, but will leave a comment on the pull request linking to the relevant
+# contributor documentation.
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  diffgrep:
+    runs-on: ubuntu-latest
+    outputs:
+      found: ${{ steps.diff.outputs.found }}
+    steps:
+      # checkout base ref
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+
+      # checkout pull request head ref
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Check diff for AWS SDK Go V1
+        id: diff
+        run: |
+          git diff origin/${{ github.event.pull_request.base.ref }} internal/ |
+            (grep "github.com/aws/aws-sdk-go/" && echo "found=true" >> "$GITHUB_OUTPUT") || echo "found=false" >> "$GITHUB_OUTPUT"
+
+  comment:
+    runs-on: ubuntu-latest
+    needs: diffgrep
+    if: needs.diffgrep.outputs.found == 'true'
+    steps:
+      - name: Find Existing PR Comment
+        id: prc
+        uses: peter-evans/find-comment@a54c31d7fa095754bfef525c0c8e5e5674c4b4b1 # v2.4.0
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: "Please note that typically Go dependency changes"
+
+      - run: echo ${{ steps.prc.outputs.comment-id }}
+
+      - name: PR Comment
+        if: steps.prc.outputs.comment-id == ''
+        uses: peter-evans/create-or-update-comment@23ff15729ef2fc348714a3bb66d2f655ca9066f2 # v3.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |-
+            Thank you for your contribution! :rocket:
+
+            A new usage of AWS SDK for Go V1 was detected. Please prefer AWS SDK for Go V2 for all net-new services. If this is an enhancement or bug fix to an existing AWS SDK Go V1 based resource, this comment can be safely ignored.
+
+            For additional information refer to the [AWS SDK for Go Versions](https://hashicorp.github.io/terraform-provider-aws/aws-go-sdk-versions/) page in the contributor guide.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds a new CI check which inspects a pull request diff for references to non-preferred libraries (ie. AWS SDK for Go V1). The check does not fail if references are detected, but leaves an automated comment similar to the check for modifications to `go.mod`/`go.sum`.

Successfully tested the `diffgrep` job in a private repo, and the `comment` job is largely copied from an existing workflow.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #32917 

