### PR TITLE
Fix aws_lb network in AWS GovCloud

### DIFF
--- a/.changelog/34135.txt
+++ b/.changelog/34135.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lb: Remove `dns_record.client_routing_policy` attribute on creation, fixing `InvalidConfigurationRequest` errors in AWS Gov Cloud
+```

--- a/internal/service/elbv2/load_balancer.go
+++ b/internal/service/elbv2/load_balancer.go
@@ -543,7 +543,7 @@ func resourceLoadBalancerUpdate(ctx context.Context, d *schema.ResourceData, met
 		}
 
 	case elbv2.LoadBalancerTypeEnumNetwork:
-		if d.HasChange("dns_record_client_routing_policy") || d.IsNewResource() {
+		if d.HasChange("dns_record_client_routing_policy") {
 			attributes = append(attributes, &elbv2.LoadBalancerAttribute{
 				Key:   aws.String("dns_record.client_routing_policy"),
 				Value: aws.String(d.Get("dns_record_client_routing_policy").(string)),


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
This attempts to prevent trying to set the dns record options on NLB's in regions that do not support it
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #34135 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
❯ make test
==> Checking that code complies with gofmt requirements...
go test ./...  -timeout=5m
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	7.908s
```
