### PR TITLE
[Enhancement] Add NO_ENCAP support to aws_networkmanager_connect_attachment

### DIFF
--- a/.changelog/34109.txt
+++ b/.changelog/34109.txt
@@ -1,3 +1,11 @@
 ```release-note:enhancement
 resource/aws_networkmanager_connect_attachment: Add support for tunnel-less connect `NO_ENCAP` in `protocol` attribute
 ```
+
+```release-note:enhancement
+resource/aws_networkmanager_connect_peer: Add `subnet_arn` attribute to support tunnel-less Connect attachments
+```
+
+```release-note:enhancement
+resource/aws_networkmanager_connect_peer: Mark `inside_cidr_blocks` argument as optional to support tunnel-less Connect attachments
+```

--- a/.changelog/34109.txt
+++ b/.changelog/34109.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_networkmanager_connect_attachment: Add support for tunnel-less connect `NO_ENCAP` in `protocol` attribute
+```

--- a/.changelog/34109.txt
+++ b/.changelog/34109.txt
@@ -1,11 +1,11 @@
 ```release-note:enhancement
-resource/aws_networkmanager_connect_attachment: Add support for tunnel-less connect `NO_ENCAP` in `protocol` attribute
+resource/aws_networkmanager_connect_attachment: Add `NO_ENCAP` as a valid `options.protocol` value
 ```
 
 ```release-note:enhancement
-resource/aws_networkmanager_connect_peer: Add `subnet_arn` attribute to support tunnel-less Connect attachments
+resource/aws_networkmanager_connect_peer: Add `subnet_arn` argument to support [Tunnel-less Connect attachments](https://docs.aws.amazon.com/network-manager/latest/cloudwan/cloudwan-connect-attachment.html#cloudwan-connect-tlc)
 ```
 
 ```release-note:enhancement
-resource/aws_networkmanager_connect_peer: Mark `inside_cidr_blocks` argument as optional to support tunnel-less Connect attachments
+resource/aws_networkmanager_connect_peer: `inside_cidr_blocks` is Optional
 ```

--- a/internal/service/networkmanager/connect_attachment.go
+++ b/internal/service/networkmanager/connect_attachment.go
@@ -93,7 +93,7 @@ func ResourceConnectAttachment() *schema.Resource {
 						"protocol": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ValidateFunc: validation.StringInSlice([]string{"GRE", "NO_ENCAP"}, false),
+							ValidateFunc: validation.StringInSlice(networkmanager.TunnelProtocol_Values(), false),
 						},
 					},
 				},

--- a/internal/service/networkmanager/connect_attachment.go
+++ b/internal/service/networkmanager/connect_attachment.go
@@ -93,7 +93,7 @@ func ResourceConnectAttachment() *schema.Resource {
 						"protocol": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ValidateFunc: validation.StringInSlice([]string{"GRE"}, false),
+							ValidateFunc: validation.StringInSlice([]string{"GRE", "NO_ENCAP"}, false),
 						},
 					},
 				},

--- a/internal/service/networkmanager/connect_peer_test.go
+++ b/internal/service/networkmanager/connect_peer_test.go
@@ -109,7 +109,7 @@ func TestAccNetworkManagerConnectPeer_noDependsOn(t *testing.T) {
 	})
 }
 
-func TestAccNetworkManagerConnectPeer_subnetArn(t *testing.T) {
+func TestAccNetworkManagerConnectPeer_subnetARN(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v networkmanager.ConnectPeer
 	resourceName := "aws_networkmanager_connect_peer.test"
@@ -126,7 +126,7 @@ func TestAccNetworkManagerConnectPeer_subnetArn(t *testing.T) {
 		CheckDestroy:             testAccCheckConnectPeerDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConnectPeerConfig_subnetArn(rName, peerAddress, asn, protocol),
+				Config: testAccConnectPeerConfig_subnetARN(rName, peerAddress, asn, protocol),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckConnectPeerExists(ctx, resourceName, &v),
 					acctest.MatchResourceAttrGlobalARN(resourceName, "arn", "networkmanager", regexache.MustCompile(`connect-peer/.+`)),
@@ -408,7 +408,7 @@ resource "aws_networkmanager_connect_peer" "test" {
 `, rName, insideCidrBlocks, peerAddress, asn))
 }
 
