### PR TITLE
Additional Framework helpers

### DIFF
--- a/internal/framework/flex/bool.go
+++ b/internal/framework/flex/bool.go
@@ -9,12 +9,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 )
 
 // BoolFromFramework converts a Framework Bool value to a bool pointer.
 // A null Bool is converted to a nil bool pointer.
-func BoolFromFramework(ctx context.Context, v types.Bool) *bool {
+func BoolFromFramework(ctx context.Context, v basetypes.BoolValuable) *bool {
 	var output *bool
 
 	panicOnError(Expand(ctx, v, &output))

--- a/internal/framework/flex/int.go
+++ b/internal/framework/flex/int.go
@@ -8,11 +8,12 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
 // Int64FromFramework converts a Framework Int64 value to an int64 pointer.
 // A null Int64 is converted to a nil int64 pointer.
-func Int64FromFramework(ctx context.Context, v types.Int64) *int64 {
+func Int64FromFramework(ctx context.Context, v basetypes.Int64Valuable) *int64 {
 	var output *int64
 
 	panicOnError(Expand(ctx, v, &output))

--- a/internal/framework/flex/list.go
+++ b/internal/framework/flex/list.go
@@ -9,11 +9,12 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/slices"
 )
 
-func ExpandFrameworkStringList(ctx context.Context, v types.List) []*string {
+func ExpandFrameworkStringList(ctx context.Context, v basetypes.ListValuable) []*string {
 	var output []*string
 
 	panicOnError(Expand(ctx, v, &output))
@@ -21,7 +22,7 @@ func ExpandFrameworkStringList(ctx context.Context, v types.List) []*string {
 	return output
 }
 
-func ExpandFrameworkStringValueList(ctx context.Context, v types.List) []string {
+func ExpandFrameworkStringValueList(ctx context.Context, v basetypes.ListValuable) []string {
 	var output []string
 
 	panicOnError(Expand(ctx, v, &output))

--- a/internal/framework/flex/map.go
+++ b/internal/framework/flex/map.go
@@ -8,9 +8,10 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
-func ExpandFrameworkStringMap(ctx context.Context, v types.Map) map[string]*string {
+func ExpandFrameworkStringMap(ctx context.Context, v basetypes.MapValuable) map[string]*string {
 	var output map[string]*string
 
 	panicOnError(Expand(ctx, v, &output))
@@ -18,7 +19,7 @@ func ExpandFrameworkStringMap(ctx context.Context, v types.Map) map[string]*stri
 	return output
 }
 
-func ExpandFrameworkStringValueMap(ctx context.Context, v types.Map) map[string]string {
+func ExpandFrameworkStringValueMap(ctx context.Context, v basetypes.MapValuable) map[string]string {
 	var output map[string]string
 
 	panicOnError(Expand(ctx, v, &output))

--- a/internal/framework/flex/set.go
+++ b/internal/framework/flex/set.go
@@ -9,9 +9,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
-func ExpandFrameworkStringSet(ctx context.Context, v types.Set) []*string {
+func ExpandFrameworkStringSet(ctx context.Context, v basetypes.SetValuable) []*string {
 	var output []*string
 
 	panicOnError(Expand(ctx, v, &output))
@@ -19,7 +20,7 @@ func ExpandFrameworkStringSet(ctx context.Context, v types.Set) []*string {
 	return output
 }
 
-func ExpandFrameworkStringValueSet(ctx context.Context, v types.Set) Set[string] {
+func ExpandFrameworkStringValueSet(ctx context.Context, v basetypes.SetValuable) Set[string] {
 	var output []string
 
 	panicOnError(Expand(ctx, v, &output))

--- a/internal/framework/flex/string.go
+++ b/internal/framework/flex/string.go
@@ -9,12 +9,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 )
 
 // StringFromFramework converts a Framework String value to a string pointer.
 // A null String is converted to a nil string pointer.
-func StringFromFramework(ctx context.Context, v types.String) *string {
+func StringFromFramework(ctx context.Context, v basetypes.StringValuable) *string {
 	var output *string
 
 	panicOnError(Expand(ctx, v, &output))
@@ -66,14 +67,6 @@ func StringToFramework(ctx context.Context, v *string) types.String {
 // A nil string pointer is converted to an empty String.
 func StringToFrameworkLegacy(_ context.Context, v *string) types.String {
 	return types.StringValue(aws.ToString(v))
-}
-
-func ARNStringFromFramework(ctx context.Context, v fwtypes.ARN) *string {
-	var output *string
-
-	panicOnError(Expand(ctx, v, &output))
-
-	return output
 }
 
 func StringToFrameworkARN(ctx context.Context, v *string, diags *diag.Diagnostics) fwtypes.ARN {

--- a/internal/framework/flex/string.go
+++ b/internal/framework/flex/string.go
@@ -25,7 +25,7 @@ func StringFromFramework(ctx context.Context, v basetypes.StringValuable) *strin
 
 // StringFromFramework converts a single Framework String value to a string pointer slice.
 // A null String is converted to a nil slice.
-func StringSliceFromFramework(ctx context.Context, v types.String) []*string {
+func StringSliceFromFramework(ctx context.Context, v basetypes.StringValuable) []*string {
 	if v.IsNull() || v.IsUnknown() {
 		return nil
 	}
@@ -69,10 +69,17 @@ func StringToFrameworkLegacy(_ context.Context, v *string) types.String {
 	return types.StringValue(aws.ToString(v))
 }
 
+// StringToFrameworkARN converts a string pointer to a Framework custom ARN value.
+// A nil string pointer is converted to a null ARN.
+// If diags is nil, any errors cause a panic.
 func StringToFrameworkARN(ctx context.Context, v *string, diags *diag.Diagnostics) fwtypes.ARN {
 	var output fwtypes.ARN
 
-	diags.Append(Flatten(ctx, v, &output)...)
+	if diags == nil {
+		panicOnError(Flatten(ctx, v, &output))
+	} else {
+		diags.Append(Flatten(ctx, v, &output)...)
+	}
 
 	return output
 }

--- a/internal/framework/flex/string_test.go
+++ b/internal/framework/flex/string_test.go
@@ -227,7 +227,7 @@ func TestARNStringFromFramework(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got := flex.ARNStringFromFramework(context.Background(), test.input)
+			got := flex.StringFromFramework(context.Background(), test.input)
 
 			if diff := cmp.Diff(got, test.expected); diff != "" {
 				t.Errorf("unexpected diff (+wanted, -got): %s", diff)

--- a/internal/framework/types/arn.go
+++ b/internal/framework/types/arn.go
@@ -28,7 +28,8 @@ const (
 )
 
 var (
-	_ xattr.TypeWithValidate = ARNType
+	_ xattr.TypeWithValidate   = ARNType
+	_ basetypes.StringValuable = ARN{}
 )
 
 func (t arnType) TerraformType(_ context.Context) tftypes.Type {

--- a/internal/framework/types/cidr_block.go
+++ b/internal/framework/types/cidr_block.go
@@ -24,7 +24,8 @@ const (
 )
 
 var (
-	_ xattr.TypeWithValidate = CIDRBlockType
+	_ xattr.TypeWithValidate   = CIDRBlockType
+	_ basetypes.StringValuable = CIDRBlock{}
 )
 
 func (t cidrBlockType) TerraformType(_ context.Context) tftypes.Type {

--- a/internal/framework/types/duration.go
+++ b/internal/framework/types/duration.go
@@ -24,7 +24,8 @@ const (
 )
 
 var (
-	_ xattr.TypeWithValidate = DurationType
+	_ xattr.TypeWithValidate   = DurationType
+	_ basetypes.StringValuable = Duration{}
 )
 
 func (d durationType) TerraformType(_ context.Context) tftypes.Type {

--- a/internal/framework/types/regexp.go
+++ b/internal/framework/types/regexp.go
@@ -24,7 +24,8 @@ var (
 )
 
 var (
-	_ xattr.TypeWithValidate = RegexpType
+	_ xattr.TypeWithValidate   = RegexpType
+	_ basetypes.StringValuable = Regexp{}
 )
 
 func (t regexpType) TerraformType(_ context.Context) tftypes.Type {

--- a/internal/framework/validators/aws_account_id.go
+++ b/internal/framework/validators/aws_account_id.go
@@ -47,6 +47,6 @@ func (validator awsAccountIDValidator) ValidateString(ctx context.Context, reque
 //   - Is a string, which represents a valid AWS account ID.
 //
 // Null (unconfigured) and unknown (known after apply) values are skipped.
-func AWSAccountID() validator.String {
+func AWSAccountID() validator.String { // nosemgrep:ci.aws-in-func-name
 	return awsAccountIDValidator{}
 }

--- a/internal/framework/validators/aws_account_id.go
+++ b/internal/framework/validators/aws_account_id.go
@@ -1,0 +1,52 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validators
+
+import (
+	"context"
+
+	"github.com/YakDriver/regexache"
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+// awsAccountIDValidator validates that a string Attribute's value is a valid AWS account ID.
+type awsAccountIDValidator struct{}
+
+// Description describes the validation in plain text formatting.
+func (validator awsAccountIDValidator) Description(_ context.Context) string {
+	return "value must be a valid AWS account ID"
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (validator awsAccountIDValidator) MarkdownDescription(ctx context.Context) string {
+	return validator.Description(ctx)
+}
+
+// Validate performs the validation.
+func (validator awsAccountIDValidator) ValidateString(ctx context.Context, request validator.StringRequest, response *validator.StringResponse) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	// https://docs.aws.amazon.com/accounts/latest/reference/manage-acct-identifiers.html.
+	if !regexache.MustCompile(`^\d{12}$`).MatchString(request.ConfigValue.ValueString()) {
+		response.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
+			request.Path,
+			validator.Description(ctx),
+			request.ConfigValue.ValueString(),
+		))
+		return
+	}
+}
+
+// AWSAccountID returns a string validator which ensures that any configured
+// attribute value:
+//
+//   - Is a string, which represents a valid AWS account ID.
+//
+// Null (unconfigured) and unknown (known after apply) values are skipped.
+func AWSAccountID() validator.String {
+	return awsAccountIDValidator{}
+}

--- a/internal/framework/validators/aws_account_id_test.go
+++ b/internal/framework/validators/aws_account_id_test.go
@@ -1,0 +1,87 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validators_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	fwvalidators "github.com/hashicorp/terraform-provider-aws/internal/framework/validators"
+)
+
+func TestAWSAccountIDValidator(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		val                 types.String
+		expectedDiagnostics diag.Diagnostics
+	}
+	tests := map[string]testCase{
+		"unknown String": {
+			val: types.StringUnknown(),
+		},
+		"null String": {
+			val: types.StringNull(),
+		},
+		"invalid String": {
+			val: types.StringValue("test-value"),
+			expectedDiagnostics: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test"),
+					"Invalid Attribute Value",
+					`Attribute test value must be a valid AWS account ID, got: test-value`,
+				),
+			},
+		},
+		"valid AWS account ID": {
+			val: types.StringValue("123456789012"),
+		},
+		"too long AWS account ID": {
+			val: types.StringValue("1234567890123"),
+			expectedDiagnostics: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test"),
+					"Invalid Attribute Value",
+					`Attribute test value must be a valid AWS account ID, got: 1234567890123`,
+				),
+			},
+		},
+		"too short AWS account ID": {
+			val: types.StringValue("12345678901"),
+			expectedDiagnostics: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test"),
+					"Invalid Attribute Value",
+					`Attribute test value must be a valid AWS account ID, got: 12345678901`,
+				),
+			},
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			request := validator.StringRequest{
+				Path:           path.Root("test"),
+				PathExpression: path.MatchRoot("test"),
+				ConfigValue:    test.val,
+			}
+			response := validator.StringResponse{}
+			fwvalidators.AWSAccountID().ValidateString(ctx, request, &response)
+
+			if diff := cmp.Diff(response.Diagnostics, test.expectedDiagnostics); diff != "" {
+				t.Errorf("unexpected diagnostics difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/framework/validators/aws_account_id_test.go
+++ b/internal/framework/validators/aws_account_id_test.go
@@ -15,7 +15,7 @@ import (
 	fwvalidators "github.com/hashicorp/terraform-provider-aws/internal/framework/validators"
 )
 
-func TestAWSAccountIDValidator(t *testing.T) {
+func TestAWSAccountIDValidator(t *testing.T) { // nosemgrep:ci.aws-in-func-name
 	t.Parallel()
 
 	type testCase struct {

--- a/internal/service/batch/job_queue.go
+++ b/internal/service/batch/job_queue.go
@@ -132,7 +132,7 @@ func (r *resourceJobQueue) Create(ctx context.Context, request resource.CreateRe
 	}
 
 	if !data.SchedulingPolicyARN.IsNull() {
-		input.SchedulingPolicyArn = flex.ARNStringFromFramework(ctx, data.SchedulingPolicyARN)
+		input.SchedulingPolicyArn = flex.StringFromFramework(ctx, data.SchedulingPolicyARN)
 	}
 
 	output, err := conn.CreateJobQueueWithContext(ctx, &input)
@@ -229,13 +229,13 @@ func (r *resourceJobQueue) Update(ctx context.Context, request resource.UpdateRe
 	}
 
 	if !state.SchedulingPolicyARN.IsNull() {
-		input.SchedulingPolicyArn = flex.ARNStringFromFramework(ctx, state.SchedulingPolicyARN)
+		input.SchedulingPolicyArn = flex.StringFromFramework(ctx, state.SchedulingPolicyARN)
 		update = true
 	}
 
 	if !plan.SchedulingPolicyARN.Equal(state.SchedulingPolicyARN) {
 		if !plan.SchedulingPolicyARN.IsNull() || !plan.SchedulingPolicyARN.IsUnknown() {
-			input.SchedulingPolicyArn = flex.ARNStringFromFramework(ctx, plan.SchedulingPolicyARN)
+			input.SchedulingPolicyArn = flex.StringFromFramework(ctx, plan.SchedulingPolicyARN)
 
 			update = true
 		} else {

--- a/internal/service/cognitoidp/user_pool_client.go
+++ b/internal/service/cognitoidp/user_pool_client.go
@@ -706,10 +706,10 @@ func (ac *analyticsConfiguration) expand(ctx context.Context) *cognitoidentitypr
 		return nil
 	}
 	result := &cognitoidentityprovider.AnalyticsConfigurationType{
-		ApplicationArn: flex.ARNStringFromFramework(ctx, ac.ApplicationARN),
+		ApplicationArn: flex.StringFromFramework(ctx, ac.ApplicationARN),
 		ApplicationId:  flex.StringFromFramework(ctx, ac.ApplicationID),
 		ExternalId:     flex.StringFromFramework(ctx, ac.ExternalID),
-		RoleArn:        flex.ARNStringFromFramework(ctx, ac.RoleARN),
+		RoleArn:        flex.StringFromFramework(ctx, ac.RoleARN),
 		UserDataShared: flex.BoolFromFramework(ctx, ac.UserDataShared),
 	}
 

--- a/internal/service/globalaccelerator/accelerator_data_source.go
+++ b/internal/service/globalaccelerator/accelerator_data_source.go
@@ -6,7 +6,6 @@ package globalaccelerator
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/globalaccelerator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -150,11 +149,7 @@ func (d *dataSourceAccelerator) Read(ctx context.Context, request datasource.Rea
 
 	accelerator := results[0]
 	acceleratorARN := aws.StringValue(accelerator.AcceleratorArn)
-	if v, err := arn.Parse(acceleratorARN); err != nil {
-		response.Diagnostics.AddError("parsing ARN", err.Error())
-	} else {
-		data.ARN = fwtypes.ARNValue(v)
-	}
+	data.ARN = flex.StringToFrameworkARN(ctx, accelerator.AcceleratorArn, nil)
 	data.DnsName = flex.StringToFrameworkLegacy(ctx, accelerator.DnsName)
 	data.DualStackDNSName = flex.StringToFrameworkLegacy(ctx, accelerator.DualStackDnsName)
 	data.Enabled = flex.BoolToFrameworkLegacy(ctx, accelerator.Enabled)

--- a/internal/service/lexv2models/bot.go
+++ b/internal/service/lexv2models/bot.go
@@ -162,7 +162,7 @@ func (r *resourceBot) Create(ctx context.Context, req resource.CreateRequest, re
 		BotName:                 aws.String(plan.Name.ValueString()),
 		DataPrivacy:             dpInput,
 		IdleSessionTTLInSeconds: aws.Int32(int32(plan.IdleSessionTTLInSeconds.ValueInt64())),
-		RoleArn:                 flex.ARNStringFromFramework(ctx, plan.RoleARN),
+		RoleArn:                 flex.StringFromFramework(ctx, plan.RoleARN),
 		BotTags:                 getTagsIn(ctx),
 	}
 
@@ -295,7 +295,7 @@ func (r *resourceBot) Update(ctx context.Context, req resource.UpdateRequest, re
 			BotName:                 flex.StringFromFramework(ctx, plan.Name),
 			IdleSessionTTLInSeconds: aws.Int32(int32(plan.IdleSessionTTLInSeconds.ValueInt64())),
 			DataPrivacy:             dpInput,
-			RoleArn:                 flex.ARNStringFromFramework(ctx, plan.RoleARN),
+			RoleArn:                 flex.StringFromFramework(ctx, plan.RoleARN),
 		}
 
 		if !plan.Description.IsNull() {

--- a/internal/tfresource/retry.go
+++ b/internal/tfresource/retry.go
@@ -57,7 +57,7 @@ func RetryWhen(ctx context.Context, timeout time.Duration, f func() (interface{}
 	return output, nil
 }
 
-// RetryWhenAWSErrCodeEquals retries the specified function when it returns one of the specified AWS error code.
+// RetryWhenAWSErrCodeEquals retries the specified function when it returns one of the specified AWS error codes.
 func RetryWhenAWSErrCodeEquals(ctx context.Context, timeout time.Duration, f func() (interface{}, error), codes ...string) (interface{}, error) { // nosemgrep:ci.aws-in-func-name
 	return RetryWhen(ctx, timeout, f, func(err error) (bool, error) {
 		if tfawserr.ErrCodeEquals(err, codes...) || tfawserr_sdkv2.ErrCodeEquals(err, codes...) {
@@ -133,6 +133,17 @@ func RetryUntilEqual[T comparable](ctx context.Context, timeout time.Duration, t
 	}
 
 	return output, nil
+}
+
+// RetryWhenHTTPStatusCodeEquals retries the specified function when it returns one of the specified HTTP status codes.
+func RetryWhenHTTPStatusCodeEquals(ctx context.Context, timeout time.Duration, f func() (interface{}, error), statusCodes ...int) (interface{}, error) { // nosemgrep:ci.aws-in-func-name
+	return RetryWhen(ctx, timeout, f, func(err error) (bool, error) {
+		if tfawserr_sdkv2.ErrHTTPStatusCodeEquals(err, statusCodes...) {
+			return true, err
+		}
+
+		return false, err
+	})
 }
 
 var ErrFoundResource = errors.New(`found resource`)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Additional Terraform Plugin Framework helpers and changes.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #34034.

### Output from Acceptance Testing

```console
% go test ./internal/framework/...
?   	github.com/hashicorp/terraform-provider-aws/internal/framework	[no test files]
ok  	github.com/hashicorp/terraform-provider-aws/internal/framework/flex	0.551s
ok  	github.com/hashicorp/terraform-provider-aws/internal/framework/types	0.709s
ok  	github.com/hashicorp/terraform-provider-aws/internal/framework/validators	0.567s
```

```console
% make testacc TESTARGS='-run=TestAccBatchJobQueue_schedulingPolicy' PKG=batch
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/batch/... -v -count 1 -parallel 20  -run=TestAccBatchJobQueue_schedulingPolicy -timeout 360m
=== RUN   TestAccBatchJobQueue_schedulingPolicy
=== PAUSE TestAccBatchJobQueue_schedulingPolicy
=== CONT  TestAccBatchJobQueue_schedulingPolicy
--- PASS: TestAccBatchJobQueue_schedulingPolicy (178.69s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/batch	184.026s
```

```console
% make testacc TESTARGS='-run=TestAccCognitoIDPUserPoolClient_analyticsApplicationID' PKG=cognitoidp
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cognitoidp/... -v -count 1 -parallel 20  -run=TestAccCognitoIDPUserPoolClient_analyticsApplicationID -timeout 360m
=== RUN   TestAccCognitoIDPUserPoolClient_analyticsApplicationID
=== PAUSE TestAccCognitoIDPUserPoolClient_analyticsApplicationID
=== CONT  TestAccCognitoIDPUserPoolClient_analyticsApplicationID
--- PASS: TestAccCognitoIDPUserPoolClient_analyticsApplicationID (62.64s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp	67.931s
```

```console
% make testacc TESTARGS='-run=TestAccGlobalAcceleratorAcceleratorDataSource_basic' PKG=globalaccelerator
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/globalaccelerator/... -v -count 1 -parallel 20  -run=TestAccGlobalAcceleratorAcceleratorDataSource_basic -timeout 360m
=== RUN   TestAccGlobalAcceleratorAcceleratorDataSource_basic
=== PAUSE TestAccGlobalAcceleratorAcceleratorDataSource_basic
=== CONT  TestAccGlobalAcceleratorAcceleratorDataSource_basic
--- PASS: TestAccGlobalAcceleratorAcceleratorDataSource_basic (114.91s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/globalaccelerator	120.335s
```