### PR TITLE
r/aws_quicksight: fix window_options.bounds validator

### DIFF
--- a/.changelog/34230.txt
+++ b/.changelog/34230.txt
@@ -1,0 +1,9 @@
+```release-note:bug
+resource/aws_quicksight_analysis: Fix "expected type to be integer" errors in `window_options.bounds.*` argument validatation functions
+```
+```release-note:bug
+resource/aws_quicksight_dashboard: Fix "expected type to be integer" errors in `window_options.bounds.*` argument validatation functions
+```
+```release-note:bug
+resource/aws_quicksight_template: Fix "expected type to be integer" errors in `window_options.bounds.*` argument validatation functions
+```

--- a/internal/service/quicksight/schema/visual_map.go
+++ b/internal/service/quicksight/schema/visual_map.go
@@ -42,22 +42,22 @@ func geospatialWindowOptionsSchema() *schema.Schema {
 							"east": {
 								Type:         schema.TypeFloat,
 								Required:     true,
-								ValidateFunc: validation.IntBetween(-1800, 1800),
+								ValidateFunc: validation.FloatBetween(-1800, 1800),
 							},
 							"north": {
 								Type:         schema.TypeFloat,
 								Required:     true,
-								ValidateFunc: validation.IntBetween(-90, 90),
+								ValidateFunc: validation.FloatBetween(-90, 90),
 							},
 							"south": {
 								Type:         schema.TypeFloat,
 								Required:     true,
-								ValidateFunc: validation.IntBetween(-90, 90),
+								ValidateFunc: validation.FloatBetween(-90, 90),
 							},
 							"west": {
 								Type:         schema.TypeFloat,
 								Required:     true,
-								ValidateFunc: validation.IntBetween(-1800, 1800),
+								ValidateFunc: validation.FloatBetween(-1800, 1800),
 							},
 						},
 					},


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The various nested bounds arguments all contained validation functions checking for integer ranges, but were TypeFloat types. Changing the validation function to one which expects float types should resolve static validation failures.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #33223

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=quicksight TESTS="TestAccQuickSightAnalysis_|TestAccQuickSightDashboard_|TestAccQuickSightTemplate_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/quicksight/... -v -count 1 -parallel 20 -run='TestAccQuickSightAnalysis_|TestAccQuickSightDashboard_|TestAccQuickSightTemplate_'  -timeout 360m
?       github.com/hashicorp/terraform-provider-aws/internal/service/quicksight/schema  [no test files]

--- PASS: TestAccQuickSightTemplate_basic (1130.62s)
--- PASS: TestAccQuickSightTemplate_barChart (1140.09s)
--- PASS: TestAccQuickSightTemplate_disappears (1161.07s)
--- PASS: TestAccQuickSightTemplate_sourceEntity (1183.78s)
--- PASS: TestAccQuickSightAnalysis_forceDelete (1184.10s)
--- PASS: TestAccQuickSightDashboard_dashboardSpecificConfig (1198.54s)
--- PASS: TestAccQuickSightAnalysis_parametersConfig (1203.77s)
--- PASS: TestAccQuickSightAnalysis_Definition_calculatedFields (1203.95s)
--- PASS: TestAccQuickSightAnalysis_basic (1211.27s)
--- PASS: TestAccQuickSightAnalysis_disappears (1211.73s)
--- PASS: TestAccQuickSightDashboard_basic (1211.93s)
--- PASS: TestAccQuickSightDashboard_disappears (1218.40s)
--- PASS: TestAccQuickSightAnalysis_sourceEntity (1240.86s)
--- PASS: TestAccQuickSightDashboard_sourceEntity (1242.13s)
--- PASS: TestAccQuickSightTemplate_table (1403.49s)
--- PASS: TestAccQuickSightTemplate_update (1429.50s)
--- PASS: TestAccQuickSightDashboard_updateVersionNumber (1496.88s)
--- PASS: TestAccQuickSightAnalysis_update (1498.78s)
--- PASS: TestAccQuickSightTemplate_tags (1571.05s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/quicksight 1574.349s
```
