### PR TITLE
Added optional aws_dynamodb_table.client_token

### DIFF
--- a/.changelog/34139.txt
+++ b/.changelog/34139.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dynamodb_table: Added optional `import_table.client_token`
+```

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -314,6 +314,10 @@ func ResourceTable() *schema.Resource {
 				ConflictsWith: []string{"restore_source_name"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"client_token": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 						"input_compression_type": {
 							Type:         schema.TypeString,
 							Optional:     true,
@@ -2162,6 +2166,10 @@ func expandLocalSecondaryIndexes(cfg []interface{}, keySchemaM map[string]interf
 func expandImportTable(data map[string]interface{}) *dynamodb.ImportTableInput {
 	a := &dynamodb.ImportTableInput{
 		ClientToken: aws.String(id.UniqueId()),
+	}
+
+	if v, ok := data["client_token"].(string); ok {
+		a.ClientToken = aws.String(v)
 	}
 
 	if v, ok := data["input_compression_type"].(string); ok {


### PR DESCRIPTION
### Description
Fix to add back the optional `aws_dynamodb_table.import_table.client_token`

### Relations
Closes #34139 

### References
[DynamoDB Table Docs](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ImportTable.html#DDB-ImportTable-request-ClientToken)


### Output from Acceptance Testing
Decided against adding acceptance tests due to the nature of client tokens `If you submit a request with the same client token but a change in other parameters within the 8-hour idempotency window, DynamoDB returns an IdempotentParameterMismatch exception.` Can add a random string here if needed, though.

```console
make testacc TESTS='TestAccDynamoDBTable_importTable' PKG=dynamodb
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/dynamodb/... -v -count 1 -parallel 20 -run='TestAccDynamoDBTable_importTable'  -timeout 360m
=== RUN   TestAccDynamoDBTable_importTable
=== PAUSE TestAccDynamoDBTable_importTable
=== CONT  TestAccDynamoDBTable_importTable
    table_test.go:2561: Step 1/1 error: Error running apply: exit status 1

        Error: creating Amazon DynamoDB Table (tf-acc-test-7926348025373173001): ImportConflictException: Import conflict: Duplicate request detected with conflicting parameters
```
