### PR TITLE
Feature: AWS Batch Job Definition now creates a new version instead of ForceNew

### DIFF
--- a/.changelog/34281.txt
+++ b/.changelog/34281.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_batch_job_definition: Resource no longer recreates, but updates `revision` with any changes. Included new parameters `scheduling_priority` & `arn_prefix`.
+```
+
+```release-note:note
+resource/aws_batch_job_definition: Job Definition Delete action now `deregisters` all jobs matching the job name.
+```

--- a/internal/service/batch/job_definition.go
+++ b/internal/service/batch/job_definition.go
@@ -219,7 +219,7 @@ func ResourceJobDefinition() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{batch.JobDefinitionTypeContainer, batch.JobDefinitionTypeMultinode}, true),
+				ValidateFunc: validation.StringInSlice(batch.JobDefinitionType_Values(), true),
 			},
 		},
 

--- a/internal/service/batch/job_definition.go
+++ b/internal/service/batch/job_definition.go
@@ -479,7 +479,6 @@ func resourceJobDefinitionDelete(ctx context.Context, d *schema.ResourceData, me
 }
 
 func FindJobDefinitionByARN(ctx context.Context, conn *batch.Batch, arn string) (*batch.JobDefinition, error) {
-
 	input := &batch.DescribeJobDefinitionsInput{
 		JobDefinitions: aws.StringSlice([]string{arn}),
 	}
@@ -519,7 +518,6 @@ func findJobDefinition(ctx context.Context, conn *batch.Batch, input *batch.Desc
 }
 
 func ListActiveJobDefinitionByName(ctx context.Context, conn *batch.Batch, name string) ([]*batch.JobDefinition, error) {
-
 	input := &batch.DescribeJobDefinitionsInput{
 		JobDefinitionName: aws.String(name),
 		Status:            aws.String(jobDefinitionStatusActive),

--- a/internal/service/batch/job_definition.go
+++ b/internal/service/batch/job_definition.go
@@ -391,7 +391,7 @@ func resourceJobDefinitionUpdate(ctx context.Context, d *schema.ResourceData, me
 		if v, ok := d.GetOk("container_properties"); ok {
 			props, err := expandJobContainerProperties(v.(string))
 			if err != nil {
-				return sdkdiag.AppendErrorf(diags, "creating Batch Job Definition (%s): %s", name, err)
+				return sdkdiag.AppendErrorf(diags, "updating Batch Job Definition (%s): %s", name, err)
 			}
 
 			if aws.StringValue(input.Type) == batch.JobDefinitionTypeContainer {

--- a/internal/service/batch/job_definition.go
+++ b/internal/service/batch/job_definition.go
@@ -191,9 +191,8 @@ func ResourceJobDefinition() *schema.Resource {
 			},
 
 			"scheduling_priority": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.IntBetween(0, 9999),
+				Type:     schema.TypeInt,
+				Optional: true,
 			},
 
 			names.AttrTags:    tftags.TagsSchema(),

--- a/internal/service/batch/job_definition.go
+++ b/internal/service/batch/job_definition.go
@@ -50,7 +50,6 @@ func ResourceJobDefinition() *schema.Resource {
 			"container_properties": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 				StateFunc: func(v interface{}) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json
@@ -85,13 +84,11 @@ func ResourceJobDefinition() *schema.Resource {
 			"parameters": {
 				Type:     schema.TypeMap,
 				Optional: true,
-				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"platform_capabilities": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				ForceNew: true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
 					ValidateFunc: validation.StringInSlice(batch.PlatformCapability_Values(), false),
@@ -100,7 +97,6 @@ func ResourceJobDefinition() *schema.Resource {
 			"propagate_tags": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				ForceNew: true,
 				Default:  false,
 			},
 			"retry_strategy": {

--- a/internal/service/batch/job_definition.go
+++ b/internal/service/batch/job_definition.go
@@ -47,6 +47,10 @@ func ResourceJobDefinition() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"arn_prefix": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"container_properties": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -289,6 +293,7 @@ func resourceJobDefinitionRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	d.Set("arn", jobDefinition.JobDefinitionArn)
+	d.Set("arn_prefix", strings.TrimSuffix(*jobDefinition.JobDefinitionArn, fmt.Sprintf(":%d", *jobDefinition.Revision)))
 
 	containerProperties, err := flattenContainerProperties(jobDefinition.ContainerProperties)
 

--- a/internal/service/batch/job_definition.go
+++ b/internal/service/batch/job_definition.go
@@ -403,7 +403,7 @@ func resourceJobDefinitionUpdate(ctx context.Context, d *schema.ResourceData, me
 		if v, ok := d.GetOk("node_properties"); ok {
 			props, err := expandJobNodeProperties(v.(string))
 			if err != nil {
-				return sdkdiag.AppendErrorf(diags, "creating Batch Job Definition (%s): %s", name, err)
+				return sdkdiag.AppendErrorf(diags, "updating Batch Job Definition (%s): %s", name, err)
 			}
 
 			for _, node := range props.NodeRangeProperties {

--- a/internal/service/batch/job_definition_test.go
+++ b/internal/service/batch/job_definition_test.go
@@ -826,37 +826,6 @@ resource "aws_batch_job_definition" "test" {
 `, rName, sp, pt, rsa, timeout)
 }
 
