### PR TITLE
acctest: Bump engine versions for MQ tests

### DIFF
--- a/internal/service/lambda/event_source_mapping_test.go
+++ b/internal/service/lambda/event_source_mapping_test.go
@@ -1752,7 +1752,7 @@ resource "aws_security_group" "test" {
 resource "aws_mq_broker" "test" {
   broker_name             = %[1]q
   engine_type             = "ActiveMQ"
-  engine_version          = "5.15.0"
+  engine_version          = "5.17.6"
   host_instance_type      = "mq.t2.micro"
   security_groups         = [aws_security_group.test.id]
   authentication_strategy = "simple"

--- a/internal/service/mq/broker_data_source_test.go
+++ b/internal/service/mq/broker_data_source_test.go
@@ -71,7 +71,7 @@ func testAccBrokerDataSourceConfig_base(rName string) string {
 resource "aws_mq_configuration" "test" {
   name           = %[1]q
   engine_type    = "ActiveMQ"
-  engine_version = "5.15.12"
+  engine_version = "5.17.6"
 
   data = <<DATA
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -92,7 +92,7 @@ resource "aws_mq_broker" "test" {
 
   deployment_mode    = "ACTIVE_STANDBY_MULTI_AZ"
   engine_type        = "ActiveMQ"
-  engine_version     = "5.15.12"
+  engine_version     = "5.17.6"
   host_instance_type = "mq.t2.micro"
 
   maintenance_window_start_time {

--- a/internal/service/mq/broker_test.go
+++ b/internal/service/mq/broker_test.go
@@ -1298,7 +1298,7 @@ func TestAccMQBroker_RabbitMQ_cluster(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_start_time.0.time_zone", "UTC"),
 					resource.TestCheckResourceAttr(resourceName, "publicly_accessible", "false"),
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "4"),
+					resource.TestCheckResourceAttrPair(resourceName, "subnet_ids.#", "data.aws_subnets.default", "ids.#"),
 					resource.TestCheckResourceAttr(resourceName, "user.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
 						"console_access": "false",
@@ -2146,6 +2146,17 @@ resource "aws_mq_broker" "test" {
     username = "Test"
     password = "TestTest1234"
   }
+}
+
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+}
+
+data "aws_vpc" "default" {
+  default = true
 }
 `, rName, version)
 }

--- a/internal/service/mq/broker_test.go
+++ b/internal/service/mq/broker_test.go
@@ -239,9 +239,9 @@ func TestDiffUsers(t *testing.T) {
 }
 
 const (
-	testAccBrokerVersionNewer = "5.16.3"  // before changing, check b/c must be valid on GovCloud
-	testAccBrokerVersionOlder = "5.15.12" // before changing, check b/c must be valid on GovCloud
-	testAccRabbitVersion      = "3.8.6"   // before changing, check b/c must be valid on GovCloud
+	testAccBrokerVersionNewer = "5.17.6"  // before changing, check b/c must be valid on GovCloud
+	testAccBrokerVersionOlder = "5.16.7"  // before changing, check b/c must be valid on GovCloud
+	testAccRabbitVersion      = "3.11.20" // before changing, check b/c must be valid on GovCloud
 )
 
 func TestAccMQBroker_basic(t *testing.T) {

--- a/internal/service/mq/broker_test.go
+++ b/internal/service/mq/broker_test.go
@@ -535,7 +535,7 @@ func TestAccMQBroker_AllFields_defaultVPC(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "logs.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "logs.0.general", "false"),
 					resource.TestCheckResourceAttr(resourceName, "logs.0.audit", "false"),
-					resource.TestCheckResourceAttr(resourceName, "publicly_accessible", "true"),
+					resource.TestCheckResourceAttr(resourceName, "publicly_accessible", "false"),
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "user.#", "2"),
@@ -1581,7 +1581,7 @@ resource "aws_mq_broker" "test" {
     time_zone   = "CET"
   }
 
-  publicly_accessible = true
+  publicly_accessible = false
   security_groups     = aws_security_group.test[*].id
 
   user {

--- a/internal/service/mq/configuration_test.go
+++ b/internal/service/mq/configuration_test.go
@@ -41,7 +41,7 @@ func TestAccMQConfiguration_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "authentication_strategy", "simple"),
 					resource.TestCheckResourceAttr(resourceName, "description", "TfAccTest MQ Configuration"),
 					resource.TestCheckResourceAttr(resourceName, "engine_type", "ActiveMQ"),
-					resource.TestCheckResourceAttr(resourceName, "engine_version", "5.15.0"),
+					resource.TestCheckResourceAttr(resourceName, "engine_version", "5.17.6"),
 					resource.TestCheckResourceAttr(resourceName, "latest_revision", "2"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 				),
@@ -58,7 +58,7 @@ func TestAccMQConfiguration_basic(t *testing.T) {
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "mq", regexache.MustCompile(`configuration:+.`)),
 					resource.TestCheckResourceAttr(resourceName, "description", "TfAccTest MQ Configuration Updated"),
 					resource.TestCheckResourceAttr(resourceName, "engine_type", "ActiveMQ"),
-					resource.TestCheckResourceAttr(resourceName, "engine_version", "5.15.0"),
+					resource.TestCheckResourceAttr(resourceName, "engine_version", "5.17.6"),
 					resource.TestCheckResourceAttr(resourceName, "latest_revision", "3"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 				),
@@ -89,7 +89,7 @@ func TestAccMQConfiguration_withActiveMQData(t *testing.T) {
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "mq", regexache.MustCompile(`configuration:+.`)),
 					resource.TestCheckResourceAttr(resourceName, "description", "TfAccTest MQ Configuration"),
 					resource.TestCheckResourceAttr(resourceName, "engine_type", "ActiveMQ"),
-					resource.TestCheckResourceAttr(resourceName, "engine_version", "5.15.0"),
+					resource.TestCheckResourceAttr(resourceName, "engine_version", "5.17.6"),
 					resource.TestCheckResourceAttr(resourceName, "latest_revision", "2"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 				),
@@ -126,7 +126,7 @@ func TestAccMQConfiguration_withActiveMQLdapData(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "authentication_strategy", "ldap"),
 					resource.TestCheckResourceAttr(resourceName, "description", "TfAccTest MQ Configuration"),
 					resource.TestCheckResourceAttr(resourceName, "engine_type", "ActiveMQ"),
-					resource.TestCheckResourceAttr(resourceName, "engine_version", "5.15.0"),
+					resource.TestCheckResourceAttr(resourceName, "engine_version", "5.17.6"),
 					resource.TestCheckResourceAttr(resourceName, "latest_revision", "2"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 				),
@@ -251,7 +251,7 @@ resource "aws_mq_configuration" "test" {
   description             = "TfAccTest MQ Configuration"
   name                    = %[1]q
   engine_type             = "ActiveMQ"
-  engine_version          = "5.15.0"
+  engine_version          = "5.17.6"
   authentication_strategy = "simple"
 
   data = <<DATA
@@ -269,7 +269,7 @@ resource "aws_mq_configuration" "test" {
   description    = "TfAccTest MQ Configuration Updated"
   name           = %[1]q
   engine_type    = "ActiveMQ"
-  engine_version = "5.15.0"
+  engine_version = "5.17.6"
 
   data = <<DATA
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -286,7 +286,7 @@ resource "aws_mq_configuration" "test" {
   description    = "TfAccTest MQ Configuration"
   name           = %[1]q
   engine_type    = "ActiveMQ"
-  engine_version = "5.15.0"
+  engine_version = "5.17.6"
 
   data = <<DATA
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -321,7 +321,7 @@ resource "aws_mq_configuration" "test" {
   description             = "TfAccTest MQ Configuration"
   name                    = %[1]q
   engine_type             = "ActiveMQ"
-  engine_version          = "5.15.0"
+  engine_version          = "5.17.6"
   authentication_strategy = "ldap"
 
   data = <<DATA
@@ -364,7 +364,7 @@ resource "aws_mq_configuration" "test" {
   description             = "TfAccTest MQ Configuration"
   name                    = %[1]q
   engine_type             = "ActiveMQ"
-  engine_version          = "5.15.0"
+  engine_version          = "5.17.6"
   authentication_strategy = "simple"
 
   tags = {
@@ -386,7 +386,7 @@ resource "aws_mq_configuration" "test" {
   description             = "TfAccTest MQ Configuration"
   name                    = %[1]q
   engine_type             = "ActiveMQ"
-  engine_version          = "5.15.0"
+  engine_version          = "5.17.6"
   authentication_strategy = "simple"
 
   tags = {

--- a/internal/service/pipes/pipe_test.go
+++ b/internal/service/pipes/pipe_test.go
@@ -2264,7 +2264,7 @@ resource "aws_security_group" "source" {
 resource "aws_mq_broker" "source" {
   broker_name             = "%[1]s-source"
   engine_type             = "ActiveMQ"
-  engine_version          = "5.15.0"
+  engine_version          = "5.17.6"
   host_instance_type      = "mq.t2.micro"
   security_groups         = [aws_security_group.source.id]
   authentication_strategy = "simple"

--- a/website/docs/r/mq_broker.html.markdown
+++ b/website/docs/r/mq_broker.html.markdown
@@ -32,7 +32,7 @@ resource "aws_mq_broker" "example" {
   }
 
   engine_type        = "ActiveMQ"
-  engine_version     = "5.15.9"
+  engine_version     = "5.17.6"
   host_instance_type = "mq.t2.micro"
   security_groups    = [aws_security_group.test.id]
 
@@ -57,7 +57,7 @@ resource "aws_mq_broker" "example" {
   }
 
   engine_type        = "ActiveMQ"
-  engine_version     = "5.15.9"
+  engine_version     = "5.17.6"
   storage_type       = "ebs"
   host_instance_type = "mq.m5.large"
   security_groups    = [aws_security_group.test.id]
@@ -75,7 +75,7 @@ The following arguments are required:
 
 * `broker_name` - (Required) Name of the broker.
 * `engine_type` - (Required) Type of broker engine. Valid values are `ActiveMQ` and `RabbitMQ`.
-* `engine_version` - (Required) Version of the broker engine. See the [AmazonMQ Broker Engine docs](https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/broker-engine.html) for supported versions. For example, `5.15.0`.
+* `engine_version` - (Required) Version of the broker engine. See the [AmazonMQ Broker Engine docs](https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/broker-engine.html) for supported versions. For example, `5.17.6`.
 * `host_instance_type` - (Required) Broker's instance type. For example, `mq.t3.micro`, `mq.m5.large`.
 * `user` - (Required) Configuration block for broker users. For `engine_type` of `RabbitMQ`, Amazon MQ does not return broker users preventing this resource from making user updates and drift detection. Detailed below.
 

--- a/website/docs/r/mq_configuration.html.markdown
+++ b/website/docs/r/mq_configuration.html.markdown
@@ -21,7 +21,7 @@ resource "aws_mq_configuration" "example" {
   description    = "Example Configuration"
   name           = "example"
   engine_type    = "ActiveMQ"
-  engine_version = "5.15.0"
+  engine_version = "5.17.6"
 
   data = <<DATA
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -43,7 +43,7 @@ resource "aws_mq_configuration" "example" {
   description    = "Example Configuration"
   name           = "example"
   engine_type    = "RabbitMQ"
-  engine_version = "3.11.16"
+  engine_version = "3.11.20"
 
   data = <<DATA
 # Default RabbitMQ delivery acknowledgement timeout is 30 minutes in milliseconds


### PR DESCRIPTION
### Description

The acceptance tests for the MQ service were using outdated engine versions. Update them to current versions.

Long-term solution will be #34168

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

AWS Partition

```console
% make testacc PKG=mq

--- PASS: TestCanonicalXML (0.00s)
    --- PASS: TestCanonicalXML/Config_sample_from_MSDN (0.00s)
    --- PASS: TestCanonicalXML/A_note (0.00s)
    --- PASS: TestCanonicalXML/Config_sample_from_MSDN,_flaw (0.00s)
    --- PASS: TestCanonicalXML/Config_sample_from_MSDN,_modified (0.00s)
--- PASS: TestDiffUsers (0.00s)
--- PASS: TestAccMQConfiguration_withRabbitMQData (394.04s)
--- PASS: TestAccMQConfiguration_withActiveMQLdapData (396.93s)
--- PASS: TestAccMQConfiguration_withActiveMQData (401.39s)
--- PASS: TestValidateBrokerName (0.00s)
--- PASS: TestBrokerPasswordValidation (0.00s)
--- PASS: TestAccMQConfiguration_basic (484.37s)
--- PASS: TestAccMQConfiguration_tags (541.74s)
--- PASS: TestAccMQBrokerInstanceTypeOfferingsDataSource_basic (172.47s)
--- PASS: TestAccMQBroker_RabbitMQ_basic (957.79s)
--- PASS: TestAccMQBroker_RabbitMQ_logs (1044.55s)
--- PASS: TestAccMQBroker_RabbitMQ_validationAuditLog (1053.80s)
--- PASS: TestAccMQBroker_RabbitMQ_config (1149.59s)
--- PASS: TestAccMQBroker_throughputOptimized (1245.99s)
--- PASS: TestAccMQBroker_RabbitMQ_cluster (1334.46s)
--- PASS: TestAccMQBroker_ldap (1355.60s)
--- PASS: TestAccMQBroker_EncryptionOptions_managedKeyDisabled (1381.60s)
--- PASS: TestAccMQBroker_disappears (1035.86s)
--- PASS: TestAccMQBroker_basic (1107.37s)
--- PASS: TestAccMQBroker_tags (1528.09s)
--- PASS: TestAccMQBroker_EncryptionOptions_managedKeyEnabled (1028.45s)
--- PASS: TestAccMQBroker_Update_engineVersion (1692.03s)
--- PASS: TestAccMQBroker_Update_hostInstanceType (1733.86s)
--- PASS: TestAccMQBroker_EncryptionOptions_kmsKeyID (1202.07s)
--- PASS: TestAccMQBroker_Update_securityGroup (1787.63s)
--- PASS: TestAccMQBroker_Update_users (1761.31s)
--- PASS: TestAccMQBrokerDataSource_basic (2348.65s)
--- PASS: TestAccMQBroker_AllFields_defaultVPC (2700.93s)
--- PASS: TestAccMQBroker_AllFields_customVPC (3549.34s)
```

GovCloud Partition

```console
% make testacc PKG=mq

--- PASS: TestValidateBrokerName (0.00s)
--- PASS: TestBrokerPasswordValidation (0.00s)
--- PASS: TestDiffUsers (0.00s)
--- PASS: TestAccMQConfiguration_withActiveMQLdapData (387.69s)
--- PASS: TestAccMQConfiguration_withActiveMQData (394.66s)
--- PASS: TestAccMQConfiguration_withRabbitMQData (396.42s)
--- PASS: TestAccMQConfiguration_basic (476.93s)
--- PASS: TestAccMQConfiguration_tags (544.89s)
--- PASS: TestAccMQBrokerInstanceTypeOfferingsDataSource_basic (124.82s)
--- PASS: TestAccMQBroker_RabbitMQ_basic (915.90s)
--- PASS: TestCanonicalXML (0.00s)
    --- PASS: TestCanonicalXML/Config_sample_from_MSDN (0.00s)
    --- PASS: TestCanonicalXML/Config_sample_from_MSDN,_modified (0.00s)
    --- PASS: TestCanonicalXML/Config_sample_from_MSDN,_flaw (0.00s)
    --- PASS: TestCanonicalXML/A_note (0.00s)
--- PASS: TestAccMQBroker_RabbitMQ_validationAuditLog (641.50s)
--- PASS: TestAccMQBroker_RabbitMQ_config (1031.62s)
--- PASS: TestAccMQBroker_throughputOptimized (1098.29s)
--- PASS: TestAccMQBroker_RabbitMQ_logs (590.77s)
--- PASS: TestAccMQBroker_RabbitMQ_cluster (845.70s)
--- PASS: TestAccMQBroker_EncryptionOptions_managedKeyDisabled (1314.33s)
--- PASS: TestAccMQBroker_disappears (1343.43s)
--- PASS: TestAccMQBroker_ldap (1351.15s)
--- PASS: TestAccMQBroker_basic (1366.97s)
--- PASS: TestAccMQBroker_EncryptionOptions_kmsKeyID (1422.61s)
--- PASS: TestAccMQBroker_tags (1459.05s)
--- PASS: TestAccMQBroker_EncryptionOptions_managedKeyEnabled (1030.76s)
--- PASS: TestAccMQBroker_Update_engineVersion (1643.29s)
--- PASS: TestAccMQBroker_Update_securityGroup (1752.42s)
--- PASS: TestAccMQBroker_Update_users (1996.48s)
--- PASS: TestAccMQBroker_Update_hostInstanceType (1998.15s)
--- PASS: TestAccMQBrokerDataSource_basic (2308.90s)
--- PASS: TestAccMQBroker_AllFields_defaultVPC (2447.43s)
--- PASS: TestAccMQBroker_AllFields_customVPC (3298.89s)
```
