### PR TITLE
chime service: fix race condition when not using `us-east-1`

### DIFF
--- a/.changelog/34334.txt
+++ b/.changelog/34334.txt
@@ -5,3 +5,7 @@ resource/aws_chime_voice_connector: Fix `read` error when resource is not create
 ```release-note:bug
 resource/aws_chime_voice_connector_termination: Fix `read` error when resource is not created in `us-east-1`
 ```
+
+```release-note:bug
+resource/aws_chime_voice_connector_group: Fix `read` error when resource is not created in `us-east-1`
+```

--- a/.changelog/34334.txt
+++ b/.changelog/34334.txt
@@ -9,3 +9,7 @@ resource/aws_chime_voice_connector_termination: Fix `read` error when resource i
 ```release-note:bug
 resource/aws_chime_voice_connector_group: Fix `read` error when resource is not created in `us-east-1`
 ```
+
+```release-note:bug
+resource/aws_chime_voice_connector_logging: Fix `read` error when resource is not created in `us-east-1`
+```

--- a/.changelog/34334.txt
+++ b/.changelog/34334.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_chime_voice_connector: Fix `read` error when resource is not created in `us-east-1`
+```

--- a/.changelog/34334.txt
+++ b/.changelog/34334.txt
@@ -19,5 +19,9 @@ resource/aws_chime_voice_connector_origination: Fix `read` error when resource i
 ```
 
 ```release-note:bug
+resource/aws_chime_voice_connector_termination_credentials: Fix `read` error when resource is not created in `us-east-1`
+```
+
+```release-note:bug
 resource/aws_chimesdkmediapipelines_media_insights_pipeline_configuration: Fix eventual consistency error when resource is not created in `us-east-1`
 ```

--- a/.changelog/34334.txt
+++ b/.changelog/34334.txt
@@ -1,3 +1,7 @@
 ```release-note:bug
 resource/aws_chime_voice_connector: Fix `read` error when resource is not created in `us-east-1`
 ```
+
+```release-note:bug
+resource/aws_chime_voice_connector_termination: Fix `read` error when resource is not created in `us-east-1`
+```

--- a/.changelog/34334.txt
+++ b/.changelog/34334.txt
@@ -13,3 +13,7 @@ resource/aws_chime_voice_connector_group: Fix `read` error when resource is not 
 ```release-note:bug
 resource/aws_chime_voice_connector_logging: Fix `read` error when resource is not created in `us-east-1`
 ```
+
+```release-note:bug
+resource/aws_chime_voice_connector_origination: Fix `read` error when resource is not created in `us-east-1`
+```

--- a/.changelog/34334.txt
+++ b/.changelog/34334.txt
@@ -17,3 +17,7 @@ resource/aws_chime_voice_connector_logging: Fix `read` error when resource is no
 ```release-note:bug
 resource/aws_chime_voice_connector_origination: Fix `read` error when resource is not created in `us-east-1`
 ```
+
+```release-note:bug
+resource/aws_chimesdkmediapipelines_media_insights_pipeline_configuration: Fix eventual consistency error when resource is not created in `us-east-1`
+```

