### PR TITLE
Rolls back AWS SDK modules with shared config parsing bug

### DIFF
--- a/.changelog/34300.txt
+++ b/.changelog/34300.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+provider: Fixes parsing error in AWS shared config files with extra whitespace
+```
+
+```release-note:bug
+provider: Fixes poor performance when parsing AWS shared config files
+```

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/YakDriver/regexache v0.23.0
 	github.com/aws/aws-sdk-go v1.47.4
 	github.com/aws/aws-sdk-go-v2 v1.22.1
-	github.com/aws/aws-sdk-go-v2/config v1.22.1
+	github.com/aws/aws-sdk-go-v2/config v1.20.0
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.14.2
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.13.2
 	github.com/aws/aws-sdk-go-v2/service/accessanalyzer v1.23.0
@@ -129,7 +129,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.15.1 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.2.1 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.5.1 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/ini v1.5.0 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/ini v1.4.0 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.2.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.23.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/iam v1.22.7 // indirect
@@ -199,3 +199,11 @@ require (
 )
 
 replace github.com/hashicorp/terraform-plugin-log => github.com/gdavison/terraform-plugin-log v0.0.0-20230928191232-6c653d8ef8fb
+
+exclude ( // Contains INI parsing regression
+	github.com/aws/aws-sdk-go-v2/config v1.21.0
+	github.com/aws/aws-sdk-go-v2/config v1.22.0
+	github.com/aws/aws-sdk-go-v2/config v1.22.1
+	github.com/aws/aws-sdk-go-v2/internal/ini v1.5.0
+	github.com/aws/aws-sdk-go-v2/internal/ini v1.5.1
+)

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/aws/aws-sdk-go-v2 v1.22.1 h1:sjnni/AuoTXxHitsIdT0FwmqUuNUuHtufcVDErVF
 github.com/aws/aws-sdk-go-v2 v1.22.1/go.mod h1:Kd0OJtkW3Q0M0lUWGszapWjEvrXDzRW+D21JNsroB+c=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.5.0 h1:hHgLiIrTRtddC0AKcJr5s7i/hLgcpTt+q/FKxf1Zayk=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.5.0/go.mod h1:w4I/v3NOWgD+qvs1NPEwhd++1h3XPHFaVxasfY6HlYQ=
-github.com/aws/aws-sdk-go-v2/config v1.22.1 h1:UrRYnF7mXCGuKmZWlczOXeH0WUbQpi/gseQIPtrhme8=
-github.com/aws/aws-sdk-go-v2/config v1.22.1/go.mod h1:2eWgw5lps8fKI7LZVTrRTYP6HE6k/uEFUuTSHfXwqP0=
+github.com/aws/aws-sdk-go-v2/config v1.20.0 h1:q2+/mqFhY0J9m3Tb5RGFE3R4sdaUkIe4k2EuDfE3c08=
+github.com/aws/aws-sdk-go-v2/config v1.20.0/go.mod h1:7+1riCZXyT+sAGvneR5j+Zl1GyfbBUNQurpQTE6FP6k=
 github.com/aws/aws-sdk-go-v2/credentials v1.15.1 h1:hmf6lAm9hk7uLCfapZn/jL05lm6Uwdbn1B0fgjyuf4M=
 github.com/aws/aws-sdk-go-v2/credentials v1.15.1/go.mod h1:QTcHga3ZbQOneJuxmGBOCxiClxmp+TlvmjFexAnJ790=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.14.2 h1:gIeH4+o1MN/caGBWjoGQTUTIu94xD6fI5B2+TcwBf70=
@@ -43,8 +43,8 @@ github.com/aws/aws-sdk-go-v2/internal/configsources v1.2.1/go.mod h1:V5CY8wNurvP
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.37/go.mod h1:Qe+2KtKml+FEsQF/DHmDV+xjtche/hwoF75EG4UlHW8=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.5.1 h1:ZpaV/j48RlPc4AmOZuPv22pJliXjXq8/reL63YzyFnw=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.5.1/go.mod h1:R8aXraabD2e3qv1csxM14/X9WF4wFMIY0kH4YEtYD5M=
-github.com/aws/aws-sdk-go-v2/internal/ini v1.5.0 h1:DqOQvIfmGkXZUVJnl9VRk0AnxyS59tCtX9k1Pyss4Ak=
-github.com/aws/aws-sdk-go-v2/internal/ini v1.5.0/go.mod h1:VV/Kbw9Mg1GWJOT9WK+oTL3cWZiXtapnNvDSRqTZLsg=
+github.com/aws/aws-sdk-go-v2/internal/ini v1.4.0 h1:21tlTXq3ev10yLMAjXZzpkZbrl49h3ElSjmxD57tD/E=
+github.com/aws/aws-sdk-go-v2/internal/ini v1.4.0/go.mod h1:d9YrBHJhyzDCv5UsEVRizHlFV6Q0sLemFq6uxuqWfUw=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.2.1 h1:vzYLDkwTw4CY0vUk84MeSufRf8XIsC/GsoIFXD60sTg=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.2.1/go.mod h1:ToBFBnjeGR2ruMx8IWp/y7vSK3Irj5/oPwifruiqoOM=
 github.com/aws/aws-sdk-go-v2/service/accessanalyzer v1.23.0 h1:po7m50dyaYEThawBGQigDwXcIPdZ2TbL43mBwgAG1K4=

--- a/internal/errs/sdkdiag/compare.go
+++ b/internal/errs/sdkdiag/compare.go
@@ -1,0 +1,28 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package sdkdiag
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+)
+
+// Comparer is a Comparer function for use with cmp.Diff to compare two diag.Diagnostic values
+func Comparer(l, r diag.Diagnostic) bool {
+	if l.Severity != r.Severity {
+		return false
+	}
+	if l.Summary != r.Summary {
+		return false
+	}
+	if l.Detail != r.Detail {
+		return false
+	}
+
+	lp := l.AttributePath
+	rp := r.AttributePath
+	if len(lp) != len(rp) {
+		return false
+	}
+	return lp.Equals(rp)
+}

--- a/internal/errs/sdkdiag/diags.go
+++ b/internal/errs/sdkdiag/diags.go
@@ -6,6 +6,7 @@ package sdkdiag
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
@@ -47,4 +48,15 @@ func DiagnosticString(d diag.Diagnostic) string {
 		return d.Summary
 	}
 	return fmt.Sprintf("%s\n\n%s", d.Summary, d.Detail)
+}
+
+// DiagnosticsString formats a Diagnostics
+func DiagnosticsString(diags diag.Diagnostics) string {
+	var buf strings.Builder
+
+	for _, d := range diags {
+		fmt.Fprintln(&buf, DiagnosticString(d))
+	}
+
+	return buf.String()
 }

--- a/internal/provider/provider_config_test.go
+++ b/internal/provider/provider_config_test.go
@@ -19,7 +19,7 @@ import (
 
 // TestSharedConfigFileParsing prevents regression in shared config file parsing
 // * https://github.com/aws/aws-sdk-go-v2/issues/2349: indented keys
-func TestSharedConfigFileParsing(t *testing.T) {
+func TestSharedConfigFileParsing(t *testing.T) { //nolint:paralleltest
 	testcases := map[string]struct {
 		Config                  map[string]any
 		SharedConfigurationFile string
@@ -30,8 +30,9 @@ func TestSharedConfigFileParsing(t *testing.T) {
 			SharedConfigurationFile: `
 	[default]
 	region = us-west-2
