### PR TITLE
autoflex: Add fuzzy matching fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,6 +76,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/xray v1.19.0
 	github.com/beevik/etree v1.2.0
 	github.com/google/go-cmp v0.6.0
+	github.com/gertd/go-pluralize v0.2.1
 	github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go v0.21.0
 	github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.37
 	github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2 v2.0.0-beta.38

--- a/go.mod
+++ b/go.mod
@@ -75,8 +75,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/workspaces v1.31.3
 	github.com/aws/aws-sdk-go-v2/service/xray v1.19.0
 	github.com/beevik/etree v1.2.0
-	github.com/google/go-cmp v0.6.0
 	github.com/gertd/go-pluralize v0.2.1
+	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go v0.21.0
 	github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.37
 	github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2 v2.0.0-beta.38

--- a/go.sum
+++ b/go.sum
@@ -227,6 +227,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/gdavison/terraform-plugin-log v0.0.0-20230928191232-6c653d8ef8fb h1:HM67IMNxlkqGxAM5ymxMg2ANCcbL4oEr5cy+tGZ6fNo=
 github.com/gdavison/terraform-plugin-log v0.0.0-20230928191232-6c653d8ef8fb/go.mod h1:rKL8egZQ/eXSyDqzLUuwUYLVdlYeamldAHSxjUFADow=
+github.com/gertd/go-pluralize v0.2.1 h1:M3uASbVjMnTsPb0PNqg+E/24Vwigyo/tvyMTtAlLgiA=
+github.com/gertd/go-pluralize v0.2.1/go.mod h1:rbYaKDbsXxmRfr8uygAEKhOWsjyrrqrkHVpZvoOp8zk=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66DAb0lQFJrpS6731Oaa12ikc+DiI=
 github.com/go-git/go-billy/v5 v5.4.1 h1:Uwp5tDRkPr+l/TnbHOQzp+tmJfLceOlbVucgpTz8ix4=
 github.com/go-git/go-git/v5 v5.8.1 h1:Zo79E4p7TRk0xoRgMq0RShiTHGKcKI4+DI6BfJc/Q+A=

--- a/internal/framework/flex/autoflex.go
+++ b/internal/framework/flex/autoflex.go
@@ -7,7 +7,9 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 
+	pluralize "github.com/gertd/go-pluralize"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -114,6 +116,10 @@ func autoFlexValues(_ context.Context, from, to any) (reflect.Value, reflect.Val
 	return valFrom, valTo, diags
 }
 
+var (
+	plural = pluralize.NewClient()
+)
+
 // autoFlexConvertStruct traverses struct `from` calling `flexer` for each exported field.
 func autoFlexConvertStruct(ctx context.Context, from any, to any, flexer autoFlexer) diag.Diagnostics {
 	var diags diag.Diagnostics
@@ -133,7 +139,7 @@ func autoFlexConvertStruct(ctx context.Context, from any, to any, flexer autoFle
 		if fieldName == "Tags" {
 			continue // Resource tags are handled separately.
 		}
-		toFieldVal := valTo.FieldByName(fieldName)
+		toFieldVal := findFieldFuzzy(fieldName, valTo)
 		if !toFieldVal.IsValid() {
 			continue // Corresponding field not found in to.
 		}
@@ -148,6 +154,45 @@ func autoFlexConvertStruct(ctx context.Context, from any, to any, flexer autoFle
 	}
 
 	return diags
+}
+
+func findFieldFuzzy(fieldNameFrom string, valTo reflect.Value) reflect.Value {
+	// first precedence is exact match (case sensitive)
+	if v := valTo.FieldByName(fieldNameFrom); v.IsValid() {
+		return v
+	}
+
+	// second precedence is exact match (case insensitive)
+	for i, typTo := 0, valTo.Type(); i < typTo.NumField(); i++ {
+		field := typTo.Field(i)
+		if field.PkgPath != "" {
+			continue // Skip unexported fields.
+		}
+		fieldNameTo := field.Name
+		if fieldNameTo == "Tags" {
+			continue // Resource tags are handled separately.
+		}
+		if v := valTo.FieldByName(fieldNameTo); v.IsValid() && strings.EqualFold(fieldNameFrom, fieldNameTo) {
+			// probably could assume validity here since reflect gave the field name
+			return v
+		}
+	}
+
+	// third precedence is singular/plural
+	if plural.IsSingular(fieldNameFrom) {
+		if v := valTo.FieldByName(plural.Plural(fieldNameFrom)); v.IsValid() {
+			return v
+		}
+	}
+
+	if plural.IsPlural(fieldNameFrom) {
+		if v := valTo.FieldByName(plural.Singular(fieldNameFrom)); v.IsValid() {
+			return v
+		}
+	}
+
+	// no finds, fuzzy or otherwise - return invalid
+	return valTo.FieldByName(fieldNameFrom)
 }
 
 // convert converts a single Plugin Framework value to its AWS API equivalent.

--- a/internal/framework/flex/autoflex_test.go
+++ b/internal/framework/flex/autoflex_test.go
@@ -65,6 +65,16 @@ type TestFlexTF07 struct {
 	Field4 fwtypes.SetNestedObjectValueOf[TestFlexTF02]  `tfsdk:"field4"`
 }
 
+// TestFlexTF08 testing for idiomatic singular on TF side but plural on AWS side
+type TestFlexTF08 struct {
+	Field fwtypes.ListNestedObjectValueOf[TestFlexTF01] `tfsdk:"field"`
+}
+
+// TestFlexTF09 testing for fields that only differ by capitalization
+type TestFlexTF09 struct {
+	FieldURL types.String `tfsdk:"field_url"`
+}
+
 type TestFlexAWS01 struct {
 	Field1 string
 }
@@ -118,6 +128,14 @@ type TestFlexAWS09 struct {
 	Field2 *TestFlexAWS06
 	Field3 map[string]*string
 	Field4 []TestFlexAWS03
+}
+
+type TestFlexAWS10 struct {
+	Fields []TestFlexAWS01
+}
+
+type TestFlexAWS11 struct {
+	FieldUrl *string
 }
 
 func TestGenericExpand(t *testing.T) {
@@ -394,6 +412,28 @@ func TestGenericExpand(t *testing.T) {
 				Field2: &TestFlexAWS06{Field1: &TestFlexAWS01{Field1: "n"}},
 				Field3: aws.StringMap(map[string]string{"X": "x", "Y": "y"}),
 				Field4: []TestFlexAWS03{{Field1: 100}, {Field1: 2000}, {Field1: 30000}},
+			},
+		},
+		{
+			TestName: "plural field names",
+			Source: &TestFlexTF08{
+				Field: fwtypes.NewListNestedObjectValueOfPtr(ctx, &TestFlexTF01{
+					Field1: types.StringValue("a"),
+				}),
+			},
+			Target: &TestFlexAWS10{},
+			WantTarget: &TestFlexAWS10{
+				Fields: []TestFlexAWS01{{Field1: "a"}},
+			},
+		},
+		{
+			TestName: "capitalization field names",
+			Source: &TestFlexTF09{
+				FieldURL: types.StringValue("h"),
+			},
+			Target: &TestFlexAWS11{},
+			WantTarget: &TestFlexAWS11{
+				FieldUrl: aws.String("h"),
 			},
 		},
 	}
