### PR TITLE
fix[aws_route53_record]: Allow importing with empty record name

### DIFF
--- a/.changelog/34212.txt
+++ b/.changelog/34212.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_route53_record: Allow import of records with an empty record name.
+```

--- a/internal/service/route53/record.go
+++ b/internal/service/route53/record.go
@@ -43,7 +43,9 @@ func ResourceRecord() *schema.Resource {
 				parts := ParseRecordID(d.Id())
 				// We check that we have parsed the id into the correct number of segments.
 				// We need at least 3 segments!
-				if parts[0] == "" || parts[1] == "" || parts[2] == "" {
+				// However, parts[1] can be the empty string if it is the root domain of the zone,
+				// and isn't using a FQDN. See https://github.com/hashicorp/terraform-provider-aws/issues/4792
+				if parts[0] == "" || parts[2] == "" {
 					return nil, fmt.Errorf("unexpected format of ID (%q), expected ZONEID_RECORDNAME_TYPE_SET-IDENTIFIER (e.g. Z4KAPRWWNC7JR_dev.example.com_NS_dev), where SET-IDENTIFIER is optional", d.Id())
 				}
 

--- a/internal/service/route53/record_test.go
+++ b/internal/service/route53/record_test.go
@@ -112,6 +112,7 @@ func TestParseRecordId(t *testing.T) {
 		{"ABCDEF_prefix._underscore.example.com_A", "ABCDEF", "prefix._underscore.example.com", "A", ""},
 		{"ABCDEF_prefix._underscore.example.com_A_set", "ABCDEF", "prefix._underscore.example.com", "A", "set"},
 		{"ABCDEF_prefix._underscore.example.com_A_set_underscore", "ABCDEF", "prefix._underscore.example.com", "A", "set_underscore"},
+		{"ABCDEF__A", "ABCDEF", "", "A", ""},
 	}
 
 	for _, tc := range cases {
@@ -1403,6 +1404,12 @@ func TestAccRoute53Record_empty(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(ctx, resourceName, &record1),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "weight"},
 			},
 		},
 	})

--- a/website/docs/r/route53_record.html.markdown
+++ b/website/docs/r/route53_record.html.markdown
@@ -210,6 +210,15 @@ import {
 }
 ```
 
+If the record name is the empty string, it can be omitted:
+
+```terraform
+import {
+  to = aws_route53_record.myrecord
+  id = "Z4KAPRWWNC7JR__NS"
+}
+```
+
 **Using `terraform import` to import** Route53 Records using the ID of the record, record name, record type, and set identifier. For example:
 
 Using the ID of the record, which is the zone identifier, record name, and record type, separated by underscores (`_`):


### PR DESCRIPTION
Fixes: #4792