-	`,
+	`, //lintignore:AWSAT003
 			Check: func(t *testing.T, meta *conns.AWSClient) {
+				//lintignore:AWSAT003
 				if a, e := meta.Region, "us-west-2"; a != e {
 					t.Errorf("expected region %q, got %q", e, a)
 				}
@@ -39,7 +40,7 @@ func TestSharedConfigFileParsing(t *testing.T) {
 		},
 	}
 
-	for name, tc := range testcases {
+	for name, tc := range testcases { //nolint:paralleltest
 		tc := tc
 
 		t.Run(name, func(t *testing.T) {
@@ -64,7 +65,7 @@ func TestSharedConfigFileParsing(t *testing.T) {
 
 				defer os.Remove(file.Name())
 
-				err = os.WriteFile(file.Name(), []byte(tc.SharedConfigurationFile), 0600) //nolint:gomnd
+				err = os.WriteFile(file.Name(), []byte(tc.SharedConfigurationFile), 0600)
 
 				if err != nil {
 					t.Fatalf("unexpected error writing shared configuration file: %s", err)

--- a/internal/provider/provider_config_test.go
+++ b/internal/provider/provider_config_test.go
@@ -1,0 +1,109 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+)
+
+// TestSharedConfigFileParsing prevents regression in shared config file parsing
+// * https://github.com/aws/aws-sdk-go-v2/issues/2349: indented keys
+func TestSharedConfigFileParsing(t *testing.T) {
+	testcases := map[string]struct {
+		Config                  map[string]any
+		SharedConfigurationFile string
+		Check                   func(t *testing.T, meta *conns.AWSClient)
+	}{
+		"leading whitespace": {
+			// Do not "fix" indentation!
+			SharedConfigurationFile: `
+	[default]
+	region = us-west-2
+	`,
+			Check: func(t *testing.T, meta *conns.AWSClient) {
+				if a, e := meta.Region, "us-west-2"; a != e {
+					t.Errorf("expected region %q, got %q", e, a)
+				}
+			},
+		},
+	}
+
+	for name, tc := range testcases {
+		tc := tc
+
+		t.Run(name, func(t *testing.T) {
+			ctx := context.TODO()
+
+			oldenv := servicemocks.InitSessionTestEnv()
+			defer servicemocks.PopEnv(oldenv)
+
+			config := map[string]any{
+				"access_key":                  servicemocks.MockStaticAccessKey,
+				"secret_key":                  servicemocks.MockStaticSecretKey,
+				"skip_credentials_validation": true,
+				"skip_requesting_account_id":  true,
+			}
+
+			if tc.SharedConfigurationFile != "" {
+				file, err := os.CreateTemp("", "aws-sdk-go-base-shared-configuration-file")
+
+				if err != nil {
+					t.Fatalf("unexpected error creating temporary shared configuration file: %s", err)
+				}
+
+				defer os.Remove(file.Name())
+
+				err = os.WriteFile(file.Name(), []byte(tc.SharedConfigurationFile), 0600) //nolint:gomnd
+
+				if err != nil {
+					t.Fatalf("unexpected error writing shared configuration file: %s", err)
+				}
+
+				config["shared_config_files"] = []any{file.Name()}
+			}
+
+			rc := terraformsdk.NewResourceConfigRaw(config)
+
+			p, err := New(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var diags diag.Diagnostics
+			diags = append(diags, p.Validate(rc)...)
+			if diags.HasError() {
+				t.Fatalf("validating: %s", sdkdiag.DiagnosticsString(diags))
+			}
+
+			diags = append(diags, p.Configure(ctx, rc)...)
+
+			// The provider always returns a warning if there is no account ID
+			var expected diag.Diagnostics
+			expected = append(expected,
+				errs.NewWarningDiagnostic(
+					"AWS account ID not found for provider",
+					"See https://www.terraform.io/docs/providers/aws/index.html#skip_requesting_account_id for implications.",
+				),
+			)
+
+			if diff := cmp.Diff(diags, expected, cmp.Comparer(sdkdiag.Comparer)); diff != "" {
+				t.Errorf("unexpected diagnostics difference: %s", diff)
+			}
+
+			meta := p.Meta().(*conns.AWSClient)
+
+			tc.Check(t, meta)
+		})
+	}
+}

--- a/internal/service/acmpca/certificate_test.go
+++ b/internal/service/acmpca/certificate_test.go
@@ -473,6 +473,10 @@ resource "aws_acmpca_certificate" "test" {
     type  = "YEARS"
     value = 1
   }
+
+  depends_on = [
+	aws_acmpca_certificate_authority_certificate.root,
+  ]
 }
 
 resource "aws_acmpca_certificate_authority" "test" {
@@ -506,6 +510,10 @@ resource "aws_acmpca_certificate" "test" {
     type  = "DAYS"
     value = 1
   }
+
+  depends_on = [
+	aws_acmpca_certificate_authority_certificate.root,
+  ]
 }
 `, csr))
 }
@@ -525,6 +533,10 @@ resource "aws_acmpca_certificate" "test" {
     type  = "END_DATE"
     value = %[2]q
   }
+
+  depends_on = [
+	aws_acmpca_certificate_authority_certificate.root,
+  ]
 }
 `, csr, expiry))
 }
@@ -544,6 +556,10 @@ resource "aws_acmpca_certificate" "test" {
     type  = "ABSOLUTE"
     value = %[2]d
   }
+
+  depends_on = [
+	aws_acmpca_certificate_authority_certificate.root,
+  ]
 }
 `, csr, expiry))
 }

--- a/internal/service/acmpca/certificate_test.go
+++ b/internal/service/acmpca/certificate_test.go
@@ -473,10 +473,6 @@ resource "aws_acmpca_certificate" "test" {
     type  = "YEARS"
     value = 1
   }
-
-  depends_on = [
-	aws_acmpca_certificate_authority_certificate.root,
-  ]
 }
 
 resource "aws_acmpca_certificate_authority" "test" {
@@ -510,10 +506,6 @@ resource "aws_acmpca_certificate" "test" {
     type  = "DAYS"
     value = 1
   }
-
-  depends_on = [
-	aws_acmpca_certificate_authority_certificate.root,
-  ]
 }
 `, csr))
 }
@@ -533,10 +525,6 @@ resource "aws_acmpca_certificate" "test" {
     type  = "END_DATE"
     value = %[2]q
   }
-
-  depends_on = [
-	aws_acmpca_certificate_authority_certificate.root,
-  ]
 }
 `, csr, expiry))
 }
@@ -556,10 +544,6 @@ resource "aws_acmpca_certificate" "test" {
     type  = "ABSOLUTE"
     value = %[2]d
   }
-
-  depends_on = [
-	aws_acmpca_certificate_authority_certificate.root,
-  ]
 }
 `, csr, expiry))
 }


### PR DESCRIPTION
### Description

Rolls back `github.com/aws/aws-sdk-go-v2/config` and `github.com/aws/aws-sdk-go-v2/internal/ini` versions which contain shared config file parsing bug https://github.com/aws/aws-sdk-go-v2/issues/2349

Adds exclusions to `go.mod` file and adds test for this regression

Relates #34234.
Closes #34257.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% go test -v ./internal/provider/... -run=TestSharedConfigFileParsing

--- PASS: TestSharedConfigFileParsing (0.08s)
    --- PASS: TestSharedConfigFileParsing/leading_whitespace (0.08s)
```
