### PR TITLE
Add Kafka message headers to IoT topic rules

### DIFF
--- a/.changelog/34191.txt
+++ b/.changelog/34191.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_iot_topic_rule: Add `kafka.header` and `error_action.kafka.header` arguments
+```

--- a/.changelog/34191.txt
+++ b/.changelog/34191.txt
@@ -1,3 +1,3 @@
-```release-note:bug
+```release-note:enhancement
 resource/aws_iot_topic_rule: Add `kafka.header` and `error_action.kafka.header` arguments
 ```

--- a/internal/service/iot/topic_rule.go
+++ b/internal/service/iot/topic_rule.go
@@ -573,18 +573,6 @@ func ResourceTopicRule() *schema.Resource {
 										Required:     true,
 										ValidateFunc: verify.ValidARN,
 									},
-									"key": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									"partition": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									"topic": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
 									"header": {
 										Type:     schema.TypeList,
 										Optional: true,
@@ -600,6 +588,18 @@ func ResourceTopicRule() *schema.Resource {
 												},
 											},
 										},
+									},
+									"key": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"partition": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"topic": {
+										Type:     schema.TypeString,
+										Required: true,
 									},
 								},
 							},
@@ -945,18 +945,6 @@ func ResourceTopicRule() *schema.Resource {
 							Required:     true,
 							ValidateFunc: verify.ValidARN,
 						},
-						"key": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"partition": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"topic": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
 						"header": {
 							Type:     schema.TypeList,
 							Optional: true,
@@ -972,6 +960,18 @@ func ResourceTopicRule() *schema.Resource {
 									},
 								},
 							},
+						},
+						"key": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"partition": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"topic": {
+							Type:     schema.TypeString,
+							Required: true,
 						},
 					},
 				},
@@ -1724,6 +1724,10 @@ func expandKafkaAction(tfList []interface{}) *iot.KafkaAction {
 		apiObject.DestinationArn = aws.String(v)
 	}
 
+	if v, ok := tfMap["header"].([]interface{}); ok && len(v) > 0 {
+		apiObject.Headers = expandKafkaHeader(v)
+	}
+
 	if v, ok := tfMap["key"].(string); ok && v != "" {
 		apiObject.Key = aws.String(v)
 	}
