### PR TITLE
AWS Batch Compute Environment add `update_policy` parameter

### DIFF
--- a/.changelog/34353.txt
+++ b/.changelog/34353.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_batch_compute_environment: Add `update_policy` parameter
+```
+
+```release-note:enhancement
+data-source/aws_batch_compute_environment: Add `update_policy` attribute
+```

--- a/.changelog/CHANGEME.txt
+++ b/.changelog/CHANGEME.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_batch_compute_environment: Add `update_policy` parameter
+```
+
+```release-note:enhancement
+data-source/aws_batch_compute_environment: Add `update_policy` attribute
+```

--- a/.changelog/CHANGEME.txt
+++ b/.changelog/CHANGEME.txt
@@ -1,7 +1,0 @@
-```release-note:enhancement
-resource/aws_batch_compute_environment: Add `update_policy` parameter
-```
-
-```release-note:enhancement
-data-source/aws_batch_compute_environment: Add `update_policy` attribute
-```

--- a/internal/service/batch/compute_environment.go
+++ b/internal/service/batch/compute_environment.go
@@ -329,7 +329,7 @@ func resourceComputeEnvironmentCreate(ctx context.Context, d *schema.ResourceDat
 			return sdkdiag.AppendErrorf(diags, "Create Batch Compute Environment extra arguments through UpdateComputeEnvironment (%s): %s", d.Id(), err)
 		}
 
-		if _, err := waitComputeEnvironmentUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
+		if err := waitComputeEnvironmentUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return sdkdiag.AppendErrorf(diags, "Create waiting for Batch Compute Environment (%s) extra arguments through UpdateComputeEnvironment: %s", d.Id(), err)
 		}
 	}
@@ -521,7 +521,7 @@ func resourceComputeEnvironmentUpdate(ctx context.Context, d *schema.ResourceDat
 			return sdkdiag.AppendErrorf(diags, "updating Batch Compute Environment (%s): %s", d.Id(), err)
 		}
 
-		if _, err := waitComputeEnvironmentUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
+		if err := waitComputeEnvironmentUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for Batch Compute Environment (%s) update: %s", d.Id(), err)
 		}
 	}
@@ -796,7 +796,7 @@ func waitComputeEnvironmentDisabled(ctx context.Context, conn *batch.Batch, name
 	return nil, err
 }
 
