### PR TITLE
r/aws_kms key: add configurable timeout

### DIFF
--- a/.changelog/34112.txt
+++ b/.changelog/34112.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_kms_key: Add configurable timeouts
+```

--- a/internal/service/kms/external_key.go
+++ b/internal/service/kms/external_key.go
@@ -155,7 +155,7 @@ func resourceExternalKeyCreate(ctx context.Context, d *schema.ResourceData, meta
 	// KMS will report this error until it can validate the policy itself.
 	// They acknowledge this here:
 	// http://docs.aws.amazon.com/kms/latest/APIReference/API_CreateKey.html
-	output, err := WaitIAMPropagation(ctx, func() (*kms.CreateKeyOutput, error) {
+	output, err := WaitIAMPropagation(ctx, propagationTimeout, func() (*kms.CreateKeyOutput, error) {
 		return conn.CreateKeyWithContext(ctx, input)
 	})
 

--- a/internal/service/kms/key.go
+++ b/internal/service/kms/key.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/kms"
@@ -37,6 +38,10 @@ func ResourceKey() *schema.Resource {
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(2 * time.Minute),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -157,7 +162,7 @@ func resourceKeyCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 	// The KMS service's awareness of principals is limited by "eventual consistency".
 	// They acknowledge this here:
 	// http://docs.aws.amazon.com/kms/latest/APIReference/API_CreateKey.html
-	output, err := WaitIAMPropagation(ctx, func() (*kms.CreateKeyOutput, error) {
+	output, err := WaitIAMPropagation(ctx, d.Timeout(schema.TimeoutCreate), func() (*kms.CreateKeyOutput, error) {
 		return conn.CreateKeyWithContext(ctx, input)
 	})
 

--- a/internal/service/kms/replica_external_key.go
+++ b/internal/service/kms/replica_external_key.go
@@ -151,7 +151,7 @@ func resourceReplicaExternalKeyCreate(ctx context.Context, d *schema.ResourceDat
 
 	replicateConn := kms.New(session)
 
-	output, err := WaitIAMPropagation(ctx, func() (*kms.ReplicateKeyOutput, error) {
+	output, err := WaitIAMPropagation(ctx, propagationTimeout, func() (*kms.ReplicateKeyOutput, error) {
 		return replicateConn.ReplicateKeyWithContext(ctx, input)
 	})
 

--- a/internal/service/kms/replica_key.go
+++ b/internal/service/kms/replica_key.go
@@ -139,7 +139,7 @@ func resourceReplicaKeyCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 	replicateConn := kms.New(session)
 
-	output, err := WaitIAMPropagation(ctx, func() (*kms.ReplicateKeyOutput, error) {
+	output, err := WaitIAMPropagation(ctx, propagationTimeout, func() (*kms.ReplicateKeyOutput, error) {
 		return replicateConn.ReplicateKeyWithContext(ctx, input)
 	})
 

--- a/internal/service/kms/wait.go
+++ b/internal/service/kms/wait.go
@@ -35,8 +35,8 @@ const (
 
 // WaitIAMPropagation retries the specified function if the returned error indicates an IAM eventual consistency issue.
 // If the retries time out the specified function is called one last time.
-func WaitIAMPropagation[T any](ctx context.Context, f func() (T, error)) (T, error) {
-	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (interface{}, error) {
+func WaitIAMPropagation[T any](ctx context.Context, timeout time.Duration, f func() (T, error)) (T, error) {
+	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout, func() (interface{}, error) {
 		return f()
 	},
 		kms.ErrCodeMalformedPolicyDocumentException)

--- a/website/docs/r/kms_key.html.markdown
+++ b/website/docs/r/kms_key.html.markdown
@@ -57,6 +57,14 @@ This resource exports the following attributes in addition to the arguments abov
 * `key_id` - The globally unique identifier for the key.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
+## Timeouts
+
+~> **Note:** There are a variety of default timeouts set internally. If you set a shorter custom timeout than one of the defaults, the custom timeout will not be respected as the longer of the custom or internal default will be used.
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+* `create` - (Default `2m`)
+
 ## Import
 
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import KMS Keys using the `id`. For example:


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Add configurable timeout to `aws_kms_key`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:
--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTARGS='-run=TestAccKMSKey_' PKG=kms

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/kms/... -v -count 1 -parallel 20  -run=TestAccKMSKey_ -timeout 360m
--- PASS: TestAccKMSKey_disappears (101.00s)
--- PASS: TestAccKMSKey_hmacKey (114.48s)
--- PASS: TestAccKMSKey_asymmetricKey (114.94s)
--- PASS: TestAccKMSKey_multiRegion (121.88s)
--- PASS: TestAccKMSKey_Policy_basic (174.00s)
--- PASS: TestAccKMSKey_basic (178.62s)
--- PASS: TestAccKMSKey_updateTagsEmptyValue (180.75s)
--- PASS: TestAccKMSKey_Policy_bypassUpdate (212.23s)
--- PASS: TestAccKMSKey_ignoreTags (224.56s)
--- PASS: TestAccKMSKey_Policy_booleanCondition (232.03s)
--- PASS: TestAccKMSKey_Policy_iamRole (237.76s)
--- PASS: TestAccKMSKey_Policy_iamServiceLinkedRole (247.98s)
--- PASS: TestAccKMSKey_tags (271.27s)
--- PASS: TestAccKMSKey_Policy_bypass (273.51s)
--- PASS: TestAccKMSKey_isEnabled (275.95s)
--- PASS: TestAccKMSKey_Policy_iamRoleUpdate (277.74s)
--- PASS: TestAccKMSKey_Policy_iamRoleOrder (573.22s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kms	576.527s
```
