### PR TITLE
ci: fix diff grep regex

### DIFF
--- a/.github/workflows/library_versions.yml
+++ b/.github/workflows/library_versions.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: "github-actions[bot]"
-          body-includes: "Please note that typically Go dependency changes"
+          body-includes: "A new usage of AWS SDK for Go V1 was detected"
 
       - run: echo ${{ steps.prc.outputs.comment-id }}
 

--- a/.github/workflows/library_versions.yml
+++ b/.github/workflows/library_versions.yml
@@ -31,7 +31,7 @@ jobs:
         id: diff
         run: |
           git diff origin/${{ github.event.pull_request.base.ref }} internal/ |
-            (grep "github.com/aws/aws-sdk-go/" && echo "found=true" >> "$GITHUB_OUTPUT") || echo "found=false" >> "$GITHUB_OUTPUT"
+            (grep '^\+\s*"github.com/aws/aws-sdk-go/' && echo "found=true" >> "$GITHUB_OUTPUT") || echo "found=false" >> "$GITHUB_OUTPUT"
 
   comment:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adjusts the grep regular expression so that only added import lines will match. Previously unmodified lines which are displayed with the diff for context could also match the provided expression. Now the line must start with a literal +, contain only whitespace prior to a double quote, and match the root path of the AWS SDK for Go v1 library.

Also fixes the `body-includes` argument in the check for existing comments so that the comment is not repeated on subsequent commits.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #34083 


