### PR TITLE
Add support for multinode batch job definitions

### DIFF
--- a/internal/service/batch/job_definition.go
+++ b/internal/service/batch/job_definition.go
@@ -68,6 +68,20 @@ func ResourceJobDefinition() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validName,
 			},
+			"node_properties": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				StateFunc: func(v interface{}) string {
+					json, _ := structure.NormalizeJsonString(v)
+					return json
+				},
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					equal, _ := EquivalentNodePropertiesJSON(old, new)
+					return equal
+				},
+				ValidateFunc: validJobNodeProperties,
+			},
 			"parameters": {
 				Type:     schema.TypeMap,
 				Optional: true,
@@ -178,7 +192,7 @@ func ResourceJobDefinition() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{batch.JobDefinitionTypeContainer}, true),
+				ValidateFunc: validation.StringInSlice([]string{batch.JobDefinitionTypeContainer, batch.JobDefinitionTypeMultinode}, true),
 			},
 		},
 
@@ -215,6 +229,27 @@ func resourceJobDefinitionCreate(ctx context.Context, d *schema.ResourceData, me
 		}
 
 		input.ContainerProperties = props
+	}
+
+	if v, ok := d.GetOk("node_properties"); ok {
+		props, err := expandJobNodeProperties(v.(string))
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "creating Batch Job Definition (%s): %s", name, err)
+		}
+
+		for _, node := range props.NodeRangeProperties {
+			for _, env := range node.Container.Environment {
+				if aws.StringValue(env.Value) == "" {
+					diags = append(diags, errs.NewAttributeWarningDiagnostic(
+						cty.GetAttrPath("container_properties"),
+						"Ignoring environment variable",
+						fmt.Sprintf("The environment variable %q has an empty value, which is ignored by the Batch service", aws.StringValue(env.Name))),
+					)
+				}
+			}
+		}
+
+		input.NodeProperties = props
 	}
 
 	if v, ok := d.GetOk("parameters"); ok {
@@ -270,6 +305,16 @@ func resourceJobDefinitionRead(ctx context.Context, d *schema.ResourceData, meta
 
 	if err := d.Set("container_properties", containerProperties); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting container_properties: %s", err)
+	}
+
+	nodeProperties, err := flattenNodeProperties(jobDefinition.NodeProperties)
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "converting Batch Node Properties to JSON: %s", err)
+	}
+
+	if err := d.Set("node_properties", nodeProperties); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting node_properties: %s", err)
 	}
 
 	d.Set("name", jobDefinition.JobDefinitionName)
