### PR TITLE
Add `aws_opensearchserverless_lifecycle_policy` resource and data source

### DIFF
--- a/.changelog/34144.txt
+++ b/.changelog/34144.txt
@@ -1,3 +1,7 @@
 ```release-note:new-resource
 aws_opensearchserverless_lifecycle_policy
 ```
+
+```release-note:new-data-source
+aws_opensearchserverless_lifecycle_policy
+```

--- a/.changelog/34144.txt
+++ b/.changelog/34144.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_opensearchserverless_lifecycle_policy
+```

--- a/internal/service/opensearchserverless/exports_test.go
+++ b/internal/service/opensearchserverless/exports_test.go
@@ -5,15 +5,17 @@ package opensearchserverless
 
 // Exports for use in tests only.
 var (
-	ResourceAccessPolicy   = newResourceAccessPolicy
-	ResourceCollection     = newResourceCollection
-	ResourceSecurityConfig = newResourceSecurityConfig
-	ResourceSecurityPolicy = newResourceSecurityPolicy
-	ResourceVPCEndpoint    = newResourceVPCEndpoint
+	ResourceAccessPolicy    = newResourceAccessPolicy
+	ResourceCollection      = newResourceCollection
+	ResourceLifecyclePolicy = newResourceLifecyclePolicy
+	ResourceSecurityConfig  = newResourceSecurityConfig
+	ResourceSecurityPolicy  = newResourceSecurityPolicy
+	ResourceVPCEndpoint     = newResourceVPCEndpoint
 
-	FindAccessPolicyByNameAndType   = findAccessPolicyByNameAndType
-	FindCollectionByID              = findCollectionByID
-	FindSecurityConfigByID          = findSecurityConfigByID
-	FindSecurityPolicyByNameAndType = findSecurityPolicyByNameAndType
-	FindVPCEndpointByID             = findVPCEndpointByID
+	FindAccessPolicyByNameAndType    = findAccessPolicyByNameAndType
+	FindCollectionByID               = findCollectionByID
+	FindLifecyclePolicyByNameAndType = findLifecyclePolicyByNameAndType
+	FindSecurityConfigByID           = findSecurityConfigByID
+	FindSecurityPolicyByNameAndType  = findSecurityPolicyByNameAndType
+	FindVPCEndpointByID              = findVPCEndpointByID
 )

--- a/internal/service/opensearchserverless/find.go
+++ b/internal/service/opensearchserverless/find.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/opensearchserverless"
 	"github.com/aws/aws-sdk-go-v2/service/opensearchserverless/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
@@ -176,15 +177,14 @@ func findLifecyclePolicyByNameAndType(ctx context.Context, conn *opensearchserve
 	}
 
 	out, err := conn.BatchGetLifecyclePolicy(ctx, in)
-	if err != nil {
-		var nfe *types.ResourceNotFoundException
-		if errors.As(err, &nfe) {
-			return nil, &retry.NotFoundError{
-				LastError:   err,
-				LastRequest: in,
-			}
+	if errs.IsA[*types.ResourceNotFoundException](err) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: in,
 		}
+	}
 
+	if err != nil {
 		return nil, err
 	}
 

--- a/internal/service/opensearchserverless/lifecycle_policy.go
+++ b/internal/service/opensearchserverless/lifecycle_policy.go
@@ -1,0 +1,296 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package opensearchserverless
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/opensearchserverless"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/opensearchserverless/types"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// Function annotations are used for resource registration to the Provider. DO NOT EDIT.
+// @FrameworkResource(name="Lifecycle Policy")
+func newResourceLifecyclePolicy(_ context.Context) (resource.ResourceWithConfigure, error) {
+	return &resourceLifecyclePolicy{}, nil
+}
+
+const (
+	ResNameLifecyclePolicy = "Lifecycle Policy"
+)
+
+type resourceLifecyclePolicy struct {
+	framework.ResourceWithConfigure
+	framework.WithTimeouts
+}
+
+func (r *resourceLifecyclePolicy) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "aws_opensearchserverless_lifecycle_policy"
+}
+
+func (r *resourceLifecyclePolicy) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"description": schema.StringAttribute{
+				Optional: true,
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 1000),
+				},
+			},
+			"id": framework.IDAttribute(),
+			"name": schema.StringAttribute{
+				Required: true,
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(3, 32),
+				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"policy": schema.StringAttribute{
+				Required: true,
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 20480),
+				},
+			},
+			"policy_version": schema.StringAttribute{
+				Computed: true,
+			},
+			"type": schema.StringAttribute{
+				Required: true,
+				Validators: []validator.String{
+					enum.FrameworkValidate[awstypes.LifecyclePolicyType](),
+				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+		},
+	}
+}
+
+func (r *resourceLifecyclePolicy) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().OpenSearchServerlessClient(ctx)
+
+	var plan resourceLifecyclePolicyData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := &opensearchserverless.CreateLifecyclePolicyInput{
+		ClientToken: aws.String(id.UniqueId()),
+		Name:        aws.String(plan.Name.ValueString()),
+		Policy:      aws.String(plan.Policy.ValueString()),
+		Type:        awstypes.LifecyclePolicyType(plan.Type.ValueString()),
+	}
+
+	if !plan.Description.IsNull() {
+		in.Description = aws.String(plan.Description.ValueString())
+	}
+
+	out, err := conn.CreateLifecyclePolicy(ctx, in)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionCreating, ResNameLifecyclePolicy, plan.Name.String(), err),
+			err.Error(),
+		)
+		return
+	}
+	if out == nil || out.LifecyclePolicyDetail == nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionCreating, ResNameLifecyclePolicy, plan.Name.String(), nil),
+			errors.New("empty output").Error(),
+		)
+		return
+	}
+
+	state := plan
+	resp.Diagnostics.Append(state.refreshFromOutput(ctx, out.LifecyclePolicyDetail)...)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *resourceLifecyclePolicy) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().OpenSearchServerlessClient(ctx)
+
+	var state resourceLifecyclePolicyData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := findLifecyclePolicyByNameAndType(ctx, conn, state.ID.ValueString(), state.Type.ValueString())
+
+	if tfresource.NotFound(err) {
+		resp.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionSetting, ResNameLifecyclePolicy, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(state.refreshFromOutput(ctx, out)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *resourceLifecyclePolicy) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	conn := r.Meta().OpenSearchServerlessClient(ctx)
+
+	var plan, state resourceLifecyclePolicyData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !plan.Description.Equal(state.Description) || !plan.Policy.Equal(state.Policy) {
+		in := &opensearchserverless.UpdateLifecyclePolicyInput{
+			ClientToken:   aws.String(id.UniqueId()),
+			Name:          flex.StringFromFramework(ctx, plan.Name),
+			PolicyVersion: flex.StringFromFramework(ctx, state.PolicyVersion),
+			Type:          awstypes.LifecyclePolicyType(plan.Type.ValueString()),
+		}
+
+		if !plan.Policy.Equal(state.Policy) {
+			in.Policy = aws.String(plan.Policy.ValueString())
+		}
+
+		if !plan.Description.Equal(state.Description) {
+			in.Description = aws.String(plan.Description.ValueString())
+		}
+
+		out, err := conn.UpdateLifecyclePolicy(ctx, in)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionUpdating, ResNameLifecyclePolicy, plan.ID.String(), err),
+				err.Error(),
+			)
+			return
+		}
+		if out == nil || out.LifecyclePolicyDetail == nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionUpdating, ResNameLifecyclePolicy, plan.ID.String(), nil),
+				errors.New("empty output").Error(),
+			)
+			return
+		}
+
+		resp.Diagnostics.Append(state.refreshFromOutput(ctx, out.LifecyclePolicyDetail)...)
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *resourceLifecyclePolicy) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	conn := r.Meta().OpenSearchServerlessClient(ctx)
+
+	var state resourceLifecyclePolicyData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := &opensearchserverless.DeleteLifecyclePolicyInput{
+		ClientToken: aws.String(id.UniqueId()),
+		Name:        aws.String(state.Name.ValueString()),
+		Type:        awstypes.LifecyclePolicyType(state.Type.ValueString()),
+	}
+
+	_, err := conn.DeleteLifecyclePolicy(ctx, in)
+
+	if err != nil {
+		var nfe *awstypes.ResourceNotFoundException
+		if errors.As(err, &nfe) {
+			return
+		}
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionDeleting, ResNameLifecyclePolicy, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+}
+
+func (r *resourceLifecyclePolicy) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	parts := strings.Split(req.ID, idSeparator)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		err := fmt.Errorf("unexpected format for ID (%[1]s), expected lifecycle-policy-name%[2]slifecycle-policy-type", req.ID, idSeparator)
+		resp.Diagnostics.AddError(fmt.Sprintf("importing %s (%s)", ResNameLifecyclePolicy, req.ID), err.Error())
+		return
+	}
+
+	state := resourceLifecyclePolicyData{
+		ID:   types.StringValue(parts[0]),
+		Name: types.StringValue(parts[0]),
+		Type: types.StringValue(parts[1]),
+	}
+
+	diags := resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// refreshFromOutput writes state data from an AWS response object
+func (rd *resourceLifecyclePolicyData) refreshFromOutput(ctx context.Context, out *awstypes.LifecyclePolicyDetail) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if out == nil {
+		return diags
+	}
+
+	rd.ID = flex.StringToFramework(ctx, out.Name)
+	rd.Description = flex.StringToFramework(ctx, out.Description)
+	rd.Name = flex.StringToFramework(ctx, out.Name)
+	rd.Type = flex.StringValueToFramework(ctx, out.Type)
+	rd.PolicyVersion = flex.StringToFramework(ctx, out.PolicyVersion)
+
+	policyBytes, err := out.Policy.MarshalSmithyDocument()
+	if err != nil {
+		diags.AddError(fmt.Sprintf("refreshing state for %s (%s)", ResNameLifecyclePolicy, rd.Name), err.Error())
+		return diags
+	}
+
+	p := string(policyBytes)
+
+	rd.Policy = flex.StringToFramework(ctx, &p)
+
+	return diags
+}
+
+type resourceLifecyclePolicyData struct {
+	Description   types.String `tfsdk:"description"`
+	ID            types.String `tfsdk:"id"`
+	Name          types.String `tfsdk:"name"`
+	Policy        types.String `tfsdk:"policy"`
+	PolicyVersion types.String `tfsdk:"policy_version"`
+	Type          types.String `tfsdk:"type"`
+}

--- a/internal/service/opensearchserverless/lifecycle_policy.go
+++ b/internal/service/opensearchserverless/lifecycle_policy.go
@@ -101,26 +101,26 @@ func (r *resourceLifecyclePolicy) Create(ctx context.Context, req resource.Creat
 
 	in := &opensearchserverless.CreateLifecyclePolicyInput{
 		ClientToken: aws.String(id.UniqueId()),
-		Name:        aws.String(plan.Name.ValueString()),
-		Policy:      aws.String(plan.Policy.ValueString()),
+		Name:        flex.StringFromFramework(ctx, plan.Name),
+		Policy:      flex.StringFromFramework(ctx, plan.Policy),
 		Type:        awstypes.LifecyclePolicyType(plan.Type.ValueString()),
 	}
 
 	if !plan.Description.IsNull() {
-		in.Description = aws.String(plan.Description.ValueString())
+		in.Description = flex.StringFromFramework(ctx, plan.Description)
 	}
 
 	out, err := conn.CreateLifecyclePolicy(ctx, in)
 	if err != nil {
 		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionCreating, ResNameLifecyclePolicy, plan.Name.String(), err),
+			create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionCreating, ResNameLifecyclePolicy, plan.Name.ValueString(), err),
 			err.Error(),
 		)
 		return
 	}
 	if out == nil || out.LifecyclePolicyDetail == nil {
 		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionCreating, ResNameLifecyclePolicy, plan.Name.String(), nil),
+			create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionCreating, ResNameLifecyclePolicy, plan.Name.ValueString(), nil),
 			errors.New("empty output").Error(),
 		)
 		return
@@ -150,7 +150,7 @@ func (r *resourceLifecyclePolicy) Read(ctx context.Context, req resource.ReadReq
 	}
 	if err != nil {
 		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionSetting, ResNameLifecyclePolicy, state.ID.String(), err),
+			create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionReading, ResNameLifecyclePolicy, state.ID.String(), err),
 			err.Error(),
 		)
 		return
@@ -179,24 +179,24 @@ func (r *resourceLifecyclePolicy) Update(ctx context.Context, req resource.Updat
 		}
 
 		if !plan.Policy.Equal(state.Policy) {
-			in.Policy = aws.String(plan.Policy.ValueString())
+			in.Policy = flex.StringFromFramework(ctx, plan.Policy)
 		}
 
 		if !plan.Description.Equal(state.Description) {
-			in.Description = aws.String(plan.Description.ValueString())
+			in.Description = flex.StringFromFramework(ctx, plan.Description)
 		}
 
 		out, err := conn.UpdateLifecyclePolicy(ctx, in)
 		if err != nil {
 			resp.Diagnostics.AddError(
-				create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionUpdating, ResNameLifecyclePolicy, plan.ID.String(), err),
+				create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionUpdating, ResNameLifecyclePolicy, plan.ID.ValueString(), err),
 				err.Error(),
 			)
 			return
 		}
 		if out == nil || out.LifecyclePolicyDetail == nil {
 			resp.Diagnostics.AddError(
-				create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionUpdating, ResNameLifecyclePolicy, plan.ID.String(), nil),
+				create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionUpdating, ResNameLifecyclePolicy, plan.ID.ValueString(), nil),
 				errors.New("empty output").Error(),
 			)
 			return
@@ -219,7 +219,7 @@ func (r *resourceLifecyclePolicy) Delete(ctx context.Context, req resource.Delet
 
 	in := &opensearchserverless.DeleteLifecyclePolicyInput{
 		ClientToken: aws.String(id.UniqueId()),
-		Name:        aws.String(state.Name.ValueString()),
+		Name:        flex.StringFromFramework(ctx, state.Name),
 		Type:        awstypes.LifecyclePolicyType(state.Type.ValueString()),
 	}
 

--- a/internal/service/opensearchserverless/lifecycle_policy.go
+++ b/internal/service/opensearchserverless/lifecycle_policy.go
@@ -30,7 +30,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// Function annotations are used for resource registration to the Provider. DO NOT EDIT.
 // @FrameworkResource(name="Lifecycle Policy")
 func newResourceLifecyclePolicy(_ context.Context) (resource.ResourceWithConfigure, error) {
 	return &resourceLifecyclePolicy{}, nil
@@ -45,11 +44,11 @@ type resourceLifecyclePolicy struct {
 	framework.WithTimeouts
 }
 
-func (r *resourceLifecyclePolicy) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+func (r *resourceLifecyclePolicy) Metadata(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = "aws_opensearchserverless_lifecycle_policy"
 }
 
-func (r *resourceLifecyclePolicy) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (r *resourceLifecyclePolicy) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"description": schema.StringAttribute{
@@ -76,6 +75,9 @@ func (r *resourceLifecyclePolicy) Schema(ctx context.Context, req resource.Schem
 			},
 			"policy_version": schema.StringAttribute{
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"type": schema.StringAttribute{
 				Required: true,

--- a/internal/service/opensearchserverless/lifecycle_policy.go
+++ b/internal/service/opensearchserverless/lifecycle_policy.go
@@ -41,7 +41,6 @@ const (
 
 type resourceLifecyclePolicy struct {
 	framework.ResourceWithConfigure
-	framework.WithTimeouts
 }
 
 func (r *resourceLifecyclePolicy) Metadata(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {

--- a/internal/service/opensearchserverless/lifecycle_policy_data_source.go
+++ b/internal/service/opensearchserverless/lifecycle_policy_data_source.go
@@ -85,7 +85,7 @@ func (d *dataSourceLifecyclePolicy) Read(ctx context.Context, req datasource.Rea
 	out, err := findLifecyclePolicyByNameAndType(ctx, conn, data.Name.ValueString(), data.Type.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionReading, DSNameLifecyclePolicy, data.Name.String(), err),
+			create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionReading, DSNameLifecyclePolicy, data.Name.ValueString(), err),
 			err.Error(),
 		)
 		return
@@ -107,7 +107,7 @@ func (d *dataSourceLifecyclePolicy) Read(ctx context.Context, req datasource.Rea
 
 	if err != nil {
 		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionReading, DSNameLifecyclePolicy, data.Name.String(), err),
+			create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionReading, DSNameLifecyclePolicy, data.Name.ValueString(), err),
 			err.Error(),
 		)
 	}

--- a/internal/service/opensearchserverless/lifecycle_policy_data_source.go
+++ b/internal/service/opensearchserverless/lifecycle_policy_data_source.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// Function annotations are used for datasource registration to the Provider. DO NOT EDIT.
 // @FrameworkDataSource(name="Lifecycle Policy")
 func newDataSourceLifecyclePolicy(context.Context) (datasource.DataSourceWithConfigure, error) {
 	return &dataSourceLifecyclePolicy{}, nil
@@ -35,11 +34,11 @@ type dataSourceLifecyclePolicy struct {
 	framework.DataSourceWithConfigure
 }
 
-func (d *dataSourceLifecyclePolicy) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) { // nosemgrep:ci.meta-in-func-name
+func (d *dataSourceLifecyclePolicy) Metadata(_ context.Context, _ datasource.MetadataRequest, resp *datasource.MetadataResponse) { // nosemgrep:ci.meta-in-func-name
 	resp.TypeName = "aws_opensearchserverless_lifecycle_policy"
 }
 
-func (d *dataSourceLifecyclePolicy) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+func (d *dataSourceLifecyclePolicy) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"created_date": schema.StringAttribute{

--- a/internal/service/opensearchserverless/lifecycle_policy_data_source.go
+++ b/internal/service/opensearchserverless/lifecycle_policy_data_source.go
@@ -1,0 +1,131 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package opensearchserverless
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/opensearchserverless/types"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// Function annotations are used for datasource registration to the Provider. DO NOT EDIT.
+// @FrameworkDataSource(name="Lifecycle Policy")
+func newDataSourceLifecyclePolicy(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &dataSourceLifecyclePolicy{}, nil
+}
+
+const (
+	DSNameLifecyclePolicy = "Lifecycle Policy Data Source"
+)
+
+type dataSourceLifecyclePolicy struct {
+	framework.DataSourceWithConfigure
+}
+
+func (d *dataSourceLifecyclePolicy) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) { // nosemgrep:ci.meta-in-func-name
+	resp.TypeName = "aws_opensearchserverless_lifecycle_policy"
+}
+
+func (d *dataSourceLifecyclePolicy) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"created_date": schema.StringAttribute{
+				Computed: true,
+			},
+			"description": schema.StringAttribute{
+				Computed: true,
+			},
+			"id": framework.IDAttribute(),
+			"last_modified_date": schema.StringAttribute{
+				Computed: true,
+			},
+			"name": schema.StringAttribute{
+				Required: true,
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(3, 32),
+				},
+			},
+			"policy": schema.StringAttribute{
+				Computed: true,
+			},
+			"policy_version": schema.StringAttribute{
+				Computed: true,
+			},
+			"type": schema.StringAttribute{
+				Required: true,
+				Validators: []validator.String{
+					enum.FrameworkValidate[awstypes.LifecyclePolicyType](),
+				},
+			},
+		},
+	}
+}
+
+func (d *dataSourceLifecyclePolicy) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	conn := d.Meta().OpenSearchServerlessClient(ctx)
+
+	var data dataSourceLifecyclePolicyData
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := findLifecyclePolicyByNameAndType(ctx, conn, data.Name.ValueString(), data.Type.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionReading, DSNameLifecyclePolicy, data.Name.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	data.ID = flex.StringToFramework(ctx, out.Name)
+	data.Description = flex.StringToFramework(ctx, out.Description)
+	data.Name = flex.StringToFramework(ctx, out.Name)
+	data.Type = flex.StringValueToFramework(ctx, out.Type)
+	data.PolicyVersion = flex.StringToFramework(ctx, out.PolicyVersion)
+
+	createdDate := time.UnixMilli(aws.ToInt64(out.CreatedDate))
+	data.CreatedDate = flex.StringValueToFramework(ctx, createdDate.Format(time.RFC3339))
+
+	lastModifiedDate := time.UnixMilli(aws.ToInt64(out.LastModifiedDate))
+	data.LastModifiedDate = flex.StringValueToFramework(ctx, lastModifiedDate.Format(time.RFC3339))
+
+	policyBytes, err := out.Policy.MarshalSmithyDocument()
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionReading, DSNameLifecyclePolicy, data.Name.String(), err),
+			err.Error(),
+		)
+	}
+
+	pb := string(policyBytes)
+	data.Policy = flex.StringToFramework(ctx, &pb)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+type dataSourceLifecyclePolicyData struct {
+	CreatedDate      types.String `tfsdk:"created_date"`
+	Description      types.String `tfsdk:"description"`
+	ID               types.String `tfsdk:"id"`
+	LastModifiedDate types.String `tfsdk:"last_modified_date"`
+	Name             types.String `tfsdk:"name"`
+	Policy           types.String `tfsdk:"policy"`
+	PolicyVersion    types.String `tfsdk:"policy_version"`
+	Type             types.String `tfsdk:"type"`
+}

--- a/internal/service/opensearchserverless/lifecycle_policy_data_source_test.go
+++ b/internal/service/opensearchserverless/lifecycle_policy_data_source_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package opensearchserverless_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/opensearchserverless/types"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccOpenSearchServerlessLifecyclePolicyDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var lifecyclepolicy types.LifecyclePolicyDetail
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_opensearchserverless_lifecycle_policy.test"
+	resourceName := "aws_opensearchserverless_lifecycle_policy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.OpenSearchServerlessEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.OpenSearchServerlessEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLifecyclePolicyDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLifecyclePolicyDataSourceConfig_basic(rName, "retention"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLifecyclePolicyExists(ctx, dataSourceName, &lifecyclepolicy),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "policy", resourceName, "policy"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "policy_version", resourceName, "policy_version"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "created_date"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "last_modified_date"),
+				),
+			},
+		},
+	})
+}
+
+func testAccLifecyclePolicyDataSourceConfig_basic(rName, policyType string) string {
+	return fmt.Sprintf(`
+resource "aws_opensearchserverless_lifecycle_policy" "test" {
+  name        = %[1]q
+  type        = %[2]q
+  description = %[1]q
+  policy = jsonencode({
+    "Rules" : [
+      {
+        "ResourceType" : "index",
+        "Resource" : ["index/autoparts-inventory/*"],
+        "MinIndexRetention" : "81d"
+      },
+      {
+        "ResourceType" : "index",
+        "Resource" : ["index/sales/orders*"],
+        "NoMinIndexRetention" : true
+      }
+    ]
+  })
+}
+
+data "aws_opensearchserverless_lifecycle_policy" "test" {
+  name = aws_opensearchserverless_lifecycle_policy.test.name
+  type = aws_opensearchserverless_lifecycle_policy.test.type
+}
+`, rName, policyType)
+}

--- a/internal/service/opensearchserverless/lifecycle_policy_data_source_test.go
+++ b/internal/service/opensearchserverless/lifecycle_policy_data_source_test.go
@@ -58,12 +58,12 @@ resource "aws_opensearchserverless_lifecycle_policy" "test" {
     "Rules" : [
       {
         "ResourceType" : "index",
-        "Resource" : ["index/autoparts-inventory/*"],
+        "Resource" : ["index/%[1]sy/*"],
         "MinIndexRetention" : "81d"
       },
       {
         "ResourceType" : "index",
-        "Resource" : ["index/sales/orders*"],
+        "Resource" : ["index/local-sales/%[1]s*"],
         "NoMinIndexRetention" : true
       }
     ]

--- a/internal/service/opensearchserverless/lifecycle_policy_test.go
+++ b/internal/service/opensearchserverless/lifecycle_policy_test.go
@@ -74,7 +74,7 @@ func TestAccOpenSearchServerlessLifecyclePolicy_disappears(t *testing.T) {
 		CheckDestroy:             testAccCheckLifecyclePolicyDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLifecyclePolicyConfig_disappears(rName),
+				Config: testAccLifecyclePolicyConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLifecyclePolicyExists(ctx, resourceName, &lifecyclepolicy),
 					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfopensearchserverless.ResourceLifecyclePolicy, resourceName),
@@ -206,35 +206,12 @@ resource "aws_opensearchserverless_lifecycle_policy" "test" {
     "Rules" : [
       {
         "ResourceType" : "index",
-        "Resource" : ["index/autoparts-inventory/*"],
+        "Resource" : ["index/%[1]s/*"],
         "MinIndexRetention" : "81d"
       },
       {
         "ResourceType" : "index",
-        "Resource" : ["index/sales/orders*"],
-        "NoMinIndexRetention" : true
-      }
-    ]
-  })
-}
-`, rName)
-}
-
-func testAccLifecyclePolicyConfig_disappears(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_opensearchserverless_lifecycle_policy" "test" {
-  name = %[1]q
-  type = "retention"
-  policy = jsonencode({
-    "Rules" : [
-      {
-        "ResourceType" : "index",
-        "Resource" : ["index/computer-inventory/*"],
-        "MinIndexRetention" : "81d"
-      },
-      {
-        "ResourceType" : "index",
-        "Resource" : ["index/national-sales/orders*"],
+        "Resource" : ["index/sales/%[1]s*"],
         "NoMinIndexRetention" : true
       }
     ]
@@ -253,12 +230,12 @@ resource "aws_opensearchserverless_lifecycle_policy" "test" {
     "Rules" : [
       {
         "ResourceType" : "index",
-        "Resource" : ["index/toy-inventory/*"],
+        "Resource" : ["index/%[1]s/*"],
         "MinIndexRetention" : "81d"
       },
       {
         "ResourceType" : "index",
-        "Resource" : ["index/holiday-sales/orders*"],
+        "Resource" : ["index/holiday-sales/%[1]s*"],
         "NoMinIndexRetention" : true
       }
     ]

--- a/internal/service/opensearchserverless/lifecycle_policy_test.go
+++ b/internal/service/opensearchserverless/lifecycle_policy_test.go
@@ -1,0 +1,268 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package opensearchserverless_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/opensearchserverless"
+	"github.com/aws/aws-sdk-go-v2/service/opensearchserverless/types"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tfopensearchserverless "github.com/hashicorp/terraform-provider-aws/internal/service/opensearchserverless"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccOpenSearchServerlessLifecyclePolicy_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var lifecyclepolicy types.LifecyclePolicyDetail
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_opensearchserverless_lifecycle_policy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.OpenSearchServerlessEndpointID)
+			testAccPreCheckLifecyclePolicy(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.OpenSearchServerlessEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLifecyclePolicyDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLifecyclePolicyConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLifecyclePolicyExists(ctx, resourceName, &lifecyclepolicy),
+					resource.TestCheckResourceAttr(resourceName, "type", "retention"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccLifecyclePolicyImportStateIdFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccOpenSearchServerlessLifecyclePolicy_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var lifecyclepolicy types.LifecyclePolicyDetail
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_opensearchserverless_lifecycle_policy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.OpenSearchServerlessEndpointID)
+			testAccPreCheckLifecyclePolicy(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.OpenSearchServerlessEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLifecyclePolicyDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLifecyclePolicyConfig_disappears(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLifecyclePolicyExists(ctx, resourceName, &lifecyclepolicy),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfopensearchserverless.ResourceLifecyclePolicy, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccOpenSearchServerlessLifecyclePolicy_update(t *testing.T) {
+	ctx := acctest.Context(t)
+	var lifecyclepolicy types.LifecyclePolicyDetail
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_opensearchserverless_lifecycle_policy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.OpenSearchServerlessEndpointID)
+			testAccPreCheckLifecyclePolicy(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.OpenSearchServerlessEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLifecyclePolicyDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLifecyclePolicyConfig_update(rName, "description"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLifecyclePolicyExists(ctx, resourceName, &lifecyclepolicy),
+					resource.TestCheckResourceAttr(resourceName, "type", "retention"),
+					resource.TestCheckResourceAttr(resourceName, "description", "description"),
+				),
+			},
+			{
+				Config: testAccLifecyclePolicyConfig_update(rName, "description updated"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLifecyclePolicyExists(ctx, resourceName, &lifecyclepolicy),
+					resource.TestCheckResourceAttr(resourceName, "type", "retention"),
+					resource.TestCheckResourceAttr(resourceName, "description", "description updated"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckLifecyclePolicyDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).OpenSearchServerlessClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_opensearchserverless_lifecycle_policy" {
+				continue
+			}
+
+			_, err := tfopensearchserverless.FindLifecyclePolicyByNameAndType(ctx, conn, rs.Primary.ID, rs.Primary.Attributes["type"])
+
+			if tfresource.NotFound(err) {
+				continue
+			}
+			if err != nil {
+				return create.Error(names.OpenSearchServerless, create.ErrActionCheckingDestroyed, tfopensearchserverless.ResNameLifecyclePolicy, rs.Primary.ID, err)
+			}
+
+			return create.Error(names.OpenSearchServerless, create.ErrActionCheckingDestroyed, tfopensearchserverless.ResNameLifecyclePolicy, rs.Primary.ID, errors.New("not destroyed"))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckLifecyclePolicyExists(ctx context.Context, name string, lifecyclepolicy *types.LifecyclePolicyDetail) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.OpenSearchServerless, create.ErrActionCheckingExistence, tfopensearchserverless.ResNameLifecyclePolicy, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.OpenSearchServerless, create.ErrActionCheckingExistence, tfopensearchserverless.ResNameLifecyclePolicy, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).OpenSearchServerlessClient(ctx)
+		resp, err := tfopensearchserverless.FindLifecyclePolicyByNameAndType(ctx, conn, rs.Primary.ID, rs.Primary.Attributes["type"])
+
+		if err != nil {
+			return create.Error(names.OpenSearchServerless, create.ErrActionCheckingExistence, tfopensearchserverless.ResNameLifecyclePolicy, rs.Primary.ID, err)
+		}
+
+		*lifecyclepolicy = *resp
+
+		return nil
+	}
+}
+
+func testAccLifecyclePolicyImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["name"], rs.Primary.Attributes["type"]), nil
+	}
+}
+
+func testAccPreCheckLifecyclePolicy(ctx context.Context, t *testing.T) {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).OpenSearchServerlessClient(ctx)
+
+	input := &opensearchserverless.ListLifecyclePoliciesInput{
+		Type: types.LifecyclePolicyTypeRetention,
+	}
+	_, err := conn.ListLifecyclePolicies(ctx, input)
+
+	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func testAccLifecyclePolicyConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_opensearchserverless_lifecycle_policy" "test" {
+  name = %[1]q
+  type = "retention"
+  policy = jsonencode({
+    "Rules" : [
+      {
+        "ResourceType" : "index",
+        "Resource" : ["index/autoparts-inventory/*"],
+        "MinIndexRetention" : "81d"
+      },
+      {
+        "ResourceType" : "index",
+        "Resource" : ["index/sales/orders*"],
+        "NoMinIndexRetention" : true
+      }
+    ]
+  })
+}
+`, rName)
+}
+
+func testAccLifecyclePolicyConfig_disappears(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_opensearchserverless_lifecycle_policy" "test" {
+  name = %[1]q
+  type = "retention"
+  policy = jsonencode({
+    "Rules" : [
+      {
+        "ResourceType" : "index",
+        "Resource" : ["index/computer-inventory/*"],
+        "MinIndexRetention" : "81d"
+      },
+      {
+        "ResourceType" : "index",
+        "Resource" : ["index/national-sales/orders*"],
+        "NoMinIndexRetention" : true
+      }
+    ]
+  })
+}
+`, rName)
+}
+
+func testAccLifecyclePolicyConfig_update(rName, description string) string {
+	return fmt.Sprintf(`
+resource "aws_opensearchserverless_lifecycle_policy" "test" {
+  name        = %[1]q
+  type        = "retention"
+  description = %[2]q
+  policy = jsonencode({
+    "Rules" : [
+      {
+        "ResourceType" : "index",
+        "Resource" : ["index/toy-inventory/*"],
+        "MinIndexRetention" : "81d"
+      },
+      {
+        "ResourceType" : "index",
+        "Resource" : ["index/holiday-sales/orders*"],
+        "NoMinIndexRetention" : true
+      }
+    ]
+  })
+}
+`, rName, description)
+}

