### PR TITLE
docs: Fix id and name attr descs for aws_iam_group and aws_iam_user

### DIFF
--- a/website/docs/d/iam_group.html.markdown
+++ b/website/docs/d/iam_group.html.markdown
@@ -30,6 +30,7 @@ This data source exports the following attributes in addition to the arguments a
 
 * `arn` - Group ARN.
 * `group_id` - Stable and unique string identifying the group.
+* `id` - Stable and unique string identifying the group.
 * `path` - Path to the group.
 * `users` - List of objects containing group member information. See below.
 

--- a/website/docs/d/iam_user.html.markdown
+++ b/website/docs/d/iam_user.html.markdown
@@ -29,6 +29,7 @@ data "aws_iam_user" "example" {
 This data source exports the following attributes in addition to the arguments above:
 
 * `arn` - ARN assigned by AWS for this user.
+* `id` - Unique ID assigned by AWS for this user.
 * `path` - Path in which this user was created.
 * `permissions_boundary` - The ARN of the policy that is used to set the permissions boundary for the user.
 * `user_id` - Unique ID assigned by AWS for this user.

--- a/website/docs/r/iam_group.html.markdown
+++ b/website/docs/r/iam_group.html.markdown
@@ -32,7 +32,7 @@ This resource supports the following arguments:
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `id` - The group's ID.
+* `id` - The group's name.
 * `arn` - The ARN assigned by AWS for this group.
 * `name` - The group's name.
 * `path` - The path of the group in IAM.

--- a/website/docs/r/iam_user.html.markdown
+++ b/website/docs/r/iam_user.html.markdown
@@ -60,6 +60,7 @@ This resource supports the following arguments:
 This resource exports the following attributes in addition to the arguments above:
 
 * `arn` - The ARN assigned by AWS for this user.
+* `id` - The user's name.
 * `name` - The user's name.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 * `unique_id` - The [unique ID][1] assigned by AWS.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add or correct id- and name-related attributes for `aws_iam_group` and `aws_iam_user` resources and data sources.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #34107

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Refer to https://github.com/hashicorp/terraform-provider-aws/issues/34107#issuecomment-1791714689 for a table of the name- and id-related attribute values for `aws_iam_*` resources and data sources.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
n/a