### PR TITLE
Tech debt: Use Plugin SDK v2 `All` `Diag`-flavor validator combinator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/account v1.11.7
 	github.com/aws/aws-sdk-go-v2/service/acm v1.19.2
 	github.com/aws/aws-sdk-go-v2/service/appconfig v1.23.0
+	github.com/aws/aws-sdk-go-v2/service/athena v1.32.0
 	github.com/aws/aws-sdk-go-v2/service/auditmanager v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.4.2
 	github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.12.7

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,8 @@ github.com/aws/aws-sdk-go-v2/service/acm v1.19.2 h1:M+BY1Sk+AcWg596Nz3MMX630a3vp
 github.com/aws/aws-sdk-go-v2/service/acm v1.19.2/go.mod h1:Zx0vrYeKZEZIPnggUx09FdoXze1+2i6Od+lHsG/L3vU=
 github.com/aws/aws-sdk-go-v2/service/appconfig v1.23.0 h1:lN+EsDRxYDYeRHYXZ+3uTSYeEhmXYULg5qBABSqVIrk=
 github.com/aws/aws-sdk-go-v2/service/appconfig v1.23.0/go.mod h1:7bTOwXFz4+VxkDVB26d7TAhFKloGA3EtwtLAydyv1ek=
+github.com/aws/aws-sdk-go-v2/service/athena v1.32.0 h1:n4ui9xL0VbmOVNi2+hiWIrVLVhew/1/4BdzjJY3Px58=
+github.com/aws/aws-sdk-go-v2/service/athena v1.32.0/go.mod h1:vKT/ZbLHt0S5hlmf0T5OzcPhs4LJoEmqlr49JP+9Hy8=
 github.com/aws/aws-sdk-go-v2/service/auditmanager v1.27.0 h1:pz81qsD+FxrrHOaNrfGSWbQ4cU6Dxj2I5tvlrLmgCUE=
 github.com/aws/aws-sdk-go-v2/service/auditmanager v1.27.0/go.mod h1:zEDWBhc3yodpWk3ZLDNPlTOZGNx0bGx90XQma07xR1Q=
 github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.4.2 h1:qt0XqbZAU+ZnaqQqvuafocTm/KPKIxf0GPRObbMvhGc=

