### PR TITLE
feat(rds): Add aws_rds_engine_versions

### DIFF
--- a/internal/service/rds/engine_versions_data_source.go
+++ b/internal/service/rds/engine_versions_data_source.go
@@ -1,0 +1,94 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package rds
+
+import (
+	"context"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/generate/namevaluesfilters"
+)
+
+// @SDKDataSource("aws_rds_engine_versions")
+func DataSourceEngineVersions() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceEngineVersionsRead,
+		Schema: map[string]*schema.Schema{
+			"filter": namevaluesfilters.Schema(),
+
+			"versions": {
+				Type: schema.TypeList,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"engine": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"engine_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"db_parameter_group_family": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceEngineVersionsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).RDSConn(ctx)
+
+	input := &rds.DescribeDBEngineVersionsInput{
+		ListSupportedCharacterSets: aws.Bool(true),
+		ListSupportedTimezones:     aws.Bool(true),
+	}
+
+	if v, ok := d.GetOk("filter"); ok {
+		input.Filters = namevaluesfilters.New(v.(*schema.Set)).RDSFilters()
+	}
+
+	log.Printf("[DEBUG] Reading RDS engine versions: %v", input)
+	var engineVersions []map[string]interface{}
+
+	err := conn.DescribeDBEngineVersionsPagesWithContext(ctx, input, func(resp *rds.DescribeDBEngineVersionsOutput, lastPage bool) bool {
+		for _, engineVersion := range resp.DBEngineVersions {
+			if engineVersion == nil {
+				continue
+			}
+
+			out := make(map[string]interface{})
+			out["engine"] = aws.StringValue(engineVersion.Engine)
+			out["engine_version"] = aws.StringValue(engineVersion.EngineVersion)
+			out["db_parameter_group_family"] = aws.StringValue(engineVersion.DBParameterGroupFamily)
+			out["status"] = aws.StringValue(engineVersion.Status)
+			engineVersions = append(engineVersions, out)
+		}
+		return !lastPage
+	})
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading RDS engine versions: %s", err)
+	}
+
+	d.SetId(meta.(*conns.AWSClient).Region)
+
+	d.Set("versions", engineVersions)
+
+	return diags
+}

--- a/internal/service/rds/engine_versions_data_source_test.go
+++ b/internal/service/rds/engine_versions_data_source_test.go
@@ -1,0 +1,44 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package rds_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccRDSEngineVersionsDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_rds_engine_versions.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccEngineVersionPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, rds.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEngineVersionsDataSourceConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "versions.0.engine", "mysql"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "versions.0.engine_version"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "versions.0.db_parameter_group_family"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "versions.0.status"),
+				),
+			},
+		},
+	})
+}
+
+func testAccEngineVersionsDataSourceConfig_basic() string {
+	return `data "aws_rds_engine_versions" "test" {
+		filter {
+			name   = "engine"
+			values = ["mysql"]
+		}
+	}`
+}

--- a/internal/service/rds/service_package_gen.go
+++ b/internal/service/rds/service_package_gen.go
@@ -82,6 +82,10 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 			TypeName: "aws_rds_engine_version",
 		},
 		{
+			Factory:  DataSourceEngineVersions,
+			TypeName: "aws_rds_engine_versions",
+		},
+		{
 			Factory:  DataSourceOrderableInstance,
 			TypeName: "aws_rds_orderable_db_instance",
 		},

--- a/website/docs/d/rds_engine_versions.markdown
+++ b/website/docs/d/rds_engine_versions.markdown
@@ -1,0 +1,57 @@
+---
+subcategory: "RDS (Relational Database)"
+layout: "aws"
+page_title: "AWS: aws_rds_engine_versions"
+description: |-
+  List of RDS engine versions.
+---
+
+# Data Source: aws_rds_engine_version
+
+List of RDS engine versions.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_rds_engine_versions" "test" {
+  filter {
+    name   = "engine"
+    values = ["aurora-mysql"]
+  }
+  filter {
+    name   = "db-parameter-group-family"
+    values = ["aurora-mysql8.0"]
+  }
+  filter {
+    name   = "engine-mode"
+    values = ["provisioned"]
+  }
+}
+locals {
+  versions       = data.aws_rds_engine_versions.test.versions
+  latest_version = element(local.versions, length(local.versions) - 1)
+}
+data "aws_rds_cluster" "test" {
+  engine         = "aurora-mysql"
+  engine_version = local.latest_version.engine_version
+  # ...
+}
+```
+
+## Argument Reference
+
+This data source supports the following arguments:
+
+* `filter` - (Optional) One or more name/value pairs to filter off of. There are several valid keys; for a full reference, check out [describe-db-engine-versions in the AWS CLI reference](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/describe-db-engine-versions.html).
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `versions` - List of all matching RDS engine versions. Each item contains:
+  * `engine`
+  * `engine_version`
+  * `db_parameter_group_family`
+  * `status` - Status of this version, either 'available' or 'deprecated'.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
A less constrained version of `aws_rds_engine_version`.

This has a number of use-cases:

1. The existing data source `aws_rds_engine_version` cannot return the latest version of a particular engine / db parameter group family. It can only return the default version. For example, `aurora-mysql` engine latest version is `3.05.0`, while the default version is `3.04.0`. The existing data source cannot be configured to return `3.05.0`.
2. You can use this data source to validate that a user-specified engine version is in the most recent N for a particular configuration. For example, you can validate that `var.rds_engine_version` is within the most recent 5 engine versions for `engine = var.rds_engine`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccRDSEngineVersionsDataSource_basic PKG=rds
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSEngineVersionsDataSource_basic'  -timeout 360m
=== RUN   TestAccRDSEngineVersionsDataSource_basic
=== PAUSE TestAccRDSEngineVersionsDataSource_basic
=== CONT  TestAccRDSEngineVersionsDataSource_basic
--- PASS: TestAccRDSEngineVersionsDataSource_basic (34.39s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	39.627s

...
```
