### PR TITLE
Retain automated backups by default when deleting RDS instances

### DIFF
--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -215,7 +215,7 @@ func ResourceInstance() *schema.Resource {
 			"delete_automated_backups": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  true,
+				Default:  false,
 			},
 			"deletion_protection": {
 				Type:     schema.TypeBool,
@@ -2351,7 +2351,7 @@ func resourceInstanceImport(_ context.Context, d *schema.ResourceData, meta inte
 	// from any API call, so we need to default skip_final_snapshot to true so
 	// that final_snapshot_identifier is not required.
 	d.Set("skip_final_snapshot", true)
-	d.Set("delete_automated_backups", true)
+	d.Set("delete_automated_backups", false)
 	return []*schema.ResourceData{d}, nil
 }
 

--- a/internal/service/rds/instance_migrate.go
+++ b/internal/service/rds/instance_migrate.go
@@ -396,7 +396,7 @@ func InstanceStateUpgradeV0(_ context.Context, rawState map[string]interface{}, 
 		return nil, nil
 	}
 
-	rawState["delete_automated_backups"] = true
+	rawState["delete_automated_backups"] = false
 
 	return rawState, nil
 }

--- a/website/docs/cdktf/python/r/db_instance.html.markdown
+++ b/website/docs/cdktf/python/r/db_instance.html.markdown
@@ -331,7 +331,7 @@ with read replicas, it should be specified only if the source database
 specifies an instance in another AWS Region. See [DBSubnetGroupName in API
 action CreateDBInstanceReadReplica](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstanceReadReplica.html)
 for additional read replica constraints.
-* `delete_automated_backups` - (Optional) Specifies whether to remove automated backups immediately after the DB instance is deleted. Default is `true`.
+* `delete_automated_backups` - (Optional) Specifies whether to remove automated backups immediately after the DB instance is deleted. Default is `false`.
 * `deletion_protection` - (Optional) If the DB instance should have deletion protection enabled. The database can't be deleted when this value is set to `true`. The default is `false`.
 * `domain` - (Optional) The ID of the Directory Service Active Directory domain to create the instance in.
 * `domain_iam_role_name` - (Optional, but required if domain is provided) The name of the IAM role to be used when making API calls to the Directory Service.


### PR DESCRIPTION
### Description

This matches the default when deleting instances through the console, and avoids quite a large foot-gun.

### Relations

https://github.com/hashicorp/terraform-provider-aws/issues/13257

### References

![image](https://github.com/hashicorp/terraform-provider-aws/assets/6527489/b608d15e-acdd-41a2-8f34-a822e0c8a7ea)


