### PR TITLE
Update sqs_queue dead letter queue section documentation

### DIFF
--- a/website/docs/r/sqs_queue.html.markdown
+++ b/website/docs/r/sqs_queue.html.markdown
@@ -22,6 +22,7 @@ resource "aws_sqs_queue" "terraform_queue" {
     maxReceiveCount     = 4
   })
 
+
   tags = {
     Environment = "production"
   }
@@ -52,8 +53,21 @@ resource "aws_sqs_queue" "terraform_queue" {
 ## Dead-letter queue
 
 ```terraform
+resource "aws_sqs_queue" "terraform_queue" {
+  name                      = "terraform-example-queue"
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.terraform_queue_deadletter.arn
+    maxReceiveCount     = 4
+  })
+}
+
 resource "aws_sqs_queue" "terraform_queue_deadletter" {
   name = "terraform-example-deadletter-queue"
+}
+
+resource "aws_sqs_queue_redrive_allow_policy" "terraform_queue_redrive_allow_policy" {
+  queue_url = aws_sqs_queue.terraform_queue_deadletter.id
+
   redrive_allow_policy = jsonencode({
     redrivePermission = "byQueue",
     sourceQueueArns   = [aws_sqs_queue.terraform_queue.arn]


### PR DESCRIPTION
### Description
Updated the documentation of the sqs_queue resource related to the dead letter queue. The current documentation will lead developers to a cycle error. The updated documentation shows how to use the aws_sqs_queue_redrive_allow_policy resource to set up a dead letter queue.

### Relations
Closes #34219 

### References
https://github.com/hashicorp/terraform-provider-aws/issues/22577#issuecomment-1326119133