-func testAccJobDefinitionConfig_capabilitiesEC2(rName string, sp int, pt bool, cpu int, rsa int, timeout int) string {
-	return fmt.Sprintf(`
-resource "aws_batch_job_definition" "test" {
-  name = %[1]q
-  type = "container"
-
-  platform_capabilities = [
-    "EC2",
-  ]
-
-  container_properties = jsonencode({
-    command = ["echo", "test"]
-    image   = "busybox"
-    memory  = 128
-    vcpus   = %[4]d
-  })
-
-  scheduling_priority = %[2]d
-  propagate_tags      = %[3]t
-
-  retry_strategy {
-	attempts = %[5]d
-  }
-
-  timeout {
-	attempt_duration_seconds = %[6]d
-  }
-}
-`, rName, sp, pt, cpu, rsa, timeout)
-}
-
 func testAccJobDefinitionConfig_capabilitiesFargateContainerPropertiesDefaults(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}

--- a/internal/service/batch/job_definition_test.go
+++ b/internal/service/batch/job_definition_test.go
@@ -176,7 +176,7 @@ func TestAccBatchJobDefinition_disappears(t *testing.T) {
 	})
 }
 
-func TestAccBatchJobDefinition_containerPropertiesFargateDefaults(t *testing.T) {
+func TestAccBatchJobDefinition_ContainerProperties_fargateDefaults(t *testing.T) {
 	ctx := acctest.Context(t)
 	var jd batch.JobDefinition
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -189,7 +189,7 @@ func TestAccBatchJobDefinition_containerPropertiesFargateDefaults(t *testing.T) 
 		CheckDestroy:             testAccCheckJobDefinitionDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccJobDefinitionConfig_capabilitiesFargateContainerPropertiesDefaults(rName),
+				Config: testAccJobDefinitionConfig_ContainerProperties_defaultsFargate(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckJobDefinitionExists(ctx, resourceName, &jd),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "batch", regexache.MustCompile(fmt.Sprintf(`job-definition/%s:\d+`, rName))),
@@ -221,7 +221,7 @@ func TestAccBatchJobDefinition_containerPropertiesFargateDefaults(t *testing.T) 
 	})
 }
 
-func TestAccBatchJobDefinition_containerPropertiesFargate(t *testing.T) {
+func TestAccBatchJobDefinition_ContainerProperties_fargate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var jd batch.JobDefinition
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -266,7 +266,7 @@ func TestAccBatchJobDefinition_containerPropertiesFargate(t *testing.T) {
 	})
 }
 
