### PR TITLE
rds/cluster: Use AWS backup retention default

### DIFF
--- a/.changelog/34187.txt
+++ b/.changelog/34187.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_rds_cluster: Remove the provider default (previously "1") and use the AWS default for `backup_retention_period` (also "1") 
+```

--- a/.changelog/34187.txt
+++ b/.changelog/34187.txt
@@ -1,5 +1,5 @@
 ```release-note:enhancement
-resource/aws_rds_cluster: Remove the provider default (previously, "1") and use the AWS default for `backup_retention_period` (also, "1") to allow intergration with AWS Backup
+resource/aws_rds_cluster: Remove the provider default (previously, "1") and use the AWS default for `backup_retention_period` (also, "1") to allow integration with AWS Backup
 ```
 
 ```release-note:bug

--- a/.changelog/34187.txt
+++ b/.changelog/34187.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
-resource/aws_rds_cluster: Remove the provider default (previously "1") and use the AWS default for `backup_retention_period` (also "1") 
+resource/aws_rds_cluster: Remove the provider default (previously, "1") and use the AWS default for `backup_retention_period` (also, "1") to allow intergration with AWS Backup
+```
+
+```release-note:bug
+resource/aws_rds_cluster: Avoid an error on delete related to `unexpected state 'scaling-compute'`
 ```

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -87,7 +87,7 @@ func ResourceCluster() *schema.Resource {
 			"backup_retention_period": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				Default:      1,
+				Computed:     true,
 				ValidateFunc: validation.IntAtMost(35),
 			},
 			"backtrack_window": {
@@ -1740,6 +1740,7 @@ func waitDBClusterDeleted(ctx context.Context, conn *rds.RDS, id string, timeout
 			ClusterStatusDeleting,
 			ClusterStatusModifying,
 			ClusterStatusPromoting,
+			ClusterStatusScalingCompute,
 		},
 		Target:     []string{},
 		Refresh:    statusDBCluster(ctx, conn, id),


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #33465

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccRDSCluster_ K=rds     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSCluster_'  -timeout 360m
=== RUN   TestAccRDSCluster_basic
=== PAUSE TestAccRDSCluster_basic
=== RUN   TestAccRDSCluster_disappears
=== PAUSE TestAccRDSCluster_disappears
=== RUN   TestAccRDSCluster_identifierGenerated
=== PAUSE TestAccRDSCluster_identifierGenerated
=== RUN   TestAccRDSCluster_identifierPrefix
=== PAUSE TestAccRDSCluster_identifierPrefix
=== RUN   TestAccRDSCluster_tags
=== PAUSE TestAccRDSCluster_tags
=== RUN   TestAccRDSCluster_allowMajorVersionUpgrade
=== PAUSE TestAccRDSCluster_allowMajorVersionUpgrade
=== RUN   TestAccRDSCluster_allowMajorVersionUpgradeNoApplyImmediately
=== PAUSE TestAccRDSCluster_allowMajorVersionUpgradeNoApplyImmediately
=== RUN   TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParametersApplyImm
=== PAUSE TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParametersApplyImm
=== RUN   TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParameters
=== PAUSE TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParameters
=== RUN   TestAccRDSCluster_onlyMajorVersion
=== PAUSE TestAccRDSCluster_onlyMajorVersion
=== RUN   TestAccRDSCluster_minorVersion
=== PAUSE TestAccRDSCluster_minorVersion
=== RUN   TestAccRDSCluster_availabilityZones
=== PAUSE TestAccRDSCluster_availabilityZones
=== RUN   TestAccRDSCluster_storageTypeIo1
=== PAUSE TestAccRDSCluster_storageTypeIo1
=== RUN   TestAccRDSCluster_storageTypeAuroraReturnsBlank
=== PAUSE TestAccRDSCluster_storageTypeAuroraReturnsBlank
=== RUN   TestAccRDSCluster_storageTypeAuroraIopt1
=== PAUSE TestAccRDSCluster_storageTypeAuroraIopt1
=== RUN   TestAccRDSCluster_storageTypeAuroraUpdateAuroraIopt1
=== PAUSE TestAccRDSCluster_storageTypeAuroraUpdateAuroraIopt1
=== RUN   TestAccRDSCluster_allocatedStorage
=== PAUSE TestAccRDSCluster_allocatedStorage
=== RUN   TestAccRDSCluster_storageTypeAuroraIopt1UpdateAurora
=== PAUSE TestAccRDSCluster_storageTypeAuroraIopt1UpdateAurora
=== RUN   TestAccRDSCluster_iops
=== PAUSE TestAccRDSCluster_iops
=== RUN   TestAccRDSCluster_dbClusterInstanceClass
=== PAUSE TestAccRDSCluster_dbClusterInstanceClass
=== RUN   TestAccRDSCluster_backtrackWindow
=== PAUSE TestAccRDSCluster_backtrackWindow
=== RUN   TestAccRDSCluster_dbSubnetGroupName
=== PAUSE TestAccRDSCluster_dbSubnetGroupName
=== RUN   TestAccRDSCluster_pointInTimeRestore
=== PAUSE TestAccRDSCluster_pointInTimeRestore
=== RUN   TestAccRDSCluster_PointInTimeRestore_enabledCloudWatchLogsExports
=== PAUSE TestAccRDSCluster_PointInTimeRestore_enabledCloudWatchLogsExports
=== RUN   TestAccRDSCluster_takeFinalSnapshot
=== PAUSE TestAccRDSCluster_takeFinalSnapshot
=== RUN   TestAccRDSCluster_missingUserNameCausesError
=== PAUSE TestAccRDSCluster_missingUserNameCausesError
=== RUN   TestAccRDSCluster_EnabledCloudWatchLogsExports_mySQL
=== PAUSE TestAccRDSCluster_EnabledCloudWatchLogsExports_mySQL
=== RUN   TestAccRDSCluster_EnabledCloudWatchLogsExports_postgresql
=== PAUSE TestAccRDSCluster_EnabledCloudWatchLogsExports_postgresql
=== RUN   TestAccRDSCluster_updateIAMRoles
=== PAUSE TestAccRDSCluster_updateIAMRoles
=== RUN   TestAccRDSCluster_kmsKey
=== PAUSE TestAccRDSCluster_kmsKey
=== RUN   TestAccRDSCluster_networkType
=== PAUSE TestAccRDSCluster_networkType
=== RUN   TestAccRDSCluster_encrypted
=== PAUSE TestAccRDSCluster_encrypted
=== RUN   TestAccRDSCluster_copyTagsToSnapshot
=== PAUSE TestAccRDSCluster_copyTagsToSnapshot
=== RUN   TestAccRDSCluster_ReplicationSourceIdentifier_kmsKeyID
=== PAUSE TestAccRDSCluster_ReplicationSourceIdentifier_kmsKeyID
=== RUN   TestAccRDSCluster_backupsUpdate
=== PAUSE TestAccRDSCluster_backupsUpdate
=== RUN   TestAccRDSCluster_iamAuth
=== PAUSE TestAccRDSCluster_iamAuth
=== RUN   TestAccRDSCluster_deletionProtection
=== PAUSE TestAccRDSCluster_deletionProtection
=== RUN   TestAccRDSCluster_engineMode
=== PAUSE TestAccRDSCluster_engineMode
=== RUN   TestAccRDSCluster_engineVersion
=== PAUSE TestAccRDSCluster_engineVersion
=== RUN   TestAccRDSCluster_engineVersionWithPrimaryInstance
=== PAUSE TestAccRDSCluster_engineVersionWithPrimaryInstance
=== RUN   TestAccRDSCluster_GlobalClusterIdentifierEngineMode_global
=== PAUSE TestAccRDSCluster_GlobalClusterIdentifierEngineMode_global
=== RUN   TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_add
=== PAUSE TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_add
=== RUN   TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_remove
=== PAUSE TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_remove
=== RUN   TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_update
=== PAUSE TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_update
=== RUN   TestAccRDSCluster_GlobalClusterIdentifierEngineMode_provisioned
=== PAUSE TestAccRDSCluster_GlobalClusterIdentifierEngineMode_provisioned
=== RUN   TestAccRDSCluster_GlobalClusterIdentifier_primarySecondaryClusters
=== PAUSE TestAccRDSCluster_GlobalClusterIdentifier_primarySecondaryClusters
=== RUN   TestAccRDSCluster_GlobalClusterIdentifier_replicationSourceIdentifier
=== PAUSE TestAccRDSCluster_GlobalClusterIdentifier_replicationSourceIdentifier
=== RUN   TestAccRDSCluster_GlobalClusterIdentifier_secondaryClustersWriteForwarding
=== PAUSE TestAccRDSCluster_GlobalClusterIdentifier_secondaryClustersWriteForwarding
=== RUN   TestAccRDSCluster_ManagedMasterPassword_managed
=== PAUSE TestAccRDSCluster_ManagedMasterPassword_managed
=== RUN   TestAccRDSCluster_ManagedMasterPassword_managedSpecificKMSKey
=== PAUSE TestAccRDSCluster_ManagedMasterPassword_managedSpecificKMSKey
=== RUN   TestAccRDSCluster_ManagedMasterPassword_convertToManaged
=== PAUSE TestAccRDSCluster_ManagedMasterPassword_convertToManaged
=== RUN   TestAccRDSCluster_port
=== PAUSE TestAccRDSCluster_port
=== RUN   TestAccRDSCluster_scaling
=== PAUSE TestAccRDSCluster_scaling
=== RUN   TestAccRDSCluster_serverlessV2ScalingConfiguration
=== PAUSE TestAccRDSCluster_serverlessV2ScalingConfiguration
=== RUN   TestAccRDSCluster_Scaling_defaultMinCapacity
=== PAUSE TestAccRDSCluster_Scaling_defaultMinCapacity
=== RUN   TestAccRDSCluster_snapshotIdentifier
=== PAUSE TestAccRDSCluster_snapshotIdentifier
=== RUN   TestAccRDSCluster_SnapshotIdentifier_deletionProtection
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_deletionProtection
=== RUN   TestAccRDSCluster_SnapshotIdentifierEngineMode_provisioned
=== PAUSE TestAccRDSCluster_SnapshotIdentifierEngineMode_provisioned
=== RUN   TestAccRDSCluster_SnapshotIdentifierEngineMode_serverless
    cluster_test.go:1988: serverless does not support snapshot restore on an empty volume
--- SKIP: TestAccRDSCluster_SnapshotIdentifierEngineMode_serverless (0.00s)
=== RUN   TestAccRDSCluster_SnapshotIdentifierEngineVersion_different
=== PAUSE TestAccRDSCluster_SnapshotIdentifierEngineVersion_different
=== RUN   TestAccRDSCluster_SnapshotIdentifierEngineVersion_equal
=== PAUSE TestAccRDSCluster_SnapshotIdentifierEngineVersion_equal
=== RUN   TestAccRDSCluster_SnapshotIdentifier_kmsKeyID
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_kmsKeyID
=== RUN   TestAccRDSCluster_SnapshotIdentifier_masterPassword
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_masterPassword
=== RUN   TestAccRDSCluster_SnapshotIdentifier_masterUsername
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_masterUsername
=== RUN   TestAccRDSCluster_SnapshotIdentifier_preferredBackupWindow
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_preferredBackupWindow
=== RUN   TestAccRDSCluster_SnapshotIdentifier_preferredMaintenanceWindow
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_preferredMaintenanceWindow
=== RUN   TestAccRDSCluster_SnapshotIdentifier_tags
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_tags
=== RUN   TestAccRDSCluster_SnapshotIdentifier_vpcSecurityGroupIDs
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_vpcSecurityGroupIDs
=== RUN   TestAccRDSCluster_SnapshotIdentifierVPCSecurityGroupIDs_tags
=== PAUSE TestAccRDSCluster_SnapshotIdentifierVPCSecurityGroupIDs_tags
=== RUN   TestAccRDSCluster_SnapshotIdentifier_encryptedRestore
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_encryptedRestore
=== RUN   TestAccRDSCluster_enableHTTPEndpoint
=== PAUSE TestAccRDSCluster_enableHTTPEndpoint
=== RUN   TestAccRDSCluster_password
=== PAUSE TestAccRDSCluster_password
=== CONT  TestAccRDSCluster_basic
=== CONT  TestAccRDSCluster_deletionProtection
=== CONT  TestAccRDSCluster_serverlessV2ScalingConfiguration
=== CONT  TestAccRDSCluster_Scaling_defaultMinCapacity
=== CONT  TestAccRDSCluster_GlobalClusterIdentifier_primarySecondaryClusters
=== CONT  TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_remove
=== CONT  TestAccRDSCluster_GlobalClusterIdentifier_secondaryClustersWriteForwarding
=== CONT  TestAccRDSCluster_ManagedMasterPassword_managedSpecificKMSKey
=== CONT  TestAccRDSCluster_scaling
=== CONT  TestAccRDSCluster_port
=== CONT  TestAccRDSCluster_ManagedMasterPassword_convertToManaged
=== CONT  TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_add
=== CONT  TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_update
=== CONT  TestAccRDSCluster_GlobalClusterIdentifierEngineMode_provisioned
=== CONT  TestAccRDSCluster_engineVersion
=== CONT  TestAccRDSCluster_engineVersionWithPrimaryInstance
=== CONT  TestAccRDSCluster_engineMode
=== CONT  TestAccRDSCluster_iops
=== CONT  TestAccRDSCluster_ManagedMasterPassword_managed
=== CONT  TestAccRDSCluster_GlobalClusterIdentifierEngineMode_global
=== CONT  TestAccRDSCluster_iamAuth
--- PASS: TestAccRDSCluster_basic (313.64s)
--- PASS: TestAccRDSCluster_ManagedMasterPassword_managed (385.51s)
=== CONT  TestAccRDSCluster_backupsUpdate
--- PASS: TestAccRDSCluster_ManagedMasterPassword_convertToManaged (472.97s)
=== CONT  TestAccRDSCluster_ReplicationSourceIdentifier_kmsKeyID
--- PASS: TestAccRDSCluster_port (475.68s)
=== CONT  TestAccRDSCluster_copyTagsToSnapshot
--- PASS: TestAccRDSCluster_deletionProtection (493.90s)
=== CONT  TestAccRDSCluster_encrypted
--- PASS: TestAccRDSCluster_GlobalClusterIdentifierEngineMode_provisioned (535.69s)
=== CONT  TestAccRDSCluster_networkType
--- PASS: TestAccRDSCluster_Scaling_defaultMinCapacity (567.99s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_preferredBackupWindow
--- PASS: TestAccRDSCluster_GlobalClusterIdentifierEngineMode_global (602.01s)
=== CONT  TestAccRDSCluster_password
--- PASS: TestAccRDSCluster_iamAuth (288.90s)
=== CONT  TestAccRDSCluster_enableHTTPEndpoint
--- PASS: TestAccRDSCluster_scaling (634.16s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_encryptedRestore
--- PASS: TestAccRDSCluster_ManagedMasterPassword_managedSpecificKMSKey (634.67s)
=== CONT  TestAccRDSCluster_SnapshotIdentifierVPCSecurityGroupIDs_tags
--- PASS: TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_add (646.68s)
=== CONT  TestAccRDSCluster_kmsKey
--- PASS: TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_update (700.97s)
=== CONT  TestAccRDSCluster_PointInTimeRestore_enabledCloudWatchLogsExports
--- PASS: TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_remove (705.51s)
=== CONT  TestAccRDSCluster_pointInTimeRestore
--- PASS: TestAccRDSCluster_serverlessV2ScalingConfiguration (741.43s)
=== CONT  TestAccRDSCluster_dbSubnetGroupName
--- PASS: TestAccRDSCluster_encrypted (268.06s)
=== CONT  TestAccRDSCluster_SnapshotIdentifierEngineVersion_equal
--- PASS: TestAccRDSCluster_backupsUpdate (402.52s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_masterUsername
--- PASS: TestAccRDSCluster_engineMode (807.32s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_masterPassword
--- PASS: TestAccRDSCluster_password (346.71s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_kmsKeyID
--- PASS: TestAccRDSCluster_copyTagsToSnapshot (537.19s)
=== CONT  TestAccRDSCluster_SnapshotIdentifierEngineMode_provisioned
--- PASS: TestAccRDSCluster_engineVersion (1068.75s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_vpcSecurityGroupIDs
--- PASS: TestAccRDSCluster_kmsKey (473.23s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_tags
--- PASS: TestAccRDSCluster_enableHTTPEndpoint (584.42s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_preferredMaintenanceWindow
--- PASS: TestAccRDSCluster_SnapshotIdentifier_preferredBackupWindow (663.92s)
=== CONT  TestAccRDSCluster_backtrackWindow
--- PASS: TestAccRDSCluster_SnapshotIdentifier_encryptedRestore (703.07s)
=== CONT  TestAccRDSCluster_SnapshotIdentifierEngineVersion_different
=== CONT  TestAccRDSCluster_dbClusterInstanceClass
--- PASS: TestAccRDSCluster_dbSubnetGroupName (643.16s)
--- PASS: TestAccRDSCluster_SnapshotIdentifierVPCSecurityGroupIDs_tags (765.02s)
=== CONT  TestAccRDSCluster_takeFinalSnapshot
--- PASS: TestAccRDSCluster_SnapshotIdentifier_masterUsername (656.24s)
=== CONT  TestAccRDSCluster_onlyMajorVersion
=== CONT  TestAccRDSCluster_updateIAMRoles
--- PASS: TestAccRDSCluster_SnapshotIdentifier_masterPassword (656.54s)
--- PASS: TestAccRDSCluster_backtrackWindow (388.69s)
=== CONT  TestAccRDSCluster_storageTypeAuroraIopt1UpdateAurora
--- PASS: TestAccRDSCluster_networkType (1095.86s)
=== CONT  TestAccRDSCluster_allowMajorVersionUpgrade
--- PASS: TestAccRDSCluster_SnapshotIdentifierEngineVersion_equal (920.11s)
=== CONT  TestAccRDSCluster_allocatedStorage
--- PASS: TestAccRDSCluster_SnapshotIdentifierEngineMode_provisioned (670.58s)
=== CONT  TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParameters
--- PASS: TestAccRDSCluster_PointInTimeRestore_enabledCloudWatchLogsExports (982.58s)
=== CONT  TestAccRDSCluster_storageTypeAuroraUpdateAuroraIopt1
--- PASS: TestAccRDSCluster_pointInTimeRestore (978.91s)
=== CONT  TestAccRDSCluster_storageTypeAuroraIopt1
--- PASS: TestAccRDSCluster_SnapshotIdentifier_kmsKeyID (772.30s)
=== CONT  TestAccRDSCluster_storageTypeAuroraReturnsBlank
--- PASS: TestAccRDSCluster_takeFinalSnapshot (362.55s)
=== CONT  TestAccRDSCluster_storageTypeIo1
--- PASS: TestAccRDSCluster_SnapshotIdentifier_tags (644.35s)
=== CONT  TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParametersApplyImm
--- PASS: TestAccRDSCluster_SnapshotIdentifier_vpcSecurityGroupIDs (695.90s)
=== CONT  TestAccRDSCluster_availabilityZones
--- PASS: TestAccRDSCluster_SnapshotIdentifier_preferredMaintenanceWindow (702.94s)
=== CONT  TestAccRDSCluster_allowMajorVersionUpgradeNoApplyImmediately
--- PASS: TestAccRDSCluster_storageTypeAuroraIopt1 (462.85s)
=== CONT  TestAccRDSCluster_minorVersion
--- PASS: TestAccRDSCluster_storageTypeAuroraReturnsBlank (433.72s)
=== CONT  TestAccRDSCluster_identifierPrefix
--- PASS: TestAccRDSCluster_availabilityZones (450.48s)
=== CONT  TestAccRDSCluster_tags
--- PASS: TestAccRDSCluster_SnapshotIdentifierEngineVersion_different (918.50s)
=== CONT  TestAccRDSCluster_GlobalClusterIdentifier_replicationSourceIdentifier
--- PASS: TestAccRDSCluster_storageTypeAuroraIopt1UpdateAurora (643.75s)
=== CONT  TestAccRDSCluster_identifierGenerated
--- PASS: TestAccRDSCluster_updateIAMRoles (827.09s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_deletionProtection
--- PASS: TestAccRDSCluster_storageTypeAuroraUpdateAuroraIopt1 (636.15s)
=== CONT  TestAccRDSCluster_EnabledCloudWatchLogsExports_postgresql
--- PASS: TestAccRDSCluster_iops (2345.88s)
=== CONT  TestAccRDSCluster_snapshotIdentifier
--- PASS: TestAccRDSCluster_identifierPrefix (277.35s)
=== CONT  TestAccRDSCluster_missingUserNameCausesError
--- PASS: TestAccRDSCluster_missingUserNameCausesError (43.04s)
=== CONT  TestAccRDSCluster_disappears
--- PASS: TestAccRDSCluster_identifierGenerated (315.94s)
=== CONT  TestAccRDSCluster_EnabledCloudWatchLogsExports_mySQL
--- PASS: TestAccRDSCluster_tags (371.74s)
--- PASS: TestAccRDSCluster_disappears (205.61s)
--- PASS: TestAccRDSCluster_engineVersionWithPrimaryInstance (2684.41s)
--- PASS: TestAccRDSCluster_onlyMajorVersion (1449.88s)
--- PASS: TestAccRDSCluster_snapshotIdentifier (557.39s)
--- PASS: TestAccRDSCluster_EnabledCloudWatchLogsExports_mySQL (422.68s)
--- PASS: TestAccRDSCluster_SnapshotIdentifier_deletionProtection (719.21s)
--- PASS: TestAccRDSCluster_dbClusterInstanceClass (4237.01s)
--- PASS: TestAccRDSCluster_ReplicationSourceIdentifier_kmsKeyID (3156.72s)
--- PASS: TestAccRDSCluster_allowMajorVersionUpgradeNoApplyImmediately (2042.49s)
--- PASS: TestAccRDSCluster_allocatedStorage (2313.43s)
--- PASS: TestAccRDSCluster_minorVersion (1854.61s)
--- PASS: TestAccRDSCluster_storageTypeIo1 (2455.25s)
--- PASS: TestAccRDSCluster_GlobalClusterIdentifier_primarySecondaryClusters (4345.68s)
--- PASS: TestAccRDSCluster_GlobalClusterIdentifier_secondaryClustersWriteForwarding (4411.68s)
--- PASS: TestAccRDSCluster_allowMajorVersionUpgrade (3040.84s)
--- PASS: TestAccRDSCluster_EnabledCloudWatchLogsExports_postgresql (2698.61s)
--- PASS: TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParameters (3356.64s)
--- PASS: TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParametersApplyImm (3320.30s)
--- PASS: TestAccRDSCluster_GlobalClusterIdentifier_replicationSourceIdentifier (3401.69s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	5659.546s
```