### PR TITLE
dms/endpoint: Pause replication tasks for updates

### DIFF
--- a/.changelog/34316.txt
+++ b/.changelog/34316.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_dms_endpoint: Add `pause_replication_tasks` to stop running replication tasks before an endpoint is modified and restart the tasks when the modification is complete
+resource/aws_dms_endpoint: Add `pause_replication_tasks`, which when set to true pauses associated running replication tasks prior to modifying the endpoint (Only tasks paused by the resource will be restarted after the modification completes)
 ```

--- a/.changelog/34316.txt
+++ b/.changelog/34316.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_dms_endpoint: Add `pause_replication_tasks`, which when set to true pauses associated running replication tasks prior to modifying the endpoint (Only tasks paused by the resource will be restarted after the modification completes)
+resource/aws_dms_endpoint: Add `pause_replication_tasks`, which when set to `true`, pauses associated running replication tasks prior to modifying the endpoint (only tasks paused by the resource will be restarted after the modification completes)
 ```

--- a/.changelog/34316.txt
+++ b/.changelog/34316.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_dms_endpoint: Add `pause_replication_tasks` to stop running replication tasks before an endpoint is modified and restart the tasks when the modification is complete
+```

--- a/.changelog/34316.txt
+++ b/.changelog/34316.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_dms_endpoint: Add `pause_replication_tasks`, which when set to `true`, pauses associated running replication tasks prior to modifying the endpoint (only tasks paused by the resource will be restarted after the modification completes)
+resource/aws_dms_endpoint: Add `pause_replication_tasks`, which when set to `true`, pauses associated running replication tasks, regardless if they are managed by Terraform, prior to modifying the endpoint (only tasks paused by the resource will be restarted after the modification completes)
 ```

--- a/internal/service/dms/endpoint.go
+++ b/internal/service/dms/endpoint.go
@@ -1645,7 +1645,6 @@ func stopEndpointReplicationTasks(ctx context.Context, conn *dms.DatabaseMigrati
 				return stoppedTasks, err
 			}
 			stoppedTasks = append(stoppedTasks, task)
-
 		default:
 			continue
 		}

--- a/internal/service/dms/endpoint.go
+++ b/internal/service/dms/endpoint.go
@@ -339,6 +339,11 @@ func ResourceEndpoint() *schema.Resource {
 				Sensitive:     true,
 				ConflictsWith: []string{"secrets_manager_access_role_arn", "secrets_manager_arn"},
 			},
+			"pause_replication_tasks": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"port": {
 				Type:          schema.TypeInt,
 				Optional:      true,
@@ -1304,10 +1309,24 @@ func resourceEndpointUpdate(ctx context.Context, d *schema.ResourceData, meta in
 			}
 		}
 
-		_, err := conn.ModifyEndpointWithContext(ctx, input)
+		var tasks []*dms.ReplicationTask
+		if v, ok := d.GetOk("pause_replication_tasks"); ok && v.(bool) {
+			var err error
+			tasks, err = stopEndpointReplicationTasks(ctx, conn, d.Get("endpoint_arn").(string))
+			if err != nil {
+				return sdkdiag.AppendErrorf(diags, "pausing replication tasks before updating DMS Endpoint (%s): %s", d.Id(), err)
+			}
+		}
 
+		_, err := conn.ModifyEndpointWithContext(ctx, input)
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating DMS Endpoint (%s): %s", d.Id(), err)
+		}
+
+		if v, ok := d.GetOk("pause_replication_tasks"); ok && v.(bool) && len(tasks) > 0 {
+			if err := startEndpointReplicationTasks(ctx, conn, d.Get("endpoint_arn").(string), tasks); err != nil {
+				return sdkdiag.AppendErrorf(diags, "starting replication tasks after updating DMS Endpoint (%s): %s", d.Id(), err)
+			}
 		}
 	}
 
@@ -1577,6 +1596,104 @@ func resourceEndpointSetState(d *schema.ResourceData, endpoint *dms.Endpoint) er
 
 	d.Set("kms_key_arn", endpoint.KmsKeyId)
 	d.Set("ssl_mode", endpoint.SslMode)