-func testAccConnectPeerConfig_subnetArn(rName string, peerAddress string, asn string, protocol string) string {
+func testAccConnectPeerConfig_subnetARN(rName string, peerAddress string, asn string, protocol string) string {
 	return acctest.ConfigCompose(testAccConnectPeerConfig_base(rName, protocol), fmt.Sprintf(`
 resource "aws_networkmanager_connect_peer" "test" {
   connect_attachment_id = aws_networkmanager_connect_attachment.test.id

--- a/internal/service/networkmanager/connect_peer_test.go
+++ b/internal/service/networkmanager/connect_peer_test.go
@@ -26,6 +26,7 @@ func TestAccNetworkManagerConnectPeer_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	insideCidrBlocksv4 := "169.254.10.0/29"
 	peerAddress := "1.1.1.1"
+	protocol := "GRE"
 	asn := "65501"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -35,7 +36,7 @@ func TestAccNetworkManagerConnectPeer_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckConnectPeerDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConnectPeerConfig_basic(rName, insideCidrBlocksv4, peerAddress, asn),
+				Config: testAccConnectPeerConfig_basic(rName, insideCidrBlocksv4, peerAddress, asn, protocol),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckConnectPeerExists(ctx, resourceName, &v),
 					acctest.MatchResourceAttrGlobalARN(resourceName, "arn", "networkmanager", regexache.MustCompile(`connect-peer/.+`)),
@@ -70,6 +71,7 @@ func TestAccNetworkManagerConnectPeer_noDependsOn(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	insideCidrBlocksv4 := "169.254.10.0/29"
 	peerAddress := "1.1.1.1"
+	protocol := "GRE"
 	asn := "65501"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -79,7 +81,7 @@ func TestAccNetworkManagerConnectPeer_noDependsOn(t *testing.T) {
 		CheckDestroy:             testAccCheckConnectPeerDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConnectPeerConfig_noDependsOn(rName, insideCidrBlocksv4, peerAddress, asn),
+				Config: testAccConnectPeerConfig_noDependsOn(rName, insideCidrBlocksv4, peerAddress, asn, protocol),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckConnectPeerExists(ctx, resourceName, &v),
 					acctest.MatchResourceAttrGlobalARN(resourceName, "arn", "networkmanager", regexache.MustCompile(`connect-peer/.+`)),
@@ -107,13 +109,14 @@ func TestAccNetworkManagerConnectPeer_noDependsOn(t *testing.T) {
 	})
 }
 
-func TestAccNetworkManagerConnectPeer_tags(t *testing.T) {
+func TestAccNetworkManagerConnectPeer_subnetArn(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v networkmanager.ConnectPeer
 	resourceName := "aws_networkmanager_connect_peer.test"
+	subnetResourceName := "aws_subnet.test2"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	insideCidrBlocksv4 := "169.254.10.0/29"
 	peerAddress := "1.1.1.1"
+	protocol := "NO_ENCAP"
 	asn := "65501"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -123,7 +126,50 @@ func TestAccNetworkManagerConnectPeer_tags(t *testing.T) {
 		CheckDestroy:             testAccCheckConnectPeerDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConnectPeerConfig_tags1(rName, "Name", "test", insideCidrBlocksv4, peerAddress, asn),
+				Config: testAccConnectPeerConfig_subnetArn(rName, peerAddress, asn, protocol),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckConnectPeerExists(ctx, resourceName, &v),
+					acctest.MatchResourceAttrGlobalARN(resourceName, "arn", "networkmanager", regexache.MustCompile(`connect-peer/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.peer_address", peerAddress),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.protocol", "NO_ENCAP"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.bgp_configurations.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "connect_attachment_id"),
+					resource.TestCheckResourceAttr(resourceName, "peer_address", peerAddress),
+					resource.TestCheckResourceAttr(resourceName, "edge_location", acctest.Region()),
+					resource.TestCheckResourceAttrSet(resourceName, "connect_attachment_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "subnet_arn", subnetResourceName, "arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "state"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccNetworkManagerConnectPeer_tags(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v networkmanager.ConnectPeer
+	resourceName := "aws_networkmanager_connect_peer.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	insideCidrBlocksv4 := "169.254.10.0/29"
+	peerAddress := "1.1.1.1"
+	protocol := "GRE"
+	asn := "65501"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, networkmanager.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckConnectPeerDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConnectPeerConfig_tags1(rName, "Name", "test", insideCidrBlocksv4, peerAddress, asn, protocol),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConnectPeerExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -131,7 +177,7 @@ func TestAccNetworkManagerConnectPeer_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccConnectPeerConfig_tags2(rName, "Name", "test", "env", "test", insideCidrBlocksv4, peerAddress, asn),
+				Config: testAccConnectPeerConfig_tags2(rName, "Name", "test", "env", "test", insideCidrBlocksv4, peerAddress, asn, protocol),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConnectPeerExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -140,7 +186,7 @@ func TestAccNetworkManagerConnectPeer_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccConnectPeerConfig_tags1(rName, "Name", "test", insideCidrBlocksv4, peerAddress, asn),
+				Config: testAccConnectPeerConfig_tags1(rName, "Name", "test", insideCidrBlocksv4, peerAddress, asn, protocol),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConnectPeerExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -206,7 +252,7 @@ func testAccCheckConnectPeerDestroy(ctx context.Context) resource.TestCheckFunc 
 	}
 }
 
-func testAccConnectPeerConfig_base(rName string) string {
+func testAccConnectPeerConfig_base(rName string, protocol string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 data "aws_region" "current" {}
 
@@ -306,7 +352,7 @@ resource "aws_networkmanager_connect_attachment" "test" {
   transport_attachment_id = aws_networkmanager_vpc_attachment.test.id
   edge_location           = aws_networkmanager_vpc_attachment.test.edge_location
   options {
-    protocol = "GRE"
+    protocol = %[2]q
   }
   tags = {
     segment = "shared"
@@ -320,11 +366,11 @@ resource "aws_networkmanager_attachment_accepter" "test2" {
   attachment_id   = aws_networkmanager_connect_attachment.test.id
   attachment_type = aws_networkmanager_connect_attachment.test.attachment_type
 }
-`, rName))
+`, rName, protocol))
 }
 
-func testAccConnectPeerConfig_basic(rName string, insideCidrBlocks string, peerAddress string, asn string) string {
-	return acctest.ConfigCompose(testAccConnectPeerConfig_base(rName), fmt.Sprintf(`
+func testAccConnectPeerConfig_basic(rName string, insideCidrBlocks string, peerAddress string, asn string, protocol string) string {
+	return acctest.ConfigCompose(testAccConnectPeerConfig_base(rName, protocol), fmt.Sprintf(`
 resource "aws_networkmanager_connect_peer" "test" {
   connect_attachment_id = aws_networkmanager_connect_attachment.test.id
   peer_address          = %[3]q
@@ -344,8 +390,8 @@ resource "aws_networkmanager_connect_peer" "test" {
 `, rName, insideCidrBlocks, peerAddress, asn))
 }
 
-func testAccConnectPeerConfig_noDependsOn(rName string, insideCidrBlocks string, peerAddress string, asn string) string {
-	return acctest.ConfigCompose(testAccConnectPeerConfig_base(rName), fmt.Sprintf(`
+func testAccConnectPeerConfig_noDependsOn(rName string, insideCidrBlocks string, peerAddress string, asn string, protocol string) string {
+	return acctest.ConfigCompose(testAccConnectPeerConfig_base(rName, protocol), fmt.Sprintf(`
 resource "aws_networkmanager_connect_peer" "test" {
   connect_attachment_id = aws_networkmanager_connect_attachment.test.id
   peer_address          = %[3]q
@@ -362,8 +408,32 @@ resource "aws_networkmanager_connect_peer" "test" {
 `, rName, insideCidrBlocks, peerAddress, asn))
 }
 
-func testAccConnectPeerConfig_tags1(rName, tagKey1, tagValue1 string, insideCidrBlocks string, peerAddress string, asn string) string {
-	return acctest.ConfigCompose(testAccConnectPeerConfig_base(rName), fmt.Sprintf(`
+func testAccConnectPeerConfig_subnetArn(rName string, peerAddress string, asn string, protocol string) string {
+	return acctest.ConfigCompose(testAccConnectPeerConfig_base(rName, protocol), fmt.Sprintf(`
+resource "aws_networkmanager_connect_peer" "test" {
+  connect_attachment_id = aws_networkmanager_connect_attachment.test.id
+  peer_address          = %[2]q
+  bgp_options {
+    peer_asn = %[3]q
+  }
+  subnet_arn = aws_subnet.test2.arn
+  tags = {
+    Name = %[1]q
+  }
+  depends_on = [
+    "aws_networkmanager_attachment_accepter.test"
+  ]
+}
+
+resource "aws_subnet" "test2" {
+  vpc_id     = aws_vpc.test.id
+  cidr_block = cidrsubnet(aws_vpc.test.cidr_block, 8, 2)
+}
+`, rName, peerAddress, asn))
+}
+
+func testAccConnectPeerConfig_tags1(rName, tagKey1, tagValue1 string, insideCidrBlocks string, peerAddress string, asn string, protocol string) string {
+	return acctest.ConfigCompose(testAccConnectPeerConfig_base(rName, protocol), fmt.Sprintf(`
 resource "aws_networkmanager_connect_peer" "test" {
   connect_attachment_id = aws_networkmanager_connect_attachment.test.id
   peer_address          = %[4]q
@@ -380,8 +450,8 @@ resource "aws_networkmanager_connect_peer" "test" {
 `, tagKey1, tagValue1, insideCidrBlocks, peerAddress, asn))
 }
 
-func testAccConnectPeerConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string, insideCidrBlocks string, peerAddress string, asn string) string {
-	return acctest.ConfigCompose(testAccConnectPeerConfig_base(rName), fmt.Sprintf(`
+func testAccConnectPeerConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string, insideCidrBlocks string, peerAddress string, asn string, protocol string) string {
+	return acctest.ConfigCompose(testAccConnectPeerConfig_base(rName, protocol), fmt.Sprintf(`
 resource "aws_networkmanager_connect_peer" "test" {
   connect_attachment_id = aws_networkmanager_connect_attachment.test.id
   peer_address          = %[6]q

--- a/website/docs/r/networkmanager_connect_attachment.html.markdown
+++ b/website/docs/r/networkmanager_connect_attachment.html.markdown
@@ -70,11 +70,15 @@ The following arguments are required:
 - `core_network_id` - (Required) The ID of a core network where you want to create the attachment.
 - `transport_attachment_id` - (Required) The ID of the attachment between the two connections.
 - `edge_location` - (Required) The Region where the edge is located.
-- `options` - (Required) Options for creating an attachment.
+- `options` - (Required) Options block. See [options](#options) for more information.
 
 The following arguments are optional:
 
 - `tags` - (Optional) Key-value tags for the attachment. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### options
+
+* `protocol` - (Required) The protocol used for the attachment connection. Possible values are `GRE` and `NO_ENCAP`.
 
 ## Attribute Reference
 

--- a/website/docs/r/networkmanager_connect_peer.html.markdown
+++ b/website/docs/r/networkmanager_connect_peer.html.markdown
@@ -84,18 +84,47 @@ resource "aws_networkmanager_connect_peer" "example" {
 }
 ```
 
+### Usage with a Tunnel-less Connect attachment
+
+```terraform
+resource "aws_networkmanager_vpc_attachment" "example" {
+  subnet_arns     = aws_subnet.example[*].arn
+  core_network_id = awscc_networkmanager_core_network.example.id
+  vpc_arn         = aws_vpc.example.arn
+}
+
+resource "aws_networkmanager_connect_attachment" "example" {
+  core_network_id         = awscc_networkmanager_core_network.example.id
+  transport_attachment_id = aws_networkmanager_vpc_attachment.example.id
+  edge_location           = aws_networkmanager_vpc_attachment.example.edge_location
+  options {
+    protocol = "NO_ENCAP"
+  }
+}
+
+resource "aws_networkmanager_connect_peer" "example" {
+  connect_attachment_id = aws_networkmanager_connect_attachment.example.id
+  peer_address          = "127.0.0.1"
+  bgp_options {
+    peer_asn = 65000
+  }
+  subnet_arn = aws_subnet.test2.arn
+}
+```
+
 ## Argument Reference
 
 The following arguments are required:
 
 - `connect_attachment_id` - (Required) The ID of the connection attachment.
-- `inside_cidr_blocks` - (Required) The inside IP addresses used for BGP peering.
 - `peer_address` - (Required) The Connect peer address.
 
 The following arguments are optional:
 
 - `bgp_options` (Optional) The Connect peer BGP options.
 - `core_network_address` (Optional) A Connect peer core network address.
+- `inside_cidr_blocks` - (Optional) The inside IP addresses used for BGP peering. Required when the Connect attachment protocol is `GRE`. See [`aws_networkmanager_connect_attachment`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/networkmanager_connect_attachment) for details.
+- `subnet_arn` - (Optional) The subnet ARN for the Connect peer. Required when the Connect attachment protocol is `NO_ENCAP`. See [`aws_networkmanager_connect_attachment`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/networkmanager_connect_attachment) for details.
 - `tags` - (Optional) Key-value tags for the attachment. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attribute Reference


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
- `aws_networkmanager_connect_attachment`: Add support for the `NO_ENCAP` protocol option required for tunnel-less connect.
- `aws_networkmanager_connect_peer`: Add `subnet_arn` attribute to support tunnel-less Connect attachments
- `aws_networkmanager_connect_peer`: Mark `inside_cidr_blocks` argument as optional to support tunnel-less Connect attachments

This also updates the existing acceptance tests to check for the protocol type.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #34101

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Launch announcement: https://aws.amazon.com/about-aws/whats-new/2023/10/aws-cloud-wan-tunnel-less-high-performant-global-sd-wans/
API reference: https://docs.aws.amazon.com/networkmanager/latest/APIReference/API_ConnectAttachmentOptions.html#networkmanager-Type-ConnectAttachmentOptions-Protocol

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS='TestAccNetworkManagerConnectAttachment_' PKG=networkmanager 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/networkmanager/... -v -count 1 -parallel 20 -run='TestAccNetworkManagerConnectAttachment_'  -timeout 360m
=== RUN   TestAccNetworkManagerConnectAttachment_basic
=== PAUSE TestAccNetworkManagerConnectAttachment_basic
=== RUN   TestAccNetworkManagerConnectAttachment_basic_NoDependsOn
=== PAUSE TestAccNetworkManagerConnectAttachment_basic_NoDependsOn
=== RUN   TestAccNetworkManagerConnectAttachment_disappears
=== PAUSE TestAccNetworkManagerConnectAttachment_disappears
=== RUN   TestAccNetworkManagerConnectAttachment_protocolNoEncap
=== PAUSE TestAccNetworkManagerConnectAttachment_protocolNoEncap
=== RUN   TestAccNetworkManagerConnectAttachment_tags
=== PAUSE TestAccNetworkManagerConnectAttachment_tags
=== CONT  TestAccNetworkManagerConnectAttachment_basic
=== CONT  TestAccNetworkManagerConnectAttachment_protocolNoEncap
=== CONT  TestAccNetworkManagerConnectAttachment_tags
=== CONT  TestAccNetworkManagerConnectAttachment_disappears
=== CONT  TestAccNetworkManagerConnectAttachment_basic_NoDependsOn
--- PASS: TestAccNetworkManagerConnectAttachment_tags (1055.17s)
--- PASS: TestAccNetworkManagerConnectAttachment_protocolNoEncap (1132.04s)
--- PASS: TestAccNetworkManagerConnectAttachment_basic_NoDependsOn (1171.50s)
--- PASS: TestAccNetworkManagerConnectAttachment_basic (1199.77s)
--- PASS: TestAccNetworkManagerConnectAttachment_disappears (1241.14s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/networkmanager     1246.530s

$ make testacc TESTS='TestAccNetworkManagerConnectPeer_' PKG=networkmanager ACCTEST_PARALLELISM=4 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/networkmanager/... -v -count 1 -parallel 4 -run='TestAccNetworkManagerConnectPeer_'  -timeout 360m
=== RUN   TestAccNetworkManagerConnectPeer_basic
=== PAUSE TestAccNetworkManagerConnectPeer_basic
=== RUN   TestAccNetworkManagerConnectPeer_noDependsOn
=== PAUSE TestAccNetworkManagerConnectPeer_noDependsOn
=== RUN   TestAccNetworkManagerConnectPeer_subnetArn
=== PAUSE TestAccNetworkManagerConnectPeer_subnetArn
=== RUN   TestAccNetworkManagerConnectPeer_tags
=== PAUSE TestAccNetworkManagerConnectPeer_tags
=== CONT  TestAccNetworkManagerConnectPeer_basic
=== CONT  TestAccNetworkManagerConnectPeer_subnetArn
=== CONT  TestAccNetworkManagerConnectPeer_noDependsOn
=== CONT  TestAccNetworkManagerConnectPeer_tags
--- PASS: TestAccNetworkManagerConnectPeer_basic (1461.53s)
--- PASS: TestAccNetworkManagerConnectPeer_tags (1483.78s)
--- PASS: TestAccNetworkManagerConnectPeer_noDependsOn (1515.02s)
--- PASS: TestAccNetworkManagerConnectPeer_subnetArn (1522.34s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/networkmanager     1525.729s
```