@@ -390,6 +435,37 @@ func expandJobContainerProperties(rawProps string) (*batch.ContainerProperties, 
 // Convert batch.ContainerProperties object into its JSON representation
 func flattenContainerProperties(containerProperties *batch.ContainerProperties) (string, error) {
 	b, err := jsonutil.BuildJSON(containerProperties)
+
+	if err != nil {
+		return "", err
+	}
+
+	return string(b), nil
+}
+
+func validJobNodeProperties(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	_, err := expandJobNodeProperties(value)
+	if err != nil {
+		errors = append(errors, fmt.Errorf("AWS Batch Job node_properties is invalid: %s", err))
+	}
+	return
+}
+
+func expandJobNodeProperties(rawProps string) (*batch.NodeProperties, error) {
+	var props *batch.NodeProperties
+
+	err := json.Unmarshal([]byte(rawProps), &props)
+	if err != nil {
+		return nil, fmt.Errorf("decoding JSON: %s", err)
+	}
+
+	return props, nil
+}
+
+// Convert batch.NodeProperties object into its JSON representation
+func flattenNodeProperties(nodeProperties *batch.NodeProperties) (string, error) {
+	b, err := jsonutil.BuildJSON(nodeProperties)
 
 	if err != nil {
 		return "", err

--- a/internal/service/batch/job_definition_test.go
+++ b/internal/service/batch/job_definition_test.go
@@ -567,6 +567,78 @@ func TestAccBatchJobDefinition_NodePropertiesupdateForcesNewResource(t *testing.
 	})
 }
 
+func TestAccBatchJobDefinition_createTypeContainerWithBothProperties(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckJobDefinitionDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccJobDefinitionConfig_createTypeContainerWithBothProperties(rName),
+				ExpectError: regexache.MustCompile("No `node_properties` can be specified when `type` is \"container\""),
+			},
+		},
+	})
+}
+
+func TestAccBatchJobDefinition_createTypeContainerWithNodeProperties(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckJobDefinitionDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccJobDefinitionConfig_createTypeContainerWithNodeProperties(rName),
+				ExpectError: regexache.MustCompile("No `node_properties` can be specified when `type` is \"container\""),
+			},
+		},
+	})
+}
+
+func TestAccBatchJobDefinition_createTypeMultiNodeWithBothProperties(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckJobDefinitionDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccJobDefinitionConfig_createTypeMultiNodeWithBothProperties(rName),
+				ExpectError: regexache.MustCompile("No `container_properties` can be specified when `type` is \"multinode\""),
+			},
+		},
+	})
+}
+
+func TestAccBatchJobDefinition_createTypeMultiNodeWithContainerProperties(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckJobDefinitionDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccJobDefinitionConfig_createTypeMultiNodeWithBothProperties(rName),
+				ExpectError: regexache.MustCompile("No `container_properties` can be specified when `type` is \"multinode\""),
+			},
+		},
+	})
+}
+
 func testAccCheckJobDefinitionExists(ctx context.Context, n string, jd *batch.JobDefinition) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -1139,6 +1211,186 @@ func testAccJobDefinitionConfig_nodePropertiesAdvancedUpdate(rName string) strin
 			]
 			numNodes = 4
 		})