@@ -751,6 +791,28 @@ func TestGenericFlatten(t *testing.T) {
 					{Field1: types.Int64Value(2000)},
 					{Field1: types.Int64Value(30000)},
 				}),
+			},
+		},
+		{
+			TestName: "plural field names",
+			Source: &TestFlexAWS10{
+				Fields: []TestFlexAWS01{{Field1: "a"}},
+			},
+			Target: &TestFlexTF08{},
+			WantTarget: &TestFlexTF08{
+				Field: fwtypes.NewListNestedObjectValueOfPtr(ctx, &TestFlexTF01{
+					Field1: types.StringValue("a"),
+				}),
+			},
+		},
+		{
+			TestName: "capitalization field names",
+			Source: &TestFlexAWS11{
+				FieldUrl: aws.String("h"),
+			},
+			Target: &TestFlexTF09{},
+			WantTarget: &TestFlexTF09{
+				FieldURL: types.StringValue("h"),
 			},
 		},
 	}

--- a/internal/framework/flex/autoflex_test.go
+++ b/internal/framework/flex/autoflex_test.go
@@ -70,8 +70,18 @@ type TestFlexTF08 struct {
 	Field fwtypes.ListNestedObjectValueOf[TestFlexTF01] `tfsdk:"field"`
 }
 
-// TestFlexTF09 testing for fields that only differ by capitalization
 type TestFlexTF09 struct {
+	City      types.List `tfsdk:"city"`
+	Coach     types.List `tfsdk:"coach"`
+	Tomato    types.List `tfsdk:"tomato"`
+	Vertex    types.List `tfsdk:"vertex"`
+	Criterion types.List `tfsdk:"criterion"`
+	Datum     types.List `tfsdk:"datum"`
+	Hive      types.List `tfsdk:"hive"`
+}
+
+// TestFlexTF10 testing for fields that only differ by capitalization
+type TestFlexTF10 struct {
 	FieldURL types.String `tfsdk:"field_url"`
 }
 
@@ -135,6 +145,16 @@ type TestFlexAWS10 struct {
 }
 
 type TestFlexAWS11 struct {
+	Cities   []*string
+	Coaches  []*string
+	Tomatoes []*string
+	Vertices []*string
+	Criteria []*string
+	Data     []*string
+	Hives    []*string
+}
+
+type TestFlexAWS12 struct {
 	FieldUrl *string
 }
 