--- a/internal/service/chime/chime_test.go
+++ b/internal/service/chime/chime_test.go
@@ -37,7 +37,7 @@ func TestAccChime_serial(t *testing.T) {
 		"VoiceConnectorStreaming": {
 			"basic":      testAccVoiceConnectorStreaming_basic,
 			"disappears": testAccVoiceConnectorStreaming_disappears,
-			"update":     TestAccVoiceConnectorStreaming_update,
+			"update":     testAccVoiceConnectorStreaming_update,
 		},
 		"VoiceConnectorTermination": {
 			"basic":      testAccVoiceConnectorTermination_basic,

--- a/internal/service/chime/chime_test.go
+++ b/internal/service/chime/chime_test.go
@@ -19,31 +19,31 @@ func TestAccChime_serial(t *testing.T) {
 			"update":     testAccVoiceConnector_update,
 			"tags":       testAccVoiceConnector_tags,
 		},
-		"VoiceConnectorGroup": {
-			"basic":      testAccVoiceConnectorGroup_basic,
-			"disappears": testAccVoiceConnectorGroup_disappears,
-			"update":     testAccVoiceConnectorGroup_update,
-		},
-		"VoiceConnectorLogging": {
-			"basic":      testAccVoiceConnectorLogging_basic,
-			"disappears": testAccVoiceConnectorLogging_disappears,
-			"update":     testAccVoiceConnectorLogging_update,
-		},
-		"VoiceConnectorOrigination": {
-			"basic":      testAccVoiceConnectorOrigination_basic,
-			"disappears": testAccVoiceConnectorOrigination_disappears,
-			"update":     testAccVoiceConnectorOrigination_update,
-		},
-		"VoiceConnectorTermination": {
-			"basic":      testAccVoiceConnectorTermination_basic,
-			"disappears": testAccVoiceConnectorTermination_disappears,
-			"update":     testAccVoiceConnectorTermination_update,
-		},
-		"VoiceConnectorTerminationCredentials": {
-			"basic":      testAccVoiceConnectorTerminationCredentials_basic,
-			"disappears": testAccVoiceConnectorTerminationCredentials_disappears,
-			"update":     testAccVoiceConnectorTerminationCredentials_update,
-		},
+		//"VoiceConnectorGroup": {
+		//	"basic":      testAccVoiceConnectorGroup_basic,
+		//	"disappears": testAccVoiceConnectorGroup_disappears,
+		//	"update":     testAccVoiceConnectorGroup_update,
+		//},
+		//"VoiceConnectorLogging": {
+		//	"basic":      testAccVoiceConnectorLogging_basic,
+		//	"disappears": testAccVoiceConnectorLogging_disappears,
+		//	"update":     testAccVoiceConnectorLogging_update,
+		//},
+		//"VoiceConnectorOrigination": {
+		//	"basic":      testAccVoiceConnectorOrigination_basic,
+		//	"disappears": testAccVoiceConnectorOrigination_disappears,
+		//	"update":     testAccVoiceConnectorOrigination_update,
+		//},
+		//"VoiceConnectorTermination": {
+		//	"basic":      testAccVoiceConnectorTermination_basic,
+		//	"disappears": testAccVoiceConnectorTermination_disappears,
+		//	"update":     testAccVoiceConnectorTermination_update,
+		//},
+		//"VoiceConnectorTerminationCredentials": {
+		//	"basic":      testAccVoiceConnectorTerminationCredentials_basic,
+		//	"disappears": testAccVoiceConnectorTerminationCredentials_disappears,
+		//	"update":     testAccVoiceConnectorTerminationCredentials_update,
+		//},
 	}
 
 	acctest.RunSerialTests2Levels(t, testCases, 0)

--- a/internal/service/chime/chime_test.go
+++ b/internal/service/chime/chime_test.go
@@ -19,31 +19,31 @@ func TestAccChime_serial(t *testing.T) {
 			"update":     testAccVoiceConnector_update,
 			"tags":       testAccVoiceConnector_tags,
 		},
-		//"VoiceConnectorGroup": {
-		//	"basic":      testAccVoiceConnectorGroup_basic,
-		//	"disappears": testAccVoiceConnectorGroup_disappears,
-		//	"update":     testAccVoiceConnectorGroup_update,
-		//},
-		//"VoiceConnectorLogging": {
-		//	"basic":      testAccVoiceConnectorLogging_basic,
-		//	"disappears": testAccVoiceConnectorLogging_disappears,
-		//	"update":     testAccVoiceConnectorLogging_update,
-		//},
-		//"VoiceConnectorOrigination": {
-		//	"basic":      testAccVoiceConnectorOrigination_basic,
-		//	"disappears": testAccVoiceConnectorOrigination_disappears,
-		//	"update":     testAccVoiceConnectorOrigination_update,
-		//},
-		//"VoiceConnectorTermination": {
-		//	"basic":      testAccVoiceConnectorTermination_basic,
-		//	"disappears": testAccVoiceConnectorTermination_disappears,
-		//	"update":     testAccVoiceConnectorTermination_update,
-		//},
-		//"VoiceConnectorTerminationCredentials": {
-		//	"basic":      testAccVoiceConnectorTerminationCredentials_basic,
-		//	"disappears": testAccVoiceConnectorTerminationCredentials_disappears,
-		//	"update":     testAccVoiceConnectorTerminationCredentials_update,
-		//},
+		"VoiceConnectorGroup": {
+			"basic":      testAccVoiceConnectorGroup_basic,
+			"disappears": testAccVoiceConnectorGroup_disappears,
+			"update":     testAccVoiceConnectorGroup_update,
+		},
+		"VoiceConnectorLogging": {
+			"basic":      testAccVoiceConnectorLogging_basic,
+			"disappears": testAccVoiceConnectorLogging_disappears,
+			"update":     testAccVoiceConnectorLogging_update,
+		},
+		"VoiceConnectorOrigination": {
+			"basic":      testAccVoiceConnectorOrigination_basic,
+			"disappears": testAccVoiceConnectorOrigination_disappears,
+			"update":     testAccVoiceConnectorOrigination_update,
+		},
+		"VoiceConnectorTermination": {
+			"basic":      testAccVoiceConnectorTermination_basic,
+			"disappears": testAccVoiceConnectorTermination_disappears,
+			"update":     testAccVoiceConnectorTermination_update,
+		},
+		"VoiceConnectorTerminationCredentials": {
+			"basic":      testAccVoiceConnectorTerminationCredentials_basic,
+			"disappears": testAccVoiceConnectorTerminationCredentials_disappears,
+			"update":     testAccVoiceConnectorTerminationCredentials_update,
+		},
 	}
 
 	acctest.RunSerialTests2Levels(t, testCases, 0)