+
+	return nil
+}
+
+func steadyEndpointReplicationTasks(ctx context.Context, conn *dms.DatabaseMigrationService, arn string) error {
+	tasks, err := FindReplicationTasksByEndpointARN(ctx, conn, arn)
+	if err != nil {
+		return err
+	}
+
+	for _, task := range tasks {
+		rtID := aws.StringValue(task.ReplicationTaskIdentifier)
+		switch aws.StringValue(task.Status) {
+		case replicationTaskStatusRunning, replicationTaskStatusFailed, replicationTaskStatusReady, replicationTaskStatusStopped:
+			continue
+		case replicationTaskStatusCreating, replicationTaskStatusDeleting, replicationTaskStatusModifying, replicationTaskStatusStopping, replicationTaskStatusStarting:
+			if err := waitReplicationTaskSteady(ctx, conn, rtID); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func stopEndpointReplicationTasks(ctx context.Context, conn *dms.DatabaseMigrationService, arn string) ([]*dms.ReplicationTask, error) {
+	if err := steadyEndpointReplicationTasks(ctx, conn, arn); err != nil {
+		return nil, err
+	}
+
+	tasks, err := FindReplicationTasksByEndpointARN(ctx, conn, arn)
+	if err != nil {
+		return nil, err
+	}
+
+	var stoppedTasks []*dms.ReplicationTask
+	for _, task := range tasks {
+		rtID := aws.StringValue(task.ReplicationTaskIdentifier)
+		switch aws.StringValue(task.Status) {
+		case replicationTaskStatusRunning:
+			err := stopReplicationTask(ctx, rtID, conn)
+			if tfawserr.ErrCodeEquals(err, dms.ErrCodeInvalidResourceStateFault) {
+				continue
+			}
+
+			if err != nil {
+				return stoppedTasks, err
+			}
+			stoppedTasks = append(stoppedTasks, task)
+
+		default:
+			continue
+		}
+	}
+
+	return stoppedTasks, nil
+}
+
+func startEndpointReplicationTasks(ctx context.Context, conn *dms.DatabaseMigrationService, arn string, tasks []*dms.ReplicationTask) error {
+	if len(tasks) == 0 {
+		return nil
+	}
+
+	if err := steadyEndpointReplicationTasks(ctx, conn, arn); err != nil {
+		return err
+	}
+
+	for _, task := range tasks {
+		_, err := conn.TestConnectionWithContext(ctx, &dms.TestConnectionInput{
+			EndpointArn:            aws.String(arn),
+			ReplicationInstanceArn: task.ReplicationInstanceArn,
+		})
+
+		if tfawserr.ErrMessageContains(err, dms.ErrCodeInvalidResourceStateFault, "already being tested") {
+			continue
+		}
+
+		if err != nil {
+			return fmt.Errorf("testing connection: %w", err)
+		}
+
+		err = conn.WaitUntilTestConnectionSucceedsWithContext(ctx, &dms.DescribeConnectionsInput{
+			Filters: []*dms.Filter{
+				{
+					Name:   aws.String("endpoint-arn"),
+					Values: []*string{aws.String(arn)}, // Must use d.Id() to work with import.
+				},
+			},
+		})
+
+		if err != nil {
+			return fmt.Errorf("waiting until test connection succeeds: %w", err)
+		}
+
+		if err := startReplicationTask(ctx, aws.StringValue(task.ReplicationTaskIdentifier), conn); err != nil {
+			return fmt.Errorf("starting replication task: %w", err)
+		}
+	}
 
 	return nil
 }

--- a/internal/service/dms/endpoint.go
+++ b/internal/service/dms/endpoint.go
@@ -342,7 +342,6 @@ func ResourceEndpoint() *schema.Resource {
 			"pause_replication_tasks": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  false,
 			},
 			"port": {
 				Type:          schema.TypeInt,

--- a/internal/service/dms/endpoint.go
+++ b/internal/service/dms/endpoint.go
@@ -1681,7 +1681,7 @@ func startEndpointReplicationTasks(ctx context.Context, conn *dms.DatabaseMigrat
 			Filters: []*dms.Filter{
 				{
 					Name:   aws.String("endpoint-arn"),
-					Values: []*string{aws.String(arn)}, // Must use d.Id() to work with import.
+					Values: []*string{aws.String(arn)},
 				},
 			},
 		})
@@ -1690,7 +1690,7 @@ func startEndpointReplicationTasks(ctx context.Context, conn *dms.DatabaseMigrat
 			return fmt.Errorf("waiting until test connection succeeds: %w", err)
 		}
 
-		if err := startReplicationTask(ctx, aws.StringValue(task.ReplicationTaskIdentifier), conn); err != nil {
+		if err := startReplicationTask(ctx, conn, aws.StringValue(task.ReplicationTaskIdentifier)); err != nil {
 			return fmt.Errorf("starting replication task: %w", err)
 		}
 	}

--- a/internal/service/dms/endpoint_test.go
+++ b/internal/service/dms/endpoint_test.go
@@ -2112,6 +2112,43 @@ func TestAccDMSEndpoint_Redshift_SSEKMSKeyId(t *testing.T) {
 	})
 }
 
+func TestAccDMSEndpoint_pauseReplicationTasks(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	endpointNameSource := "aws_dms_endpoint.source"
+	endpointNameTarget := "aws_dms_endpoint.target"
+	replicationTaskName := "aws_dms_replication_task.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, dms.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckReplicationTaskDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEndpointConfig_pauseReplicationTasks(rName, "3306"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEndpointExists(ctx, endpointNameSource),
+					testAccCheckEndpointExists(ctx, endpointNameTarget),
+					testAccCheckReplicationTaskExists(ctx, replicationTaskName),
+					resource.TestCheckResourceAttr(endpointNameTarget, "port", "3306"),
+					resource.TestCheckResourceAttr(replicationTaskName, "status", "running"),
+				),
+			},
+			{
+				Config: testAccEndpointConfig_pauseReplicationTasks(rName, "3307"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEndpointExists(ctx, endpointNameSource),
+					testAccCheckEndpointExists(ctx, endpointNameTarget),
+					testAccCheckReplicationTaskExists(ctx, replicationTaskName),
+					resource.TestCheckResourceAttr(endpointNameTarget, "port", "3307"),
+					resource.TestCheckResourceAttr(replicationTaskName, "status", "running"),
+				),
+			},
+		},
+	})
+}
+
 // testAccCheckResourceAttrRegionalHostname ensures the Terraform state exactly matches a formatted DNS hostname with region and partition DNS suffix
 func testAccCheckResourceAttrRegionalHostname(resourceName, attributeName, serviceName, hostnamePrefix string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -4470,4 +4507,206 @@ resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
 }
 `, rName))
+}
+
+func testAccEndpointConfig_pauseReplicationTasks(rName, port string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigAvailableAZsNoOptIn(),
+		fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test1" {
+  cidr_block        = "10.1.1.0/24"
+  availability_zone = data.aws_availability_zones.available.names[0]
+  vpc_id            = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test2" {
+  cidr_block        = "10.1.2.0/24"
+  availability_zone = data.aws_availability_zones.available.names[1]
+  vpc_id            = aws_vpc.test.id
+
+  tags = {
+    Name = "%[1]s-2"
+  }
+}
+
+resource "aws_security_group" "test" {
+  vpc_id = aws_vpc.test.id
+
+  ingress {
+    protocol  = -1
+    self      = true
+    from_port = 0
+    to_port   = 0
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_db_subnet_group" "test" {
+  name       = %[1]q
+  subnet_ids = [aws_subnet.test1.id, aws_subnet.test2.id]
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+data "aws_rds_engine_version" "default" {
+  engine = "aurora-mysql"
+}
+
+data "aws_rds_orderable_db_instance" "test" {
+  engine                     = data.aws_rds_engine_version.default.engine
+  engine_version             = data.aws_rds_engine_version.default.version
+  preferred_instance_classes = ["db.t3.small", "db.t3.medium", "db.t3.large"]
+}
+
+resource "aws_rds_cluster_parameter_group" "test" {
+  name        = "%[1]s-pg-cluster"
+  family      = data.aws_rds_engine_version.default.parameter_group_family
+  description = "DMS cluster parameter group"
+
+  parameter {
+    name         = "binlog_format"
+    value        = "ROW"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name         = "binlog_row_image"
+    value        = "Full"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name         = "binlog_checksum"
+    value        = "NONE"
+    apply_method = "pending-reboot"
+  }
+}
+
+resource "aws_rds_cluster" "source" {
+  cluster_identifier              = "%[1]s-aurora-cluster-source"
+  engine                          = data.aws_rds_orderable_db_instance.test.engine
+  engine_version                  = data.aws_rds_orderable_db_instance.test.engine_version
+  database_name                   = "tftest"
+  master_username                 = "tftest"
+  master_password                 = "mustbeeightcharaters"
+  skip_final_snapshot             = true
+  vpc_security_group_ids          = [aws_security_group.test.id]
+  db_subnet_group_name            = aws_db_subnet_group.test.name
+  db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.test.name
+}
+
+resource "aws_rds_cluster_instance" "source" {
+  identifier           = "%[1]s-source-primary"
+  cluster_identifier   = aws_rds_cluster.source.id
+  engine               = data.aws_rds_orderable_db_instance.test.engine
+  engine_version       = data.aws_rds_orderable_db_instance.test.engine_version
+  instance_class       = data.aws_rds_orderable_db_instance.test.instance_class
+  db_subnet_group_name = aws_db_subnet_group.test.name
+}
+
+resource "aws_rds_cluster" "target" {
+  cluster_identifier     = "%[1]s-aurora-cluster-target"
+  engine                 = data.aws_rds_orderable_db_instance.test.engine
+  engine_version         = data.aws_rds_orderable_db_instance.test.engine_version
+  database_name          = "tftest"
+  master_username        = "tftest"
+  master_password        = "mustbeeightcharaters"
+  skip_final_snapshot    = true
+  vpc_security_group_ids = [aws_security_group.test.id]
+  db_subnet_group_name   = aws_db_subnet_group.test.name
+}
+
+resource "aws_rds_cluster_instance" "target" {
+  identifier           = "%[1]s-target-primary"
+  cluster_identifier   = aws_rds_cluster.target.id
+  engine               = data.aws_rds_orderable_db_instance.test.engine
+  engine_version       = data.aws_rds_orderable_db_instance.test.engine_version
+  instance_class       = data.aws_rds_orderable_db_instance.test.instance_class
+  db_subnet_group_name = aws_db_subnet_group.test.name
+}
+
+resource "aws_dms_endpoint" "source" {
+  database_name           = "tftest"
+  endpoint_id             = "%[1]s-source"
+  endpoint_type           = "source"
+  engine_name             = "aurora"
+  password                = "mustbeeightcharaters"
+  pause_replication_tasks = true
+  port                    = %[2]s
+  server_name             = aws_rds_cluster.source.endpoint
+  username                = "tftest"
+}
+
+resource "aws_dms_endpoint" "target" {
+  database_name           = "tftest"
+  endpoint_id             = "%[1]s-target"
+  endpoint_type           = "target"
+  engine_name             = "aurora"
+  password                = "mustbeeightcharaters"
+  pause_replication_tasks = true
+  port                    = %[2]s
+  server_name             = aws_rds_cluster.target.endpoint
+  username                = "tftest"
+}
+
+resource "aws_dms_replication_subnet_group" "test" {
+  replication_subnet_group_id          = %[1]q
+  replication_subnet_group_description = "terraform test for replication subnet group"
+  subnet_ids                           = [aws_subnet.test1.id, aws_subnet.test2.id]
+}
+
+resource "aws_dms_replication_instance" "test" {
+  allocated_storage            = 5
+  auto_minor_version_upgrade   = true
+  replication_instance_class   = "dms.c4.large"
+  replication_instance_id      = %[1]q
+  preferred_maintenance_window = "sun:00:30-sun:02:30"
+  publicly_accessible          = false
+  replication_subnet_group_id  = aws_dms_replication_subnet_group.test.replication_subnet_group_id
+  vpc_security_group_ids       = [aws_security_group.test.id]
+}
+
+resource "aws_dms_replication_task" "test" {
+  migration_type            = "full-load-and-cdc"
+  replication_instance_arn  = aws_dms_replication_instance.test.replication_instance_arn
+  replication_task_id       = %[1]q
+  replication_task_settings = "{\"BeforeImageSettings\":null,\"FailTaskWhenCleanTaskResourceFailed\":false,\"ChangeProcessingDdlHandlingPolicy\":{\"HandleSourceTableAltered\":true,\"HandleSourceTableDropped\":true,\"HandleSourceTableTruncated\":true},\"ChangeProcessingTuning\":{\"BatchApplyMemoryLimit\":500,\"BatchApplyPreserveTransaction\":true,\"BatchApplyTimeoutMax\":30,\"BatchApplyTimeoutMin\":1,\"BatchSplitSize\":0,\"CommitTimeout\":1,\"MemoryKeepTime\":60,\"MemoryLimitTotal\":1024,\"MinTransactionSize\":1000,\"StatementCacheSize\":50},\"CharacterSetSettings\":null,\"ControlTablesSettings\":{\"ControlSchema\":\"\",\"FullLoadExceptionTableEnabled\":false,\"HistoryTableEnabled\":false,\"HistoryTimeslotInMinutes\":5,\"StatusTableEnabled\":false,\"SuspendedTablesTableEnabled\":false},\"ErrorBehavior\":{\"ApplyErrorDeletePolicy\":\"IGNORE_RECORD\",\"ApplyErrorEscalationCount\":0,\"ApplyErrorEscalationPolicy\":\"LOG_ERROR\",\"ApplyErrorFailOnTruncationDdl\":false,\"ApplyErrorInsertPolicy\":\"LOG_ERROR\",\"ApplyErrorUpdatePolicy\":\"LOG_ERROR\",\"DataErrorEscalationCount\":0,\"DataErrorEscalationPolicy\":\"SUSPEND_TABLE\",\"DataErrorPolicy\":\"LOG_ERROR\",\"DataTruncationErrorPolicy\":\"LOG_ERROR\",\"EventErrorPolicy\":\"IGNORE\",\"FailOnNoTablesCaptured\":false,\"FailOnTransactionConsistencyBreached\":false,\"FullLoadIgnoreConflicts\":true,\"RecoverableErrorCount\":-1,\"RecoverableErrorInterval\":5,\"RecoverableErrorStopRetryAfterThrottlingMax\":false,\"RecoverableErrorThrottling\":true,\"RecoverableErrorThrottlingMax\":1800,\"TableErrorEscalationCount\":0,\"TableErrorEscalationPolicy\":\"STOP_TASK\",\"TableErrorPolicy\":\"SUSPEND_TABLE\"},\"FullLoadSettings\":{\"CommitRate\":10000,\"CreatePkAfterFullLoad\":false,\"MaxFullLoadSubTasks\":8,\"StopTaskCachedChangesApplied\":false,\"StopTaskCachedChangesNotApplied\":false,\"TargetTablePrepMode\":\"DROP_AND_CREATE\",\"TransactionConsistencyTimeout\":600},\"Logging\":{\"EnableLogging\":false,\"LogComponents\":[{\"Id\":\"TRANSFORMATION\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"SOURCE_UNLOAD\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"IO\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"TARGET_LOAD\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"PERFORMANCE\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"SOURCE_CAPTURE\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"SORTER\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"REST_SERVER\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"VALIDATOR_EXT\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"TARGET_APPLY\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"TASK_MANAGER\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"TABLES_MANAGER\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"METADATA_MANAGER\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"FILE_FACTORY\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"COMMON\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"ADDONS\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"DATA_STRUCTURE\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"COMMUNICATION\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"FILE_TRANSFER\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"}]},\"LoopbackPreventionSettings\":null,\"PostProcessingRules\":null,\"StreamBufferSettings\":{\"CtrlStreamBufferSizeInMB\":5,\"StreamBufferCount\":3,\"StreamBufferSizeInMB\":8},\"TargetMetadata\":{\"BatchApplyEnabled\":false,\"FullLobMode\":false,\"InlineLobMaxSize\":0,\"LimitedSizeLobMode\":true,\"LoadMaxFileSize\":0,\"LobChunkSize\":0,\"LobMaxSize\":32,\"ParallelApplyBufferSize\":0,\"ParallelApplyQueuesPerThread\":0,\"ParallelApplyThreads\":0,\"ParallelLoadBufferSize\":0,\"ParallelLoadQueuesPerThread\":0,\"ParallelLoadThreads\":0,\"SupportLobs\":true,\"TargetSchema\":\"\",\"TaskRecoveryTableEnabled\":false},\"TTSettings\":{\"EnableTT\":false,\"TTRecordSettings\":null,\"TTS3Settings\":null}}"
+  source_endpoint_arn       = aws_dms_endpoint.source.endpoint_arn
+  table_mappings            = "{\"rules\":[{\"rule-type\":\"selection\",\"rule-id\":\"1\",\"rule-name\":\"testrule\",\"object-locator\":{\"schema-name\":\"%%\",\"table-name\":\"%%\"},\"rule-action\":\"include\"}]}"
+
+  start_replication_task = true
+
+  tags = {
+    Name = %[1]q
+  }
+
+  target_endpoint_arn = aws_dms_endpoint.target.endpoint_arn
+
+  depends_on = [aws_rds_cluster_instance.source, aws_rds_cluster_instance.target]
+}
+`, rName, port))
 }

