### PR TITLE
`flex.PointersMapToStringList` -> `flex.FlattenStringMap`

### DIFF
--- a/internal/flex/flex.go
+++ b/internal/flex/flex.go
@@ -174,6 +174,12 @@ func FlattenStringValueSet(list []string) *schema.Set {
 	return schema.NewSet(schema.HashString, FlattenStringValueList(list)) // nosemgrep: helper-schema-Set-extraneous-NewSet-with-FlattenStringList
 }
 
+func FlattenStringMap(m map[string]*string) map[string]interface{} {
+	return tfmaps.ApplyToAllValues(m, func(v *string) any {
+		return aws.StringValue(v)
+	})
+}
+
 // Takes the result of schema.Set of strings and returns a []*int64
 func ExpandInt64Set(configured *schema.Set) []*int64 {
 	return ExpandInt64List(configured.List())
@@ -215,15 +221,6 @@ func FlattenFloat64List(list []*float64) []interface{} {
 	return tfslices.ApplyToAll(list, func(v *float64) any {
 		return int(aws.Float64Value(v))
 	})
-}
-
-// TODO -> FlattenStringMap
-func FlattenStringMap(pointers map[string]*string) map[string]interface{} {
-	list := make(map[string]interface{}, len(pointers))
-	for i, v := range pointers {
-		list[i] = *v
-	}
-	return list
 }
 
 // Takes a string of resource attributes separated by the ResourceIdSeparator constant, an expected number of Id Parts, and a boolean specifying if empty parts are to be allowed

--- a/internal/flex/flex.go
+++ b/internal/flex/flex.go
@@ -218,7 +218,7 @@ func FlattenFloat64List(list []*float64) []interface{} {
 }
 
 // TODO -> FlattenStringMap
-func PointersMapToStringList(pointers map[string]*string) map[string]interface{} {
+func FlattenStringMap(pointers map[string]*string) map[string]interface{} {
 	list := make(map[string]interface{}, len(pointers))
 	for i, v := range pointers {
 		list[i] = *v

--- a/internal/maps/maps.go
+++ b/internal/maps/maps.go
@@ -4,7 +4,7 @@
 package maps
 
 // ApplyToAllKeys returns a new map containing the results of applying the function `f` to each key of the original map `m`.
-func ApplyToAllKeys[K1, K2 comparable, V any](m map[K1]V, f func(K1) K2) map[K2]V {
+func ApplyToAllKeys[M ~map[K1]V, K1, K2 comparable, V any](m M, f func(K1) K2) map[K2]V {
 	n := make(map[K2]V, len(m))
 
 	for k, v := range m {
@@ -15,7 +15,7 @@ func ApplyToAllKeys[K1, K2 comparable, V any](m map[K1]V, f func(K1) K2) map[K2]
 }
 
 // ApplyToAllValues returns a new map containing the results of applying the function `f` to each value of the original map `m`.
-func ApplyToAllValues[K comparable, V1, V2 any](m map[K]V1, f func(V1) V2) map[K]V2 {
+func ApplyToAllValues[M ~map[K]V1, K comparable, V1, V2 any](m M, f func(V1) V2) map[K]V2 {
 	n := make(map[K]V2, len(m))
 
 	for k, v := range m {

--- a/internal/service/apigatewayv2/integration.go
+++ b/internal/service/apigatewayv2/integration.go
@@ -273,11 +273,11 @@ func resourceIntegrationRead(ctx context.Context, d *schema.ResourceData, meta i
 	d.Set("integration_uri", resp.IntegrationUri)
 	d.Set("passthrough_behavior", resp.PassthroughBehavior)
 	d.Set("payload_format_version", resp.PayloadFormatVersion)
-	err = d.Set("request_parameters", flex.PointersMapToStringList(resp.RequestParameters))
+	err = d.Set("request_parameters", flex.FlattenStringMap(resp.RequestParameters))
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting request_parameters: %s", err)
 	}
-	err = d.Set("request_templates", flex.PointersMapToStringList(resp.RequestTemplates))
+	err = d.Set("request_templates", flex.FlattenStringMap(resp.RequestTemplates))
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting request_templates: %s", err)
 	}

--- a/internal/service/apigatewayv2/integration_response.go
+++ b/internal/service/apigatewayv2/integration_response.go
@@ -117,7 +117,7 @@ func resourceIntegrationResponseRead(ctx context.Context, d *schema.ResourceData
 
 	d.Set("content_handling_strategy", resp.ContentHandlingStrategy)
 	d.Set("integration_response_key", resp.IntegrationResponseKey)
-	err = d.Set("response_templates", flex.PointersMapToStringList(resp.ResponseTemplates))
+	err = d.Set("response_templates", flex.FlattenStringMap(resp.ResponseTemplates))
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting response_templates: %s", err)
 	}

--- a/internal/service/apigatewayv2/route.go
+++ b/internal/service/apigatewayv2/route.go
@@ -178,7 +178,7 @@ func resourceRouteRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	d.Set("authorizer_id", resp.AuthorizerId)
 	d.Set("model_selection_expression", resp.ModelSelectionExpression)
 	d.Set("operation_name", resp.OperationName)
-	if err := d.Set("request_models", flex.PointersMapToStringList(resp.RequestModels)); err != nil {
+	if err := d.Set("request_models", flex.FlattenStringMap(resp.RequestModels)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting request_models: %s", err)
 	}
 	if err := d.Set("request_parameter", flattenRouteRequestParameters(resp.RequestParameters)); err != nil {

--- a/internal/service/apigatewayv2/route_response.go
+++ b/internal/service/apigatewayv2/route_response.go
@@ -104,7 +104,7 @@ func resourceRouteResponseRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	d.Set("model_selection_expression", resp.ModelSelectionExpression)
-	if err := d.Set("response_models", flex.PointersMapToStringList(resp.ResponseModels)); err != nil {
+	if err := d.Set("response_models", flex.FlattenStringMap(resp.ResponseModels)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting response_models: %s", err)
 	}
 	d.Set("route_response_key", resp.RouteResponseKey)

--- a/internal/service/apigatewayv2/stage.go
+++ b/internal/service/apigatewayv2/stage.go
@@ -301,7 +301,7 @@ func resourceStageRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting route_settings: %s", err)
 	}
-	err = d.Set("stage_variables", flex.PointersMapToStringList(resp.StageVariables))
+	err = d.Set("stage_variables", flex.FlattenStringMap(resp.StageVariables))
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting stage_variables: %s", err)
 	}

--- a/internal/service/ecs/task_definition.go
+++ b/internal/service/ecs/task_definition.go
@@ -1075,11 +1075,11 @@ func flattenDockerVolumeConfiguration(config *ecs.DockerVolumeConfiguration) []i
 	}
 
 	if config.DriverOpts != nil {
-		m["driver_opts"] = flex.PointersMapToStringList(config.DriverOpts)
+		m["driver_opts"] = flex.FlattenStringMap(config.DriverOpts)
 	}
 
 	if v := config.Labels; v != nil {
-		m["labels"] = flex.PointersMapToStringList(v)
+		m["labels"] = flex.FlattenStringMap(v)
 	}
 
 	items = append(items, m)

--- a/internal/service/elasticsearch/domain.go
+++ b/internal/service/elasticsearch/domain.go
@@ -751,7 +751,7 @@ func resourceDomainRead(ctx context.Context, d *schema.ResourceData, meta interf
 		d.Set("access_policies", policies)
 	}
 
-	options := advancedOptionsIgnoreDefault(d.Get("advanced_options").(map[string]interface{}), flex.PointersMapToStringList(ds.AdvancedOptions))
+	options := advancedOptionsIgnoreDefault(d.Get("advanced_options").(map[string]interface{}), flex.FlattenStringMap(ds.AdvancedOptions))
 	if err = d.Set("advanced_options", options); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting advanced_options: %s", err)
 	}
@@ -811,7 +811,7 @@ func resourceDomainRead(ctx context.Context, d *schema.ResourceData, meta interf
 			return sdkdiag.AppendErrorf(diags, "setting vpc_options: %s", err)
 		}
 
-		endpoints := flex.PointersMapToStringList(ds.Endpoints)
+		endpoints := flex.FlattenStringMap(ds.Endpoints)
 		d.Set("endpoint", endpoints["vpc"])
 
 		d.Set("kibana_endpoint", getKibanaEndpoint(d))

--- a/internal/service/elasticsearch/domain_data_source.go
+++ b/internal/service/elasticsearch/domain_data_source.go
@@ -379,7 +379,7 @@ func dataSourceDomainRead(ctx context.Context, d *schema.ResourceData, meta inte
 		d.Set("access_policies", policies)
 	}
 
-	if err := d.Set("advanced_options", flex.PointersMapToStringList(ds.AdvancedOptions)); err != nil {
+	if err := d.Set("advanced_options", flex.FlattenStringMap(ds.AdvancedOptions)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting advanced_options: %s", err)
 	}
 
@@ -423,7 +423,7 @@ func dataSourceDomainRead(ctx context.Context, d *schema.ResourceData, meta inte
 			return sdkdiag.AppendErrorf(diags, "setting vpc_options: %s", err)
 		}
 
-		endpoints := flex.PointersMapToStringList(ds.Endpoints)
+		endpoints := flex.FlattenStringMap(ds.Endpoints)
 		if err := d.Set("endpoint", endpoints["vpc"]); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting endpoint: %s", err)
 		}

--- a/internal/service/kinesisanalyticsv2/application.go
+++ b/internal/service/kinesisanalyticsv2/application.go
@@ -2570,7 +2570,7 @@ func flattenApplicationConfigurationDescription(applicationConfigurationDescript
 			if propertyGroup != nil {
 				mPropertyGroup := map[string]interface{}{
 					"property_group_id": aws.StringValue(propertyGroup.PropertyGroupId),
-					"property_map":      flex.PointersMapToStringList(propertyGroup.PropertyMap),
+					"property_map":      flex.FlattenStringMap(propertyGroup.PropertyMap),
 				}
 
 				vPropertyGroups = append(vPropertyGroups, mPropertyGroup)

--- a/internal/service/kms/grant.go
+++ b/internal/service/kms/grant.go
@@ -461,12 +461,12 @@ func flattenGrantConstraints(constraint *kms.GrantConstraints) *schema.Set {
 	m := make(map[string]interface{})
 	if constraint.EncryptionContextEquals != nil {
 		if len(constraint.EncryptionContextEquals) > 0 {
-			m["encryption_context_equals"] = flex.PointersMapToStringList(constraint.EncryptionContextEquals)
+			m["encryption_context_equals"] = flex.FlattenStringMap(constraint.EncryptionContextEquals)
 		}
 	}
 	if constraint.EncryptionContextSubset != nil {
 		if len(constraint.EncryptionContextSubset) > 0 {
-			m["encryption_context_subset"] = flex.PointersMapToStringList(constraint.EncryptionContextSubset)
+			m["encryption_context_subset"] = flex.FlattenStringMap(constraint.EncryptionContextSubset)
 		}
 	}
 	constraints.Add(m)

--- a/internal/service/opensearch/domain.go
+++ b/internal/service/opensearch/domain.go
@@ -865,7 +865,7 @@ func resourceDomainRead(ctx context.Context, d *schema.ResourceData, meta interf
 		d.Set("access_policies", policies)
 	}
 
-	options := advancedOptionsIgnoreDefault(d.Get("advanced_options").(map[string]interface{}), flex.PointersMapToStringList(ds.AdvancedOptions))
+	options := advancedOptionsIgnoreDefault(d.Get("advanced_options").(map[string]interface{}), flex.FlattenStringMap(ds.AdvancedOptions))
 	if err = d.Set("advanced_options", options); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting advanced_options %v: %s", options, err)
 	}
@@ -928,7 +928,7 @@ func resourceDomainRead(ctx context.Context, d *schema.ResourceData, meta interf
 			return sdkdiag.AppendErrorf(diags, "setting vpc_options: %s", err)
 		}
 
-		endpoints := flex.PointersMapToStringList(ds.Endpoints)
+		endpoints := flex.FlattenStringMap(ds.Endpoints)
 		d.Set("endpoint", endpoints["vpc"])
 		d.Set("dashboard_endpoint", getDashboardEndpoint(d))
 		d.Set("kibana_endpoint", getKibanaEndpoint(d))

--- a/internal/service/opensearch/domain_data_source.go
+++ b/internal/service/opensearch/domain_data_source.go
@@ -441,7 +441,7 @@ func dataSourceDomainRead(ctx context.Context, d *schema.ResourceData, meta inte
 		d.Set("access_policies", policies)
 	}
 
-	if err := d.Set("advanced_options", flex.PointersMapToStringList(ds.AdvancedOptions)); err != nil {
+	if err := d.Set("advanced_options", flex.FlattenStringMap(ds.AdvancedOptions)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting advanced_options: %s", err)
 	}
 
@@ -490,7 +490,7 @@ func dataSourceDomainRead(ctx context.Context, d *schema.ResourceData, meta inte
 			return sdkdiag.AppendErrorf(diags, "setting vpc_options: %s", err)
 		}
 
-		endpoints := flex.PointersMapToStringList(ds.Endpoints)
+		endpoints := flex.FlattenStringMap(ds.Endpoints)
 		if err := d.Set("endpoint", endpoints["vpc"]); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting endpoint: %s", err)
 		}

--- a/internal/slices/slices.go
+++ b/internal/slices/slices.go
@@ -5,10 +5,10 @@ package slices
 
 import "golang.org/x/exp/slices"
 
-// Reverse returns a reversed copy of the slice.
+// Reverse returns a reversed copy of the slice `s`.
 func Reverse[S ~[]E, E any](s S) S {
-	v := S([]E{})
 	n := len(s)
+	v := S(make([]E, 0, n))
 
 	for i := 0; i < n; i++ {
 		v = append(v, s[n-(i+1)])
@@ -17,9 +17,9 @@ func Reverse[S ~[]E, E any](s S) S {
 	return v
 }
 
-// RemoveAll removes all occurrences of the specified value from a slice.
-func RemoveAll[E comparable](s []E, r E) []E {
-	v := []E{}
+// RemoveAll removes all occurrences of the specified value `r` from a slice `s`.
+func RemoveAll[S ~[]E, E comparable](s S, r E) S {
+	v := S(make([]E, 0, len(s)))
 
 	for _, e := range s {
 		if e != r {
@@ -27,12 +27,12 @@ func RemoveAll[E comparable](s []E, r E) []E {
 		}
 	}
 
-	return v
+	return slices.Clip(v)
 }
 
 // ApplyToAll returns a new slice containing the results of applying the function `f` to each element of the original slice `s`.
-func ApplyToAll[T, U any](s []T, f func(T) U) []U {
-	v := make([]U, len(s))
+func ApplyToAll[S ~[]E1, E1, E2 any](s S, f func(E1) E2) []E2 {
+	v := make([]E2, len(s))
 
 	for i, e := range s {
 		v[i] = f(e)
@@ -44,9 +44,9 @@ func ApplyToAll[T, U any](s []T, f func(T) U) []U {
 // Predicate represents a predicate (boolean-valued function) of one argument.
 type Predicate[T any] func(T) bool
 
-// Filter returns a new slice containing all values that return `true` for the filter function `f`
-func Filter[T any](s []T, f Predicate[T]) []T {
-	v := make([]T, 0, len(s))
+// Filter returns a new slice containing all values that return `true` for the filter function `f`.
+func Filter[S ~[]E, E any](s S, f Predicate[E]) S {
+	v := S(make([]E, 0, len(s)))
 
 	for _, e := range s {
 		if f(e) {
@@ -57,8 +57,8 @@ func Filter[T any](s []T, f Predicate[T]) []T {
 	return slices.Clip(v)
 }
 
-// All returns `true` if the filter function `f` retruns `true` for all items
-func All[T any](s []T, f Predicate[T]) bool {
+// All returns `true` if the filter function `f` retruns `true` for all items in slice `s`.
+func All[S ~[]E, E any](s S, f Predicate[E]) bool {
 	for _, e := range s {
 		if !f(e) {
 			return false
@@ -67,8 +67,8 @@ func All[T any](s []T, f Predicate[T]) bool {
 	return true
 }
 
-// Any returns `true` if the filter function `f` retruns `true` for any item
-func Any[T any](s []T, f Predicate[T]) bool {
+// Any returns `true` if the filter function `f` retruns `true` for any item in slice `s`.
+func Any[S ~[]E, E any](s S, f Predicate[E]) bool {
 	for _, e := range s {
 		if f(e) {
 			return true
@@ -95,7 +95,7 @@ func Chunks[S ~[]E, E any](s S, size int) []S {
 }
 
 // AppendUnique appends unique (not already in the slice) values to a slice.
-func AppendUnique[T comparable](s []T, vs ...T) []T {
+func AppendUnique[S ~[]E, E comparable](s S, vs ...E) S {
 	for _, v := range vs {
 		var exists bool
 

--- a/internal/verify/diff_test.go
+++ b/internal/verify/diff_test.go
@@ -148,9 +148,9 @@ func TestDiffStringMaps(t *testing.T) {
 
 	for i, tc := range cases {
 		c, r, u := DiffStringMaps(tc.Old, tc.New)
-		cm := flex.PointersMapToStringList(c)
-		rm := flex.PointersMapToStringList(r)
-		um := flex.PointersMapToStringList(u)
+		cm := flex.FlattenStringMap(c)
+		rm := flex.FlattenStringMap(r)
+		um := flex.FlattenStringMap(u)
 		if !reflect.DeepEqual(cm, tc.Create) {
 			t.Fatalf("%d: bad create: %#v", i, cm)
 		}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Consistent FlEx function naming.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccAPIGatewayV2Integration_' PKG=apigatewayv2 ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/apigatewayv2/... -v -count 1 -parallel 2  -run=TestAccAPIGatewayV2Integration_ -timeout 360m
=== RUN   TestAccAPIGatewayV2Integration_basicWebSocket
=== PAUSE TestAccAPIGatewayV2Integration_basicWebSocket
=== RUN   TestAccAPIGatewayV2Integration_basicHTTP
=== PAUSE TestAccAPIGatewayV2Integration_basicHTTP
=== RUN   TestAccAPIGatewayV2Integration_disappears
=== PAUSE TestAccAPIGatewayV2Integration_disappears
=== RUN   TestAccAPIGatewayV2Integration_dataMappingHTTP
=== PAUSE TestAccAPIGatewayV2Integration_dataMappingHTTP
=== RUN   TestAccAPIGatewayV2Integration_integrationTypeHTTP
=== PAUSE TestAccAPIGatewayV2Integration_integrationTypeHTTP
=== RUN   TestAccAPIGatewayV2Integration_lambdaWebSocket
=== PAUSE TestAccAPIGatewayV2Integration_lambdaWebSocket
=== RUN   TestAccAPIGatewayV2Integration_lambdaHTTP
=== PAUSE TestAccAPIGatewayV2Integration_lambdaHTTP
=== RUN   TestAccAPIGatewayV2Integration_vpcLinkWebSocket
=== PAUSE TestAccAPIGatewayV2Integration_vpcLinkWebSocket
=== RUN   TestAccAPIGatewayV2Integration_vpcLinkHTTP
=== PAUSE TestAccAPIGatewayV2Integration_vpcLinkHTTP
=== RUN   TestAccAPIGatewayV2Integration_serviceIntegration
=== PAUSE TestAccAPIGatewayV2Integration_serviceIntegration
=== CONT  TestAccAPIGatewayV2Integration_basicWebSocket
=== CONT  TestAccAPIGatewayV2Integration_lambdaWebSocket
--- PASS: TestAccAPIGatewayV2Integration_basicWebSocket (26.52s)
=== CONT  TestAccAPIGatewayV2Integration_serviceIntegration
--- PASS: TestAccAPIGatewayV2Integration_lambdaWebSocket (50.79s)
=== CONT  TestAccAPIGatewayV2Integration_vpcLinkHTTP
--- PASS: TestAccAPIGatewayV2Integration_serviceIntegration (69.53s)
=== CONT  TestAccAPIGatewayV2Integration_vpcLinkWebSocket
--- PASS: TestAccAPIGatewayV2Integration_vpcLinkHTTP (258.06s)
=== CONT  TestAccAPIGatewayV2Integration_lambdaHTTP
--- PASS: TestAccAPIGatewayV2Integration_lambdaHTTP (40.76s)
=== CONT  TestAccAPIGatewayV2Integration_dataMappingHTTP
--- PASS: TestAccAPIGatewayV2Integration_dataMappingHTTP (40.68s)
=== CONT  TestAccAPIGatewayV2Integration_integrationTypeHTTP
--- PASS: TestAccAPIGatewayV2Integration_integrationTypeHTTP (52.98s)
=== CONT  TestAccAPIGatewayV2Integration_disappears
--- PASS: TestAccAPIGatewayV2Integration_disappears (21.73s)
=== CONT  TestAccAPIGatewayV2Integration_basicHTTP
--- PASS: TestAccAPIGatewayV2Integration_basicHTTP (23.63s)
--- PASS: TestAccAPIGatewayV2Integration_vpcLinkWebSocket (683.98s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/apigatewayv2	785.794s
```