-func TestAccBatchJobDefinition_containerPropertiesEC2(t *testing.T) {
+func TestAccBatchJobDefinition_ContainerProperties_EC2(t *testing.T) {
 	ctx := acctest.Context(t)
 	var jd batch.JobDefinition
 	compare := batch.JobDefinition{
@@ -318,7 +318,7 @@ func TestAccBatchJobDefinition_containerPropertiesEC2(t *testing.T) {
 		CheckDestroy:             testAccCheckJobDefinitionDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccJobDefinitionConfig_containerPropertiesAdvanced(rName),
+				Config: testAccJobDefinitionConfig_ContainerProperties_advanced(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckJobDefinitionExists(ctx, resourceName, &jd),
 					testAccCheckJobDefinitionAttributes(&jd, &compare),
@@ -379,7 +379,7 @@ func TestAccBatchJobDefinition_tags(t *testing.T) {
 	})
 }
 
-func TestAccBatchJobDefinition_containerPropertiesEC2EmptyField(t *testing.T) {
+func TestAccBatchJobDefinition_ContainerProperties_EC2EmptyField(t *testing.T) {
 	ctx := acctest.Context(t)
 	var jd batch.JobDefinition
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -395,7 +395,7 @@ func TestAccBatchJobDefinition_containerPropertiesEC2EmptyField(t *testing.T) {
 		CheckDestroy:             testAccCheckJobDefinitionDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccJobDefinitionConfig_containerProperties_emptyField(rName),
+				Config: testAccJobDefinitionConfig_ContainerProperties_emptyField(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckJobDefinitionExists(ctx, resourceName, &jd),
 					acctest.CheckResourceAttrJMES(resourceName, "container_properties", "length(environment)", "1"),
@@ -481,58 +481,58 @@ func TestAccBatchJobDefinition_NodeProperties_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-		},
-	})
-}
-
-func TestAccBatchJobDefinition_NodePropertiesupdateForcesNewResource(t *testing.T) {
-	ctx := acctest.Context(t)
-	var before, after batch.JobDefinition
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_batch_job_definition.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckJobDefinitionDestroy(ctx),
-		Steps: []resource.TestStep{
 			{
-				Config: testAccJobDefinitionConfig_nodePropertiesAdvanced(rName),
+				Config: testAccJobDefinitionConfig_NodeProperties_advancedUpdate(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckJobDefinitionExists(ctx, resourceName, &before),
-					testAccCheckJobDefinitionAttributes(&before, nil),
+					testAccCheckJobDefinitionExists(ctx, resourceName, &jd),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "batch", regexache.MustCompile(fmt.Sprintf(`job-definition/%s:\d+`, rName))),
+					acctest.CheckResourceAttrEquivalentJSON(resourceName, "node_properties", `{
+						"mainNode": 1,
+						"nodeRangeProperties": [
+							{
+								"container": {
+									"command": ["ls","-la"],
+									"environment": [],
+									"image": "busybox",
+									"memory": 512,
+									"mountPoints": [],
+									"resourceRequirements": [],
+									"secrets": [],
+									"ulimits": [],
+									"vcpus": 1,
+									"volumes": []
+								},
+								"targetNodes": "0:"
+							},
+							{
+								"container": {
+									"command": ["echo","test"],
+									"environment": [],
+									"image": "busybox",
+									"memory": 128,
+									"mountPoints": [],
+									"resourceRequirements": [],
+									"secrets": [],
+									"ulimits": [],
+									"vcpus": 1,
+									"volumes": []
+								},
+								"targetNodes": "1:"
+							}
+						],
+						"numNodes": 4
+					}`),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "platform_capabilities.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "propagate_tags", "false"),
+					resource.TestCheckResourceAttr(resourceName, "retry_strategy.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "revision", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "timeout.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "type", "multinode"),
 				),
-			},
-			{
-				Config: testAccJobDefinitionConfig_nodePropertiesAdvancedUpdate(rName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckJobDefinitionExists(ctx, resourceName, &after),
-					testAccCheckJobDefinitionRecreated(t, &before, &after),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccBatchJobDefinition_createTypeContainerWithBothProperties(t *testing.T) {
-	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckJobDefinitionDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccJobDefinitionConfig_createTypeContainerWithBothProperties(rName),
-				ExpectError: regexache.MustCompile("No `node_properties` can be specified when `type` is \"container\""),
 			},
 		},
 	})
@@ -549,14 +549,14 @@ func TestAccBatchJobDefinition_createTypeContainerWithNodeProperties(t *testing.
 		CheckDestroy:             testAccCheckJobDefinitionDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccJobDefinitionConfig_createTypeContainerWithNodeProperties(rName),
+				Config:      testAccJobDefinitionConfig_NodeProperties_createTypeContainerErr(rName),
 				ExpectError: regexache.MustCompile("No `node_properties` can be specified when `type` is \"container\""),
 			},
 		},
 	})
 }
 
-func TestAccBatchJobDefinition_createTypeMultiNodeWithBothProperties(t *testing.T) {
+func TestAccBatchJobDefinition_ContainerProperties_createTypeMultiNodeErr(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -567,25 +567,7 @@ func TestAccBatchJobDefinition_createTypeMultiNodeWithBothProperties(t *testing.
 		CheckDestroy:             testAccCheckJobDefinitionDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccJobDefinitionConfig_createTypeMultiNodeWithBothProperties(rName),
-				ExpectError: regexache.MustCompile("No `container_properties` can be specified when `type` is \"multinode\""),
-			},
-		},
-	})
-}
-
-func TestAccBatchJobDefinition_createTypeMultiNodeWithContainerProperties(t *testing.T) {
-	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckJobDefinitionDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccJobDefinitionConfig_createTypeMultiNodeWithContainerProperties(rName),
+				Config:      testAccJobDefinitionConfig_ContainerProperties_createTypeMultiNodeErr(rName),
 				ExpectError: regexache.MustCompile("No `container_properties` can be specified when `type` is \"multinode\""),
 			},
 		},
@@ -613,6 +595,34 @@ func testAccCheckJobDefinitionExists(ctx context.Context, n string, jd *batch.Jo
 
 		*jd = *jobDefinition
 
+		return nil
+	}
+}
+
+func testAccCheckJobDefinitionDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).BatchConn(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_batch_job_definition" {
+				continue
+			}
+
+			re := regexp.MustCompile(`job-definition/(.*?):`)
+			name := re.FindStringSubmatch(rs.Primary.ID)[1]
+
+			jds, err := tfbatch.ListActiveJobDefinitionByName(ctx, conn, name)
+
+			if count := len(jds); count == 0 {
+				continue
+			}
+
+			if err != nil {
+				return err
+			}
+
+			return fmt.Errorf("Batch Job Definition %s has revisions that still exist", name)
+		}
 		return nil
 	}
 }
@@ -648,35 +658,7 @@ func testAccCheckJobDefinitionAttributes(jd *batch.JobDefinition, compare *batch
 	}
 }
 
