### PR TITLE
r/aws_appflow_connector_profile: add salesforce jwt_token and oauth2_grant_type arguments

### DIFF
--- a/.changelog/34248.txt
+++ b/.changelog/34248.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_appflow_connector_profile: Add `jwt_token` and `oauth2_grant_type` arguments to the `connector_profile_config.connector_profile_credentials.salesforce` block.
+```

--- a/internal/service/appflow/connector_profile.go
+++ b/internal/service/appflow/connector_profile.go
@@ -560,6 +560,16 @@ func ResourceConnectorProfile() *schema.Resource {
 													Optional:     true,
 													ValidateFunc: verify.ValidARN,
 												},
+												"jwt_token": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validation.StringLenBetween(1, 8000),
+												},
+												"oauth2_grant_type": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validation.StringInSlice(appflow.OAuth2GrantType_Values(), false),
+												},
 												"oauth_request": {
 													Type:     schema.TypeList,
 													Optional: true,
@@ -1719,6 +1729,12 @@ func expandSalesforceConnectorProfileCredentials(m map[string]interface{}) *appf
 	}
 	if v, ok := m["client_credentials_arn"].(string); ok && v != "" {
 		credentials.ClientCredentialsArn = aws.String(v)
+	}
+	if v, ok := m["jwt_token"].(string); ok && v != "" {
+		credentials.JwtToken = aws.String(v)
+	}
+	if v, ok := m["oauth2_grant_type"].(string); ok && v != "" {
+		credentials.OAuth2GrantType = aws.String(v)
 	}
 	if v, ok := m["oauth_request"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 		credentials.OAuthRequest = expandOAuthRequest(v[0].(map[string]interface{}))

--- a/website/docs/r/appflow_connector_profile.html.markdown
+++ b/website/docs/r/appflow_connector_profile.html.markdown
@@ -186,6 +186,8 @@ The AppFlow connector profile argument layout is a complex structure. The follow
 
 * `access_token` (Optional) - The credentials used to access protected Salesforce resources.
 * `client_credentials_arn` (Optional) - The secret manager ARN, which contains the client ID and client secret of the connected app.
+* `jwt_token` (Optional) - A JSON web token (JWT) that authorizes access to Salesforce records.
+* `oauth2_grant_type` (Optional) - The OAuth 2.0 grant type used when requesting an access token from Salesforce. Valid values are `CLIENT_CREDENTIALS`, `AUTHORIZATION_CODE`, and `JWT_BEARER`.
 * `oauth_request` (Optional) - The OAuth requirement needed to request security tokens from the connector endpoint. See [OAuth Request](#oauth-request) for more details.
 * `refresh_token` (Optional) - The credentials used to acquire new access tokens.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds support for JWT related arguments in the `salesforce` configuration block.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #31306

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=appflow TESTS=TestAccAppFlowConnectorProfile_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/appflow/... -v -count 1 -parallel 20 -run='TestAccAppFlowConnectorProfile_'  -timeout 360m

--- PASS: TestAccAppFlowConnectorProfile_basic (574.54s)
--- PASS: TestAccAppFlowConnectorProfile_disappears (588.36s)
--- PASS: TestAccAppFlowConnectorProfile_update (764.88s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appflow    768.024s
```
