### PR TITLE
docs: Add catalog_target description for aws_glue_crawler

### DIFF
--- a/website/docs/r/glue_crawler.html.markdown
+++ b/website/docs/r/glue_crawler.html.markdown
@@ -142,6 +142,7 @@ This argument supports the following arguments:
 * `dynamodb_target` (Optional) List of nested DynamoDB target arguments. See [Dynamodb Target](#dynamodb-target) below.
 * `jdbc_target` (Optional) List of nested JBDC target arguments. See [JDBC Target](#jdbc-target) below.
 * `s3_target` (Optional) List of nested Amazon S3 target arguments. See [S3 Target](#s3-target) below.
+* `catalog_target` (Optional) List of nested AWS Glue Data Catalog target arguments. See [Catalog Target](#catalog-target) below.
 * `mongodb_target` (Optional) List of nested MongoDB target arguments. See [MongoDB Target](#mongodb-target) below.
 * `hudi_target` (Optional) List of nested Hudi target arguments. See [Iceberg Target](#hudi-target) below.
 * `iceberg_target` (Optional) List of nested Iceberg target arguments. See [Iceberg Target](#iceberg-target) below.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add the missing description for the `catalog_target` attribute of the `aws_glue_crawler` resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #34081

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

- Referred to [Crawler API](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-crawler-crawling.html#aws-glue-api-crawler-crawling-CatalogTarget) for the standard name of the target (vs. just calling it "catalog target") in the description.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
n/a
