### PR TITLE
Add AWS SDK for Go v2 logger to acceptance test `Context`

### DIFF
--- a/internal/acctest/context.go
+++ b/internal/acctest/context.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"testing"
 
+	baselogging "github.com/hashicorp/aws-sdk-go-base/v2/logging"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-log/tfsdklog"
 	helperlogging "github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
@@ -16,10 +17,9 @@ func Context(t *testing.T) context.Context {
 	helperlogging.SetOutput(t)
 
 	ctx := context.Background()
-
 	ctx = tfsdklog.RegisterTestSink(ctx, t)
-
 	ctx = logger(ctx, t, "acctest")
+	ctx = awsSDKLogger(ctx)
 
 	return ctx
 }
@@ -38,6 +38,13 @@ func logger(ctx context.Context, t *testing.T, name string) context.Context {
 // testNameContext adds the current test name to loggers.
 func testNameContext(ctx context.Context, testName string) context.Context {
 	ctx = tflog.SetField(ctx, "test_name", testName)
+
+	return ctx
+}
+
+func awsSDKLogger(ctx context.Context) context.Context {
+	ctx, logger := baselogging.NewTfLogger(ctx)
+	ctx = baselogging.RegisterLogger(ctx, logger)
 
 	return ctx
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

AWS SDK for Go v2 HTTP requests and responses made directly from `terraform-plugin-test` `TestCase`s and `TestStep`s (e.g. from the _CheckExists_ and _CheckDestroy_ functions) were missing when `TF_LOG=debug` was defined.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/33936.