### PR TITLE
r/aws_redshift_cluster: support managed master passwords

### DIFF
--- a/.changelog/34182.txt
+++ b/.changelog/34182.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_redshift_cluster: Add the `manage_master_password` and `master_password_secret_kms_key_id` arguments to support managed admin credentials
+```

--- a/internal/service/redshift/cluster.go
+++ b/internal/service/redshift/cluster.go
@@ -255,6 +255,11 @@ func ResourceCluster() *schema.Resource {
 				Optional: true,
 				Default:  "current",
 			},
+			"manage_master_password": {
+				Type:          schema.TypeBool,
+				Optional:      true,
+				ConflictsWith: []string{"master_password"},
+			},
 			"manual_snapshot_retention_period": {
 				Type:         schema.TypeInt,
 				Optional:     true,
@@ -272,6 +277,17 @@ func ResourceCluster() *schema.Resource {
 					validation.StringMatch(regexache.MustCompile(`^.*[0-9].*`), "must contain at least one number"),
 					validation.StringMatch(regexache.MustCompile(`^[^\@\/'" ]*$`), "cannot contain [/@\"' ]"),
 				),
+				ConflictsWith: []string{"manage_master_password"},
+			},
+			"master_password_secret_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"master_password_secret_kms_key_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: verify.ValidKMSKeyID,
 			},
 			"master_username": {
 				Type:     schema.TypeString,
@@ -415,7 +431,6 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 		ClusterVersion:                   aws.String(d.Get("cluster_version").(string)),
 		DBName:                           aws.String(d.Get("database_name").(string)),
 		MasterUsername:                   aws.String(d.Get("master_username").(string)),
-		MasterUserPassword:               aws.String(d.Get("master_password").(string)),
 		NodeType:                         aws.String(d.Get("node_type").(string)),
 		Port:                             aws.Int64(int64(d.Get("port").(int))),
 		PubliclyAccessible:               aws.Bool(d.Get("publicly_accessible").(bool)),
@@ -477,9 +492,23 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 		input.MaintenanceTrackName = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("manage_master_password"); ok {
+		backupInput.ManageMasterPassword = aws.Bool(v.(bool))
+		input.ManageMasterPassword = aws.Bool(v.(bool))
+	}
+
 	if v, ok := d.GetOk("manual_snapshot_retention_period"); ok {
 		backupInput.ManualSnapshotRetentionPeriod = aws.Int64(int64(v.(int)))
 		input.ManualSnapshotRetentionPeriod = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("master_password"); ok {
+		input.MasterUserPassword = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("master_password_secret_kms_key_id"); ok {
+		backupInput.MasterPasswordSecretKmsKeyId = aws.String(v.(string))
+		input.MasterPasswordSecretKmsKeyId = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("number_of_nodes"); ok {
@@ -524,7 +553,9 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 		d.SetId(aws.StringValue(output.Cluster.ClusterIdentifier))
 	} else {
 		if _, ok := d.GetOk("master_password"); !ok {
-			return sdkdiag.AppendErrorf(diags, `provider.aws: aws_redshift_cluster: %s: "master_password": required field is not set`, d.Get("cluster_identifier").(string))
+			if _, ok := d.GetOk("manage_master_password"); !ok {
+				return sdkdiag.AppendErrorf(diags, `provider.aws: aws_redshift_cluster: %s: one of "manage_master_password" or "master_password" is required`, d.Get("cluster_identifier").(string))
+			}
 		}
 
 		if _, ok := d.GetOk("master_username"); !ok {
@@ -647,6 +678,8 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set("maintenance_track_name", rsc.MaintenanceTrackName)
 	d.Set("manual_snapshot_retention_period", rsc.ManualSnapshotRetentionPeriod)
 	d.Set("master_username", rsc.MasterUsername)
+	d.Set("master_password_secret_arn", rsc.MasterPasswordSecretArn)
+	d.Set("master_password_secret_kms_key_id", rsc.MasterPasswordSecretKmsKeyId)
 	d.Set("node_type", rsc.NodeType)
 	d.Set("number_of_nodes", rsc.NumberOfNodes)
 	d.Set("preferred_maintenance_window", rsc.PreferredMaintenanceWindow)
@@ -753,6 +786,14 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 		if d.HasChange("master_password") {
 			input.MasterUserPassword = aws.String(d.Get("master_password").(string))
+		}
+
+		if d.HasChange("master_password_secret_kms_key_id") {
+			input.MasterPasswordSecretKmsKeyId = aws.String(d.Get("master_password_secret_kms_key_id").(string))
+		}
+
+		if d.HasChange("manage_master_password") {
+			input.ManageMasterPassword = aws.Bool(d.Get("manage_master_password").(bool))
 		}
 
 		if d.HasChange("preferred_maintenance_window") {

--- a/website/docs/r/redshift_cluster.html.markdown
+++ b/website/docs/r/redshift_cluster.html.markdown
@@ -17,6 +17,8 @@ Provides a Redshift Cluster Resource.
 
 ## Example Usage
 
+### Basic Usage
+
 ```terraform
 resource "aws_redshift_cluster" "example" {
   cluster_identifier = "tf-redshift-cluster"
@@ -28,12 +30,26 @@ resource "aws_redshift_cluster" "example" {
 }
 ```
 
+### With Managed Credentials
+
+```terraform
+resource "aws_redshift_cluster" "example" {
+  cluster_identifier = "tf-redshift-cluster"
+  database_name      = "mydb"
+  master_username    = "exampleuser"
+  node_type          = "dc1.large"
+  cluster_type       = "single-node"
+
+  manage_master_password = true
+}
+```
+
 ## Argument Reference
 
 For more detailed documentation about each argument, refer to
 the [AWS official documentation](http://docs.aws.amazon.com/cli/latest/reference/redshift/index.html#cli-aws-redshift).
 
-This argument supports the following arguments:
+This resource supports the following arguments:
 
 * `cluster_identifier` - (Required) The Cluster Identifier. Must be a lower case string.
 * `database_name` - (Optional) The name of the first database to be created when the cluster is created.
@@ -41,9 +57,15 @@ This argument supports the following arguments:
 * `default_iam_role_arn` - (Optional) The Amazon Resource Name (ARN) for the IAM role that was set as default for the cluster when the cluster was created.
 * `node_type` - (Required) The node type to be provisioned for the cluster.
 * `cluster_type` - (Optional) The cluster type to use. Either `single-node` or `multi-node`.
-* `master_password` - (Required unless a `snapshot_identifier` is provided) Password for the master DB user.
-  Note that this may show up in logs, and it will be stored in the state file. Password must contain at least 8 chars and
-  contain at least one uppercase letter, one lowercase letter, and one number.
+* `manage_master_password` - (Optional) Whether to use AWS SecretsManager to manage the cluster admin credentials.
+  Conflicts with `master_password`.
+  One of `master_password` or `manage_master_password` is required unless `snapshot_identifier` is provided.
+* `master_password` - (Optional) Password for the master DB user.
+  Conflicts with `manage_master_password`.
+  One of `master_password` or `manage_master_password` is required unless `snapshot_identifier` is provided.
+  Note that this may show up in logs, and it will be stored in the state file.
+  Password must contain at least 8 characters and contain at least one uppercase letter, one lowercase letter, and one number.
+* `master_password_secret_kms_key_id` - (Optional) ID of the KMS key used to encrypt the cluster admin credentials secret.
 * `master_username` - (Required unless a `snapshot_identifier` is provided) Username for the master DB user.
 * `vpc_security_group_ids` - (Optional) A list of Virtual Private Cloud (VPC) security groups to be associated with the cluster.
 * `cluster_subnet_group_name` - (Optional) The name of a cluster subnet group to be associated with this cluster. If this parameter is not provided the resulting cluster will be deployed outside virtual private cloud (VPC).
@@ -117,6 +139,7 @@ This resource exports the following attributes in addition to the arguments abov
 * `encrypted` - Whether the data in the cluster is encrypted
 * `vpc_security_group_ids` - The VPC security group Ids associated with the cluster
 * `dns_name` - The DNS name of the cluster
+* `master_password_secret_arn` - ARN of the cluster admin credentials secret
 * `port` - The Port the cluster responds on
 * `cluster_version` - The version of Redshift engine software
 * `cluster_parameter_group_name` - The name of the parameter group to be associated with this cluster


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This change adds the `manage_master_password` and `master_password_secret_kms_key_id` arguments allowing the configuration of AWS managed credentials via SecretsManager. The `manage_master_password` argument conflicts with the `master_password` argument, and at least one must be set when creating a new cluster not restored from a snapshot. The `master_password_secret_arn` attribute was added to track the ARN of the SecretsManager secret which stores cluster credentials.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #34169 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/redshift/latest/APIReference/API_Cluster.html
- https://docs.aws.amazon.com/redshift/latest/APIReference/API_CreateCluster.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
%  make testacc PKG=redshift TESTS="TestAccRedshiftCluster_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/redshift/... -v -count 1 -parallel 20 -run='TestAccRedshiftCluster_'  -timeout 360m

--- PASS: TestAccRedshiftCluster_disappears (368.71s)
=== CONT  TestAccRedshiftCluster_aqua
--- PASS: TestAccRedshiftCluster_manageMasterPassword (387.65s)
=== CONT  TestAccRedshiftCluster_changeAvailabilityZone
--- PASS: TestAccRedshiftCluster_basic (391.55s)
=== CONT  TestAccRedshiftCluster_forceNewUsername
--- PASS: TestAccRedshiftCluster_changeAvailabilityZone_availabilityZoneRelocationNotSet (499.37s)
--- PASS: TestAccRedshiftCluster_snapshotCopy (506.43s)
--- PASS: TestAccRedshiftCluster_iamRoles (515.61s)
--- PASS: TestAccRedshiftCluster_tags (516.56s)
--- PASS: TestAccRedshiftCluster_availabilityZoneRelocation (552.05s)
--- PASS: TestAccRedshiftCluster_kmsKey (556.19s)
--- PASS: TestAccRedshiftCluster_availabilityZoneRelocation_publiclyAccessible (556.92s)
--- PASS: TestAccRedshiftCluster_withFinalSnapshot (574.15s)
--- PASS: TestAccRedshiftCluster_enhancedVPCRoutingEnabled (581.81s)
--- PASS: TestAccRedshiftCluster_changeAvailabilityZoneAndSetAvailabilityZoneRelocation (723.83s)
--- PASS: TestAccRedshiftCluster_loggingEnabled (766.36s)
--- PASS: TestAccRedshiftCluster_aqua (415.38s)
--- PASS: TestAccRedshiftCluster_publiclyAccessible (833.06s)
--- PASS: TestAccRedshiftCluster_forceNewUsername (602.32s)
--- PASS: TestAccRedshiftCluster_changeAvailabilityZone (642.96s)
--- PASS: TestAccRedshiftCluster_updateNodeType (1091.19s)
--- PASS: TestAccRedshiftCluster_changeEncryption1 (1115.82s)
--- PASS: TestAccRedshiftCluster_updateNodeCount (1162.75s)
--- PASS: TestAccRedshiftCluster_restoreFromSnapshot (1194.38s)
--- PASS: TestAccRedshiftCluster_changeEncryption2 (1346.13s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/redshift   1349.395s
```