-func testAccCheckJobDefinitionDestroy(ctx context.Context) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).BatchConn(ctx)
-
-		for _, rs := range s.RootModule().Resources {
-			if rs.Type != "aws_batch_job_definition" {
-				continue
-			}
-
-			re := regexp.MustCompile(`job-definition/(.*?):`)
-			name := re.FindStringSubmatch(rs.Primary.ID)[1]
-
-			jds, err := tfbatch.ListActiveJobDefinitionByName(ctx, conn, name)
-
-			if count := len(jds); count == 0 {
-				continue
-			}
-
-			if err != nil {
-				return err
-			}
-
-			return fmt.Errorf("Batch Job Definition %s has revisions that still exist", name)
-		}
-		return nil
-	}
-}
-
-func testAccJobDefinitionConfig_containerPropertiesAdvanced(rName string) string {
+func testAccJobDefinitionConfig_ContainerProperties_advanced(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_batch_job_definition" "test" {
   name = %[1]q
@@ -704,49 +686,6 @@ resource "aws_batch_job_definition" "test" {
     "command": ["ls", "-la"],
     "image": "busybox",
     "memory": 512,
-    "vcpus": 1,
-    "volumes": [
-      {
-        "host": {
-          "sourcePath": "/tmp"
-        },
-        "name": "tmp"
-      }
-    ],
-    "environment": [
-        {"name": "VARNAME", "value": "VARVAL"}
-    ],
-    "mountPoints": [
-        {
-          "sourceVolume": "tmp",
-          "containerPath": "/tmp",
-          "readOnly": false
-        }
-    ],
-    "ulimits": [
-      {
-        "hardLimit": 1024,
-        "name": "nofile",
-        "softLimit": 1024
-      }
-    ]
-}
-CONTAINER_PROPERTIES
-
-}
-`, rName)
-}
-
-func testAccJobDefinitionConfig_containerPropertiesAdvancedUpdate(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_batch_job_definition" "test" {
-  name                 = %[1]q
-  type                 = "container"
-  container_properties = <<CONTAINER_PROPERTIES
-{
-    "command": ["ls", "-la"],
-    "image": "busybox",
-    "memory": 1024,
     "vcpus": 1,
     "volumes": [
       {
@@ -826,7 +765,7 @@ resource "aws_batch_job_definition" "test" {
 `, rName, sp, pt, rsa, timeout)
 }
 
-func testAccJobDefinitionConfig_capabilitiesFargateContainerPropertiesDefaults(rName string) string {
+func testAccJobDefinitionConfig_ContainerProperties_defaultsFargate(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -966,24 +905,7 @@ resource "aws_batch_job_definition" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccJobDefinitionConfig_propagateTags(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_batch_job_definition" "test" {
-  container_properties = jsonencode({
-    command = ["echo", "test"]
-    image   = "busybox"
-    memory  = 128
-    vcpus   = 1
-  })
-  name = %[1]q
-  type = "container"
-
-  propagate_tags = true
-}
-`, rName)
-}
-
-func testAccJobDefinitionConfig_containerProperties_emptyField(rName string) string {
+func testAccJobDefinitionConfig_ContainerProperties_emptyField(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_batch_job_definition" "test" {
   container_properties = jsonencode({
@@ -1042,10 +964,8 @@ resource "aws_batch_job_definition" "test" {
 `, rName)
 }
 
-func testAccJobDefinitionConfig_nodePropertiesAdvanced(rName string) string {
+func testAccJobDefinitionConfig_NodeProperties_advanced(rName string) string {
 	return fmt.Sprintf(`
-
-
 resource "aws_batch_job_definition" "test" {
   name = %[1]q
   type = "multinode"
@@ -1116,10 +1036,8 @@ resource "aws_batch_job_definition" "test" {
 `, rName)
 }
 
-func testAccJobDefinitionConfig_nodePropertiesAdvancedUpdate(rName string) string {
+func testAccJobDefinitionConfig_NodeProperties_advancedUpdate(rName string) string {
 	return fmt.Sprintf(`
-
-
 resource "aws_batch_job_definition" "test" {
   name = %[1]q
   type = "multinode"
@@ -1160,68 +1078,11 @@ resource "aws_batch_job_definition" "test" {
     numNodes = 4
   })
 }
-	`, rName)
+`, rName)
 }
 
-func testAccJobDefinitionConfig_createTypeContainerWithBothProperties(rName string) string {
+func testAccJobDefinitionConfig_NodeProperties_createTypeContainerErr(rName string) string {
 	return fmt.Sprintf(`
-
-
-resource "aws_batch_job_definition" "test" {
-  name = %[1]q
-  type = "container"
-  parameters = {
-    param1 = "val1"
-    param2 = "val2"
-  }
-  timeout {
-    attempt_duration_seconds = 60
-  }
-
-  container_properties = jsonencode({
-    command = ["echo", "test"]
-    image   = "busybox"
-    memory  = 128
-    vcpus   = 1
-  })
-
-  node_properties = jsonencode({
-    mainNode = 1
-    nodeRangeProperties = [
-      {
-        container = {
-          "command" : ["ls", "-la"],
-          "image" : "busybox",
-          "memory" : 512,
-          "vcpus" : 1
-        }
-        targetNodes = "0:"
-      },
-      {
-        container = {
-          command     = ["echo", "test"]
-          environment = []
-          image       = "busybox"
-          memory      = 128
-          mountPoints = []
-          ulimits     = []
-          vcpus       = 1
-          volumes     = []
-        }
-        targetNodes = "1:"
-      }
-    ]
-    numNodes = 4
-  })
-
-}
-	`, rName)
-}
-
-func testAccJobDefinitionConfig_createTypeContainerWithNodeProperties(rName string) string {
-	return fmt.Sprintf(`
-
-
 resource "aws_batch_job_definition" "test" {
   name = %[1]q
   type = "container"
@@ -1261,70 +1122,12 @@ resource "aws_batch_job_definition" "test" {
     ]
     numNodes = 4
   })
-
 }
-	`, rName)
+`, rName)
 }
 