--- a/internal/service/chime/chime_test.go
+++ b/internal/service/chime/chime_test.go
@@ -34,6 +34,11 @@ func TestAccChime_serial(t *testing.T) {
 			"disappears": testAccVoiceConnectorOrigination_disappears,
 			"update":     testAccVoiceConnectorOrigination_update,
 		},
+		"VoiceConnectorStreaming": {
+			"basic":      testAccVoiceConnectorStreaming_basic,
+			"disappears": testAccVoiceConnectorStreaming_disappears,
+			"update":     TestAccVoiceConnectorStreaming_update,
+		},
 		"VoiceConnectorTermination": {
 			"basic":      testAccVoiceConnectorTermination_basic,
 			"disappears": testAccVoiceConnectorTermination_disappears,

--- a/internal/service/chime/exports_test.go
+++ b/internal/service/chime/exports_test.go
@@ -7,5 +7,6 @@ package chime
 var (
 	FindVoiceConnectorByID            = findVoiceConnectorByID
 	FindVoiceConnectorGroupByID       = findVoiceConnectorGroupByID
+	FindVoiceConnectorLoggingByID     = findVoiceConnectorLoggingByID
 	FindVoiceConnectorTerminationByID = findVoiceConnectorTerminationByID
 )

--- a/internal/service/chime/exports_test.go
+++ b/internal/service/chime/exports_test.go
@@ -6,5 +6,6 @@ package chime
 // Exports for use in tests only.
 var (
 	FindVoiceConnectorByID            = findVoiceConnectorByID
+	FindVoiceConnectorGroupByID       = findVoiceConnectorGroupByID
 	FindVoiceConnectorTerminationByID = findVoiceConnectorTerminationByID
 )

--- a/internal/service/chime/exports_test.go
+++ b/internal/service/chime/exports_test.go
@@ -5,9 +5,10 @@ package chime
 
 // Exports for use in tests only.
 var (
-	FindVoiceConnectorByID            = findVoiceConnectorByID
-	FindVoiceConnectorGroupByID       = findVoiceConnectorGroupByID
-	FindVoiceConnectorLoggingByID     = findVoiceConnectorLoggingByID
-	FindVoiceConnectorOriginationByID = findVoiceConnectorOriginationByID
-	FindVoiceConnectorTerminationByID = findVoiceConnectorTerminationByID
+	FindVoiceConnectorByID                       = findVoiceConnectorByID
+	FindVoiceConnectorGroupByID                  = findVoiceConnectorGroupByID
+	FindVoiceConnectorLoggingByID                = findVoiceConnectorLoggingByID
+	FindVoiceConnectorOriginationByID            = findVoiceConnectorOriginationByID
+	FindVoiceConnectorTerminationByID            = findVoiceConnectorTerminationByID
+	FindVoiceConnectorTerminationCredentialsByID = findVoiceConnectorTerminationCredentialsByID
 )

--- a/internal/service/chime/exports_test.go
+++ b/internal/service/chime/exports_test.go
@@ -1,0 +1,9 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package chime
+
+// Exports for use in tests only.
+var (
+	FindVoiceConnectorWithRetry = findVoiceConnectorWithRetry
+)

--- a/internal/service/chime/exports_test.go
+++ b/internal/service/chime/exports_test.go
@@ -8,5 +8,6 @@ var (
 	FindVoiceConnectorByID            = findVoiceConnectorByID
 	FindVoiceConnectorGroupByID       = findVoiceConnectorGroupByID
 	FindVoiceConnectorLoggingByID     = findVoiceConnectorLoggingByID
+	FindVoiceConnectorOriginationByID = findVoiceConnectorOriginationByID
 	FindVoiceConnectorTerminationByID = findVoiceConnectorTerminationByID
 )

--- a/internal/service/chime/exports_test.go
+++ b/internal/service/chime/exports_test.go
@@ -5,5 +5,6 @@ package chime
 
 // Exports for use in tests only.
 var (
-	FindVoiceConnectorWithRetry = findVoiceConnectorWithRetry
+	FindVoiceConnectorByID            = findVoiceConnectorByID
+	FindVoiceConnectorTerminationByID = findVoiceConnectorTerminationByID
 )

--- a/internal/service/chime/find.go
+++ b/internal/service/chime/find.go
@@ -11,9 +11,13 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
+const (
+	voiceConnectorResourcePropagationTimeout = 1 * time.Minute
+)
+
 func FindVoiceConnectorResourceWithRetry[T any](ctx context.Context, isNewResource bool, f func() (T, error)) (T, error) {
 	var resp T
-	err := tfresource.Retry(ctx, 1*time.Minute, func() *retry.RetryError {
+	err := tfresource.Retry(ctx, voiceConnectorResourcePropagationTimeout, func() *retry.RetryError {
 		var err error
 		resp, err = f()
 		if isNewResource && tfresource.NotFound(err) {

--- a/internal/service/chime/find.go
+++ b/internal/service/chime/find.go
@@ -1,0 +1,31 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package chime
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func FindVoiceConnectorResourceWithRetry[T any](ctx context.Context, isNewResource bool, f func() (T, error)) (T, error) {
+	var resp T
+	err := tfresource.Retry(ctx, 1*time.Minute, func() *retry.RetryError {
+		var err error
+		resp, err = f()
+		if isNewResource && tfresource.NotFound(err) {
+			return retry.RetryableError(err)
+		}
+
+		if err != nil {
+			return retry.NonRetryableError(err)
+		}
+
+		return nil
+	}, tfresource.WithDelay(5*time.Second))
+
+	return resp, err
+}

--- a/internal/service/chime/generate.go
+++ b/internal/service/chime/generate.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-//go:generate go run ../../generate/tags/main.go -ListTags -ListTagsInIDElem=ResourceARN -ServiceTagsSlice -TagInIDElem=ResourceARN -CreateTags -UpdateTags -AWSSDKServicePackage=chimesdkvoice
+//go:generate go run ../../generate/tags/main.go -ListTags -ListTagsInIDElem=ResourceARN -ServiceTagsSlice -TagInIDElem=ResourceARN -UpdateTags -AWSSDKServicePackage=chimesdkvoice
 //go:generate go run ../../generate/servicepackage/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/chime/tags_gen.go
+++ b/internal/service/chime/tags_gen.go
@@ -97,15 +97,6 @@ func setTagsOut(ctx context.Context, tags []*chimesdkvoice.Tag) {
 	}
 }
 
-// createTags creates chime service tags for new resources.
-func createTags(ctx context.Context, conn chimesdkvoiceiface.ChimeSDKVoiceAPI, identifier string, tags []*chimesdkvoice.Tag) error {
-	if len(tags) == 0 {
-		return nil
-	}
-
-	return updateTags(ctx, conn, identifier, nil, KeyValueTags(ctx, tags))
-}
-
 // updateTags updates chime service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.

--- a/internal/service/chime/voice_connector.go
+++ b/internal/service/chime/voice_connector.go
@@ -106,11 +106,6 @@ func resourceVoiceConnectorCreate(ctx context.Context, d *schema.ResourceData, m
 
 	d.SetId(aws.StringValue(resp.VoiceConnector.VoiceConnectorId))
 
-	//tagsConn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
-	//if err := createTags(ctx, tagsConn, aws.StringValue(resp.VoiceConnector.VoiceConnectorArn), getTagsIn(ctx)); err != nil {
-	//	return sdkdiag.AppendErrorf(diags, "setting Chime Voice Connector (%s) tags: %s", d.Id(), err)
-	//}
-
 	return append(diags, resourceVoiceConnectorRead(ctx, d, meta)...)
 }
 
@@ -118,29 +113,11 @@ func resourceVoiceConnectorRead(ctx context.Context, d *schema.ResourceData, met
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
 
-	//var resp *chimesdkvoice.VoiceConnector
-	//err := tfresource.Retry(ctx, 1*time.Minute, func() *retry.RetryError {
-	//	var err error
-	//	resp, err = findVoiceConnectorByID(ctx, conn, d.Id())
-	//	if d.IsNewResource() && tfresource.NotFound(err) {
-	//		return retry.RetryableError(err)
-	//	}
-	//
-	//	if err != nil {
-	//		return retry.NonRetryableError(err)
-	//	}
-	//
-	//	return nil
-	//}, tfresource.WithDelay(5*time.Second))
-
 	resp, err := findVoiceConnectorWithRetry(ctx, conn, d.IsNewResource(), d.Id())
 
 	if tfresource.TimedOut(err) {
 		resp, err = findVoiceConnectorByID(ctx, conn, d.Id())
 	}
-	//outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, 1*time.Minute, func() (interface{}, error) {
-	//	return findVoiceConnectorByID(ctx, conn, d.Id())
-	//}, d.IsNewResource())
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Chime Voice connector %s not found", d.Id())
@@ -151,8 +128,6 @@ func resourceVoiceConnectorRead(ctx context.Context, d *schema.ResourceData, met
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading Voice Connector (%s): %s", d.Id(), err)
 	}
-
-	// resp := outputRaw.(*chimesdkvoice.VoiceConnector)
 
 	d.Set("arn", resp.VoiceConnectorArn)
 	d.Set("aws_region", resp.AwsRegion)

--- a/internal/service/chime/voice_connector.go
+++ b/internal/service/chime/voice_connector.go
@@ -94,8 +94,6 @@ func resourceVoiceConnectorCreate(ctx context.Context, d *schema.ResourceData, m
 
 	if v, ok := d.GetOk("aws_region"); ok {
 		createInput.AwsRegion = aws.String(v.(string))
-	} else {
-		createInput.AwsRegion = aws.String(meta.(*conns.AWSClient).Region)
 	}
 
 	resp, err := conn.CreateVoiceConnectorWithContext(ctx, createInput)

--- a/internal/service/chime/voice_connector_logging_test.go
+++ b/internal/service/chime/voice_connector_logging_test.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -27,7 +25,6 @@ func testAccVoiceConnectorLogging_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
@@ -59,7 +56,6 @@ func testAccVoiceConnectorLogging_disappears(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
@@ -86,7 +82,6 @@ func testAccVoiceConnectorLogging_update(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
@@ -158,17 +153,13 @@ func testAccCheckVoiceConnectorLoggingExists(ctx context.Context, name string) r
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
-		input := &chimesdkvoice.GetVoiceConnectorLoggingConfigurationInput{
-			VoiceConnectorId: aws.String(rs.Primary.ID),
-		}
 
-		resp, err := conn.GetVoiceConnectorLoggingConfigurationWithContext(ctx, input)
+		_, err := tfchime.FindVoiceConnectorResourceWithRetry(ctx, false, func() (*chimesdkvoice.LoggingConfiguration, error) {
+			return tfchime.FindVoiceConnectorLoggingByID(ctx, conn, rs.Primary.ID)
+		})
+
 		if err != nil {
 			return err
-		}
-
-		if resp == nil || resp.LoggingConfiguration == nil {
-			return fmt.Errorf("no Chime Voice Connector logging configureation (%s) found", rs.Primary.ID)
 		}
 
 		return nil

--- a/internal/service/chime/voice_connector_logging_test.go
+++ b/internal/service/chime/voice_connector_logging_test.go
@@ -158,10 +158,6 @@ func testAccCheckVoiceConnectorLoggingExists(ctx context.Context, name string) r
 			return tfchime.FindVoiceConnectorLoggingByID(ctx, conn, rs.Primary.ID)
 		})
 
-		if err != nil {
-			return err
-		}
-
-		return nil
+		return err
 	}
 }

--- a/internal/service/chime/voice_connector_streaming_test.go
+++ b/internal/service/chime/voice_connector_streaming_test.go
@@ -21,12 +21,12 @@ import (
 	tfchime "github.com/hashicorp/terraform-provider-aws/internal/service/chime"
 )
 
-func TestAccChimeVoiceConnectorStreaming_basic(t *testing.T) {
+func testAccVoiceConnectorStreaming_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector_streaming.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -53,12 +53,12 @@ func TestAccChimeVoiceConnectorStreaming_basic(t *testing.T) {
 	})
 }
 
-func TestAccChimeVoiceConnectorStreaming_disappears(t *testing.T) {
+func testAccVoiceConnectorStreaming_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector_streaming.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -79,12 +79,12 @@ func TestAccChimeVoiceConnectorStreaming_disappears(t *testing.T) {
 	})
 }
 
-func TestAccChimeVoiceConnectorStreaming_update(t *testing.T) {
+func TestAccVoiceConnectorStreaming_update(t *testing.T) {
 	ctx := acctest.Context(t)
 	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector_streaming.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)

--- a/internal/service/chime/voice_connector_streaming_test.go
+++ b/internal/service/chime/voice_connector_streaming_test.go
@@ -79,7 +79,7 @@ func testAccVoiceConnectorStreaming_disappears(t *testing.T) {
 	})
 }
 
-func TestAccVoiceConnectorStreaming_update(t *testing.T) {
+func testAccVoiceConnectorStreaming_update(t *testing.T) {
 	ctx := acctest.Context(t)
 	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector_streaming.test"

--- a/internal/service/chime/voice_connector_termination.go
+++ b/internal/service/chime/voice_connector_termination.go
@@ -12,10 +12,12 @@ import (
 	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 // @SDKResource("aws_chime_voice_connector_termination")
@@ -113,13 +115,15 @@ func resourceVoiceConnectorTerminationCreate(ctx context.Context, d *schema.Reso
 func resourceVoiceConnectorTerminationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
 
-	input := &chimesdkvoice.GetVoiceConnectorTerminationInput{
-		VoiceConnectorId: aws.String(d.Id()),
+	resp, err := FindVoiceConnectorResourceWithRetry(ctx, d.IsNewResource(), func() (*chimesdkvoice.Termination, error) {
+		return findVoiceConnectorTerminationByID(ctx, conn, d.Id())
+	})
+
+	if tfresource.TimedOut(err) {
+		resp, err = findVoiceConnectorTerminationByID(ctx, conn, d.Id())
 	}
 
-	resp, err := conn.GetVoiceConnectorTerminationWithContext(ctx, input)
-
-	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, chimesdkvoice.ErrCodeNotFoundException) {
+	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Chime Voice Connector (%s) termination not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
@@ -129,18 +133,14 @@ func resourceVoiceConnectorTerminationRead(ctx context.Context, d *schema.Resour
 		return diag.Errorf("getting Chime Voice Connector (%s) termination: %s", d.Id(), err)
 	}
 
-	if resp == nil || resp.Termination == nil {
-		return diag.Errorf("getting Chime Voice Connector (%s) termination: empty response", d.Id())
-	}
+	d.Set("cps_limit", resp.CpsLimit)
+	d.Set("disabled", resp.Disabled)
+	d.Set("default_phone_number", resp.DefaultPhoneNumber)
 
-	d.Set("cps_limit", resp.Termination.CpsLimit)
-	d.Set("disabled", resp.Termination.Disabled)
-	d.Set("default_phone_number", resp.Termination.DefaultPhoneNumber)
-
-	if err := d.Set("calling_regions", flex.FlattenStringList(resp.Termination.CallingRegions)); err != nil {
+	if err := d.Set("calling_regions", flex.FlattenStringList(resp.CallingRegions)); err != nil {
 		return diag.Errorf("setting termination calling regions (%s): %s", d.Id(), err)
 	}
-	if err := d.Set("cidr_allow_list", flex.FlattenStringList(resp.Termination.CidrAllowedList)); err != nil {
+	if err := d.Set("cidr_allow_list", flex.FlattenStringList(resp.CidrAllowedList)); err != nil {
 		return diag.Errorf("setting termination cidr allow list (%s): %s", d.Id(), err)
 	}
 
@@ -200,4 +200,32 @@ func resourceVoiceConnectorTerminationDelete(ctx context.Context, d *schema.Reso
 	}
 
 	return nil
+}
+
+func findVoiceConnectorTerminationByID(ctx context.Context, conn *chimesdkvoice.ChimeSDKVoice, id string) (*chimesdkvoice.Termination, error) {
+	in := &chimesdkvoice.GetVoiceConnectorInput{
+		VoiceConnectorId: aws.String(id),
+	}
+
+	input := &chimesdkvoice.GetVoiceConnectorTerminationInput{
+		VoiceConnectorId: aws.String(id),
+	}
+
+	resp, err := conn.GetVoiceConnectorTerminationWithContext(ctx, input)
+	if tfawserr.ErrCodeEquals(err, chimesdkvoice.ErrCodeNotFoundException) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: in,
+		}
+	}
+
+	if resp == nil || resp.Termination == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Termination, nil
 }

--- a/internal/service/chime/voice_connector_termination_credentials_test.go
+++ b/internal/service/chime/voice_connector_termination_credentials_test.go
@@ -124,11 +124,7 @@ func testAccCheckVoiceConnectorTerminationCredentialsExists(ctx context.Context,
 			return tfchime.FindVoiceConnectorTerminationCredentialsByID(ctx, conn, rs.Primary.ID)
 		})
 
-		if err != nil {
-			return err
-		}
-
-		return nil
+		return err
 	}
 }
 

--- a/internal/service/chime/voice_connector_termination_credentials_test.go
+++ b/internal/service/chime/voice_connector_termination_credentials_test.go
@@ -8,16 +8,14 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfchime "github.com/hashicorp/terraform-provider-aws/internal/service/chime"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func testAccVoiceConnectorTerminationCredentials_basic(t *testing.T) {
@@ -28,7 +26,6 @@ func testAccVoiceConnectorTerminationCredentials_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
@@ -60,7 +57,6 @@ func testAccVoiceConnectorTerminationCredentials_disappears(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
@@ -87,7 +83,6 @@ func testAccVoiceConnectorTerminationCredentials_update(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
@@ -124,17 +119,13 @@ func testAccCheckVoiceConnectorTerminationCredentialsExists(ctx context.Context,
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
-		input := &chimesdkvoice.ListVoiceConnectorTerminationCredentialsInput{
-			VoiceConnectorId: aws.String(rs.Primary.ID),
-		}
 
-		resp, err := conn.ListVoiceConnectorTerminationCredentialsWithContext(ctx, input)
+		_, err := tfchime.FindVoiceConnectorResourceWithRetry(ctx, false, func() (*chimesdkvoice.ListVoiceConnectorTerminationCredentialsOutput, error) {
+			return tfchime.FindVoiceConnectorTerminationCredentialsByID(ctx, conn, rs.Primary.ID)
+		})
+
 		if err != nil {
 			return err
-		}
-
-		if resp == nil || resp.Usernames == nil {
-			return fmt.Errorf("no Chime Voice Connector Termintation credentials (%s) found", rs.Primary.ID)
 		}
 
 		return nil
@@ -148,12 +139,12 @@ func testAccCheckVoiceConnectorTerminationCredentialsDestroy(ctx context.Context
 				continue
 			}
 			conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
-			input := &chimesdkvoice.ListVoiceConnectorTerminationCredentialsInput{
-				VoiceConnectorId: aws.String(rs.Primary.ID),
-			}
-			resp, err := conn.ListVoiceConnectorTerminationCredentialsWithContext(ctx, input)
 
-			if tfawserr.ErrCodeEquals(err, chimesdkvoice.ErrCodeNotFoundException) {
+			_, err := tfchime.FindVoiceConnectorResourceWithRetry(ctx, false, func() (*chimesdkvoice.ListVoiceConnectorTerminationCredentialsOutput, error) {
+				return tfchime.FindVoiceConnectorTerminationCredentialsByID(ctx, conn, rs.Primary.ID)
+			})
+
+			if tfresource.NotFound(err) {
 				continue
 			}
 
@@ -161,9 +152,7 @@ func testAccCheckVoiceConnectorTerminationCredentialsDestroy(ctx context.Context
 				return err
 			}
 
-			if resp != nil && resp.Usernames != nil {
-				return fmt.Errorf("error Chime Voice Connector Termination credentials still exists")
-			}
+			return fmt.Errorf("voice connector terimination credentials still exists: (%s)", rs.Primary.ID)
 		}
 
 		return nil

--- a/internal/service/chime/voice_connector_termination_test.go
+++ b/internal/service/chime/voice_connector_termination_test.go
@@ -27,7 +27,6 @@ func testAccVoiceConnectorTermination_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			// acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
@@ -61,7 +60,6 @@ func testAccVoiceConnectorTermination_disappears(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			// acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
@@ -88,7 +86,6 @@ func testAccVoiceConnectorTermination_update(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			// acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),

--- a/internal/service/chime/voice_connector_termination_test.go
+++ b/internal/service/chime/voice_connector_termination_test.go
@@ -9,15 +9,14 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfchime "github.com/hashicorp/terraform-provider-aws/internal/service/chime"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func testAccVoiceConnectorTermination_basic(t *testing.T) {
@@ -28,7 +27,7 @@ func testAccVoiceConnectorTermination_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
+			// acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
@@ -62,7 +61,7 @@ func testAccVoiceConnectorTermination_disappears(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
+			// acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
@@ -89,7 +88,7 @@ func testAccVoiceConnectorTermination_update(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
+			// acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
@@ -190,12 +189,12 @@ func testAccCheckVoiceConnectorTerminationDestroy(ctx context.Context) resource.
 				continue
 			}
 			conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
-			input := &chimesdkvoice.GetVoiceConnectorTerminationInput{
-				VoiceConnectorId: aws.String(rs.Primary.ID),
-			}
-			resp, err := conn.GetVoiceConnectorTerminationWithContext(ctx, input)
 
-			if tfawserr.ErrCodeEquals(err, chimesdkvoice.ErrCodeNotFoundException) {
+			_, err := tfchime.FindVoiceConnectorResourceWithRetry(ctx, false, func() (*chimesdkvoice.Termination, error) {
+				return tfchime.FindVoiceConnectorTerminationByID(ctx, conn, rs.Primary.ID)
+			})
+
+			if tfresource.NotFound(err) {
 				continue
 			}
 
@@ -203,9 +202,7 @@ func testAccCheckVoiceConnectorTerminationDestroy(ctx context.Context) resource.
 				return err
 			}
 
-			if resp != nil && resp.Termination != nil {
-				return fmt.Errorf("error Chime Voice Connector Termination still exists")
-			}
+			return fmt.Errorf("voice connector termination still exists: (%s)", rs.Primary.ID)
 		}
 
 		return nil

--- a/internal/service/chime/voice_connector_test.go
+++ b/internal/service/chime/voice_connector_test.go
@@ -29,7 +29,6 @@ func testAccVoiceConnector_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			// acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
@@ -64,7 +63,6 @@ func testAccVoiceConnector_disappears(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			// acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
@@ -93,7 +91,6 @@ func testAccVoiceConnector_update(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			// acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
@@ -269,15 +266,6 @@ func testAccCheckVoiceConnectorDestroy(ctx context.Context) resource.TestCheckFu
 				return err
 			}
 
-			//input := &chimesdkvoice.GetVoiceConnectorInput{
-			//	VoiceConnectorId: aws.String(rs.Primary.ID),
-			//}
-			//resp, err := conn.GetVoiceConnectorWithContext(ctx, input)
-			//if err == nil {
-			//	if resp.VoiceConnector != nil && aws.StringValue(resp.VoiceConnector.Name) != "" {
-			//		return fmt.Errorf("error Chime Voice Connector still exists")
-			//	}
-			//}
 			return fmt.Errorf("voice connector still exists: (%s)", rs.Primary.ID)
 		}
 

--- a/internal/service/chime/voice_connector_test.go
+++ b/internal/service/chime/voice_connector_test.go
@@ -130,9 +130,6 @@ func testAccVoiceConnector_tags(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			// Legacy chime resources are always created in us-east-1, and the ListTags operation
-			// can behave unexpectedly when configured with a different region.
-			// acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
 			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),

--- a/internal/service/chime/voice_connector_test.go
+++ b/internal/service/chime/voice_connector_test.go
@@ -256,7 +256,9 @@ func testAccCheckVoiceConnectorDestroy(ctx context.Context) resource.TestCheckFu
 			}
 			conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
 
-			_, err := tfchime.FindVoiceConnectorWithRetry(ctx, conn, false, rs.Primary.ID)
+			_, err := tfchime.FindVoiceConnectorResourceWithRetry(ctx, false, func() (*chimesdkvoice.VoiceConnector, error) {
+				return tfchime.FindVoiceConnectorByID(ctx, conn, rs.Primary.ID)
+			})
 
 			if tfresource.NotFound(err) {
 				continue

--- a/internal/service/chime/voice_connector_test.go
+++ b/internal/service/chime/voice_connector_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -234,15 +233,16 @@ func testAccCheckVoiceConnectorExists(ctx context.Context, name string, vc *chim
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
-		input := &chimesdkvoice.GetVoiceConnectorInput{
-			VoiceConnectorId: aws.String(rs.Primary.ID),
-		}
-		resp, err := conn.GetVoiceConnectorWithContext(ctx, input)
+
+		resp, err := tfchime.FindVoiceConnectorResourceWithRetry(ctx, false, func() (*chimesdkvoice.VoiceConnector, error) {
+			return tfchime.FindVoiceConnectorByID(ctx, conn, rs.Primary.ID)
+		})
+
 		if err != nil {
 			return err
 		}
 
-		vc = resp.VoiceConnector
+		vc = resp
 
 		return nil
 	}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

multiple fixes for eventual consistency errors.

Tests are now successful in regions other than `us-east-1`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

--->

Closes #34218

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTARGS="-run=TestAccChime_serial" PKG=chime

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/chime/... -v -count 1 -parallel 20  -run=TestAccChime_serial -timeout 360m
--- PASS: TestAccChime_serial (2349.97s)
    --- PASS: TestAccChime_serial/VoiceConnectorTerminationCredentials (427.25s)
        --- PASS: TestAccChime_serial/VoiceConnectorTerminationCredentials/disappears (110.37s)
        --- PASS: TestAccChime_serial/VoiceConnectorTerminationCredentials/update (199.87s)
        --- PASS: TestAccChime_serial/VoiceConnectorTerminationCredentials/basic (117.01s)
    --- PASS: TestAccChime_serial/VoiceConnector (338.63s)
        --- PASS: TestAccChime_serial/VoiceConnector/basic (58.42s)
        --- PASS: TestAccChime_serial/VoiceConnector/disappears (41.24s)
        --- PASS: TestAccChime_serial/VoiceConnector/update (95.37s)
        --- PASS: TestAccChime_serial/VoiceConnector/tags (143.61s)
    --- PASS: TestAccChime_serial/VoiceConnectorGroup (335.48s)
        --- PASS: TestAccChime_serial/VoiceConnectorGroup/basic (91.50s)
        --- PASS: TestAccChime_serial/VoiceConnectorGroup/disappears (85.25s)
        --- PASS: TestAccChime_serial/VoiceConnectorGroup/update (158.73s)
    --- PASS: TestAccChime_serial/VoiceConnectorLogging (319.68s)
        --- PASS: TestAccChime_serial/VoiceConnectorLogging/basic (86.02s)
        --- PASS: TestAccChime_serial/VoiceConnectorLogging/disappears (81.72s)
        --- PASS: TestAccChime_serial/VoiceConnectorLogging/update (151.94s)
    --- PASS: TestAccChime_serial/VoiceConnectorOrigination (311.77s)
        --- PASS: TestAccChime_serial/VoiceConnectorOrigination/basic (85.51s)
        --- PASS: TestAccChime_serial/VoiceConnectorOrigination/disappears (74.62s)
        --- PASS: TestAccChime_serial/VoiceConnectorOrigination/update (151.64s)
    --- PASS: TestAccChime_serial/VoiceConnectorStreaming (323.72s)
        --- PASS: TestAccChime_serial/VoiceConnectorStreaming/basic (61.08s)
        --- PASS: TestAccChime_serial/VoiceConnectorStreaming/disappears (59.67s)
        --- PASS: TestAccChime_serial/VoiceConnectorStreaming/update (202.97s)
    --- PASS: TestAccChime_serial/VoiceConnectorTermination (293.45s)
        --- PASS: TestAccChime_serial/VoiceConnectorTermination/update (142.66s)
        --- PASS: TestAccChime_serial/VoiceConnectorTermination/basic (81.38s)
        --- PASS: TestAccChime_serial/VoiceConnectorTermination/disappears (69.41s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/chime	2353.273s
```

```console
$ make testacc TESTARGS="-run=TestAccChimeSDKMediaPipelinesMediaInsightsPipelineConfiguration_" PKG=chimesdkmediapipelines

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/chimesdkmediapipelines/... -v -count 1 -parallel 20  -run=TestAccChimeSDKMediaPipelinesMediaInsightsPipelineConfiguration_ -timeout 360m
--- PASS: TestAccChimeSDKMediaPipelinesMediaInsightsPipelineConfiguration_disappears (137.72s)
--- PASS: TestAccChimeSDKMediaPipelinesMediaInsightsPipelineConfiguration_basic (182.36s)
--- PASS: TestAccChimeSDKMediaPipelinesMediaInsightsPipelineConfiguration_tags (270.45s)
--- PASS: TestAccChimeSDKMediaPipelinesMediaInsightsPipelineConfiguration_updateAllProcessorTypes (490.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/chimesdkmediapipelines	493.279s
```