### PR TITLE
r/aws_autoscaling_group: Force new in case of initial_lifecycle_hook update

### DIFF
--- a/.changelog/34260.txt
+++ b/.changelog/34260.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_autoscaling_group: Fix issue where group was not recreated if `initial_lifecycle_hook` changed
+```

--- a/.changelog/34260.txt
+++ b/.changelog/34260.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_autoscaling_group: Fix issue where group was not recreated if `initial_lifecycle_hook` changed
+resource/aws_autoscaling_group: Change all `initial_lifecycle_hook` configuration block attributes to [ForceNew](https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-behaviors#forcenew)
 ```

--- a/internal/service/autoscaling/group.go
+++ b/internal/service/autoscaling/group.go
@@ -153,6 +153,7 @@ func ResourceGroup() *schema.Resource {
 						"name": {
 							Type:     schema.TypeString,
 							Required: true,
+							ForceNew: true,
 						},
 						"notification_metadata": {
 							Type:     schema.TypeString,

--- a/internal/service/autoscaling/group.go
+++ b/internal/service/autoscaling/group.go
@@ -141,14 +141,17 @@ func ResourceGroup() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							Computed: true,
+							ForceNew: true,
 						},
 						"heartbeat_timeout": {
 							Type:     schema.TypeInt,
 							Optional: true,
+							ForceNew: true,
 						},
 						"lifecycle_transition": {
 							Type:     schema.TypeString,
 							Required: true,
+							ForceNew: true,
 						},
 						"name": {
 							Type:     schema.TypeString,
@@ -158,14 +161,17 @@ func ResourceGroup() *schema.Resource {
 						"notification_metadata": {
 							Type:     schema.TypeString,
 							Optional: true,
+							ForceNew: true,
 						},
 						"notification_target_arn": {
 							Type:     schema.TypeString,
 							Optional: true,
+							ForceNew: true,
 						},
 						"role_arn": {
 							Type:     schema.TypeString,
 							Optional: true,
+							ForceNew: true,
 						},
 					},
 				},

--- a/internal/service/autoscaling/group_test.go
+++ b/internal/service/autoscaling/group_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -1049,7 +1050,7 @@ func TestAccAutoScalingGroup_initialLifecycleHook(t *testing.T) {
 		CheckDestroy:             testAccCheckGroupDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGroupConfig_initialLifecycleHook(rName),
+				Config: testAccGroupConfig_initialLifecycleHook(rName, 30),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGroupExists(ctx, resourceName, &group),
 					testAccCheckGroupHealthyInstanceCount(&group, 2),
@@ -1063,6 +1064,25 @@ func TestAccAutoScalingGroup_initialLifecycleHook(t *testing.T) {
 				),
 			},
 			testAccGroupImportStep(resourceName),
+			{
+				Config: testAccGroupConfig_initialLifecycleHook(rName, 40),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGroupExists(ctx, resourceName, &group),
+					testAccCheckGroupHealthyInstanceCount(&group, 2),
+					resource.TestCheckResourceAttr(resourceName, "initial_lifecycle_hook.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "initial_lifecycle_hook.*", map[string]string{
+						"default_result":       "CONTINUE",
+						"heartbeat_timeout":    "40",
+						"lifecycle_transition": "autoscaling:EC2_INSTANCE_LAUNCHING",
+						"name":                 "launching",
+					}),
+				),
+			},
 		},
 	})
 }
@@ -4778,7 +4798,7 @@ resource "aws_autoscaling_group" "test" {
 `, rName, maxInstanceLifetime))
 }
 
-func testAccGroupConfig_initialLifecycleHook(rName string) string {
+func testAccGroupConfig_initialLifecycleHook(rName string, timeout int) string {
 	return acctest.ConfigCompose(testAccGroupConfig_launchConfigurationBase(rName, "t2.micro"), fmt.Sprintf(`
 resource "aws_autoscaling_group" "test" {
   availability_zones   = [data.aws_availability_zones.available.names[0]]
@@ -4794,7 +4814,7 @@ resource "aws_autoscaling_group" "test" {
   initial_lifecycle_hook {
     name                 = "launching"
     default_result       = "CONTINUE"
-    heartbeat_timeout    = 30 # minimum value
+    heartbeat_timeout    = %[2]d # minimum value
     lifecycle_transition = "autoscaling:EC2_INSTANCE_LAUNCHING"
   }
 
@@ -4804,7 +4824,7 @@ resource "aws_autoscaling_group" "test" {
     propagate_at_launch = true
   }
 }
-`, rName))
+`, rName, timeout))
 }
 
 func testAccGroupConfig_launchTemplate(rName string) string {

--- a/internal/service/autoscaling/group_test.go
+++ b/internal/service/autoscaling/group_test.go
@@ -4814,7 +4814,7 @@ resource "aws_autoscaling_group" "test" {
   initial_lifecycle_hook {
     name                 = "launching"
     default_result       = "CONTINUE"
-    heartbeat_timeout    = %[2]d # minimum value
+    heartbeat_timeout    = %[2]d
     lifecycle_transition = "autoscaling:EC2_INSTANCE_LAUNCHING"
   }
 


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
Fix a bug where if an `initial_lifecycle_hook` attribute is updated, it doesn't replace `aws_autoscaling_group` to apply `initial_lifecycle_hook` change.
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #34178

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS='TestAccAutoScalingGroup_initialLifecycleHook' PKG=autoscaling ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/autoscaling/... -v -count 1 -parallel 3 -run='TestAccAutoScalingGroup_initialLifecycleHook'  -timeout 360m
=== RUN   TestAccAutoScalingGroup_initialLifecycleHook
=== PAUSE TestAccAutoScalingGroup_initialLifecycleHook
=== CONT  TestAccAutoScalingGroup_initialLifecycleHook
--- PASS: TestAccAutoScalingGroup_initialLifecycleHook (923.37s)
PASS
ok   [github.com/hashicorp/terraform-provider-aws/internal/service/autoscaling](http://github.com/hashicorp/terraform-provider-aws/internal/service/autoscaling) 923.532s
```
