### PR TITLE
Tech debt: Use `errs.IsUnsupportedOperationInPartitionError` instead of `verify.ErrorISOUnsupported`

### DIFF
--- a/internal/errs/unsupported.go
+++ b/internal/errs/unsupported.go
@@ -31,7 +31,7 @@ const (
 // to make an educated guess about whether the problem stems from a feature not being
 // available in a non-standard partitions (e.g. ISO) that is normally available.
 // A return value of `true` means that there is an error AND it suggests a feature is not supported in ISO.
-// Be careful with a return value of `false“, which means either there is NO error
+// Be careful with a return value of `false`, which means either there is NO error
 // or there is an error but not one that suggests an unsupported feature in ISO.
 func IsUnsupportedOperationInPartitionError(partition string, err error) bool {
 	if partition == endpoints.AwsPartitionID {

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -29,6 +29,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
@@ -1313,10 +1314,10 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta inte
 			Attribute:  aws.String(ec2.InstanceAttributeNameDisableApiStop),
 			InstanceId: aws.String(d.Id()),
 		})
-		if err != nil && !verify.ErrorISOUnsupported(meta.(*conns.AWSClient).Partition, err) {
+		if err != nil && !errs.IsUnsupportedOperationInPartitionError(meta.(*conns.AWSClient).Partition, err) {
 			return sdkdiag.AppendErrorf(diags, "getting attribute (%s): %s", ec2.InstanceAttributeNameDisableApiStop, err)
 		}
-		if !verify.ErrorISOUnsupported(meta.(*conns.AWSClient).Partition, err) {
+		if !errs.IsUnsupportedOperationInPartitionError(meta.(*conns.AWSClient).Partition, err) {
 			d.Set("disable_api_stop", attr.DisableApiStop.Value)
 		}
 	}

--- a/internal/service/ecr/repository_data_source.go
+++ b/internal/service/ecr/repository_data_source.go
@@ -13,9 +13,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
-	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"golang.org/x/exp/slices"
 )
 
@@ -121,7 +121,7 @@ func dataSourceRepositoryRead(ctx context.Context, d *schema.ResourceData, meta 
 	tags, err := listTags(ctx, conn, arn)
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
-	if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.ErrorISOUnsupported(conn.PartitionID, err) {
+	if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && errs.IsUnsupportedOperationInPartitionError(conn.PartitionID, err) {
 		log.Printf("[WARN] failed listing tags for ECR Repository (%s): %s", d.Id(), err)
 		return diags
 	}

--- a/internal/service/ecs/task_definition.go
+++ b/internal/service/ecs/task_definition.go
@@ -570,7 +570,7 @@ func resourceTaskDefinitionRead(ctx context.Context, d *schema.ResourceData, met
 	out, err := conn.DescribeTaskDefinitionWithContext(ctx, &input)
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
-	if verify.ErrorISOUnsupported(conn.PartitionID, err) {
+	if errs.IsUnsupportedOperationInPartitionError(conn.PartitionID, err) {
 		log.Printf("[WARN] ECS tagging failed describing Task Definition (%s) with tags: %s; retrying without tags", d.Id(), err)
 
 		input.Include = nil

--- a/internal/service/ecs/task_set.go
+++ b/internal/service/ecs/task_set.go
@@ -384,7 +384,7 @@ func resourceTaskSetRead(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
-	if verify.ErrorISOUnsupported(conn.PartitionID, err) {
+	if errs.IsUnsupportedOperationInPartitionError(conn.PartitionID, err) {
 		log.Printf("[WARN] ECS tagging failed describing Task Set (%s) with tags: %s; retrying without tags", d.Id(), err)
 
 		input.Include = nil

--- a/internal/service/elasticache/cluster_data_source.go
+++ b/internal/service/elasticache/cluster_data_source.go
@@ -13,10 +13,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
-	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 // @SDKDataSource("aws_elasticache_cluster")
@@ -230,7 +230,7 @@ func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta int
 
 	tags, err := listTags(ctx, conn, aws.StringValue(cluster.ARN))
 
-	if err != nil && !verify.ErrorISOUnsupported(conn.PartitionID, err) {
+	if err != nil && !errs.IsUnsupportedOperationInPartitionError(conn.PartitionID, err) {
 		return sdkdiag.AppendErrorf(diags, "listing tags for ElastiCache Cluster (%s): %s", d.Id(), err)
 	}
 

--- a/internal/service/elasticache/parameter_group.go
+++ b/internal/service/elasticache/parameter_group.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -102,7 +103,7 @@ func resourceParameterGroupCreate(ctx context.Context, d *schema.ResourceData, m
 
 	output, err := conn.CreateCacheParameterGroupWithContext(ctx, input)
 
-	if input.Tags != nil && verify.ErrorISOUnsupported(conn.PartitionID, err) {
+	if input.Tags != nil && errs.IsUnsupportedOperationInPartitionError(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating ElastiCache Parameter Group with tags: %s. Trying create without tags.", err)
 
 		input.Tags = nil

--- a/internal/service/elbv2/listener_data_source.go
+++ b/internal/service/elbv2/listener_data_source.go
@@ -14,9 +14,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
-	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 // @SDKDataSource("aws_alb_listener")
@@ -353,7 +353,7 @@ func dataSourceListenerRead(ctx context.Context, d *schema.ResourceData, meta in
 
 	tags, err := listTags(ctx, conn, d.Id())
 
-	if verify.ErrorISOUnsupported(conn.PartitionID, err) {
+	if errs.IsUnsupportedOperationInPartitionError(conn.PartitionID, err) {
 		log.Printf("[WARN] Unable to list tags for ELBv2 Listener %s: %s", d.Id(), err)
 		return diags
 	}

--- a/internal/service/elbv2/load_balancer_data_source.go
+++ b/internal/service/elbv2/load_balancer_data_source.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
@@ -322,7 +323,7 @@ func dataSourceLoadBalancerRead(ctx context.Context, d *schema.ResourceData, met
 
 	tags, err := listTags(ctx, conn, d.Id())
 
-	if verify.ErrorISOUnsupported(conn.PartitionID, err) {
+	if errs.IsUnsupportedOperationInPartitionError(conn.PartitionID, err) {
 		log.Printf("[WARN] Unable to list tags for ELBv2 Load Balancer %s: %s", d.Id(), err)
 		return diags
 	}

--- a/internal/service/elbv2/target_group_data_source.go
+++ b/internal/service/elbv2/target_group_data_source.go
@@ -15,9 +15,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
-	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 // @SDKDataSource("aws_alb_target_group")
@@ -307,7 +307,7 @@ func dataSourceTargetGroupRead(ctx context.Context, d *schema.ResourceData, meta
 
 	tags, err := listTags(ctx, conn, d.Id())
 
-	if verify.ErrorISOUnsupported(conn.PartitionID, err) {
+	if errs.IsUnsupportedOperationInPartitionError(conn.PartitionID, err) {
 		log.Printf("[WARN] Unable to list tags for ELBv2 Target Group %s: %s", d.Id(), err)
 		return diags
 	}

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -4,8 +4,6 @@
 package verify
 
 import (
-	"github.com/aws/aws-sdk-go/aws/endpoints"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"gopkg.in/yaml.v2"
 )
 
@@ -36,100 +34,4 @@ func checkYAMLString(yamlString interface{}) (string, error) {
 	err := yaml.Unmarshal([]byte(s), &y)
 
 	return s, err
-}
-
-const (
-	ErrCodeAccessDenied                = "AccessDenied"
-	ErrCodeAuthorizationError          = "AuthorizationError"
-	ErrCodeInternalException           = "InternalException"
-	ErrCodeInternalServiceError        = "InternalServiceError"
-	ErrCodeInvalidAction               = "InvalidAction"
-	ErrCodeInvalidParameterException   = "InvalidParameterException"
-	ErrCodeInvalidParameterValue       = "InvalidParameterValue"
-	ErrCodeInvalidRequest              = "InvalidRequest"
-	ErrCodeOperationDisabledException  = "OperationDisabledException"
-	ErrCodeOperationNotPermitted       = "OperationNotPermitted"
-	ErrCodeUnknownOperationException   = "UnknownOperationException"
-	ErrCodeUnsupportedFeatureException = "UnsupportedFeatureException"
-	ErrCodeUnsupportedOperation        = "UnsupportedOperation"
-	ErrCodeValidationError             = "ValidationError"
-	ErrCodeValidationException         = "ValidationException"
-)
-
-// ErrorISOUnsupported checks the partition and specific error to make
-// an educated guess about whether the problem stems from a feature not being
-// available in ISO (or non standard partitions) that is normally available.
-// true means that there is an error AND it suggests a feature is not supported
-// in ISO. Be careful with false, which means either there is NO error or there
-// is an error but not one that suggests an unsupported feature in ISO.
-func ErrorISOUnsupported(partition string, err error) bool {
-	if partition == endpoints.AwsPartitionID {
-		return false
-	}
-
-	if err == nil { // not strictly necessary but make logic clearer
-		return false
-	}
-
-	if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) {
-		return true
-	}
-
-	if tfawserr.ErrCodeContains(err, ErrCodeAuthorizationError) {
-		return true
-	}
-
-	if tfawserr.ErrCodeContains(err, ErrCodeInternalException) {
-		return true
-	}
-
-	if tfawserr.ErrCodeContains(err, ErrCodeInternalServiceError) {
-		return true
-	}
-
-	if tfawserr.ErrCodeContains(err, ErrCodeInvalidAction) {
-		return true
-	}
-
-	if tfawserr.ErrCodeContains(err, ErrCodeInvalidParameterException) {
-		return true
-	}
-
-	if tfawserr.ErrCodeContains(err, ErrCodeInvalidParameterValue) {
-		return true
-	}
-
-	if tfawserr.ErrCodeContains(err, ErrCodeInvalidRequest) {
-		return true
-	}
-
-	if tfawserr.ErrCodeContains(err, ErrCodeOperationDisabledException) {
-		return true
-	}
-
-	if tfawserr.ErrCodeContains(err, ErrCodeOperationNotPermitted) {
-		return true
-	}
-
-	if tfawserr.ErrCodeContains(err, ErrCodeUnknownOperationException) {
-		return true
-	}
-
-	if tfawserr.ErrCodeContains(err, ErrCodeUnsupportedFeatureException) {
-		return true
-	}
-
-	if tfawserr.ErrCodeContains(err, ErrCodeUnsupportedOperation) {
-		return true
-	}
-
-	if tfawserr.ErrMessageContains(err, ErrCodeValidationError, "not support tagging") {
-		return true
-	}
-
-	if tfawserr.ErrCodeContains(err, ErrCodeValidationException) {
-		return true
-	}
-
-	return false
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Replace `verify.ErrorISOUnsupported` with `errs.IsUnsupportedOperationInPartitionError`, which supports AWS SDK for Go v2 errors.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccEC2Instance_basic' PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccEC2Instance_basic -timeout 360m
=== RUN   TestAccEC2Instance_basic
=== PAUSE TestAccEC2Instance_basic
=== RUN   TestAccEC2Instance_basicWithSpot
=== PAUSE TestAccEC2Instance_basicWithSpot
=== CONT  TestAccEC2Instance_basic
=== CONT  TestAccEC2Instance_basicWithSpot
--- PASS: TestAccEC2Instance_basicWithSpot (91.66s)
--- PASS: TestAccEC2Instance_basic (123.64s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	129.271s
% make testacc TESTARGS='-run=TestAccECSTaskDefinition_basic' PKG=ecs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 20  -run=TestAccECSTaskDefinition_basic -timeout 360m
=== RUN   TestAccECSTaskDefinition_basic
=== PAUSE TestAccECSTaskDefinition_basic
=== CONT  TestAccECSTaskDefinition_basic
--- PASS: TestAccECSTaskDefinition_basic (40.72s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	46.702s
```