### PR TITLE
Tech debt: Replace `verify.SliceContainsString`

### DIFF
--- a/internal/service/cloudfront/origin_access_identities_data_source.go
+++ b/internal/service/cloudfront/origin_access_identities_data_source.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
-	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 )
 
 // @SDKDataSource("aws_cloudfront_origin_access_identities")
@@ -70,7 +70,7 @@ func dataSourceOriginAccessIdentitiesRead(ctx context.Context, d *schema.Resourc
 			}
 
 			if len(comments) > 0 {
-				if _, ok := verify.SliceContainsString(comments, aws.StringValue(v.Comment)); !ok {
+				if idx := tfslices.IndexOf(comments, aws.StringValue(v.Comment)); idx == -1 {
 					continue
 				}
 			}

--- a/internal/service/docdb/cluster.go
+++ b/internal/service/docdb/cluster.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -705,13 +706,13 @@ func diffCloudWatchLogsExportConfiguration(old, new []interface{}) ([]interface{
 	disable := make([]interface{}, 0)
 
 	for _, n := range new {
-		if _, contains := verify.SliceContainsString(old, n.(string)); !contains {
+		if idx := tfslices.IndexOf(old, n.(string)); idx == -1 {
 			add = append(add, n)
 		}
 	}
 
 	for _, o := range old {
-		if _, contains := verify.SliceContainsString(new, o.(string)); !contains {
+		if idx := tfslices.IndexOf(new, o.(string)); idx == -1 {
 			disable = append(disable, o)
 		}
 	}

--- a/internal/service/resourceexplorer2/index.go
+++ b/internal/service/resourceexplorer2/index.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
@@ -24,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -58,10 +58,8 @@ func (r *resourceIndex) Schema(ctx context.Context, request resource.SchemaReque
 			names.AttrTags:    tftags.TagsAttribute(),
 			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
 			"type": schema.StringAttribute{
-				Required: true,
-				Validators: []validator.String{
-					enum.FrameworkValidate[awstypes.IndexType](),
-				},
+				CustomType: fwtypes.StringEnumType[awstypes.IndexType](),
+				Required:   true,
 			},
 		},
 		Blocks: map[string]schema.Block{
@@ -75,7 +73,7 @@ func (r *resourceIndex) Schema(ctx context.Context, request resource.SchemaReque
 }
 
 func (r *resourceIndex) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
-	var data resourceIndexData
+	var data indexResourceModel
 
 	response.Diagnostics.Append(request.Plan.Get(ctx, &data)...)
 
@@ -108,7 +106,7 @@ func (r *resourceIndex) Create(ctx context.Context, request resource.CreateReque
 		return
 	}
 
-	if data.Type.ValueString() == string(awstypes.IndexTypeAggregator) {
+	if data.Type.ValueEnum() == awstypes.IndexTypeAggregator {
 		input := &resourceexplorer2.UpdateIndexTypeInput{
 			Arn:  flex.StringFromFramework(ctx, data.ID),
 			Type: awstypes.IndexTypeAggregator,
@@ -130,13 +128,13 @@ func (r *resourceIndex) Create(ctx context.Context, request resource.CreateReque
 	}
 
 	// Set values for unknowns.
-	data.Arn = types.StringValue(arn)
+	data.ARN = types.StringValue(arn)
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
 
 func (r *resourceIndex) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
-	var data resourceIndexData
+	var data indexResourceModel
 
 	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
 
@@ -173,7 +171,7 @@ func (r *resourceIndex) Read(ctx context.Context, request resource.ReadRequest, 
 }
 
 func (r *resourceIndex) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
-	var old, new resourceIndexData
+	var old, new indexResourceModel
 
 	response.Diagnostics.Append(request.State.Get(ctx, &old)...)
 
@@ -191,8 +189,8 @@ func (r *resourceIndex) Update(ctx context.Context, request resource.UpdateReque
 		conn := r.Meta().ResourceExplorer2Client(ctx)
 
 		input := &resourceexplorer2.UpdateIndexTypeInput{
-			Arn:  flex.StringFromFramework(ctx, new.ID),
-			Type: awstypes.IndexType(new.Type.ValueString()),
+			Arn:  flex.StringFromFramework(ctx, new.ARN),
+			Type: new.Type.ValueEnum(),
 		}
 
 		_, err := conn.UpdateIndexType(ctx, input)
@@ -215,7 +213,7 @@ func (r *resourceIndex) Update(ctx context.Context, request resource.UpdateReque
 }
 
 func (r *resourceIndex) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {
-	var data resourceIndexData
+	var data indexResourceModel
 
 	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
 
@@ -229,7 +227,7 @@ func (r *resourceIndex) Delete(ctx context.Context, request resource.DeleteReque
 		"id": data.ID.ValueString(),
 	})
 	_, err := conn.DeleteIndex(ctx, &resourceexplorer2.DeleteIndexInput{
-		Arn: flex.StringFromFramework(ctx, data.ID),
+		Arn: flex.StringFromFramework(ctx, data.ARN),
 	})
 
 	if err != nil {
@@ -251,13 +249,13 @@ func (r *resourceIndex) ModifyPlan(ctx context.Context, request resource.ModifyP
 }
 
 // See https://docs.aws.amazon.com/resource-explorer/latest/apireference/API_Index.html.
-type resourceIndexData struct {
-	Arn      types.String   `tfsdk:"arn"`
-	ID       types.String   `tfsdk:"id"`
-	Tags     types.Map      `tfsdk:"tags"`
-	TagsAll  types.Map      `tfsdk:"tags_all"`
-	Timeouts timeouts.Value `tfsdk:"timeouts"`
-	Type     types.String   `tfsdk:"type"`
+type indexResourceModel struct {
+	ARN      types.String                           `tfsdk:"arn"`
+	ID       types.String                           `tfsdk:"id"`
+	Tags     types.Map                              `tfsdk:"tags"`
+	TagsAll  types.Map                              `tfsdk:"tags_all"`
+	Timeouts timeouts.Value                         `tfsdk:"timeouts"`
+	Type     fwtypes.StringEnum[awstypes.IndexType] `tfsdk:"type"`
 }
 
 func findIndex(ctx context.Context, conn *resourceexplorer2.Client) (*resourceexplorer2.GetIndexOutput, error) {

--- a/internal/service/resourceexplorer2/view.go
+++ b/internal/service/resourceexplorer2/view.go
@@ -15,7 +15,6 @@ import (
 	awstypes "github.com/aws/aws-sdk-go-v2/service/resourceexplorer2/types"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -27,11 +26,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
-	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -81,6 +80,7 @@ func (r *resourceView) Schema(ctx context.Context, request resource.SchemaReques
 		},
 		Blocks: map[string]schema.Block{
 			"filters": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[searchFilterModel](ctx),
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"filter_string": schema.StringAttribute{
@@ -96,13 +96,12 @@ func (r *resourceView) Schema(ctx context.Context, request resource.SchemaReques
 				},
 			},
 			"included_property": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[includedPropertyModel](ctx),
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"name": schema.StringAttribute{
-							Required: true,
-							Validators: []validator.String{
-								enum.FrameworkValidate[propertyName](),
-							},
+							CustomType: fwtypes.StringEnumType[propertyName](),
+							Required:   true,
 						},
 					},
 				},
@@ -112,7 +111,7 @@ func (r *resourceView) Schema(ctx context.Context, request resource.SchemaReques
 }
 
 func (r *resourceView) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
-	var data resourceViewData
+	var data viewResourceModel
 
 	response.Diagnostics.Append(request.Plan.Get(ctx, &data)...)
 
@@ -122,13 +121,14 @@ func (r *resourceView) Create(ctx context.Context, request resource.CreateReques
 
 	conn := r.Meta().ResourceExplorer2Client(ctx)
 
-	input := &resourceexplorer2.CreateViewInput{
-		ClientToken:        aws.String(id.UniqueId()),
-		Filters:            flex.ExpandFrameworkListNestedBlockPtr(ctx, data.Filters, r.expandSearchFilter),
-		IncludedProperties: flex.ExpandFrameworkListNestedBlock(ctx, data.IncludedProperties, r.expandIncludedProperty),
-		Tags:               getTagsIn(ctx),
-		ViewName:           aws.String(data.ViewName.ValueString()),
+	input := &resourceexplorer2.CreateViewInput{}
+	response.Diagnostics.Append(flex.Expand(ctx, data, input)...)
+	if response.Diagnostics.HasError() {
+		return
 	}
+
+	input.ClientToken = aws.String(id.UniqueId())
+	input.Tags = getTagsIn(ctx)
 
 	output, err := conn.CreateView(ctx, input)
 
@@ -155,14 +155,14 @@ func (r *resourceView) Create(ctx context.Context, request resource.CreateReques
 	}
 
 	// Set values for unknowns.
-	data.ViewArn = types.StringValue(arn)
-	data.ID = types.StringValue(arn)
+	data.ViewARN = types.StringValue(arn)
+	data.setID()
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
 
 func (r *resourceView) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
-	var data resourceViewData
+	var data viewResourceModel
 
 	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
 
@@ -170,9 +170,15 @@ func (r *resourceView) Read(ctx context.Context, request resource.ReadRequest, r
 		return
 	}
 
+	if err := data.InitFromID(); err != nil {
+		response.Diagnostics.AddError("parsing resource ID", err.Error())
+
+		return
+	}
+
 	conn := r.Meta().ResourceExplorer2Client(ctx)
 
-	output, err := findViewByARN(ctx, conn, data.ID.ValueString())
+	output, err := findViewByARN(ctx, conn, data.ViewARN.ValueString())
 
 	if tfresource.NotFound(err) {
 		response.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
@@ -196,30 +202,23 @@ func (r *resourceView) Read(ctx context.Context, request resource.ReadRequest, r
 	}
 
 	view := output.View
-	data.ViewArn = flex.StringToFramework(ctx, view.ViewArn)
-	data.DefaultView = types.BoolValue(defaultViewARN == data.ViewArn.ValueString())
-	data.Filters = r.flattenSearchFilter(ctx, view.Filters)
-	data.IncludedProperties = flex.FlattenFrameworkListNestedBlock[viewIncludedPropertyData](ctx, view.IncludedProperties, r.flattenIncludedProperty)
-
-	arn, err := arn.Parse(data.ViewArn.ValueString())
-
-	if err != nil {
-		response.Diagnostics.AddError("parsing Resource Explorer View ARN", err.Error())
-
+	// The default is
+	//
+	//   "Filters": {
+	// 	   "FilterString": ""
+	//   },
+	//
+	// a view that performs no filtering.
+	// See https://docs.aws.amazon.com/resource-explorer/latest/apireference/API_CreateView.html#API_CreateView_Example_1.
+	if view.Filters != nil && len(aws.ToString(view.Filters.FilterString)) == 0 {
+		view.Filters = nil
+	}
+	response.Diagnostics.Append(flex.Flatten(ctx, view, &data)...)
+	if response.Diagnostics.HasError() {
 		return
 	}
 
-	// view/${ViewName}/${ViewUuid}
-	parts := strings.Split(arn.Resource, "/")
-
-	if n := len(parts); n != 3 {
-		response.Diagnostics.AddError("incorrect Resource Explorer View ARN format", fmt.Sprintf("%d parts", n))
-
-		return
-	}
-
-	name := parts[1]
-	data.ViewName = types.StringValue(name)
+	data.DefaultView = types.BoolValue(defaultViewARN == data.ViewARN.ValueString())
 
 	setTagsOut(ctx, output.Tags)
 
@@ -227,7 +226,7 @@ func (r *resourceView) Read(ctx context.Context, request resource.ReadRequest, r
 }
 
 func (r *resourceView) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
-	var old, new resourceViewData
+	var old, new viewResourceModel
 
 	response.Diagnostics.Append(request.State.Get(ctx, &old)...)
 
@@ -244,10 +243,10 @@ func (r *resourceView) Update(ctx context.Context, request resource.UpdateReques
 	conn := r.Meta().ResourceExplorer2Client(ctx)
 
 	if !new.Filters.Equal(old.Filters) || !new.IncludedProperties.Equal(old.IncludedProperties) {
-		input := &resourceexplorer2.UpdateViewInput{
-			Filters:            flex.ExpandFrameworkListNestedBlockPtr(ctx, new.Filters, r.expandSearchFilter),
-			IncludedProperties: flex.ExpandFrameworkListNestedBlock(ctx, new.IncludedProperties, r.expandIncludedProperty),
-			ViewArn:            flex.StringFromFramework(ctx, new.ID),
+		input := &resourceexplorer2.UpdateViewInput{}
+		response.Diagnostics.Append(flex.Expand(ctx, new, input)...)
+		if response.Diagnostics.HasError() {
+			return
 		}
 
 		_, err := conn.UpdateView(ctx, input)
@@ -262,7 +261,7 @@ func (r *resourceView) Update(ctx context.Context, request resource.UpdateReques
 	if !new.DefaultView.Equal(old.DefaultView) {
 		if new.DefaultView.ValueBool() {
 			input := &resourceexplorer2.AssociateDefaultViewInput{
-				ViewArn: flex.StringFromFramework(ctx, new.ID),
+				ViewArn: flex.StringFromFramework(ctx, new.ViewARN),
 			}
 
 			_, err := conn.AssociateDefaultView(ctx, input)
@@ -289,7 +288,7 @@ func (r *resourceView) Update(ctx context.Context, request resource.UpdateReques
 }
 
 func (r *resourceView) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {
-	var data resourceViewData
+	var data viewResourceModel
 
 	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
 
@@ -303,7 +302,7 @@ func (r *resourceView) Delete(ctx context.Context, request resource.DeleteReques
 		"id": data.ID.ValueString(),
 	})
 	_, err := conn.DeleteView(ctx, &resourceexplorer2.DeleteViewInput{
-		ViewArn: flex.StringFromFramework(ctx, data.ID),
+		ViewArn: flex.StringFromFramework(ctx, data.ViewARN),
 	})
 
 	if err != nil {
@@ -321,65 +320,45 @@ func (r *resourceView) ModifyPlan(ctx context.Context, request resource.ModifyPl
 	r.SetTagsAll(ctx, request, response)
 }
 
-func (r *resourceView) expandSearchFilter(ctx context.Context, data viewSearchFilterData) *awstypes.SearchFilter {
-	return &awstypes.SearchFilter{
-		FilterString: flex.StringFromFramework(ctx, data.FilterString),
-	}
-}
-
-func (r *resourceView) flattenSearchFilter(ctx context.Context, apiObject *awstypes.SearchFilter) types.List {
-	attributeTypes := flex.AttributeTypesMust[viewSearchFilterData](ctx)
-	elementType := types.ObjectType{AttrTypes: attributeTypes}
-
-	// The default is
-	//
-	//   "Filters": {
-	// 	   "FilterString": ""
-	//   },
-	//
-	// a view that performs no filtering.
-	// See https://docs.aws.amazon.com/resource-explorer/latest/apireference/API_CreateView.html#API_CreateView_Example_1.
-	if apiObject == nil || len(aws.ToString(apiObject.FilterString)) == 0 {
-		return types.ListNull(elementType)
-	}
-
-	return types.ListValueMust(elementType, []attr.Value{
-		types.ObjectValueMust(attributeTypes, map[string]attr.Value{
-			"filter_string": flex.StringToFramework(ctx, apiObject.FilterString),
-		}),
-	})
-}
-
-func (r *resourceView) expandIncludedProperty(ctx context.Context, data viewIncludedPropertyData) awstypes.IncludedProperty {
-	return awstypes.IncludedProperty{
-		Name: flex.StringFromFramework(ctx, data.Name),
-	}
-}
-
-func (r *resourceView) flattenIncludedProperty(ctx context.Context, apiObject awstypes.IncludedProperty) viewIncludedPropertyData {
-	return viewIncludedPropertyData{
-		Name: flex.StringToFramework(ctx, apiObject.Name),
-	}
-}
-
 // See https://docs.aws.amazon.com/resource-explorer/latest/apireference/API_View.html.
-type resourceViewData struct {
-	ViewArn            types.String `tfsdk:"arn"`
-	DefaultView        types.Bool   `tfsdk:"default_view"`
-	Filters            types.List   `tfsdk:"filters"`
-	ID                 types.String `tfsdk:"id"`
-	IncludedProperties types.List   `tfsdk:"included_property"`
-	ViewName           types.String `tfsdk:"name"`
-	Tags               types.Map    `tfsdk:"tags"`
-	TagsAll            types.Map    `tfsdk:"tags_all"`
+type viewResourceModel struct {
+	DefaultView        types.Bool                                             `tfsdk:"default_view"`
+	Filters            fwtypes.ListNestedObjectValueOf[searchFilterModel]     `tfsdk:"filters"`
+	ID                 types.String                                           `tfsdk:"id"`
+	IncludedProperties fwtypes.ListNestedObjectValueOf[includedPropertyModel] `tfsdk:"included_property"`
+	ViewARN            types.String                                           `tfsdk:"arn"`
+	ViewName           types.String                                           `tfsdk:"name"`
+	Tags               types.Map                                              `tfsdk:"tags"`
+	TagsAll            types.Map                                              `tfsdk:"tags_all"`
 }
 
-type viewSearchFilterData struct {
+func (data *viewResourceModel) InitFromID() error {
+	data.ViewARN = data.ID
+	arn, err := arn.Parse(data.ViewARN.ValueString())
+	if err != nil {
+		return err
+	}
+	// view/${ViewName}/${ViewUuid}
+	parts := strings.Split(arn.Resource, "/")
+	if n := len(parts); n != 3 {
+		return fmt.Errorf("incorrect Resource Explorer View ARN format: %d parts", n)
+	}
+	name := parts[1]
+	data.ViewName = types.StringValue(name)
+
+	return nil
+}
+
+func (data *viewResourceModel) setID() {
+	data.ID = data.ViewARN
+}
+
+type searchFilterModel struct {
 	FilterString types.String `tfsdk:"filter_string"`
 }
 
-type viewIncludedPropertyData struct {
-	Name types.String `tfsdk:"name"`
+type includedPropertyModel struct {
+	Name fwtypes.StringEnum[propertyName] `tfsdk:"name"`
 }
 
 func findDefaultViewARN(ctx context.Context, conn *resourceexplorer2.Client) (string, error) {

--- a/internal/service/waf/helpers.go
+++ b/internal/service/waf/helpers.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
-	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 )
 
 func SizeConstraintSetSchema() map[string]*schema.Schema {
@@ -168,7 +168,7 @@ func DiffRegexPatternSetPatternStrings(oldPatterns, newPatterns []interface{}) [
 	updates := make([]*waf.RegexPatternSetUpdate, 0)
 
 	for _, op := range oldPatterns {
-		if idx, contains := verify.SliceContainsString(newPatterns, op.(string)); contains {
+		if idx := tfslices.IndexOf(newPatterns, op.(string)); idx > -1 {
 			newPatterns = append(newPatterns[:idx], newPatterns[idx+1:]...)
 			continue
 		}

--- a/internal/slices/slices.go
+++ b/internal/slices/slices.go
@@ -113,3 +113,13 @@ func AppendUnique[S ~[]E, E comparable](s S, vs ...E) S {
 
 	return s
 }
+
+// IndexOf returns the index of the first occurrence of `v` in `s`, or -1 if not present.
+func IndexOf[S ~[]any, E comparable](s S, v E) int {
+	for i := range s {
+		if e, ok := s[i].(E); ok && v == e {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/slices/slices_test.go
+++ b/internal/slices/slices_test.go
@@ -262,3 +262,43 @@ func TestAppendUnique(t *testing.T) {
 		})
 	}
 }
+
+func TestIndexOf(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input    []any
+		element  string
+		expected int
+	}
+	tests := map[string]testCase{
+		"index 0": {
+			input:    []any{"one", 2.0, 3, "four"},
+			element:  "one",
+			expected: 0,
+		},
+		"index 3": {
+			input:    []any{"one", 2.0, 3, "four"},
+			element:  "four",
+			expected: 3,
+		},
+		"index -1": {
+			input:    []any{"one", 2.0, 3, "four"},
+			element:  "3",
+			expected: -1,
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := IndexOf(test.input, test.element)
+
+			if diff := cmp.Diff(got, test.expected); diff != "" {
+				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -9,16 +9,6 @@ import (
 
 const UUIDRegexPattern = `[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[ab89][0-9a-f]{3}-[0-9a-f]{12}`
 
-func SliceContainsString(slice []interface{}, s string) (int, bool) {
-	for idx, value := range slice {
-		v := value.(string)
-		if v == s {
-			return idx, true
-		}
-	}
-	return -1, false
-}
-
 // Takes a value containing YAML string and passes it through
 // the YAML parser. Returns either a parsing
 // error or original YAML string.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Replaces `verify.SliceContainsString` with a more generic function in `internal/slices`.
Also migrates the `resourceexplorer2` resources to AutoFlEx.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccCloudFrontOriginAccessIdentitiesDataSource_comments' PKG=cloudfront
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudfront/... -v -count 1 -parallel 20  -run=TestAccCloudFrontOriginAccessIdentitiesDataSource_comments -timeout 360m
=== RUN   TestAccCloudFrontOriginAccessIdentitiesDataSource_comments
=== PAUSE TestAccCloudFrontOriginAccessIdentitiesDataSource_comments
=== CONT  TestAccCloudFrontOriginAccessIdentitiesDataSource_comments
--- PASS: TestAccCloudFrontOriginAccessIdentitiesDataSource_comments (23.97s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront	29.879s
```
```console
% make testacc TESTARGS='-run=TestAccDocDBCluster_updateCloudWatchLogsExports' PKG=docdb
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/docdb/... -v -count 1 -parallel 20  -run=TestAccDocDBCluster_updateCloudWatchLogsExports -timeout 360m
=== RUN   TestAccDocDBCluster_updateCloudWatchLogsExports
=== PAUSE TestAccDocDBCluster_updateCloudWatchLogsExports
=== CONT  TestAccDocDBCluster_updateCloudWatchLogsExports
--- PASS: TestAccDocDBCluster_updateCloudWatchLogsExports (229.40s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/docdb	235.476s
```
```console
% make testacc TESTARGS='-run=TestAccWAFRegexPatternSet_serial' PKG=waf
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/waf/... -v -count 1 -parallel 20  -run=TestAccWAFRegexPatternSet_serial -timeout 360m
=== RUN   TestAccWAFRegexPatternSet_serial
=== PAUSE TestAccWAFRegexPatternSet_serial
=== CONT  TestAccWAFRegexPatternSet_serial
=== RUN   TestAccWAFRegexPatternSet_serial/basic
=== RUN   TestAccWAFRegexPatternSet_serial/changePatterns
=== RUN   TestAccWAFRegexPatternSet_serial/noPatterns
=== RUN   TestAccWAFRegexPatternSet_serial/disappears
--- PASS: TestAccWAFRegexPatternSet_serial (108.71s)
    --- PASS: TestAccWAFRegexPatternSet_serial/basic (27.72s)
    --- PASS: TestAccWAFRegexPatternSet_serial/changePatterns (38.50s)
    --- PASS: TestAccWAFRegexPatternSet_serial/noPatterns (22.90s)
    --- PASS: TestAccWAFRegexPatternSet_serial/disappears (19.59s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/waf	114.394s
```
```console
% make testacc TESTARGS='-run=TestAccResourceExplorer2_serial/Index' PKG=resourceexplorer2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/resourceexplorer2/... -v -count 1 -parallel 20  -run=TestAccResourceExplorer2_serial/Index -timeout 360m
=== RUN   TestAccResourceExplorer2_serial
=== PAUSE TestAccResourceExplorer2_serial
=== CONT  TestAccResourceExplorer2_serial
=== RUN   TestAccResourceExplorer2_serial/Index
=== RUN   TestAccResourceExplorer2_serial/Index/type
=== RUN   TestAccResourceExplorer2_serial/Index/basic
=== RUN   TestAccResourceExplorer2_serial/Index/disappears
=== RUN   TestAccResourceExplorer2_serial/Index/tags
--- PASS: TestAccResourceExplorer2_serial (149.09s)
    --- PASS: TestAccResourceExplorer2_serial/Index (149.09s)
        --- PASS: TestAccResourceExplorer2_serial/Index/type (43.28s)
        --- PASS: TestAccResourceExplorer2_serial/Index/basic (26.59s)
        --- PASS: TestAccResourceExplorer2_serial/Index/disappears (20.95s)
        --- PASS: TestAccResourceExplorer2_serial/Index/tags (58.27s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/resourceexplorer2	154.503s
```