+	}
+	`, rName)
+}
+
+func testAccJobDefinitionConfig_createTypeContainerWithBothProperties(rName string) string {
+	return fmt.Sprintf(`
+
+	resource "aws_batch_job_definition" "test" {
+		name = %[1]q
+		type = "container"
+		parameters = {
+		  param1 = "val1"
+		  param2 = "val2"
+		}
+		timeout {
+		  attempt_duration_seconds = 60
+		}
+
+		container_properties = jsonencode({
+			command = ["echo", "test"]
+			image   = "busybox"
+			memory  = 128
+			vcpus   = 1
+		  })
+
+		node_properties = jsonencode({
+			mainNode     = 1
+			nodeRangeProperties = [
+			{
+				container = {
+					"command": ["ls", "-la"],
+					"image": "busybox",
+					"memory": 512,
+					"vcpus": 1
+				}
+				targetNodes = "0:"
+			},
+			{
+				container = {
+				  command             = ["echo", "test"]
+				  environment         = []
+				  image               = "busybox"
+				  memory              = 128
+				  mountPoints         = []
+				  ulimits             = []
+				  vcpus               = 1
+				  volumes             = []
+				}
+				targetNodes = "1:"
+			}
+			]
+			numNodes = 4
+		})
+
+	}
+	`, rName)
+}
+
+func testAccJobDefinitionConfig_createTypeContainerWithNodeProperties(rName string) string {
+	return fmt.Sprintf(`
+
+	resource "aws_batch_job_definition" "test" {
+		name = %[1]q
+		type = "container"
+		parameters = {
+		  param1 = "val1"
+		  param2 = "val2"
+		}
+		timeout {
+		  attempt_duration_seconds = 60
+		}
+
+		node_properties = jsonencode({
+			mainNode     = 1
+			nodeRangeProperties = [
+			{
+				container = {
+					"command": ["ls", "-la"],
+					"image": "busybox",
+					"memory": 512,
+					"vcpus": 1
+				}
+				targetNodes = "0:"
+			},
+			{
+				container = {
+				  command             = ["echo", "test"]
+				  environment         = []
+				  image               = "busybox"
+				  memory              = 128
+				  mountPoints         = []
+				  ulimits             = []
+				  vcpus               = 1
+				  volumes             = []
+				}
+				targetNodes = "1:"
+			}
+			]
+			numNodes = 4
+		})
+
+	}
+	`, rName)
+}
+
+func testAccJobDefinitionConfig_createTypeMultiNodeWithBothProperties(rName string) string {
+	return fmt.Sprintf(`
+
+	resource "aws_batch_job_definition" "test" {
+		name = %[1]q
+		type = "multinode"
+		parameters = {
+		  param1 = "val1"
+		  param2 = "val2"
+		}
+		timeout {
+		  attempt_duration_seconds = 60
+		}
+
+		container_properties = jsonencode({
+			command = ["echo", "test"]
+			image   = "busybox"
+			memory  = 128
+			vcpus   = 1
+		  })
+
+		node_properties = jsonencode({
+			mainNode     = 1
+			nodeRangeProperties = [
+			{
+				container = {
+					"command": ["ls", "-la"],
+					"image": "busybox",
+					"memory": 512,
+					"vcpus": 1
+				}
+				targetNodes = "0:"
+			},
+			{
+				container = {
+				  command             = ["echo", "test"]
+				  environment         = []
+				  image               = "busybox"
+				  memory              = 128
+				  mountPoints         = []
+				  ulimits             = []
+				  vcpus               = 1
+				  volumes             = []
+				}
+				targetNodes = "1:"
+			}
+			]
+			numNodes = 4
+		})
+
+	}
+	`, rName)
+}
+
+func testAccJobDefinitionConfig_createTypeMultiNodeWithContainerProperties(rName string) string {
+	return fmt.Sprintf(`
+
+	resource "aws_batch_job_definition" "test" {
+		name = %[1]q
+		type = "multinode"
+		parameters = {
+		  param1 = "val1"
+		  param2 = "val2"
+		}
+		timeout {
+		  attempt_duration_seconds = 60
+		}
+
+		container_properties = jsonencode({
+			command = ["echo", "test"]
+			image   = "busybox"
+			memory  = 128
+			vcpus   = 1
+		  })
+
 	}
 	`, rName)
 }

--- a/internal/service/batch/job_definition_test.go
+++ b/internal/service/batch/job_definition_test.go
@@ -492,9 +492,24 @@ func TestAccBatchJobDefinition_NodeProperties(t *testing.T) {
 									"volumes": []
 								},
 								"targetNodes": "0:"
+							},
+							{
+								"container": {
+									"command": ["echo","test"],
+									"environment": [],
+									"image": "busybox",
+									"memory": 128,
+									"mountPoints": [],
+									"resourceRequirements": [],
+									"secrets": [],
+									"ulimits": [],
+									"vcpus": 1,
+									"volumes": []
+								},
+								"targetNodes": "1:"
 							}
 						],
-						"numNodes": 1
+						"numNodes": 2
 					}`),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "parameters.%", "0"),
@@ -506,6 +521,41 @@ func TestAccBatchJobDefinition_NodeProperties(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "timeout.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "type", "multinode"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccBatchJobDefinition_NodePropertiesupdateForcesNewResource(t *testing.T) {
+	ctx := acctest.Context(t)
+	var before, after batch.JobDefinition
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_batch_job_definition.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckJobDefinitionDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccJobDefinitionConfig_nodePropertiesAdvanced(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckJobDefinitionExists(ctx, resourceName, &before),
+					testAccCheckJobDefinitionAttributes(&before, nil),
+				),
+			},
+			{
+				Config: testAccJobDefinitionConfig_nodePropertiesAdvancedUpdate(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckJobDefinitionExists(ctx, resourceName, &after),
+					testAccCheckJobDefinitionRecreated(t, &before, &after),
 				),
 			},
 			{
@@ -734,9 +784,24 @@ resource "aws_batch_job_definition" "test" {
 			volumes             = []
 		  }
 		  targetNodes = "0:"
-		}
+		},
+		{
+			container = {
+			  command             = ["echo", "test"]
+			  environment         = []
+			  image               = "busybox"
+			  memory              = 128
+			  mountPoints         = []
+			  resourceRequirements = []
+			  secrets             = []
+			  ulimits             = []
+			  vcpus               = 1
+			  volumes             = []
+			}
+			targetNodes = "1:"
+		  }
 	  ]
