### PR TITLE
Update db_snapshot.html.markdown

### DIFF
--- a/website/docs/d/db_snapshot.html.markdown
+++ b/website/docs/d/db_snapshot.html.markdown
@@ -63,7 +63,7 @@ AWS accounts that this AWS account has been given permission to copy or restore,
 The default is `false`.
 * `include_public` - (Optional) Set this value to true to include manual DB snapshots that are public and can be
 copied or restored by any AWS account, otherwise set this value to false. The default is `false`.
-`tags` - (Optional) Mapping of tags, each pair of which must exactly match
+* `tags` - (Optional) Mapping of tags, each pair of which must exactly match
   a pair on the desired DB snapshot.
 
 ## Attribute Reference


### PR DESCRIPTION
### Original Sentence
- include_public - (Optional) Set this value to true to include manual DB snapshots that are public and can be copied or restored by any AWS account, otherwise set this value to false. The default is false. tags - (Optional) Mapping of tags, each pair of which must exactly match a pair on the desired DB snapshot.

### Issues
Incorrect formatting of the `tags` argument reference.

### New Sentence
- include_public - (Optional) Set this value to true to include manual DB snapshots that are public and can be copied or restored by any AWS account, otherwise set this value to false. The default is false. 
- tags - (Optional) Mapping of tags, each pair of which must exactly match a pair on the desired DB snapshot.

This PR properly formats the argument reference, hence, improving readability.

### Relations
Closes #0000

### References
https://github.com/hashicorp/terraform-provider-aws/issues/34072