### PR TITLE
r/redshift_cluster - add support for restoring from `snapshot_arn`

### DIFF
--- a/.changelog/34181.txt
+++ b/.changelog/34181.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_redshift_cluster: Add support for `snapshot_arn` argument
+resource/aws_redshift_cluster: Add `snapshot_arn` argument
 ```

--- a/.changelog/34181.txt
+++ b/.changelog/34181.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_redshift_cluster: Add support for `snapshot_arn` argument
+```

--- a/internal/service/redshift/cluster.go
+++ b/internal/service/redshift/cluster.go
@@ -325,6 +325,13 @@ func ResourceCluster() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"snapshot_arn": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ValidateFunc:  verify.ValidARN,
+				ConflictsWith: []string{"snapshot_identifier"},
+			},
 			"snapshot_cluster_identifier": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -353,9 +360,10 @@ func ResourceCluster() *schema.Resource {
 				},
 			},
 			"snapshot_identifier": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"snapshot_arn"},
 			},
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
@@ -491,7 +499,13 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 	if v, ok := d.GetOk("snapshot_identifier"); ok {
 		backupInput.SnapshotIdentifier = aws.String(v.(string))
+	}
 
+	if v, ok := d.GetOk("snapshot_arn"); ok {
+		backupInput.SnapshotArn = aws.String(v.(string))
+	}
+
+	if backupInput.SnapshotArn != nil || backupInput.SnapshotIdentifier != nil {
 		if v, ok := d.GetOk("owner_account"); ok {
 			backupInput.OwnerAccount = aws.String(v.(string))
 		}

--- a/internal/service/redshift/cluster_test.go
+++ b/internal/service/redshift/cluster_test.go
@@ -768,7 +768,7 @@ func TestAccRedshiftCluster_availabilityZoneRelocation_publiclyAccessible(t *tes
 func TestAccRedshiftCluster_restoreFromSnapshot(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v redshift.Cluster
-	resourceName := "aws_redshift_cluster.test"
+	resourceName := "aws_redshift_cluster.test2"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -803,7 +803,7 @@ func TestAccRedshiftCluster_restoreFromSnapshot(t *testing.T) {
 func TestAccRedshiftCluster_restoreFromSnapshotArn(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v redshift.Cluster
-	resourceName := "aws_redshift_cluster.test"
+	resourceName := "aws_redshift_cluster.test2"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/redshift/cluster_test.go
+++ b/internal/service/redshift/cluster_test.go
@@ -800,7 +800,7 @@ func TestAccRedshiftCluster_restoreFromSnapshot(t *testing.T) {
 	})
 }
 
-func TestAccRedshiftCluster_restoreFromSnapshotArn(t *testing.T) {
+func TestAccRedshiftCluster_restoreFromSnapshotARN(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v redshift.Cluster
 	resourceName := "aws_redshift_cluster.test2"
@@ -813,7 +813,7 @@ func TestAccRedshiftCluster_restoreFromSnapshotArn(t *testing.T) {
 		CheckDestroy:             testAccCheckClusterSnapshotDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_restoreFromSnapshotArn(rName),
+				Config: testAccClusterConfig_restoreFromSnapshotARN(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "snapshot_arn", "aws_redshift_cluster_snapshot.test", "arn"),
@@ -1715,7 +1715,7 @@ resource "aws_redshift_cluster" "test2" {
 `, rName))
 }
 
-func testAccClusterConfig_restoreFromSnapshotArn(rName string) string {
+func testAccClusterConfig_restoreFromSnapshotARN(rName string) string {
 	return acctest.ConfigCompose(testAccClusterConfig_basic(rName), fmt.Sprintf(`
 resource "aws_redshift_cluster_snapshot" "test" {
   cluster_identifier  = aws_redshift_cluster.test.cluster_identifier

--- a/internal/service/redshift/cluster_test.go
+++ b/internal/service/redshift/cluster_test.go
@@ -1703,14 +1703,14 @@ resource "aws_redshift_cluster_snapshot" "test" {
 }
 
 resource "aws_redshift_cluster" "test2" {
-  cluster_identifier        = "%[1]s-2"
-  snapshot_identifier       = aws_redshift_cluster_snapshot.test.id
-  availability_zone         = data.aws_availability_zones.available.names[0]
-  database_name             = "mydb"
-  master_username           = "foo_test"
-  master_password           = "Mustbe8characters"
-  node_type                 = "dc2.large"
-  skip_final_snapshot       = true
+  cluster_identifier  = "%[1]s-2"
+  snapshot_identifier = aws_redshift_cluster_snapshot.test.id
+  availability_zone   = data.aws_availability_zones.available.names[0]
+  database_name       = "mydb"
+  master_username     = "foo_test"
+  master_password     = "Mustbe8characters"
+  node_type           = "dc2.large"
+  skip_final_snapshot = true
 }
 `, rName))
 }

--- a/internal/service/redshift/cluster_test.go
+++ b/internal/service/redshift/cluster_test.go
@@ -775,28 +775,13 @@ func TestAccRedshiftCluster_restoreFromSnapshot(t *testing.T) {
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, redshift.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterTestSnapshotDestroy(ctx, rName),
+		CheckDestroy:             testAccCheckClusterSnapshotDestroy(ctx),
 		Steps: []resource.TestStep{
-			{
-				Config: testAccClusterConfig_createSnapshot(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &v),
-					resource.TestCheckResourceAttrPair(resourceName, "availability_zone", "data.aws_availability_zones.available", "names.0"),
-					resource.TestCheckResourceAttr(resourceName, "node_type", "dc2.8xlarge"),
-					resource.TestCheckResourceAttr(resourceName, "number_of_nodes", "2"),
-				),
-			},
-			// Apply a configuration without the source cluster to ensure final snapshot creation.
-			{ // nosemgrep:ci.test-config-funcs-correct-form
-				Config: acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"),
-			},
 			{
 				Config: testAccClusterConfig_restoreFromSnapshot(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
-					resource.TestCheckResourceAttrPair(resourceName, "availability_zone", "data.aws_availability_zones.available", "names.1"),
-					resource.TestCheckResourceAttr(resourceName, "node_type", "dc2.large"),
-					resource.TestCheckResourceAttr(resourceName, "number_of_nodes", "8"),
+					resource.TestCheckResourceAttrPair(resourceName, "snapshot_identifier", "aws_redshift_cluster_snapshot.test", "id"),
 				),
 			},
 			{
@@ -808,6 +793,41 @@ func TestAccRedshiftCluster_restoreFromSnapshot(t *testing.T) {
 					"master_password",
 					"skip_final_snapshot",
 					"snapshot_identifier",
+					"apply_immediately",
+				},
+			},
+		},
+	})
+}
+
+func TestAccRedshiftCluster_restoreFromSnapshotArn(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v redshift.Cluster
+	resourceName := "aws_redshift_cluster.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, redshift.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterSnapshotDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfig_restoreFromSnapshotArn(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttrPair(resourceName, "snapshot_arn", "aws_redshift_cluster_snapshot.test", "arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"final_snapshot_identifier",
+					"master_password",
+					"skip_final_snapshot",
+					"snapshot_arn",
 					"apply_immediately",
 				},
 			},
@@ -1675,32 +1695,41 @@ resource "aws_redshift_cluster" "test" {
 `, rName))
 }
 
-func testAccClusterConfig_createSnapshot(rName string) string {
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"), fmt.Sprintf(`
-resource "aws_redshift_cluster" "test" {
-  cluster_identifier        = %[1]q
+func testAccClusterConfig_restoreFromSnapshot(rName string) string {
+	return acctest.ConfigCompose(testAccClusterConfig_basic(rName), fmt.Sprintf(`
+resource "aws_redshift_cluster_snapshot" "test" {
+  cluster_identifier  = aws_redshift_cluster.test.cluster_identifier
+  snapshot_identifier = %[1]q
+}
+
+resource "aws_redshift_cluster" "test2" {
+  cluster_identifier        = "%[1]s-2"
+  snapshot_identifier       = aws_redshift_cluster_snapshot.test.id
   availability_zone         = data.aws_availability_zones.available.names[0]
   database_name             = "mydb"
   master_username           = "foo_test"
   master_password           = "Mustbe8characters"
-  node_type                 = "dc2.8xlarge"
-  number_of_nodes           = 2
-  final_snapshot_identifier = %[1]q
+  node_type                 = "dc2.large"
+  skip_final_snapshot       = true
 }
 `, rName))
 }
 
-func testAccClusterConfig_restoreFromSnapshot(rName string) string {
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"), fmt.Sprintf(`
-resource "aws_redshift_cluster" "test" {
-  cluster_identifier  = %[1]q
+func testAccClusterConfig_restoreFromSnapshotArn(rName string) string {
+	return acctest.ConfigCompose(testAccClusterConfig_basic(rName), fmt.Sprintf(`
+resource "aws_redshift_cluster_snapshot" "test" {
+  cluster_identifier  = aws_redshift_cluster.test.cluster_identifier
   snapshot_identifier = %[1]q
-  availability_zone   = data.aws_availability_zones.available.names[1]
+}
+
+resource "aws_redshift_cluster" "test2" {
+  cluster_identifier  = "%[1]s-2"
+  snapshot_arn        = aws_redshift_cluster_snapshot.test.arn
+  availability_zone   = data.aws_availability_zones.available.names[0]
   database_name       = "mydb"
   master_username     = "foo_test"
   master_password     = "Mustbe8characters"
   node_type           = "dc2.large"
-  number_of_nodes     = 8
   skip_final_snapshot = true
 }
 `, rName))

--- a/website/docs/r/redshift_cluster.html.markdown
+++ b/website/docs/r/redshift_cluster.html.markdown
@@ -72,7 +72,8 @@ This argument supports the following arguments:
 * `elastic_ip` - (Optional) The Elastic IP (EIP) address for the cluster.
 * `skip_final_snapshot` - (Optional) Determines whether a final snapshot of the cluster is created before Amazon Redshift deletes the cluster. If true , a final cluster snapshot is not created. If false , a final cluster snapshot is created before the cluster is deleted. Default is false.
 * `final_snapshot_identifier` - (Optional) The identifier of the final snapshot that is to be created immediately before deleting the cluster. If this parameter is provided, `skip_final_snapshot` must be false.
-* `snapshot_identifier` - (Optional) The name of the snapshot from which to create the new cluster.
+* `snapshot_arn` - (Optional) The ARN of the snapshot from which to create the new cluster. Conflicts with `snapshot_identifier`.
+* `snapshot_identifier` - (Optional) The name of the snapshot from which to create the new cluster.  Conflicts with `snapshot_arn`.
 * `snapshot_cluster_identifier` - (Optional) The name of the cluster the source snapshot was created from.
 * `owner_account` - (Optional) The AWS customer account used to create or copy the snapshot. Required if you are restoring a snapshot you do not own, optional if you own the snapshot.
 * `iam_roles` - (Optional) A list of IAM Role ARNs to associate with the cluster. A Maximum of 10 can be associated to the cluster at any time.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #29293

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
%  make testacc TESTS=TestAccRedshiftCluster_restoreFromSnapshot
--- PASS: TestAccRedshiftCluster_restoreFromSnapshotArn (698.39s)
```
