### PR TITLE
docs: Update compatible runtime limit for lambada_layer_version

### DIFF
--- a/website/docs/r/lambda_layer_version.html.markdown
+++ b/website/docs/r/lambda_layer_version.html.markdown
@@ -45,7 +45,7 @@ The following arguments are required:
 The following arguments are optional:
 
 * `compatible_architectures` - (Optional) List of [Architectures][4] this layer is compatible with. Currently `x86_64` and `arm64` can be specified.
-* `compatible_runtimes` - (Optional) List of [Runtimes][2] this layer is compatible with. Up to 5 runtimes can be specified.
+* `compatible_runtimes` - (Optional) List of [Runtimes][2] this layer is compatible with. Up to 15 runtimes can be specified.
 * `description` - (Optional) Description of what your Lambda Layer does.
 * `filename` (Optional) Path to the function's deployment package within the local filesystem. If defined, The `s3_`-prefixed options cannot be used.
 * `license_info` - (Optional) License info for your Lambda Layer. See [License Info][3].


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is a doc update for the `compatible_runtimes` argument description for the `aws_lambda_layer_version` resource to change the max # of items of the list from 5 to 15.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #27375

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
n/a

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
n/a