### PR TITLE
Add support for policy_document property to VerifiedAccessEndpoint resource

### DIFF
--- a/.changelog/34354.txt
+++ b/.changelog/34354.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_verifiedaccess_endpoint: Added `policy_document` property to resource.
+```

--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -7329,6 +7329,20 @@ func FindVerifiedAccessEndpoints(ctx context.Context, conn *ec2_sdkv2.Client, in
 	return output, nil
 }
 
+func FindVerifiedAccessEndpointPolicyByEndpointId(ctx context.Context, conn *ec2_sdkv2.Client, id string) (*ec2_sdkv2.GetVerifiedAccessEndpointPolicyOutput, error) {
+	input := &ec2_sdkv2.GetVerifiedAccessEndpointPolicyInput{
+		VerifiedAccessEndpointId: &id,
+	}
+
+	out, err := conn.GetVerifiedAccessEndpointPolicy(ctx, input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
 func FindVerifiedAccessEndpointByID(ctx context.Context, conn *ec2_sdkv2.Client, id string) (*awstypes.VerifiedAccessEndpoint, error) {
 	input := &ec2_sdkv2.DescribeVerifiedAccessEndpointsInput{
 		VerifiedAccessEndpointIds: []string{id},

--- a/internal/service/ec2/verifiedaccess_endpoint_test.go
+++ b/internal/service/ec2/verifiedaccess_endpoint_test.go
@@ -525,7 +525,6 @@ resource "aws_verifiedaccess_endpoint" "test" {
   endpoint_domain_prefix = "example"
   endpoint_type          = "load-balancer"
   policy_document        = %[4]q
-  policy_enabled         = true
   sse_specification {
     customer_managed_key_enabled = false
   }

--- a/website/docs/r/verifiedaccess_endpoint.html.markdown
+++ b/website/docs/r/verifiedaccess_endpoint.html.markdown
@@ -71,6 +71,7 @@ The following arguments are optional:
 * `load_balancer_options` - (Optional) The load balancer details. This parameter is required if the endpoint type is `load-balancer`.
 * `network_interface_options` - (Optional) The network interface details. This parameter is required if the endpoint type is `network-interface`.
 * `security_group_ids` - (Optional) List of the the security groups IDs to associate with the Verified Access endpoint.
+* `policy_document` - (Optional) Policy for this endpoint.
 * `tags` - (Optional) Key-value tags for the Verified Access Endpoint. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attribute Reference
@@ -79,6 +80,7 @@ This resource exports the following attributes in addition to the arguments abov
 
 * `device_validation_domain` - Returned if endpoint has a device trust provider attached.
 * `endpoint_domain` - A DNS name that is generated for the endpoint.
+* `policy_enabled` - Boolean indicating if a policy was enabled.
 * `id` - The ID of the AWS Verified Access endpoint.
 
 ## Timeouts


### PR DESCRIPTION
### Description
Adds support for the `policy_document` property on the VerifiedAccessEndpoint resource


### Relations
Relates: #29689 

### References
* Docs on [ModifyVerifiedAccessEndpointPolicy](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifyVerifiedAccessEndpointPolicy.html)


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccVerifiedAccessEndpoint_' PKG=ec2 ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 2  -run=TestAccVerifiedAccessEndpoint_ -timeout 360m
=== RUN   TestAccVerifiedAccessEndpoint_basic
=== PAUSE TestAccVerifiedAccessEndpoint_basic
=== RUN   TestAccVerifiedAccessEndpoint_policy
=== PAUSE TestAccVerifiedAccessEndpoint_policy
=== RUN   TestAccVerifiedAccessEndpoint_policyUpdate
=== PAUSE TestAccVerifiedAccessEndpoint_policyUpdate
=== RUN   TestAccVerifiedAccessEndpoint_networkInterface
=== PAUSE TestAccVerifiedAccessEndpoint_networkInterface
=== RUN   TestAccVerifiedAccessEndpoint_tags
=== PAUSE TestAccVerifiedAccessEndpoint_tags
=== RUN   TestAccVerifiedAccessEndpoint_disappears
=== PAUSE TestAccVerifiedAccessEndpoint_disappears
=== CONT  TestAccVerifiedAccessEndpoint_basic
=== CONT  TestAccVerifiedAccessEndpoint_networkInterface
--- PASS: TestAccVerifiedAccessEndpoint_networkInterface (445.39s)
=== CONT  TestAccVerifiedAccessEndpoint_disappears
--- PASS: TestAccVerifiedAccessEndpoint_basic (455.03s)
=== CONT  TestAccVerifiedAccessEndpoint_tags
--- PASS: TestAccVerifiedAccessEndpoint_tags (1011.99s)
=== CONT  TestAccVerifiedAccessEndpoint_policyUpdate
--- PASS: TestAccVerifiedAccessEndpoint_disappears (1396.51s)
=== CONT  TestAccVerifiedAccessEndpoint_policy
--- PASS: TestAccVerifiedAccessEndpoint_policyUpdate (1327.78s)
--- PASS: TestAccVerifiedAccessEndpoint_policy (1250.39s)
PASS
...
```
Note: Tests take long to run.