-func testAccJobDefinitionConfig_createTypeMultiNodeWithBothProperties(rName string) string {
+func testAccJobDefinitionConfig_ContainerProperties_createTypeMultiNodeErr(rName string) string {
 	return fmt.Sprintf(`
-
-
-resource "aws_batch_job_definition" "test" {
-  name = %[1]q
-  type = "multinode"
-  parameters = {
-    param1 = "val1"
-    param2 = "val2"
-  }
-  timeout {
-    attempt_duration_seconds = 60
-  }
-
-  container_properties = jsonencode({
-    command = ["echo", "test"]
-    image   = "busybox"
-    memory  = 128
-    vcpus   = 1
-  })
-
-  node_properties = jsonencode({
-    mainNode = 1
-    nodeRangeProperties = [
-      {
-        container = {
-          "command" : ["ls", "-la"],
-          "image" : "busybox",
-          "memory" : 512,
-          "vcpus" : 1
-        }
-        targetNodes = "0:"
-      },
-      {
-        container = {
-          command     = ["echo", "test"]
-          environment = []
-          image       = "busybox"
-          memory      = 128
-          mountPoints = []
-          ulimits     = []
-          vcpus       = 1
-          volumes     = []
-        }
-        targetNodes = "1:"
-      }
-    ]
-    numNodes = 4
-  })
-
-}
-	`, rName)
-}
-
-func testAccJobDefinitionConfig_createTypeMultiNodeWithContainerProperties(rName string) string {
-	return fmt.Sprintf(`
-
-
 resource "aws_batch_job_definition" "test" {
   name = %[1]q
   type = "multinode"
@@ -1344,5 +1147,5 @@ resource "aws_batch_job_definition" "test" {
   })
 
 }
-	`, rName)
+`, rName)
 }

--- a/internal/service/batch/job_definition_test.go
+++ b/internal/service/batch/job_definition_test.go
@@ -39,6 +39,7 @@ func TestAccBatchJobDefinition_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckJobDefinitionExists(ctx, resourceName, &jd),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "batch", regexache.MustCompile(fmt.Sprintf(`job-definition/%s:\d+`, rName))),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn_prefix", "batch", regexache.MustCompile(fmt.Sprintf(`job-definition/%s`, rName))),
 					acctest.CheckResourceAttrEquivalentJSON(resourceName, "container_properties", `{
 						"command": ["echo", "test"],
 						"image": "busybox",
@@ -113,6 +114,7 @@ func TestAccBatchJobDefinition_PlatformCapabilities_ec2(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckJobDefinitionExists(ctx, resourceName, &jd),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "batch", regexache.MustCompile(fmt.Sprintf(`job-definition/%s:\d+`, rName))),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn_prefix", "batch", regexache.MustCompile(fmt.Sprintf(`job-definition/%s`, rName))),
 					acctest.CheckResourceAttrEquivalentJSON(resourceName, "container_properties", `{
 						"command": ["echo", "test"],
 						"image": "busybox",
@@ -163,6 +165,7 @@ func TestAccBatchJobDefinition_PlatformCapabilitiesFargate_containerPropertiesDe
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckJobDefinitionExists(ctx, resourceName, &jd),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "batch", regexache.MustCompile(fmt.Sprintf(`job-definition/%s:\d+`, rName))),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn_prefix", "batch", regexache.MustCompile(fmt.Sprintf(`job-definition/%s`, rName))),
 					acctest.CheckResourceAttrJMES(resourceName, "container_properties", "length(command)", "0"),
 					acctest.CheckResourceAttrJMESPair(resourceName, "container_properties", "executionRoleArn", "aws_iam_role.ecs_task_execution_role", "arn"),
 					acctest.CheckResourceAttrJMES(resourceName, "container_properties", "fargatePlatformConfiguration.platformVersion", "LATEST"),
@@ -207,6 +210,7 @@ func TestAccBatchJobDefinition_PlatformCapabilities_fargate(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckJobDefinitionExists(ctx, resourceName, &jd),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "batch", regexache.MustCompile(fmt.Sprintf(`job-definition/%s:\d+`, rName))),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn_prefix", "batch", regexache.MustCompile(fmt.Sprintf(`job-definition/%s`, rName))),
 					acctest.CheckResourceAttrJMESPair(resourceName, "container_properties", "executionRoleArn", "aws_iam_role.ecs_task_execution_role", "arn"),
 					acctest.CheckResourceAttrJMES(resourceName, "container_properties", "fargatePlatformConfiguration.platformVersion", "LATEST"),
 					acctest.CheckResourceAttrJMES(resourceName, "container_properties", "networkConfiguration.assignPublicIp", "DISABLED"),
@@ -399,6 +403,7 @@ func TestAccBatchJobDefinition_propagateTags(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckJobDefinitionExists(ctx, resourceName, &jd),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "batch", regexache.MustCompile(fmt.Sprintf(`job-definition/%s:\d+`, rName))),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn_prefix", "batch", regexache.MustCompile(fmt.Sprintf(`job-definition/%s`, rName))),
 					acctest.CheckResourceAttrEquivalentJSON(resourceName, "container_properties", `{
 						"command": ["echo", "test"],
 						"image": "busybox",

--- a/internal/service/batch/job_definition_test.go
+++ b/internal/service/batch/job_definition_test.go
@@ -68,6 +68,9 @@ func TestAccBatchJobDefinition_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"deregister_on_new_revision",
+				},
 			},
 		},
 	})
