### PR TITLE
feat: Add lambda_code attr to aws_inspector2_organization_configuration resource

### DIFF
--- a/.changelog/34261.txt
+++ b/.changelog/34261.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_inspector2_organization_configuration: Add `lambda_code` argument to the `auto_enable` configuration block
+```

--- a/internal/service/inspector2/inspector2_test.go
+++ b/internal/service/inspector2/inspector2_test.go
@@ -39,6 +39,7 @@ func TestAccInspector2_serial(t *testing.T) {
 			"disappears": testAccOrganizationConfiguration_disappears,
 			"ec2ECR":     testAccOrganizationConfiguration_ec2ECR,
 			"lambda":     testAccOrganizationConfiguration_lambda,
+			"lambdaCode": testAccOrganizationConfiguration_lambdaCode,
 		},
 	}
 

--- a/website/docs/r/inspector2_organization_configuration.html.markdown
+++ b/website/docs/r/inspector2_organization_configuration.html.markdown
@@ -12,7 +12,7 @@ Terraform resource for managing an Amazon Inspector Organization Configuration.
 
 ~> **NOTE:** In order for this resource to work, the account you use must be an Inspector Delegated Admin Account.
 
-~> **NOTE:** When this resource is deleted, EC2, ECR and Lambda scans will no longer be automatically enabled for new members of your Amazon Inspector organization.
+~> **NOTE:** When this resource is deleted, EC2, ECR, Lambda, and Lambda code scans will no longer be automatically enabled for new members of your Amazon Inspector organization.
 
 ## Example Usage
 
@@ -21,9 +21,10 @@ Terraform resource for managing an Amazon Inspector Organization Configuration.
 ```terraform
 resource "aws_inspector2_organization_configuration" "example" {
   auto_enable {
-    ec2    = true
-    ecr    = false
-    lambda = true
+    ec2         = true
+    ecr         = false
+    lambda      = true
+    lambda_code = true
   }
 }
 ```
@@ -39,6 +40,7 @@ The following arguments are required:
 * `ec2` - (Required) Whether Amazon EC2 scans are automatically enabled for new members of your Amazon Inspector organization.
 * `ecr` - (Required) Whether Amazon ECR scans are automatically enabled for new members of your Amazon Inspector organization.
 * `lambda` - (Optional) Whether Lambda Function scans are automatically enabled for new members of your Amazon Inspector organization.
+* `lambda_code` - (Optional) Whether AWS Lambda code scans are automatically enabled for new members of your Amazon Inspector organization. **Note:** Lambda code scanning requires Lambda standard scanning to be activated. Consequently, if you are setting this argument to `true`, you must also set the `lambda` argument to `true`. See [Scanning AWS Lambda functions with Amazon Inspector](https://docs.aws.amazon.com/inspector/latest/user/scanning-lambda.html#lambda-code-scans) for more information.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is for adding the `lambda_code` attribute to the `auto_enable` block of the `aws_inspector2_organization_configuration` resource, which will add support for managing Lambda code scanning at the organizational level.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #34200

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- Reference links that were included in #34200
- [Scanning AWS Lambda functions with Amazon Inspector](https://docs.aws.amazon.com/inspector/latest/user/scanning-lambda.html)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
antw@U-UQPXPV4N2NIW:~/git/terraform-provider-aws$ make testacc TESTS=TestAccInspector2_serial PKG=inspector2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/inspector2/... -v -count 1 -parallel 20 -run='TestAccInspector2_serial'  -timeout 360m
=== RUN   TestAccInspector2_serial
=== PAUSE TestAccInspector2_serial
=== CONT  TestAccInspector2_serial
=== RUN   TestAccInspector2_serial/Enabler
=== RUN   TestAccInspector2_serial/Enabler/memberAccount_updateMemberAccounts
    acctest.go:827: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
=== RUN   TestAccInspector2_serial/Enabler/memberAccount_disappearsMemberAssociation
    acctest.go:827: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
=== RUN   TestAccInspector2_serial/Enabler/basic
=== RUN   TestAccInspector2_serial/Enabler/accountID
=== RUN   TestAccInspector2_serial/Enabler/updateResourceTypes_disjoint
=== RUN   TestAccInspector2_serial/Enabler/memberAccount_basic
    acctest.go:827: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
=== RUN   TestAccInspector2_serial/Enabler/memberAccount_multiple
    acctest.go:827: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
=== RUN   TestAccInspector2_serial/Enabler/memberAccount_updateMemberAccountsAndScanTypes
    acctest.go:827: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
=== RUN   TestAccInspector2_serial/Enabler/disappears
=== RUN   TestAccInspector2_serial/Enabler/lambda
=== RUN   TestAccInspector2_serial/Enabler/updateResourceTypes
=== RUN   TestAccInspector2_serial/DelegatedAdminAccount
=== RUN   TestAccInspector2_serial/DelegatedAdminAccount/disappears
=== RUN   TestAccInspector2_serial/DelegatedAdminAccount/basic
=== RUN   TestAccInspector2_serial/MemberAssociation
=== RUN   TestAccInspector2_serial/MemberAssociation/basic
    acctest.go:827: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
=== RUN   TestAccInspector2_serial/MemberAssociation/disappears
    acctest.go:827: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
=== RUN   TestAccInspector2_serial/OrganizationConfiguration
=== RUN   TestAccInspector2_serial/OrganizationConfiguration/basic
=== RUN   TestAccInspector2_serial/OrganizationConfiguration/disappears
=== RUN   TestAccInspector2_serial/OrganizationConfiguration/ec2ECR
=== RUN   TestAccInspector2_serial/OrganizationConfiguration/lambda
=== RUN   TestAccInspector2_serial/OrganizationConfiguration/lambdaCode
--- PASS: TestAccInspector2_serial (1165.64s)
    --- PASS: TestAccInspector2_serial/Enabler (874.79s)
        --- SKIP: TestAccInspector2_serial/Enabler/memberAccount_updateMemberAccounts (1.03s)
        --- SKIP: TestAccInspector2_serial/Enabler/memberAccount_disappearsMemberAssociation (0.31s)
        --- PASS: TestAccInspector2_serial/Enabler/basic (147.89s)
        --- PASS: TestAccInspector2_serial/Enabler/accountID (289.35s)
        --- PASS: TestAccInspector2_serial/Enabler/updateResourceTypes_disjoint (134.30s)
        --- SKIP: TestAccInspector2_serial/Enabler/memberAccount_basic (0.38s)
        --- SKIP: TestAccInspector2_serial/Enabler/memberAccount_multiple (0.36s)
        --- SKIP: TestAccInspector2_serial/Enabler/memberAccount_updateMemberAccountsAndScanTypes (1.28s)
        --- PASS: TestAccInspector2_serial/Enabler/disappears (60.23s)
        --- PASS: TestAccInspector2_serial/Enabler/lambda (62.09s)
        --- PASS: TestAccInspector2_serial/Enabler/updateResourceTypes (177.57s)
    --- PASS: TestAccInspector2_serial/DelegatedAdminAccount (64.57s)
        --- PASS: TestAccInspector2_serial/DelegatedAdminAccount/disappears (29.93s)
        --- PASS: TestAccInspector2_serial/DelegatedAdminAccount/basic (34.64s)
    --- PASS: TestAccInspector2_serial/MemberAssociation (0.40s)
        --- SKIP: TestAccInspector2_serial/MemberAssociation/basic (0.20s)
        --- SKIP: TestAccInspector2_serial/MemberAssociation/disappears (0.20s)
    --- PASS: TestAccInspector2_serial/OrganizationConfiguration (225.89s)
        --- PASS: TestAccInspector2_serial/OrganizationConfiguration/basic (43.96s)
        --- PASS: TestAccInspector2_serial/OrganizationConfiguration/disappears (51.41s)
        --- PASS: TestAccInspector2_serial/OrganizationConfiguration/ec2ECR (44.34s)
        --- PASS: TestAccInspector2_serial/OrganizationConfiguration/lambda (44.40s)
        --- PASS: TestAccInspector2_serial/OrganizationConfiguration/lambdaCode (41.78s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/inspector2 1165.820s
antw@U-UQPXPV4N2NIW:~/git/terraform-provider-aws$ 
```
