### PR TITLE
docs: Added service_role_arn conditional req for aws_appsync_datasource

### DIFF
--- a/website/docs/r/appsync_datasource.html.markdown
+++ b/website/docs/r/appsync_datasource.html.markdown
@@ -88,7 +88,7 @@ This resource supports the following arguments:
 * `lambda_config` - (Optional) AWS Lambda settings. See [Lambda Config](#lambda-config)
 * `opensearchservice_config` - (Optional) Amazon OpenSearch Service settings. See [OpenSearch Service Config](#opensearch-service-config)
 * `relational_database_config` (Optional) AWS RDS settings. See [Relational Database Config](#relational-database-config)
-* `service_role_arn` - (Optional) IAM service role ARN for the data source.
+* `service_role_arn` - (Optional) IAM service role ARN for the data source. Required if `type` is specified as `AWS_LAMBDA`, `AMAZON_DYNAMODB`, `AMAZON_ELASTICSEARCH`, `AMAZON_EVENTBRIDGE`, or `AMAZON_OPENSEARCH_SERVICE`.
 
 ### DynamoDB Config
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is a doc update for the `service_role_arn` argument description for the `aws_appsync_datasource` resource to include the conditions under which the argument is required (when `type` is of certain values).

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #27498

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- AWS doc reference: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-datasource.html#cfn-appsync-datasource-servicerolearn

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
n/a