-func waitComputeEnvironmentUpdated(ctx context.Context, conn *batch.Batch, name string, timeout time.Duration) (*batch.ComputeEnvironmentDetail, error) {
+func waitComputeEnvironmentUpdated(ctx context.Context, conn *batch.Batch, name string, timeout time.Duration) error {
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{batch.CEStatusUpdating},
 		Target:  []string{batch.CEStatusValid},
@@ -806,11 +806,11 @@ func waitComputeEnvironmentUpdated(ctx context.Context, conn *batch.Batch, name 
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
-	if v, ok := outputRaw.(*batch.ComputeEnvironmentDetail); ok {
-		return v, err
+	if _, ok := outputRaw.(*batch.ComputeEnvironmentDetail); ok {
+		return err
 	}
 
-	return nil, err
+	return err
 }
 
 func isFargateType(computeResourceType string) bool {
@@ -1265,7 +1265,7 @@ func expandComputeEnvironmentUpdatePolicy(l []interface{}) *batch.UpdatePolicy {
 
 	up := &batch.UpdatePolicy{
 		JobExecutionTimeoutMinutes: aws.Int64(int64(m["job_execution_timeout_minutes"].(int))),
-		TerminateJobsOnUpdate:      aws.Bool(bool(m["terminate_jobs_on_update"].(bool))),
+		TerminateJobsOnUpdate:      aws.Bool(m["terminate_jobs_on_update"].(bool)),
 	}
 
 	return up

--- a/internal/service/batch/compute_environment.go
+++ b/internal/service/batch/compute_environment.go
@@ -1,22 +1,15 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package batch
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"strings"
-	"time"
 
-	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/batch"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -26,11 +19,8 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
-	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_batch_compute_environment", name="Compute Environment")
-// @Tags(identifierAttribute="arn")
 func ResourceComputeEnvironment() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceComputeEnvironmentCreate,
@@ -79,6 +69,7 @@ func ResourceComputeEnvironment() *schema.Resource {
 						"allocation_strategy": {
 							Type:     schema.TypeString,
 							Optional: true,
+							ForceNew: true,
 							StateFunc: func(val interface{}) string {
 								return strings.ToUpper(val.(string))
 							},
@@ -87,6 +78,7 @@ func ResourceComputeEnvironment() *schema.Resource {
 						"bid_percentage": {
 							Type:     schema.TypeInt,
 							Optional: true,
+							ForceNew: true,
 						},
 						"desired_vcpus": {
 							Type:     schema.TypeInt,
@@ -98,18 +90,20 @@ func ResourceComputeEnvironment() *schema.Resource {
 							Optional: true,
 							Computed: true,
 							ForceNew: true,
-							MaxItems: 2,
+							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"image_id_override": {
 										Type:         schema.TypeString,
 										Optional:     true,
 										Computed:     true,
+										ForceNew:     true,
 										ValidateFunc: validation.StringLenBetween(1, 256),
 									},
 									"image_type": {
 										Type:         schema.TypeString,
 										Optional:     true,
+										ForceNew:     true,
 										ValidateFunc: validation.StringLenBetween(1, 256),
 									},
 								},
@@ -118,19 +112,23 @@ func ResourceComputeEnvironment() *schema.Resource {
 						"ec2_key_pair": {
 							Type:     schema.TypeString,
 							Optional: true,
+							ForceNew: true,
 						},
 						"image_id": {
 							Type:     schema.TypeString,
 							Optional: true,
+							ForceNew: true,
 						},
 						"instance_role": {
 							Type:         schema.TypeString,
 							Optional:     true,
+							ForceNew:     true,
 							ValidateFunc: verify.ValidARN,
 						},
 						"instance_type": {
 							Type:     schema.TypeSet,
 							Optional: true,
+							ForceNew: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 						"launch_template": {
@@ -143,17 +141,19 @@ func ResourceComputeEnvironment() *schema.Resource {
 									"launch_template_id": {
 										Type:          schema.TypeString,
 										Optional:      true,
+										ForceNew:      true,
 										ConflictsWith: []string{"compute_resources.0.launch_template.0.launch_template_name"},
 									},
 									"launch_template_name": {
 										Type:          schema.TypeString,
 										Optional:      true,
+										ForceNew:      true,
 										ConflictsWith: []string{"compute_resources.0.launch_template.0.launch_template_id"},
 									},
 									"version": {
 										Type:     schema.TypeString,
 										Optional: true,
-										Computed: true,
+										ForceNew: true,
 									},
 								},
 							},
@@ -165,11 +165,6 @@ func ResourceComputeEnvironment() *schema.Resource {
 						"min_vcpus": {
 							Type:     schema.TypeInt,
 							Optional: true,
-						},
-						"placement_group": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
 						},
 						"security_group_ids": {
 							Type:     schema.TypeSet,
@@ -187,10 +182,11 @@ func ResourceComputeEnvironment() *schema.Resource {
 							Required: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
-						"tags": tftags.TagsSchema(),
+						"tags": tftags.TagsSchemaForceNew(),
 						"type": {
 							Type:     schema.TypeString,
 							Required: true,
+							ForceNew: true,
 							StateFunc: func(val interface{}) string {
 								return strings.ToUpper(val.(string))
 							},
@@ -248,8 +244,8 @@ func ResourceComputeEnvironment() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			"tags":     tftags.TagsSchema(),
+			"tags_all": tftags.TagsSchemaComputed(),
 			"type": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -265,19 +261,21 @@ func ResourceComputeEnvironment() *schema.Resource {
 
 func resourceComputeEnvironmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).BatchConn(ctx)
+	conn := meta.(*conns.AWSClient).BatchConn()
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
 
 	computeEnvironmentName := create.Name(d.Get("compute_environment_name").(string), d.Get("compute_environment_name_prefix").(string))
 	computeEnvironmentType := d.Get("type").(string)
+
 	input := &batch.CreateComputeEnvironmentInput{
 		ComputeEnvironmentName: aws.String(computeEnvironmentName),
 		ServiceRole:            aws.String(d.Get("service_role").(string)),
-		Tags:                   getTagsIn(ctx),
 		Type:                   aws.String(computeEnvironmentType),
 	}
 
 	if v, ok := d.GetOk("compute_resources"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.ComputeResources = expandComputeResource(ctx, v.([]interface{})[0].(map[string]interface{}))
+		input.ComputeResources = expandComputeResource(v.([]interface{})[0].(map[string]interface{}))
 	}
 
 	if v, ok := d.GetOk("eks_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
@@ -288,6 +286,11 @@ func resourceComputeEnvironmentCreate(ctx context.Context, d *schema.ResourceDat
 		input.State = aws.String(v.(string))
 	}
 
+	if len(tags) > 0 {
+		input.Tags = Tags(tags.IgnoreAWS())
+	}
+
+	log.Printf("[DEBUG] Creating Batch Compute Environment: %s", input)
 	output, err := conn.CreateComputeEnvironmentWithContext(ctx, input)
 
 	if err != nil {
@@ -305,9 +308,11 @@ func resourceComputeEnvironmentCreate(ctx context.Context, d *schema.ResourceDat
 
 func resourceComputeEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).BatchConn(ctx)
+	conn := meta.(*conns.AWSClient).BatchConn()
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	computeEnvironment, err := findComputeEnvironmentDetailByName(ctx, conn, d.Id())
+	computeEnvironment, err := FindComputeEnvironmentDetailByName(ctx, conn, d.Id())
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Batch Compute Environment (%s) not found, removing from state", d.Id())
@@ -324,14 +329,21 @@ func resourceComputeEnvironmentRead(ctx context.Context, d *schema.ResourceData,
 	d.Set("arn", computeEnvironment.ComputeEnvironmentArn)
 	d.Set("compute_environment_name", computeEnvironment.ComputeEnvironmentName)
 	d.Set("compute_environment_name_prefix", create.NamePrefixFromName(aws.StringValue(computeEnvironment.ComputeEnvironmentName)))
+	d.Set("ecs_cluster_arn", computeEnvironment.EcsClusterArn)
+	d.Set("service_role", computeEnvironment.ServiceRole)
+	d.Set("state", computeEnvironment.State)
+	d.Set("status", computeEnvironment.Status)
+	d.Set("status_reason", computeEnvironment.StatusReason)
+	d.Set("type", computeEnvironmentType)
+
 	if computeEnvironment.ComputeResources != nil {
-		if err := d.Set("compute_resources", []interface{}{flattenComputeResource(ctx, computeEnvironment.ComputeResources)}); err != nil {
+		if err := d.Set("compute_resources", []interface{}{flattenComputeResource(computeEnvironment.ComputeResources)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting compute_resources: %s", err)
 		}
 	} else {
 		d.Set("compute_resources", nil)
 	}
-	d.Set("ecs_cluster_arn", computeEnvironment.EcsClusterArn)
+
 	if computeEnvironment.EksConfiguration != nil {
 		if err := d.Set("eks_configuration", []interface{}{flattenEKSConfiguration(computeEnvironment.EksConfiguration)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting eks_configuration: %s", err)
@@ -339,20 +351,24 @@ func resourceComputeEnvironmentRead(ctx context.Context, d *schema.ResourceData,
 	} else {
 		d.Set("eks_configuration", nil)
 	}
-	d.Set("service_role", computeEnvironment.ServiceRole)
-	d.Set("state", computeEnvironment.State)
-	d.Set("status", computeEnvironment.Status)
-	d.Set("status_reason", computeEnvironment.StatusReason)
-	d.Set("type", computeEnvironmentType)
 
-	setTagsOut(ctx, computeEnvironment.Tags)
+	tags := KeyValueTags(computeEnvironment.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
+	}
 
 	return diags
 }
 
 func resourceComputeEnvironmentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).BatchConn(ctx)
+	conn := meta.(*conns.AWSClient).BatchConn()
 
 	if d.HasChangesExcept("tags", "tags_all") {
 		input := &batch.UpdateComputeEnvironmentInput{
@@ -373,102 +389,20 @@ func resourceComputeEnvironmentUpdate(ctx context.Context, d *schema.ResourceDat
 				MaxvCpus: aws.Int64(int64(d.Get("compute_resources.0.max_vcpus").(int))),
 			}
 
+			if d.HasChange("compute_resources.0.desired_vcpus") {
+				computeResourceUpdate.DesiredvCpus = aws.Int64(int64(d.Get("compute_resources.0.desired_vcpus").(int)))
+			}
+
+			if d.HasChange("compute_resources.0.min_vcpus") {
+				computeResourceUpdate.MinvCpus = aws.Int64(int64(d.Get("compute_resources.0.min_vcpus").(int)))
+			}
+
 			if d.HasChange("compute_resources.0.security_group_ids") {
 				computeResourceUpdate.SecurityGroupIds = flex.ExpandStringSet(d.Get("compute_resources.0.security_group_ids").(*schema.Set))
 			}
 
 			if d.HasChange("compute_resources.0.subnets") {
 				computeResourceUpdate.Subnets = flex.ExpandStringSet(d.Get("compute_resources.0.subnets").(*schema.Set))
-			}
-
-			if d.HasChange("compute_resources.0.allocation_strategy") {
-				if allocationStrategy, ok := d.GetOk("compute_resources.0.allocation_strategy"); ok {
-					computeResourceUpdate.AllocationStrategy = aws.String(allocationStrategy.(string))
-				} else {
-					computeResourceUpdate.AllocationStrategy = aws.String("")
-				}
-			}
-
-			computeResourceEnvironmentType := d.Get("compute_resources.0.type").(string)
-
-			if d.HasChange("compute_resources.0.type") {
-				computeResourceUpdate.Type = aws.String(computeResourceEnvironmentType)
-			}
-
-			if !isFargateType(computeResourceEnvironmentType) {
-				if d.HasChange("compute_resources.0.desired_vcpus") {
-					if desiredvCpus, ok := d.GetOk("compute_resources.0.desired_vcpus"); ok {
-						computeResourceUpdate.DesiredvCpus = aws.Int64(int64(desiredvCpus.(int)))
-					} else {
-						computeResourceUpdate.DesiredvCpus = aws.Int64(0)
-					}
-				}
-
-				if d.HasChange("compute_resources.0.min_vcpus") {
-					if minVcpus, ok := d.GetOk("compute_resources.0.min_vcpus"); ok {
-						computeResourceUpdate.MinvCpus = aws.Int64(int64(minVcpus.(int)))
-					} else {
-						computeResourceUpdate.MinvCpus = aws.Int64(0)
-					}
-				}
-
-				if d.HasChange("compute_resources.0.bid_percentage") {
-					if bidPercentage, ok := d.GetOk("compute_resources.0.bid_percentage"); ok {
-						computeResourceUpdate.BidPercentage = aws.Int64(int64(bidPercentage.(int)))
-					} else {
-						computeResourceUpdate.BidPercentage = aws.Int64(0)
-					}
-				}
-
-				if d.HasChange("compute_resources.0.ec2_configuration") {
-					defaultImageType := "ECS_AL2"
-					if _, ok := d.GetOk("eks_configuration.#"); ok {
-						defaultImageType = "EKS_AL2"
-					}
-					ec2Configuration := d.Get("compute_resources.0.ec2_configuration").([]interface{})
-					computeResourceUpdate.Ec2Configuration = expandEC2ConfigurationsUpdate(ec2Configuration, defaultImageType)
-				}
-
-				if d.HasChange("compute_resources.0.ec2_key_pair") {
-					if keyPair, ok := d.GetOk("compute_resources.0.ec2_key_pair"); ok {
-						computeResourceUpdate.Ec2KeyPair = aws.String(keyPair.(string))
-					} else {
-						computeResourceUpdate.Ec2KeyPair = aws.String("")
-					}
-				}
-
-				if d.HasChange("compute_resources.0.image_id") {
-					if imageId, ok := d.GetOk("compute_resources.0.image_id"); ok {
-						computeResourceUpdate.ImageId = aws.String(imageId.(string))
-					} else {
-						computeResourceUpdate.ImageId = aws.String("")
-					}
-				}
-
-				if d.HasChange("compute_resources.0.instance_role") {
-					if instanceRole, ok := d.GetOk("compute_resources.0.instance_role"); ok {
-						computeResourceUpdate.InstanceRole = aws.String(instanceRole.(string))
-					} else {
-						computeResourceUpdate.InstanceRole = aws.String("")
-					}
-				}
-
-				if d.HasChange("compute_resources.0.instance_type") {
-					computeResourceUpdate.InstanceTypes = flex.ExpandStringSet(d.Get("compute_resources.0.instance_type").(*schema.Set))
-				}
-
-				if d.HasChange("compute_resources.0.launch_template") {
-					launchTemplate := d.Get("compute_resources.0.launch_template").([]interface{})
-					computeResourceUpdate.LaunchTemplate = expandLaunchTemplateSpecificationUpdate(launchTemplate)
-				}
-
-				if d.HasChange("compute_resources.0.tags") {
-					if tags, ok := d.GetOk("compute_resources.0.tags"); ok {
-						computeResourceUpdate.Tags = Tags(tftags.New(ctx, tags.(map[string]interface{})).IgnoreAWS())
-					} else {
-						computeResourceUpdate.Tags = aws.StringMap(map[string]string{})
-					}
-				}
 			}
 
 			input.ComputeResources = computeResourceUpdate
@@ -484,12 +418,20 @@ func resourceComputeEnvironmentUpdate(ctx context.Context, d *schema.ResourceDat
 		}
 	}
 
+	if d.HasChange("tags_all") {
+		o, n := d.GetChange("tags_all")
+
+		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
+			return sdkdiag.AppendErrorf(diags, "updating tags: %s", err)
+		}
+	}
+
 	return append(diags, resourceComputeEnvironmentRead(ctx, d, meta)...)
 }
 
 func resourceComputeEnvironmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).BatchConn(ctx)
+	conn := meta.(*conns.AWSClient).BatchConn()
 
 	log.Printf("[DEBUG] Disabling Batch Compute Environment: %s", d.Id())
 	{
@@ -536,103 +478,21 @@ func resourceComputeEnvironmentCustomizeDiff(_ context.Context, diff *schema.Res
 	if diff.Id() != "" {
 		// Update.
 
-		fargateComputeResources := isFargateType(diff.Get("compute_resources.0.type").(string))
+		computeResourceType := strings.ToUpper(diff.Get("compute_resources.0.type").(string))
+		fargateComputeResources := false
+		if computeResourceType == batch.CRTypeFargate || computeResourceType == batch.CRTypeFargateSpot {
+			fargateComputeResources = true
+		}
 
-		if !isUpdatableComputeEnvironment(diff) {
-			if diff.HasChange("compute_resources.0.security_group_ids") && !fargateComputeResources {
-				if err := diff.ForceNew("compute_resources.0.security_group_ids"); err != nil {
-					return err
-				}
+		if diff.HasChange("compute_resources.0.security_group_ids") && !fargateComputeResources {
+			if err := diff.ForceNew("compute_resources.0.security_group_ids"); err != nil {
+				return err
 			}
+		}
 
-			if diff.HasChange("compute_resources.0.subnets") && !fargateComputeResources {
-				if err := diff.ForceNew("compute_resources.0.subnets"); err != nil {
-					return err
-				}
-			}
-
-			if diff.HasChange("compute_resources.0.allocation_strategy") {
-				if err := diff.ForceNew("compute_resources.0.allocation_strategy"); err != nil {
-					return err
-				}
-			}
-
-			if diff.HasChange("compute_resources.0.bid_percentage") {
-				if err := diff.ForceNew("compute_resources.0.bid_percentage"); err != nil {
-					return err
-				}
-			}
-
-			if diff.HasChange("compute_resources.0.ec2_configuration.#") {
-				if err := diff.ForceNew("compute_resources.0.ec2_configuration.#"); err != nil {
-					return err
-				}
-			}
-
-			if diff.HasChange("compute_resources.0.ec2_configuration.0.image_id_override") {
-				if err := diff.ForceNew("compute_resources.0.ec2_configuration.0.image_id_override"); err != nil {
-					return err
-				}
-			}
-
-			if diff.HasChange("compute_resources.0.ec2_configuration.0.image_type") {
-				if err := diff.ForceNew("compute_resources.0.ec2_configuration.0.image_type"); err != nil {
-					return err
-				}
-			}
-
-			if diff.HasChange("compute_resources.0.ec2_key_pair") {
-				if err := diff.ForceNew("compute_resources.0.ec2_key_pair"); err != nil {
-					return err
-				}
-			}
-
-			if diff.HasChange("compute_resources.0.image_id") {
-				if err := diff.ForceNew("compute_resources.0.image_id"); err != nil {
-					return err
-				}
-			}
-
-			if diff.HasChange("compute_resources.0.instance_role") {
-				if err := diff.ForceNew("compute_resources.0.instance_role"); err != nil {
-					return err
-				}
-			}
-
-			if diff.HasChange("compute_resources.0.instance_type") {
-				if err := diff.ForceNew("compute_resources.0.instance_type"); err != nil {
-					return err
-				}
-			}
-
-			if diff.HasChange("compute_resources.0.launch_template.#") {
-				if err := diff.ForceNew("compute_resources.0.launch_template.#"); err != nil {
-					return err
-				}
-			}
-
-			if diff.HasChange("compute_resources.0.launch_template.0.launch_template_id") {
-				if err := diff.ForceNew("compute_resources.0.launch_template.0.launch_template_id"); err != nil {
-					return err
-				}
-			}
-
-			if diff.HasChange("compute_resources.0.launch_template.0.launch_template_name") {
-				if err := diff.ForceNew("compute_resources.0.launch_template.0.launch_template_name"); err != nil {
-					return err
-				}
-			}
-
-			if diff.HasChange("compute_resources.0.launch_template.0.version") {
-				if err := diff.ForceNew("compute_resources.0.launch_template.0.version"); err != nil {
-					return err
-				}
-			}
-
-			if diff.HasChange("compute_resources.0.tags") {
-				if err := diff.ForceNew("compute_resources.0.tags"); err != nil {
-					return err
-				}
+		if diff.HasChange("compute_resources.0.subnets") && !fargateComputeResources {
+			if err := diff.ForceNew("compute_resources.0.subnets"); err != nil {
+				return err
 			}
 		}
 	}
@@ -640,199 +500,7 @@ func resourceComputeEnvironmentCustomizeDiff(_ context.Context, diff *schema.Res
 	return nil
 }
 
-func findComputeEnvironmentDetailByName(ctx context.Context, conn *batch.Batch, name string) (*batch.ComputeEnvironmentDetail, error) {
-	input := &batch.DescribeComputeEnvironmentsInput{
-		ComputeEnvironments: aws.StringSlice([]string{name}),
-	}
-
-	output, err := findComputeEnvironmentDetail(ctx, conn, input)
-
-	if err != nil {
-		return nil, err
-	}
-
-	if status := aws.StringValue(output.Status); status == batch.CEStatusDeleted {
-		return nil, &retry.NotFoundError{
-			Message:     status,
-			LastRequest: input,
-		}
-	}
-
-	return output, nil
-}
-
-func findComputeEnvironmentDetail(ctx context.Context, conn *batch.Batch, input *batch.DescribeComputeEnvironmentsInput) (*batch.ComputeEnvironmentDetail, error) {
-	output, err := conn.DescribeComputeEnvironmentsWithContext(ctx, input)
-
-	if err != nil {
-		return nil, err
-	}
-
-	if output == nil {
-		return nil, tfresource.NewEmptyResultError(input)
-	}
-
-	return tfresource.AssertSinglePtrResult(output.ComputeEnvironments)
-}
-
-func statusComputeEnvironment(ctx context.Context, conn *batch.Batch, name string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		computeEnvironmentDetail, err := findComputeEnvironmentDetailByName(ctx, conn, name)
-
-		if tfresource.NotFound(err) {
-			return nil, "", nil
-		}
-
-		if err != nil {
-			return nil, "", err
-		}
-
-		return computeEnvironmentDetail, aws.StringValue(computeEnvironmentDetail.Status), nil
-	}
-}
-
-func waitComputeEnvironmentCreated(ctx context.Context, conn *batch.Batch, name string, timeout time.Duration) (*batch.ComputeEnvironmentDetail, error) {
-	stateConf := &retry.StateChangeConf{
-		Pending: []string{batch.CEStatusCreating},
-		Target:  []string{batch.CEStatusValid},
-		Refresh: statusComputeEnvironment(ctx, conn, name),
-		Timeout: timeout,
-	}
-
-	outputRaw, err := stateConf.WaitForStateContext(ctx)
-
-	if output, ok := outputRaw.(*batch.ComputeEnvironmentDetail); ok {
-		if status := aws.StringValue(output.Status); status == batch.CEStatusInvalid {
-			tfresource.SetLastError(err, errors.New(aws.StringValue(output.StatusReason)))
-		}
-
-		return output, err
-	}
-
-	return nil, err
-}
-
-func waitComputeEnvironmentDeleted(ctx context.Context, conn *batch.Batch, name string, timeout time.Duration) (*batch.ComputeEnvironmentDetail, error) {
-	stateConf := &retry.StateChangeConf{
-		Pending: []string{batch.CEStatusDeleting},
-		Target:  []string{},
-		Refresh: statusComputeEnvironment(ctx, conn, name),
-		Timeout: timeout,
-	}
-
-	outputRaw, err := stateConf.WaitForStateContext(ctx)
-
-	if output, ok := outputRaw.(*batch.ComputeEnvironmentDetail); ok {
-		if status := aws.StringValue(output.Status); status == batch.CEStatusInvalid {
-			tfresource.SetLastError(err, errors.New(aws.StringValue(output.StatusReason)))
-		}
-
-		return output, err
-	}
-
-	return nil, err
-}
-
-func waitComputeEnvironmentDisabled(ctx context.Context, conn *batch.Batch, name string, timeout time.Duration) (*batch.ComputeEnvironmentDetail, error) {
-	stateConf := &retry.StateChangeConf{
-		Pending: []string{batch.CEStatusUpdating},
-		Target:  []string{batch.CEStatusValid},
-		Refresh: statusComputeEnvironment(ctx, conn, name),
-		Timeout: timeout,
-	}
-
-	outputRaw, err := stateConf.WaitForStateContext(ctx)
-
-	if output, ok := outputRaw.(*batch.ComputeEnvironmentDetail); ok {
-		if status := aws.StringValue(output.Status); status == batch.CEStatusInvalid {
-			tfresource.SetLastError(err, errors.New(aws.StringValue(output.StatusReason)))
-		}
-
-		return output, err
-	}
-
-	return nil, err
-}
-
-func waitComputeEnvironmentUpdated(ctx context.Context, conn *batch.Batch, name string, timeout time.Duration) (*batch.ComputeEnvironmentDetail, error) {
-	stateConf := &retry.StateChangeConf{
-		Pending: []string{batch.CEStatusUpdating},
-		Target:  []string{batch.CEStatusValid},
-		Refresh: statusComputeEnvironment(ctx, conn, name),
-		Timeout: timeout,
-	}
-
-	outputRaw, err := stateConf.WaitForStateContext(ctx)
-
-	if v, ok := outputRaw.(*batch.ComputeEnvironmentDetail); ok {
-		return v, err
-	}
-
-	return nil, err
-}
-
-func isFargateType(computeResourceType string) bool {
-	if computeResourceType == batch.CRTypeFargate || computeResourceType == batch.CRTypeFargateSpot {
-		return true
-	}
-	return false
-}
-
-func isUpdatableComputeEnvironment(diff *schema.ResourceDiff) bool {
-	if !isServiceLinkedRoleDiff(diff) {
-		return false
-	}
-	if !isUpdatableAllocationStrategyDiff(diff) {
-		return false
-	}
-	return true
-}
-
-func isServiceLinkedRoleDiff(diff *schema.ResourceDiff) bool {
-	var before, after string
-	if diff.HasChange("service_role") {
-		beforeRaw, afterRaw := diff.GetChange("service_role")
-		before, _ = beforeRaw.(string)
-		after, _ := afterRaw.(string)
-		return isServiceLinkedRole(before) && isServiceLinkedRole(after)
-	}
-	afterRaw, _ := diff.GetOk("service_role")
-	after, _ = afterRaw.(string)
-	return isServiceLinkedRole(after)
-}
-
-func isServiceLinkedRole(roleArn string) bool {
-	if roleArn == "" {
-		// Empty role ARN defaults to AWS service-linked role
-		return true
-	}
-	re := regexache.MustCompile(`arn:[^:]+:iam::\d{12}:role/aws-service-role/batch\.amazonaws\.com/*`)
-	return re.MatchString(roleArn)
-}
-
-func isUpdatableAllocationStrategyDiff(diff *schema.ResourceDiff) bool {
-	var before, after string
-	if computeResourcesCount, ok := diff.Get("compute_resources.#").(int); ok {
-		if computeResourcesCount > 0 {
-			if diff.HasChange("compute_resources.0.allocation_strategy") {
-				beforeRaw, afterRaw := diff.GetChange("compute_resources.0.allocation_strategy")
-				before, _ = beforeRaw.(string)
-				after, _ = afterRaw.(string)
-				return isUpdatableAllocationStrategy(before) && isUpdatableAllocationStrategy(after)
-			}
-			afterRaw, _ := diff.GetOk("compute_resources.0.allocation_strategy")
-			after, _ := afterRaw.(string)
-			return isUpdatableAllocationStrategy(after)
-		}
-	}
-	return false
-}
-
-func isUpdatableAllocationStrategy(allocationStrategy string) bool {
-	return allocationStrategy == batch.CRAllocationStrategyBestFitProgressive || allocationStrategy == batch.CRAllocationStrategySpotCapacityOptimized
-}
-
-func expandComputeResource(ctx context.Context, tfMap map[string]interface{}) *batch.ComputeResource {
+func expandComputeResource(tfMap map[string]interface{}) *batch.ComputeResource {
 	if tfMap == nil {
 		return nil
 	}
@@ -877,7 +545,7 @@ func expandComputeResource(ctx context.Context, tfMap map[string]interface{}) *b
 		apiObject.InstanceTypes = flex.ExpandStringSet(v)
 	}
 
-	if v, ok := tfMap["launch_template"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+	if v, ok := tfMap["launch_template"].([]interface{}); ok && len(v) > 0 {
 		apiObject.LaunchTemplate = expandLaunchTemplateSpecification(v[0].(map[string]interface{}))
 	}
 
@@ -889,10 +557,6 @@ func expandComputeResource(ctx context.Context, tfMap map[string]interface{}) *b
 		apiObject.MinvCpus = aws.Int64(int64(v))
 	} else if computeResourceType := strings.ToUpper(computeResourceType); computeResourceType == batch.CRTypeEc2 || computeResourceType == batch.CRTypeSpot {
 		apiObject.MinvCpus = aws.Int64(0)
-	}
-
-	if v, ok := tfMap["placement_group"].(string); ok && v != "" {
-		apiObject.PlacementGroup = aws.String(v)
 	}
 
 	if v, ok := tfMap["security_group_ids"].(*schema.Set); ok && v.Len() > 0 {
@@ -908,7 +572,7 @@ func expandComputeResource(ctx context.Context, tfMap map[string]interface{}) *b
 	}
 
 	if v, ok := tfMap["tags"].(map[string]interface{}); ok && len(v) > 0 {
-		apiObject.Tags = Tags(tftags.New(ctx, v).IgnoreAWS())
+		apiObject.Tags = Tags(tftags.New(v).IgnoreAWS())
 	}
 
 	if computeResourceType != "" {
@@ -1002,65 +666,7 @@ func expandLaunchTemplateSpecification(tfMap map[string]interface{}) *batch.Laun
 	return apiObject
 }
 
-func expandEC2ConfigurationsUpdate(tfList []interface{}, defaultImageType string) []*batch.Ec2Configuration {
-	if len(tfList) == 0 {
-		return []*batch.Ec2Configuration{
-			{
-				ImageType: aws.String(defaultImageType),
-			},
-		}
-	}
-
-	var apiObjects []*batch.Ec2Configuration
-
-	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
-
-		if !ok {
-			continue
-		}
-
-		apiObject := expandEC2Configuration(tfMap)
-
-		if apiObject == nil {
-			continue
-		}
-
-		apiObjects = append(apiObjects, apiObject)
-	}
-
-	return apiObjects
-}
-
-func expandLaunchTemplateSpecificationUpdate(tfList []interface{}) *batch.LaunchTemplateSpecification {
-	if len(tfList) == 0 || tfList[0] == nil {
-		// delete any existing launch template configuration
-		return &batch.LaunchTemplateSpecification{
-			LaunchTemplateId: aws.String(""),
-		}
-	}
-
-	tfMap := tfList[0].(map[string]interface{})
-	apiObject := &batch.LaunchTemplateSpecification{}
-
-	if v, ok := tfMap["launch_template_id"].(string); ok && v != "" {
-		apiObject.LaunchTemplateId = aws.String(v)
-	}
-
-	if v, ok := tfMap["launch_template_name"].(string); ok && v != "" {
-		apiObject.LaunchTemplateName = aws.String(v)
-	}
-
-	if v, ok := tfMap["version"].(string); ok {
-		apiObject.Version = aws.String(v)
-	} else {
-		apiObject.Version = aws.String("")
-	}
-
-	return apiObject
-}
-
-func flattenComputeResource(ctx context.Context, apiObject *batch.ComputeResource) map[string]interface{} {
+func flattenComputeResource(apiObject *batch.ComputeResource) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}
@@ -1111,10 +717,6 @@ func flattenComputeResource(ctx context.Context, apiObject *batch.ComputeResourc
 		tfMap["min_vcpus"] = aws.Int64Value(v)
 	}
 
-	if v := apiObject.PlacementGroup; v != nil {
-		tfMap["placement_group"] = aws.StringValue(v)
-	}
-
 	if v := apiObject.SecurityGroupIds; v != nil {
 		tfMap["security_group_ids"] = aws.StringValueSlice(v)
 	}
@@ -1128,7 +730,7 @@ func flattenComputeResource(ctx context.Context, apiObject *batch.ComputeResourc
 	}
 
 	if v := apiObject.Tags; v != nil {
-		tfMap["tags"] = KeyValueTags(ctx, v).IgnoreAWS().Map()
+		tfMap["tags"] = KeyValueTags(v).IgnoreAWS().Map()
 	}
 
 	if v := apiObject.Type; v != nil {

--- a/internal/service/batch/compute_environment.go
+++ b/internal/service/batch/compute_environment.go
@@ -1,15 +1,22 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package batch
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
+	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/batch"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -19,8 +26,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
+// @SDKResource("aws_batch_compute_environment", name="Compute Environment")
+// @Tags(identifierAttribute="arn")
 func ResourceComputeEnvironment() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceComputeEnvironmentCreate,
@@ -69,7 +79,6 @@ func ResourceComputeEnvironment() *schema.Resource {
 						"allocation_strategy": {
 							Type:     schema.TypeString,
 							Optional: true,
-							ForceNew: true,
 							StateFunc: func(val interface{}) string {
 								return strings.ToUpper(val.(string))
 							},
@@ -78,7 +87,6 @@ func ResourceComputeEnvironment() *schema.Resource {
 						"bid_percentage": {
 							Type:     schema.TypeInt,
 							Optional: true,
-							ForceNew: true,
 						},
 						"desired_vcpus": {
 							Type:     schema.TypeInt,
@@ -90,20 +98,18 @@ func ResourceComputeEnvironment() *schema.Resource {
 							Optional: true,
 							Computed: true,
 							ForceNew: true,
-							MaxItems: 1,
+							MaxItems: 2,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"image_id_override": {
 										Type:         schema.TypeString,
 										Optional:     true,
 										Computed:     true,
-										ForceNew:     true,
 										ValidateFunc: validation.StringLenBetween(1, 256),
 									},
 									"image_type": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ForceNew:     true,
 										ValidateFunc: validation.StringLenBetween(1, 256),
 									},
 								},
@@ -112,23 +118,19 @@ func ResourceComputeEnvironment() *schema.Resource {
 						"ec2_key_pair": {
 							Type:     schema.TypeString,
 							Optional: true,
-							ForceNew: true,
 						},
 						"image_id": {
 							Type:     schema.TypeString,
 							Optional: true,
-							ForceNew: true,
 						},
 						"instance_role": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ForceNew:     true,
 							ValidateFunc: verify.ValidARN,
 						},
 						"instance_type": {
 							Type:     schema.TypeSet,
 							Optional: true,
-							ForceNew: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 						"launch_template": {
@@ -141,19 +143,17 @@ func ResourceComputeEnvironment() *schema.Resource {
 									"launch_template_id": {
 										Type:          schema.TypeString,
 										Optional:      true,
-										ForceNew:      true,
 										ConflictsWith: []string{"compute_resources.0.launch_template.0.launch_template_name"},
 									},
 									"launch_template_name": {
 										Type:          schema.TypeString,
 										Optional:      true,
-										ForceNew:      true,
 										ConflictsWith: []string{"compute_resources.0.launch_template.0.launch_template_id"},
 									},
 									"version": {
 										Type:     schema.TypeString,
 										Optional: true,
-										ForceNew: true,
+										Computed: true,
 									},
 								},
 							},
@@ -165,6 +165,11 @@ func ResourceComputeEnvironment() *schema.Resource {
 						"min_vcpus": {
 							Type:     schema.TypeInt,
 							Optional: true,
+						},
+						"placement_group": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
 						},
 						"security_group_ids": {
 							Type:     schema.TypeSet,
@@ -182,11 +187,10 @@ func ResourceComputeEnvironment() *schema.Resource {
 							Required: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
-						"tags": tftags.TagsSchemaForceNew(),
+						"tags": tftags.TagsSchema(),
 						"type": {
 							Type:     schema.TypeString,
 							Required: true,
-							ForceNew: true,
 							StateFunc: func(val interface{}) string {
 								return strings.ToUpper(val.(string))
 							},
@@ -244,8 +248,8 @@ func ResourceComputeEnvironment() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"type": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -255,27 +259,42 @@ func ResourceComputeEnvironment() *schema.Resource {
 				},
 				ValidateFunc: validation.StringInSlice(batch.CEType_Values(), true),
 			},
+			"update_policy": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"job_execution_timeout_minutes": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"terminate_jobs_on_update": {
+							Type:     schema.TypeBool,
+							Required: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
 
 func resourceComputeEnvironmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).BatchConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
+	conn := meta.(*conns.AWSClient).BatchConn(ctx)
 
 	computeEnvironmentName := create.Name(d.Get("compute_environment_name").(string), d.Get("compute_environment_name_prefix").(string))
 	computeEnvironmentType := d.Get("type").(string)
-
 	input := &batch.CreateComputeEnvironmentInput{
 		ComputeEnvironmentName: aws.String(computeEnvironmentName),
 		ServiceRole:            aws.String(d.Get("service_role").(string)),
+		Tags:                   getTagsIn(ctx),
 		Type:                   aws.String(computeEnvironmentType),
 	}
 
 	if v, ok := d.GetOk("compute_resources"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.ComputeResources = expandComputeResource(v.([]interface{})[0].(map[string]interface{}))
+		input.ComputeResources = expandComputeResource(ctx, v.([]interface{})[0].(map[string]interface{}))
 	}
 
 	if v, ok := d.GetOk("eks_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
@@ -286,11 +305,6 @@ func resourceComputeEnvironmentCreate(ctx context.Context, d *schema.ResourceDat
 		input.State = aws.String(v.(string))
 	}
 
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
-	}
-
-	log.Printf("[DEBUG] Creating Batch Compute Environment: %s", input)
 	output, err := conn.CreateComputeEnvironmentWithContext(ctx, input)
 
 	if err != nil {
@@ -303,16 +317,31 @@ func resourceComputeEnvironmentCreate(ctx context.Context, d *schema.ResourceDat
 		return sdkdiag.AppendErrorf(diags, "waiting for Batch Compute Environment (%s) create: %s", d.Id(), err)
 	}
 
+	// UpdatePolicy is not possible to set with CreateComputeEnvironment
+	if v, ok := d.GetOk("update_policy"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		inputeUpdateOnCreate := &batch.UpdateComputeEnvironmentInput{
+			ComputeEnvironment: aws.String(d.Id()),
+			UpdatePolicy:       expandComputeEnvironmentUpdatePolicy(v.([]interface{})),
+		}
+		log.Printf("[DEBUG] Creating Batch Compute Environment extra arguments: %s", input)
+
+		if _, err := conn.UpdateComputeEnvironmentWithContext(ctx, inputeUpdateOnCreate); err != nil {
+			return sdkdiag.AppendErrorf(diags, "Create Batch Compute Environment extra arguments through UpdateComputeEnvironment (%s): %s", d.Id(), err)
+		}
+
+		if _, err := waitComputeEnvironmentUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "Create waiting for Batch Compute Environment (%s) extra arguments through UpdateComputeEnvironment: %s", d.Id(), err)
+		}
+	}
+
 	return append(diags, resourceComputeEnvironmentRead(ctx, d, meta)...)
 }
 
 func resourceComputeEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).BatchConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+	conn := meta.(*conns.AWSClient).BatchConn(ctx)
 
-	computeEnvironment, err := FindComputeEnvironmentDetailByName(ctx, conn, d.Id())
+	computeEnvironment, err := findComputeEnvironmentDetailByName(ctx, conn, d.Id())
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Batch Compute Environment (%s) not found, removing from state", d.Id())
@@ -329,21 +358,14 @@ func resourceComputeEnvironmentRead(ctx context.Context, d *schema.ResourceData,
 	d.Set("arn", computeEnvironment.ComputeEnvironmentArn)
 	d.Set("compute_environment_name", computeEnvironment.ComputeEnvironmentName)
 	d.Set("compute_environment_name_prefix", create.NamePrefixFromName(aws.StringValue(computeEnvironment.ComputeEnvironmentName)))
-	d.Set("ecs_cluster_arn", computeEnvironment.EcsClusterArn)
-	d.Set("service_role", computeEnvironment.ServiceRole)
-	d.Set("state", computeEnvironment.State)
-	d.Set("status", computeEnvironment.Status)
-	d.Set("status_reason", computeEnvironment.StatusReason)
-	d.Set("type", computeEnvironmentType)
-
 	if computeEnvironment.ComputeResources != nil {
-		if err := d.Set("compute_resources", []interface{}{flattenComputeResource(computeEnvironment.ComputeResources)}); err != nil {
+		if err := d.Set("compute_resources", []interface{}{flattenComputeResource(ctx, computeEnvironment.ComputeResources)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting compute_resources: %s", err)
 		}
 	} else {
 		d.Set("compute_resources", nil)
 	}
-
+	d.Set("ecs_cluster_arn", computeEnvironment.EcsClusterArn)
 	if computeEnvironment.EksConfiguration != nil {
 		if err := d.Set("eks_configuration", []interface{}{flattenEKSConfiguration(computeEnvironment.EksConfiguration)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting eks_configuration: %s", err)
@@ -351,24 +373,24 @@ func resourceComputeEnvironmentRead(ctx context.Context, d *schema.ResourceData,
 	} else {
 		d.Set("eks_configuration", nil)
 	}
+	d.Set("service_role", computeEnvironment.ServiceRole)
+	d.Set("state", computeEnvironment.State)
+	d.Set("status", computeEnvironment.Status)
+	d.Set("status_reason", computeEnvironment.StatusReason)
+	d.Set("type", computeEnvironmentType)
 
-	tags := KeyValueTags(computeEnvironment.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
+	if err := d.Set("update_policy", flattenComputeEnvironmentUpdatePolicy(computeEnvironment.UpdatePolicy)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting update_policy: %s", err)
 	}
 
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	setTagsOut(ctx, computeEnvironment.Tags)
 
 	return diags
 }
 
 func resourceComputeEnvironmentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).BatchConn()
+	conn := meta.(*conns.AWSClient).BatchConn(ctx)
 
 	if d.HasChangesExcept("tags", "tags_all") {
 		input := &batch.UpdateComputeEnvironmentInput{
@@ -383,18 +405,14 @@ func resourceComputeEnvironmentUpdate(ctx context.Context, d *schema.ResourceDat
 			input.State = aws.String(d.Get("state").(string))
 		}
 
+		if d.HasChange("update_policy") {
+			input.UpdatePolicy = expandComputeEnvironmentUpdatePolicy(d.Get("update_policy").([]interface{}))
+		}
+
 		if computeEnvironmentType := strings.ToUpper(d.Get("type").(string)); computeEnvironmentType == batch.CETypeManaged {
 			// "At least one compute-resources attribute must be specified"
 			computeResourceUpdate := &batch.ComputeResourceUpdate{
 				MaxvCpus: aws.Int64(int64(d.Get("compute_resources.0.max_vcpus").(int))),
-			}
-
-			if d.HasChange("compute_resources.0.desired_vcpus") {
-				computeResourceUpdate.DesiredvCpus = aws.Int64(int64(d.Get("compute_resources.0.desired_vcpus").(int)))
-			}
-
-			if d.HasChange("compute_resources.0.min_vcpus") {
-				computeResourceUpdate.MinvCpus = aws.Int64(int64(d.Get("compute_resources.0.min_vcpus").(int)))
 			}
 
 			if d.HasChange("compute_resources.0.security_group_ids") {
@@ -403,6 +421,96 @@ func resourceComputeEnvironmentUpdate(ctx context.Context, d *schema.ResourceDat
 
 			if d.HasChange("compute_resources.0.subnets") {
 				computeResourceUpdate.Subnets = flex.ExpandStringSet(d.Get("compute_resources.0.subnets").(*schema.Set))
+			}
+
+			if d.HasChange("compute_resources.0.allocation_strategy") {
+				if allocationStrategy, ok := d.GetOk("compute_resources.0.allocation_strategy"); ok {
+					computeResourceUpdate.AllocationStrategy = aws.String(allocationStrategy.(string))
+				} else {
+					computeResourceUpdate.AllocationStrategy = aws.String("")
+				}
+			}
+
+			computeResourceEnvironmentType := d.Get("compute_resources.0.type").(string)
+
+			if d.HasChange("compute_resources.0.type") {
+				computeResourceUpdate.Type = aws.String(computeResourceEnvironmentType)
+			}
+
+			if !isFargateType(computeResourceEnvironmentType) {
+				if d.HasChange("compute_resources.0.desired_vcpus") {
+					if desiredvCpus, ok := d.GetOk("compute_resources.0.desired_vcpus"); ok {
+						computeResourceUpdate.DesiredvCpus = aws.Int64(int64(desiredvCpus.(int)))
+					} else {
+						computeResourceUpdate.DesiredvCpus = aws.Int64(0)
+					}
+				}
+
+				if d.HasChange("compute_resources.0.min_vcpus") {
+					if minVcpus, ok := d.GetOk("compute_resources.0.min_vcpus"); ok {
+						computeResourceUpdate.MinvCpus = aws.Int64(int64(minVcpus.(int)))
+					} else {
+						computeResourceUpdate.MinvCpus = aws.Int64(0)
+					}
+				}
+
+				if d.HasChange("compute_resources.0.bid_percentage") {
+					if bidPercentage, ok := d.GetOk("compute_resources.0.bid_percentage"); ok {
+						computeResourceUpdate.BidPercentage = aws.Int64(int64(bidPercentage.(int)))
+					} else {
+						computeResourceUpdate.BidPercentage = aws.Int64(0)
+					}
+				}
+
+				if d.HasChange("compute_resources.0.ec2_configuration") {
+					defaultImageType := "ECS_AL2"
+					if _, ok := d.GetOk("eks_configuration.#"); ok {
+						defaultImageType = "EKS_AL2"
+					}
+					ec2Configuration := d.Get("compute_resources.0.ec2_configuration").([]interface{})
+					computeResourceUpdate.Ec2Configuration = expandEC2ConfigurationsUpdate(ec2Configuration, defaultImageType)
+				}
+
+				if d.HasChange("compute_resources.0.ec2_key_pair") {
+					if keyPair, ok := d.GetOk("compute_resources.0.ec2_key_pair"); ok {
+						computeResourceUpdate.Ec2KeyPair = aws.String(keyPair.(string))
+					} else {
+						computeResourceUpdate.Ec2KeyPair = aws.String("")
+					}
+				}
+
+				if d.HasChange("compute_resources.0.image_id") {
+					if imageId, ok := d.GetOk("compute_resources.0.image_id"); ok {
+						computeResourceUpdate.ImageId = aws.String(imageId.(string))
+					} else {
+						computeResourceUpdate.ImageId = aws.String("")
+					}
+				}
+
+				if d.HasChange("compute_resources.0.instance_role") {
+					if instanceRole, ok := d.GetOk("compute_resources.0.instance_role"); ok {
+						computeResourceUpdate.InstanceRole = aws.String(instanceRole.(string))
+					} else {
+						computeResourceUpdate.InstanceRole = aws.String("")
+					}
+				}
+
+				if d.HasChange("compute_resources.0.instance_type") {
+					computeResourceUpdate.InstanceTypes = flex.ExpandStringSet(d.Get("compute_resources.0.instance_type").(*schema.Set))
+				}
+
+				if d.HasChange("compute_resources.0.launch_template") {
+					launchTemplate := d.Get("compute_resources.0.launch_template").([]interface{})
+					computeResourceUpdate.LaunchTemplate = expandLaunchTemplateSpecificationUpdate(launchTemplate)
+				}
+
+				if d.HasChange("compute_resources.0.tags") {
+					if tags, ok := d.GetOk("compute_resources.0.tags"); ok {
+						computeResourceUpdate.Tags = Tags(tftags.New(ctx, tags.(map[string]interface{})).IgnoreAWS())
+					} else {
+						computeResourceUpdate.Tags = aws.StringMap(map[string]string{})
+					}
+				}
 			}
 
 			input.ComputeResources = computeResourceUpdate
@@ -418,20 +526,12 @@ func resourceComputeEnvironmentUpdate(ctx context.Context, d *schema.ResourceDat
 		}
 	}
 
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating tags: %s", err)
-		}
-	}
-
 	return append(diags, resourceComputeEnvironmentRead(ctx, d, meta)...)
 }
 
 func resourceComputeEnvironmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).BatchConn()
+	conn := meta.(*conns.AWSClient).BatchConn(ctx)
 
 	log.Printf("[DEBUG] Disabling Batch Compute Environment: %s", d.Id())
 	{
@@ -478,21 +578,103 @@ func resourceComputeEnvironmentCustomizeDiff(_ context.Context, diff *schema.Res
 	if diff.Id() != "" {
 		// Update.
 
-		computeResourceType := strings.ToUpper(diff.Get("compute_resources.0.type").(string))
-		fargateComputeResources := false
-		if computeResourceType == batch.CRTypeFargate || computeResourceType == batch.CRTypeFargateSpot {
-			fargateComputeResources = true
-		}
+		fargateComputeResources := isFargateType(diff.Get("compute_resources.0.type").(string))
 
-		if diff.HasChange("compute_resources.0.security_group_ids") && !fargateComputeResources {
-			if err := diff.ForceNew("compute_resources.0.security_group_ids"); err != nil {
-				return err
+		if !isUpdatableComputeEnvironment(diff) {
+			if diff.HasChange("compute_resources.0.security_group_ids") && !fargateComputeResources {
+				if err := diff.ForceNew("compute_resources.0.security_group_ids"); err != nil {
+					return err
+				}
 			}
-		}
 
-		if diff.HasChange("compute_resources.0.subnets") && !fargateComputeResources {
-			if err := diff.ForceNew("compute_resources.0.subnets"); err != nil {
-				return err
+			if diff.HasChange("compute_resources.0.subnets") && !fargateComputeResources {
+				if err := diff.ForceNew("compute_resources.0.subnets"); err != nil {
+					return err
+				}
+			}
+
+			if diff.HasChange("compute_resources.0.allocation_strategy") {
+				if err := diff.ForceNew("compute_resources.0.allocation_strategy"); err != nil {
+					return err
+				}
+			}
+
+			if diff.HasChange("compute_resources.0.bid_percentage") {
+				if err := diff.ForceNew("compute_resources.0.bid_percentage"); err != nil {
+					return err
+				}
+			}
+
+			if diff.HasChange("compute_resources.0.ec2_configuration.#") {
+				if err := diff.ForceNew("compute_resources.0.ec2_configuration.#"); err != nil {
+					return err
+				}
+			}
+
+			if diff.HasChange("compute_resources.0.ec2_configuration.0.image_id_override") {
+				if err := diff.ForceNew("compute_resources.0.ec2_configuration.0.image_id_override"); err != nil {
+					return err
+				}
+			}
+
+			if diff.HasChange("compute_resources.0.ec2_configuration.0.image_type") {
+				if err := diff.ForceNew("compute_resources.0.ec2_configuration.0.image_type"); err != nil {
+					return err
+				}
+			}
+
+			if diff.HasChange("compute_resources.0.ec2_key_pair") {
+				if err := diff.ForceNew("compute_resources.0.ec2_key_pair"); err != nil {
+					return err
+				}
+			}
+
+			if diff.HasChange("compute_resources.0.image_id") {
+				if err := diff.ForceNew("compute_resources.0.image_id"); err != nil {
+					return err
+				}
+			}
+
+			if diff.HasChange("compute_resources.0.instance_role") {
+				if err := diff.ForceNew("compute_resources.0.instance_role"); err != nil {
+					return err
+				}
+			}
+
+			if diff.HasChange("compute_resources.0.instance_type") {
+				if err := diff.ForceNew("compute_resources.0.instance_type"); err != nil {
+					return err
+				}
+			}
+
+			if diff.HasChange("compute_resources.0.launch_template.#") {
+				if err := diff.ForceNew("compute_resources.0.launch_template.#"); err != nil {
+					return err
+				}
+			}
+
+			if diff.HasChange("compute_resources.0.launch_template.0.launch_template_id") {
+				if err := diff.ForceNew("compute_resources.0.launch_template.0.launch_template_id"); err != nil {
+					return err
+				}
+			}
+
+			if diff.HasChange("compute_resources.0.launch_template.0.launch_template_name") {
+				if err := diff.ForceNew("compute_resources.0.launch_template.0.launch_template_name"); err != nil {
+					return err
+				}
+			}
+
+			if diff.HasChange("compute_resources.0.launch_template.0.version") {
+				if err := diff.ForceNew("compute_resources.0.launch_template.0.version"); err != nil {
+					return err
+				}
+			}
+
+			if diff.HasChange("compute_resources.0.tags") {
+				if err := diff.ForceNew("compute_resources.0.tags"); err != nil {
+					return err
+				}
 			}
 		}
 	}
@@ -500,7 +682,199 @@ func resourceComputeEnvironmentCustomizeDiff(_ context.Context, diff *schema.Res
 	return nil
 }
 
-func expandComputeResource(tfMap map[string]interface{}) *batch.ComputeResource {
+func findComputeEnvironmentDetailByName(ctx context.Context, conn *batch.Batch, name string) (*batch.ComputeEnvironmentDetail, error) {
+	input := &batch.DescribeComputeEnvironmentsInput{
+		ComputeEnvironments: aws.StringSlice([]string{name}),
+	}
+
+	output, err := findComputeEnvironmentDetail(ctx, conn, input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if status := aws.StringValue(output.Status); status == batch.CEStatusDeleted {
+		return nil, &retry.NotFoundError{
+			Message:     status,
+			LastRequest: input,
+		}
+	}
+
+	return output, nil
+}
+
+func findComputeEnvironmentDetail(ctx context.Context, conn *batch.Batch, input *batch.DescribeComputeEnvironmentsInput) (*batch.ComputeEnvironmentDetail, error) {
+	output, err := conn.DescribeComputeEnvironmentsWithContext(ctx, input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return tfresource.AssertSinglePtrResult(output.ComputeEnvironments)
+}
+
+func statusComputeEnvironment(ctx context.Context, conn *batch.Batch, name string) retry.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		computeEnvironmentDetail, err := findComputeEnvironmentDetailByName(ctx, conn, name)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return computeEnvironmentDetail, aws.StringValue(computeEnvironmentDetail.Status), nil
+	}
+}
+
+func waitComputeEnvironmentCreated(ctx context.Context, conn *batch.Batch, name string, timeout time.Duration) (*batch.ComputeEnvironmentDetail, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{batch.CEStatusCreating},
+		Target:  []string{batch.CEStatusValid},
+		Refresh: statusComputeEnvironment(ctx, conn, name),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*batch.ComputeEnvironmentDetail); ok {
+		if status := aws.StringValue(output.Status); status == batch.CEStatusInvalid {
+			tfresource.SetLastError(err, errors.New(aws.StringValue(output.StatusReason)))
+		}
+
+		return output, err
+	}
+
+	return nil, err
+}
+
+func waitComputeEnvironmentDeleted(ctx context.Context, conn *batch.Batch, name string, timeout time.Duration) (*batch.ComputeEnvironmentDetail, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{batch.CEStatusDeleting},
+		Target:  []string{},
+		Refresh: statusComputeEnvironment(ctx, conn, name),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*batch.ComputeEnvironmentDetail); ok {
+		if status := aws.StringValue(output.Status); status == batch.CEStatusInvalid {
+			tfresource.SetLastError(err, errors.New(aws.StringValue(output.StatusReason)))
+		}
+
+		return output, err
+	}
+
+	return nil, err
+}
+
+func waitComputeEnvironmentDisabled(ctx context.Context, conn *batch.Batch, name string, timeout time.Duration) (*batch.ComputeEnvironmentDetail, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{batch.CEStatusUpdating},
+		Target:  []string{batch.CEStatusValid},
+		Refresh: statusComputeEnvironment(ctx, conn, name),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*batch.ComputeEnvironmentDetail); ok {
+		if status := aws.StringValue(output.Status); status == batch.CEStatusInvalid {
+			tfresource.SetLastError(err, errors.New(aws.StringValue(output.StatusReason)))
+		}
+
+		return output, err
+	}
+
+	return nil, err
+}
+
+func waitComputeEnvironmentUpdated(ctx context.Context, conn *batch.Batch, name string, timeout time.Duration) (*batch.ComputeEnvironmentDetail, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{batch.CEStatusUpdating},
+		Target:  []string{batch.CEStatusValid},
+		Refresh: statusComputeEnvironment(ctx, conn, name),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if v, ok := outputRaw.(*batch.ComputeEnvironmentDetail); ok {
+		return v, err
+	}
+
+	return nil, err
+}
+
+func isFargateType(computeResourceType string) bool {
+	if computeResourceType == batch.CRTypeFargate || computeResourceType == batch.CRTypeFargateSpot {
+		return true
+	}
+	return false
+}
+
+func isUpdatableComputeEnvironment(diff *schema.ResourceDiff) bool {
+	if !isServiceLinkedRoleDiff(diff) {
+		return false
+	}
+	if !isUpdatableAllocationStrategyDiff(diff) {
+		return false
+	}
+	return true
+}
+
+func isServiceLinkedRoleDiff(diff *schema.ResourceDiff) bool {
+	var before, after string
+	if diff.HasChange("service_role") {
+		beforeRaw, afterRaw := diff.GetChange("service_role")
+		before, _ = beforeRaw.(string)
+		after, _ := afterRaw.(string)
+		return isServiceLinkedRole(before) && isServiceLinkedRole(after)
+	}
+	afterRaw, _ := diff.GetOk("service_role")
+	after, _ = afterRaw.(string)
+	return isServiceLinkedRole(after)
+}
+
+func isServiceLinkedRole(roleArn string) bool {
+	if roleArn == "" {
+		// Empty role ARN defaults to AWS service-linked role
+		return true
+	}
+	re := regexache.MustCompile(`arn:[^:]+:iam::\d{12}:role/aws-service-role/batch\.amazonaws\.com/*`)
+	return re.MatchString(roleArn)
+}
+
+func isUpdatableAllocationStrategyDiff(diff *schema.ResourceDiff) bool {
+	var before, after string
+	if computeResourcesCount, ok := diff.Get("compute_resources.#").(int); ok {
+		if computeResourcesCount > 0 {
+			if diff.HasChange("compute_resources.0.allocation_strategy") {
+				beforeRaw, afterRaw := diff.GetChange("compute_resources.0.allocation_strategy")
+				before, _ = beforeRaw.(string)
+				after, _ = afterRaw.(string)
+				return isUpdatableAllocationStrategy(before) && isUpdatableAllocationStrategy(after)
+			}
+			afterRaw, _ := diff.GetOk("compute_resources.0.allocation_strategy")
+			after, _ := afterRaw.(string)
+			return isUpdatableAllocationStrategy(after)
+		}
+	}
+	return false
+}
+
+func isUpdatableAllocationStrategy(allocationStrategy string) bool {
+	return allocationStrategy == batch.CRAllocationStrategyBestFitProgressive || allocationStrategy == batch.CRAllocationStrategySpotCapacityOptimized
+}
+
+func expandComputeResource(ctx context.Context, tfMap map[string]interface{}) *batch.ComputeResource {
 	if tfMap == nil {
 		return nil
 	}
@@ -545,7 +919,7 @@ func expandComputeResource(tfMap map[string]interface{}) *batch.ComputeResource 
 		apiObject.InstanceTypes = flex.ExpandStringSet(v)
 	}
 
-	if v, ok := tfMap["launch_template"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["launch_template"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 		apiObject.LaunchTemplate = expandLaunchTemplateSpecification(v[0].(map[string]interface{}))
 	}
 
@@ -557,6 +931,10 @@ func expandComputeResource(tfMap map[string]interface{}) *batch.ComputeResource 
 		apiObject.MinvCpus = aws.Int64(int64(v))
 	} else if computeResourceType := strings.ToUpper(computeResourceType); computeResourceType == batch.CRTypeEc2 || computeResourceType == batch.CRTypeSpot {
 		apiObject.MinvCpus = aws.Int64(0)
+	}
+
+	if v, ok := tfMap["placement_group"].(string); ok && v != "" {
+		apiObject.PlacementGroup = aws.String(v)
 	}
 
 	if v, ok := tfMap["security_group_ids"].(*schema.Set); ok && v.Len() > 0 {
@@ -572,7 +950,7 @@ func expandComputeResource(tfMap map[string]interface{}) *batch.ComputeResource 
 	}
 
 	if v, ok := tfMap["tags"].(map[string]interface{}); ok && len(v) > 0 {
-		apiObject.Tags = Tags(tftags.New(v).IgnoreAWS())
+		apiObject.Tags = Tags(tftags.New(ctx, v).IgnoreAWS())
 	}
 
 	if computeResourceType != "" {
@@ -666,7 +1044,65 @@ func expandLaunchTemplateSpecification(tfMap map[string]interface{}) *batch.Laun
 	return apiObject
 }
 
-func flattenComputeResource(apiObject *batch.ComputeResource) map[string]interface{} {
+func expandEC2ConfigurationsUpdate(tfList []interface{}, defaultImageType string) []*batch.Ec2Configuration {
+	if len(tfList) == 0 {
+		return []*batch.Ec2Configuration{
+			{
+				ImageType: aws.String(defaultImageType),
+			},
+		}
+	}
+
+	var apiObjects []*batch.Ec2Configuration
+
+	for _, tfMapRaw := range tfList {
+		tfMap, ok := tfMapRaw.(map[string]interface{})
+
+		if !ok {
+			continue
+		}
+
+		apiObject := expandEC2Configuration(tfMap)
+
+		if apiObject == nil {
+			continue
+		}
+
+		apiObjects = append(apiObjects, apiObject)
+	}
+
+	return apiObjects
+}
+
+func expandLaunchTemplateSpecificationUpdate(tfList []interface{}) *batch.LaunchTemplateSpecification {
+	if len(tfList) == 0 || tfList[0] == nil {
+		// delete any existing launch template configuration
+		return &batch.LaunchTemplateSpecification{
+			LaunchTemplateId: aws.String(""),
+		}
+	}
+
+	tfMap := tfList[0].(map[string]interface{})
+	apiObject := &batch.LaunchTemplateSpecification{}
+
+	if v, ok := tfMap["launch_template_id"].(string); ok && v != "" {
+		apiObject.LaunchTemplateId = aws.String(v)
+	}
+
+	if v, ok := tfMap["launch_template_name"].(string); ok && v != "" {
+		apiObject.LaunchTemplateName = aws.String(v)
+	}
+
+	if v, ok := tfMap["version"].(string); ok {
+		apiObject.Version = aws.String(v)
+	} else {
+		apiObject.Version = aws.String("")
+	}
+
+	return apiObject
+}
+
+func flattenComputeResource(ctx context.Context, apiObject *batch.ComputeResource) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}
@@ -717,6 +1153,10 @@ func flattenComputeResource(apiObject *batch.ComputeResource) map[string]interfa
 		tfMap["min_vcpus"] = aws.Int64Value(v)
 	}
 
+	if v := apiObject.PlacementGroup; v != nil {
+		tfMap["placement_group"] = aws.StringValue(v)
+	}
+
 	if v := apiObject.SecurityGroupIds; v != nil {
 		tfMap["security_group_ids"] = aws.StringValueSlice(v)
 	}
@@ -730,7 +1170,7 @@ func flattenComputeResource(apiObject *batch.ComputeResource) map[string]interfa
 	}
 
 	if v := apiObject.Tags; v != nil {
-		tfMap["tags"] = KeyValueTags(v).IgnoreAWS().Map()
+		tfMap["tags"] = KeyValueTags(ctx, v).IgnoreAWS().Map()
 	}
 
 	if v := apiObject.Type; v != nil {
@@ -814,4 +1254,32 @@ func flattenLaunchTemplateSpecification(apiObject *batch.LaunchTemplateSpecifica
 	}
 
 	return tfMap
+}
+
+func expandComputeEnvironmentUpdatePolicy(l []interface{}) *batch.UpdatePolicy {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	up := &batch.UpdatePolicy{
+		JobExecutionTimeoutMinutes: aws.Int64(int64(m["job_execution_timeout_minutes"].(int))),
+		TerminateJobsOnUpdate:      aws.Bool(bool(m["terminate_jobs_on_update"].(bool))),
+	}
+
+	return up
+}
+
+func flattenComputeEnvironmentUpdatePolicy(up *batch.UpdatePolicy) []interface{} {
+	if up == nil {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"job_execution_timeout_minutes": aws.Int64Value(up.JobExecutionTimeoutMinutes),
+		"terminate_jobs_on_update":      aws.BoolValue(up.TerminateJobsOnUpdate),
+	}
+
+	return []interface{}{m}
 }

--- a/internal/service/batch/compute_environment.go
+++ b/internal/service/batch/compute_environment.go
@@ -319,13 +319,13 @@ func resourceComputeEnvironmentCreate(ctx context.Context, d *schema.ResourceDat
 
 	// UpdatePolicy is not possible to set with CreateComputeEnvironment
 	if v, ok := d.GetOk("update_policy"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		inputeUpdateOnCreate := &batch.UpdateComputeEnvironmentInput{
+		inputUpdateOnCreate := &batch.UpdateComputeEnvironmentInput{
 			ComputeEnvironment: aws.String(d.Id()),
 			UpdatePolicy:       expandComputeEnvironmentUpdatePolicy(v.([]interface{})),
 		}
-		log.Printf("[DEBUG] Creating Batch Compute Environment extra arguments: %s", input)
+		log.Printf("[DEBUG] Creating Batch Compute Environment extra arguments: %s", inputUpdateOnCreate)
 
-		if _, err := conn.UpdateComputeEnvironmentWithContext(ctx, inputeUpdateOnCreate); err != nil {
+		if _, err := conn.UpdateComputeEnvironmentWithContext(ctx, inputUpdateOnCreate); err != nil {
 			return sdkdiag.AppendErrorf(diags, "Create Batch Compute Environment extra arguments through UpdateComputeEnvironment (%s): %s", d.Id(), err)
 		}
 

--- a/internal/service/batch/compute_environment_data_source.go
+++ b/internal/service/batch/compute_environment_data_source.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package batch
 
 import (
@@ -15,7 +12,6 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 )
 
-// @SDKDataSource("aws_batch_compute_environment")
 func DataSourceComputeEnvironment() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceComputeEnvironmentRead,
@@ -68,7 +64,7 @@ func DataSourceComputeEnvironment() *schema.Resource {
 
 func dataSourceComputeEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).BatchConn(ctx)
+	conn := meta.(*conns.AWSClient).BatchConn()
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	params := &batch.DescribeComputeEnvironmentsInput{
@@ -97,7 +93,7 @@ func dataSourceComputeEnvironmentRead(ctx context.Context, d *schema.ResourceDat
 	d.Set("status_reason", computeEnvironment.StatusReason)
 	d.Set("state", computeEnvironment.State)
 
-	if err := d.Set("tags", KeyValueTags(ctx, computeEnvironment.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+	if err := d.Set("tags", KeyValueTags(computeEnvironment.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
 	}
 

--- a/internal/service/batch/compute_environment_data_source_test.go
+++ b/internal/service/batch/compute_environment_data_source_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package batch_test
 
 import (
@@ -5,8 +8,8 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/batch"
-	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
@@ -17,7 +20,7 @@ func TestAccBatchComputeEnvironmentDataSource_basic(t *testing.T) {
 	datasourceName := "data.aws_batch_compute_environment.by_name"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(ctx, t) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
@@ -31,6 +34,32 @@ func TestAccBatchComputeEnvironmentDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, "state", resourceName, "state"),
 					resource.TestCheckResourceAttrPair(datasourceName, "tags.%", resourceName, "tags.%"),
 					resource.TestCheckResourceAttrPair(datasourceName, "type", resourceName, "type"),
+					resource.TestCheckResourceAttr(datasourceName, "update_policy.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccBatchComputeEnvironmentDataSource_basicUpdatePolicy(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix("tf_acc_test_")
+	resourceName := "aws_batch_compute_environment.test"
+	datasourceName := "data.aws_batch_compute_environment.by_name"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeEnvironmentDataSourceConfig_updatePolicy(rName, 30, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttr(datasourceName, "update_policy.#", "1"),
+					resource.TestCheckResourceAttr(datasourceName, "update_policy.0.%", "2"),
+					resource.TestCheckResourceAttr(datasourceName, "update_policy.0.terminate_jobs_on_update", "false"),
+					resource.TestCheckResourceAttr(datasourceName, "update_policy.0.job_execution_timeout_minutes", "30"),
 				),
 			},
 		},
@@ -70,30 +99,6 @@ resource "aws_iam_instance_profile" "ecs_instance_role" {
   role = aws_iam_role.ecs_instance_role.name
 }
 
-resource "aws_iam_role" "aws_batch_service_role" {
-  name = "batch_%[1]s"
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "batch.${data.aws_partition.current.dns_suffix}"
-      }
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_role_policy_attachment" "aws_batch_service_role" {
-  role       = aws_iam_role.aws_batch_service_role.name
-  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSBatchServiceRole"
-}
-
 resource "aws_security_group" "sample" {
   name = "%[1]s"
 }
@@ -131,42 +136,44 @@ resource "aws_batch_compute_environment" "test" {
     type = "EC2"
   }
 
-  service_role = aws_iam_role.aws_batch_service_role.arn
   type         = "MANAGED"
-  depends_on   = [aws_iam_role_policy_attachment.aws_batch_service_role]
-}
-
-resource "aws_batch_compute_environment" "wrong" {
-  compute_environment_name = "%[1]s_wrong"
-
-  compute_resources {
-    instance_role = aws_iam_instance_profile.ecs_instance_role.arn
-
-    instance_type = [
-      "c4.large",
-    ]
-
-    max_vcpus = 16
-    min_vcpus = 0
-
-    security_group_ids = [
-      aws_security_group.sample.id,
-    ]
-
-    subnets = [
-      aws_subnet.sample.id,
-    ]
-
-    type = "EC2"
-  }
-
-  service_role = aws_iam_role.aws_batch_service_role.arn
-  type         = "MANAGED"
-  depends_on   = [aws_iam_role_policy_attachment.aws_batch_service_role]
 }
 
 data "aws_batch_compute_environment" "by_name" {
   compute_environment_name = aws_batch_compute_environment.test.compute_environment_name
 }
 `, rName)
+}
+
+func testAccComputeEnvironmentDataSourceConfig_updatePolicy(rName string, timeout int, terminate bool) string {
+	return acctest.ConfigCompose(testAccComputeEnvironmentConfig_baseDefaultSLR(rName), fmt.Sprintf(`
+resource "aws_batch_compute_environment" "test" {
+  compute_environment_name = %[1]q
+
+  compute_resources {
+		allocation_strategy = "BEST_FIT_PROGRESSIVE"
+    instance_role       = aws_iam_instance_profile.ecs_instance.arn
+		instance_type       = ["optimal"]
+    max_vcpus           = 4
+		min_vcpus           = 0
+    security_group_ids  = [
+      aws_security_group.test.id
+    ]
+    subnets = [
+      aws_subnet.test.id
+    ]
+    type = "EC2"
+  }
+	update_policy {
+		job_execution_timeout_minutes = %[2]d
+		terminate_jobs_on_update      = %[3]v
+	}
+
+  type         = "MANAGED"
+}
+
+data "aws_batch_compute_environment" "by_name" {
+  compute_environment_name = aws_batch_compute_environment.test.compute_environment_name
+}
+`, rName, timeout, terminate))
 }

--- a/internal/service/batch/compute_environment_data_source_test.go
+++ b/internal/service/batch/compute_environment_data_source_test.go
@@ -151,12 +151,12 @@ resource "aws_batch_compute_environment" "test" {
   compute_environment_name = %[1]q
 
   compute_resources {
-		allocation_strategy = "BEST_FIT_PROGRESSIVE"
+    allocation_strategy = "BEST_FIT_PROGRESSIVE"
     instance_role       = aws_iam_instance_profile.ecs_instance.arn
-		instance_type       = ["optimal"]
+    instance_type       = ["optimal"]
     max_vcpus           = 4
-		min_vcpus           = 0
-    security_group_ids  = [
+    min_vcpus           = 0
+    security_group_ids = [
       aws_security_group.test.id
     ]
     subnets = [
@@ -164,12 +164,12 @@ resource "aws_batch_compute_environment" "test" {
     ]
     type = "EC2"
   }
-	update_policy {
-		job_execution_timeout_minutes = %[2]d
-		terminate_jobs_on_update      = %[3]v
-	}
+  update_policy {
+    job_execution_timeout_minutes = %[2]d
+    terminate_jobs_on_update      = %[3]t
+  }
 
-  type         = "MANAGED"
+  type = "MANAGED"
 }
 
 data "aws_batch_compute_environment" "by_name" {

--- a/internal/service/batch/compute_environment_data_source_test.go
+++ b/internal/service/batch/compute_environment_data_source_test.go
@@ -136,7 +136,7 @@ resource "aws_batch_compute_environment" "test" {
     type = "EC2"
   }
 
-  type         = "MANAGED"
+  type = "MANAGED"
 }
 
 data "aws_batch_compute_environment" "by_name" {

--- a/internal/service/batch/compute_environment_data_source_test.go
+++ b/internal/service/batch/compute_environment_data_source_test.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package batch_test
 
 import (
@@ -8,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/batch"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
@@ -20,7 +17,7 @@ func TestAccBatchComputeEnvironmentDataSource_basic(t *testing.T) {
 	datasourceName := "data.aws_batch_compute_environment.by_name"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/service/batch/compute_environment_test.go
+++ b/internal/service/batch/compute_environment_test.go
@@ -2493,7 +2493,7 @@ resource "aws_batch_compute_environment" "test" {
     instance_type       = ["optimal"]
     max_vcpus           = 4
     min_vcpus           = 0
-    security_group_ids  = [
+    security_group_ids = [
       aws_security_group.test.id
     ]
     subnets = [
@@ -2504,7 +2504,7 @@ resource "aws_batch_compute_environment" "test" {
 
   update_policy {
     job_execution_timeout_minutes = %[2]d
-    terminate_jobs_on_update      = %[3]v
+    terminate_jobs_on_update      = %[3]t
   }
 
   type = "MANAGED"

--- a/internal/service/batch/compute_environment_test.go
+++ b/internal/service/batch/compute_environment_test.go
@@ -1,20 +1,158 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package batch_test
 
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"testing"
 
+	"github.com/YakDriver/regexache"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/batch"
-	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/google/go-cmp/cmp"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfbatch "github.com/hashicorp/terraform-provider-aws/internal/service/batch"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
+
+func TestExpandEC2ConfigurationsUpdate(t *testing.T) {
+	t.Parallel()
+
+	//lintignore:AWSAT002
+	testCases := []struct {
+		flattened []interface{}
+		expected  []*batch.Ec2Configuration
+	}{
+		{
+			flattened: []interface{}{},
+			expected: []*batch.Ec2Configuration{
+				{
+					ImageType: aws.String("default"),
+				},
+			},
+		},
+		{
+			flattened: []interface{}{
+				map[string]interface{}{
+					"image_type": "ECS_AL1",
+				},
+			},
+			expected: []*batch.Ec2Configuration{
+				{
+					ImageType: aws.String("ECS_AL1"),
+				},
+			},
+		},
+		{
+			flattened: []interface{}{
+				map[string]interface{}{
+					"image_id_override": "ami-deadbeef",
+				},
+			},
+			expected: []*batch.Ec2Configuration{
+				{
+					ImageIdOverride: aws.String("ami-deadbeef"),
+				},
+			},
+		},
+		{
+			flattened: []interface{}{
+				map[string]interface{}{
+					"image_id_override": "ami-deadbeef",
+					"image_type":        "ECS_AL1",
+				},
+			},
+			expected: []*batch.Ec2Configuration{
+				{
+					ImageIdOverride: aws.String("ami-deadbeef"),
+					ImageType:       aws.String("ECS_AL1"),
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		expanded := tfbatch.ExpandEC2ConfigurationsUpdate(testCase.flattened, "default")
+		if diff := cmp.Diff(expanded, testCase.expected); diff != "" {
+			t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+		}
+	}
+}
+
+func TestExpandLaunchTemplateSpecificationUpdate(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		flattened []interface{}
+		expected  *batch.LaunchTemplateSpecification
+	}{
+		{
+			flattened: []interface{}{},
+			expected: &batch.LaunchTemplateSpecification{
+				LaunchTemplateId: aws.String(""),
+			},
+		},
+		{
+			flattened: []interface{}{
+				map[string]interface{}{
+					"launch_template_id": "lt-123456",
+				},
+			},
+			expected: &batch.LaunchTemplateSpecification{
+				LaunchTemplateId: aws.String("lt-123456"),
+				Version:          aws.String(""),
+			},
+		},
+		{
+			flattened: []interface{}{
+				map[string]interface{}{
+					"launch_template_name": "my-launch-template",
+				},
+			},
+			expected: &batch.LaunchTemplateSpecification{
+				LaunchTemplateName: aws.String("my-launch-template"),
+				Version:            aws.String(""),
+			},
+		},
+		{
+			flattened: []interface{}{
+				map[string]interface{}{
+					"launch_template_id": "lt-123456",
+					"version":            "$LATEST",
+				},
+			},
+			expected: &batch.LaunchTemplateSpecification{
+				LaunchTemplateId: aws.String("lt-123456"),
+				Version:          aws.String("$LATEST"),
+			},
+		},
+		{
+			flattened: []interface{}{
+				map[string]interface{}{
+					"launch_template_name": "my-launch-template",
+					"version":              "$LATEST",
+				},
+			},
+			expected: &batch.LaunchTemplateSpecification{
+				LaunchTemplateName: aws.String("my-launch-template"),
+				Version:            aws.String("$LATEST"),
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		expanded := tfbatch.ExpandLaunchTemplateSpecificationUpdate(testCase.flattened)
+		if diff := cmp.Diff(expanded, testCase.expected); diff != "" {
+			t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+		}
+	}
+}
 
 func TestAccBatchComputeEnvironment_basic(t *testing.T) {
 	ctx := acctest.Context(t)
@@ -24,7 +162,7 @@ func TestAccBatchComputeEnvironment_basic(t *testing.T) {
 	serviceRoleResourceName := "aws_iam_role.batch_service"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(ctx, t) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx),
@@ -58,7 +196,7 @@ func TestAccBatchComputeEnvironment_disappears(t *testing.T) {
 	resourceName := "aws_batch_compute_environment.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(ctx, t) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx),
@@ -82,7 +220,7 @@ func TestAccBatchComputeEnvironment_nameGenerated(t *testing.T) {
 	resourceName := "aws_batch_compute_environment.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(ctx, t) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx),
@@ -111,7 +249,7 @@ func TestAccBatchComputeEnvironment_namePrefix(t *testing.T) {
 	resourceName := "aws_batch_compute_environment.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(ctx, t) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx),
@@ -141,7 +279,7 @@ func TestAccBatchComputeEnvironment_eksConfiguration(t *testing.T) {
 	eksClusterResourceName := "aws_eks_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(ctx, t) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		ExternalProviders: map[string]resource.ExternalProvider{
@@ -176,7 +314,7 @@ func TestAccBatchComputeEnvironment_createEC2(t *testing.T) {
 	subnetResourceName := "aws_subnet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(ctx, t) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx),
@@ -202,6 +340,7 @@ func TestAccBatchComputeEnvironment_createEC2(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.launch_template.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.max_vcpus", "16"),
 					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.min_vcpus", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.placement_group", ""),
 					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.security_group_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "compute_resources.0.security_group_ids.*", securityGroupResourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.spot_iam_fleet_role", ""),
@@ -227,6 +366,101 @@ func TestAccBatchComputeEnvironment_createEC2(t *testing.T) {
 	})
 }
 
+func TestAccBatchComputeEnvironment_updatePolicyCreate(t *testing.T) {
+	ctx := acctest.Context(t)
+	var ce batch.ComputeEnvironmentDetail
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_batch_compute_environment.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeEnvironmentConfig_ec2UpdatePolicyCreate(rName, 30, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckComputeEnvironmentExists(ctx, resourceName, &ce),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "batch", fmt.Sprintf("compute-environment/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "compute_environment_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.max_vcpus", "4"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.allocation_strategy", "BEST_FIT_PROGRESSIVE"),
+					resource.TestCheckResourceAttr(resourceName, "update_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "update_policy.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "update_policy.0.terminate_jobs_on_update", "false"),
+					resource.TestCheckResourceAttr(resourceName, "update_policy.0.job_execution_timeout_minutes", "30"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeEnvironmentConfig_ec2UpdatePolicyCreate(rName, 60, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckComputeEnvironmentExists(ctx, resourceName, &ce),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "batch", fmt.Sprintf("compute-environment/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "compute_environment_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.max_vcpus", "4"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.allocation_strategy", "BEST_FIT_PROGRESSIVE"),
+					resource.TestCheckResourceAttr(resourceName, "update_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "update_policy.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "update_policy.0.terminate_jobs_on_update", "true"),
+					resource.TestCheckResourceAttr(resourceName, "update_policy.0.job_execution_timeout_minutes", "60"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccBatchComputeEnvironment_updatePolicyUpdate(t *testing.T) {
+	ctx := acctest.Context(t)
+	var ce batch.ComputeEnvironmentDetail
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_batch_compute_environment.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeEnvironmentConfig_ec2UpdatePolicyUpdate(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckComputeEnvironmentExists(ctx, resourceName, &ce),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "batch", fmt.Sprintf("compute-environment/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "compute_environment_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.max_vcpus", "4"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.allocation_strategy", "BEST_FIT_PROGRESSIVE"),
+					resource.TestCheckResourceAttr(resourceName, "update_policy.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeEnvironmentConfig_ec2UpdatePolicyCreate(rName, 60, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckComputeEnvironmentExists(ctx, resourceName, &ce),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "batch", fmt.Sprintf("compute-environment/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "compute_environment_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.max_vcpus", "4"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.allocation_strategy", "BEST_FIT_PROGRESSIVE"),
+					resource.TestCheckResourceAttr(resourceName, "update_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "update_policy.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "update_policy.0.terminate_jobs_on_update", "true"),
+					resource.TestCheckResourceAttr(resourceName, "update_policy.0.job_execution_timeout_minutes", "60"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccBatchComputeEnvironment_CreateEC2DesiredVCPUsEC2KeyPairImageID_computeResourcesTags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var ce batch.ComputeEnvironmentDetail
@@ -245,7 +479,7 @@ func TestAccBatchComputeEnvironment_CreateEC2DesiredVCPUsEC2KeyPairImageID_compu
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(ctx, t) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx),
@@ -307,7 +541,7 @@ func TestAccBatchComputeEnvironment_createSpot(t *testing.T) {
 	subnetResourceName := "aws_subnet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(ctx, t) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx),
@@ -368,7 +602,7 @@ func TestAccBatchComputeEnvironment_CreateSpotAllocationStrategy_bidPercentage(t
 	subnetResourceName := "aws_subnet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(ctx, t) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx),
@@ -427,7 +661,7 @@ func TestAccBatchComputeEnvironment_createFargate(t *testing.T) {
 	subnetResourceName := "aws_subnet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(ctx, t) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx),
@@ -485,7 +719,7 @@ func TestAccBatchComputeEnvironment_createFargateSpot(t *testing.T) {
 	subnetResourceName := "aws_subnet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(ctx, t) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx),
@@ -541,7 +775,7 @@ func TestAccBatchComputeEnvironment_updateState(t *testing.T) {
 	serviceRoleResourceName := "aws_iam_role.batch_service"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(ctx, t) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx),
@@ -600,7 +834,7 @@ func TestAccBatchComputeEnvironment_updateServiceRole(t *testing.T) {
 	subnetResourceName := "aws_subnet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(ctx, t) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx),
@@ -692,9 +926,9 @@ func TestAccBatchComputeEnvironment_defaultServiceRole(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
-			acctest.PreCheck(t)
+			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
-			acctest.PreCheckIAMServiceLinkedRole(t, "/aws-service-role/batch")
+			acctest.PreCheckIAMServiceLinkedRole(ctx, t, "/aws-service-role/batch")
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -726,7 +960,7 @@ func TestAccBatchComputeEnvironment_defaultServiceRole(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.type", "FARGATE"),
 					resource.TestCheckResourceAttrSet(resourceName, "ecs_cluster_arn"),
-					acctest.MatchResourceAttrGlobalARN(resourceName, "service_role", "iam", regexp.MustCompile(`role/aws-service-role/batch`)),
+					acctest.MatchResourceAttrGlobalARN(resourceName, "service_role", "iam", regexache.MustCompile(`role/aws-service-role/batch`)),
 					resource.TestCheckResourceAttr(resourceName, "state", "ENABLED"),
 					resource.TestCheckResourceAttrSet(resourceName, "status"),
 					resource.TestCheckResourceAttrSet(resourceName, "status_reason"),
@@ -754,7 +988,7 @@ func TestAccBatchComputeEnvironment_ComputeResources_minVCPUs(t *testing.T) {
 	subnetResourceName := "aws_subnet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(ctx, t) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx),
@@ -884,7 +1118,7 @@ func TestAccBatchComputeEnvironment_ComputeResources_maxVCPUs(t *testing.T) {
 	subnetResourceName := "aws_subnet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(ctx, t) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx),
@@ -1015,7 +1249,7 @@ func TestAccBatchComputeEnvironment_ec2Configuration(t *testing.T) {
 	subnetResourceName := "aws_subnet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(ctx, t) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx),
@@ -1036,11 +1270,79 @@ func TestAccBatchComputeEnvironment_ec2Configuration(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "compute_resources.0.instance_role", instanceProfileResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.instance_type.#", "1"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "compute_resources.0.instance_type.*", "optimal"),
-					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.ec2_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.ec2_configuration.#", "2"),
 					resource.TestCheckResourceAttrSet(resourceName, "compute_resources.0.ec2_configuration.0.image_id_override"),
 					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.ec2_configuration.0.image_type", "ECS_AL2"),
+					resource.TestCheckResourceAttrSet(resourceName, "compute_resources.0.ec2_configuration.1.image_id_override"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.ec2_configuration.1.image_type", "ECS_AL2_NVIDIA"),
 					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.max_vcpus", "16"),
 					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.min_vcpus", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.security_group_ids.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "compute_resources.0.security_group_ids.*", securityGroupResourceName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "compute_resources.0.spot_iam_fleet_role", spotFleetRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.subnets.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "compute_resources.0.subnets.*", subnetResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.type", "SPOT"),
+					resource.TestCheckResourceAttrSet(resourceName, "ecs_cluster_arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "service_role", serviceRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "state", "ENABLED"),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttrSet(resourceName, "status_reason"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "type", "MANAGED"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccBatchComputeEnvironment_ec2ConfigurationPlacementGroup(t *testing.T) {
+	ctx := acctest.Context(t)
+	var ce batch.ComputeEnvironmentDetail
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_batch_compute_environment.test"
+	instanceProfileResourceName := "aws_iam_instance_profile.ecs_instance"
+	securityGroupResourceName := "aws_security_group.test"
+	serviceRoleResourceName := "aws_iam_role.batch_service"
+	spotFleetRoleResourceName := "aws_iam_role.ec2_spot_fleet"
+	subnetResourceName := "aws_subnet.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeEnvironmentConfig_ec2ConfigurationPlacementGroup(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckComputeEnvironmentExists(ctx, resourceName, &ce),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "batch", fmt.Sprintf("compute-environment/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "compute_environment_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "compute_environment_name_prefix", ""),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.allocation_strategy", ""),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.bid_percentage", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.desired_vcpus", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.ec2_key_pair", ""),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.image_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "compute_resources.0.instance_role", instanceProfileResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.instance_type.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "compute_resources.0.instance_type.*", "optimal"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.ec2_configuration.#", "2"),
+					resource.TestCheckResourceAttrSet(resourceName, "compute_resources.0.ec2_configuration.0.image_id_override"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.ec2_configuration.0.image_type", "ECS_AL2"),
+					resource.TestCheckResourceAttrSet(resourceName, "compute_resources.0.ec2_configuration.1.image_id_override"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.ec2_configuration.1.image_type", "ECS_AL2_NVIDIA"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.max_vcpus", "16"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.min_vcpus", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.placement_group", rName),
 					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.security_group_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "compute_resources.0.security_group_ids.*", securityGroupResourceName, "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "compute_resources.0.spot_iam_fleet_role", spotFleetRoleResourceName, "arn"),
@@ -1078,7 +1380,7 @@ func TestAccBatchComputeEnvironment_launchTemplate(t *testing.T) {
 	subnetResourceName := "aws_subnet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(ctx, t) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx),
@@ -1142,7 +1444,7 @@ func TestAccBatchComputeEnvironment_updateLaunchTemplate(t *testing.T) {
 	subnetResourceName := "aws_subnet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(ctx, t) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx),
@@ -1245,7 +1547,7 @@ func TestAccBatchComputeEnvironment_UpdateSecurityGroupsAndSubnets_fargate(t *te
 	subnetResourceName2 := "aws_subnet.test_2"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(ctx, t) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx),
@@ -1335,7 +1637,7 @@ func TestAccBatchComputeEnvironment_tags(t *testing.T) {
 	resourceName := "aws_batch_compute_environment.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(ctx, t) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx),
@@ -1379,14 +1681,160 @@ func TestAccBatchComputeEnvironment_createUnmanagedWithComputeResources(t *testi
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(ctx, t) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccComputeEnvironmentConfig_unmanagedResources(rName),
-				ExpectError: regexp.MustCompile("no `compute_resources` can be specified when `type` is \"UNMANAGED\""),
+				ExpectError: regexache.MustCompile("no `compute_resources` can be specified when `type` is \"UNMANAGED\""),
+			},
+		},
+	})
+}
+
+func TestAccBatchComputeEnvironment_updateEC2(t *testing.T) {
+	ctx := acctest.Context(t)
+	var ce batch.ComputeEnvironmentDetail
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_batch_compute_environment.test"
+	instanceProfileResourceName := "aws_iam_instance_profile.ecs_instance"
+	updatedInstanceProfileResourceName := "aws_iam_instance_profile.ecs_instance_2"
+	securityGroupResourceName := "aws_security_group.test"
+	updatedSecurityGroupResourceName := "aws_security_group.test_2"
+	subnetResourceName := "aws_subnet.test"
+	updatedSubnetResourceName := "aws_subnet.test_2"
+	ec2KeyPairResourceName := "aws_key_pair.test"
+	launchTemplateResourceName := "aws_launch_template.test"
+	spotFleetRoleResourceName := "aws_iam_role.ec2_spot_fleet"
+	publicKey, _, err := sdkacctest.RandSSHKeyPair(acctest.DefaultEmailAddress)
+	if err != nil {
+		t.Fatalf("error generating random SSH key: %s", err)
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeenvironmentConfig_ec2PreUpdate(rName, publicKey),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeEnvironmentExists(ctx, resourceName, &ce),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "batch", fmt.Sprintf("compute-environment/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "compute_environment_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "compute_environment_name_prefix", ""),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.allocation_strategy", "BEST_FIT_PROGRESSIVE"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.bid_percentage", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.desired_vcpus", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.ec2_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.ec2_configuration.0.image_type", "ECS_AL2"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.ec2_key_pair", ""),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.image_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "compute_resources.0.instance_role", instanceProfileResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.instance_type.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "compute_resources.0.instance_type.*", "optimal"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.launch_template.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.max_vcpus", "16"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.min_vcpus", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.security_group_ids.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "compute_resources.0.security_group_ids.*", securityGroupResourceName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "compute_resources.0.spot_iam_fleet_role", spotFleetRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.subnets.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "compute_resources.0.subnets.*", subnetResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.type", "EC2"),
+					resource.TestCheckResourceAttrSet(resourceName, "ecs_cluster_arn"),
+					resource.TestCheckResourceAttr(resourceName, "state", "ENABLED"),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttrSet(resourceName, "status_reason"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "type", "MANAGED"),
+				),
+			},
+			{
+				Config: testAccComputeenvironmentConfig_ec2Update(rName, publicKey),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeEnvironmentExists(ctx, resourceName, &ce),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "batch", fmt.Sprintf("compute-environment/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "compute_environment_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "compute_environment_name_prefix", ""),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.allocation_strategy", "SPOT_CAPACITY_OPTIMIZED"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.bid_percentage", "100"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.desired_vcpus", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.ec2_configuration.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "compute_resources.0.ec2_configuration.0.image_id_override"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.ec2_configuration.0.image_type", "ECS_AL2"),
+					resource.TestCheckResourceAttrPair(resourceName, "compute_resources.0.ec2_key_pair", ec2KeyPairResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.image_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "compute_resources.0.instance_role", updatedInstanceProfileResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.instance_type.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "compute_resources.0.instance_type.*", "c4.large"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.launch_template.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "compute_resources.0.launch_template.0.launch_template_id", launchTemplateResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.launch_template.0.version", "$Latest"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.max_vcpus", "16"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.min_vcpus", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.security_group_ids.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "compute_resources.0.security_group_ids.*", updatedSecurityGroupResourceName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "compute_resources.0.spot_iam_fleet_role", spotFleetRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.subnets.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "compute_resources.0.subnets.*", updatedSubnetResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.tags.updated", "yes"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.type", "SPOT"),
+					resource.TestCheckResourceAttrSet(resourceName, "ecs_cluster_arn"),
+					resource.TestCheckResourceAttr(resourceName, "state", "ENABLED"),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttrSet(resourceName, "status_reason"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "type", "MANAGED"),
+				),
+			},
+			{
+				Config: testAccComputeenvironmentConfig_ec2PreUpdate(rName, publicKey),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeEnvironmentExists(ctx, resourceName, &ce),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "batch", fmt.Sprintf("compute-environment/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "compute_environment_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "compute_environment_name_prefix", ""),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.allocation_strategy", "BEST_FIT_PROGRESSIVE"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.bid_percentage", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.desired_vcpus", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.ec2_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.ec2_configuration.0.image_type", "ECS_AL2"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.ec2_key_pair", ""),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.image_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "compute_resources.0.instance_role", instanceProfileResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.instance_type.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "compute_resources.0.instance_type.*", "optimal"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.launch_template.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.max_vcpus", "16"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.min_vcpus", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.security_group_ids.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "compute_resources.0.security_group_ids.*", securityGroupResourceName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "compute_resources.0.spot_iam_fleet_role", spotFleetRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.subnets.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "compute_resources.0.subnets.*", subnetResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.type", "EC2"),
+					resource.TestCheckResourceAttrSet(resourceName, "ecs_cluster_arn"),
+					resource.TestCheckResourceAttr(resourceName, "state", "ENABLED"),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttrSet(resourceName, "status_reason"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "type", "MANAGED"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -1399,32 +1847,14 @@ func TestAccBatchComputeEnvironment_createEC2WithoutComputeResources(t *testing.
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(ctx, t) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccComputeEnvironmentConfig_ec2NoResources(rName),
-				ExpectError: regexp.MustCompile(`computeResources must be provided for a MANAGED compute environment`),
-			},
-		},
-	})
-}
-
-func TestAccBatchComputeEnvironment_createSpotWithoutIAMFleetRole(t *testing.T) {
-	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccComputeEnvironmentConfig_spotNoIAMFleetRole(rName),
-				ExpectError: regexp.MustCompile(`ComputeResources.spotIamFleetRole cannot not be null or empty`),
+				ExpectError: regexache.MustCompile(`computeResources must be provided for a MANAGED compute environment`),
 			},
 		},
 	})
@@ -1432,7 +1862,7 @@ func TestAccBatchComputeEnvironment_createSpotWithoutIAMFleetRole(t *testing.T) 
 
 func testAccCheckComputeEnvironmentDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).BatchConn()
+		conn := acctest.Provider.Meta().(*conns.AWSClient).BatchConn(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_batch_compute_environment" {
@@ -1466,22 +1896,22 @@ func testAccCheckComputeEnvironmentExists(ctx context.Context, n string, v *batc
 			return fmt.Errorf("No Batch Compute Environment ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).BatchConn()
+		conn := acctest.Provider.Meta().(*conns.AWSClient).BatchConn(ctx)
 
-		computeEnvironment, err := tfbatch.FindComputeEnvironmentDetailByName(ctx, conn, rs.Primary.ID)
+		output, err := tfbatch.FindComputeEnvironmentDetailByName(ctx, conn, rs.Primary.ID)
 
 		if err != nil {
 			return err
 		}
 
-		*v = *computeEnvironment
+		*v = *output
 
 		return nil
 	}
 }
 
 func testAccPreCheck(ctx context.Context, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).BatchConn()
+	conn := acctest.Provider.Meta().(*conns.AWSClient).BatchConn(ctx)
 
 	input := &batch.DescribeComputeEnvironmentsInput{}
 
@@ -1547,6 +1977,87 @@ EOF
 resource "aws_iam_role_policy_attachment" "batch_service" {
   role       = aws_iam_role.batch_service.name
   policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSBatchServiceRole"
+}
+
+resource "aws_iam_role" "ec2_spot_fleet" {
+  name = "%[1]s_ec2_spot_fleet"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Action": "sts:AssumeRole",
+    "Effect": "Allow",
+    "Principal": {
+      "Service": "spotfleet.${data.aws_partition.current.dns_suffix}"
+    }
+  }]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "ec2_spot_fleet" {
+  role       = aws_iam_role.ec2_spot_fleet.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole"
+}
+
+resource "aws_security_group" "test" {
+  name   = %[1]q
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test" {
+  vpc_id     = aws_vpc.test.id
+  cidr_block = "10.1.1.0/24"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName)
+}
+
+func testAccComputeEnvironmentConfig_baseDefaultSLR(rName string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_iam_role" "ecs_instance" {
+  name = "%[1]s_ecs_instance"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Action": "sts:AssumeRole",
+    "Effect": "Allow",
+    "Principal": {
+      "Service": "ec2.${data.aws_partition.current.dns_suffix}"
+    }
+  }]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_instance" {
+  role       = aws_iam_role.ecs_instance.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+}
+
+resource "aws_iam_instance_profile" "ecs_instance" {
+  name = %[1]q
+  role = aws_iam_role_policy_attachment.ecs_instance.role
 }
 
 resource "aws_iam_role" "ec2_spot_fleet" {
@@ -1971,6 +2482,85 @@ resource "aws_batch_compute_environment" "test" {
 `, rName))
 }
 
+func testAccComputeEnvironmentConfig_ec2UpdatePolicyCreate(rName string, timeout int, terminate bool) string {
+	return acctest.ConfigCompose(testAccComputeEnvironmentConfig_baseDefaultSLR(rName), fmt.Sprintf(`
+resource "aws_batch_compute_environment" "test" {
+  compute_environment_name = %[1]q
+
+  compute_resources {
+		allocation_strategy = "BEST_FIT_PROGRESSIVE"
+    instance_role       = aws_iam_instance_profile.ecs_instance.arn
+		instance_type       = ["optimal"]
+    max_vcpus           = 4
+		min_vcpus           = 0
+    security_group_ids  = [
+      aws_security_group.test.id
+    ]
+    subnets = [
+      aws_subnet.test.id
+    ]
+    type = "EC2"
+  }
+	update_policy {
+		job_execution_timeout_minutes = %[2]d
+		terminate_jobs_on_update      = %[3]v
+	}
+
+  type         = "MANAGED"
+}
+`, rName, timeout, terminate))
+}
+
+func testAccComputeEnvironmentConfig_ec2UpdatePolicyUpdate(rName string) string {
+	return acctest.ConfigCompose(testAccComputeEnvironmentConfig_baseDefaultSLR(rName), fmt.Sprintf(`
+resource "aws_batch_compute_environment" "test" {
+  compute_environment_name = %[1]q
+
+  compute_resources {
+		allocation_strategy = "BEST_FIT_PROGRESSIVE"
+    instance_role       = aws_iam_instance_profile.ecs_instance.arn
+		instance_type       = ["optimal"]
+    max_vcpus           = 4
+		min_vcpus           = 0
+    security_group_ids  = [
+      aws_security_group.test.id
+    ]
+    subnets = [
+      aws_subnet.test.id
+    ]
+    type = "EC2"
+  }
+
+  type         = "MANAGED"
+}
+`, rName))
+}
+
+func testAccComputeEnvironmentConfig_ec2UpdatePolicyOmitted(rName string) string {
+	return acctest.ConfigCompose(testAccComputeEnvironmentConfig_baseDefaultSLR(rName), fmt.Sprintf(`
+resource "aws_batch_compute_environment" "test" {
+  compute_environment_name = %[1]q
+
+  compute_resources {
+		allocation_strategy = "BEST_FIT_PROGRESSIVE"
+    instance_role       = aws_iam_instance_profile.ecs_instance.arn
+		instance_type       = ["optimal"]
+    max_vcpus           = 4
+		min_vcpus           = 0
+    security_group_ids  = [
+      aws_security_group.test.id
+    ]
+    subnets = [
+      aws_subnet.test.id
+    ]
+    type = "EC2"
+  }
+
+  type         = "MANAGED"
+}
+`, rName))
+}
+
 func testAccComputeEnvironmentConfig_ec2DesiredVCPUsEC2KeyPairImageIDAndResourcesTags(rName, publicKey string) string {
 	return acctest.ConfigCompose(testAccComputeEnvironmentConfig_base(rName), acctest.ConfigLatestAmazonLinuxHVMEBSAMI(), fmt.Sprintf(`
 resource "aws_batch_compute_environment" "test" {
@@ -2314,34 +2904,6 @@ resource "aws_batch_compute_environment" "test" {
 `, rName))
 }
 
-func testAccComputeEnvironmentConfig_spotNoIAMFleetRole(rName string) string {
-	return acctest.ConfigCompose(testAccComputeEnvironmentConfig_base(rName), fmt.Sprintf(`
-resource "aws_batch_compute_environment" "test" {
-  compute_environment_name = %[1]q
-
-  compute_resources {
-    instance_role = aws_iam_instance_profile.ecs_instance.arn
-    instance_type = [
-      "c4.large",
-    ]
-    max_vcpus = 16
-    min_vcpus = 0
-    security_group_ids = [
-      aws_security_group.test.id
-    ]
-    subnets = [
-      aws_subnet.test.id
-    ]
-    type = "SPOT"
-  }
-
-  service_role = aws_iam_role.batch_service.arn
-  type         = "MANAGED"
-  depends_on   = [aws_iam_role_policy_attachment.batch_service]
-}
-`, rName))
-}
-
 func testAccComputeEnvironmentConfig_launchTemplate(rName string) string {
 	return acctest.ConfigCompose(testAccComputeEnvironmentConfig_base(rName), fmt.Sprintf(`
 resource "aws_launch_template" "test" {
@@ -2461,9 +3023,15 @@ resource "aws_batch_compute_environment" "test" {
   compute_resources {
     instance_role = aws_iam_instance_profile.ecs_instance.arn
     instance_type = ["optimal"]
+
     ec2_configuration {
       image_id_override = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
       image_type        = "ECS_AL2"
+    }
+
+    ec2_configuration {
+      image_id_override = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+      image_type        = "ECS_AL2_NVIDIA"
     }
 
     max_vcpus = 16
@@ -2482,6 +3050,184 @@ resource "aws_batch_compute_environment" "test" {
   service_role = aws_iam_role.batch_service.arn
   type         = "MANAGED"
   depends_on   = [aws_iam_role_policy_attachment.batch_service]
+}
+`, rName))
+}
+
+func testAccComputeEnvironmentConfig_ec2ConfigurationPlacementGroup(rName string) string {
+	return acctest.ConfigCompose(testAccComputeEnvironmentConfig_base(rName), acctest.ConfigLatestAmazonLinuxHVMEBSAMI(), fmt.Sprintf(`
+resource "aws_placement_group" "test" {
+  name     = %[1]q
+  strategy = "cluster"
+}
+
+resource "aws_batch_compute_environment" "test" {
+  compute_environment_name = %[1]q
+
+  compute_resources {
+    instance_role = aws_iam_instance_profile.ecs_instance.arn
+    instance_type = ["optimal"]
+
+    ec2_configuration {
+      image_id_override = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+      image_type        = "ECS_AL2"
+    }
+
+    ec2_configuration {
+      image_id_override = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+      image_type        = "ECS_AL2_NVIDIA"
+    }
+
+    max_vcpus = 16
+    min_vcpus = 0
+
+    placement_group = aws_placement_group.test.name
+
+    security_group_ids = [
+      aws_security_group.test.id
+    ]
+    spot_iam_fleet_role = aws_iam_role.ec2_spot_fleet.arn
+    subnets = [
+      aws_subnet.test.id
+    ]
+    type = "SPOT"
+  }
+
+  service_role = aws_iam_role.batch_service.arn
+  type         = "MANAGED"
+  depends_on   = [aws_iam_role_policy_attachment.batch_service]
+}
+`, rName))
+}
+
+func testAccComputeEnvironmentConfig_baseForUpdates(rName string, publicKey string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "ecs_instance_2" {
+  name = "%[1]s_ecs_instance_2"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Action": "sts:AssumeRole",
+    "Effect": "Allow",
+    "Principal": {
+      "Service": "ec2.${data.aws_partition.current.dns_suffix}"
+    }
+  }]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_instance_2" {
+  role       = aws_iam_role.ecs_instance_2.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+}
+
+resource "aws_iam_instance_profile" "ecs_instance_2" {
+  name = "%[1]s_2"
+  role = aws_iam_role_policy_attachment.ecs_instance_2.role
+}
+
+resource "aws_security_group" "test_2" {
+  name   = "%[1]s_2"
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = "%[1]s_2"
+  }
+}
+
+resource "aws_subnet" "test_2" {
+  vpc_id     = aws_vpc.test.id
+  cidr_block = "10.1.2.0/24"
+
+  tags = {
+    Name = "%[1]s_2"
+  }
+}
+
+resource "aws_key_pair" "test" {
+  key_name   = %[1]q
+  public_key = %[2]q
+}
+
+resource "aws_launch_template" "test" {
+  name = %[1]q
+}
+`, rName, publicKey)
+}
+
+func testAccComputeenvironmentConfig_ec2PreUpdate(rName string, publicKey string) string {
+	return acctest.ConfigCompose(
+		testAccComputeEnvironmentConfig_base(rName),
+		testAccComputeEnvironmentConfig_baseForUpdates(rName, publicKey),
+		fmt.Sprintf(`
+resource "aws_batch_compute_environment" "test" {
+  compute_environment_name = %[1]q
+
+  compute_resources {
+    allocation_strategy = "BEST_FIT_PROGRESSIVE"
+    instance_role       = aws_iam_instance_profile.ecs_instance.arn
+    instance_type = [
+      "optimal",
+    ]
+    max_vcpus = 16
+    security_group_ids = [
+      aws_security_group.test.id
+    ]
+    spot_iam_fleet_role = aws_iam_role.ec2_spot_fleet.arn
+    subnets = [
+      aws_subnet.test.id
+    ]
+    type = "EC2"
+  }
+
+  type = "MANAGED"
+}
+`, rName))
+}
+
+func testAccComputeenvironmentConfig_ec2Update(rName string, publicKey string) string {
+	return acctest.ConfigCompose(
+		testAccComputeEnvironmentConfig_base(rName),
+		testAccComputeEnvironmentConfig_baseForUpdates(rName, publicKey),
+		acctest.ConfigLatestAmazonLinuxHVMEBSAMI(),
+		fmt.Sprintf(`
+resource "aws_batch_compute_environment" "test" {
+  compute_environment_name = %[1]q
+
+  compute_resources {
+    allocation_strategy = "SPOT_CAPACITY_OPTIMIZED"
+    bid_percentage      = 100
+    ec2_key_pair        = aws_key_pair.test.id
+    instance_role       = aws_iam_instance_profile.ecs_instance_2.arn
+    ec2_configuration {
+      image_id_override = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+      image_type        = "ECS_AL2"
+    }
+    launch_template {
+      launch_template_id = aws_launch_template.test.id
+      version            = "$Latest"
+    }
+    instance_type = [
+      "c4.large",
+    ]
+    max_vcpus = 16
+    security_group_ids = [
+      aws_security_group.test_2.id
+    ]
+    spot_iam_fleet_role = aws_iam_role.ec2_spot_fleet.arn
+    subnets = [
+      aws_subnet.test_2.id
+    ]
+    type = "SPOT"
+    tags = {
+      updated = "yes"
+    }
+  }
+
+  type = "MANAGED"
 }
 `, rName))
 }

--- a/internal/service/batch/compute_environment_test.go
+++ b/internal/service/batch/compute_environment_test.go
@@ -428,7 +428,7 @@ func TestAccBatchComputeEnvironment_updatePolicyUpdate(t *testing.T) {
 		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeEnvironmentConfig_ec2UpdatePolicyUpdate(rName),
+				Config: testAccComputeEnvironmentConfig_ec2UpdatePolicyOmitted(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckComputeEnvironmentExists(ctx, resourceName, &ce),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "batch", fmt.Sprintf("compute-environment/%s", rName)),
@@ -2488,11 +2488,11 @@ resource "aws_batch_compute_environment" "test" {
   compute_environment_name = %[1]q
 
   compute_resources {
-		allocation_strategy = "BEST_FIT_PROGRESSIVE"
+    allocation_strategy = "BEST_FIT_PROGRESSIVE"
     instance_role       = aws_iam_instance_profile.ecs_instance.arn
-		instance_type       = ["optimal"]
+    instance_type       = ["optimal"]
     max_vcpus           = 4
-		min_vcpus           = 0
+    min_vcpus           = 0
     security_group_ids  = [
       aws_security_group.test.id
     ]
@@ -2501,39 +2501,15 @@ resource "aws_batch_compute_environment" "test" {
     ]
     type = "EC2"
   }
-	update_policy {
-		job_execution_timeout_minutes = %[2]d
-		terminate_jobs_on_update      = %[3]v
-	}
 
-  type         = "MANAGED"
+  update_policy {
+    job_execution_timeout_minutes = %[2]d
+    terminate_jobs_on_update      = %[3]v
+  }
+
+  type = "MANAGED"
 }
 `, rName, timeout, terminate))
-}
-
-func testAccComputeEnvironmentConfig_ec2UpdatePolicyUpdate(rName string) string {
-	return acctest.ConfigCompose(testAccComputeEnvironmentConfig_baseDefaultSLR(rName), fmt.Sprintf(`
-resource "aws_batch_compute_environment" "test" {
-  compute_environment_name = %[1]q
-
-  compute_resources {
-		allocation_strategy = "BEST_FIT_PROGRESSIVE"
-    instance_role       = aws_iam_instance_profile.ecs_instance.arn
-		instance_type       = ["optimal"]
-    max_vcpus           = 4
-		min_vcpus           = 0
-    security_group_ids  = [
-      aws_security_group.test.id
-    ]
-    subnets = [
-      aws_subnet.test.id
-    ]
-    type = "EC2"
-  }
-
-  type         = "MANAGED"
-}
-`, rName))
 }
 
 func testAccComputeEnvironmentConfig_ec2UpdatePolicyOmitted(rName string) string {
@@ -2542,12 +2518,12 @@ resource "aws_batch_compute_environment" "test" {
   compute_environment_name = %[1]q
 
   compute_resources {
-		allocation_strategy = "BEST_FIT_PROGRESSIVE"
+    allocation_strategy = "BEST_FIT_PROGRESSIVE"
     instance_role       = aws_iam_instance_profile.ecs_instance.arn
-		instance_type       = ["optimal"]
+    instance_type       = ["optimal"]
     max_vcpus           = 4
-		min_vcpus           = 0
-    security_group_ids  = [
+    min_vcpus           = 0
+    security_group_ids = [
       aws_security_group.test.id
     ]
     subnets = [
@@ -2556,7 +2532,7 @@ resource "aws_batch_compute_environment" "test" {
     type = "EC2"
   }
 
-  type         = "MANAGED"
+  type = "MANAGED"
 }
 `, rName))
 }

--- a/website/docs/d/batch_compute_environment.html.markdown
+++ b/website/docs/d/batch_compute_environment.html.markdown
@@ -36,5 +36,5 @@ This data source exports the following attributes in addition to the arguments a
 * `status` - Current status of the compute environment (for example, `CREATING` or `VALID`).
 * `status_reason` - Short, human-readable string to provide additional details about the current status of the compute environment.
 * `state` - State of the compute environment (for example, `ENABLED` or `DISABLED`). If the state is `ENABLED`, then the compute environment accepts jobs from a queue and can scale out automatically based on queues.
-* `update_policy` - (Optional) Specifies the infrastructure update policy for the compute environment. 
+* `update_policy` - (Optional) Specifies the infrastructure update policy for the compute environment.
 * `tags` - Key-value map of resource tags

--- a/website/docs/d/batch_compute_environment.html.markdown
+++ b/website/docs/d/batch_compute_environment.html.markdown
@@ -21,13 +21,13 @@ data "aws_batch_compute_environment" "batch-mongo" {
 
 ## Argument Reference
 
-The following arguments are supported:
+This data source supports the following arguments:
 
 * `compute_environment_name` - (Required) Name of the Batch Compute Environment
 
-## Attributes Reference
+## Attribute Reference
 
-In addition to all arguments above, the following attributes are exported:
+This data source exports the following attributes in addition to the arguments above:
 
 * `arn` - ARN of the compute environment.
 * `ecs_cluster_arn` - ARN of the underlying Amazon ECS cluster used by the compute environment.
@@ -36,4 +36,5 @@ In addition to all arguments above, the following attributes are exported:
 * `status` - Current status of the compute environment (for example, `CREATING` or `VALID`).
 * `status_reason` - Short, human-readable string to provide additional details about the current status of the compute environment.
 * `state` - State of the compute environment (for example, `ENABLED` or `DISABLED`). If the state is `ENABLED`, then the compute environment accepts jobs from a queue and can scale out automatically based on queues.
+* `update_policy` - (Optional) Specifies the infrastructure update policy for the compute environment. 
 * `tags` - Key-value map of resource tags

--- a/website/docs/d/batch_compute_environment.html.markdown
+++ b/website/docs/d/batch_compute_environment.html.markdown
@@ -21,13 +21,13 @@ data "aws_batch_compute_environment" "batch-mongo" {
 
 ## Argument Reference
 
-This data source supports the following arguments:
+The following arguments are supported:
 
 * `compute_environment_name` - (Required) Name of the Batch Compute Environment
 
-## Attribute Reference
+## Attributes Reference
 
-This data source exports the following attributes in addition to the arguments above:
+In addition to all arguments above, the following attributes are exported:
 
 * `arn` - ARN of the compute environment.
 * `ecs_cluster_arn` - ARN of the underlying Amazon ECS cluster used by the compute environment.

--- a/website/docs/d/batch_compute_environment.html.markdown
+++ b/website/docs/d/batch_compute_environment.html.markdown
@@ -36,5 +36,5 @@ This data source exports the following attributes in addition to the arguments a
 * `status` - Current status of the compute environment (for example, `CREATING` or `VALID`).
 * `status_reason` - Short, human-readable string to provide additional details about the current status of the compute environment.
 * `state` - State of the compute environment (for example, `ENABLED` or `DISABLED`). If the state is `ENABLED`, then the compute environment accepts jobs from a queue and can scale out automatically based on queues.
-* `update_policy` - (Optional) Specifies the infrastructure update policy for the compute environment.
+* `update_policy` - Specifies the infrastructure update policy for the compute environment.
 * `tags` - Key-value map of resource tags

--- a/website/docs/r/batch_compute_environment.html.markdown
+++ b/website/docs/r/batch_compute_environment.html.markdown
@@ -21,23 +21,22 @@ otherwise, the policy may be destroyed too soon and the compute environment will
 ### EC2 Type
 
 ```terraform
-resource "aws_iam_role" "ecs_instance_role" {
-  name = "ecs_instance_role"
+data "aws_iam_policy_document" "ec2_assume_role" {
+  statement {
+    effect = "Allow"
 
-  assume_role_policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-	{
-	    "Action": "sts:AssumeRole",
-	    "Effect": "Allow",
-	    "Principal": {
-	        "Service": "ec2.amazonaws.com"
-	    }
-	}
-    ]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
 }
-EOF
+
+resource "aws_iam_role" "ecs_instance_role" {
+  name               = "ecs_instance_role"
+  assume_role_policy = data.aws_iam_policy_document.ec2_assume_role.json
 }
 
 resource "aws_iam_role_policy_attachment" "ecs_instance_role" {
@@ -50,23 +49,22 @@ resource "aws_iam_instance_profile" "ecs_instance_role" {
   role = aws_iam_role.ecs_instance_role.name
 }
 
-resource "aws_iam_role" "aws_batch_service_role" {
-  name = "aws_batch_service_role"
+data "aws_iam_policy_document" "batch_assume_role" {
+  statement {
+    effect = "Allow"
 
-  assume_role_policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-	{
-	    "Action": "sts:AssumeRole",
-	    "Effect": "Allow",
-	    "Principal": {
-		"Service": "batch.amazonaws.com"
-	    }
-	}
-    ]
+    principals {
+      type        = "Service"
+      identifiers = ["batch.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
 }
-EOF
+
+resource "aws_iam_role" "aws_batch_service_role" {
+  name               = "aws_batch_service_role"
+  assume_role_policy = data.aws_iam_policy_document.batch_assume_role.json
 }
 
 resource "aws_iam_role_policy_attachment" "aws_batch_service_role" {
@@ -94,6 +92,11 @@ resource "aws_subnet" "sample" {
   cidr_block = "10.1.1.0/24"
 }
 
+resource "aws_placement_group" "sample" {
+  name     = "sample"
+  strategy = "cluster"
+}
+
 resource "aws_batch_compute_environment" "sample" {
   compute_environment_name = "sample"
 
@@ -106,6 +109,8 @@ resource "aws_batch_compute_environment" "sample" {
 
     max_vcpus = 16
     min_vcpus = 0
+
+    placement_group = aws_placement_group.sample.name
 
     security_group_ids = [
       aws_security_group.sample.id,
@@ -150,6 +155,36 @@ resource "aws_batch_compute_environment" "sample" {
 }
 ```
 
+### Setting Update Policy
+
+```hcl
+resource "aws_batch_compute_environment" "sample" {
+  compute_environment_name = "sample"
+
+  compute_resources {
+    allocation_strategy = "BEST_FIT_PROGRESSIVE"
+    instance_role       = aws_iam_instance_profile.ecs_instance.arn
+    instance_type       = ["optimal"]
+    max_vcpus           = 4
+    min_vcpus           = 0
+    security_group_ids  = [
+      aws_security_group.sample.id
+    ]
+    subnets = [
+      aws_subnet.sample.id
+    ]
+    type = "EC2"
+  }
+
+	update_policy {
+		job_execution_timeout_minutes = 30
+		terminate_jobs_on_update      = false
+	}
+
+  type       = "MANAGED"
+}
+```
+
 ## Argument Reference
 
 * `compute_environment_name` - (Optional, Forces new resource) The name for your compute environment. Up to 128 letters (uppercase and lowercase), numbers, and underscores are allowed. If omitted, Terraform will assign a random, unique name.
@@ -160,6 +195,7 @@ resource "aws_batch_compute_environment" "sample" {
 * `state` - (Optional) The state of the compute environment. If the state is `ENABLED`, then the compute environment accepts jobs from a queue and can scale out automatically based on queues. Valid items are `ENABLED` or `DISABLED`. Defaults to `ENABLED`.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `type` - (Required) The type of the compute environment. Valid items are `MANAGED` or `UNMANAGED`.
+* `update_policy` - (Optional) Specifies the infrastructure update policy for the compute environment. See details below.
 
 ### compute_resources
 
@@ -174,6 +210,7 @@ resource "aws_batch_compute_environment" "sample" {
 * `launch_template` - (Optional) The launch template to use for your compute resources. See details below. This parameter isn't applicable to jobs running on Fargate resources, and shouldn't be specified.
 * `max_vcpus` - (Required) The maximum number of EC2 vCPUs that an environment can reach.
 * `min_vcpus` - (Optional) The minimum number of EC2 vCPUs that an environment should maintain. For `EC2` or `SPOT` compute environments, if the parameter is not explicitly defined, a `0` default value will be set. This parameter isn't applicable to jobs running on Fargate resources, and shouldn't be specified.
+* `placement_group` - (Optional) The Amazon EC2 placement group to associate with your compute resources.
 * `security_group_ids` - (Optional) A list of EC2 security group that are associated with instances launched in the compute environment. This parameter is required for Fargate compute environments.
 * `spot_iam_fleet_role` - (Optional) The Amazon Resource Name (ARN) of the Amazon EC2 Spot Fleet IAM role applied to a SPOT compute environment. This parameter is required for SPOT compute environments. This parameter isn't applicable to jobs running on Fargate resources, and shouldn't be specified.
 * `subnets` - (Required) A list of VPC subnets into which the compute resources are launched.
@@ -202,9 +239,16 @@ resource "aws_batch_compute_environment" "sample" {
 * `eks_cluster_arn` - (Required) The Amazon Resource Name (ARN) of the Amazon EKS cluster.
 * `kubernetes_namespace` - (Required) The namespace of the Amazon EKS cluster. AWS Batch manages pods in this namespace.
 
-## Attributes Reference
+### update_policy
 
-In addition to all arguments above, the following attributes are exported:
+`update_policy` supports the following:
+
+* `job_execution_timeout_minutes` - (Required) Specifies the job timeout (in minutes) when the compute environment infrastructure is updated.
+* `terminate_jobs_on_update` - (Required) Specifies whether jobs are automatically terminated when the computer environment infrastructure is updated.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
 
 * `arn` - The Amazon Resource Name (ARN) of the compute environment.
 * `ecs_cluster_arn` - The Amazon Resource Name (ARN) of the underlying Amazon ECS cluster used by the compute environment.
@@ -214,13 +258,21 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-AWS Batch compute can be imported using the `compute_environment_name`, e.g.,
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import AWS Batch compute using the `compute_environment_name`. For example:
 
+```terraform
+import {
+  to = aws_batch_compute_environment.sample
+  id = "sample"
+}
 ```
-$ terraform import aws_batch_compute_environment.sample sample
+
+Using `terraform import`, import AWS Batch compute using the `compute_environment_name`. For example:
+
+```console
+% terraform import aws_batch_compute_environment.sample sample
 ```
 
 [1]: http://docs.aws.amazon.com/batch/latest/userguide/what-is-batch.html
 [2]: http://docs.aws.amazon.com/batch/latest/userguide/compute_environments.html
 [3]: http://docs.aws.amazon.com/batch/latest/userguide/troubleshooting.html
-[4]: https://docs.aws.amazon.com/batch/latest/userguide/allocation-strategies.html

--- a/website/docs/r/batch_compute_environment.html.markdown
+++ b/website/docs/r/batch_compute_environment.html.markdown
@@ -167,7 +167,7 @@ resource "aws_batch_compute_environment" "sample" {
     instance_type       = ["optimal"]
     max_vcpus           = 4
     min_vcpus           = 0
-    security_group_ids  = [
+    security_group_ids = [
       aws_security_group.sample.id
     ]
     subnets = [
@@ -176,12 +176,12 @@ resource "aws_batch_compute_environment" "sample" {
     type = "EC2"
   }
 
-	update_policy {
-		job_execution_timeout_minutes = 30
-		terminate_jobs_on_update      = false
-	}
+  update_policy {
+    job_execution_timeout_minutes = 30
+    terminate_jobs_on_update      = false
+  }
 
-  type       = "MANAGED"
+  type = "MANAGED"
 }
 ```
 


### PR DESCRIPTION
Closes: #32927, #34145

## Resource

```shell
$ make testacc TESTS=TestAccBatchComputeEnvironment_ PKG=batch
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/batch/... -v -count 1 -parallel 20 -run='TestAccBatchComputeEnvironment_'  -timeout 360m
=== RUN   TestAccBatchComputeEnvironment_basic
=== PAUSE TestAccBatchComputeEnvironment_basic
=== RUN   TestAccBatchComputeEnvironment_disappears
=== PAUSE TestAccBatchComputeEnvironment_disappears
=== RUN   TestAccBatchComputeEnvironment_nameGenerated
=== PAUSE TestAccBatchComputeEnvironment_nameGenerated
=== RUN   TestAccBatchComputeEnvironment_namePrefix
=== PAUSE TestAccBatchComputeEnvironment_namePrefix
=== RUN   TestAccBatchComputeEnvironment_eksConfiguration
=== PAUSE TestAccBatchComputeEnvironment_eksConfiguration
=== RUN   TestAccBatchComputeEnvironment_createEC2
=== PAUSE TestAccBatchComputeEnvironment_createEC2
=== RUN   TestAccBatchComputeEnvironment_updatePolicyCreate
=== PAUSE TestAccBatchComputeEnvironment_updatePolicyCreate
=== RUN   TestAccBatchComputeEnvironment_updatePolicyUpdate
=== PAUSE TestAccBatchComputeEnvironment_updatePolicyUpdate
=== RUN   TestAccBatchComputeEnvironment_CreateEC2DesiredVCPUsEC2KeyPairImageID_computeResourcesTags
=== PAUSE TestAccBatchComputeEnvironment_CreateEC2DesiredVCPUsEC2KeyPairImageID_computeResourcesTags
=== RUN   TestAccBatchComputeEnvironment_createSpot
=== PAUSE TestAccBatchComputeEnvironment_createSpot
=== RUN   TestAccBatchComputeEnvironment_CreateSpotAllocationStrategy_bidPercentage
=== PAUSE TestAccBatchComputeEnvironment_CreateSpotAllocationStrategy_bidPercentage
=== RUN   TestAccBatchComputeEnvironment_createFargate
=== PAUSE TestAccBatchComputeEnvironment_createFargate
=== RUN   TestAccBatchComputeEnvironment_createFargateSpot
=== PAUSE TestAccBatchComputeEnvironment_createFargateSpot
=== RUN   TestAccBatchComputeEnvironment_updateState
=== PAUSE TestAccBatchComputeEnvironment_updateState
=== RUN   TestAccBatchComputeEnvironment_updateServiceRole
=== PAUSE TestAccBatchComputeEnvironment_updateServiceRole
=== RUN   TestAccBatchComputeEnvironment_defaultServiceRole
=== PAUSE TestAccBatchComputeEnvironment_defaultServiceRole
=== RUN   TestAccBatchComputeEnvironment_ComputeResources_minVCPUs
=== PAUSE TestAccBatchComputeEnvironment_ComputeResources_minVCPUs
=== RUN   TestAccBatchComputeEnvironment_ComputeResources_maxVCPUs
=== PAUSE TestAccBatchComputeEnvironment_ComputeResources_maxVCPUs
=== RUN   TestAccBatchComputeEnvironment_ec2Configuration
=== PAUSE TestAccBatchComputeEnvironment_ec2Configuration
=== RUN   TestAccBatchComputeEnvironment_ec2ConfigurationPlacementGroup
=== PAUSE TestAccBatchComputeEnvironment_ec2ConfigurationPlacementGroup
=== RUN   TestAccBatchComputeEnvironment_launchTemplate
=== PAUSE TestAccBatchComputeEnvironment_launchTemplate
=== RUN   TestAccBatchComputeEnvironment_updateLaunchTemplate
=== PAUSE TestAccBatchComputeEnvironment_updateLaunchTemplate
=== RUN   TestAccBatchComputeEnvironment_UpdateSecurityGroupsAndSubnets_fargate
=== PAUSE TestAccBatchComputeEnvironment_UpdateSecurityGroupsAndSubnets_fargate
=== RUN   TestAccBatchComputeEnvironment_tags
=== PAUSE TestAccBatchComputeEnvironment_tags
=== RUN   TestAccBatchComputeEnvironment_createUnmanagedWithComputeResources
=== PAUSE TestAccBatchComputeEnvironment_createUnmanagedWithComputeResources
=== RUN   TestAccBatchComputeEnvironment_updateEC2
=== PAUSE TestAccBatchComputeEnvironment_updateEC2
=== RUN   TestAccBatchComputeEnvironment_createEC2WithoutComputeResources
=== PAUSE TestAccBatchComputeEnvironment_createEC2WithoutComputeResources
=== CONT  TestAccBatchComputeEnvironment_basic
=== CONT  TestAccBatchComputeEnvironment_updateServiceRole
=== CONT  TestAccBatchComputeEnvironment_createEC2WithoutComputeResources
=== CONT  TestAccBatchComputeEnvironment_createEC2
=== CONT  TestAccBatchComputeEnvironment_ec2Configuration
=== CONT  TestAccBatchComputeEnvironment_createUnmanagedWithComputeResources
=== CONT  TestAccBatchComputeEnvironment_ComputeResources_minVCPUs
=== CONT  TestAccBatchComputeEnvironment_tags
=== CONT  TestAccBatchComputeEnvironment_eksConfiguration
=== CONT  TestAccBatchComputeEnvironment_updatePolicyUpdate
=== CONT  TestAccBatchComputeEnvironment_updateEC2
=== CONT  TestAccBatchComputeEnvironment_createFargateSpot
=== CONT  TestAccBatchComputeEnvironment_createFargate
=== CONT  TestAccBatchComputeEnvironment_CreateSpotAllocationStrategy_bidPercentage
=== CONT  TestAccBatchComputeEnvironment_createSpot
=== CONT  TestAccBatchComputeEnvironment_CreateEC2DesiredVCPUsEC2KeyPairImageID_computeResourcesTags
=== CONT  TestAccBatchComputeEnvironment_updateLaunchTemplate
=== CONT  TestAccBatchComputeEnvironment_updatePolicyCreate
=== CONT  TestAccBatchComputeEnvironment_ec2ConfigurationPlacementGroup
=== CONT  TestAccBatchComputeEnvironment_updateState
--- PASS: TestAccBatchComputeEnvironment_createUnmanagedWithComputeResources (144.33s)
=== CONT  TestAccBatchComputeEnvironment_UpdateSecurityGroupsAndSubnets_fargate
--- PASS: TestAccBatchComputeEnvironment_createEC2WithoutComputeResources (637.26s)
=== CONT  TestAccBatchComputeEnvironment_ComputeResources_maxVCPUs
--- PASS: TestAccBatchComputeEnvironment_basic (1007.97s)
=== CONT  TestAccBatchComputeEnvironment_defaultServiceRole
--- PASS: TestAccBatchComputeEnvironment_createFargate (1131.06s)
=== CONT  TestAccBatchComputeEnvironment_nameGenerated
--- PASS: TestAccBatchComputeEnvironment_createFargateSpot (1164.89s)
=== CONT  TestAccBatchComputeEnvironment_disappears
--- PASS: TestAccBatchComputeEnvironment_createEC2 (1211.40s)
=== CONT  TestAccBatchComputeEnvironment_namePrefix
--- PASS: TestAccBatchComputeEnvironment_CreateSpotAllocationStrategy_bidPercentage (1281.13s)
=== CONT  TestAccBatchComputeEnvironment_launchTemplate
--- PASS: TestAccBatchComputeEnvironment_ec2Configuration (1400.07s)
--- PASS: TestAccBatchComputeEnvironment_ec2ConfigurationPlacementGroup (1498.77s)
--- PASS: TestAccBatchComputeEnvironment_CreateEC2DesiredVCPUsEC2KeyPairImageID_computeResourcesTags (1517.84s)
--- PASS: TestAccBatchComputeEnvironment_updatePolicyUpdate (1649.08s)
--- PASS: TestAccBatchComputeEnvironment_updateState (1661.37s)
--- PASS: TestAccBatchComputeEnvironment_updatePolicyCreate (1661.56s)
--- PASS: TestAccBatchComputeEnvironment_createSpot (1702.94s)
--- PASS: TestAccBatchComputeEnvironment_defaultServiceRole (843.08s)
--- PASS: TestAccBatchComputeEnvironment_updateServiceRole (1889.38s)
--- PASS: TestAccBatchComputeEnvironment_nameGenerated (787.80s)
--- PASS: TestAccBatchComputeEnvironment_disappears (784.71s)
--- PASS: TestAccBatchComputeEnvironment_namePrefix (744.84s)
--- PASS: TestAccBatchComputeEnvironment_UpdateSecurityGroupsAndSubnets_fargate (1848.79s)
--- PASS: TestAccBatchComputeEnvironment_updateLaunchTemplate (2014.04s)
--- PASS: TestAccBatchComputeEnvironment_tags (2019.20s)
--- PASS: TestAccBatchComputeEnvironment_launchTemplate (795.59s)
--- PASS: TestAccBatchComputeEnvironment_eksConfiguration (2218.33s)
--- PASS: TestAccBatchComputeEnvironment_ComputeResources_maxVCPUs (1623.90s)
--- PASS: TestAccBatchComputeEnvironment_ComputeResources_minVCPUs (2263.76s)
--- PASS: TestAccBatchComputeEnvironment_updateEC2 (2337.19s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/batch      2339.211s
```

## Data Source

```shell
make testacc TESTS=TestAccBatchComputeEnvironmentDataSource_ PKG=batch
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/batch/... -v -count 1 -parallel 20 -run='TestAccBatchComputeEnvironmentDataSource_'  -timeout 360m
=== RUN   TestAccBatchComputeEnvironmentDataSource_basic
=== PAUSE TestAccBatchComputeEnvironmentDataSource_basic
=== RUN   TestAccBatchComputeEnvironmentDataSource_basicUpdatePolicy
=== PAUSE TestAccBatchComputeEnvironmentDataSource_basicUpdatePolicy
=== CONT  TestAccBatchComputeEnvironmentDataSource_basic
=== CONT  TestAccBatchComputeEnvironmentDataSource_basicUpdatePolicy
--- PASS: TestAccBatchComputeEnvironmentDataSource_basic (156.73s)
--- PASS: TestAccBatchComputeEnvironmentDataSource_basicUpdatePolicy (192.10s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/batch      194.059s
```

