### PR TITLE
key_algorithm argument in the tls_cert_request resource is read only

### DIFF
--- a/website/docs/r/acmpca_certificate.html.markdown
+++ b/website/docs/r/acmpca_certificate.html.markdown
@@ -31,7 +31,7 @@ resource "aws_acmpca_certificate" "example" {
 }
 
 resource "aws_acmpca_certificate_authority" "example" {
-  private_certificate_configuration {
+  certificate_authority_configuration {
     key_algorithm     = "RSA_4096"
     signing_algorithm = "SHA512WITHRSA"
 
@@ -48,7 +48,6 @@ resource "tls_private_key" "key" {
 }
 
 resource "tls_cert_request" "csr" {
-  key_algorithm   = "RSA"
   private_key_pem = tls_private_key.key.private_key_pem
 
   subject {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
---> I have update the document 
### Description
<!---  certificate_authority_configuration {
    key_algorithm     = "RSA_4096"
    signing_algorithm = "SHA512WITHRSA"
}
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/33481.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