@@ -1734,10 +1738,6 @@ func expandKafkaAction(tfList []interface{}) *iot.KafkaAction {
 
 	if v, ok := tfMap["topic"].(string); ok && v != "" {
 		apiObject.Topic = aws.String(v)
-	}
-
-	if v, ok := tfMap["header"].([]interface{}); ok && len(v) > 0 {
-		apiObject.Headers = expandKafkaHeader(v)
 	}
 
 	if reflect.DeepEqual(&iot.KafkaAction{}, apiObject) {
@@ -2908,6 +2908,10 @@ func flattenKafkaAction(apiObject *iot.KafkaAction) []interface{} {
 		tfMap["destination_arn"] = aws.StringValue(v)
 	}
 
+	if v := apiObject.Headers; v != nil {
+		tfMap["header"] = flattenKafkaHeaders(v)
+	}
+
 	if v := apiObject.Key; v != nil {
 		tfMap["key"] = aws.StringValue(v)
 	}
@@ -2918,10 +2922,6 @@ func flattenKafkaAction(apiObject *iot.KafkaAction) []interface{} {
 
 	if v := apiObject.Topic; v != nil {
 		tfMap["topic"] = aws.StringValue(v)
-	}
-
-	if v := apiObject.Headers; v != nil {
-		tfMap["header"] = flattenKafkaHeaders(v)
 	}
 
 	return []interface{}{tfMap}

--- a/internal/service/iot/topic_rule_test.go
+++ b/internal/service/iot/topic_rule_test.go
@@ -1376,6 +1376,11 @@ func TestAccIoTTopicRule_kafka(t *testing.T) {
 						"client_properties.ssl.keystore.password": "password",
 						"client_properties.value.serializer":      "org.apache.kafka.common.serialization.ByteBufferSerializer",
 						"topic":                                   "fake_topic",
+						"header.#":                                "2",
+						"header.0.key":                            "header-1",
+						"header.0.value":                          "value-1",
+						"header.1.key":                            "header-2",
+						"header.1.value":                          "value-2",
 					}),
 					resource.TestCheckResourceAttr(resourceName, "kinesis.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "lambda.#", "0"),
@@ -1413,6 +1418,11 @@ func TestAccIoTTopicRule_kafka(t *testing.T) {
 						"client_properties.ssl.keystore.password": "password",
 						"client_properties.value.serializer":      "org.apache.kafka.common.serialization.ByteBufferSerializer",
 						"topic":                                   "different_topic",
+						"header.#":                                "2",
+						"header.0.key":                            "header-1",
+						"header.0.value":                          "value-1",
+						"header.1.key":                            "header-2",
+						"header.1.value":                          "value-2",
 					}),
 					resource.TestCheckResourceAttr(resourceName, "kinesis.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "lambda.#", "0"),
@@ -1451,6 +1461,11 @@ func TestAccIoTTopicRule_kafka(t *testing.T) {
 						"client_properties.ssl.keystore.password": "password",
 						"client_properties.value.serializer":      "org.apache.kafka.common.serialization.ByteBufferSerializer",
 						"topic":                                   "different_topic",
+						"header.#":                                "2",
+						"header.0.key":                            "header-1",
+						"header.0.value":                          "value-1",
+						"header.1.key":                            "header-2",
+						"header.1.value":                          "value-2",
 					}),
 					resource.TestCheckResourceAttr(resourceName, "kinesis.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "lambda.#", "0"),
@@ -2864,6 +2879,16 @@ resource "aws_iot_topic_rule" "test" {
       "ssl.keystore"          = "$${get_secret('secret_name', 'SecretBinary', '', '${aws_iam_role.test.arn}')}"
       "ssl.keystore.password" = "password"
       "value.serializer"      = "org.apache.kafka.common.serialization.ByteBufferSerializer"
+    }
+
+    header {
+      key   = "header-1"
+      value = "value-1"
+    }
+
+    header {
+      key   = "header-2"
+      value = "value-2"
     }
   }
 }

--- a/website/docs/r/iot_topic_rule.html.markdown
+++ b/website/docs/r/iot_topic_rule.html.markdown
@@ -166,7 +166,10 @@ The `iot_events` object takes the following arguments:
 The `kafka` object takes the following arguments:
 
 * `client_properties` - (Required) Properties of the Apache Kafka producer client. For more info, see the [AWS documentation](https://docs.aws.amazon.com/iot/latest/developerguide/apache-kafka-rule-action.html).
-* `destination_arn` - (Required) The ARN of Kafka action's VPC [`aws_iot_topic_rule_destination`](iot_topic_rule_destination.html) .
+* `destination_arn` - (Required) The ARN of Kafka action's VPC [`aws_iot_topic_rule_destination`](iot_topic_rule_destination.html).
+* `header` - (Optional) The list of Kafka headers that you specify. Nested arguments below.
+    * `key` - (Required) The key of the Kafka header.
+    * `value` - (Required) The value of the Kafka header.
 * `key` - (Optional) The Kafka message key.
 * `partition` - (Optional) The Kafka message partition.
 * `topic` - (Optional) The Kafka topic for messages to be sent to the Kafka broker.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Allow adding Kafka headers to AWS IoT topic rules.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #34005


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
make testacc TESTS=TestAccIoTTopicRule_kafka PKG=iot
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iot/... -v -count 1 -parallel 20 -run='TestAccIoTTopicRule_kafka'  -timeout 360m
=== RUN   TestAccIoTTopicRule_kafka
=== PAUSE TestAccIoTTopicRule_kafka
=== CONT  TestAccIoTTopicRule_kafka
--- PASS: TestAccIoTTopicRule_kafka (402.14s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iot        404.107s
```