-	  numNodes = 1
+	  numNodes = 2
 	})
   }
 `, rName)
@@ -957,4 +1022,123 @@ resource "aws_batch_job_definition" "test" {
   type = "container"
 }
 `, rName)
+}
+
+func testAccJobDefinitionConfig_nodePropertiesAdvanced(rName string) string {
+	return fmt.Sprintf(`
+
+resource "aws_batch_job_definition" "test" {
+	name = %[1]q
+	type = "multinode"
+	parameters = {
+	  param1 = "val1"
+	  param2 = "val2"
+	}
+	timeout {
+	  attempt_duration_seconds = 60
+	}
+
+	node_properties = jsonencode({
+		mainNode     = 1
+		nodeRangeProperties = [
+		{
+			container = {
+				"command": ["ls", "-la"],
+				"image": "busybox",
+				"memory": 512,
+				"vcpus": 1,
+				"volumes": [
+				{
+					"host": {
+					"sourcePath": "/tmp"
+					},
+					"name": "tmp"
+				}
+				],
+				"environment": [
+					{"name": "VARNAME", "value": "VARVAL"}
+				],
+				"mountPoints": [
+					{
+					"sourceVolume": "tmp",
+					"containerPath": "/tmp",
+					"readOnly": false
+					}
+				],
+				"ulimits": [
+				{
+					"hardLimit": 1024,
+					"name": "nofile",
+					"softLimit": 1024
+				}
+				]
+			}
+			targetNodes = "0:"
+		},
+		{
+			container = {
+			  command             = ["echo", "test"]
+			  environment         = []
+			  image               = "busybox"
+			  memory              = 128
+			  mountPoints         = []
+			  resourceRequirements = []
+			  secrets             = []
+			  ulimits             = []
+			  vcpus               = 1
+			  volumes             = []
+			}
+			targetNodes = "1:"
+		}
+		]
+		numNodes = 4
+	})
+}
+`, rName)
+}
+
+func testAccJobDefinitionConfig_nodePropertiesAdvancedUpdate(rName string) string {
+	return fmt.Sprintf(`
+
+	resource "aws_batch_job_definition" "test" {
+		name = %[1]q
+		type = "multinode"
+		parameters = {
+		  param1 = "val1"
+		  param2 = "val2"
+		}
+		timeout {
+		  attempt_duration_seconds = 60
+		}
+
+		node_properties = jsonencode({
+			mainNode     = 1
+			nodeRangeProperties = [
+			{
+				container = {
+					"command": ["ls", "-la"],
+					"image": "busybox",
+					"memory": 512,
+					"vcpus": 1
+				}
+				targetNodes = "0:"
+			},
+			{
+				container = {
+				  command             = ["echo", "test"]
+				  environment         = []
+				  image               = "busybox"
+				  memory              = 128
+				  mountPoints         = []
+				  ulimits             = []
+				  vcpus               = 1
+				  volumes             = []
+				}
+				targetNodes = "1:"
+			}
+			]
+			numNodes = 4
+		})
+	}
+	`, rName)
 }

--- a/internal/service/batch/node_properties.go
+++ b/internal/service/batch/node_properties.go
@@ -1,0 +1,73 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package batch
+
+import (
+	"bytes"
+	"encoding/json"
+	"log"
+
+	"github.com/aws/aws-sdk-go/private/protocol/json/jsonutil"
+	"github.com/aws/aws-sdk-go/service/batch"
+)
+
+type nodeProperties batch.NodeProperties
+
+func (np *nodeProperties) Reduce() error {
+	// Prevent difference of API response that adds an empty array when not configured during the request
+	if len(np.NodeRangeProperties) == 0 {
+		np.NodeRangeProperties = nil
+	}
+
+	return nil
+}
+
+// EquivalentNodePropertiesJSON determines equality between two Batch NodeProperties JSON strings
+func EquivalentNodePropertiesJSON(str1, str2 string) (bool, error) {
+	if str1 == "" {
+		str1 = "{}"
+	}
+
+	if str2 == "" {
+		str2 = "{}"
+	}
+
+	var np1, np2 nodeProperties
+
+	if err := json.Unmarshal([]byte(str1), &np1); err != nil {
+		return false, err
+	}
+
+	if err := np2.Reduce(); err != nil {
+		return false, err
+	}
+
+	canonicalJson1, err := jsonutil.BuildJSON(np1)
+
+	if err != nil {
+		return false, err
+	}
+
+	if err := json.Unmarshal([]byte(str2), &np2); err != nil {
+		return false, err
+	}
+
+	if err := np2.Reduce(); err != nil {
+		return false, err
+	}
+
+	canonicalJson2, err := jsonutil.BuildJSON(np2)
+
+	if err != nil {
+		return false, err
+	}
+
+	equal := bytes.Equal(canonicalJson1, canonicalJson2)
+
+	if !equal {
+		log.Printf("[DEBUG] Canonical Batch Node Properties JSON are not equal.\nFirst: %s\nSecond: %s\n", canonicalJson1, canonicalJson2)
+	}
+
+	return equal, nil
+}

