### PR TITLE
Various sweeper fixes

### DIFF
--- a/internal/service/dynamodb/sweep.go
+++ b/internal/service/dynamodb/sweep.go
@@ -54,10 +54,19 @@ func sweepTables(region string) error {
 		}
 
 		for _, tableName := range page.TableNames {
+			id := aws.StringValue(tableName)
+
+			_, err := conn.UpdateTableWithContext(ctx, &dynamodb.UpdateTableInput{
+				DeletionProtectionEnabled: aws.Bool(false),
+				TableName:                 aws.String(id),
+			})
+
+			if err != nil {
+				log.Printf("[WARN] DynamoDB Table (%s): %s", id, err)
+			}
+
 			r := ResourceTable()
 			d := r.Data(nil)
-
-			id := aws.StringValue(tableName)
 			d.SetId(id)
 
 			// read concurrently and gather errors

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -2004,8 +2004,8 @@ func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta in
 		log.Printf("[WARN] attempting to terminate EC2 Instance (%s) despite error disabling API termination: %s", d.Id(), err)
 	}
 
-	if v, ok := d.GetOk("disable_api_stop"); ok {
-		if err := disableInstanceAPIStop(ctx, conn, d.Id(), v.(bool)); err != nil {
+	if v := d.GetRawConfig().GetAttr("disable_api_stop"); v.IsKnown() && !v.IsNull() {
+		if err := disableInstanceAPIStop(ctx, conn, d.Id(), v.True()); err != nil {
 			log.Printf("[WARN] attempting to terminate EC2 Instance (%s) despite error disabling API stop: %s", d.Id(), err)
 		}
 	}

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -2004,8 +2004,8 @@ func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta in
 		log.Printf("[WARN] attempting to terminate EC2 Instance (%s) despite error disabling API termination: %s", d.Id(), err)
 	}
 
-	if v := d.GetRawConfig().GetAttr("disable_api_stop"); v.IsKnown() && !v.IsNull() {
-		if err := disableInstanceAPIStop(ctx, conn, d.Id(), v.True()); err != nil {
+	if v, ok := d.GetOk("disable_api_stop"); ok {
+		if err := disableInstanceAPIStop(ctx, conn, d.Id(), v.(bool)); err != nil {
 			log.Printf("[WARN] attempting to terminate EC2 Instance (%s) despite error disabling API stop: %s", d.Id(), err)
 		}
 	}

--- a/internal/service/ec2/sweep.go
+++ b/internal/service/ec2/sweep.go
@@ -955,54 +955,59 @@ func sweepInstances(region string) error {
 	if err != nil {
 		return fmt.Errorf("error getting client: %s", err)
 	}
-
 	conn := client.EC2Conn(ctx)
+	input := &ec2.DescribeInstancesInput{}
 	sweepResources := make([]sweep.Sweepable, 0)
-	var errs *multierror.Error
 
-	err = conn.DescribeInstancesPagesWithContext(ctx, &ec2.DescribeInstancesInput{}, func(page *ec2.DescribeInstancesOutput, lastPage bool) bool {
+	err = conn.DescribeInstancesPagesWithContext(ctx, input, func(page *ec2.DescribeInstancesOutput, lastPage bool) bool {
 		if page == nil {
 			return !lastPage
 		}
 
-		for _, reservation := range page.Reservations {
-			if reservation == nil {
+		for _, v := range page.Reservations {
+			if v == nil {
 				continue
 			}
 
-			for _, instance := range reservation.Instances {
-				id := aws.StringValue(instance.InstanceId)
+			for _, v := range v.Instances {
+				id := aws.StringValue(v.InstanceId)
 
-				if instance.State != nil && aws.StringValue(instance.State.Name) == ec2.InstanceStateNameTerminated {
+				if v.State != nil && aws.StringValue(v.State.Name) == ec2.InstanceStateNameTerminated {
 					log.Printf("[INFO] Skipping terminated EC2 Instance: %s", id)
 					continue
+				}
+
+				if err := disableInstanceAPIStop(ctx, conn, id, false); err != nil {
+					log.Printf("[INFO] EC2 Instance (%s): %s", id, err)
 				}
 
 				r := ResourceInstance()
 				d := r.Data(nil)
 				d.SetId(id)
-				d.Set("disable_api_stop", false)
 
 				sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 			}
 		}
+
 		return !lastPage
 	})
 
-	if err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error describing EC2 Instances for %s: %w", region, err))
-	}
-
-	if err = sweep.SweepOrchestrator(ctx, sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error sweeping EC2 Instances for %s: %w", region, err))
-	}
-
-	if awsv1.SkipSweepError(errs.ErrorOrNil()) {
-		log.Printf("[WARN] Skipping EC2 Instance sweep for %s: %s", region, errs)
+	if awsv1.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping EC2 Instance sweep for %s: %s", region, err)
 		return nil
 	}
 
-	return errs.ErrorOrNil()
+	if err != nil {
+		return fmt.Errorf("error listing EC2 Instances (%s): %w", region, err)
+	}
+
+	err = sweep.SweepOrchestrator(ctx, sweepResources)
+
+	if err != nil {
+		return fmt.Errorf("error sweeping EC2 Instances (%s): %w", region, err)
+	}
+
+	return nil
 }
 
 func sweepInternetGateways(region string) error {

--- a/internal/service/finspace/sweep.go
+++ b/internal/service/finspace/sweep.go
@@ -48,7 +48,7 @@ func sweepKxEnvironments(region string) error {
 		for _, v := range page.Environments {
 			id := aws.ToString(v.EnvironmentId)
 
-			if status := v.Status; status == types.EnvironmentStatusDeleted {
+			if status := v.Status; status == types.EnvironmentStatusDeleted || status == types.EnvironmentStatusDeleting || status == types.EnvironmentStatusCreating {
 				log.Printf("[INFO] Skipping FinSpace Kx Environment %s: Status=%s", id, status)
 				continue
 			}

--- a/internal/service/sagemaker/project.go
+++ b/internal/service/sagemaker/project.go
@@ -200,15 +200,17 @@ func resourceProjectDelete(ctx context.Context, d *schema.ResourceData, meta int
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SageMakerConn(ctx)
 
-	input := &sagemaker.DeleteProjectInput{
+	log.Printf("[DEBUG] Deleting SageMaker Project: %s", d.Id())
+	_, err := conn.DeleteProjectWithContext(ctx, &sagemaker.DeleteProjectInput{
 		ProjectName: aws.String(d.Id()),
+	})
+
+	if tfawserr.ErrMessageContains(err, "ValidationException", "does not exist") ||
+		tfawserr.ErrMessageContains(err, "ValidationException", "Cannot delete Project in DeleteCompleted status") {
+		return diags
 	}
 
-	if _, err := conn.DeleteProjectWithContext(ctx, input); err != nil {
-		if tfawserr.ErrMessageContains(err, "ValidationException", "does not exist") ||
-			tfawserr.ErrMessageContains(err, "ValidationException", "Cannot delete Project in DeleteCompleted status") {
-			return diags
-		}
+	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "deleting SageMaker Project (%s): %s", d.Id(), err)
 	}
 

--- a/internal/service/sagemaker/sweep.go
+++ b/internal/service/sagemaker/sweep.go
@@ -974,7 +974,7 @@ func sweepProjects(region string) error {
 			d := r.Data(nil)
 			d.SetId(name)
 
-			if err := sdk.NewSweepResource(r, d, client).Delete(ctx, sweep.ThrottlingRetryTimeout); err != nil {
+			if err := sdk.NewSweepResource(r, d, client).Delete(ctx, sweep.ThrottlingRetryTimeout); err != nil { // nosemgrep:ci.semgrep.migrate.direct-CRUD-calls
 				sweeperErrs = multierror.Append(sweeperErrs, err)
 			}
 		}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Various sweeper fixes:

* `aws_instance` always enable API Stop
* `aws_dynamodb_table` always disable Deletion Protection
* `aws_finspace_kx_environment` skip environments in non-deletable state
* `aws_sagemaker_project` serialize to avoid throttling errors

`make sweep SWEEP=us-west-2` and `make sweep SWEEP=us-gov-west-1` successfully run to completion.