--- a/internal/service/opensearchserverless/lifecycle_policy_test.go
+++ b/internal/service/opensearchserverless/lifecycle_policy_test.go
@@ -44,6 +44,8 @@ func TestAccOpenSearchServerlessLifecyclePolicy_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLifecyclePolicyExists(ctx, resourceName, &lifecyclepolicy),
 					resource.TestCheckResourceAttr(resourceName, "type", "retention"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy_version"),
 				),
 			},
 			{

--- a/internal/service/opensearchserverless/service_package_gen.go
+++ b/internal/service/opensearchserverless/service_package_gen.go
@@ -25,6 +25,10 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.Serv
 			Name:    "Collection",
 		},
 		{
+			Factory: newDataSourceLifecyclePolicy,
+			Name:    "Lifecycle Policy",
+		},
+		{
 			Factory: newDataSourceSecurityConfig,
 			Name:    "Security Config",
 		},

--- a/internal/service/opensearchserverless/service_package_gen.go
+++ b/internal/service/opensearchserverless/service_package_gen.go
@@ -44,6 +44,10 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 			},
 		},
 		{
+			Factory: newResourceLifecyclePolicy,
+			Name:    "Lifecycle Policy",
+		},
+		{
 			Factory: newResourceSecurityConfig,
 		},
 		{

--- a/website/docs/d/opensearchserverless_lifecycle_policy.html.markdown
+++ b/website/docs/d/opensearchserverless_lifecycle_policy.html.markdown
@@ -1,0 +1,39 @@
+---
+subcategory: "OpenSearch Serverless"
+layout: "aws"
+page_title: "AWS: aws_opensearchserverless_lifecycle_policy"
+description: |-
+  Terraform data source for managing an AWS OpenSearch Serverless Lifecycle Policy.
+---
+
+# Data Source: aws_opensearchserverless_lifecycle_policy
+
+Terraform data source for managing an AWS OpenSearch Serverless Lifecycle Policy.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_opensearchserverless_lifecycle_policy" "example" {
+  name = "example-lifecycle-policy"
+  type = "retention"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `name` - (Required) Name of the policy
+* `type` - (Required) Type of lifecycle policy. Must be `retention`.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `created_date` - The date the lifecycle policy was created.
+* `description` - Description of the policy. Typically used to store information about the permissions defined in the policy.
+* `last_modified_date` - The date the lifecycle policy was last modified.
+* `policy` - JSON policy document to use as the content for the new policy.
+* `policy_version` - Version of the policy.

--- a/website/docs/r/opensearchserverless_lifecycle_policy.html.markdown
+++ b/website/docs/r/opensearchserverless_lifecycle_policy.html.markdown
@@ -1,0 +1,71 @@
+---
+subcategory: "OpenSearch Serverless"
+layout: "aws"
+page_title: "AWS: aws_opensearchserverless_lifecycle_policy"
+description: |-
+  Terraform resource for managing an AWS OpenSearch Serverless Lifecycle Policy.
+---
+
+# Resource: aws_opensearchserverless_lifecycle_policy
+
+Terraform resource for managing an AWS OpenSearch Serverless Lifecycle Policy. See AWS documentation for [lifecycle policies](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-lifecycle.html).
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_opensearchserverless_lifecycle_policy" "example" {
+  name = "example"
+  type = "retention"
+  policy = jsonencode({
+    "Rules" : [
+      {
+        "ResourceType" : "index",
+        "Resource" : ["index/autoparts-inventory/*"],
+        "MinIndexRetention" : "81d"
+      },
+      {
+        "ResourceType" : "index",
+        "Resource" : ["index/sales/orders*"],
+        "NoMinIndexRetention" : true
+      }
+    ]
+  })
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `name` - (Required) Name of the policy.
+* `policy` - (Required) JSON policy document to use as the content for the new policy.
+* `type` - (Required) Type of lifecycle policy. Must be `retention`.
+
+The following arguments are optional:
+
+* `description` - (Optional) Description of the policy.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `policy_version` - Version of the policy.
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import OpenSearch Serverless Lifecycle Policy using the `name` and `type` arguments separated by a slash (`/`). For example:
+
+```terraform
+import {
+  to = aws_opensearchserverless_lifecycle_policy.example
+  id = "example/retention"
+}
+```
+
+Using `terraform import`, import OpenSearch Serverless Lifecycle Policy using the `name` and `type` arguments separated by a slash (`/`). For example:
+
+```console
+% terraform import aws_opensearchserverless_lifecycle_policy.example example/retention
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Combining the resource and data source into 1 PR with 2 separate commits.
- Adding new resource for OpenSearch Serverless Lifecycle Policy
- Adding new data source for OpenSearch Serverless Lifecycle Policy


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #34092

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/opensearch-service/latest/ServerlessAPIReference/API_CreateLifecyclePolicy.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

#### Resource
```console
% make testacc TESTS=TestAccOpenSearchServerlessLifecyclePolicy PKG=opensearchserverless
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/opensearchserverless/... -v -count 1 -parallel 20 -run='TestAccOpenSearchServerlessLifecyclePolicy'  -timeout 360m
=== RUN   TestAccOpenSearchServerlessLifecyclePolicy_basic
=== PAUSE TestAccOpenSearchServerlessLifecyclePolicy_basic
=== RUN   TestAccOpenSearchServerlessLifecyclePolicy_disappears
=== PAUSE TestAccOpenSearchServerlessLifecyclePolicy_disappears
=== RUN   TestAccOpenSearchServerlessLifecyclePolicy_update
=== PAUSE TestAccOpenSearchServerlessLifecyclePolicy_update
=== CONT  TestAccOpenSearchServerlessLifecyclePolicy_basic
=== CONT  TestAccOpenSearchServerlessLifecyclePolicy_update
=== CONT  TestAccOpenSearchServerlessLifecyclePolicy_disappears
--- PASS: TestAccOpenSearchServerlessLifecyclePolicy_disappears (14.76s)
--- PASS: TestAccOpenSearchServerlessLifecyclePolicy_basic (19.08s)
--- PASS: TestAccOpenSearchServerlessLifecyclePolicy_update (27.52s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/opensearchserverless       30.770s
```

#### Data source
```console
% make testacc TESTS=TestAccOpenSearchServerlessLifecyclePolicyDataSource PKG=opensearchserverless
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/opensearchserverless/... -v -count 1 -parallel 20 -run='TestAccOpenSearchServerlessLifecyclePolicyDataSource'  -timeout 360m
=== RUN   TestAccOpenSearchServerlessLifecyclePolicyDataSource_basic
=== PAUSE TestAccOpenSearchServerlessLifecyclePolicyDataSource_basic
=== CONT  TestAccOpenSearchServerlessLifecyclePolicyDataSource_basic
--- PASS: TestAccOpenSearchServerlessLifecyclePolicyDataSource_basic (16.61s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/opensearchserverless       19.760s
```