### PR TITLE
r/aws_autoscaling_group: launch_template name update

### DIFF
--- a/.changelog/34086.txt
+++ b/.changelog/34086.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_autoscaling_group: Fix error when `launch_template` name is updated.
+```

--- a/internal/service/autoscaling/consts.go
+++ b/internal/service/autoscaling/consts.go
@@ -85,3 +85,7 @@ const (
 	TrafficSourceStateRemoving  = "Removing"
 	TrafficSourceStateRemoved   = "Removed"
 )
+
+const (
+	launchTemplateIDUnknown = "unknown"
+)

--- a/internal/service/autoscaling/group.go
+++ b/internal/service/autoscaling/group.go
@@ -877,33 +877,30 @@ func launchTemplateCustomDiff(baseAttribute, subAttribute string) schema.Customi
 	return func(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
 		if diff.HasChange(subAttribute) {
 			n := diff.Get(baseAttribute)
-			nmip, ok := n.([]interface{})
+			ba, ok := n.([]interface{})
 			if !ok {
 				return nil
 			}
 
 			if baseAttribute == "launch_template" {
-				launchTemplate := nmip[0].(map[string]interface{})
+				launchTemplate := ba[0].(map[string]interface{})
 				launchTemplate["id"] = launchTemplateIDUnknown
 
-				if err := diff.SetNew(baseAttribute, nmip); err != nil {
+				if err := diff.SetNew(baseAttribute, ba); err != nil {
 					return err
 				}
 			}
 
 			if baseAttribute == "mixed_instances_policy" {
-				launchTemplate := nmip[0].(map[string]interface{})["launch_template"].([]interface{})[0].(map[string]interface{})["launch_template_specification"].([]interface{})[0]
+				launchTemplate := ba[0].(map[string]interface{})["launch_template"].([]interface{})[0].(map[string]interface{})["launch_template_specification"].([]interface{})[0]
 				launchTemplateSpecification := launchTemplate.(map[string]interface{})
 
 				launchTemplateSpecification["launch_template_id"] = launchTemplateIDUnknown
 
-				launchTemplate = launchTemplateSpecification
-
-				if err := diff.SetNew(baseAttribute, nmip); err != nil {
+				if err := diff.SetNew(baseAttribute, ba); err != nil {
 					return err
 				}
 			}
-
 		}
 
 		return nil

--- a/internal/service/autoscaling/group.go
+++ b/internal/service/autoscaling/group.go
@@ -904,7 +904,6 @@ func launchTemplateCustomDiff(baseAttribute, subAttribute string) schema.Customi
 			}
 
 			if baseAttribute == "mixed_instances_policy" && strings.Contains(subAttribute, "override") {
-				log.Printf("[DEBUG] we got here")
 				launchTemplate := ba[0].(map[string]interface{})["launch_template"].([]interface{})[0].(map[string]interface{})["override"].([]interface{})
 
 				for i := range launchTemplate {

--- a/internal/service/autoscaling/group.go
+++ b/internal/service/autoscaling/group.go
@@ -884,7 +884,7 @@ func launchTemplateCustomDiff(baseAttribute, subAttribute string) schema.Customi
 
 			if baseAttribute == "launch_template" {
 				launchTemplate := nmip[0].(map[string]interface{})
-				launchTemplate["id"] = "unknown"
+				launchTemplate["id"] = launchTemplateIDUnknown
 
 				if err := diff.SetNew(baseAttribute, nmip); err != nil {
 					return err
@@ -895,7 +895,7 @@ func launchTemplateCustomDiff(baseAttribute, subAttribute string) schema.Customi
 				launchTemplate := nmip[0].(map[string]interface{})["launch_template"].([]interface{})[0].(map[string]interface{})["launch_template_specification"].([]interface{})[0]
 				launchTemplateSpecification := launchTemplate.(map[string]interface{})
 
-				launchTemplateSpecification["launch_template_id"] = "unknown"
+				launchTemplateSpecification["launch_template_id"] = launchTemplateIDUnknown
 
 				launchTemplate = launchTemplateSpecification
 
@@ -3070,7 +3070,7 @@ func expandLaunchTemplateSpecificationForMixedInstancesPolicy(tfMap map[string]i
 	// API returns both ID and name, which Terraform saves to state. Next update returns:
 	// ValidationError: Valid requests must contain either launchTemplateId or LaunchTemplateName
 	// Prefer the ID if we have both.
-	if v, ok := tfMap["launch_template_id"]; ok && v != "" && v != "unknown" {
+	if v, ok := tfMap["launch_template_id"]; ok && v != "" && v != launchTemplateIDUnknown {
 		apiObject.LaunchTemplateId = aws.String(v.(string))
 	} else if v, ok := tfMap["launch_template_name"]; ok && v != "" {
 		apiObject.LaunchTemplateName = aws.String(v.(string))
@@ -3092,7 +3092,7 @@ func expandLaunchTemplateSpecification(tfMap map[string]interface{}) *autoscalin
 
 	// DescribeAutoScalingGroups returns both name and id but LaunchTemplateSpecification
 	// allows only one of them to be set.
-	if v, ok := tfMap["id"]; ok && v != "" && v != "unknown" {
+	if v, ok := tfMap["id"]; ok && v != "" && v != launchTemplateIDUnknown {
 		apiObject.LaunchTemplateId = aws.String(v.(string))
 	} else if v, ok := tfMap["name"]; ok && v != "" {
 		apiObject.LaunchTemplateName = aws.String(v.(string))

--- a/internal/service/autoscaling/group.go
+++ b/internal/service/autoscaling/group.go
@@ -894,7 +894,6 @@ func launchTemplateCustomDiff(baseAttribute, subAttribute string) schema.Customi
 			if baseAttribute == "mixed_instances_policy" {
 				launchTemplate := ba[0].(map[string]interface{})["launch_template"].([]interface{})[0].(map[string]interface{})["launch_template_specification"].([]interface{})[0]
 				launchTemplateSpecification := launchTemplate.(map[string]interface{})
-
 				launchTemplateSpecification["launch_template_id"] = launchTemplateIDUnknown
 
 				if err := diff.SetNew(baseAttribute, ba); err != nil {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #33912.
Closes https://github.com/hashicorp/terraform-provider-aws/pull/34027.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTARGS='-run=TestAccAutoScalingGroup_basic\|TestAccAutoScalingGroup_disappears\|TestAccAutoScalingGroup_LaunchTemplate_update\|TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateLaunchTemplateSpecification_launchTemplateName' PKG=autoscaling

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/autoscaling/... -v -count 1 -parallel 20  -run=TestAccAutoScalingGroup_basic\|TestAccAutoScalingGroup_disappears\|TestAccAutoScalingGroup_LaunchTemplate_update\|TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateLaunchTemplateSpecification_launchTemplateName -timeout 360m
--- PASS: TestAccAutoScalingGroup_disappears (115.66s)
--- PASS: TestAccAutoScalingGroup_basic (130.35s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateLaunchTemplateSpecification_launchTemplateName (210.53s)
--- PASS: TestAccAutoScalingGroup_LaunchTemplate_update (522.29s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/autoscaling	525.518s
```