@@ -110,7 +113,7 @@ func TestAccBatchJobDefinition_attributes(t *testing.T) {
 				Config: testAccJobDefinitionConfig_attributes(rName, 2, true, 4, 120, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckJobDefinitionExists(ctx, resourceName, &jd),
-					testAccCheckJobDefinitionPreviousRegistered(ctx, resourceName, &jd),
+					testAccCheckJobDefinitionPreviousRegistered(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "revision", "2"),
 				),
 			},
@@ -118,7 +121,7 @@ func TestAccBatchJobDefinition_attributes(t *testing.T) {
 				Config: testAccJobDefinitionConfig_name(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckJobDefinitionExists(ctx, resourceName, &jd),
-					testAccCheckJobDefinitionPreviousDeregistered(ctx, resourceName, &jd),
+					testAccCheckJobDefinitionPreviousDeregistered(ctx, resourceName),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "batch", regexache.MustCompile(fmt.Sprintf(`job-definition/%s:\d+`, rName))),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn_prefix", "batch", regexache.MustCompile(fmt.Sprintf(`job-definition/%s`, rName))),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -143,7 +146,7 @@ func TestAccBatchJobDefinition_attributes(t *testing.T) {
 				Config: testAccJobDefinitionConfig_attributes(rName, 1, false, 1, 60, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckJobDefinitionExists(ctx, resourceName, &jd),
-					testAccCheckJobDefinitionPreviousDeregistered(ctx, resourceName, &jd),
+					testAccCheckJobDefinitionPreviousDeregistered(ctx, resourceName),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "batch", regexache.MustCompile(fmt.Sprintf(`job-definition/%s:\d+`, rName))),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn_prefix", "batch", regexache.MustCompile(fmt.Sprintf(`job-definition/%s`, rName))),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -229,6 +232,9 @@ func TestAccBatchJobDefinition_ContainerProperties_fargateDefaults(t *testing.T)
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"deregister_on_new_revision",
+				},
 			},
 		},
 	})
@@ -274,6 +280,9 @@ func TestAccBatchJobDefinition_ContainerProperties_fargate(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"deregister_on_new_revision",
+				},
 			},
 		},
 	})
@@ -341,6 +350,9 @@ func TestAccBatchJobDefinition_ContainerProperties_EC2(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"deregister_on_new_revision",
+				},
 			},
 		},
 	})
@@ -370,6 +382,9 @@ func TestAccBatchJobDefinition_tags(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"deregister_on_new_revision",
+				},
 			},
 			{
 				Config: testAccJobDefinitionConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
@@ -419,6 +434,9 @@ func TestAccBatchJobDefinition_ContainerProperties_EC2EmptyField(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"deregister_on_new_revision",
+				},
 			},
 		},
 	})
@@ -493,6 +511,9 @@ func TestAccBatchJobDefinition_NodeProperties_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"deregister_on_new_revision",
+				},
 			},
 			{
 				Config: testAccJobDefinitionConfig_NodeProperties_advancedUpdate(rName),
@@ -640,7 +661,7 @@ func testAccCheckJobDefinitionDestroy(ctx context.Context) resource.TestCheckFun
 	}
 }
 