@@ -415,7 +435,7 @@ func TestGenericExpand(t *testing.T) {
 			},
 		},
 		{
-			TestName: "plural field names",
+			TestName: "plural ordinary field names",
 			Source: &TestFlexTF08{
 				Field: fwtypes.NewListNestedObjectValueOfPtr(ctx, &TestFlexTF01{
 					Field1: types.StringValue("a"),
@@ -427,12 +447,76 @@ func TestGenericExpand(t *testing.T) {
 			},
 		},
 		{
-			TestName: "capitalization field names",
+			TestName: "plural field names",
 			Source: &TestFlexTF09{
-				FieldURL: types.StringValue("h"),
+				City: types.ListValueMust(types.StringType, []attr.Value{
+					types.StringValue("paris"),
+					types.StringValue("london"),
+				}),
+				Coach: types.ListValueMust(types.StringType, []attr.Value{
+					types.StringValue("guardiola"),
+					types.StringValue("mourinho"),
+				}),
+				Tomato: types.ListValueMust(types.StringType, []attr.Value{
+					types.StringValue("brandywine"),
+					types.StringValue("roma"),
+				}),
+				Vertex: types.ListValueMust(types.StringType, []attr.Value{
+					types.StringValue("ab"),
+					types.StringValue("bc"),
+				}),
+				Criterion: types.ListValueMust(types.StringType, []attr.Value{
+					types.StringValue("votes"),
+					types.StringValue("editors"),
+				}),
+				Datum: types.ListValueMust(types.StringType, []attr.Value{
+					types.StringValue("d1282f78-fa99-5d9d-bd51-e6f0173eb74a"),
+					types.StringValue("0f10cb10-2076-5254-bd21-d3f62fe66303"),
+				}),
+				Hive: types.ListValueMust(types.StringType, []attr.Value{
+					types.StringValue("Cegieme"),
+					types.StringValue("Fahumvid"),
+				}),
 			},
 			Target: &TestFlexAWS11{},
 			WantTarget: &TestFlexAWS11{
+				Cities: []*string{
+					aws.String("paris"),
+					aws.String("london"),
+				},
+				Coaches: []*string{
+					aws.String("guardiola"),
+					aws.String("mourinho"),
+				},
+				Tomatoes: []*string{
+					aws.String("brandywine"),
+					aws.String("roma"),
+				},
+				Vertices: []*string{
+					aws.String("ab"),
+					aws.String("bc"),
+				},
+				Criteria: []*string{
+					aws.String("votes"),
+					aws.String("editors"),
+				},
+				Data: []*string{
+					aws.String("d1282f78-fa99-5d9d-bd51-e6f0173eb74a"),
+					aws.String("0f10cb10-2076-5254-bd21-d3f62fe66303"),
+				},
+				Hives: []*string{
+					aws.String("Cegieme"),
+					aws.String("Fahumvid"),
+				},
+			},
+		},
+		{
+			TestName: "capitalization field names",
+			Source: &TestFlexTF10{
+				FieldURL: types.StringValue("h"),
+			},
+			Target: &TestFlexAWS12{},
+			WantTarget: &TestFlexAWS12{
 				FieldUrl: aws.String("h"),
 			},
 		},
@@ -794,7 +878,7 @@ func TestGenericFlatten(t *testing.T) {
 			},
 		},
 		{
-			TestName: "plural field names",
+			TestName: "plural ordinary field names",
 			Source: &TestFlexAWS10{
 				Fields: []TestFlexAWS01{{Field1: "a"}},
 			},
@@ -806,12 +890,76 @@ func TestGenericFlatten(t *testing.T) {
 			},
 		},
 		{
-			TestName: "capitalization field names",
+			TestName: "plural field names",
 			Source: &TestFlexAWS11{
-				FieldUrl: aws.String("h"),
+				Cities: []*string{
+					aws.String("paris"),
+					aws.String("london"),
+				},
+				Coaches: []*string{
+					aws.String("guardiola"),
+					aws.String("mourinho"),
+				},
+				Tomatoes: []*string{
+					aws.String("brandywine"),
+					aws.String("roma"),
+				},
+				Vertices: []*string{
+					aws.String("ab"),
+					aws.String("bc"),
+				},
+				Criteria: []*string{
+					aws.String("votes"),
+					aws.String("editors"),
+				},
+				Data: []*string{
+					aws.String("d1282f78-fa99-5d9d-bd51-e6f0173eb74a"),
+					aws.String("0f10cb10-2076-5254-bd21-d3f62fe66303"),
+				},
+				Hives: []*string{
+					aws.String("Cegieme"),
+					aws.String("Fahumvid"),
+				},
 			},
 			Target: &TestFlexTF09{},
 			WantTarget: &TestFlexTF09{
+				City: types.ListValueMust(types.StringType, []attr.Value{
+					types.StringValue("paris"),
+					types.StringValue("london"),
+				}),
+				Coach: types.ListValueMust(types.StringType, []attr.Value{
+					types.StringValue("guardiola"),
+					types.StringValue("mourinho"),
+				}),
+				Tomato: types.ListValueMust(types.StringType, []attr.Value{
+					types.StringValue("brandywine"),
+					types.StringValue("roma"),
+				}),
+				Vertex: types.ListValueMust(types.StringType, []attr.Value{
+					types.StringValue("ab"),
+					types.StringValue("bc"),
+				}),
+				Criterion: types.ListValueMust(types.StringType, []attr.Value{
+					types.StringValue("votes"),
+					types.StringValue("editors"),
+				}),
+				Datum: types.ListValueMust(types.StringType, []attr.Value{
+					types.StringValue("d1282f78-fa99-5d9d-bd51-e6f0173eb74a"),
+					types.StringValue("0f10cb10-2076-5254-bd21-d3f62fe66303"),
+				}),
+				Hive: types.ListValueMust(types.StringType, []attr.Value{
+					types.StringValue("Cegieme"),
+					types.StringValue("Fahumvid"),
+				}),
+			},
+		},
+		{
+			TestName: "capitalization field names",
+			Source: &TestFlexAWS12{
+				FieldUrl: aws.String("h"),
+			},
+			Target: &TestFlexTF10{},
+			WantTarget: &TestFlexTF10{
 				FieldURL: types.StringValue("h"),
 			},
 		},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% go test ./internal/framework/flex... -v -count 1 -parallel 20 -run='TestGeneric'  -timeout 360m
=== RUN   TestGenericExpand
=== PAUSE TestGenericExpand
=== RUN   TestGenericFlatten
=== PAUSE TestGenericFlatten
=== CONT  TestGenericExpand
=== CONT  TestGenericFlatten
=== RUN   TestGenericExpand/nil_Source_and_Target
=== PAUSE TestGenericExpand/nil_Source_and_Target
=== RUN   TestGenericFlatten/nil_Source_and_Target
=== RUN   TestGenericExpand/non-pointer_Target
=== PAUSE TestGenericExpand/non-pointer_Target
=== RUN   TestGenericExpand/non-struct_Source
=== PAUSE TestGenericFlatten/nil_Source_and_Target
=== PAUSE TestGenericExpand/non-struct_Source
=== RUN   TestGenericFlatten/non-pointer_Target
=== RUN   TestGenericExpand/non-struct_Target
=== PAUSE TestGenericFlatten/non-pointer_Target
=== PAUSE TestGenericExpand/non-struct_Target
=== RUN   TestGenericFlatten/non-struct_Source
=== RUN   TestGenericExpand/types.String_to_string
=== PAUSE TestGenericFlatten/non-struct_Source
=== PAUSE TestGenericExpand/types.String_to_string
=== RUN   TestGenericFlatten/non-struct_Target
=== PAUSE TestGenericFlatten/non-struct_Target
=== RUN   TestGenericExpand/empty_struct_Source_and_Target
=== RUN   TestGenericFlatten/empty_struct_Source_and_Target
=== PAUSE TestGenericExpand/empty_struct_Source_and_Target
=== PAUSE TestGenericFlatten/empty_struct_Source_and_Target
=== RUN   TestGenericExpand/empty_struct_pointer_Source_and_Target
=== PAUSE TestGenericExpand/empty_struct_pointer_Source_and_Target
=== RUN   TestGenericFlatten/empty_struct_pointer_Source_and_Target
=== RUN   TestGenericExpand/single_string_struct_pointer_Source_and_empty_Target
=== PAUSE TestGenericFlatten/empty_struct_pointer_Source_and_Target
=== PAUSE TestGenericExpand/single_string_struct_pointer_Source_and_empty_Target
=== RUN   TestGenericFlatten/single_string_struct_pointer_Source_and_empty_Target
=== RUN   TestGenericExpand/does_not_implement_attr.Value_Source
=== PAUSE TestGenericExpand/does_not_implement_attr.Value_Source
=== PAUSE TestGenericFlatten/single_string_struct_pointer_Source_and_empty_Target
=== RUN   TestGenericExpand/single_string_Source_and_single_string_Target
=== RUN   TestGenericFlatten/does_not_implement_attr.Value_Target
=== PAUSE TestGenericExpand/single_string_Source_and_single_string_Target
=== PAUSE TestGenericFlatten/does_not_implement_attr.Value_Target
=== RUN   TestGenericExpand/single_string_Source_and_single_*string_Target
=== RUN   TestGenericFlatten/single_empty_string_Source_and_single_string_Target
=== PAUSE TestGenericFlatten/single_empty_string_Source_and_single_string_Target
=== PAUSE TestGenericExpand/single_string_Source_and_single_*string_Target
=== RUN   TestGenericFlatten/single_string_Source_and_single_string_Target
=== PAUSE TestGenericFlatten/single_string_Source_and_single_string_Target
=== RUN   TestGenericExpand/single_string_Source_and_single_int64_Target
=== PAUSE TestGenericExpand/single_string_Source_and_single_int64_Target
=== RUN   TestGenericFlatten/single_nil_*string_Source_and_single_string_Target
=== RUN   TestGenericExpand/primtive_types_Source_and_primtive_types_Target
=== PAUSE TestGenericFlatten/single_nil_*string_Source_and_single_string_Target
=== PAUSE TestGenericExpand/primtive_types_Source_and_primtive_types_Target
=== RUN   TestGenericFlatten/single_*string_Source_and_single_string_Target
=== PAUSE TestGenericFlatten/single_*string_Source_and_single_string_Target
=== RUN   TestGenericExpand/List/Set/Map_of_primitive_types_Source_and_slice/map_of_primtive_types_Target
=== PAUSE TestGenericExpand/List/Set/Map_of_primitive_types_Source_and_slice/map_of_primtive_types_Target
=== RUN   TestGenericFlatten/single_string_Source_and_single_int64_Target
=== PAUSE TestGenericFlatten/single_string_Source_and_single_int64_Target
=== RUN   TestGenericExpand/single_list_Source_and_*struct_Target
=== PAUSE TestGenericExpand/single_list_Source_and_*struct_Target
=== RUN   TestGenericFlatten/zero_value_primtive_types_Source_and_primtive_types_Target
=== PAUSE TestGenericFlatten/zero_value_primtive_types_Source_and_primtive_types_Target
=== RUN   TestGenericExpand/single_set_Source_and_*struct_Target
=== PAUSE TestGenericExpand/single_set_Source_and_*struct_Target
=== RUN   TestGenericFlatten/primtive_types_Source_and_primtive_types_Target
=== PAUSE TestGenericFlatten/primtive_types_Source_and_primtive_types_Target
=== RUN   TestGenericExpand/empty_list_Source_and_empty_[]struct_Target
=== PAUSE TestGenericExpand/empty_list_Source_and_empty_[]struct_Target
=== RUN   TestGenericFlatten/zero_value_slice/map_of_primtive_primtive_types_Source_and_List/Set/Map_of_primtive_types_Target
=== PAUSE TestGenericFlatten/zero_value_slice/map_of_primtive_primtive_types_Source_and_List/Set/Map_of_primtive_types_Target
=== RUN   TestGenericExpand/non-empty_list_Source_and_non-empty_[]struct_Target
=== PAUSE TestGenericExpand/non-empty_list_Source_and_non-empty_[]struct_Target
=== RUN   TestGenericFlatten/slice/map_of_primtive_primtive_types_Source_and_List/Set/Map_of_primtive_types_Target
=== PAUSE TestGenericFlatten/slice/map_of_primtive_primtive_types_Source_and_List/Set/Map_of_primtive_types_Target
=== RUN   TestGenericExpand/empty_list_Source_and_empty_[]*struct_Target
=== PAUSE TestGenericExpand/empty_list_Source_and_empty_[]*struct_Target
=== RUN   TestGenericFlatten/nil_*struct_Source_and_single_list_Target
=== PAUSE TestGenericFlatten/nil_*struct_Source_and_single_list_Target
=== RUN   TestGenericExpand/non-empty_list_Source_and_non-empty_[]*struct_Target
=== RUN   TestGenericFlatten/*struct_Source_and_single_list_Target
=== PAUSE TestGenericExpand/non-empty_list_Source_and_non-empty_[]*struct_Target
=== PAUSE TestGenericFlatten/*struct_Source_and_single_list_Target
=== RUN   TestGenericExpand/empty_list_Source_and_empty_[]struct_Target#01
=== RUN   TestGenericFlatten/*struct_Source_and_single_set_Target
=== PAUSE TestGenericExpand/empty_list_Source_and_empty_[]struct_Target#01
=== PAUSE TestGenericFlatten/*struct_Source_and_single_set_Target
=== RUN   TestGenericExpand/non-empty_list_Source_and_non-empty_[]struct_Target#01
=== RUN   TestGenericFlatten/nil_[]struct_and_null_list_Target
=== PAUSE TestGenericExpand/non-empty_list_Source_and_non-empty_[]struct_Target#01
=== PAUSE TestGenericFlatten/nil_[]struct_and_null_list_Target
=== RUN   TestGenericExpand/empty_set_Source_and_empty_[]*struct_Target
=== PAUSE TestGenericExpand/empty_set_Source_and_empty_[]*struct_Target
=== RUN   TestGenericFlatten/nil_[]struct_and_null_set_Target
=== PAUSE TestGenericFlatten/nil_[]struct_and_null_set_Target
=== RUN   TestGenericExpand/non-empty_set_Source_and_non-empty_[]*struct_Target
=== PAUSE TestGenericExpand/non-empty_set_Source_and_non-empty_[]*struct_Target
=== RUN   TestGenericFlatten/empty_[]struct_and_empty_list_Target
=== PAUSE TestGenericFlatten/empty_[]struct_and_empty_list_Target
=== RUN   TestGenericExpand/non-empty_set_Source_and_non-empty_[]struct_Target
=== RUN   TestGenericFlatten/empty_[]struct_and_empty_struct_Target
=== PAUSE TestGenericExpand/non-empty_set_Source_and_non-empty_[]struct_Target
=== PAUSE TestGenericFlatten/empty_[]struct_and_empty_struct_Target
=== RUN   TestGenericExpand/complex_Source_and_complex_Target
=== PAUSE TestGenericExpand/complex_Source_and_complex_Target
=== RUN   TestGenericFlatten/non-empty_[]struct_and_non-empty_list_Target
=== PAUSE TestGenericFlatten/non-empty_[]struct_and_non-empty_list_Target
=== RUN   TestGenericExpand/plural_ordinary_field_names
=== PAUSE TestGenericExpand/plural_ordinary_field_names
=== RUN   TestGenericFlatten/non-empty_[]struct_and_non-empty_set_Target
=== RUN   TestGenericExpand/plural_field_names
=== PAUSE TestGenericFlatten/non-empty_[]struct_and_non-empty_set_Target
=== PAUSE TestGenericExpand/plural_field_names
=== RUN   TestGenericFlatten/nil_[]*struct_and_null_list_Target
=== PAUSE TestGenericFlatten/nil_[]*struct_and_null_list_Target
=== RUN   TestGenericExpand/capitalization_field_names
=== PAUSE TestGenericExpand/capitalization_field_names
=== RUN   TestGenericFlatten/nil_[]*struct_and_null_set_Target
=== PAUSE TestGenericFlatten/nil_[]*struct_and_null_set_Target
=== CONT  TestGenericExpand/non-empty_list_Source_and_non-empty_[]struct_Target#01
=== RUN   TestGenericFlatten/empty_[]*struct_and_empty_list_Target
=== CONT  TestGenericExpand/single_string_Source_and_single_int64_Target
=== PAUSE TestGenericFlatten/empty_[]*struct_and_empty_list_Target
=== CONT  TestGenericExpand/empty_list_Source_and_empty_[]*struct_Target
=== CONT  TestGenericExpand/single_string_Source_and_single_*string_Target
=== CONT  TestGenericExpand/plural_ordinary_field_names
=== CONT  TestGenericExpand/capitalization_field_names
=== CONT  TestGenericExpand/does_not_implement_attr.Value_Source
=== CONT  TestGenericExpand/complex_Source_and_complex_Target
=== CONT  TestGenericExpand/primtive_types_Source_and_primtive_types_Target
=== CONT  TestGenericExpand/non-struct_Target
=== CONT  TestGenericExpand/non-empty_set_Source_and_non-empty_[]*struct_Target
=== CONT  TestGenericExpand/empty_struct_Source_and_Target
=== CONT  TestGenericExpand/types.String_to_string
=== CONT  TestGenericExpand/empty_set_Source_and_empty_[]*struct_Target
=== CONT  TestGenericExpand/non-struct_Source
=== CONT  TestGenericExpand/non-pointer_Target
=== CONT  TestGenericExpand/List/Set/Map_of_primitive_types_Source_and_slice/map_of_primtive_types_Target
=== CONT  TestGenericExpand/empty_list_Source_and_empty_[]struct_Target
=== CONT  TestGenericExpand/empty_list_Source_and_empty_[]struct_Target#01
=== CONT  TestGenericExpand/non-empty_list_Source_and_non-empty_[]*struct_Target
=== RUN   TestGenericFlatten/empty_[]*struct_and_empty_set_Target
=== CONT  TestGenericExpand/plural_field_names
=== PAUSE TestGenericFlatten/empty_[]*struct_and_empty_set_Target
=== CONT  TestGenericExpand/single_list_Source_and_*struct_Target
=== CONT  TestGenericExpand/single_set_Source_and_*struct_Target
=== RUN   TestGenericFlatten/non-empty_[]*struct_and_non-empty_list_Target
=== CONT  TestGenericExpand/single_string_Source_and_single_string_Target
=== PAUSE TestGenericFlatten/non-empty_[]*struct_and_non-empty_list_Target
=== CONT  TestGenericExpand/empty_struct_pointer_Source_and_Target
=== RUN   TestGenericFlatten/non-empty_[]*struct_and_non-empty_set_Target
=== CONT  TestGenericExpand/nil_Source_and_Target
=== PAUSE TestGenericFlatten/non-empty_[]*struct_and_non-empty_set_Target
=== RUN   TestGenericFlatten/complex_Source_and_complex_Target
=== CONT  TestGenericExpand/single_string_struct_pointer_Source_and_empty_Target
=== PAUSE TestGenericFlatten/complex_Source_and_complex_Target
=== RUN   TestGenericFlatten/plural_ordinary_field_names
=== CONT  TestGenericExpand/non-empty_list_Source_and_non-empty_[]struct_Target
=== PAUSE TestGenericFlatten/plural_ordinary_field_names
=== CONT  TestGenericExpand/non-empty_set_Source_and_non-empty_[]struct_Target
=== RUN   TestGenericFlatten/plural_field_names
=== PAUSE TestGenericFlatten/plural_field_names
=== RUN   TestGenericFlatten/capitalization_field_names
=== PAUSE TestGenericFlatten/capitalization_field_names
=== CONT  TestGenericFlatten/nil_Source_and_Target
=== CONT  TestGenericFlatten/nil_[]*struct_and_null_set_Target
=== CONT  TestGenericFlatten/plural_field_names
=== CONT  TestGenericFlatten/*struct_Source_and_single_set_Target
=== CONT  TestGenericFlatten/single_string_Source_and_single_int64_Target
=== CONT  TestGenericFlatten/nil_*struct_Source_and_single_list_Target
=== CONT  TestGenericFlatten/complex_Source_and_complex_Target
=== CONT  TestGenericFlatten/nil_[]*struct_and_null_list_Target
=== CONT  TestGenericFlatten/*struct_Source_and_single_list_Target
=== CONT  TestGenericFlatten/non-empty_[]struct_and_non-empty_set_Target
=== CONT  TestGenericFlatten/non-empty_[]struct_and_non-empty_list_Target
=== CONT  TestGenericFlatten/single_*string_Source_and_single_string_Target
=== CONT  TestGenericFlatten/single_nil_*string_Source_and_single_string_Target
=== CONT  TestGenericFlatten/single_empty_string_Source_and_single_string_Target
=== CONT  TestGenericFlatten/does_not_implement_attr.Value_Target
=== CONT  TestGenericFlatten/single_string_Source_and_single_string_Target
=== CONT  TestGenericFlatten/single_string_struct_pointer_Source_and_empty_Target
=== CONT  TestGenericFlatten/empty_struct_pointer_Source_and_Target
=== CONT  TestGenericFlatten/empty_struct_Source_and_Target
=== CONT  TestGenericFlatten/non-struct_Source
--- PASS: TestGenericExpand (0.00s)
    --- PASS: TestGenericExpand/single_string_Source_and_single_int64_Target (0.00s)
    --- PASS: TestGenericExpand/empty_list_Source_and_empty_[]*struct_Target (0.00s)
    --- PASS: TestGenericExpand/single_string_Source_and_single_*string_Target (0.00s)
    --- PASS: TestGenericExpand/capitalization_field_names (0.00s)
    --- PASS: TestGenericExpand/non-empty_list_Source_and_non-empty_[]struct_Target#01 (0.00s)
    --- PASS: TestGenericExpand/non-struct_Target (0.00s)
    --- PASS: TestGenericExpand/does_not_implement_attr.Value_Source (0.00s)
    --- PASS: TestGenericExpand/empty_struct_Source_and_Target (0.00s)
    --- PASS: TestGenericExpand/non-struct_Source (0.00s)
    --- PASS: TestGenericExpand/types.String_to_string (0.00s)
    --- PASS: TestGenericExpand/non-pointer_Target (0.00s)
    --- PASS: TestGenericExpand/empty_set_Source_and_empty_[]*struct_Target (0.00s)
    --- PASS: TestGenericExpand/primtive_types_Source_and_primtive_types_Target (0.00s)
    --- PASS: TestGenericExpand/empty_list_Source_and_empty_[]struct_Target#01 (0.00s)
    --- PASS: TestGenericExpand/empty_list_Source_and_empty_[]struct_Target (0.00s)
    --- PASS: TestGenericExpand/plural_ordinary_field_names (0.00s)
    --- PASS: TestGenericExpand/non-empty_set_Source_and_non-empty_[]*struct_Target (0.00s)
    --- PASS: TestGenericExpand/non-empty_list_Source_and_non-empty_[]*struct_Target (0.00s)
    --- PASS: TestGenericExpand/List/Set/Map_of_primitive_types_Source_and_slice/map_of_primtive_types_Target (0.00s)
    --- PASS: TestGenericExpand/single_list_Source_and_*struct_Target (0.00s)
    --- PASS: TestGenericExpand/single_set_Source_and_*struct_Target (0.00s)
    --- PASS: TestGenericExpand/single_string_Source_and_single_string_Target (0.00s)
    --- PASS: TestGenericExpand/empty_struct_pointer_Source_and_Target (0.00s)
    --- PASS: TestGenericExpand/nil_Source_and_Target (0.00s)
    --- PASS: TestGenericExpand/complex_Source_and_complex_Target (0.00s)
    --- PASS: TestGenericExpand/non-empty_list_Source_and_non-empty_[]struct_Target (0.00s)
    --- PASS: TestGenericExpand/non-empty_set_Source_and_non-empty_[]struct_Target (0.00s)
    --- PASS: TestGenericExpand/single_string_struct_pointer_Source_and_empty_Target (0.00s)
    --- PASS: TestGenericExpand/plural_field_names (0.00s)
=== CONT  TestGenericFlatten/empty_[]*struct_and_empty_set_Target
=== CONT  TestGenericFlatten/empty_[]*struct_and_empty_list_Target
=== CONT  TestGenericFlatten/non-empty_[]*struct_and_non-empty_set_Target
=== CONT  TestGenericFlatten/empty_[]struct_and_empty_list_Target
=== CONT  TestGenericFlatten/plural_ordinary_field_names
=== CONT  TestGenericFlatten/nil_[]struct_and_null_set_Target
=== CONT  TestGenericFlatten/nil_[]struct_and_null_list_Target
=== CONT  TestGenericFlatten/slice/map_of_primtive_primtive_types_Source_and_List/Set/Map_of_primtive_types_Target
=== CONT  TestGenericFlatten/zero_value_slice/map_of_primtive_primtive_types_Source_and_List/Set/Map_of_primtive_types_Target
=== CONT  TestGenericFlatten/primtive_types_Source_and_primtive_types_Target
=== CONT  TestGenericFlatten/zero_value_primtive_types_Source_and_primtive_types_Target
=== CONT  TestGenericFlatten/non-empty_[]*struct_and_non-empty_list_Target
=== CONT  TestGenericFlatten/empty_[]struct_and_empty_struct_Target
=== CONT  TestGenericFlatten/non-pointer_Target
=== CONT  TestGenericFlatten/capitalization_field_names
=== CONT  TestGenericFlatten/non-struct_Target
--- PASS: TestGenericFlatten (0.00s)
    --- PASS: TestGenericFlatten/nil_Source_and_Target (0.00s)
    --- PASS: TestGenericFlatten/single_string_Source_and_single_int64_Target (0.00s)
    --- PASS: TestGenericFlatten/nil_*struct_Source_and_single_list_Target (0.00s)
    --- PASS: TestGenericFlatten/single_*string_Source_and_single_string_Target (0.00s)
    --- PASS: TestGenericFlatten/*struct_Source_and_single_list_Target (0.00s)
    --- PASS: TestGenericFlatten/single_nil_*string_Source_and_single_string_Target (0.00s)
    --- PASS: TestGenericFlatten/does_not_implement_attr.Value_Target (0.00s)
    --- PASS: TestGenericFlatten/single_empty_string_Source_and_single_string_Target (0.00s)
    --- PASS: TestGenericFlatten/*struct_Source_and_single_set_Target (0.00s)
    --- PASS: TestGenericFlatten/single_string_Source_and_single_string_Target (0.00s)
    --- PASS: TestGenericFlatten/empty_struct_pointer_Source_and_Target (0.00s)
    --- PASS: TestGenericFlatten/non-empty_[]struct_and_non-empty_list_Target (0.00s)
    --- PASS: TestGenericFlatten/empty_struct_Source_and_Target (0.00s)
    --- PASS: TestGenericFlatten/non-struct_Source (0.00s)
    --- PASS: TestGenericFlatten/non-empty_[]struct_and_non-empty_set_Target (0.00s)
    --- PASS: TestGenericFlatten/nil_[]*struct_and_null_set_Target (0.00s)
    --- PASS: TestGenericFlatten/nil_[]*struct_and_null_list_Target (0.00s)
    --- PASS: TestGenericFlatten/empty_[]struct_and_empty_list_Target (0.00s)
    --- PASS: TestGenericFlatten/empty_[]*struct_and_empty_list_Target (0.00s)
    --- PASS: TestGenericFlatten/empty_[]*struct_and_empty_set_Target (0.00s)
    --- PASS: TestGenericFlatten/nil_[]struct_and_null_set_Target (0.00s)
    --- PASS: TestGenericFlatten/single_string_struct_pointer_Source_and_empty_Target (0.00s)
    --- PASS: TestGenericFlatten/nil_[]struct_and_null_list_Target (0.00s)
    --- PASS: TestGenericFlatten/zero_value_slice/map_of_primtive_primtive_types_Source_and_List/Set/Map_of_primtive_types_Target (0.00s)
    --- PASS: TestGenericFlatten/slice/map_of_primtive_primtive_types_Source_and_List/Set/Map_of_primtive_types_Target (0.00s)
    --- PASS: TestGenericFlatten/non-empty_[]*struct_and_non-empty_set_Target (0.00s)
    --- PASS: TestGenericFlatten/complex_Source_and_complex_Target (0.00s)
    --- PASS: TestGenericFlatten/empty_[]struct_and_empty_struct_Target (0.00s)
    --- PASS: TestGenericFlatten/non-pointer_Target (0.00s)
    --- PASS: TestGenericFlatten/plural_ordinary_field_names (0.00s)
    --- PASS: TestGenericFlatten/capitalization_field_names (0.00s)
    --- PASS: TestGenericFlatten/non-struct_Target (0.00s)
    --- PASS: TestGenericFlatten/zero_value_primtive_types_Source_and_primtive_types_Target (0.00s)
    --- PASS: TestGenericFlatten/primtive_types_Source_and_primtive_types_Target (0.00s)
    --- PASS: TestGenericFlatten/non-empty_[]*struct_and_non-empty_list_Target (0.00s)
    --- PASS: TestGenericFlatten/plural_field_names (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/framework/flex	0.355s
```
