### PR TITLE
fix resourceDashboardUpdate

### DIFF
--- a/.changelog/34227.txt
+++ b/.changelog/34227.txt
@@ -1,3 +1,11 @@
 ```release-note:bug
 resource/aws_quicksight_dashboard: Fix failure when updating a dashboard takes a while
 ```
+
+```release-note:bug
+resource/aws_quicksight_template: Fix "a number is required" errors when state contains an empty string
+```
+
+```release-note:bug
+resource/aws_quicksight_template: Fix "Invalid address to set" errors
+```

--- a/.changelog/34227.txt
+++ b/.changelog/34227.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_quicksight_dashboard: Fix failure when updating a dashboard takes a while
+```

--- a/internal/service/quicksight/dashboard.go
+++ b/internal/service/quicksight/dashboard.go
@@ -138,7 +138,7 @@ func ResourceDashboard() *schema.Resource {
 }
 
 const (
-	ResNameDashboard = "Dashboard"
+	ResNameDashboard             = "Dashboard"
 	DashboardLatestVersion int64 = -1
 )
 

--- a/internal/service/quicksight/dashboard_test.go
+++ b/internal/service/quicksight/dashboard_test.go
@@ -125,7 +125,7 @@ func TestAccQuickSightDashboard_updateVersionNumber(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var dashboard quicksight.Dashboard
-  var dashboardV1 quicksight.Dashboard
+	var dashboardV1 quicksight.Dashboard
 	resourceName := "aws_quicksight_dashboard.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rNameUpdated := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/quicksight/dashboard_test.go
+++ b/internal/service/quicksight/dashboard_test.go
@@ -206,7 +206,7 @@ func testAccCheckDashboardDestroy(ctx context.Context) resource.TestCheckFunc {
 				continue
 			}
 
-			output, err := tfquicksight.FindDashboardByID(ctx, conn, rs.Primary.ID)
+			output, err := tfquicksight.FindDashboardByID(ctx, conn, rs.Primary.ID, -1)
 			if err != nil {
 				if tfawserr.ErrCodeEquals(err, quicksight.ErrCodeResourceNotFoundException) {
 					return nil
@@ -235,7 +235,7 @@ func testAccCheckDashboardExists(ctx context.Context, name string, dashboard *qu
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).QuickSightConn(ctx)
-		output, err := tfquicksight.FindDashboardByID(ctx, conn, rs.Primary.ID)
+		output, err := tfquicksight.FindDashboardByID(ctx, conn, rs.Primary.ID, -1)
 
 		if err != nil {
 			return create.Error(names.QuickSight, create.ErrActionCheckingExistence, tfquicksight.ResNameDashboard, rs.Primary.ID, err)

--- a/internal/service/quicksight/dashboard_test.go
+++ b/internal/service/quicksight/dashboard_test.go
@@ -125,6 +125,7 @@ func TestAccQuickSightDashboard_updateVersionNumber(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var dashboard quicksight.Dashboard
+  var dashboardV1 quicksight.Dashboard
 	resourceName := "aws_quicksight_dashboard.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rNameUpdated := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -151,13 +152,13 @@ func TestAccQuickSightDashboard_updateVersionNumber(t *testing.T) {
 			{
 				Config: testAccDashboardConfig_basic(rId, rNameUpdated),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDashboardExists(ctx, resourceName, &dashboard),
+					testAccCheckDashboardExists(ctx, resourceName, &dashboardV1),
 					resource.TestCheckResourceAttr(resourceName, "dashboard_id", rId),
 					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
 					resource.TestCheckResourceAttr(resourceName, "status", quicksight.ResourceStatusCreationSuccessful),
 					resource.TestCheckResourceAttr(resourceName, "version_number", "2"),
-					testAccCheckDashboardVersionExists(ctx, resourceName, 1, &dashboard),
-					testAccCheckDashboardName(&dashboard, rName),
+					testAccCheckDashboardVersionExists(ctx, resourceName, 1, &dashboardV1),
+					testAccCheckDashboardName(&dashboardV1, rName),
 				),
 			},
 		},

--- a/internal/service/quicksight/dashboard_test.go
+++ b/internal/service/quicksight/dashboard_test.go
@@ -208,7 +208,7 @@ func testAccCheckDashboardDestroy(ctx context.Context) resource.TestCheckFunc {
 				continue
 			}
 
-			output, err := tfquicksight.FindDashboardByID(ctx, conn, rs.Primary.ID, -1)
+			output, err := tfquicksight.FindDashboardByID(ctx, conn, rs.Primary.ID, tfquicksight.DashboardLatestVersion)
 			if err != nil {
 				if tfawserr.ErrCodeEquals(err, quicksight.ErrCodeResourceNotFoundException) {
 					return nil
@@ -226,7 +226,7 @@ func testAccCheckDashboardDestroy(ctx context.Context) resource.TestCheckFunc {
 }
 
 func testAccCheckDashboardExists(ctx context.Context, name string, dashboard *quicksight.Dashboard) resource.TestCheckFunc {
-	return testAccCheckDashboardVersionExists(ctx, name, -1, dashboard)
+	return testAccCheckDashboardVersionExists(ctx, name, tfquicksight.DashboardLatestVersion, dashboard)
 }
 
 func testAccCheckDashboardVersionExists(ctx context.Context, name string, version int64, dashboard *quicksight.Dashboard) resource.TestCheckFunc {

--- a/internal/service/quicksight/schema/template_sheet.go
+++ b/internal/service/quicksight/schema/template_sheet.go
@@ -1284,11 +1284,15 @@ func expandGridLayoutElement(tfMap map[string]interface{}) *quicksight.GridLayou
 	if v, ok := tfMap["row_span"].(int); ok && v != 0 {
 		layout.RowSpan = aws.Int64(int64(v))
 	}
-	if v, null, _ := nullable.Int(tfMap["column_index"].(string)).Value(); !null {
-		layout.ColumnIndex = aws.Int64(v)
+	if v, ok := tfMap["column_index"].(string); ok && v != "" {
+		if i, null, _ := nullable.Int(v).Value(); !null {
+			layout.ColumnIndex = aws.Int64(i)
+		}
 	}
-	if v, null, _ := nullable.Int(tfMap["row_index"].(string)).Value(); !null {
-		layout.RowIndex = aws.Int64(v)
+	if v, ok := tfMap["row_index"].(string); ok && v != "" {
+		if i, null, _ := nullable.Int(v).Value(); !null {
+			layout.RowIndex = aws.Int64(i)
+		}
 	}
 
 	return layout
@@ -1739,7 +1743,7 @@ func flattenFreeFormLayoutCanvasSizeOptions(apiObject *quicksight.FreeFormLayout
 
 	tfMap := map[string]interface{}{}
 	if apiObject.ScreenCanvasSizeOptions != nil {
-		tfMap["canvas_size_options"] = flattenFreeFormLayoutScreenCanvasSizeOptions(apiObject.ScreenCanvasSizeOptions)
+		tfMap["screen_canvas_size_options"] = flattenFreeFormLayoutScreenCanvasSizeOptions(apiObject.ScreenCanvasSizeOptions)
 	}
 
 	return []interface{}{tfMap}

--- a/internal/service/quicksight/schema/visual_table.go
+++ b/internal/service/quicksight/schema/visual_table.go
@@ -1091,7 +1091,7 @@ func flattenTableFieldOption(apiObject []*quicksight.TableFieldOption) []interfa
 			tfMap["url_styling"] = flattenTableFieldURLConfiguration(config.URLStyling)
 		}
 		if config.Visibility != nil {
-			tfMap["visbility"] = aws.StringValue(config.Visibility)
+			tfMap["visibility"] = aws.StringValue(config.Visibility)
 		}
 		if config.Width != nil {
 			tfMap["width"] = aws.StringValue(config.Width)

--- a/internal/service/quicksight/status.go
+++ b/internal/service/quicksight/status.go
@@ -51,9 +51,9 @@ func statusTemplate(ctx context.Context, conn *quicksight.QuickSight, id string)
 }
 
 // Fetch Dashboard status
-func statusDashboard(ctx context.Context, conn *quicksight.QuickSight, id string) retry.StateRefreshFunc {
+func statusDashboard(ctx context.Context, conn *quicksight.QuickSight, id string, version int64) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		out, err := FindDashboardByID(ctx, conn, id)
+		out, err := FindDashboardByID(ctx, conn, id, version)
 		if tfresource.NotFound(err) {
 			return nil, "", nil
 		}

--- a/internal/service/quicksight/wait.go
+++ b/internal/service/quicksight/wait.go
@@ -133,7 +133,7 @@ func waitDashboardCreated(ctx context.Context, conn *quicksight.QuickSight, id s
 	stateConf := &retry.StateChangeConf{
 		Pending:                   []string{quicksight.ResourceStatusCreationInProgress},
 		Target:                    []string{quicksight.ResourceStatusCreationSuccessful},
-		Refresh:                   statusDashboard(ctx, conn, id, -1),
+		Refresh:                   statusDashboard(ctx, conn, id, DashboardLatestVersion),
 		Timeout:                   timeout,
 		NotFoundChecks:            20,
 		ContinuousTargetOccurence: 2,

--- a/internal/service/quicksight/wait.go
+++ b/internal/service/quicksight/wait.go
@@ -133,7 +133,7 @@ func waitDashboardCreated(ctx context.Context, conn *quicksight.QuickSight, id s
 	stateConf := &retry.StateChangeConf{
 		Pending:                   []string{quicksight.ResourceStatusCreationInProgress},
 		Target:                    []string{quicksight.ResourceStatusCreationSuccessful},
-		Refresh:                   statusDashboard(ctx, conn, id),
+		Refresh:                   statusDashboard(ctx, conn, id, -1),
 		Timeout:                   timeout,
 		NotFoundChecks:            20,
 		ContinuousTargetOccurence: 2,
@@ -161,11 +161,11 @@ func waitDashboardCreated(ctx context.Context, conn *quicksight.QuickSight, id s
 	return nil, err
 }
 
-func waitDashboardUpdated(ctx context.Context, conn *quicksight.QuickSight, id string, timeout time.Duration) (*quicksight.Dashboard, error) {
+func waitDashboardUpdated(ctx context.Context, conn *quicksight.QuickSight, id string, version int64, timeout time.Duration) (*quicksight.Dashboard, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending:                   []string{quicksight.ResourceStatusUpdateInProgress, quicksight.ResourceStatusCreationInProgress},
 		Target:                    []string{quicksight.ResourceStatusUpdateSuccessful, quicksight.ResourceStatusCreationSuccessful},
-		Refresh:                   statusDashboard(ctx, conn, id),
+		Refresh:                   statusDashboard(ctx, conn, id, version),
 		Timeout:                   timeout,
 		NotFoundChecks:            20,
 		ContinuousTargetOccurence: 2,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR addresses a bug in the aws_quicksight_dashboard resource.

When terraform updates a dashboard resource, two AWS API calls are made. The first updates the dashboard which results in a new dashboard version. The second call should update the published version of the dashboard to the new version.

The bug manifests when the first call takes a little time, which results in the second call returning an error about the dashboard creation still being in progress.

This is because the provider waits for the dashboard status to change to creation successful, however the API call used is checking the current published version, not the new version just made. As such it returns early and doesn’t actually wait.

This PR fixes this by explicitly waiting for the new version of the dashboard to be created before trying to update the published version.

Additionally this PR fixes two minor typo issues, and an issue caused when the state file for a template contains an empty string, resulting in "Error: a number is required" errors.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->
Closes #33463
Closes #35109

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Redacted screenshot showing the failure:
![image-20230824-081431](https://github.com/hashicorp/terraform-provider-aws/assets/17053612/85e161d8-01b5-4d97-9adf-a8782e55f137)


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccQuickSightDashboard PKG=quicksight
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/quicksight/... -v -count 1 -parallel 20 -run='TestAccQuickSightDashboard'  -timeout 360m
?       github.com/hashicorp/terraform-provider-aws/internal/service/quicksight/schema  [no test files]
=== RUN   TestAccQuickSightDashboard_basic
=== PAUSE TestAccQuickSightDashboard_basic
=== RUN   TestAccQuickSightDashboard_disappears
=== PAUSE TestAccQuickSightDashboard_disappears
=== RUN   TestAccQuickSightDashboard_sourceEntity
=== PAUSE TestAccQuickSightDashboard_sourceEntity
=== RUN   TestAccQuickSightDashboard_updateVersionNumber
=== PAUSE TestAccQuickSightDashboard_updateVersionNumber
=== RUN   TestAccQuickSightDashboard_dashboardSpecificConfig
=== PAUSE TestAccQuickSightDashboard_dashboardSpecificConfig
=== CONT  TestAccQuickSightDashboard_basic
=== CONT  TestAccQuickSightDashboard_updateVersionNumber
=== CONT  TestAccQuickSightDashboard_sourceEntity
=== CONT  TestAccQuickSightDashboard_dashboardSpecificConfig
=== CONT  TestAccQuickSightDashboard_disappears
--- PASS: TestAccQuickSightDashboard_disappears (40.98s)
--- PASS: TestAccQuickSightDashboard_dashboardSpecificConfig (45.02s)
--- PASS: TestAccQuickSightDashboard_basic (45.43s)
--- PASS: TestAccQuickSightDashboard_sourceEntity (48.19s)
--- PASS: TestAccQuickSightDashboard_updateVersionNumber (95.68s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/quicksight 99.768s
```
