### PR TITLE
docs: fix resource id

### DIFF
--- a/website/docs/r/budgets_budget.html.markdown
+++ b/website/docs/r/budgets_budget.html.markdown
@@ -268,7 +268,7 @@ Valid keys for `planned_limit` parameter.
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import budgets using `AccountID:ActionID:BudgetName`. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import budgets using `AccountID:BudgetName`. For example:
 
 ```terraform
 import {
@@ -277,7 +277,7 @@ import {
 }
 ```
 
-Using `terraform import`, import budgets using `AccountID:ActionID:BudgetName`. For example:
+Using `terraform import`, import budgets using `AccountID:BudgetName`. For example:
 
 ```console
 % terraform import aws_budgets_budget.myBudget 123456789012:myBudget


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Importing `aws_budgets_budget` only requires the account ID and budget name.
The action ID required is `aws_budgets_budget_action`.

The following document was also affected, but I did not change it because I thought it would be fixed automatically.

```
website/docs/cdktf/python/r/budgets_budget.html.markdown
website/docs/cdktf/typescript/r/budgets_budget.html.markdown
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
