### PR TITLE
remove deprecated threshold field references

### DIFF
--- a/website/docs/r/ce_anomaly_subscription.html.markdown
+++ b/website/docs/r/ce_anomaly_subscription.html.markdown
@@ -23,7 +23,6 @@ resource "aws_ce_anomaly_monitor" "test" {
 
 resource "aws_ce_anomaly_subscription" "test" {
   name      = "DAILYSUBSCRIPTION"
-  threshold = 100
   frequency = "DAILY"
 
   monitor_arn_list = [
@@ -180,7 +179,6 @@ resource "aws_ce_anomaly_monitor" "anomaly_monitor" {
 
 resource "aws_ce_anomaly_subscription" "realtime_subscription" {
   name      = "RealtimeAnomalySubscription"
-  threshold = 0
   frequency = "IMMEDIATE"
 
   monitor_arn_list = [
@@ -209,7 +207,6 @@ The following arguments are required:
 * `subscriber` - (Required) A subscriber configuration. Multiple subscribers can be defined.
     * `type` - (Required) The type of subscription. Valid Values: `SNS` | `EMAIL`.
     * `address` - (Required) The address of the subscriber. If type is `SNS`, this will be the arn of the sns topic. If type is `EMAIL`, this will be the destination email address.
-* `threshold` - (Optional) The dollar value that triggers a notification if the threshold is exceeded. Depracated, use `threshold_expression` instead.
 * `threshold_expression` - (Optional) An Expression object used to specify the anomalies that you want to generate alerts for. See [Threshold Expression](#threshold-expression).
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 


### PR DESCRIPTION
### Description
Remove mentions of the deprecated _threshold_ variable from aws_ce_anomaly_subscription documentation.

### Relations

Closes #33947