--- a/internal/service/dms/replication_task.go
+++ b/internal/service/dms/replication_task.go
@@ -164,7 +164,7 @@ func resourceReplicationTaskCreate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if d.Get("start_replication_task").(bool) {
-		if err := startReplicationTask(ctx, d.Id(), conn); err != nil {
+		if err := startReplicationTask(ctx, conn, d.Id()); err != nil {
 			return sdkdiag.AppendFromErr(diags, err)
 		}
 	}
@@ -262,7 +262,7 @@ func resourceReplicationTaskUpdate(ctx context.Context, d *schema.ResourceData, 
 		}
 
 		if d.Get("start_replication_task").(bool) {
-			err := startReplicationTask(ctx, d.Id(), conn)
+			err := startReplicationTask(ctx, conn, d.Id())
 			if err != nil {
 				return sdkdiag.AppendFromErr(diags, err)
 			}
@@ -273,7 +273,7 @@ func resourceReplicationTaskUpdate(ctx context.Context, d *schema.ResourceData, 
 		status := d.Get("status").(string)
 		if d.Get("start_replication_task").(bool) {
 			if status != replicationTaskStatusRunning {
-				if err := startReplicationTask(ctx, d.Id(), conn); err != nil {
+				if err := startReplicationTask(ctx, conn, d.Id()); err != nil {
 					return sdkdiag.AppendFromErr(diags, err)
 				}
 			}
@@ -352,7 +352,7 @@ func replicationTaskRemoveReadOnlySettings(settings string) (*string, error) {
 	return &cleanedSettingsString, nil
 }
 
-func startReplicationTask(ctx context.Context, id string, conn *dms.DatabaseMigrationService) error {
+func startReplicationTask(ctx context.Context, conn *dms.DatabaseMigrationService, id string) error {
 	log.Printf("[DEBUG] Starting DMS Replication Task: (%s)", id)
 
 	task, err := FindReplicationTaskByID(ctx, conn, id)

--- a/internal/service/dms/replication_task.go
+++ b/internal/service/dms/replication_task.go
@@ -471,7 +471,7 @@ func FindReplicationTasksByEndpointARN(ctx context.Context, conn *dms.DatabaseMi
 		Filters: []*dms.Filter{
 			{
 				Name:   aws.String("endpoint-arn"),
-				Values: []*string{aws.String(arn)}, // Must use d.Id() to work with import.
+				Values: []*string{aws.String(arn)},
 			},
 		},
 	}

--- a/website/docs/r/dms_endpoint.html.markdown
+++ b/website/docs/r/dms_endpoint.html.markdown
@@ -58,7 +58,7 @@ The following arguments are optional:
 * `kinesis_settings` - (Optional) Configuration block for Kinesis settings. See below.
 * `mongodb_settings` - (Optional) Configuration block for MongoDB settings. See below.
 * `password` - (Optional) Password to be used to login to the endpoint database.
-* `pause_replication_tasks` - (Optional) Whether to pause associated running replication tasks prior to modifying the endpoint. Only tasks paused by the resource will be restarted after the modification completes. Default is `false`.
+* `pause_replication_tasks` - (Optional) Whether to pause associated running replication tasks, regardless if they are managed by Terraform, prior to modifying the endpoint. Only tasks paused by the resource will be restarted after the modification completes. Default is `false`.
 * `port` - (Optional) Port used by the endpoint database.
 * `redshift_settings` - (Optional) Configuration block for Redshift settings. See below.
 * `s3_settings` - (Optional) (**Deprecated**, use the [`aws_dms_s3_endpoint`](/docs/providers/aws/r/dms_s3_endpoint.html) resource instead) Configuration block for S3 settings. See below.

--- a/website/docs/r/dms_endpoint.html.markdown
+++ b/website/docs/r/dms_endpoint.html.markdown
@@ -58,6 +58,7 @@ The following arguments are optional:
 * `kinesis_settings` - (Optional) Configuration block for Kinesis settings. See below.
 * `mongodb_settings` - (Optional) Configuration block for MongoDB settings. See below.
 * `password` - (Optional) Password to be used to login to the endpoint database.
+* `pause_replication_tasks` - (Optional) Whether to pause associated running replication tasks prior to modifying the endpoint. Only tasks paused by the resource will be restarted after the modification completes. Default is `false`.
 * `port` - (Optional) Port used by the endpoint database.
 * `redshift_settings` - (Optional) Configuration block for Redshift settings. See below.
 * `s3_settings` - (Optional) (**Deprecated**, use the [`aws_dms_s3_endpoint`](/docs/providers/aws/r/dms_s3_endpoint.html) resource instead) Configuration block for S3 settings. See below.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
h

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #27661

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->


```console
% make t T=TestAccDMSEndpoint_pauseReplicationTasks K=dms
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/dms/... -v -count 1 -parallel 20 -run='TestAccDMSEndpoint_pauseReplicationTasks'  -timeout 360m
=== RUN   TestAccDMSEndpoint_pauseReplicationTasks
=== PAUSE TestAccDMSEndpoint_pauseReplicationTasks
=== CONT  TestAccDMSEndpoint_pauseReplicationTasks
--- PASS: TestAccDMSEndpoint_pauseReplicationTasks (2599.54s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dms	2602.433s
% make t T=TestAccDMSReplicationTask_ K=dms
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/dms/... -v -count 1 -parallel 20 -run='TestAccDMSReplicationTask_'  -timeout 360m
=== RUN   TestAccDMSReplicationTask_basic
=== PAUSE TestAccDMSReplicationTask_basic
=== RUN   TestAccDMSReplicationTask_update
=== PAUSE TestAccDMSReplicationTask_update
=== RUN   TestAccDMSReplicationTask_cdcStartPosition
=== PAUSE TestAccDMSReplicationTask_cdcStartPosition
=== RUN   TestAccDMSReplicationTask_startReplicationTask
=== PAUSE TestAccDMSReplicationTask_startReplicationTask
=== RUN   TestAccDMSReplicationTask_s3ToRDS
=== PAUSE TestAccDMSReplicationTask_s3ToRDS
=== RUN   TestAccDMSReplicationTask_disappears
=== PAUSE TestAccDMSReplicationTask_disappears
=== CONT  TestAccDMSReplicationTask_basic
=== CONT  TestAccDMSReplicationTask_startReplicationTask
=== CONT  TestAccDMSReplicationTask_disappears
=== CONT  TestAccDMSReplicationTask_s3ToRDS
=== CONT  TestAccDMSReplicationTask_update
=== CONT  TestAccDMSReplicationTask_cdcStartPosition
--- PASS: TestAccDMSReplicationTask_cdcStartPosition (1132.13s)
--- PASS: TestAccDMSReplicationTask_disappears (1259.14s)
--- PASS: TestAccDMSReplicationTask_basic (2002.82s)
--- PASS: TestAccDMSReplicationTask_s3ToRDS (2900.78s)
--- PASS: TestAccDMSReplicationTask_update (4081.73s)
--- PASS: TestAccDMSReplicationTask_startReplicationTask (4452.25s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dms	4454.344s
% make t T=TestAccDMSEndpoint_ K=dms P=4
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/dms/... -v -count 1 -parallel 4 -run='TestAccDMSEndpoint_'  -timeout 360m
=== RUN   TestAccDMSEndpoint_basic
=== PAUSE TestAccDMSEndpoint_basic
=== RUN   TestAccDMSEndpoint_Aurora_basic
=== PAUSE TestAccDMSEndpoint_Aurora_basic
=== RUN   TestAccDMSEndpoint_Aurora_secretID
=== PAUSE TestAccDMSEndpoint_Aurora_secretID
=== RUN   TestAccDMSEndpoint_Aurora_update
=== PAUSE TestAccDMSEndpoint_Aurora_update
=== RUN   TestAccDMSEndpoint_AuroraPostgreSQL_basic
=== PAUSE TestAccDMSEndpoint_AuroraPostgreSQL_basic
=== RUN   TestAccDMSEndpoint_AuroraPostgreSQL_secretID
=== PAUSE TestAccDMSEndpoint_AuroraPostgreSQL_secretID
=== RUN   TestAccDMSEndpoint_AuroraPostgreSQL_update
=== PAUSE TestAccDMSEndpoint_AuroraPostgreSQL_update
=== RUN   TestAccDMSEndpoint_S3_basic
=== PAUSE TestAccDMSEndpoint_S3_basic
=== RUN   TestAccDMSEndpoint_S3_detachTargetOnLobLookupFailureParquet
=== PAUSE TestAccDMSEndpoint_S3_detachTargetOnLobLookupFailureParquet
=== RUN   TestAccDMSEndpoint_S3_key
=== PAUSE TestAccDMSEndpoint_S3_key
=== RUN   TestAccDMSEndpoint_S3_extraConnectionAttributes
=== PAUSE TestAccDMSEndpoint_S3_extraConnectionAttributes
=== RUN   TestAccDMSEndpoint_S3_SSEKMSKeyARN
=== PAUSE TestAccDMSEndpoint_S3_SSEKMSKeyARN
=== RUN   TestAccDMSEndpoint_S3_SSEKMSKeyId
=== PAUSE TestAccDMSEndpoint_S3_SSEKMSKeyId
=== RUN   TestAccDMSEndpoint_dynamoDB
=== PAUSE TestAccDMSEndpoint_dynamoDB
=== RUN   TestAccDMSEndpoint_OpenSearch_basic
=== PAUSE TestAccDMSEndpoint_OpenSearch_basic
=== RUN   TestAccDMSEndpoint_OpenSearch_extraConnectionAttributes
=== PAUSE TestAccDMSEndpoint_OpenSearch_extraConnectionAttributes
=== RUN   TestAccDMSEndpoint_OpenSearch_errorRetryDuration
=== PAUSE TestAccDMSEndpoint_OpenSearch_errorRetryDuration
=== RUN   TestAccDMSEndpoint_OpenSearch_fullLoadErrorPercentage
=== PAUSE TestAccDMSEndpoint_OpenSearch_fullLoadErrorPercentage
=== RUN   TestAccDMSEndpoint_kafka
=== PAUSE TestAccDMSEndpoint_kafka
=== RUN   TestAccDMSEndpoint_kinesis
=== PAUSE TestAccDMSEndpoint_kinesis
=== RUN   TestAccDMSEndpoint_MongoDB_basic
=== PAUSE TestAccDMSEndpoint_MongoDB_basic
=== RUN   TestAccDMSEndpoint_MongoDB_secretID
=== PAUSE TestAccDMSEndpoint_MongoDB_secretID
=== RUN   TestAccDMSEndpoint_MongoDB_update
=== PAUSE TestAccDMSEndpoint_MongoDB_update
=== RUN   TestAccDMSEndpoint_MariaDB_basic
=== PAUSE TestAccDMSEndpoint_MariaDB_basic
=== RUN   TestAccDMSEndpoint_MariaDB_secretID
=== PAUSE TestAccDMSEndpoint_MariaDB_secretID
=== RUN   TestAccDMSEndpoint_MariaDB_update
=== PAUSE TestAccDMSEndpoint_MariaDB_update
=== RUN   TestAccDMSEndpoint_MySQL_basic
=== PAUSE TestAccDMSEndpoint_MySQL_basic
=== RUN   TestAccDMSEndpoint_MySQL_secretID
=== PAUSE TestAccDMSEndpoint_MySQL_secretID
=== RUN   TestAccDMSEndpoint_MySQL_update
=== PAUSE TestAccDMSEndpoint_MySQL_update
=== RUN   TestAccDMSEndpoint_Oracle_basic
=== PAUSE TestAccDMSEndpoint_Oracle_basic
=== RUN   TestAccDMSEndpoint_Oracle_secretID
=== PAUSE TestAccDMSEndpoint_Oracle_secretID
=== RUN   TestAccDMSEndpoint_Oracle_update
=== PAUSE TestAccDMSEndpoint_Oracle_update
=== RUN   TestAccDMSEndpoint_PostgreSQL_basic
=== PAUSE TestAccDMSEndpoint_PostgreSQL_basic
=== RUN   TestAccDMSEndpoint_PostgreSQL_secretID
=== PAUSE TestAccDMSEndpoint_PostgreSQL_secretID
=== RUN   TestAccDMSEndpoint_PostgreSQL_update
=== PAUSE TestAccDMSEndpoint_PostgreSQL_update
=== RUN   TestAccDMSEndpoint_PostgreSQL_kmsKey
=== PAUSE TestAccDMSEndpoint_PostgreSQL_kmsKey
=== RUN   TestAccDMSEndpoint_SQLServer_basic
=== PAUSE TestAccDMSEndpoint_SQLServer_basic
=== RUN   TestAccDMSEndpoint_SQLServer_secretID
=== PAUSE TestAccDMSEndpoint_SQLServer_secretID
=== RUN   TestAccDMSEndpoint_SQLServer_update
=== PAUSE TestAccDMSEndpoint_SQLServer_update
=== RUN   TestAccDMSEndpoint_babelfish
=== PAUSE TestAccDMSEndpoint_babelfish
=== RUN   TestAccDMSEndpoint_SQLServer_kmsKey
=== PAUSE TestAccDMSEndpoint_SQLServer_kmsKey
=== RUN   TestAccDMSEndpoint_Sybase_basic
=== PAUSE TestAccDMSEndpoint_Sybase_basic
=== RUN   TestAccDMSEndpoint_Sybase_secretID
=== PAUSE TestAccDMSEndpoint_Sybase_secretID
=== RUN   TestAccDMSEndpoint_Sybase_update
=== PAUSE TestAccDMSEndpoint_Sybase_update
=== RUN   TestAccDMSEndpoint_Sybase_kmsKey
=== PAUSE TestAccDMSEndpoint_Sybase_kmsKey
=== RUN   TestAccDMSEndpoint_docDB
=== PAUSE TestAccDMSEndpoint_docDB
=== RUN   TestAccDMSEndpoint_db2_basic
=== PAUSE TestAccDMSEndpoint_db2_basic
=== RUN   TestAccDMSEndpoint_db2zOS_basic
=== PAUSE TestAccDMSEndpoint_db2zOS_basic
=== RUN   TestAccDMSEndpoint_azureSQLManagedInstance
=== PAUSE TestAccDMSEndpoint_azureSQLManagedInstance
=== RUN   TestAccDMSEndpoint_db2_secretID
=== PAUSE TestAccDMSEndpoint_db2_secretID
=== RUN   TestAccDMSEndpoint_db2zOS_secretID
=== PAUSE TestAccDMSEndpoint_db2zOS_secretID
=== RUN   TestAccDMSEndpoint_redis
=== PAUSE TestAccDMSEndpoint_redis
=== RUN   TestAccDMSEndpoint_Redshift_basic
=== PAUSE TestAccDMSEndpoint_Redshift_basic
=== RUN   TestAccDMSEndpoint_Redshift_secretID
=== PAUSE TestAccDMSEndpoint_Redshift_secretID
=== RUN   TestAccDMSEndpoint_Redshift_update
=== PAUSE TestAccDMSEndpoint_Redshift_update
=== RUN   TestAccDMSEndpoint_Redshift_kmsKey
=== PAUSE TestAccDMSEndpoint_Redshift_kmsKey
=== RUN   TestAccDMSEndpoint_Redshift_SSEKMSKeyARN
=== PAUSE TestAccDMSEndpoint_Redshift_SSEKMSKeyARN
=== RUN   TestAccDMSEndpoint_Redshift_SSEKMSKeyId
=== PAUSE TestAccDMSEndpoint_Redshift_SSEKMSKeyId
=== RUN   TestAccDMSEndpoint_pauseReplicationTasks
=== PAUSE TestAccDMSEndpoint_pauseReplicationTasks
=== CONT  TestAccDMSEndpoint_basic
=== CONT  TestAccDMSEndpoint_Oracle_secretID
=== CONT  TestAccDMSEndpoint_docDB
=== CONT  TestAccDMSEndpoint_pauseReplicationTasks
--- PASS: TestAccDMSEndpoint_basic (192.33s)
=== CONT  TestAccDMSEndpoint_Redshift_SSEKMSKeyId
--- PASS: TestAccDMSEndpoint_docDB (192.44s)
=== CONT  TestAccDMSEndpoint_Redshift_SSEKMSKeyARN
--- PASS: TestAccDMSEndpoint_Oracle_secretID (420.85s)
=== CONT  TestAccDMSEndpoint_Redshift_kmsKey
--- PASS: TestAccDMSEndpoint_Redshift_SSEKMSKeyId (587.98s)
=== CONT  TestAccDMSEndpoint_Redshift_update
--- PASS: TestAccDMSEndpoint_Redshift_SSEKMSKeyARN (646.81s)
=== CONT  TestAccDMSEndpoint_Redshift_secretID
--- PASS: TestAccDMSEndpoint_Redshift_kmsKey (668.31s)
=== CONT  TestAccDMSEndpoint_Redshift_basic
--- PASS: TestAccDMSEndpoint_Redshift_secretID (289.57s)
=== CONT  TestAccDMSEndpoint_redis
--- PASS: TestAccDMSEndpoint_redis (125.07s)
=== CONT  TestAccDMSEndpoint_db2zOS_secretID
--- PASS: TestAccDMSEndpoint_Redshift_update (748.92s)
=== CONT  TestAccDMSEndpoint_db2_secretID
--- PASS: TestAccDMSEndpoint_db2zOS_secretID (356.18s)
=== CONT  TestAccDMSEndpoint_azureSQLManagedInstance
--- PASS: TestAccDMSEndpoint_Redshift_basic (555.48s)
=== CONT  TestAccDMSEndpoint_db2zOS_basic
--- PASS: TestAccDMSEndpoint_azureSQLManagedInstance (163.57s)
=== CONT  TestAccDMSEndpoint_db2_basic
--- PASS: TestAccDMSEndpoint_db2zOS_basic (159.55s)
=== CONT  TestAccDMSEndpoint_OpenSearch_extraConnectionAttributes
--- PASS: TestAccDMSEndpoint_db2_secretID (366.76s)
=== CONT  TestAccDMSEndpoint_Oracle_basic
--- PASS: TestAccDMSEndpoint_db2_basic (152.43s)
=== CONT  TestAccDMSEndpoint_MySQL_update
--- PASS: TestAccDMSEndpoint_Oracle_basic (86.58s)
=== CONT  TestAccDMSEndpoint_MySQL_secretID
--- PASS: TestAccDMSEndpoint_MySQL_update (154.83s)
=== CONT  TestAccDMSEndpoint_MySQL_basic
--- PASS: TestAccDMSEndpoint_OpenSearch_extraConnectionAttributes (300.64s)
=== CONT  TestAccDMSEndpoint_MariaDB_update
--- PASS: TestAccDMSEndpoint_MySQL_basic (83.45s)
=== CONT  TestAccDMSEndpoint_MariaDB_secretID
--- PASS: TestAccDMSEndpoint_MariaDB_update (140.33s)
=== CONT  TestAccDMSEndpoint_MariaDB_basic
--- PASS: TestAccDMSEndpoint_MySQL_secretID (283.46s)
=== CONT  TestAccDMSEndpoint_MongoDB_update
--- PASS: TestAccDMSEndpoint_MariaDB_basic (84.92s)
=== CONT  TestAccDMSEndpoint_MongoDB_secretID
--- PASS: TestAccDMSEndpoint_MariaDB_secretID (277.53s)
=== CONT  TestAccDMSEndpoint_OpenSearch_fullLoadErrorPercentage
--- PASS: TestAccDMSEndpoint_MongoDB_update (195.79s)
=== CONT  TestAccDMSEndpoint_OpenSearch_errorRetryDuration
--- PASS: TestAccDMSEndpoint_MongoDB_secretID (257.40s)
=== CONT  TestAccDMSEndpoint_MongoDB_basic
--- PASS: TestAccDMSEndpoint_OpenSearch_fullLoadErrorPercentage (230.83s)
=== CONT  TestAccDMSEndpoint_SQLServer_update
--- PASS: TestAccDMSEndpoint_MongoDB_basic (96.73s)
=== CONT  TestAccDMSEndpoint_Sybase_kmsKey
--- PASS: TestAccDMSEndpoint_OpenSearch_errorRetryDuration (234.88s)
=== CONT  TestAccDMSEndpoint_Sybase_update
--- PASS: TestAccDMSEndpoint_Sybase_kmsKey (97.37s)
=== CONT  TestAccDMSEndpoint_Sybase_secretID
--- PASS: TestAccDMSEndpoint_SQLServer_update (109.02s)
=== CONT  TestAccDMSEndpoint_Sybase_basic
--- PASS: TestAccDMSEndpoint_Sybase_update (108.10s)
=== CONT  TestAccDMSEndpoint_SQLServer_kmsKey
--- PASS: TestAccDMSEndpoint_Sybase_basic (62.86s)
=== CONT  TestAccDMSEndpoint_babelfish
--- PASS: TestAccDMSEndpoint_SQLServer_kmsKey (98.52s)
=== CONT  TestAccDMSEndpoint_S3_detachTargetOnLobLookupFailureParquet
--- PASS: TestAccDMSEndpoint_babelfish (112.05s)
=== CONT  TestAccDMSEndpoint_OpenSearch_basic
--- PASS: TestAccDMSEndpoint_Sybase_secretID (240.79s)
=== CONT  TestAccDMSEndpoint_dynamoDB
--- PASS: TestAccDMSEndpoint_OpenSearch_basic (267.66s)
=== CONT  TestAccDMSEndpoint_S3_SSEKMSKeyId
--- PASS: TestAccDMSEndpoint_dynamoDB (337.17s)
=== CONT  TestAccDMSEndpoint_S3_SSEKMSKeyARN
--- PASS: TestAccDMSEndpoint_S3_SSEKMSKeyId (191.82s)
=== CONT  TestAccDMSEndpoint_kafka
--- PASS: TestAccDMSEndpoint_S3_detachTargetOnLobLookupFailureParquet (563.98s)
=== CONT  TestAccDMSEndpoint_kinesis
--- PASS: TestAccDMSEndpoint_pauseReplicationTasks (3483.45s)
=== CONT  TestAccDMSEndpoint_S3_key
--- PASS: TestAccDMSEndpoint_kafka (104.74s)
=== CONT  TestAccDMSEndpoint_PostgreSQL_update
--- PASS: TestAccDMSEndpoint_S3_SSEKMSKeyARN (217.33s)
=== CONT  TestAccDMSEndpoint_SQLServer_secretID
--- PASS: TestAccDMSEndpoint_S3_key (119.05s)
=== CONT  TestAccDMSEndpoint_SQLServer_basic
--- PASS: TestAccDMSEndpoint_PostgreSQL_update (123.13s)
=== CONT  TestAccDMSEndpoint_PostgreSQL_kmsKey
--- PASS: TestAccDMSEndpoint_SQLServer_basic (70.29s)
=== CONT  TestAccDMSEndpoint_PostgreSQL_basic
--- PASS: TestAccDMSEndpoint_PostgreSQL_kmsKey (104.17s)
=== CONT  TestAccDMSEndpoint_PostgreSQL_secretID
--- PASS: TestAccDMSEndpoint_PostgreSQL_basic (78.47s)
=== CONT  TestAccDMSEndpoint_S3_extraConnectionAttributes
--- PASS: TestAccDMSEndpoint_SQLServer_secretID (251.15s)
=== CONT  TestAccDMSEndpoint_Oracle_update
--- PASS: TestAccDMSEndpoint_Oracle_update (115.38s)
=== CONT  TestAccDMSEndpoint_AuroraPostgreSQL_basic
--- PASS: TestAccDMSEndpoint_AuroraPostgreSQL_basic (76.55s)
=== CONT  TestAccDMSEndpoint_AuroraPostgreSQL_update
--- PASS: TestAccDMSEndpoint_PostgreSQL_secretID (278.57s)
=== CONT  TestAccDMSEndpoint_AuroraPostgreSQL_secretID
--- PASS: TestAccDMSEndpoint_kinesis (564.60s)
=== CONT  TestAccDMSEndpoint_S3_basic
--- PASS: TestAccDMSEndpoint_AuroraPostgreSQL_update (121.80s)
=== CONT  TestAccDMSEndpoint_Aurora_basic
--- PASS: TestAccDMSEndpoint_Aurora_basic (72.04s)
=== CONT  TestAccDMSEndpoint_Aurora_update
--- PASS: TestAccDMSEndpoint_AuroraPostgreSQL_secretID (250.41s)
=== CONT  TestAccDMSEndpoint_Aurora_secretID
--- PASS: TestAccDMSEndpoint_Aurora_update (112.95s)
--- PASS: TestAccDMSEndpoint_S3_extraConnectionAttributes (612.36s)
--- PASS: TestAccDMSEndpoint_S3_basic (433.07s)
--- PASS: TestAccDMSEndpoint_Aurora_secretID (220.65s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dms	4501.937s
```
