### PR TITLE
ci: switch library_versions action to pull_request_target event

### DIFF
--- a/.github/workflows/library_versions.yml
+++ b/.github/workflows/library_versions.yml
@@ -9,7 +9,7 @@ name: Preferred Library Version Check
 # contributor documentation.
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
 
@@ -21,11 +21,11 @@ jobs:
     steps:
       # checkout base ref
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          ref: ${{ github.event.pull_request.base.ref }}
 
       # checkout pull request head ref
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Check diff for AWS SDK Go V1
         id: diff


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This change should allow the Github comment job to have the necessary write permissions, even when pull requests are opened from forks.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #34083

### References

- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
