### PR TITLE
[WIP] Add support for GPG key sourced from GitHub

### DIFF
--- a/internal/service/iam/encryption.go
+++ b/internal/service/iam/encryption.go
@@ -4,11 +4,13 @@
 package iam
 
 import (
+	"bytes"
 	"encoding/base64"
 	"fmt"
-	"strings"
-
 	"github.com/hashicorp/terraform-provider-aws/internal/vault/helper/pgpkeys"
+	"golang.org/x/crypto/openpgp"
+	"net/http"
+	"strings"
 )
 
 // retrieveGPGKey returns the PGP key specified as the pgpKey parameter, or queries
@@ -16,14 +18,43 @@ import (
 // prefixed with the phrase "keybase:"
 func retrieveGPGKey(pgpKey string) (string, error) {
 	const keybasePrefix = "keybase:"
+	const githubPrefix = "github:"
 
 	encryptionKey := pgpKey
 	if strings.HasPrefix(pgpKey, keybasePrefix) {
 		publicKeys, err := pgpkeys.FetchKeybasePubkeys([]string{pgpKey})
 		if err != nil {
-			return "", fmt.Errorf("retrieving Public Key (%s): %w", pgpKey, err)
+			return "", fmt.Errorf("retrieving Unarmored (Raw) Public Key from Keybase (%s): %w", pgpKey, err)
 		}
 		encryptionKey = publicKeys[pgpKey]
+	} else if strings.HasPrefix(pgpKey, githubPrefix) {
+		stringComponents := strings.Split(pgpKey, ":")
+		if len(stringComponents) != 2 {
+			return "", fmt.Errorf("invalid GPG key format for Github, received='%s', expected='github:$username'", pgpKey)
+		}
+
+		url := fmt.Sprintf("https://github.com/%s.gpg", stringComponents[1])
+		resp, err := http.Get(url)
+
+		if err != nil {
+			return "", fmt.Errorf("retrieving Armored (ASCII) Public Key from Github (%s): %w", pgpKey, err)
+		}
+		defer resp.Body.Close()
+
+		keyring, err := openpgp.ReadArmoredKeyRing(resp.Body)
+		if err != nil {
+			return "", fmt.Errorf("error reading keyring: %w", err)
+		}
+		if len(keyring) < 1 {
+			return "", fmt.Errorf("no key found in keyring")
+		}
+
+		var buf bytes.Buffer
+		err = keyring[0].Serialize(&buf)
+		if err != nil {
+			return "", fmt.Errorf("serialize first GitHub GPG Key from keyring: %w", err)
+		}
+		encryptionKey = base64.StdEncoding.EncodeToString(buf.Bytes())
 	}
 
 	return encryptionKey, nil


### PR DESCRIPTION
### Description
In a similar fashion to `Keybase`, this PR adds support to reference GPG public keys added to a `GitHub` account.

### References
- `aws_iam_access_key`
- `aws_iam_user_login_profile`

### Output from Acceptance Testing
```console
% make testacc TESTS=TestAccIAMUserLoginProfile_github PKG=iam
% make testacc TESTS=TestAccIAMUserLoginProfile_github PKG=iam
...
```