-func testAccCheckJobDefinitionPreviousRegistered(ctx context.Context, n string, jd *batch.JobDefinition) resource.TestCheckFunc {
+func testAccCheckJobDefinitionPreviousRegistered(ctx context.Context, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -669,7 +690,7 @@ func testAccCheckJobDefinitionPreviousRegistered(ctx context.Context, n string, 
 	}
 }
 
-func testAccCheckJobDefinitionPreviousDeregistered(ctx context.Context, n string, jd *batch.JobDefinition) resource.TestCheckFunc {
+func testAccCheckJobDefinitionPreviousDeregistered(ctx context.Context, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -705,7 +726,7 @@ func parseJobDefinitionPreviousARN(currentARN string) (previousARN string) {
 	revisionCurrent, _ := strconv.Atoi(revisionCurrentStr)
 	revisionPrevious := revisionCurrent - 1
 
-	re = regexache.MustCompile(`^(arn:aws:batch:[a-z0-9-]+:[0-9]+:job-definition/[a-z0-9-]+):`)
+	re = regexache.MustCompile(`^(arn:.*:batch:[a-z0-9-]+:[0-9]+:job-definition/[a-z0-9-]+):`)
 	arnPrefix := re.FindStringSubmatch(currentARN)[1]
 	previousARN = fmt.Sprintf("%s:%d", arnPrefix, revisionPrevious)
 

--- a/website/docs/r/batch_job_definition.html.markdown
+++ b/website/docs/r/batch_job_definition.html.markdown
@@ -202,7 +202,7 @@ The following arguments are optional:
 This resource exports the following attributes in addition to the arguments above:
 
 * `arn` - The Amazon Resource Name of the job definition, includes revision (`:#`).
-* `arn_prefix` - The ARN without the revision
+* `arn_prefix` - The ARN without the revision number.
 * `revision` - The revision of the job definition.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 

--- a/website/docs/r/batch_job_definition.html.markdown
+++ b/website/docs/r/batch_job_definition.html.markdown
@@ -170,6 +170,7 @@ The following arguments are optional:
 
 * `container_properties` - (Optional) A valid [container properties](http://docs.aws.amazon.com/batch/latest/APIReference/API_RegisterJobDefinition.html)
     provided as a single valid JSON document. This parameter is required if the `type` parameter is `container`.
+* `deregister_on_new_revision` - (Optional) When updating a job definition a new revision is created. This parameter determines if the previous version is `deregistered` (`INACTIVE`) or left `ACTIVE`. Defaults to `true`.
 * `node_properties` - (Optional) A valid [node properties](http://docs.aws.amazon.com/batch/latest/APIReference/API_RegisterJobDefinition.html)
     provided as a single valid JSON document. This parameter is required if the `type` parameter is `multinode`.
 * `parameters` - (Optional) Specifies the parameter substitution placeholders to set in the job definition.

--- a/website/docs/r/batch_job_definition.html.markdown
+++ b/website/docs/r/batch_job_definition.html.markdown
@@ -177,6 +177,7 @@ The following arguments are optional:
 * `propagate_tags` - (Optional) Specifies whether to propagate the tags from the job definition to the corresponding Amazon ECS task. Default is `false`.
 * `retry_strategy` - (Optional) Specifies the retry strategy to use for failed jobs that are submitted with this job definition.
     Maximum number of `retry_strategy` is `1`.  Defined below.
+* `scheduling_priority` - (Optional) The scheduling priority of the job definition. This only affects jobs in job queues with a fair share policy. Jobs with a higher scheduling priority are scheduled before jobs with a lower scheduling priority. Allowed values `0` through `9999`.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `timeout` - (Optional) Specifies the timeout for jobs so that if a job runs longer, AWS Batch terminates the job. Maximum number of `timeout` is `1`. Defined below.
 
@@ -200,7 +201,8 @@ The following arguments are optional:
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `arn` - The Amazon Resource Name of the job definition.
+* `arn` - The Amazon Resource Name of the job definition, includes revision (`:#`).
+* `arn_prefix` - The ARN without the revision
 * `revision` - The revision of the job definition.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 


### PR DESCRIPTION
Closes #29819.
Closes #18111.
Closes #31226.

## Summary

`job_definition` (JD) was previously a ForceNew resource on all parameters. This was interesting because when a JD is deleted in AWS the revision still lasts but is marked as inactive. In some ways, the ForceNew didnt matter because a new revision was being created. This PR modifies the behavior so that instead of deleting each revision as a new is created, we merely add a new one. 

### Design decisions
- old revisions are deactivated by default (prior behavior). This can be disabled by new param `deregister_on_new_revision`
- delete now deregisters all JDs with the associated name
- testing delete function (`testAccCheckJobDefinitionDestroy`) now checks to see if any revisions exist and fails accordingly
- refactored tests for naming consistency, simplicity, and better alignment with provider norms. Details below

### Refactored tests
- renamed test: `_capabilitiesEC2` -> `_attributes` - new parent test for root level attribute checks
- renamed test: `_PlatformCapabilitiesFargate_containerPropertiesDefaults` -> `_ContainerProperties_fargateDefaults`
- renamed test: `_PlatformCapabilities_fargate` -> `_ContainerProperties_fargate`
- renamed test: `_ContainerProperties_advanced` -> `_ContainerProperties_EC2`
- renamed test: `_ContainerProperties_EmptyField` -> `_ContainerProperties_EC2EmptyField`
- removed test: `_PlatformCapabilities_ec2` -> coverage by `_attributes`
- removed test: `_updateForcesNewResource` -> coverage by `_attributes`
- removed test: `_propagateTags` -> coverage by `_attributes`
- removed test: `_NodePropertiesupdateForcesNewResource` -> coverage by `_NodeProperties_basic`
- removed test: `createTypeContainerWithBothProperties` -> added `ConflictsWith` which prevents setting both properties
- removed test: `_createTypeMultiNodeWithBothProperties` -> added `ConflictsWith` which prevents setting both properties 
- removed test: `_NodeProperties_advanced` -> replaced by `_advancedUpdate`
- removed function: `testAccCheckJobDefinitionRecreated` -> covered by `_attributes` and `jd.Revision` parameter
- modified function: `testAccCheckJobDefinitionDestroy` now checks for all revisions to be deregistered
- removed config: `_propagateTags` -> covered by `_attributes`
- removed config: `_containerProperties_advancedUpdate` -> covered by `_attributes`
- removed config: `_createTypeMultiNodeWithBothProperties` -> added `ConflictsWith` which prevents setting both properties 

```shell
$ make testacc TESTS=TestAccBatchJobDefinition_ PKG=batch    
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/batch/... -v -count 1 -parallel 20 -run='TestAccBatchJobDefinition_'  -timeout 360m
=== RUN   TestAccBatchJobDefinition_basic
=== PAUSE TestAccBatchJobDefinition_basic
=== RUN   TestAccBatchJobDefinition_attributes
=== PAUSE TestAccBatchJobDefinition_attributes
=== RUN   TestAccBatchJobDefinition_disappears
=== PAUSE TestAccBatchJobDefinition_disappears
=== RUN   TestAccBatchJobDefinition_ContainerProperties_fargateDefaults
=== PAUSE TestAccBatchJobDefinition_ContainerProperties_fargateDefaults
=== RUN   TestAccBatchJobDefinition_ContainerProperties_fargate
=== PAUSE TestAccBatchJobDefinition_ContainerProperties_fargate
=== RUN   TestAccBatchJobDefinition_ContainerProperties_EC2
=== PAUSE TestAccBatchJobDefinition_ContainerProperties_EC2
=== RUN   TestAccBatchJobDefinition_tags
=== PAUSE TestAccBatchJobDefinition_tags
=== RUN   TestAccBatchJobDefinition_ContainerProperties_EC2EmptyField
=== PAUSE TestAccBatchJobDefinition_ContainerProperties_EC2EmptyField
=== RUN   TestAccBatchJobDefinition_NodeProperties_basic
=== PAUSE TestAccBatchJobDefinition_NodeProperties_basic
=== RUN   TestAccBatchJobDefinition_NodeProperties_createTypeContainerErr
=== PAUSE TestAccBatchJobDefinition_NodeProperties_createTypeContainerErr
=== RUN   TestAccBatchJobDefinition_ContainerProperties_createTypeMultiNodeErr
=== PAUSE TestAccBatchJobDefinition_ContainerProperties_createTypeMultiNodeErr
=== CONT  TestAccBatchJobDefinition_basic
=== CONT  TestAccBatchJobDefinition_tags
=== CONT  TestAccBatchJobDefinition_ContainerProperties_fargateDefaults
=== CONT  TestAccBatchJobDefinition_ContainerProperties_EC2EmptyField
=== CONT  TestAccBatchJobDefinition_ContainerProperties_fargate
=== CONT  TestAccBatchJobDefinition_ContainerProperties_EC2
=== CONT  TestAccBatchJobDefinition_attributes
=== CONT  TestAccBatchJobDefinition_ContainerProperties_createTypeMultiNodeErr
=== CONT  TestAccBatchJobDefinition_NodeProperties_createTypeContainerErr
=== CONT  TestAccBatchJobDefinition_NodeProperties_basic
=== CONT  TestAccBatchJobDefinition_disappears
--- PASS: TestAccBatchJobDefinition_ContainerProperties_createTypeMultiNodeErr (41.23s)
--- PASS: TestAccBatchJobDefinition_NodeProperties_createTypeContainerErr (41.59s)
--- PASS: TestAccBatchJobDefinition_disappears (78.78s)
--- PASS: TestAccBatchJobDefinition_basic (93.96s)
--- PASS: TestAccBatchJobDefinition_ContainerProperties_EC2 (96.96s)
--- PASS: TestAccBatchJobDefinition_ContainerProperties_EC2EmptyField (103.81s)
--- PASS: TestAccBatchJobDefinition_NodeProperties_basic (138.26s)
--- PASS: TestAccBatchJobDefinition_tags (165.20s)
--- PASS: TestAccBatchJobDefinition_attributes (168.57s)
--- PASS: TestAccBatchJobDefinition_ContainerProperties_fargate (187.95s)
--- PASS: TestAccBatchJobDefinition_ContainerProperties_fargateDefaults (189.10s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/batch      191.249s
```