--- a/internal/service/batch/node_properties_test.go
+++ b/internal/service/batch/node_properties_test.go
@@ -75,7 +75,6 @@ func TestEquivalentNodePropertiesJSON(t *testing.T) {
 		{
 			"container":
 			{
-				"command": ["ls", "-la"],
 				"image": "busybox",
 				"memory":512
 			},
@@ -86,7 +85,6 @@ func TestEquivalentNodePropertiesJSON(t *testing.T) {
 		{
 			"container":
 			{
-				"command": [],
 				"image": "123.dkr.ecr.us-east-1.amazonaws.com/my-app",
 				"memory":128
 			},
@@ -108,7 +106,7 @@ func TestEquivalentNodePropertiesJSON(t *testing.T) {
 		{
 			"container":
 			{
-				"command": ["ls", "-la"],
+				"command": [],
 				"image": "busybox",
 				"memory":512
 			},
@@ -119,7 +117,6 @@ func TestEquivalentNodePropertiesJSON(t *testing.T) {
 		{
 			"container":
 			{
-				"command": [],
 				"image": "123.dkr.ecr.us-east-1.amazonaws.com/my-app",
 				"memory":128
 			},

--- a/internal/service/batch/node_properties_test.go
+++ b/internal/service/batch/node_properties_test.go
@@ -1,0 +1,160 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package batch_test
+
+import (
+	"testing"
+
+	tfbatch "github.com/hashicorp/terraform-provider-aws/internal/service/batch"
+)
+
+func TestEquivalentNodePropertiesJSON(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		ApiJson           string
+		ConfigurationJson string
+		ExpectEquivalent  bool
+		ExpectError       bool
+	}{
+		"empty": {
+			ApiJson:           ``,
+			ConfigurationJson: ``,
+			ExpectEquivalent:  true,
+		},
+		"Single Node with empty environment variable": {
+			ApiJson: `
+{
+	"mainNode": 1,
+	"nodeRangeProperties": [
+		{
+			"container":
+			{
+				"command": ["ls", "-la"],
+				"image": "busybox",
+				"memory":512
+			},
+			"targetNodes": "0:",
+			"environment": []
+		}
+	],
+	"numNodes": 2
+}
+`,
+			ConfigurationJson: `
+{
+	"mainNode": 1,
+	"nodeRangeProperties": [
+		{
+			"container":
+			{
+				"command": ["ls", "-la"],
+				"image": "busybox",
+				"memory":512,
+				"environment": [
+					{
+						"name": "EMPTY",
+						"value": ""
+					}
+				]
+			},
+			"targetNodes": "0:"
+		}
+	],
+	"numNodes": 2
+}
+`,
+			ExpectEquivalent: true,
+		},
+		"Two Nodes with empty command and mountPoints": {
+			ApiJson: `
+{
+	"mainNode": 1,
+	"nodeRangeProperties": [
+		{
+			"container":
+			{
+				"command": ["ls", "-la"],
+				"image": "busybox",
+				"memory":512
+			},
+			"targetNodes": "0:",
+			"environment": [],
+			"mountPoints": []
+		},
+		{
+			"container":
+			{
+				"command": [],
+				"image": "123.dkr.ecr.us-east-1.amazonaws.com/my-app",
+				"memory":128
+			},
+			"targetNodes": "0:",
+			"environment": [],
+			"logConfiguration": {
+				"logDriver": "awslogs",
+				"secretOptions": []
+			}
+		}
+	],
+	"numNodes": 2
+}
+`,
+			ConfigurationJson: `
+{
+	"mainNode": 1,
+	"nodeRangeProperties": [
+		{
+			"container":
+			{
+				"command": ["ls", "-la"],
+				"image": "busybox",
+				"memory":512
+			},
+			"targetNodes": "0:",
+			"environment": [],
+			"mountPoints": []
+		},
+		{
+			"container":
+			{
+				"command": [],
+				"image": "123.dkr.ecr.us-east-1.amazonaws.com/my-app",
+				"memory":128
+			},
+			"targetNodes": "0:",
+			"environment": [],
+			"logConfiguration": {
+				"logDriver": "awslogs"
+			}
+		}
+	],
+	"numNodes": 2
+}
+`,
+			ExpectEquivalent: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		testCase := testCase
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := tfbatch.EquivalentNodePropertiesJSON(testCase.ConfigurationJson, testCase.ApiJson)
+
+			if err != nil && !testCase.ExpectError {
+				t.Errorf("got unexpected error: %s", err)
+			}
+
+			if err == nil && testCase.ExpectError {
+				t.Errorf("expected error, but received none")
+			}
+
+			if got != testCase.ExpectEquivalent {
+				t.Errorf("got %t, expected %t", got, testCase.ExpectEquivalent)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description

This PR introduces support for AWS Batch Job Definitions of the `multinode` type. When the type is set to [multinode](https://docs.aws.amazon.com/batch/latest/userguide/job_definition_parameters.html#type), it enables the use of the [node_properties](https://docs.aws.amazon.com/batch/latest/userguide/job_definition_parameters.html#nodeProperties) block. These code changes facilitate the use of multinode job definitions.


### Relations

Relates #20983
Relates #29818


### References

https://docs.aws.amazon.com/batch/latest/userguide/job_definition_parameters.html#nodeProperties
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-nodeproperties.html


### Output from Acceptance Testing
<details>

<summary> make testacc TESTS=TestAccBatchJobDefinition_ PKG=batch </summary>

```console

> make testacc TESTS=TestAccBatchJobDefinition_ PKG=batch
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/batch/... -v -count 1 -parallel 20 -run='TestAccBatchJobDefinition_'  -timeout 360m
=== RUN   TestAccBatchJobDefinition_basic
=== PAUSE TestAccBatchJobDefinition_basic
=== RUN   TestAccBatchJobDefinition_disappears
=== PAUSE TestAccBatchJobDefinition_disappears
=== RUN   TestAccBatchJobDefinition_PlatformCapabilities_ec2
=== PAUSE TestAccBatchJobDefinition_PlatformCapabilities_ec2
=== RUN   TestAccBatchJobDefinition_PlatformCapabilitiesFargate_containerPropertiesDefaults
=== PAUSE TestAccBatchJobDefinition_PlatformCapabilitiesFargate_containerPropertiesDefaults
=== RUN   TestAccBatchJobDefinition_PlatformCapabilities_fargate
=== PAUSE TestAccBatchJobDefinition_PlatformCapabilities_fargate
=== RUN   TestAccBatchJobDefinition_ContainerProperties_advanced
=== PAUSE TestAccBatchJobDefinition_ContainerProperties_advanced
=== RUN   TestAccBatchJobDefinition_updateForcesNewResource
=== PAUSE TestAccBatchJobDefinition_updateForcesNewResource
=== RUN   TestAccBatchJobDefinition_tags
=== PAUSE TestAccBatchJobDefinition_tags
=== RUN   TestAccBatchJobDefinition_propagateTags
=== PAUSE TestAccBatchJobDefinition_propagateTags
=== RUN   TestAccBatchJobDefinition_ContainerProperties_EmptyField
=== PAUSE TestAccBatchJobDefinition_ContainerProperties_EmptyField
=== RUN   TestAccBatchJobDefinition_NodeProperties
=== PAUSE TestAccBatchJobDefinition_NodeProperties
=== RUN   TestAccBatchJobDefinition_NodePropertiesupdateForcesNewResource
=== PAUSE TestAccBatchJobDefinition_NodePropertiesupdateForcesNewResource
=== RUN   TestAccBatchJobDefinition_createTypeContainerWithBothProperties
=== PAUSE TestAccBatchJobDefinition_createTypeContainerWithBothProperties
=== RUN   TestAccBatchJobDefinition_createTypeContainerWithNodeProperties
=== PAUSE TestAccBatchJobDefinition_createTypeContainerWithNodeProperties
=== RUN   TestAccBatchJobDefinition_createTypeMultiNodeWithBothProperties
=== PAUSE TestAccBatchJobDefinition_createTypeMultiNodeWithBothProperties
=== RUN   TestAccBatchJobDefinition_createTypeMultiNodeWithContainerProperties
=== PAUSE TestAccBatchJobDefinition_createTypeMultiNodeWithContainerProperties
=== CONT  TestAccBatchJobDefinition_basic
=== CONT  TestAccBatchJobDefinition_propagateTags
=== CONT  TestAccBatchJobDefinition_PlatformCapabilities_fargate
=== CONT  TestAccBatchJobDefinition_tags
=== CONT  TestAccBatchJobDefinition_updateForcesNewResource
=== CONT  TestAccBatchJobDefinition_ContainerProperties_advanced
=== CONT  TestAccBatchJobDefinition_PlatformCapabilities_ec2
=== CONT  TestAccBatchJobDefinition_PlatformCapabilitiesFargate_containerPropertiesDefaults
=== CONT  TestAccBatchJobDefinition_disappears
=== CONT  TestAccBatchJobDefinition_createTypeContainerWithBothProperties
=== CONT  TestAccBatchJobDefinition_createTypeMultiNodeWithContainerProperties
=== CONT  TestAccBatchJobDefinition_createTypeMultiNodeWithBothProperties
=== CONT  TestAccBatchJobDefinition_createTypeContainerWithNodeProperties
=== CONT  TestAccBatchJobDefinition_NodeProperties
=== CONT  TestAccBatchJobDefinition_NodePropertiesupdateForcesNewResource
=== CONT  TestAccBatchJobDefinition_ContainerProperties_EmptyField
--- PASS: TestAccBatchJobDefinition_createTypeContainerWithNodeProperties (21.40s)
--- PASS: TestAccBatchJobDefinition_createTypeContainerWithBothProperties (22.04s)
--- PASS: TestAccBatchJobDefinition_createTypeMultiNodeWithBothProperties (22.19s)
--- PASS: TestAccBatchJobDefinition_createTypeMultiNodeWithContainerProperties (22.70s)
--- PASS: TestAccBatchJobDefinition_disappears (41.41s)
--- PASS: TestAccBatchJobDefinition_basic (50.72s)
--- PASS: TestAccBatchJobDefinition_ContainerProperties_advanced (51.27s)
--- PASS: TestAccBatchJobDefinition_PlatformCapabilities_ec2 (51.38s)
--- PASS: TestAccBatchJobDefinition_propagateTags (51.58s)
--- PASS: TestAccBatchJobDefinition_NodeProperties (51.76s)
--- PASS: TestAccBatchJobDefinition_ContainerProperties_EmptyField (52.09s)
--- PASS: TestAccBatchJobDefinition_PlatformCapabilitiesFargate_containerPropertiesDefaults (53.47s)
--- PASS: TestAccBatchJobDefinition_PlatformCapabilities_fargate (53.84s)
--- PASS: TestAccBatchJobDefinition_updateForcesNewResource (66.05s)
--- PASS: TestAccBatchJobDefinition_NodePropertiesupdateForcesNewResource (68.14s)
--- PASS: TestAccBatchJobDefinition_tags (81.83s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/batch	84.985s

```

</details>

