### PR TITLE
r/aws_finspace_kx_cluster(test): add missing license check gates

### DIFF
--- a/internal/service/finspace/kx_cluster_test.go
+++ b/internal/service/finspace/kx_cluster_test.go
@@ -208,6 +208,7 @@ func TestAccFinSpaceKxCluster_cache250Configurations(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
+			testAccPreCheckManagedKxLicenseEnabled(t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, finspace.ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -245,6 +246,7 @@ func TestAccFinSpaceKxCluster_cache12Configurations(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
+			testAccPreCheckManagedKxLicenseEnabled(t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, finspace.ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Applies the license check pre-check to two Kx Cluster acceptance tests which are currently missing it. All Kx Cluster tests should be explicitly opted into running as a license is required to provision clusters.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #33745


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
%  make testacc PKG=finspace TESTS=TestAccFinSpaceKxCluster_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/finspace/... -v -count 1 -parallel 20 -run='TestAccFinSpaceKxCluster_'  -timeout 360m

=== NAME  TestAccFinSpaceKxCluster_cacheConfigurations
    kx_cluster_test.go:28: Environment variable FINSPACE_MANAGED_KX_LICENSE_ENABLED is not set. Certain managed KX resources require the target account to have an active license. Set the environment variable to any value to enable these tests.
--- SKIP: TestAccFinSpaceKxCluster_cacheConfigurations (0.35s)
=== NAME  TestAccFinSpaceKxCluster_multiAZ
    kx_cluster_test.go:28: Environment variable FINSPACE_MANAGED_KX_LICENSE_ENABLED is not set. Certain managed KX resources require the target account to have an active license. Set the environment variable to any value to enable these tests.
--- SKIP: TestAccFinSpaceKxCluster_multiAZ (0.35s)
=== NAME  TestAccFinSpaceKxCluster_cache250Configurations
    kx_cluster_test.go:28: Environment variable FINSPACE_MANAGED_KX_LICENSE_ENABLED is not set. Certain managed KX resources require the target account to have an active license. Set the environment variable to any value to enable these tests.
--- SKIP: TestAccFinSpaceKxCluster_cache250Configurations (0.35s)
=== NAME  TestAccFinSpaceKxCluster_basic
    kx_cluster_test.go:28: Environment variable FINSPACE_MANAGED_KX_LICENSE_ENABLED is not set. Certain managed KX resources require the target account to have an active license. Set the environment variable to any value to enable these tests.
--- SKIP: TestAccFinSpaceKxCluster_basic (0.35s)
=== NAME  TestAccFinSpaceKxCluster_code
    kx_cluster_test.go:28: Environment variable FINSPACE_MANAGED_KX_LICENSE_ENABLED is not set. Certain managed KX resources require the target account to have an active license. Set the environment variable to any value to enable these tests.
--- SKIP: TestAccFinSpaceKxCluster_code (0.35s)
=== NAME  TestAccFinSpaceKxCluster_database
    kx_cluster_test.go:28: Environment variable FINSPACE_MANAGED_KX_LICENSE_ENABLED is not set. Certain managed KX resources require the target account to have an active license. Set the environment variable to any value to enable these tests.
--- SKIP: TestAccFinSpaceKxCluster_database (0.35s)
=== NAME  TestAccFinSpaceKxCluster_cache12Configurations
    kx_cluster_test.go:28: Environment variable FINSPACE_MANAGED_KX_LICENSE_ENABLED is not set. Certain managed KX resources require the target account to have an active license. Set the environment variable to any value to enable these tests.
--- SKIP: TestAccFinSpaceKxCluster_cache12Configurations (0.35s)
=== NAME  TestAccFinSpaceKxCluster_autoScaling
    kx_cluster_test.go:28: Environment variable FINSPACE_MANAGED_KX_LICENSE_ENABLED is not set. Certain managed KX resources require the target account to have an active license. Set the environment variable to any value to enable these tests.
--- SKIP: TestAccFinSpaceKxCluster_autoScaling (0.35s)
=== NAME  TestAccFinSpaceKxCluster_rdb
    kx_cluster_test.go:28: Environment variable FINSPACE_MANAGED_KX_LICENSE_ENABLED is not set. Certain managed KX resources require the target account to have an active license. Set the environment variable to any value to enable these tests.
--- SKIP: TestAccFinSpaceKxCluster_rdb (0.35s)
=== NAME  TestAccFinSpaceKxCluster_description
    kx_cluster_test.go:28: Environment variable FINSPACE_MANAGED_KX_LICENSE_ENABLED is not set. Certain managed KX resources require the target account to have an active license. Set the environment variable to any value to enable these tests.
--- SKIP: TestAccFinSpaceKxCluster_description (0.35s)
=== NAME  TestAccFinSpaceKxCluster_initializationScript
    kx_cluster_test.go:28: Environment variable FINSPACE_MANAGED_KX_LICENSE_ENABLED is not set. Certain managed KX resources require the target account to have an active license. Set the environment variable to any value to enable these tests.
--- SKIP: TestAccFinSpaceKxCluster_initializationScript (0.35s)
=== NAME  TestAccFinSpaceKxCluster_tags
    kx_cluster_test.go:28: Environment variable FINSPACE_MANAGED_KX_LICENSE_ENABLED is not set. Certain managed KX resources require the target account to have an active license. Set the environment variable to any value to enable these tests.
--- SKIP: TestAccFinSpaceKxCluster_tags (0.35s)
=== NAME  TestAccFinSpaceKxCluster_disappears
    kx_cluster_test.go:28: Environment variable FINSPACE_MANAGED_KX_LICENSE_ENABLED is not set. Certain managed KX resources require the target account to have an active license. Set the environment variable to any value to enable these tests.
--- SKIP: TestAccFinSpaceKxCluster_disappears (0.35s)
=== NAME  TestAccFinSpaceKxCluster_commandLineArgs
    kx_cluster_test.go:28: Environment variable FINSPACE_MANAGED_KX_LICENSE_ENABLED is not set. Certain managed KX resources require the target account to have an active license. Set the environment variable to any value to enable these tests.
--- SKIP: TestAccFinSpaceKxCluster_commandLineArgs (0.35s)
=== NAME  TestAccFinSpaceKxCluster_executionRole
    kx_cluster_test.go:28: Environment variable FINSPACE_MANAGED_KX_LICENSE_ENABLED is not set. Certain managed KX resources require the target account to have an active license. Set the environment variable to any value to enable these tests.
--- SKIP: TestAccFinSpaceKxCluster_executionRole (0.35s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/finspace   3.456s
```
