### PR TITLE
docs: Fix desc of custom_datatype_configured arg for aws_glue_classifier

### DIFF
--- a/website/docs/r/glue_classifier.html.markdown
+++ b/website/docs/r/glue_classifier.html.markdown
@@ -83,7 +83,7 @@ This resource supports the following arguments:
 
 * `allow_single_column` - (Optional) Enables the processing of files that contain only one column.
 * `contains_header` - (Optional) Indicates whether the CSV file contains a header. This can be one of "ABSENT", "PRESENT", or "UNKNOWN".
-* `custom_datatype_configured` - (Optional) A custom symbol to denote what combines content into a single column value. It must be different from the column delimiter.
+* `custom_datatype_configured` - (Optional) Enables the custom datatype to be configured.
 * `custom_datatypes` - (Optional) A list of supported custom datatypes. Valid values are `BINARY`, `BOOLEAN`, `DATE`, `DECIMAL`, `DOUBLE`, `FLOAT`, `INT`, `LONG`, `SHORT`, `STRING`, `TIMESTAMP`.
 * `delimiter` - (Optional) The delimiter used in the Csv to separate columns.
 * `disable_value_trimming` - (Optional) Specifies whether to trim column values.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is a doc update for the `custom_datatype_configured` argument description for the `aws_glue_classifier` resource to align with the description in the AWS API reference. The original description was inaccurate/incorrect.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #33548

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- [Classifier API](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-crawler-classifiers.html)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
n/a