--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -8,6 +8,7 @@ import (
 	account_sdkv2 "github.com/aws/aws-sdk-go-v2/service/account"
 	acm_sdkv2 "github.com/aws/aws-sdk-go-v2/service/acm"
 	appconfig_sdkv2 "github.com/aws/aws-sdk-go-v2/service/appconfig"
+	athena_sdkv2 "github.com/aws/aws-sdk-go-v2/service/athena"
 	auditmanager_sdkv2 "github.com/aws/aws-sdk-go-v2/service/auditmanager"
 	cleanrooms_sdkv2 "github.com/aws/aws-sdk-go-v2/service/cleanrooms"
 	cloudcontrol_sdkv2 "github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
@@ -81,7 +82,6 @@ import (
 	apprunner_sdkv1 "github.com/aws/aws-sdk-go/service/apprunner"
 	appstream_sdkv1 "github.com/aws/aws-sdk-go/service/appstream"
 	appsync_sdkv1 "github.com/aws/aws-sdk-go/service/appsync"
-	athena_sdkv1 "github.com/aws/aws-sdk-go/service/athena"
 	autoscaling_sdkv1 "github.com/aws/aws-sdk-go/service/autoscaling"
 	autoscalingplans_sdkv1 "github.com/aws/aws-sdk-go/service/autoscalingplans"
 	backup_sdkv1 "github.com/aws/aws-sdk-go/service/backup"
@@ -295,8 +295,8 @@ func (c *AWSClient) ApplicationInsightsConn(ctx context.Context) *applicationins
 	return errs.Must(conn[*applicationinsights_sdkv1.ApplicationInsights](ctx, c, names.ApplicationInsights))
 }
 
-func (c *AWSClient) AthenaConn(ctx context.Context) *athena_sdkv1.Athena {
-	return errs.Must(conn[*athena_sdkv1.Athena](ctx, c, names.Athena))
+func (c *AWSClient) AthenaClient(ctx context.Context) *athena_sdkv2.Client {
+	return errs.Must(client[*athena_sdkv2.Client](ctx, c, names.Athena))
 }
 
 func (c *AWSClient) AuditManagerClient(ctx context.Context) *auditmanager_sdkv2.Client {

--- a/internal/service/athena/data_catalog.go
+++ b/internal/service/athena/data_catalog.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/athena"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
-	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -61,7 +60,7 @@ func ResourceDataCatalog() *schema.Resource {
 				Type:     schema.TypeMap,
 				Required: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-				ValidateDiagFunc: allDiagFunc(
+				ValidateDiagFunc: validation.AllDiag(
 					validation.MapKeyLenBetween(1, 255),
 					validation.MapValueLenBetween(0, 51200),
 				),
@@ -201,14 +200,4 @@ func resourceDataCatalogDelete(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	return nil
-}
-
-func allDiagFunc(validators ...schema.SchemaValidateDiagFunc) schema.SchemaValidateDiagFunc {
-	return func(i interface{}, k cty.Path) diag.Diagnostics {
-		var diags diag.Diagnostics
-		for _, validator := range validators {
-			diags = append(diags, validator(i, k)...)
-		}
-		return diags
-	}
 }

--- a/internal/service/athena/data_catalog.go
+++ b/internal/service/athena/data_catalog.go
@@ -9,23 +9,27 @@ import (
 	"log"
 
 	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/aws/aws-sdk-go/service/athena"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/service/athena"
+	"github.com/aws/aws-sdk-go-v2/service/athena/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 // @SDKResource("aws_athena_data_catalog", name="Data Catalog")
 // @Tags(identifierAttribute="arn")
-func ResourceDataCatalog() *schema.Resource {
+func resourceDataCatalog() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceDataCatalogCreate,
 		ReadWithoutTimeout:   resourceDataCatalogRead,
@@ -68,31 +72,30 @@ func ResourceDataCatalog() *schema.Resource {
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"type": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringInSlice(athena.DataCatalogType_Values(), false),
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateDiagFunc: enum.Validate[types.DataCatalogType](),
 			},
 		},
 	}
 }
 
 func resourceDataCatalogCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).AthenaConn(ctx)
+	conn := meta.(*conns.AWSClient).AthenaClient(ctx)
 
 	name := d.Get("name").(string)
 	input := &athena.CreateDataCatalogInput{
 		Name:        aws.String(name),
 		Description: aws.String(d.Get("description").(string)),
 		Tags:        getTagsIn(ctx),
-		Type:        aws.String(d.Get("type").(string)),
+		Type:        types.DataCatalogType(d.Get("type").(string)),
 	}
 
 	if v, ok := d.GetOk("parameters"); ok && len(v.(map[string]interface{})) > 0 {
-		input.Parameters = flex.ExpandStringMap(v.(map[string]interface{}))
+		input.Parameters = flex.ExpandStringValueMap(v.(map[string]interface{}))
 	}
 
-	log.Printf("[DEBUG] Creating Athena Data Catalog: %s", input)
-	_, err := conn.CreateDataCatalogWithContext(ctx, input)
+	_, err := conn.CreateDataCatalog(ctx, input)
 
 	if err != nil {
 		return diag.Errorf("creating Athena Data Catalog (%s): %s", name, err)
@@ -104,16 +107,11 @@ func resourceDataCatalogCreate(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func resourceDataCatalogRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).AthenaConn(ctx)
+	conn := meta.(*conns.AWSClient).AthenaClient(ctx)
 
-	input := &athena.GetDataCatalogInput{
-		Name: aws.String(d.Id()),
-	}
+	dataCatalog, err := findDataCatalogByName(ctx, conn, d.Id())
 
-	dataCatalog, err := conn.GetDataCatalogWithContext(ctx, input)
-
-	// If the resource doesn't exist, the API returns a `ErrCodeInvalidRequestException` error.
-	if !d.IsNewResource() && tfawserr.ErrMessageContains(err, athena.ErrCodeInvalidRequestException, "was not found") {
+	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Athena Data Catalog (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
@@ -131,9 +129,9 @@ func resourceDataCatalogRead(ctx context.Context, d *schema.ResourceData, meta i
 		Resource:  fmt.Sprintf("datacatalog/%s", d.Id()),
 	}.String()
 	d.Set("arn", arn)
-	d.Set("description", dataCatalog.DataCatalog.Description)
-	d.Set("name", dataCatalog.DataCatalog.Name)
-	d.Set("type", dataCatalog.DataCatalog.Type)
+	d.Set("description", dataCatalog.Description)
+	d.Set("name", dataCatalog.Name)
+	d.Set("type", dataCatalog.Type)
 
 	// NOTE: This is a workaround for the fact that the API sets default values for parameters that are not set.
 	// Because the API sets default values, what's returned by the API is different than what's set by the user.
@@ -141,8 +139,8 @@ func resourceDataCatalogRead(ctx context.Context, d *schema.ResourceData, meta i
 		parameters := make(map[string]string, 0)
 
 		for key, val := range v.(map[string]interface{}) {
-			if v, ok := dataCatalog.DataCatalog.Parameters[key]; ok {
-				parameters[key] = aws.StringValue(v)
+			if v, ok := dataCatalog.Parameters[key]; ok {
+				parameters[key] = v
 			} else {
 				parameters[key] = val.(string)
 			}
@@ -157,23 +155,22 @@ func resourceDataCatalogRead(ctx context.Context, d *schema.ResourceData, meta i
 }
 
 func resourceDataCatalogUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).AthenaConn(ctx)
+	conn := meta.(*conns.AWSClient).AthenaClient(ctx)
 
 	if d.HasChangesExcept("tags", "tags_all") {
 		input := &athena.UpdateDataCatalogInput{
 			Name:        aws.String(d.Id()),
-			Type:        aws.String(d.Get("type").(string)),
+			Type:        types.DataCatalogType(d.Get("type").(string)),
 			Description: aws.String(d.Get("description").(string)),
 		}
 
 		if d.HasChange("parameters") {
 			if v, ok := d.GetOk("parameters"); ok && len(v.(map[string]interface{})) > 0 {
-				input.Parameters = flex.ExpandStringMap(v.(map[string]interface{}))
+				input.Parameters = flex.ExpandStringValueMap(v.(map[string]interface{}))
 			}
 		}
 
-		log.Printf("[DEBUG] Updating Athena Data Catalog: %s", input)
-		_, err := conn.UpdateDataCatalogWithContext(ctx, input)
+		_, err := conn.UpdateDataCatalog(ctx, input)
 
 		if err != nil {
 			return diag.Errorf("updating Athena Data Catalog (%s): %s", d.Id(), err)
@@ -184,14 +181,14 @@ func resourceDataCatalogUpdate(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func resourceDataCatalogDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).AthenaConn(ctx)
+	conn := meta.(*conns.AWSClient).AthenaClient(ctx)
 
 	log.Printf("[DEBUG] Deleting Athena Data Catalog: (%s)", d.Id())
-	_, err := conn.DeleteDataCatalogWithContext(ctx, &athena.DeleteDataCatalogInput{
+	_, err := conn.DeleteDataCatalog(ctx, &athena.DeleteDataCatalogInput{
 		Name: aws.String(d.Id()),
 	})
 
-	if tfawserr.ErrCodeEquals(err, athena.ErrCodeResourceNotFoundException) {
+	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return nil
 	}
 
@@ -200,4 +197,29 @@ func resourceDataCatalogDelete(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	return nil
+}
+
+func findDataCatalogByName(ctx context.Context, conn *athena.Client, name string) (*types.DataCatalog, error) {
+	input := &athena.GetDataCatalogInput{
+		Name: aws.String(name),
+	}
+
+	output, err := conn.GetDataCatalog(ctx, input)
+
+	if errs.IsAErrorMessageContains[*types.InvalidRequestException](err, "was not found") {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.DataCatalog == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.DataCatalog, nil
 }

--- a/internal/service/athena/data_catalog_test.go
+++ b/internal/service/athena/data_catalog_test.go
@@ -8,15 +8,14 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/athena"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfathena "github.com/hashicorp/terraform-provider-aws/internal/service/athena"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccAthenaDataCatalog_basic(t *testing.T) {
@@ -26,7 +25,7 @@ func TestAccAthenaDataCatalog_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, athena.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDataCatalogDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -60,7 +59,7 @@ func TestAccAthenaDataCatalog_disappears(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, athena.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDataCatalogDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -83,7 +82,7 @@ func TestAccAthenaDataCatalog_tags(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, athena.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDataCatalogDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -129,7 +128,7 @@ func TestAccAthenaDataCatalog_type_lambda(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, athena.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDataCatalogDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -161,7 +160,7 @@ func TestAccAthenaDataCatalog_type_hive(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, athena.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDataCatalogDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -192,7 +191,7 @@ func TestAccAthenaDataCatalog_type_glue(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, athena.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDataCatalogDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -223,7 +222,7 @@ func TestAccAthenaDataCatalog_parameters(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, athena.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDataCatalogDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -261,17 +260,9 @@ func testAccCheckDataCatalogExists(ctx context.Context, n string) resource.TestC
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No Athena Data Catalog name is set")
-		}
+		conn := acctest.Provider.Meta().(*conns.AWSClient).AthenaClient(ctx)
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).AthenaConn(ctx)
-
-		input := &athena.GetDataCatalogInput{
-			Name: aws.String(rs.Primary.ID),
-		}
-
-		_, err := conn.GetDataCatalogWithContext(ctx, input)
+		_, err := tfathena.FindDataCatalogByName(ctx, conn, rs.Primary.ID)
 
 		return err
 	}
@@ -279,20 +270,16 @@ func testAccCheckDataCatalogExists(ctx context.Context, n string) resource.TestC
 
 func testAccCheckDataCatalogDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).AthenaConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).AthenaClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_athena_data_catalog" {
 				continue
 			}
 
-			input := &athena.GetDataCatalogInput{
-				Name: aws.String(rs.Primary.ID),
-			}
+			_, err := tfathena.FindDataCatalogByName(ctx, conn, rs.Primary.ID)
 
-			output, err := conn.GetDataCatalogWithContext(ctx, input)
-
-			if tfawserr.ErrMessageContains(err, athena.ErrCodeInvalidRequestException, "was not found") {
+			if tfresource.NotFound(err) {
 				continue
 			}
 
@@ -300,9 +287,7 @@ func testAccCheckDataCatalogDestroy(ctx context.Context) resource.TestCheckFunc 
 				return err
 			}
 
-			if output.DataCatalog != nil {
-				return fmt.Errorf("Athena Data Catalog (%s) found", rs.Primary.ID)
-			}
+			return fmt.Errorf("Athena Data Catalog %s still exists", rs.Primary.ID)
 		}
 
 		return nil

--- a/internal/service/athena/database.go
+++ b/internal/service/athena/database.go
@@ -285,7 +285,7 @@ func expandResultConfigurationACLConfig(config []interface{}) *types.AclConfigur
 }
 
 func executeAndExpectNoRows(ctx context.Context, conn *athena.Client, qeid string) error {
-	rs, err := QueryExecutionResult(ctx, conn, qeid)
+	rs, err := queryExecutionResult(ctx, conn, qeid)
 	if err != nil {
 		return err
 	}
@@ -295,7 +295,7 @@ func executeAndExpectNoRows(ctx context.Context, conn *athena.Client, qeid strin
 	return nil
 }
 
-func QueryExecutionResult(ctx context.Context, conn *athena.Client, qeid string) (*types.ResultSet, error) {
+func queryExecutionResult(ctx context.Context, conn *athena.Client, qeid string) (*types.ResultSet, error) {
 	executionStateConf := &retry.StateChangeConf{
 		Pending:    enum.Slice(types.QueryExecutionStateQueued, types.QueryExecutionStateRunning),
 		Target:     enum.Slice(types.QueryExecutionStateSucceeded),

--- a/internal/service/athena/database.go
+++ b/internal/service/athena/database.go
@@ -12,24 +12,28 @@ import (
 	"time"
 
 	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/athena"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/athena"
+	"github.com/aws/aws-sdk-go-v2/service/athena/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 // @SDKResource("aws_athena_database")
-func ResourceDatabase() *schema.Resource {
+func resourceDatabase() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceDatabaseCreate,
 		ReadWithoutTimeout:   resourceDatabaseRead,
-		UpdateWithoutTimeout: schema.NoopContext,
+		UpdateWithoutTimeout: schema.NoopContext, // force_destroy isn't ForceNew.
 		DeleteWithoutTimeout: resourceDatabaseDelete,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -43,10 +47,10 @@ func ResourceDatabase() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"s3_acl_option": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringInSlice(athena.S3AclOption_Values(), false),
-							ForceNew:     true,
+							Type:             schema.TypeString,
+							Required:         true,
+							ForceNew:         true,
+							ValidateDiagFunc: enum.Validate[types.S3AclOption](),
 						},
 					},
 				},
@@ -68,10 +72,10 @@ func ResourceDatabase() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"encryption_option": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringInSlice(athena.EncryptionOption_Values(), false),
-							ForceNew:     true,
+							Type:             schema.TypeString,
+							Required:         true,
+							ForceNew:         true,
+							ValidateDiagFunc: enum.Validate[types.EncryptionOption](),
 						},
 						"kms_key": {
 							Type:     schema.TypeString,
@@ -109,12 +113,11 @@ func ResourceDatabase() *schema.Resource {
 
 func resourceDatabaseCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).AthenaConn(ctx)
+	conn := meta.(*conns.AWSClient).AthenaClient(ctx)
 
 	name := d.Get("name").(string)
-	var queryString bytes.Buffer
-
 	createStmt := fmt.Sprintf("create database `%s`", name)
+	var queryString bytes.Buffer
 	queryString.WriteString(createStmt)
 
 	if v, ok := d.GetOk("comment"); ok && v.(string) != "" {
@@ -140,13 +143,13 @@ func resourceDatabaseCreate(ctx context.Context, d *schema.ResourceData, meta in
 		ResultConfiguration: expandResultConfiguration(d),
 	}
 
-	resp, err := conn.StartQueryExecutionWithContext(ctx, input)
+	output, err := conn.StartQueryExecution(ctx, input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating Athena Database (%s): %s", name, err)
 	}
 
-	if err := executeAndExpectNoRows(ctx, conn, aws.StringValue(resp.QueryExecutionId)); err != nil {
+	if err := executeAndExpectNoRows(ctx, conn, aws.ToString(output.QueryExecutionId)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating Athena Database (%s): %s", name, err)
 	}
 
@@ -157,15 +160,11 @@ func resourceDatabaseCreate(ctx context.Context, d *schema.ResourceData, meta in
 
 func resourceDatabaseRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).AthenaConn(ctx)
+	conn := meta.(*conns.AWSClient).AthenaClient(ctx)
 
-	input := &athena.GetDatabaseInput{
-		DatabaseName: aws.String(d.Id()),
-		CatalogName:  aws.String("AwsDataCatalog"),
-	}
-	res, err := conn.GetDatabaseWithContext(ctx, input)
+	db, err := findDatabaseByName(ctx, conn, d.Id())
 
-	if tfawserr.ErrMessageContains(err, athena.ErrCodeMetadataException, "not found") && !d.IsNewResource() {
+	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Athena Database (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
@@ -175,10 +174,8 @@ func resourceDatabaseRead(ctx context.Context, d *schema.ResourceData, meta inte
 		return sdkdiag.AppendErrorf(diags, "reading Athena Database (%s): %s", d.Id(), err)
 	}
 
-	db := res.Database
-
-	d.Set("name", db.Name)
 	d.Set("comment", db.Description)
+	d.Set("name", db.Name)
 	d.Set("properties", db.Parameters)
 
 	return diags
@@ -186,7 +183,7 @@ func resourceDatabaseRead(ctx context.Context, d *schema.ResourceData, meta inte
 
 func resourceDatabaseDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).AthenaConn(ctx)
+	conn := meta.(*conns.AWSClient).AthenaClient(ctx)
 
 	queryString := fmt.Sprintf("drop database `%s`", d.Id())
 	if d.Get("force_destroy").(bool) {
@@ -199,20 +196,47 @@ func resourceDatabaseDelete(ctx context.Context, d *schema.ResourceData, meta in
 		ResultConfiguration: expandResultConfiguration(d),
 	}
 
-	resp, err := conn.StartQueryExecutionWithContext(ctx, input)
+	output, err := conn.StartQueryExecution(ctx, input)
+
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "deleting Athena Database (%s): %s", d.Id(), err)
 	}
 
-	if err := executeAndExpectNoRows(ctx, conn, aws.StringValue(resp.QueryExecutionId)); err != nil {
+	if err := executeAndExpectNoRows(ctx, conn, aws.ToString(output.QueryExecutionId)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "deleting Athena Database (%s): %s", d.Id(), err)
 	}
 
 	return diags
 }
 
-func expandResultConfiguration(d *schema.ResourceData) *athena.ResultConfiguration {
-	resultConfig := &athena.ResultConfiguration{
+func findDatabaseByName(ctx context.Context, conn *athena.Client, name string) (*types.Database, error) {
+	input := &athena.GetDatabaseInput{
+		CatalogName:  aws.String("AwsDataCatalog"),
+		DatabaseName: aws.String(name),
+	}
+
+	output, err := conn.GetDatabase(ctx, input)
+
+	if errs.IsAErrorMessageContains[*types.MetadataException](err, "not found") {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.Database == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.Database, nil
+}
+
+func expandResultConfiguration(d *schema.ResourceData) *types.ResultConfiguration {
+	resultConfig := &types.ResultConfiguration{
 		OutputLocation:          aws.String("s3://" + d.Get("bucket").(string)),
 		EncryptionConfiguration: expandResultConfigurationEncryptionConfig(d.Get("encryption_configuration").([]interface{})),
 	}
@@ -228,15 +252,15 @@ func expandResultConfiguration(d *schema.ResourceData) *athena.ResultConfigurati
 	return resultConfig
 }
 
-func expandResultConfigurationEncryptionConfig(config []interface{}) *athena.EncryptionConfiguration {
+func expandResultConfigurationEncryptionConfig(config []interface{}) *types.EncryptionConfiguration {
 	if len(config) <= 0 {
 		return nil
 	}
 
 	data := config[0].(map[string]interface{})
 
-	encryptionConfig := &athena.EncryptionConfiguration{
-		EncryptionOption: aws.String(data["encryption_option"].(string)),
+	encryptionConfig := &types.EncryptionConfiguration{
+		EncryptionOption: types.EncryptionOption(data["encryption_option"].(string)),
 	}
 
 	if v, ok := data["kms_key"].(string); ok && v != "" {
@@ -246,21 +270,21 @@ func expandResultConfigurationEncryptionConfig(config []interface{}) *athena.Enc
 	return encryptionConfig
 }
 
-func expandResultConfigurationACLConfig(config []interface{}) *athena.AclConfiguration {
+func expandResultConfigurationACLConfig(config []interface{}) *types.AclConfiguration {
 	if len(config) <= 0 {
 		return nil
 	}
 
 	data := config[0].(map[string]interface{})
 
-	encryptionConfig := &athena.AclConfiguration{
-		S3AclOption: aws.String(data["s3_acl_option"].(string)),
+	encryptionConfig := &types.AclConfiguration{
+		S3AclOption: types.S3AclOption(data["s3_acl_option"].(string)),
 	}
 
 	return encryptionConfig
 }
 
-func executeAndExpectNoRows(ctx context.Context, conn *athena.Athena, qeid string) error {
+func executeAndExpectNoRows(ctx context.Context, conn *athena.Client, qeid string) error {
 	rs, err := QueryExecutionResult(ctx, conn, qeid)
 	if err != nil {
 		return err
@@ -271,16 +295,17 @@ func executeAndExpectNoRows(ctx context.Context, conn *athena.Athena, qeid strin
 	return nil
 }
 
-func QueryExecutionResult(ctx context.Context, conn *athena.Athena, qeid string) (*athena.ResultSet, error) {
+func QueryExecutionResult(ctx context.Context, conn *athena.Client, qeid string) (*types.ResultSet, error) {
 	executionStateConf := &retry.StateChangeConf{
-		Pending:    []string{athena.QueryExecutionStateQueued, athena.QueryExecutionStateRunning},
-		Target:     []string{athena.QueryExecutionStateSucceeded},
+		Pending:    enum.Slice(types.QueryExecutionStateQueued, types.QueryExecutionStateRunning),
+		Target:     enum.Slice(types.QueryExecutionStateSucceeded),
 		Refresh:    queryExecutionStateRefreshFunc(ctx, conn, qeid),
 		Timeout:    10 * time.Minute,
 		Delay:      3 * time.Second,
 		MinTimeout: 3 * time.Second,
 	}
 	_, err := executionStateConf.WaitForStateContext(ctx)
+
 	if err != nil {
 		return nil, err
 	}
@@ -288,19 +313,19 @@ func QueryExecutionResult(ctx context.Context, conn *athena.Athena, qeid string)
 	qrinput := &athena.GetQueryResultsInput{
 		QueryExecutionId: aws.String(qeid),
 	}
-	resp, err := conn.GetQueryResultsWithContext(ctx, qrinput)
+	resp, err := conn.GetQueryResults(ctx, qrinput)
 	if err != nil {
 		return nil, err
 	}
 	return resp.ResultSet, nil
 }
 
-func queryExecutionStateRefreshFunc(ctx context.Context, conn *athena.Athena, qeid string) retry.StateRefreshFunc {
+func queryExecutionStateRefreshFunc(ctx context.Context, conn *athena.Client, qeid string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		input := &athena.GetQueryExecutionInput{
 			QueryExecutionId: aws.String(qeid),
 		}
-		out, err := conn.GetQueryExecutionWithContext(ctx, input)
+		out, err := conn.GetQueryExecution(ctx, input)
 		if err != nil {
 			return nil, "failed", err
 		}
@@ -311,19 +336,19 @@ func queryExecutionStateRefreshFunc(ctx context.Context, conn *athena.Athena, qe
 
 		status := out.QueryExecution.Status
 
-		if aws.StringValue(status.State) == athena.QueryExecutionStateFailed && status.StateChangeReason != nil {
-			err = fmt.Errorf("reason: %s", aws.StringValue(status.StateChangeReason))
+		if status.State == types.QueryExecutionStateFailed && status.StateChangeReason != nil {
+			err = fmt.Errorf("reason: %s", aws.ToString(status.StateChangeReason))
 		}
 
-		return out, aws.StringValue(out.QueryExecution.Status.State), err
+		return out, string(out.QueryExecution.Status.State), err
 	}
 }
 
-func flattenResultSet(rs *athena.ResultSet) string {
+func flattenResultSet(rs *types.ResultSet) string {
 	ss := make([]string, 0)
 	for _, row := range rs.Rows {
 		for _, datum := range row.Data {
-			ss = append(ss, aws.StringValue(datum.VarCharValue))
+			ss = append(ss, aws.ToString(datum.VarCharValue))
 		}
 	}
 	return strings.Join(ss, "\n")

--- a/internal/service/athena/database_test.go
+++ b/internal/service/athena/database_test.go
@@ -9,14 +9,17 @@ import (
 	"testing"
 
 	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/athena"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/athena"
+	"github.com/aws/aws-sdk-go-v2/service/athena/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfathena "github.com/hashicorp/terraform-provider-aws/internal/service/athena"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccAthenaDatabase_basic(t *testing.T) {
@@ -27,14 +30,14 @@ func TestAccAthenaDatabase_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, athena.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDatabaseDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDatabaseConfig_basic(rName, dbName, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDatabaseExists(resourceName),
+					testAccCheckDatabaseExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", dbName),
 					resource.TestCheckResourceAttrPair(resourceName, "bucket", "aws_s3_bucket.test", "bucket"),
 					resource.TestCheckResourceAttr(resourceName, "acl_configuration.#", "0"),
@@ -60,14 +63,14 @@ func TestAccAthenaDatabase_properties(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, athena.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDatabaseDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDatabaseConfig_properties(rName, dbName, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDatabaseExists(resourceName),
+					testAccCheckDatabaseExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", dbName),
 					resource.TestCheckResourceAttr(resourceName, "properties.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "properties.creator", "Jane D."),
@@ -91,14 +94,14 @@ func TestAccAthenaDatabase_acl(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, athena.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDatabaseDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDatabaseConfig_acl(rName, dbName, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDatabaseExists(resourceName),
+					testAccCheckDatabaseExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", dbName),
 					resource.TestCheckResourceAttr(resourceName, "acl_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "acl_configuration.0.s3_acl_option", "BUCKET_OWNER_FULL_CONTROL"),
@@ -122,14 +125,14 @@ func TestAccAthenaDatabase_encryption(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, athena.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDatabaseDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDatabaseConfig_kms(rName, dbName, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDatabaseExists(resourceName),
+					testAccCheckDatabaseExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.0.encryption_option", "SSE_KMS"),
 					resource.TestCheckResourceAttrPair(resourceName, "encryption_configuration.0.kms_key", "aws_kms_key.test", "arn"),
@@ -153,14 +156,14 @@ func TestAccAthenaDatabase_nameStartsWithUnderscore(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, athena.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDatabaseDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDatabaseConfig_basic(rName, dbName, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDatabaseExists(resourceName),
+					testAccCheckDatabaseExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", dbName),
 				),
 			},
@@ -181,7 +184,7 @@ func TestAccAthenaDatabase_nameCantHaveUppercase(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, athena.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDatabaseDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -197,17 +200,18 @@ func TestAccAthenaDatabase_destroyFailsIfTablesExist(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dbName := sdkacctest.RandString(8)
+	resourceName := "aws_athena_database.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, athena.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDatabaseDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDatabaseConfig_basic(rName, dbName, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDatabaseExists("aws_athena_database.test"),
+					testAccCheckDatabaseExists(ctx, resourceName),
 					testAccDatabaseCreateTables(ctx, dbName),
 					testAccCheckDatabaseDropFails(ctx, dbName),
 					testAccDatabaseDestroyTables(ctx, dbName),
@@ -221,17 +225,18 @@ func TestAccAthenaDatabase_forceDestroyAlwaysSucceeds(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dbName := sdkacctest.RandString(8)
+	resourceName := "aws_athena_database.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, athena.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDatabaseDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDatabaseConfig_basic(rName, dbName, true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDatabaseExists("aws_athena_database.test"),
+					testAccCheckDatabaseExists(ctx, resourceName),
 					testAccDatabaseCreateTables(ctx, dbName),
 				),
 			},
@@ -247,14 +252,14 @@ func TestAccAthenaDatabase_description(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, athena.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDatabaseDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDatabaseConfig_comment(rName, dbName, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDatabaseExists(resourceName),
+					testAccCheckDatabaseExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", dbName),
 					resource.TestCheckResourceAttr(resourceName, "comment", "athena is a goddess"),
 				),
@@ -277,14 +282,14 @@ func TestAccAthenaDatabase_unescaped_description(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, athena.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDatabaseDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDatabaseConfig_unescapedComment(rName, dbName, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDatabaseExists(resourceName),
+					testAccCheckDatabaseExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", dbName),
 					resource.TestCheckResourceAttr(resourceName, "comment", "athena's a goddess"),
 				),
@@ -307,14 +312,14 @@ func TestAccAthenaDatabase_disppears(t *testing.T) {
 	resourceName := "aws_athena_database.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, athena.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDatabaseDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDatabaseConfig_basic(rName, dbName, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDatabaseExists(resourceName),
+					testAccCheckDatabaseExists(ctx, resourceName),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfathena.ResourceDatabase(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -325,44 +330,40 @@ func TestAccAthenaDatabase_disppears(t *testing.T) {
 
 func testAccCheckDatabaseDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).AthenaConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).AthenaClient(ctx)
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_athena_database" {
 				continue
 			}
 
-			input := &athena.ListDatabasesInput{
-				CatalogName: aws.String("AwsDataCatalog"),
+			_, err := tfathena.FindDatabaseByName(ctx, conn, rs.Primary.ID)
+
+			if tfresource.NotFound(err) {
+				continue
 			}
 
-			res, err := conn.ListDatabasesWithContext(ctx, input)
 			if err != nil {
 				return err
 			}
 
-			var database *athena.Database
-			for _, db := range res.DatabaseList {
-				if aws.StringValue(db.Name) == rs.Primary.ID {
-					database = db
-					break
-				}
-			}
-
-			if database != nil {
-				return fmt.Errorf("Athena database (%s) still exists", rs.Primary.ID)
-			}
+			return fmt.Errorf("Athena Database %s still exists", rs.Primary.ID)
 		}
 		return nil
 	}
 }
 
-func testAccCheckDatabaseExists(name string) resource.TestCheckFunc {
+func testAccCheckDatabaseExists(ctx context.Context, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		_, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("not found: %s, %v", name, s.RootModule().Resources)
+			return fmt.Errorf("Not found: %s", n)
 		}
-		return nil
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).AthenaClient(ctx)
+
+		_, err := tfathena.FindDatabaseByName(ctx, conn, rs.Primary.ID)
+
+		return err
 	}
 }
 
@@ -373,25 +374,27 @@ func testAccDatabaseCreateTables(ctx context.Context, dbName string) resource.Te
 			return err
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).AthenaConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).AthenaClient(ctx)
 
 		input := &athena.StartQueryExecutionInput{
-			QueryExecutionContext: &athena.QueryExecutionContext{
+			QueryExecutionContext: &types.QueryExecutionContext{
 				Database: aws.String(dbName),
 			},
 			QueryString: aws.String(fmt.Sprintf(
 				"create external table foo (bar int) location 's3://%s/';", bucketName)),
-			ResultConfiguration: &athena.ResultConfiguration{
+			ResultConfiguration: &types.ResultConfiguration{
 				OutputLocation: aws.String("s3://" + bucketName),
 			},
 		}
 
-		resp, err := conn.StartQueryExecutionWithContext(ctx, input)
+		output, err := conn.StartQueryExecution(ctx, input)
+
 		if err != nil {
 			return err
 		}
 
-		_, err = tfathena.QueryExecutionResult(ctx, conn, aws.StringValue(resp.QueryExecutionId))
+		_, err = tfathena.QueryExecutionResult(ctx, conn, aws.ToString(output.QueryExecutionId))
+
 		return err
 	}
 }
@@ -403,24 +406,26 @@ func testAccDatabaseDestroyTables(ctx context.Context, dbName string) resource.T
 			return err
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).AthenaConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).AthenaClient(ctx)
 
 		input := &athena.StartQueryExecutionInput{
-			QueryExecutionContext: &athena.QueryExecutionContext{
+			QueryExecutionContext: &types.QueryExecutionContext{
 				Database: aws.String(dbName),
 			},
 			QueryString: aws.String("drop table foo;"),
-			ResultConfiguration: &athena.ResultConfiguration{
+			ResultConfiguration: &types.ResultConfiguration{
 				OutputLocation: aws.String("s3://" + bucketName),
 			},
 		}
 
-		resp, err := conn.StartQueryExecutionWithContext(ctx, input)
+		output, err := conn.StartQueryExecution(ctx, input)
+
 		if err != nil {
 			return err
 		}
 
-		_, err = tfathena.QueryExecutionResult(ctx, conn, aws.StringValue(resp.QueryExecutionId))
+		_, err = tfathena.QueryExecutionResult(ctx, conn, aws.ToString(output.QueryExecutionId))
+
 		return err
 	}
 }
@@ -432,24 +437,26 @@ func testAccCheckDatabaseDropFails(ctx context.Context, dbName string) resource.
 			return err
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).AthenaConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).AthenaClient(ctx)
 
 		input := &athena.StartQueryExecutionInput{
-			QueryExecutionContext: &athena.QueryExecutionContext{
+			QueryExecutionContext: &types.QueryExecutionContext{
 				Database: aws.String(dbName),
 			},
 			QueryString: aws.String(fmt.Sprintf("drop database `%s`;", dbName)),
-			ResultConfiguration: &athena.ResultConfiguration{
+			ResultConfiguration: &types.ResultConfiguration{
 				OutputLocation: aws.String("s3://" + bucketName),
 			},
 		}
 
-		resp, err := conn.StartQueryExecutionWithContext(ctx, input)
+		output, err := conn.StartQueryExecution(ctx, input)
+
 		if err != nil {
 			return err
 		}
 
-		_, err = tfathena.QueryExecutionResult(ctx, conn, aws.StringValue(resp.QueryExecutionId))
+		_, err = tfathena.QueryExecutionResult(ctx, conn, aws.ToString(output.QueryExecutionId))
+
 		if err == nil {
 			return fmt.Errorf("drop database unexpectedly succeeded for a database with tables")
 		}

--- a/internal/service/athena/exports_test.go
+++ b/internal/service/athena/exports_test.go
@@ -1,0 +1,18 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package athena
+
+// Exports for use in tests only.
+var (
+	FindDataCatalogByName = findDataCatalogByName
+	FindDatabaseByName    = findDatabaseByName
+	FindNamedQueryByID    = findNamedQueryByID
+	FindWorkGroupByName   = findWorkGroupByName
+	QueryExecutionResult  = queryExecutionResult
+
+	ResourceDataCatalog = resourceDataCatalog
+	ResourceDatabase    = resourceDatabase
+	ResourceNamedQuery  = resourceNamedQuery
+	ResourceWorkGroup   = resourceWorkGroup
+)

--- a/internal/service/athena/generate.go
+++ b/internal/service/athena/generate.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-//go:generate go run ../../generate/tags/main.go -ListTags -ListTagsInIDElem=ResourceARN -ServiceTagsSlice -TagInIDElem=ResourceARN -UpdateTags
+//go:generate go run ../../generate/tags/main.go -AWSSDKVersion=2 -ListTags -ListTagsInIDElem=ResourceARN -ServiceTagsSlice -TagInIDElem=ResourceARN -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/athena/named_query.go
+++ b/internal/service/athena/named_query.go
@@ -7,17 +7,20 @@ import (
 	"context"
 	"log"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/athena"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/athena"
+	"github.com/aws/aws-sdk-go-v2/service/athena/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 // @SDKResource("aws_athena_named_query")
-func ResourceNamedQuery() *schema.Resource {
+func resourceNamedQuery() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceNamedQueryCreate,
 		ReadWithoutTimeout:   resourceNamedQueryRead,
@@ -28,6 +31,16 @@ func ResourceNamedQuery() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"database": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -44,80 +57,101 @@ func ResourceNamedQuery() *schema.Resource {
 				ForceNew: true,
 				Default:  "primary",
 			},
-			"database": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
 		},
 	}
 }
 
 func resourceNamedQueryCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).AthenaConn(ctx)
+	conn := meta.(*conns.AWSClient).AthenaClient(ctx)
 
+	name := d.Get("name").(string)
 	input := &athena.CreateNamedQueryInput{
 		Database:    aws.String(d.Get("database").(string)),
-		Name:        aws.String(d.Get("name").(string)),
+		Name:        aws.String(name),
 		QueryString: aws.String(d.Get("query").(string)),
 	}
-	if raw, ok := d.GetOk("workgroup"); ok {
-		input.WorkGroup = aws.String(raw.(string))
-	}
-	if raw, ok := d.GetOk("description"); ok {
-		input.Description = aws.String(raw.(string))
+
+	if v, ok := d.GetOk("workgroup"); ok {
+		input.WorkGroup = aws.String(v.(string))
 	}
 
-	resp, err := conn.CreateNamedQueryWithContext(ctx, input)
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "creating Athena Named Query (%s): %s", d.Get("name").(string), err)
+	if v, ok := d.GetOk("description"); ok {
+		input.Description = aws.String(v.(string))
 	}
-	d.SetId(aws.StringValue(resp.NamedQueryId))
+
+	output, err := conn.CreateNamedQuery(ctx, input)
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "creating Athena Named Query (%s): %s", name, err)
+	}
+
+	d.SetId(aws.ToString(output.NamedQueryId))
+
 	return append(diags, resourceNamedQueryRead(ctx, d, meta)...)
 }
 
 func resourceNamedQueryRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).AthenaConn(ctx)
+	conn := meta.(*conns.AWSClient).AthenaClient(ctx)
 
-	input := &athena.GetNamedQueryInput{
-		NamedQueryId: aws.String(d.Id()),
-	}
+	namedQuery, err := findNamedQueryByID(ctx, conn, d.Id())
 
-	resp, err := conn.GetNamedQueryWithContext(ctx, input)
-	if tfawserr.ErrMessageContains(err, athena.ErrCodeInvalidRequestException, d.Id()) && !d.IsNewResource() {
+	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Athena Named Query (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
 	}
+
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading Athena Named Query (%s): %s", d.Id(), err)
 	}
 
-	d.Set("name", resp.NamedQuery.Name)
-	d.Set("query", resp.NamedQuery.QueryString)
-	d.Set("workgroup", resp.NamedQuery.WorkGroup)
-	d.Set("database", resp.NamedQuery.Database)
-	d.Set("description", resp.NamedQuery.Description)
+	d.Set("database", namedQuery.Database)
+	d.Set("description", namedQuery.Description)
+	d.Set("name", namedQuery.Name)
+	d.Set("query", namedQuery.QueryString)
+	d.Set("workgroup", namedQuery.WorkGroup)
+
 	return diags
 }
 
 func resourceNamedQueryDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).AthenaConn(ctx)
+	conn := meta.(*conns.AWSClient).AthenaClient(ctx)
 
-	input := &athena.DeleteNamedQueryInput{
+	_, err := conn.DeleteNamedQuery(ctx, &athena.DeleteNamedQueryInput{
 		NamedQueryId: aws.String(d.Id()),
-	}
+	})
 
-	if _, err := conn.DeleteNamedQueryWithContext(ctx, input); err != nil {
+	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "deleting Athena Named Query (%s): %s", d.Id(), err)
 	}
+
 	return diags
+}
+
+func findNamedQueryByID(ctx context.Context, conn *athena.Client, id string) (*types.NamedQuery, error) {
+	input := &athena.GetNamedQueryInput{
+		NamedQueryId: aws.String(id),
+	}
+
+	output, err := conn.GetNamedQuery(ctx, input)
+
+	if errs.IsAErrorMessageContains[*types.InvalidRequestException](err, "does not exist") {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.NamedQuery == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.NamedQuery, nil
 }

--- a/internal/service/athena/named_query_test.go
+++ b/internal/service/athena/named_query_test.go
@@ -8,14 +8,14 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/athena"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfathena "github.com/hashicorp/terraform-provider-aws/internal/service/athena"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccAthenaNamedQuery_basic(t *testing.T) {
@@ -24,7 +24,7 @@ func TestAccAthenaNamedQuery_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, athena.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckNamedQueryDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -49,7 +49,7 @@ func TestAccAthenaNamedQuery_withWorkGroup(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, athena.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckNamedQueryDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -70,45 +70,39 @@ func TestAccAthenaNamedQuery_withWorkGroup(t *testing.T) {
 
 func testAccCheckNamedQueryDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).AthenaConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).AthenaClient(ctx)
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_athena_named_query" {
 				continue
 			}
 
-			input := &athena.GetNamedQueryInput{
-				NamedQueryId: aws.String(rs.Primary.ID),
+			_, err := tfathena.FindNamedQueryByID(ctx, conn, rs.Primary.ID)
+
+			if tfresource.NotFound(err) {
+				continue
 			}
 
-			resp, err := conn.GetNamedQueryWithContext(ctx, input)
 			if err != nil {
-				if tfawserr.ErrMessageContains(err, athena.ErrCodeInvalidRequestException, rs.Primary.ID) {
-					return nil
-				}
 				return err
 			}
-			if resp.NamedQuery != nil {
-				return fmt.Errorf("Athena Named Query (%s) found", rs.Primary.ID)
-			}
+
+			return fmt.Errorf("Athena Named Query %s still exists", rs.Primary.ID)
 		}
 		return nil
 	}
 }
 
-func testAccCheckNamedQueryExists(ctx context.Context, name string) resource.TestCheckFunc {
+func testAccCheckNamedQueryExists(ctx context.Context, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).AthenaConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).AthenaClient(ctx)
 
-		input := &athena.GetNamedQueryInput{
-			NamedQueryId: aws.String(rs.Primary.ID),
-		}
+		_, err := tfathena.FindNamedQueryByID(ctx, conn, rs.Primary.ID)
 
-		_, err := conn.GetNamedQueryWithContext(ctx, input)
 		return err
 	}
 }

--- a/internal/service/athena/service_package_gen.go
+++ b/internal/service/athena/service_package_gen.go
@@ -45,7 +45,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			TypeName: "aws_athena_named_query",
 		},
 		{
-			Factory:  ResourceWorkGroup,
+			Factory:  resourceWorkGroup,
 			TypeName: "aws_athena_workgroup",
 			Name:     "WorkGroup",
 			Tags: &types.ServicePackageResourceTags{

--- a/internal/service/athena/service_package_gen.go
+++ b/internal/service/athena/service_package_gen.go
@@ -41,7 +41,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			TypeName: "aws_athena_database",
 		},
 		{
-			Factory:  ResourceNamedQuery,
+			Factory:  resourceNamedQuery,
 			TypeName: "aws_athena_named_query",
 		},
 		{

--- a/internal/service/athena/service_package_gen.go
+++ b/internal/service/athena/service_package_gen.go
@@ -37,7 +37,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			},
 		},
 		{
-			Factory:  ResourceDatabase,
+			Factory:  resourceDatabase,
 			TypeName: "aws_athena_database",
 		},
 		{

--- a/internal/service/athena/service_package_gen.go
+++ b/internal/service/athena/service_package_gen.go
@@ -29,7 +29,7 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePackageSDKResource {
 	return []*types.ServicePackageSDKResource{
 		{
-			Factory:  ResourceDataCatalog,
+			Factory:  resourceDataCatalog,
 			TypeName: "aws_athena_data_catalog",
 			Name:     "Data Catalog",
 			Tags: &types.ServicePackageResourceTags{

--- a/internal/service/athena/service_package_gen.go
+++ b/internal/service/athena/service_package_gen.go
@@ -5,9 +5,8 @@ package athena
 import (
 	"context"
 
-	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
-	session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
-	athena_sdkv1 "github.com/aws/aws-sdk-go/service/athena"
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	athena_sdkv2 "github.com/aws/aws-sdk-go-v2/service/athena"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -60,11 +59,15 @@ func (p *servicePackage) ServicePackageName() string {
 	return names.Athena
 }
 
-// NewConn returns a new AWS SDK for Go v1 client for this service package's AWS API.
-func (p *servicePackage) NewConn(ctx context.Context, config map[string]any) (*athena_sdkv1.Athena, error) {
-	sess := config["session"].(*session_sdkv1.Session)
+// NewClient returns a new AWS SDK for Go v2 client for this service package's AWS API.
+func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (*athena_sdkv2.Client, error) {
+	cfg := *(config["aws_sdkv2_config"].(*aws_sdkv2.Config))
 
-	return athena_sdkv1.New(sess.Copy(&aws_sdkv1.Config{Endpoint: aws_sdkv1.String(config["endpoint"].(string))})), nil
+	return athena_sdkv2.NewFromConfig(cfg, func(o *athena_sdkv2.Options) {
+		if endpoint := config["endpoint"].(string); endpoint != "" {
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
+		}
+	}), nil
 }
 
 func ServicePackage(ctx context.Context) conns.ServicePackage {

--- a/internal/service/athena/tags_gen.go
+++ b/internal/service/athena/tags_gen.go
@@ -5,9 +5,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/athena"
-	"github.com/aws/aws-sdk-go/service/athena/athenaiface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/athena"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/athena/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/logging"
@@ -19,12 +19,12 @@ import (
 // listTags lists athena service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn athenaiface.AthenaAPI, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *athena.Client, identifier string) (tftags.KeyValueTags, error) {
 	input := &athena.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResourceWithContext(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -36,7 +36,7 @@ func listTags(ctx context.Context, conn athenaiface.AthenaAPI, identifier string
 // ListTags lists athena service tags and set them in Context.
 // It is called from outside this package.
 func (p *servicePackage) ListTags(ctx context.Context, meta any, identifier string) error {
-	tags, err := listTags(ctx, meta.(*conns.AWSClient).AthenaConn(ctx), identifier)
+	tags, err := listTags(ctx, meta.(*conns.AWSClient).AthenaClient(ctx), identifier)
 
 	if err != nil {
 		return err
@@ -52,11 +52,11 @@ func (p *servicePackage) ListTags(ctx context.Context, meta any, identifier stri
 // []*SERVICE.Tag handling
 
 // Tags returns athena service tags.
-func Tags(tags tftags.KeyValueTags) []*athena.Tag {
-	result := make([]*athena.Tag, 0, len(tags))
+func Tags(tags tftags.KeyValueTags) []awstypes.Tag {
+	result := make([]awstypes.Tag, 0, len(tags))
 
 	for k, v := range tags.Map() {
-		tag := &athena.Tag{
+		tag := awstypes.Tag{
 			Key:   aws.String(k),
 			Value: aws.String(v),
 		}
@@ -68,11 +68,11 @@ func Tags(tags tftags.KeyValueTags) []*athena.Tag {
 }
 
 // KeyValueTags creates tftags.KeyValueTags from athena service tags.
-func KeyValueTags(ctx context.Context, tags []*athena.Tag) tftags.KeyValueTags {
+func KeyValueTags(ctx context.Context, tags []awstypes.Tag) tftags.KeyValueTags {
 	m := make(map[string]*string, len(tags))
 
 	for _, tag := range tags {
-		m[aws.StringValue(tag.Key)] = tag.Value
+		m[aws.ToString(tag.Key)] = tag.Value
 	}
 
 	return tftags.New(ctx, m)
@@ -80,7 +80,7 @@ func KeyValueTags(ctx context.Context, tags []*athena.Tag) tftags.KeyValueTags {
 
 // getTagsIn returns athena service tags from Context.
 // nil is returned if there are no input tags.
-func getTagsIn(ctx context.Context) []*athena.Tag {
+func getTagsIn(ctx context.Context) []awstypes.Tag {
 	if inContext, ok := tftags.FromContext(ctx); ok {
 		if tags := Tags(inContext.TagsIn.UnwrapOrDefault()); len(tags) > 0 {
 			return tags
@@ -91,7 +91,7 @@ func getTagsIn(ctx context.Context) []*athena.Tag {
 }
 
 // setTagsOut sets athena service tags in Context.
-func setTagsOut(ctx context.Context, tags []*athena.Tag) {
+func setTagsOut(ctx context.Context, tags []awstypes.Tag) {
 	if inContext, ok := tftags.FromContext(ctx); ok {
 		inContext.TagsOut = types.Some(KeyValueTags(ctx, tags))
 	}
@@ -100,7 +100,7 @@ func setTagsOut(ctx context.Context, tags []*athena.Tag) {
 // updateTags updates athena service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn athenaiface.AthenaAPI, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *athena.Client, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -111,10 +111,10 @@ func updateTags(ctx context.Context, conn athenaiface.AthenaAPI, identifier stri
 	if len(removedTags) > 0 {
 		input := &athena.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.Keys()),
+			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResourceWithContext(ctx, input)
+		_, err := conn.UntagResource(ctx, input)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -129,7 +129,7 @@ func updateTags(ctx context.Context, conn athenaiface.AthenaAPI, identifier stri
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResourceWithContext(ctx, input)
+		_, err := conn.TagResource(ctx, input)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)
@@ -142,5 +142,5 @@ func updateTags(ctx context.Context, conn athenaiface.AthenaAPI, identifier stri
 // UpdateTags updates athena service tags.
 // It is called from outside this package.
 func (p *servicePackage) UpdateTags(ctx context.Context, meta any, identifier string, oldTags, newTags any) error {
-	return updateTags(ctx, meta.(*conns.AWSClient).AthenaConn(ctx), identifier, oldTags, newTags)
+	return updateTags(ctx, meta.(*conns.AWSClient).AthenaClient(ctx), identifier, oldTags, newTags)
 }

--- a/internal/service/athena/workgroup.go
+++ b/internal/service/athena/workgroup.go
@@ -9,28 +9,33 @@ import (
 	"log"
 
 	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/aws/aws-sdk-go/service/athena"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/service/athena"
+	"github.com/aws/aws-sdk-go-v2/service/athena/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 // @SDKResource("aws_athena_workgroup", name="WorkGroup")
 // @Tags(identifierAttribute="arn")
-func ResourceWorkGroup() *schema.Resource {
+func resourceWorkGroup() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceWorkGroupCreate,
 		ReadWithoutTimeout:   resourceWorkGroupRead,
 		UpdateWithoutTimeout: resourceWorkGroupUpdate,
 		DeleteWithoutTimeout: resourceWorkGroupDelete,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -101,9 +106,9 @@ func ResourceWorkGroup() *schema.Resource {
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"s3_acl_option": {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.StringInSlice(athena.S3AclOption_Values(), false),
+													Type:             schema.TypeString,
+													Required:         true,
+													ValidateDiagFunc: enum.Validate[types.S3AclOption](),
 												},
 											},
 										},
@@ -115,9 +120,9 @@ func ResourceWorkGroup() *schema.Resource {
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"encryption_option": {
-													Type:         schema.TypeString,
-													Optional:     true,
-													ValidateFunc: validation.StringInSlice(athena.EncryptionOption_Values(), false),
+													Type:             schema.TypeString,
+													Optional:         true,
+													ValidateDiagFunc: enum.Validate[types.EncryptionOption](),
 												},
 												"kms_key_arn": {
 													Type:         schema.TypeString,
@@ -151,6 +156,11 @@ func ResourceWorkGroup() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validation.StringLenBetween(0, 1024),
 			},
+			"force_destroy": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -161,15 +171,10 @@ func ResourceWorkGroup() *schema.Resource {
 				),
 			},
 			"state": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Default:      athena.WorkGroupStateEnabled,
-				ValidateFunc: validation.StringInSlice(athena.WorkGroupState_Values(), false),
-			},
-			"force_destroy": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
+				Type:             schema.TypeString,
+				Optional:         true,
+				Default:          types.WorkGroupStateEnabled,
+				ValidateDiagFunc: enum.Validate[types.WorkGroupState](),
 			},
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
@@ -181,7 +186,7 @@ func ResourceWorkGroup() *schema.Resource {
 
 func resourceWorkGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).AthenaConn(ctx)
+	conn := meta.(*conns.AWSClient).AthenaClient(ctx)
 
 	name := d.Get("name").(string)
 	input := &athena.CreateWorkGroupInput{
@@ -194,21 +199,23 @@ func resourceWorkGroupCreate(ctx context.Context, d *schema.ResourceData, meta i
 		input.Description = aws.String(v.(string))
 	}
 
-	_, err := conn.CreateWorkGroupWithContext(ctx, input)
+	_, err := conn.CreateWorkGroup(ctx, input)
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "creating Athena WorkGroup: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating Athena WorkGroup (%s): %s", name, err)
 	}
 
 	d.SetId(name)
 
-	if v := d.Get("state").(string); v == athena.WorkGroupStateDisabled {
+	if v := types.WorkGroupState(d.Get("state").(string)); v == types.WorkGroupStateDisabled {
 		input := &athena.UpdateWorkGroupInput{
-			State:     aws.String(v),
+			State:     v,
 			WorkGroup: aws.String(d.Id()),
 		}
 
-		if _, err := conn.UpdateWorkGroupWithContext(ctx, input); err != nil {
+		_, err := conn.UpdateWorkGroup(ctx, input)
+
+		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "disabling Athena WorkGroup (%s): %s", d.Id(), err)
 		}
 	}
@@ -218,15 +225,11 @@ func resourceWorkGroupCreate(ctx context.Context, d *schema.ResourceData, meta i
 
 func resourceWorkGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).AthenaConn(ctx)
+	conn := meta.(*conns.AWSClient).AthenaClient(ctx)
 
-	input := &athena.GetWorkGroupInput{
-		WorkGroup: aws.String(d.Id()),
-	}
+	wg, err := findWorkGroupByName(ctx, conn, d.Id())
 
-	resp, err := conn.GetWorkGroupWithContext(ctx, input)
-
-	if tfawserr.ErrMessageContains(err, athena.ErrCodeInvalidRequestException, "is not found") && !d.IsNewResource() {
+	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Athena WorkGroup (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
@@ -243,49 +246,21 @@ func resourceWorkGroupRead(ctx context.Context, d *schema.ResourceData, meta int
 		AccountID: meta.(*conns.AWSClient).AccountID,
 		Resource:  fmt.Sprintf("workgroup/%s", d.Id()),
 	}
-
 	d.Set("arn", arn.String())
-	d.Set("description", resp.WorkGroup.Description)
-
-	if err := d.Set("configuration", flattenWorkGroupConfiguration(resp.WorkGroup.Configuration)); err != nil {
+	if err := d.Set("configuration", flattenWorkGroupConfiguration(wg.Configuration)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting configuration: %s", err)
 	}
-
-	d.Set("name", resp.WorkGroup.Name)
-	d.Set("state", resp.WorkGroup.State)
-
-	if v, ok := d.GetOk("force_destroy"); ok {
-		d.Set("force_destroy", v.(bool))
-	} else {
-		d.Set("force_destroy", false)
-	}
-
-	return diags
-}
-
-func resourceWorkGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).AthenaConn(ctx)
-
-	input := &athena.DeleteWorkGroupInput{
-		WorkGroup: aws.String(d.Id()),
-	}
-
-	if v, ok := d.GetOk("force_destroy"); ok {
-		input.RecursiveDeleteOption = aws.Bool(v.(bool))
-	}
-	_, err := conn.DeleteWorkGroupWithContext(ctx, input)
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "deleting Athena WorkGroup (%s): %s", d.Id(), err)
-	}
+	d.Set("description", wg.Description)
+	d.Set("force_destroy", d.Get("force_destroy"))
+	d.Set("name", wg.Name)
+	d.Set("state", wg.State)
 
 	return diags
 }
 
 func resourceWorkGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).AthenaConn(ctx)
+	conn := meta.(*conns.AWSClient).AthenaClient(ctx)
 
 	if d.HasChangesExcept("tags", "tags_all") {
 		input := &athena.UpdateWorkGroupInput{
@@ -301,9 +276,10 @@ func resourceWorkGroupUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		}
 
 		if d.HasChange("state") {
-			input.State = aws.String(d.Get("state").(string))
+			input.State = types.WorkGroupState(d.Get("state").(string))
 		}
-		_, err := conn.UpdateWorkGroupWithContext(ctx, input)
+
+		_, err := conn.UpdateWorkGroup(ctx, input)
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating Athena WorkGroup (%s): %s", d.Id(), err)
@@ -313,14 +289,60 @@ func resourceWorkGroupUpdate(ctx context.Context, d *schema.ResourceData, meta i
 	return append(diags, resourceWorkGroupRead(ctx, d, meta)...)
 }
 
-func expandWorkGroupConfiguration(l []interface{}) *athena.WorkGroupConfiguration {
+func resourceWorkGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).AthenaClient(ctx)
+
+	input := &athena.DeleteWorkGroupInput{
+		WorkGroup: aws.String(d.Id()),
+	}
+
+	if v, ok := d.GetOk("force_destroy"); ok {
+		input.RecursiveDeleteOption = aws.Bool(v.(bool))
+	}
+
+	_, err := conn.DeleteWorkGroup(ctx, input)
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "deleting Athena WorkGroup (%s): %s", d.Id(), err)
+	}
+
+	return diags
+}
+
+func findWorkGroupByName(ctx context.Context, conn *athena.Client, name string) (*types.WorkGroup, error) {
+	input := &athena.GetWorkGroupInput{
+		WorkGroup: aws.String(name),
+	}
+
+	output, err := conn.GetWorkGroup(ctx, input)
+
+	if errs.IsAErrorMessageContains[*types.InvalidRequestException](err, "is not found") {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.WorkGroup == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.WorkGroup, nil
+}
+
+func expandWorkGroupConfiguration(l []interface{}) *types.WorkGroupConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
 	m := l[0].(map[string]interface{})
 
-	configuration := &athena.WorkGroupConfiguration{}
+	configuration := &types.WorkGroupConfiguration{}
 
 	if v, ok := m["bytes_scanned_cutoff_per_query"].(int); ok && v > 0 {
 		configuration.BytesScannedCutoffPerQuery = aws.Int64(int64(v))
@@ -353,14 +375,14 @@ func expandWorkGroupConfiguration(l []interface{}) *athena.WorkGroupConfiguratio
 	return configuration
 }
 
-func expandWorkGroupEngineVersion(l []interface{}) *athena.EngineVersion {
+func expandWorkGroupEngineVersion(l []interface{}) *types.EngineVersion {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
 	m := l[0].(map[string]interface{})
 
-	engineVersion := &athena.EngineVersion{}
+	engineVersion := &types.EngineVersion{}
 
 	if v, ok := m["selected_engine_version"].(string); ok && v != "" {
 		engineVersion.SelectedEngineVersion = aws.String(v)
@@ -369,14 +391,14 @@ func expandWorkGroupEngineVersion(l []interface{}) *athena.EngineVersion {
 	return engineVersion
 }
 
-func expandWorkGroupConfigurationUpdates(l []interface{}) *athena.WorkGroupConfigurationUpdates {
+func expandWorkGroupConfigurationUpdates(l []interface{}) *types.WorkGroupConfigurationUpdates {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
 	m := l[0].(map[string]interface{})
 
-	configurationUpdates := &athena.WorkGroupConfigurationUpdates{}
+	configurationUpdates := &types.WorkGroupConfigurationUpdates{}
 
 	if v, ok := m["bytes_scanned_cutoff_per_query"].(int); ok && v > 0 {
 		configurationUpdates.BytesScannedCutoffPerQuery = aws.Int64(int64(v))
@@ -411,14 +433,14 @@ func expandWorkGroupConfigurationUpdates(l []interface{}) *athena.WorkGroupConfi
 	return configurationUpdates
 }
 
-func expandWorkGroupResultConfiguration(l []interface{}) *athena.ResultConfiguration {
+func expandWorkGroupResultConfiguration(l []interface{}) *types.ResultConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
 	m := l[0].(map[string]interface{})
 
-	resultConfiguration := &athena.ResultConfiguration{}
+	resultConfiguration := &types.ResultConfiguration{}
 
 	if v, ok := m["encryption_configuration"]; ok {
 		resultConfiguration.EncryptionConfiguration = expandWorkGroupEncryptionConfiguration(v.([]interface{}))
@@ -439,14 +461,14 @@ func expandWorkGroupResultConfiguration(l []interface{}) *athena.ResultConfigura
 	return resultConfiguration
 }
 
-func expandWorkGroupResultConfigurationUpdates(l []interface{}) *athena.ResultConfigurationUpdates {
+func expandWorkGroupResultConfigurationUpdates(l []interface{}) *types.ResultConfigurationUpdates {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
 	m := l[0].(map[string]interface{})
 
-	resultConfigurationUpdates := &athena.ResultConfigurationUpdates{}
+	resultConfigurationUpdates := &types.ResultConfigurationUpdates{}
 
 	if v, ok := m["encryption_configuration"]; ok {
 		resultConfigurationUpdates.EncryptionConfiguration = expandWorkGroupEncryptionConfiguration(v.([]interface{}))
@@ -475,17 +497,17 @@ func expandWorkGroupResultConfigurationUpdates(l []interface{}) *athena.ResultCo
 	return resultConfigurationUpdates
 }
 
-func expandWorkGroupEncryptionConfiguration(l []interface{}) *athena.EncryptionConfiguration {
+func expandWorkGroupEncryptionConfiguration(l []interface{}) *types.EncryptionConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
 	m := l[0].(map[string]interface{})
 
-	encryptionConfiguration := &athena.EncryptionConfiguration{}
+	encryptionConfiguration := &types.EncryptionConfiguration{}
 
 	if v, ok := m["encryption_option"]; ok && v.(string) != "" {
-		encryptionConfiguration.EncryptionOption = aws.String(v.(string))
+		encryptionConfiguration.EncryptionOption = types.EncryptionOption(v.(string))
 	}
 
 	if v, ok := m["kms_key_arn"]; ok && v.(string) != "" {
@@ -495,49 +517,49 @@ func expandWorkGroupEncryptionConfiguration(l []interface{}) *athena.EncryptionC
 	return encryptionConfiguration
 }
 
-func flattenWorkGroupConfiguration(configuration *athena.WorkGroupConfiguration) []interface{} {
+func flattenWorkGroupConfiguration(configuration *types.WorkGroupConfiguration) []interface{} {
 	if configuration == nil {
 		return []interface{}{}
 	}
 
 	m := map[string]interface{}{
-		"bytes_scanned_cutoff_per_query":     aws.Int64Value(configuration.BytesScannedCutoffPerQuery),
-		"enforce_workgroup_configuration":    aws.BoolValue(configuration.EnforceWorkGroupConfiguration),
+		"bytes_scanned_cutoff_per_query":     aws.ToInt64(configuration.BytesScannedCutoffPerQuery),
+		"enforce_workgroup_configuration":    aws.ToBool(configuration.EnforceWorkGroupConfiguration),
 		"engine_version":                     flattenWorkGroupEngineVersion(configuration.EngineVersion),
-		"execution_role":                     aws.StringValue(configuration.ExecutionRole),
-		"publish_cloudwatch_metrics_enabled": aws.BoolValue(configuration.PublishCloudWatchMetricsEnabled),
+		"execution_role":                     aws.ToString(configuration.ExecutionRole),
+		"publish_cloudwatch_metrics_enabled": aws.ToBool(configuration.PublishCloudWatchMetricsEnabled),
 		"result_configuration":               flattenWorkGroupResultConfiguration(configuration.ResultConfiguration),
-		"requester_pays_enabled":             aws.BoolValue(configuration.RequesterPaysEnabled),
+		"requester_pays_enabled":             aws.ToBool(configuration.RequesterPaysEnabled),
 	}
 
 	return []interface{}{m}
 }
 
-func flattenWorkGroupEngineVersion(engineVersion *athena.EngineVersion) []interface{} {
+func flattenWorkGroupEngineVersion(engineVersion *types.EngineVersion) []interface{} {
 	if engineVersion == nil {
 		return []interface{}{}
 	}
 
 	m := map[string]interface{}{
-		"effective_engine_version": aws.StringValue(engineVersion.EffectiveEngineVersion),
-		"selected_engine_version":  aws.StringValue(engineVersion.SelectedEngineVersion),
+		"effective_engine_version": aws.ToString(engineVersion.EffectiveEngineVersion),
+		"selected_engine_version":  aws.ToString(engineVersion.SelectedEngineVersion),
 	}
 
 	return []interface{}{m}
 }
 
-func flattenWorkGroupResultConfiguration(resultConfiguration *athena.ResultConfiguration) []interface{} {
+func flattenWorkGroupResultConfiguration(resultConfiguration *types.ResultConfiguration) []interface{} {
 	if resultConfiguration == nil {
 		return []interface{}{}
 	}
 
 	m := map[string]interface{}{
 		"encryption_configuration": flattenWorkGroupEncryptionConfiguration(resultConfiguration.EncryptionConfiguration),
-		"output_location":          aws.StringValue(resultConfiguration.OutputLocation),
+		"output_location":          aws.ToString(resultConfiguration.OutputLocation),
 	}
 
 	if resultConfiguration.ExpectedBucketOwner != nil {
-		m["expected_bucket_owner"] = aws.StringValue(resultConfiguration.ExpectedBucketOwner)
+		m["expected_bucket_owner"] = aws.ToString(resultConfiguration.ExpectedBucketOwner)
 	}
 
 	if resultConfiguration.AclConfiguration != nil {
@@ -547,26 +569,26 @@ func flattenWorkGroupResultConfiguration(resultConfiguration *athena.ResultConfi
 	return []interface{}{m}
 }
 
-func flattenWorkGroupEncryptionConfiguration(encryptionConfiguration *athena.EncryptionConfiguration) []interface{} {
+func flattenWorkGroupEncryptionConfiguration(encryptionConfiguration *types.EncryptionConfiguration) []interface{} {
 	if encryptionConfiguration == nil {
 		return []interface{}{}
 	}
 
 	m := map[string]interface{}{
-		"encryption_option": aws.StringValue(encryptionConfiguration.EncryptionOption),
-		"kms_key_arn":       aws.StringValue(encryptionConfiguration.KmsKey),
+		"encryption_option": encryptionConfiguration.EncryptionOption,
+		"kms_key_arn":       aws.ToString(encryptionConfiguration.KmsKey),
 	}
 
 	return []interface{}{m}
 }
 
-func flattenWorkGroupACLConfiguration(aclConfig *athena.AclConfiguration) []interface{} {
+func flattenWorkGroupACLConfiguration(aclConfig *types.AclConfiguration) []interface{} {
 	if aclConfig == nil {
 		return []interface{}{}
 	}
 
 	m := map[string]interface{}{
-		"s3_acl_option": aws.StringValue(aclConfig.S3AclOption),
+		"s3_acl_option": aclConfig.S3AclOption,
 	}
 
 	return []interface{}{m}

--- a/internal/service/athena/workgroup_test.go
+++ b/internal/service/athena/workgroup_test.go
@@ -8,26 +8,28 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/athena"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/athena"
+	"github.com/aws/aws-sdk-go-v2/service/athena/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfathena "github.com/hashicorp/terraform-provider-aws/internal/service/athena"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccAthenaWorkGroup_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	var workgroup1 athena.WorkGroup
+	var workgroup1 types.WorkGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_athena_workgroup.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, athena.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckWorkGroupDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -48,7 +50,7 @@ func TestAccAthenaWorkGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.requester_pays_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "state", athena.WorkGroupStateEnabled),
+					resource.TestCheckResourceAttr(resourceName, "state", string(types.WorkGroupStateEnabled)),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
@@ -64,13 +66,13 @@ func TestAccAthenaWorkGroup_basic(t *testing.T) {
 
 func TestAccAthenaWorkGroup_aclConfig(t *testing.T) {
 	ctx := acctest.Context(t)
-	var workgroup1 athena.WorkGroup
+	var workgroup1 types.WorkGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_athena_workgroup.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, athena.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckWorkGroupDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -97,13 +99,13 @@ func TestAccAthenaWorkGroup_aclConfig(t *testing.T) {
 
 func TestAccAthenaWorkGroup_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	var workgroup1 athena.WorkGroup
+	var workgroup1 types.WorkGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_athena_workgroup.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, athena.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckWorkGroupDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -121,13 +123,13 @@ func TestAccAthenaWorkGroup_disappears(t *testing.T) {
 
 func TestAccAthenaWorkGroup_bytesScannedCutoffPerQuery(t *testing.T) {
 	ctx := acctest.Context(t)
-	var workgroup1, workgroup2 athena.WorkGroup
+	var workgroup1, workgroup2 types.WorkGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_athena_workgroup.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, athena.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckWorkGroupDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -159,13 +161,13 @@ func TestAccAthenaWorkGroup_bytesScannedCutoffPerQuery(t *testing.T) {
 
 func TestAccAthenaWorkGroup_enforceWorkGroup(t *testing.T) {
 	ctx := acctest.Context(t)
-	var workgroup1, workgroup2 athena.WorkGroup
+	var workgroup1, workgroup2 types.WorkGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_athena_workgroup.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, athena.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckWorkGroupDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -197,13 +199,13 @@ func TestAccAthenaWorkGroup_enforceWorkGroup(t *testing.T) {
 
 func TestAccAthenaWorkGroup_configurationEngineVersion(t *testing.T) {
 	ctx := acctest.Context(t)
-	var workgroup1, workgroup2 athena.WorkGroup
+	var workgroup1, workgroup2 types.WorkGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_athena_workgroup.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, athena.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckWorkGroupDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -253,14 +255,14 @@ func TestAccAthenaWorkGroup_configurationEngineVersion(t *testing.T) {
 
 func TestAccAthenaWorkGroup_configurationExecutionRole(t *testing.T) {
 	ctx := acctest.Context(t)
-	var workgroup1 athena.WorkGroup
+	var workgroup1 types.WorkGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_athena_workgroup.test"
 	iamRoleResourceName := "aws_iam_role.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, athena.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckWorkGroupDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -284,13 +286,13 @@ func TestAccAthenaWorkGroup_configurationExecutionRole(t *testing.T) {
 
 func TestAccAthenaWorkGroup_publishCloudWatchMetricsEnabled(t *testing.T) {
 	ctx := acctest.Context(t)
-	var workgroup1, workgroup2 athena.WorkGroup
+	var workgroup1, workgroup2 types.WorkGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_athena_workgroup.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, athena.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckWorkGroupDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -322,13 +324,13 @@ func TestAccAthenaWorkGroup_publishCloudWatchMetricsEnabled(t *testing.T) {
 
 func TestAccAthenaWorkGroup_ResultEncryption_sseS3(t *testing.T) {
 	ctx := acctest.Context(t)
-	var workgroup1 athena.WorkGroup
+	var workgroup1 types.WorkGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_athena_workgroup.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, athena.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckWorkGroupDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -339,7 +341,7 @@ func TestAccAthenaWorkGroup_ResultEncryption_sseS3(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.result_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.result_configuration.0.encryption_configuration.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "configuration.0.result_configuration.0.encryption_configuration.0.encryption_option", athena.EncryptionOptionSseS3),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.result_configuration.0.encryption_configuration.0.encryption_option", string(types.EncryptionOptionSseS3)),
 				),
 			},
 			{
@@ -354,15 +356,15 @@ func TestAccAthenaWorkGroup_ResultEncryption_sseS3(t *testing.T) {
 
 func TestAccAthenaWorkGroup_ResultEncryption_kms(t *testing.T) {
 	ctx := acctest.Context(t)
-	var workgroup1, workgroup2 athena.WorkGroup
+	var workgroup1, workgroup2 types.WorkGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_athena_workgroup.test"
-	rEncryption := athena.EncryptionOptionSseKms
-	rEncryption2 := athena.EncryptionOptionCseKms
+	rEncryption := string(types.EncryptionOptionSseKms)
+	rEncryption2 := string(types.EncryptionOptionCseKms)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, athena.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckWorkGroupDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -398,7 +400,7 @@ func TestAccAthenaWorkGroup_ResultEncryption_kms(t *testing.T) {
 
 func TestAccAthenaWorkGroup_Result_outputLocation(t *testing.T) {
 	ctx := acctest.Context(t)
-	var workgroup1, workgroup2 athena.WorkGroup
+	var workgroup1, workgroup2 types.WorkGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_athena_workgroup.test"
 	rOutputLocation1 := fmt.Sprintf("%s-1", rName)
@@ -406,7 +408,7 @@ func TestAccAthenaWorkGroup_Result_outputLocation(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, athena.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckWorkGroupDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -440,13 +442,13 @@ func TestAccAthenaWorkGroup_Result_outputLocation(t *testing.T) {
 
 func TestAccAthenaWorkGroup_requesterPaysEnabled(t *testing.T) {
 	ctx := acctest.Context(t)
-	var workgroup1 athena.WorkGroup
+	var workgroup1 types.WorkGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_athena_workgroup.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, athena.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckWorkGroupDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -482,7 +484,7 @@ func TestAccAthenaWorkGroup_requesterPaysEnabled(t *testing.T) {
 
 func TestAccAthenaWorkGroup_ResultOutputLocation_forceDestroy(t *testing.T) {
 	ctx := acctest.Context(t)
-	var workgroup1, workgroup2 athena.WorkGroup
+	var workgroup1, workgroup2 types.WorkGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_athena_workgroup.test"
 	rOutputLocation1 := fmt.Sprintf("%s-1", rName)
@@ -490,7 +492,7 @@ func TestAccAthenaWorkGroup_ResultOutputLocation_forceDestroy(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, athena.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckWorkGroupDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -524,7 +526,7 @@ func TestAccAthenaWorkGroup_ResultOutputLocation_forceDestroy(t *testing.T) {
 
 func TestAccAthenaWorkGroup_description(t *testing.T) {
 	ctx := acctest.Context(t)
-	var workgroup1, workgroup2 athena.WorkGroup
+	var workgroup1, workgroup2 types.WorkGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_athena_workgroup.test"
 	rDescription := sdkacctest.RandString(20)
@@ -532,7 +534,7 @@ func TestAccAthenaWorkGroup_description(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, athena.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckWorkGroupDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -562,21 +564,21 @@ func TestAccAthenaWorkGroup_description(t *testing.T) {
 
 func TestAccAthenaWorkGroup_state(t *testing.T) {
 	ctx := acctest.Context(t)
-	var workgroup1, workgroup2, workgroup3 athena.WorkGroup
+	var workgroup1, workgroup2, workgroup3 types.WorkGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_athena_workgroup.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, athena.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckWorkGroupDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkGroupConfig_state(rName, athena.WorkGroupStateDisabled),
+				Config: testAccWorkGroupConfig_state(rName, string(types.WorkGroupStateDisabled)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkGroupExists(ctx, resourceName, &workgroup1),
-					resource.TestCheckResourceAttr(resourceName, "state", athena.WorkGroupStateDisabled),
+					resource.TestCheckResourceAttr(resourceName, "state", string(types.WorkGroupStateDisabled)),
 				),
 			},
 			{
@@ -586,17 +588,17 @@ func TestAccAthenaWorkGroup_state(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 			{
-				Config: testAccWorkGroupConfig_state(rName, athena.WorkGroupStateEnabled),
+				Config: testAccWorkGroupConfig_state(rName, string(types.WorkGroupStateEnabled)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkGroupExists(ctx, resourceName, &workgroup2),
-					resource.TestCheckResourceAttr(resourceName, "state", athena.WorkGroupStateEnabled),
+					resource.TestCheckResourceAttr(resourceName, "state", string(types.WorkGroupStateEnabled)),
 				),
 			},
 			{
-				Config: testAccWorkGroupConfig_state(rName, athena.WorkGroupStateDisabled),
+				Config: testAccWorkGroupConfig_state(rName, string(types.WorkGroupStateDisabled)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkGroupExists(ctx, resourceName, &workgroup3),
-					resource.TestCheckResourceAttr(resourceName, "state", athena.WorkGroupStateDisabled),
+					resource.TestCheckResourceAttr(resourceName, "state", string(types.WorkGroupStateDisabled)),
 				),
 			},
 		},
@@ -605,7 +607,7 @@ func TestAccAthenaWorkGroup_state(t *testing.T) {
 
 func TestAccAthenaWorkGroup_forceDestroy(t *testing.T) {
 	ctx := acctest.Context(t)
-	var workgroup athena.WorkGroup
+	var workgroup types.WorkGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dbName := sdkacctest.RandString(5)
 	queryName1 := sdkacctest.RandomWithPrefix("tf-athena-named-query-")
@@ -614,7 +616,7 @@ func TestAccAthenaWorkGroup_forceDestroy(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, athena.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckWorkGroupDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -638,13 +640,13 @@ func TestAccAthenaWorkGroup_forceDestroy(t *testing.T) {
 
 func TestAccAthenaWorkGroup_tags(t *testing.T) {
 	ctx := acctest.Context(t)
-	var workgroup1, workgroup2, workgroup3 athena.WorkGroup
+	var workgroup1, workgroup2, workgroup3 types.WorkGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_athena_workgroup.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, athena.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckWorkGroupDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -683,9 +685,9 @@ func TestAccAthenaWorkGroup_tags(t *testing.T) {
 	})
 }
 
-func testAccCheckCreateNamedQuery(ctx context.Context, workGroup *athena.WorkGroup, databaseName, queryName, query string) resource.TestCheckFunc {
+func testAccCheckCreateNamedQuery(ctx context.Context, workGroup *types.WorkGroup, databaseName, queryName, query string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).AthenaConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).AthenaClient(ctx)
 
 		input := &athena.CreateNamedQueryInput{
 			Name:        aws.String(queryName),
@@ -695,8 +697,8 @@ func testAccCheckCreateNamedQuery(ctx context.Context, workGroup *athena.WorkGro
 			Description: aws.String("tf test"),
 		}
 
-		if _, err := conn.CreateNamedQueryWithContext(ctx, input); err != nil {
-			return fmt.Errorf("error creating Named Query (%s) on Workgroup (%s): %s", queryName, aws.StringValue(workGroup.Name), err)
+		if _, err := conn.CreateNamedQuery(ctx, input); err != nil {
+			return fmt.Errorf("error creating Named Query (%s) on Workgroup (%s): %s", queryName, aws.ToString(workGroup.Name), err)
 		}
 
 		return nil
@@ -705,19 +707,16 @@ func testAccCheckCreateNamedQuery(ctx context.Context, workGroup *athena.WorkGro
 
 func testAccCheckWorkGroupDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).AthenaConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).AthenaClient(ctx)
+
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_athena_workgroup" {
 				continue
 			}
 
-			input := &athena.GetWorkGroupInput{
-				WorkGroup: aws.String(rs.Primary.ID),
-			}
+			_, err := tfathena.FindWorkGroupByName(ctx, conn, rs.Primary.ID)
 
-			resp, err := conn.GetWorkGroupWithContext(ctx, input)
-
-			if tfawserr.ErrMessageContains(err, athena.ErrCodeInvalidRequestException, "is not found") {
+			if tfresource.NotFound(err) {
 				continue
 			}
 
@@ -725,34 +724,29 @@ func testAccCheckWorkGroupDestroy(ctx context.Context) resource.TestCheckFunc {
 				return err
 			}
 
-			if resp.WorkGroup != nil {
-				return fmt.Errorf("Athena WorkGroup (%s) found", rs.Primary.ID)
-			}
+			return fmt.Errorf("Athena WorkGroup %s still exists", rs.Primary.ID)
 		}
+
 		return nil
 	}
 }
 
-func testAccCheckWorkGroupExists(ctx context.Context, name string, workgroup *athena.WorkGroup) resource.TestCheckFunc {
+func testAccCheckWorkGroupExists(ctx context.Context, n string, v *types.WorkGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).AthenaConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).AthenaClient(ctx)
 
-		input := &athena.GetWorkGroupInput{
-			WorkGroup: aws.String(rs.Primary.ID),
-		}
-
-		output, err := conn.GetWorkGroupWithContext(ctx, input)
+		output, err := tfathena.FindWorkGroupByName(ctx, conn, rs.Primary.ID)
 
 		if err != nil {
 			return err
 		}
 
-		*workgroup = *output.WorkGroup
+		*v = *output
 
 		return nil
 	}

--- a/internal/service/events/target.go
+++ b/internal/service/events/target.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/eventbridge"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
-	"github.com/hashicorp/go-cty/cty"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
@@ -245,7 +244,7 @@ func ResourceTarget() *schema.Resource {
 						"header_parameters": {
 							Type:     schema.TypeMap,
 							Optional: true,
-							ValidateDiagFunc: allDiagFunc(
+							ValidateDiagFunc: validation.AllDiag(
 								validation.MapKeyLenBetween(0, 512),
 								validation.MapKeyMatch(regexache.MustCompile(`^[0-9A-Za-z_!#$%&'*+,.^|~-]+$`), ""), // was "," meant to be included? +-. creates a range including: +,-.
 								validation.MapValueLenBetween(0, 512),
@@ -261,7 +260,7 @@ func ResourceTarget() *schema.Resource {
 						"query_string_parameters": {
 							Type:     schema.TypeMap,
 							Optional: true,
-							ValidateDiagFunc: allDiagFunc(
+							ValidateDiagFunc: validation.AllDiag(
 								validation.MapKeyLenBetween(0, 512),
 								validation.MapKeyMatch(regexache.MustCompile(`[^\x00-\x1F\x7F]+`), ""),
 								validation.MapValueLenBetween(0, 512),
@@ -1391,14 +1390,4 @@ func resourceTargetImport(ctx context.Context, d *schema.ResourceData, meta inte
 	d.Set("event_bus_name", busName)
 
 	return []*schema.ResourceData{d}, nil
-}
-
-func allDiagFunc(validators ...schema.SchemaValidateDiagFunc) schema.SchemaValidateDiagFunc {
-	return func(i interface{}, k cty.Path) diag.Diagnostics {
-		var diags diag.Diagnostics
-		for _, validator := range validators {
-			diags = append(diags, validator(i, k)...)
-		}
-		return diags
-	}
 }

--- a/names/names.go
+++ b/names/names.go
@@ -28,6 +28,7 @@ const (
 	AccessAnalyzerEndpointID             = "access-analyzer"
 	AccountEndpointID                    = "account"
 	ACMEndpointID                        = "acm"
+	AthenaEndpointID                     = "athena"
 	AuditManagerEndpointID               = "auditmanager"
 	CleanRoomsEndpointID                 = "cleanrooms"
 	CloudWatchLogsEndpointID             = "logs"

--- a/names/names_data.csv
+++ b/names/names_data.csv
@@ -26,7 +26,7 @@ mgn,mgn,mgn,mgn,,mgn,,,Mgn,Mgn,,1,,,aws_mgn_,,mgn_,Application Migration (Mgn),A
 appstream,appstream,appstream,appstream,,appstream,,,AppStream,AppStream,,1,,,aws_appstream_,,appstream_,AppStream 2.0,Amazon,,,,,,
 appsync,appsync,appsync,appsync,,appsync,,,AppSync,AppSync,,1,,,aws_appsync_,,appsync_,AppSync,AWS,,,,,,
 ,,,,,,,,,,,,,,,,,Artifact,AWS,x,,,,,No SDK support
-athena,athena,athena,athena,,athena,,,Athena,Athena,,1,,,aws_athena_,,athena_,Athena,Amazon,,,,,,
+athena,athena,athena,athena,,athena,,,Athena,Athena,,,2,,aws_athena_,,athena_,Athena,Amazon,,,,,,
 auditmanager,auditmanager,auditmanager,auditmanager,,auditmanager,,,AuditManager,AuditManager,,,2,,aws_auditmanager_,,auditmanager_,Audit Manager,AWS,,,,,,
 autoscaling,autoscaling,autoscaling,autoscaling,,autoscaling,,,AutoScaling,AutoScaling,,1,,aws_(autoscaling_|launch_configuration),aws_autoscaling_,,autoscaling_;launch_configuration,Auto Scaling,,,,,,,
 autoscaling-plans,autoscalingplans,autoscalingplans,autoscalingplans,,autoscalingplans,,,AutoScalingPlans,AutoScalingPlans,,1,,,aws_autoscalingplans_,,autoscalingplans_,Auto Scaling Plans,,,,,,,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Replace service-specific `allDiagFunc` with Plugin SDK v2 implementation.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/33355.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/27050.
Relates https://github.com/hashicorp/terraform-plugin-sdk/pull/1155.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccAthenaDataCatalog_\|TestAccAthenaDatabase_\|TestAccAthenaNamedQuery_\|TestAccAthenaWorkGroup_' PKG=athena ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/athena/... -v -count 1 -parallel 3  -run=TestAccAthenaDataCatalog_\|TestAccAthenaDatabase_\|TestAccAthenaNamedQuery_\|TestAccAthenaWorkGroup_ -timeout 360m
=== RUN   TestAccAthenaDataCatalog_basic
=== PAUSE TestAccAthenaDataCatalog_basic
=== RUN   TestAccAthenaDataCatalog_disappears
=== PAUSE TestAccAthenaDataCatalog_disappears
=== RUN   TestAccAthenaDataCatalog_tags
=== PAUSE TestAccAthenaDataCatalog_tags
=== RUN   TestAccAthenaDataCatalog_type_lambda
=== PAUSE TestAccAthenaDataCatalog_type_lambda
=== RUN   TestAccAthenaDataCatalog_type_hive
=== PAUSE TestAccAthenaDataCatalog_type_hive
=== RUN   TestAccAthenaDataCatalog_type_glue
=== PAUSE TestAccAthenaDataCatalog_type_glue
=== RUN   TestAccAthenaDataCatalog_parameters
=== PAUSE TestAccAthenaDataCatalog_parameters
=== RUN   TestAccAthenaDatabase_basic
=== PAUSE TestAccAthenaDatabase_basic
=== RUN   TestAccAthenaDatabase_properties
=== PAUSE TestAccAthenaDatabase_properties
=== RUN   TestAccAthenaDatabase_acl
=== PAUSE TestAccAthenaDatabase_acl
=== RUN   TestAccAthenaDatabase_encryption
=== PAUSE TestAccAthenaDatabase_encryption
=== RUN   TestAccAthenaDatabase_nameStartsWithUnderscore
=== PAUSE TestAccAthenaDatabase_nameStartsWithUnderscore
=== RUN   TestAccAthenaDatabase_nameCantHaveUppercase
=== PAUSE TestAccAthenaDatabase_nameCantHaveUppercase
=== RUN   TestAccAthenaDatabase_destroyFailsIfTablesExist
=== PAUSE TestAccAthenaDatabase_destroyFailsIfTablesExist
=== RUN   TestAccAthenaDatabase_forceDestroyAlwaysSucceeds
=== PAUSE TestAccAthenaDatabase_forceDestroyAlwaysSucceeds
=== RUN   TestAccAthenaDatabase_description
=== PAUSE TestAccAthenaDatabase_description
=== RUN   TestAccAthenaDatabase_unescaped_description
=== PAUSE TestAccAthenaDatabase_unescaped_description
=== RUN   TestAccAthenaDatabase_disppears
=== PAUSE TestAccAthenaDatabase_disppears
=== RUN   TestAccAthenaNamedQuery_basic
=== PAUSE TestAccAthenaNamedQuery_basic
=== RUN   TestAccAthenaNamedQuery_withWorkGroup
=== PAUSE TestAccAthenaNamedQuery_withWorkGroup
=== RUN   TestAccAthenaWorkGroup_basic
=== PAUSE TestAccAthenaWorkGroup_basic
=== RUN   TestAccAthenaWorkGroup_aclConfig
=== PAUSE TestAccAthenaWorkGroup_aclConfig
=== RUN   TestAccAthenaWorkGroup_disappears
=== PAUSE TestAccAthenaWorkGroup_disappears
=== RUN   TestAccAthenaWorkGroup_bytesScannedCutoffPerQuery
=== PAUSE TestAccAthenaWorkGroup_bytesScannedCutoffPerQuery
=== RUN   TestAccAthenaWorkGroup_enforceWorkGroup
=== PAUSE TestAccAthenaWorkGroup_enforceWorkGroup
=== RUN   TestAccAthenaWorkGroup_configurationEngineVersion
=== PAUSE TestAccAthenaWorkGroup_configurationEngineVersion
=== RUN   TestAccAthenaWorkGroup_configurationExecutionRole
=== PAUSE TestAccAthenaWorkGroup_configurationExecutionRole
=== RUN   TestAccAthenaWorkGroup_publishCloudWatchMetricsEnabled
=== PAUSE TestAccAthenaWorkGroup_publishCloudWatchMetricsEnabled
=== RUN   TestAccAthenaWorkGroup_ResultEncryption_sseS3
=== PAUSE TestAccAthenaWorkGroup_ResultEncryption_sseS3
=== RUN   TestAccAthenaWorkGroup_ResultEncryption_kms
=== PAUSE TestAccAthenaWorkGroup_ResultEncryption_kms
=== RUN   TestAccAthenaWorkGroup_Result_outputLocation
=== PAUSE TestAccAthenaWorkGroup_Result_outputLocation
=== RUN   TestAccAthenaWorkGroup_requesterPaysEnabled
=== PAUSE TestAccAthenaWorkGroup_requesterPaysEnabled
=== RUN   TestAccAthenaWorkGroup_ResultOutputLocation_forceDestroy
=== PAUSE TestAccAthenaWorkGroup_ResultOutputLocation_forceDestroy
=== RUN   TestAccAthenaWorkGroup_description
=== PAUSE TestAccAthenaWorkGroup_description
=== RUN   TestAccAthenaWorkGroup_state
=== PAUSE TestAccAthenaWorkGroup_state
=== RUN   TestAccAthenaWorkGroup_forceDestroy
=== PAUSE TestAccAthenaWorkGroup_forceDestroy
=== RUN   TestAccAthenaWorkGroup_tags
=== PAUSE TestAccAthenaWorkGroup_tags
=== CONT  TestAccAthenaDataCatalog_basic
=== CONT  TestAccAthenaWorkGroup_basic
=== CONT  TestAccAthenaWorkGroup_ResultEncryption_kms
--- PASS: TestAccAthenaDataCatalog_basic (29.25s)
=== CONT  TestAccAthenaWorkGroup_tags
--- PASS: TestAccAthenaWorkGroup_basic (29.37s)
=== CONT  TestAccAthenaWorkGroup_forceDestroy
--- PASS: TestAccAthenaWorkGroup_ResultEncryption_kms (50.24s)
=== CONT  TestAccAthenaWorkGroup_state
--- PASS: TestAccAthenaWorkGroup_forceDestroy (58.18s)
=== CONT  TestAccAthenaWorkGroup_description
--- PASS: TestAccAthenaWorkGroup_tags (63.81s)
=== CONT  TestAccAthenaWorkGroup_ResultOutputLocation_forceDestroy
--- PASS: TestAccAthenaWorkGroup_state (65.76s)
=== CONT  TestAccAthenaWorkGroup_requesterPaysEnabled
--- PASS: TestAccAthenaWorkGroup_description (47.96s)
=== CONT  TestAccAthenaWorkGroup_Result_outputLocation
--- PASS: TestAccAthenaWorkGroup_ResultOutputLocation_forceDestroy (63.32s)
=== CONT  TestAccAthenaWorkGroup_publishCloudWatchMetricsEnabled
--- PASS: TestAccAthenaWorkGroup_requesterPaysEnabled (48.70s)
=== CONT  TestAccAthenaWorkGroup_ResultEncryption_sseS3
--- PASS: TestAccAthenaWorkGroup_ResultEncryption_sseS3 (31.10s)
=== CONT  TestAccAthenaWorkGroup_configurationExecutionRole
--- PASS: TestAccAthenaWorkGroup_Result_outputLocation (67.48s)
=== CONT  TestAccAthenaWorkGroup_bytesScannedCutoffPerQuery
--- PASS: TestAccAthenaWorkGroup_publishCloudWatchMetricsEnabled (52.75s)
=== CONT  TestAccAthenaWorkGroup_enforceWorkGroup
--- PASS: TestAccAthenaWorkGroup_configurationExecutionRole (35.02s)
=== CONT  TestAccAthenaDatabase_encryption
--- PASS: TestAccAthenaWorkGroup_bytesScannedCutoffPerQuery (46.11s)
=== CONT  TestAccAthenaNamedQuery_withWorkGroup
--- PASS: TestAccAthenaWorkGroup_enforceWorkGroup (46.47s)
=== CONT  TestAccAthenaNamedQuery_basic
--- PASS: TestAccAthenaDatabase_encryption (57.06s)
=== CONT  TestAccAthenaDatabase_disppears
--- PASS: TestAccAthenaNamedQuery_withWorkGroup (54.32s)
=== CONT  TestAccAthenaDatabase_unescaped_description
--- PASS: TestAccAthenaNamedQuery_basic (54.19s)
=== CONT  TestAccAthenaDatabase_description
--- PASS: TestAccAthenaDatabase_disppears (49.34s)
=== CONT  TestAccAthenaDatabase_forceDestroyAlwaysSucceeds
--- PASS: TestAccAthenaDatabase_unescaped_description (52.45s)
=== CONT  TestAccAthenaDatabase_destroyFailsIfTablesExist
--- PASS: TestAccAthenaDatabase_description (53.08s)
=== CONT  TestAccAthenaDatabase_nameCantHaveUppercase
--- PASS: TestAccAthenaDatabase_nameCantHaveUppercase (2.64s)
=== CONT  TestAccAthenaDatabase_nameStartsWithUnderscore
--- PASS: TestAccAthenaDatabase_forceDestroyAlwaysSucceeds (54.77s)
=== CONT  TestAccAthenaWorkGroup_disappears
--- PASS: TestAccAthenaWorkGroup_disappears (24.24s)
=== CONT  TestAccAthenaWorkGroup_aclConfig
--- PASS: TestAccAthenaDatabase_destroyFailsIfTablesExist (66.73s)
=== CONT  TestAccAthenaDataCatalog_type_glue
--- PASS: TestAccAthenaDatabase_nameStartsWithUnderscore (61.81s)
=== CONT  TestAccAthenaDatabase_acl
--- PASS: TestAccAthenaWorkGroup_aclConfig (28.98s)
=== CONT  TestAccAthenaDatabase_properties
--- PASS: TestAccAthenaDataCatalog_type_glue (31.24s)
=== CONT  TestAccAthenaDatabase_basic
--- PASS: TestAccAthenaDatabase_acl (62.45s)
=== CONT  TestAccAthenaDataCatalog_parameters
--- PASS: TestAccAthenaDatabase_properties (57.77s)
=== CONT  TestAccAthenaDataCatalog_type_lambda
--- PASS: TestAccAthenaDatabase_basic (55.24s)
=== CONT  TestAccAthenaDataCatalog_type_hive
--- PASS: TestAccAthenaDataCatalog_type_lambda (37.12s)
=== CONT  TestAccAthenaDataCatalog_tags
--- PASS: TestAccAthenaDataCatalog_parameters (55.22s)
=== CONT  TestAccAthenaDataCatalog_disappears
--- PASS: TestAccAthenaDataCatalog_type_hive (37.71s)
=== CONT  TestAccAthenaWorkGroup_configurationEngineVersion
--- PASS: TestAccAthenaDataCatalog_disappears (25.35s)
--- PASS: TestAccAthenaDataCatalog_tags (67.52s)
--- PASS: TestAccAthenaWorkGroup_configurationEngineVersion (64.96s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/athena     617.272s
```
