### PR TITLE
 Fix aws_iam_instance_profile detects that the instance profile is not associated with IAM Role.

### DIFF
--- a/.changelog/34099.txt
+++ b/.changelog/34099.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/instance_profile: Fix aws_iam_instance_profile detects that the instance profile is not associated with IAM Role.
+resource/instance_profile: Detect when the associated `role` no longer exists
 ```

--- a/.changelog/34099.txt
+++ b/.changelog/34099.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/instance_profile: Fix aws_iam_instance_profile detects that the instance profile is not associated with IAM Role.
+```

--- a/internal/service/iam/instance_profile.go
+++ b/internal/service/iam/instance_profile.go
@@ -191,6 +191,8 @@ func resourceInstanceProfileRead(ctx context.Context, d *schema.ResourceData, me
 	d.Set("path", instanceProfile.Path)
 	if len(instanceProfile.Roles) > 0 {
 		d.Set("role", instanceProfile.Roles[0].RoleName) //there will only be 1 role returned
+	} else if d.Get("role") != "" {
+		d.Set("role", nil)
 	}
 	d.Set("unique_id", instanceProfile.InstanceProfileId)
 

--- a/internal/service/iam/instance_profile.go
+++ b/internal/service/iam/instance_profile.go
@@ -189,11 +189,14 @@ func resourceInstanceProfileRead(ctx context.Context, d *schema.ResourceData, me
 	d.Set("name", instanceProfile.InstanceProfileName)
 	d.Set("name_prefix", create.NamePrefixFromName(aws.StringValue(instanceProfile.InstanceProfileName)))
 	d.Set("path", instanceProfile.Path)
-	if len(instanceProfile.Roles) > 0 {
-		d.Set("role", instanceProfile.Roles[0].RoleName) //there will only be 1 role returned
-	} else if d.Get("role") != "" {
+
+	if d.Get("role") != "" {
 		d.Set("role", nil)
 	}
+	if len(instanceProfile.Roles) > 0 {
+		d.Set("role", instanceProfile.Roles[0].RoleName) //there will only be 1 role returned
+	}
+
 	d.Set("unique_id", instanceProfile.InstanceProfileId)
 
 	setTagsOut(ctx, instanceProfile.Tags)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Changed to detect when aws_iam_instance_profile is deleted in the aws environment.

#### Before/After

<details>
<summary>example main.tf</summary>

```terraform {
required_providers {
    aws = {
      source  = "hashicorp/aws"
      version = "~> 5.0"
    }
  }
}

provider "aws" {
  region = "ap-northeast-1"
}

resource "aws_iam_role" "sample_role" {
  name = "sample_role_20231024"
  assume_role_policy = <<EOF
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Action": "sts:AssumeRole",
      "Principal": {
        "Service": "ec2.amazonaws.com"
      },
      "Effect": "Allow",
      "Sid": ""
    }
  ]
}
EOF
}

resource "aws_iam_instance_profile" "sample_profile" {
  name  = "sample_profile_20231024"
  role = aws_iam_role.sample_role.name
}
```

</details>

##### Before

```console
terraform apply
aws iam remove-role-from-instance-profile --instance-profile-name "sample_profile_20231024" --role-name "sample_role_20231024"
terraform apply # => "No changes"
```

##### After

```console
terraform apply
aws iam remove-role-from-instance-profile --instance-profile-name "sample_profile_20231024" --role-name "sample_role_20231024"
terraform apply
```

###### Output
```
  ~ resource "aws_iam_instance_profile" "sample_profile" {
        id          = "sample_profile_20231024"
        name        = "sample_profile_20231024"
      + role        = "sample_role_20231024"
        tags        = {}
        # (5 unchanged attributes hidden)
    }
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #32671
Closes #24974
Closes #25646 
Closes #24540 
Closes #1680 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
 % make testacc TESTS='TestAccIAMInstanceProfile_*' PKG=iam                                  (git)-[b-fix-iam-instance-profile-role-nil] 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMInstanceProfile_*'  -timeout 360m
=== RUN   TestAccIAMInstanceProfileDataSource_basic
=== PAUSE TestAccIAMInstanceProfileDataSource_basic
=== RUN   TestAccIAMInstanceProfile_basic
=== PAUSE TestAccIAMInstanceProfile_basic
=== RUN   TestAccIAMInstanceProfile_withoutRole
=== PAUSE TestAccIAMInstanceProfile_withoutRole
=== RUN   TestAccIAMInstanceProfile_tags
=== PAUSE TestAccIAMInstanceProfile_tags
=== RUN   TestAccIAMInstanceProfile_nameGenerated
=== PAUSE TestAccIAMInstanceProfile_nameGenerated
=== RUN   TestAccIAMInstanceProfile_namePrefix
=== PAUSE TestAccIAMInstanceProfile_namePrefix
=== RUN   TestAccIAMInstanceProfile_disappears
=== PAUSE TestAccIAMInstanceProfile_disappears
=== RUN   TestAccIAMInstanceProfile_Disappears_role
=== PAUSE TestAccIAMInstanceProfile_Disappears_role
=== RUN   TestAccIAMInstanceProfilesDataSource_basic
=== PAUSE TestAccIAMInstanceProfilesDataSource_basic
=== CONT  TestAccIAMInstanceProfileDataSource_basic
=== CONT  TestAccIAMInstanceProfile_namePrefix
=== CONT  TestAccIAMInstanceProfilesDataSource_basic
=== CONT  TestAccIAMInstanceProfile_Disappears_role
=== CONT  TestAccIAMInstanceProfile_disappears
=== CONT  TestAccIAMInstanceProfile_tags
=== CONT  TestAccIAMInstanceProfile_nameGenerated
=== CONT  TestAccIAMInstanceProfile_withoutRole
=== CONT  TestAccIAMInstanceProfile_basic
--- PASS: TestAccIAMInstanceProfileDataSource_basic (173.54s)
--- PASS: TestAccIAMInstanceProfilesDataSource_basic (173.63s)
--- PASS: TestAccIAMInstanceProfile_Disappears_role (173.70s)
--- PASS: TestAccIAMInstanceProfile_withoutRole (173.72s)
--- PASS: TestAccIAMInstanceProfile_disappears (175.87s)
--- PASS: TestAccIAMInstanceProfile_namePrefix (185.64s)
--- PASS: TestAccIAMInstanceProfile_basic (185.69s)
--- PASS: TestAccIAMInstanceProfile_nameGenerated (185.84s)
--- PASS: TestAccIAMInstanceProfile_tags (227.76s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        227.872s

...
```
