### PR TITLE
resource/aws_amplify_branch: fix forces replacement

### DIFF
--- a/.changelog/34141.txt
+++ b/.changelog/34141.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_amplify_branch: Fix forces replacement when enable_performance_mode has changed
+```

--- a/.changelog/34141.txt
+++ b/.changelog/34141.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_amplify_branch: Fix forces replacement when enable_performance_mode has changed
+resource/aws_amplify_branch: Remove [ForceNew](https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-behaviors#forcenew) from `enable_performance_mode`
 ```

--- a/internal/service/amplify/branch.go
+++ b/internal/service/amplify/branch.go
@@ -31,6 +31,7 @@ func ResourceBranch() *schema.Resource {
 		ReadWithoutTimeout:   resourceBranchRead,
 		UpdateWithoutTimeout: resourceBranchUpdate,
 		DeleteWithoutTimeout: resourceBranchDelete,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -43,24 +44,20 @@ func ResourceBranch() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
 			"associated_resources": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-
 			"backend_environment_arn": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: verify.ValidARN,
 			},
-
 			"basic_auth_credentials": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -75,87 +72,72 @@ func ResourceBranch() *schema.Resource {
 					return true
 				},
 			},
-
 			"branch_name": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z/_.-]{1,255}$`), "should be not be more than 255 letters, numbers, and the symbols /_.-"),
 			},
-
 			"custom_domains": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-
 			"description": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringLenBetween(1, 1000),
 			},
-
 			"destination_branch": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
 			"display_name": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
 				ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[0-9a-z-]{1,255}$`), "should be not be more than 255 lowercase alphanumeric or hyphen characters"),
 			},
-
 			"enable_auto_build": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
 			},
-
 			"enable_basic_auth": {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
-
 			"enable_notification": {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
-
 			"enable_performance_mode": {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
-
 			"enable_pull_request_preview": {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
-
 			"environment_variables": {
 				Type:     schema.TypeMap,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-
 			"framework": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringLenBetween(1, 255),
 			},
-
 			"pull_request_environment_name": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringLenBetween(1, 20),
 			},
-
 			"source_branch": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
 			"stage": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -169,7 +151,6 @@ func ResourceBranch() *schema.Resource {
 					return old == new
 				},
 			},
-
 			"ttl": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -182,7 +163,6 @@ func ResourceBranch() *schema.Resource {
 					return old == new
 				},
 			},
-
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
@@ -196,7 +176,6 @@ func resourceBranchCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	appID := d.Get("app_id").(string)
 	branchName := d.Get("branch_name").(string)
 	id := BranchCreateResourceID(appID, branchName)
-
 	input := &amplify.CreateBranchInput{
 		AppId:           aws.String(appID),
 		BranchName:      aws.String(branchName),
@@ -256,7 +235,6 @@ func resourceBranchCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		input.Ttl = aws.String(v.(string))
 	}
 
-	log.Printf("[DEBUG] Creating Amplify Branch: %s", input)
 	_, err := conn.CreateBranchWithContext(ctx, input)
 
 	if err != nil {
@@ -273,9 +251,8 @@ func resourceBranchRead(ctx context.Context, d *schema.ResourceData, meta interf
 	conn := meta.(*conns.AWSClient).AmplifyConn(ctx)
 
 	appID, branchName, err := BranchParseResourceID(d.Id())
-
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "parsing Amplify Branch ID: %s", err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	branch, err := FindBranchByAppIDAndBranchName(ctx, conn, appID, branchName)
@@ -323,9 +300,8 @@ func resourceBranchUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 
 	if d.HasChangesExcept("tags", "tags_all") {
 		appID, branchName, err := BranchParseResourceID(d.Id())
-
 		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "parsing Amplify Branch ID: %s", err)
+			return sdkdiag.AppendFromErr(diags, err)
 		}
 
 		input := &amplify.UpdateBranchInput{
@@ -408,9 +384,8 @@ func resourceBranchDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	conn := meta.(*conns.AWSClient).AmplifyConn(ctx)
 
 	appID, branchName, err := BranchParseResourceID(d.Id())
-
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "parsing Amplify Branch ID: %s", err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	log.Printf("[DEBUG] Deleting Amplify Branch: %s", d.Id())

--- a/internal/service/amplify/branch.go
+++ b/internal/service/amplify/branch.go
@@ -126,7 +126,6 @@ func ResourceBranch() *schema.Resource {
 			"enable_performance_mode": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				ForceNew: true,
 			},
 
 			"enable_pull_request_preview": {

--- a/internal/service/amplify/branch.go
+++ b/internal/service/amplify/branch.go
@@ -362,7 +362,7 @@ func resourceBranchUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		}
 
 		if d.HasChange("enable_performance_mode") {
-			input.EnablePullRequestPreview = aws.Bool(d.Get("enable_performance_mode").(bool))
+			input.EnablePerformanceMode = aws.Bool(d.Get("enable_performance_mode").(bool))
 		}
 
 		if d.HasChange("enable_pull_request_preview") {

--- a/internal/service/amplify/branch_test.go
+++ b/internal/service/amplify/branch_test.go
@@ -278,7 +278,7 @@ func testAccBranch_OptionalArguments(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "display_name", "testdisplayname2"),
 					resource.TestCheckResourceAttr(resourceName, "enable_auto_build", "true"),
 					resource.TestCheckResourceAttr(resourceName, "enable_notification", "false"),
-					resource.TestCheckResourceAttr(resourceName, "enable_performance_mode", "true"),
+					resource.TestCheckResourceAttr(resourceName, "enable_performance_mode", "false"),
 					resource.TestCheckResourceAttr(resourceName, "enable_pull_request_preview", "true"),
 					resource.TestCheckResourceAttr(resourceName, "framework", "Angular"),
 					resource.TestCheckResourceAttr(resourceName, "pull_request_environment_name", "testpr2"),
@@ -512,7 +512,7 @@ resource "aws_amplify_branch" "test" {
   display_name                  = "testdisplayname2"
   enable_auto_build             = true
   enable_notification           = false
-  enable_performance_mode       = true
+  enable_performance_mode       = false
   enable_pull_request_preview   = true
   framework                     = "Angular"
   pull_request_environment_name = "testpr2"


### PR DESCRIPTION
### Description
Unnecessary `ForceNew` are included at `enable_performance_mode`.

### Relations
Closes #34130

### References
`ForceNew` isn't written in document.
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/amplify_branch#enable_performance_mode

### Output from Acceptance Testing
```console
$ make testacc TESTARGS='-run=TestAccAmplify_serial/Branch/OptionalArguments' PKG=amplify
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/amplify/... -v -count 1 -parallel 20  -run=TestAccAmplify_serial/Branch/OptionalArguments -timeout 360m
=== RUN   TestAccAmplify_serial
=== PAUSE TestAccAmplify_serial
=== CONT  TestAccAmplify_serial
=== RUN   TestAccAmplify_serial/Branch
=== RUN   TestAccAmplify_serial/Branch/OptionalArguments
--- PASS: TestAccAmplify_serial (338.48s)
    --- PASS: TestAccAmplify_serial/Branch (338.48s)
        --- PASS: TestAccAmplify_serial/Branch/OptionalArguments (338.47s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/amplify	343.023s
```
