### PR TITLE
[WIP] Batch Job Queue - Add new parameter `compute_environment_order` that matches AWS API

### DIFF
--- a/internal/service/batch/job_queue.go
+++ b/internal/service/batch/job_queue.go
@@ -119,6 +119,7 @@ func (r *resourceJobQueue) Schema(ctx context.Context, request resource.SchemaRe
 			Delete: true,
 		}),
 		"compute_environment_order": schema.ListNestedBlock{
+			CustomType: fwtypes.NewListNestedObjectTypeOf[computeEnvironmentOrder](ctx),
 			NestedObject: schema.NestedBlockObject{
 				Attributes: map[string]schema.Attribute{
 					"order": schema.Int64Attribute{

--- a/internal/service/batch/job_queue_schema.go
+++ b/internal/service/batch/job_queue_schema.go
@@ -94,7 +94,7 @@ func upgradeJobQueueResourceStateV0toV1(ctx context.Context, req resource.Upgrad
 	jobQueueDataV2 := resourceJobQueueData{
 		ComputeEnvironments: jobQueueDataV0.ComputeEnvironments,
 		ID:                  jobQueueDataV0.ID,
-		Name:                jobQueueDataV0.Name,
+		JobQueueName:        jobQueueDataV0.Name,
 		Priority:            jobQueueDataV0.Priority,
 		State:               jobQueueDataV0.State,
 		Tags:                jobQueueDataV0.Tags,

--- a/internal/service/batch/job_queue_test.go
+++ b/internal/service/batch/job_queue_test.go
@@ -589,7 +589,12 @@ func testAccJobQueueConfig_state(rName string, state string) string {
 		testAccJobQueueConfigBase(rName),
 		fmt.Sprintf(`
 resource "aws_batch_job_queue" "test" {
-  compute_environments = [aws_batch_compute_environment.test.arn]
+//   compute_environments = [aws_batch_compute_environment.test.arn]
+  compute_environment_order {
+    compute_environment = aws_batch_compute_environment.test.arn
+	order = 1
+  }
+
   name                 = %[1]q
   priority             = 1
   state                = %[2]q


### PR DESCRIPTION
Opening this PR very early in development due to a issue I encountered. I haven't worked with the Plugin Framework much other than the tutorials. Its possible I'm missing something small...

```shell
$ make testacc TESTS=TestAccBatchJobQueue_basic PKG=batch
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/batch/... -v -count 1 -parallel 20 -run='TestAccBatchJobQueue_basic'  -timeout 360m
=== RUN   TestAccBatchJobQueue_basic
=== PAUSE TestAccBatchJobQueue_basic
=== CONT  TestAccBatchJobQueue_basic
    job_queue_test.go:30: Step 1/2 error: Error running apply: exit status 1
        
        Error: Value Conversion Error
        
          with aws_batch_job_queue.test,
          on terraform_plugin_test.tf line 96, in resource "aws_batch_job_queue" "test":
          96: resource "aws_batch_job_queue" "test" {
        
        An unexpected error was encountered trying to convert into a Terraform value.
        This is always an error in the provider. Please report the following to the
        provider developer:
        
        Cannot use attr.Value
        types.ListNestedObjectValueOf[github.com/hashicorp/terraform-provider-aws/internal/service/batch.computeEnvironmentOrder],
        only basetypes.ListValue is supported because basetypes.ListType is the type
        in the schema
```