### PR TITLE
service/iam: retry attaching policy on ConcurrentModificationException

### DIFF
--- a/.changelog/34378.txt
+++ b/.changelog/34378.txt
@@ -1,5 +1,5 @@
 ```release-note:bug
-resource/aws_iam_group_policy_attachment: Retry `ConcurrentModificationException` errors on create
+resource/aws_iam_group_policy_attachment: Retry `ConcurrentModificationException` errors on create and delete
 ```
 
 ```release-note:bug

--- a/.changelog/34378.txt
+++ b/.changelog/34378.txt
@@ -1,0 +1,15 @@
+```release-note:bug
+resource/aws_iam_group_policy_attachment: Retry `ConcurrentModificationException` errors on create
+```
+
+```release-note:bug
+resource/aws_iam_policy_attachment: Retry `ConcurrentModificationException` errors on create
+```
+
+```release-note:bug
+resource/aws_iam_role_policy_attachment: Retry `ConcurrentModificationException` errors on create
+```
+
+```release-note:bug
+resource/aws_iam_user_policy_attachment: Retry `ConcurrentModificationException` errors on create
+```

--- a/.changelog/34378.txt
+++ b/.changelog/34378.txt
@@ -11,7 +11,7 @@ resource/aws_iam_role_policy_attachment: Retry `ConcurrentModificationException`
 ```
 
 ```release-note:bug
-resource/aws_iam_user_policy_attachment: Retry `ConcurrentModificationException` errors on create
+resource/aws_iam_user_policy_attachment: Retry `ConcurrentModificationException` errors on create and delete
 ```
 
 ```release-note:enhancement

--- a/.changelog/34378.txt
+++ b/.changelog/34378.txt
@@ -3,7 +3,7 @@ resource/aws_iam_group_policy_attachment: Retry `ConcurrentModificationException
 ```
 
 ```release-note:bug
-resource/aws_iam_policy_attachment: Retry `ConcurrentModificationException` errors on create
+resource/aws_iam_policy_attachment: Retry `ConcurrentModificationException` errors on create and delete
 ```
 
 ```release-note:bug

--- a/.changelog/34378.txt
+++ b/.changelog/34378.txt
@@ -7,7 +7,7 @@ resource/aws_iam_policy_attachment: Retry `ConcurrentModificationException` erro
 ```
 
 ```release-note:bug
-resource/aws_iam_role_policy_attachment: Retry `ConcurrentModificationException` errors on create
+resource/aws_iam_role_policy_attachment: Retry `ConcurrentModificationException` errors on create and delete
 ```
 
 ```release-note:bug

--- a/.changelog/34378.txt
+++ b/.changelog/34378.txt
@@ -25,3 +25,7 @@ resource/aws_iam_policy_attachment: Add plan-time validation of `policy_arn`
 ```release-note:enhancement
 resource/aws_iam_role_policy_attachment: Add plan-time validation of `policy_arn`
 ```
+
+```release-note:enhancement
+resource/aws_iam_user_policy_attachment: Add plan-time validation of `policy_arn`
+```

--- a/.changelog/34378.txt
+++ b/.changelog/34378.txt
@@ -17,3 +17,7 @@ resource/aws_iam_user_policy_attachment: Retry `ConcurrentModificationException`
 ```release-note:enhancement
 resource/aws_iam_group_policy_attachment: Add plan-time validation of `policy_arn`
 ```
+
+```release-note:enhancement
+resource/aws_iam_policy_attachment: Add plan-time validation of `policy_arn`
+```

--- a/.changelog/34378.txt
+++ b/.changelog/34378.txt
@@ -21,3 +21,7 @@ resource/aws_iam_group_policy_attachment: Add plan-time validation of `policy_ar
 ```release-note:enhancement
 resource/aws_iam_policy_attachment: Add plan-time validation of `policy_arn`
 ```
+
+```release-note:enhancement
+resource/aws_iam_role_policy_attachment: Add plan-time validation of `policy_arn`
+```

--- a/.changelog/34378.txt
+++ b/.changelog/34378.txt
@@ -13,3 +13,7 @@ resource/aws_iam_role_policy_attachment: Retry `ConcurrentModificationException`
 ```release-note:bug
 resource/aws_iam_user_policy_attachment: Retry `ConcurrentModificationException` errors on create
 ```
+
+```release-note:enhancement
+resource/aws_iam_group_policy_attachment: Add plan-time validation of `policy_arn`
+```

--- a/internal/service/iam/exports_test.go
+++ b/internal/service/iam/exports_test.go
@@ -6,10 +6,13 @@ package iam
 // Exports for use in tests only.
 var (
 	ResourceGroupPolicyAttachment = resourceGroupPolicyAttachment
+	ResourceRolePolicyAttachment  = resourceRolePolicyAttachment
 	ResourceUserPolicyAttachment  = resourceUserPolicyAttachment
 
 	FindAttachedGroupPolicies           = findAttachedGroupPolicies
 	FindAttachedGroupPolicyByTwoPartKey = findAttachedGroupPolicyByTwoPartKey
+	FindAttachedRolePolicies            = findAttachedRolePolicies
+	FindAttachedRolePolicyByTwoPartKey  = findAttachedRolePolicyByTwoPartKey
 	FindAttachedUserPolicies            = findAttachedUserPolicies
 	FindAttachedUserPolicyByTwoPartKey  = findAttachedUserPolicyByTwoPartKey
 )

--- a/internal/service/iam/exports_test.go
+++ b/internal/service/iam/exports_test.go
@@ -6,7 +6,10 @@ package iam
 // Exports for use in tests only.
 var (
 	ResourceGroupPolicyAttachment = resourceGroupPolicyAttachment
+	ResourceUserPolicyAttachment  = resourceUserPolicyAttachment
 
 	FindAttachedGroupPolicies           = findAttachedGroupPolicies
 	FindAttachedGroupPolicyByTwoPartKey = findAttachedGroupPolicyByTwoPartKey
+	FindAttachedUserPolicies            = findAttachedUserPolicies
+	FindAttachedUserPolicyByTwoPartKey  = findAttachedUserPolicyByTwoPartKey
 )

--- a/internal/service/iam/exports_test.go
+++ b/internal/service/iam/exports_test.go
@@ -6,6 +6,7 @@ package iam
 // Exports for use in tests only.
 var (
 	ResourceGroupPolicyAttachment = resourceGroupPolicyAttachment
+	ResourcePolicyAttachment      = resourcePolicyAttachment
 	ResourceRolePolicyAttachment  = resourceRolePolicyAttachment
 	ResourceUserPolicyAttachment  = resourceUserPolicyAttachment
 
@@ -15,5 +16,6 @@ var (
 	FindAttachedRolePolicyByTwoPartKey  = findAttachedRolePolicyByTwoPartKey
 	FindAttachedUserPolicies            = findAttachedUserPolicies
 	FindAttachedUserPolicyByTwoPartKey  = findAttachedUserPolicyByTwoPartKey
+	FindEntitiesForPolicyByARN          = findEntitiesForPolicyByARN
 	FindPolicyByARN                     = findPolicyByARN
 )

--- a/internal/service/iam/exports_test.go
+++ b/internal/service/iam/exports_test.go
@@ -15,4 +15,5 @@ var (
 	FindAttachedRolePolicyByTwoPartKey  = findAttachedRolePolicyByTwoPartKey
 	FindAttachedUserPolicies            = findAttachedUserPolicies
 	FindAttachedUserPolicyByTwoPartKey  = findAttachedUserPolicyByTwoPartKey
+	FindPolicyByARN                     = findPolicyByARN
 )

--- a/internal/service/iam/exports_test.go
+++ b/internal/service/iam/exports_test.go
@@ -1,0 +1,12 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package iam
+
+// Exports for use in tests only.
+var (
+	ResourceGroupPolicyAttachment = resourceGroupPolicyAttachment
+
+	FindAttachedGroupPolicies           = findAttachedGroupPolicies
+	FindAttachedGroupPolicyByTwoPartKey = findAttachedGroupPolicyByTwoPartKey
+)

--- a/internal/service/iam/find.go
+++ b/internal/service/iam/find.go
@@ -14,40 +14,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-// FindGroupAttachedPolicy returns the AttachedPolicy corresponding to the specified group and policy ARN.
-func FindGroupAttachedPolicy(ctx context.Context, conn *iam.IAM, groupName string, policyARN string) (*iam.AttachedPolicy, error) {
-	input := &iam.ListAttachedGroupPoliciesInput{
-		GroupName: aws.String(groupName),
-	}
-
-	var result *iam.AttachedPolicy
-
-	err := conn.ListAttachedGroupPoliciesPagesWithContext(ctx, input, func(page *iam.ListAttachedGroupPoliciesOutput, lastPage bool) bool {
-		if page == nil {
-			return !lastPage
-		}
-
-		for _, attachedPolicy := range page.AttachedPolicies {
-			if attachedPolicy == nil {
-				continue
-			}
-
-			if aws.StringValue(attachedPolicy.PolicyArn) == policyARN {
-				result = attachedPolicy
-				return false
-			}
-		}
-
-		return !lastPage
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	return result, nil
-}
-
 // FindUserAttachedPolicy returns the AttachedPolicy corresponding to the specified user and policy ARN.
 func FindUserAttachedPolicy(ctx context.Context, conn *iam.IAM, userName string, policyARN string) (*iam.AttachedPolicy, error) {
 	input := &iam.ListAttachedUserPoliciesInput{

--- a/internal/service/iam/find.go
+++ b/internal/service/iam/find.go
@@ -14,40 +14,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-// FindUserAttachedPolicy returns the AttachedPolicy corresponding to the specified user and policy ARN.
-func FindUserAttachedPolicy(ctx context.Context, conn *iam.IAM, userName string, policyARN string) (*iam.AttachedPolicy, error) {
-	input := &iam.ListAttachedUserPoliciesInput{
-		UserName: aws.String(userName),
-	}
-
-	var result *iam.AttachedPolicy
-
-	err := conn.ListAttachedUserPoliciesPagesWithContext(ctx, input, func(page *iam.ListAttachedUserPoliciesOutput, lastPage bool) bool {
-		if page == nil {
-			return !lastPage
-		}
-
-		for _, attachedPolicy := range page.AttachedPolicies {
-			if attachedPolicy == nil {
-				continue
-			}
-
-			if aws.StringValue(attachedPolicy.PolicyArn) == policyARN {
-				result = attachedPolicy
-				return false
-			}
-		}
-
-		return !lastPage
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	return result, nil
-}
-
 func FindUsers(ctx context.Context, conn *iam.IAM, nameRegex, pathPrefix string) ([]*iam.User, error) {
 	input := &iam.ListUsersInput{}
 

--- a/internal/service/iam/group_policy_attachment.go
+++ b/internal/service/iam/group_policy_attachment.go
@@ -57,8 +57,7 @@ func resourceGroupPolicyAttachmentCreate(ctx context.Context, d *schema.Resource
 	group := d.Get("group").(string)
 	policyARN := d.Get("policy_arn").(string)
 
-	err := attachPolicyToGroup(ctx, conn, group, policyARN)
-	if err != nil {
+	if err := attachPolicyToGroup(ctx, conn, group, policyARN); err != nil {
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
@@ -98,8 +97,7 @@ func resourceGroupPolicyAttachmentDelete(ctx context.Context, d *schema.Resource
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMConn(ctx)
 
-	err := detachPolicyFromGroup(ctx, conn, d.Get("group").(string), d.Get("policy_arn").(string))
-	if err != nil {
+	if err := detachPolicyFromGroup(ctx, conn, d.Get("group").(string), d.Get("policy_arn").(string)); err != nil {
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
@@ -147,7 +145,7 @@ func detachPolicyFromGroup(ctx context.Context, conn *iam.IAM, group, policyARN 
 	}
 
 	if err != nil {
-		return fmt.Errorf("dtaching IAM Policy (%s) from IAM Group (%s): %w", policyARN, group, err)
+		return fmt.Errorf("detaching IAM Policy (%s) from IAM Group (%s): %w", policyARN, group, err)
 	}
 
 	return nil

--- a/internal/service/iam/group_policy_attachment.go
+++ b/internal/service/iam/group_policy_attachment.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 // @SDKResource("aws_iam_group_policy_attachment")
@@ -27,6 +28,7 @@ func ResourceGroupPolicyAttachment() *schema.Resource {
 		CreateWithoutTimeout: resourceGroupPolicyAttachmentCreate,
 		ReadWithoutTimeout:   resourceGroupPolicyAttachmentRead,
 		DeleteWithoutTimeout: resourceGroupPolicyAttachmentDelete,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceGroupPolicyAttachmentImport,
 		},
@@ -38,9 +40,10 @@ func ResourceGroupPolicyAttachment() *schema.Resource {
 				ForceNew: true,
 			},
 			"policy_arn": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidARN,
 			},
 		},
 	}

--- a/internal/service/iam/group_policy_attachment.go
+++ b/internal/service/iam/group_policy_attachment.go
@@ -109,11 +109,14 @@ func resourceGroupPolicyAttachmentImport(ctx context.Context, d *schema.Resource
 	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
 		return nil, fmt.Errorf("unexpected format of ID (%q), expected <group-name>/<policy_arn>", d.Id())
 	}
+
 	groupName := idParts[0]
 	policyARN := idParts[1]
+
 	d.Set("group", groupName)
 	d.Set("policy_arn", policyARN)
 	d.SetId(fmt.Sprintf("%s-%s", groupName, policyARN))
+
 	return []*schema.ResourceData{d}, nil
 }
 

--- a/internal/service/iam/group_policy_attachment.go
+++ b/internal/service/iam/group_policy_attachment.go
@@ -150,10 +150,12 @@ func resourceGroupPolicyAttachmentImport(ctx context.Context, d *schema.Resource
 }
 
 func attachPolicyToGroup(ctx context.Context, conn *iam.IAM, group string, arn string) error {
-	_, err := conn.AttachGroupPolicyWithContext(ctx, &iam.AttachGroupPolicyInput{
-		GroupName: aws.String(group),
-		PolicyArn: aws.String(arn),
-	})
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (interface{}, error) {
+		return conn.AttachGroupPolicyWithContext(ctx, &iam.AttachGroupPolicyInput{
+			GroupName: aws.String(group),
+			PolicyArn: aws.String(arn),
+		})
+	}, iam.ErrCodeConcurrentModificationException)
 	return err
 }
 

--- a/internal/service/iam/group_policy_attachment_test.go
+++ b/internal/service/iam/group_policy_attachment_test.go
@@ -153,7 +153,7 @@ func testAccCheckGroupPolicyAttachmentCount(ctx context.Context, groupName strin
 			return fmt.Errorf("GroupPolicyAttachmentCount(%q) = %v, want %v", groupName, got, want)
 		}
 
-		return err
+		return nil
 	}
 }
 

--- a/internal/service/iam/group_policy_attachment_test.go
+++ b/internal/service/iam/group_policy_attachment_test.go
@@ -6,46 +6,46 @@ package iam_test
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 
-	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/iam"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func TestAccIAMGroupPolicyAttachment_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	var out iam.ListAttachedGroupPoliciesOutput
-
-	rString := sdkacctest.RandString(8)
-	groupName := fmt.Sprintf("tf-acc-group-gpa-basic-%s", rString)
-	policyName := fmt.Sprintf("tf-acc-policy-gpa-basic-%s", rString)
-	policyName2 := fmt.Sprintf("tf-acc-policy-gpa-basic-2-%s", rString)
-	policyName3 := fmt.Sprintf("tf-acc-policy-gpa-basic-3-%s", rString)
+	groupName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	policyName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	policyName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	policyName3 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_iam_group_policy_attachment.test1"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, iam.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGroupPolicyAttachmentDestroy,
+		CheckDestroy:             testAccCheckGroupPolicyAttachmentDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGroupPolicyAttachmentConfig_attach(groupName, policyName),
+				Config: testAccGroupPolicyAttachmentConfig_attach(groupName, policyName1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGroupPolicyAttachmentExists(ctx, "aws_iam_group_policy_attachment.test-attach", 1, &out),
-					testAccCheckGroupPolicyAttachmentAttributes([]string{policyName}, &out),
+					testAccCheckGroupPolicyAttachmentExists(ctx, resourceName),
+					testAccCheckGroupPolicyAttachmentCount(ctx, groupName, 1),
 				),
 			},
 			{
-				ResourceName:      "aws_iam_group_policy_attachment.test-attach",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccGroupPolicyAttachmentImportStateIdFunc("aws_iam_group_policy_attachment.test-attach"),
+				ImportStateIdFunc: testAccGroupPolicyAttachmentImportStateIdFunc(resourceName),
 				// We do not have a way to align IDs since the Create function uses id.PrefixedUniqueId()
 				// Failed state verification, resource with ID GROUP-POLICYARN not found
 				// ImportStateVerify: true,
@@ -61,178 +61,100 @@ func TestAccIAMGroupPolicyAttachment_basic(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccGroupPolicyAttachmentConfig_attachUpdate(groupName, policyName, policyName2, policyName3),
+				Config: testAccGroupPolicyAttachmentConfig_attachUpdate(groupName, policyName1, policyName2, policyName3),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGroupPolicyAttachmentExists(ctx, "aws_iam_group_policy_attachment.test-attach", 2, &out),
-					testAccCheckGroupPolicyAttachmentAttributes([]string{policyName2, policyName3}, &out),
+					testAccCheckGroupPolicyAttachmentExists(ctx, resourceName),
+					testAccCheckGroupPolicyAttachmentCount(ctx, groupName, 2),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckGroupPolicyAttachmentDestroy(s *terraform.State) error {
-	return nil
+func TestAccIAMGroupPolicyAttachment_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	groupName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_iam_group_policy_attachment.test1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, iam.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGroupPolicyAttachmentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGroupPolicyAttachmentConfig_attach(groupName, policyName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGroupPolicyAttachmentExists(ctx, resourceName),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfiam.ResourceGroupPolicyAttachment(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
 }
 
-func testAccCheckGroupPolicyAttachmentExists(ctx context.Context, n string, c int, out *iam.ListAttachedGroupPoliciesOutput) resource.TestCheckFunc {
+func testAccCheckGroupPolicyAttachmentDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMConn(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_iam_group_policy_attachment" {
+				continue
+			}
+
+			_, err := tfiam.FindAttachedGroupPolicyByTwoPartKey(ctx, conn, rs.Primary.Attributes["group"], rs.Primary.Attributes["policy_arn"])
+
+			if tfresource.NotFound(err) {
+				continue
+			}
+
+			if err != nil {
+				return err
+			}
+
+			return fmt.Errorf("IAM Group Policy Attachment %s still exists", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckGroupPolicyAttachmentExists(ctx context.Context, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No policy name is set")
-		}
-
 		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMConn(ctx)
-		group := rs.Primary.Attributes["group"]
 
-		attachedPolicies, err := conn.ListAttachedGroupPoliciesWithContext(ctx, &iam.ListAttachedGroupPoliciesInput{
-			GroupName: aws.String(group),
-		})
-		if err != nil {
-			return fmt.Errorf("Error: Failed to get attached policies for group %s (%s)", group, n)
-		}
-		if c != len(attachedPolicies.AttachedPolicies) {
-			return fmt.Errorf("Error: Group (%s) has wrong number of policies attached on initial creation", n)
-		}
+		_, err := tfiam.FindAttachedGroupPolicyByTwoPartKey(ctx, conn, rs.Primary.Attributes["group"], rs.Primary.Attributes["policy_arn"])
 
-		*out = *attachedPolicies
-		return nil
+		return err
 	}
 }
 
-func testAccCheckGroupPolicyAttachmentAttributes(policies []string, out *iam.ListAttachedGroupPoliciesOutput) resource.TestCheckFunc {
+func testAccCheckGroupPolicyAttachmentCount(ctx context.Context, groupName string, want int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		matched := 0
+		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMConn(ctx)
 
-		for _, p := range policies {
-			for _, ap := range out.AttachedPolicies {
-				// *ap.PolicyArn like arn:aws:iam::111111111111:policy/test-policy
-				parts := strings.Split(*ap.PolicyArn, "/")
-				if len(parts) == 2 && p == parts[1] {
-					matched++
-				}
-			}
+		input := &iam.ListAttachedGroupPoliciesInput{
+			GroupName: aws.String(groupName),
 		}
-		if matched != len(policies) || matched != len(out.AttachedPolicies) {
-			return fmt.Errorf("Error: Number of attached policies was incorrect: expected %d matched policies, matched %d of %d", len(policies), matched, len(out.AttachedPolicies))
+		output, err := tfiam.FindAttachedGroupPolicies(ctx, conn, input, tfslices.PredicateTrue[*iam.AttachedPolicy]())
+
+		if err != nil {
+			return err
 		}
-		return nil
+
+		if got := len(output); got != want {
+			return fmt.Errorf("GroupPolicyAttachmentCount(%q) = %v, want %v", groupName, got, want)
+		}
+
+		return err
 	}
-}
-
-func testAccGroupPolicyAttachmentConfig_attach(groupName, policyName string) string {
-	return fmt.Sprintf(`
-resource "aws_iam_group" "group" {
-  name = "%s"
-}
-
-resource "aws_iam_policy" "policy" {
-  name        = "%s"
-  description = "A test policy"
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "iam:ChangePassword"
-      ],
-      "Resource": "*",
-      "Effect": "Allow"
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_group_policy_attachment" "test-attach" {
-  group      = aws_iam_group.group.name
-  policy_arn = aws_iam_policy.policy.arn
-}
-`, groupName, policyName)
-}
-
-func testAccGroupPolicyAttachmentConfig_attachUpdate(groupName, policyName, policyName2, policyName3 string) string {
-	return fmt.Sprintf(`
-resource "aws_iam_group" "group" {
-  name = "%s"
-}
-
-resource "aws_iam_policy" "policy" {
-  name        = "%s"
-  description = "A test policy"
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "iam:ChangePassword"
-      ],
-      "Resource": "*",
-      "Effect": "Allow"
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_policy" "policy2" {
-  name        = "%s"
-  description = "A test policy"
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "iam:ChangePassword"
-      ],
-      "Resource": "*",
-      "Effect": "Allow"
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_policy" "policy3" {
-  name        = "%s"
-  description = "A test policy"
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "iam:ChangePassword"
-      ],
-      "Resource": "*",
-      "Effect": "Allow"
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_group_policy_attachment" "test-attach" {
-  group      = aws_iam_group.group.name
-  policy_arn = aws_iam_policy.policy2.arn
-}
-
-resource "aws_iam_group_policy_attachment" "test-attach2" {
-  group      = aws_iam_group.group.name
-  policy_arn = aws_iam_policy.policy3.arn
-}
-`, groupName, policyName, policyName2, policyName3)
 }
 
 func testAccGroupPolicyAttachmentImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
@@ -243,4 +165,115 @@ func testAccGroupPolicyAttachmentImportStateIdFunc(resourceName string) resource
 		}
 		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["group"], rs.Primary.Attributes["policy_arn"]), nil
 	}
+}
+
+func testAccGroupPolicyAttachmentConfig_attach(groupName, policyName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_group" "test" {
+  name = %[1]q
+}
+
+resource "aws_iam_policy" "test1" {
+  name        = %[2]q
+  description = "A test policy"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "iam:ChangePassword"
+      ],
+      "Resource": "*",
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_group_policy_attachment" "test1" {
+  group      = aws_iam_group.test.name
+  policy_arn = aws_iam_policy.test1.arn
+}
+`, groupName, policyName)
+}
+
+func testAccGroupPolicyAttachmentConfig_attachUpdate(groupName, policyName1, policyName2, policyName3 string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_group" "test" {
+  name = %[1]q
+}
+
+resource "aws_iam_policy" "test1" {
+  name        = %[2]q
+  description = "A test policy"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "iam:ChangePassword"
+      ],
+      "Resource": "*",
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "test2" {
+  name        = %[3]q
+  description = "A test policy"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "iam:ChangePassword"
+      ],
+      "Resource": "*",
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "test3" {
+  name        = %[4]q
+  description = "A test policy"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "iam:ChangePassword"
+      ],
+      "Resource": "*",
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_group_policy_attachment" "test1" {
+  group      = aws_iam_group.test.name
+  policy_arn = aws_iam_policy.test2.arn
+}
+
+resource "aws_iam_group_policy_attachment" "test2" {
+  group      = aws_iam_group.test.name
+  policy_arn = aws_iam_policy.test3.arn
+}
+`, groupName, policyName1, policyName2, policyName3)
 }

--- a/internal/service/iam/policy.go
+++ b/internal/service/iam/policy.go
@@ -162,7 +162,7 @@ func resourcePolicyRead(ctx context.Context, d *schema.ResourceData, meta interf
 	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
 		iamPolicy := &policyWithVersion{}
 
-		if v, err := FindPolicyByARN(ctx, conn, d.Id()); err == nil {
+		if v, err := findPolicyByARN(ctx, conn, d.Id()); err == nil {
 			iamPolicy.policy = v
 		} else {
 			return nil, err
@@ -348,7 +348,7 @@ func policyDeleteVersion(ctx context.Context, conn *iam.IAM, arn, versionID stri
 	return nil
 }
 
-func FindPolicyByARN(ctx context.Context, conn *iam.IAM, arn string) (*iam.Policy, error) {
+func findPolicyByARN(ctx context.Context, conn *iam.IAM, arn string) (*iam.Policy, error) {
 	input := &iam.GetPolicyInput{
 		PolicyArn: aws.String(arn),
 	}

--- a/internal/service/iam/policy_attachment.go
+++ b/internal/service/iam/policy_attachment.go
@@ -5,24 +5,26 @@ package iam
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-// @SDKResource("aws_iam_policy_attachment")
-func ResourcePolicyAttachment() *schema.Resource {
+// @SDKResource("aws_iam_policy_attachment", name="Policy Attachment")
+func resourcePolicyAttachment() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourcePolicyAttachmentCreate,
 		ReadWithoutTimeout:   resourcePolicyAttachmentRead,
@@ -31,9 +33,10 @@ func ResourcePolicyAttachment() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"groups": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type:         schema.TypeSet,
+				Optional:     true,
+				Elem:         &schema.Schema{Type: schema.TypeString},
+				AtLeastOneOf: []string{"groups", "roles", "users"},
 			},
 			"name": {
 				Type:         schema.TypeString,
@@ -48,14 +51,16 @@ func ResourcePolicyAttachment() *schema.Resource {
 				ValidateFunc: verify.ValidARN,
 			},
 			"roles": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type:         schema.TypeSet,
+				Optional:     true,
+				Elem:         &schema.Schema{Type: schema.TypeString},
+				AtLeastOneOf: []string{"groups", "roles", "users"},
 			},
 			"users": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type:         schema.TypeSet,
+				Optional:     true,
+				Elem:         &schema.Schema{Type: schema.TypeString},
+				AtLeastOneOf: []string{"groups", "roles", "users"},
 			},
 		},
 	}
@@ -65,84 +70,51 @@ func resourcePolicyAttachmentCreate(ctx context.Context, d *schema.ResourceData,
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMConn(ctx)
 
-	name := d.Get("name").(string)
-	arn := d.Get("policy_arn").(string)
-	users := flex.ExpandStringSet(d.Get("users").(*schema.Set))
-	roles := flex.ExpandStringSet(d.Get("roles").(*schema.Set))
-	groups := flex.ExpandStringSet(d.Get("groups").(*schema.Set))
-
-	if len(users) == 0 && len(roles) == 0 && len(groups) == 0 {
-		return sdkdiag.AppendErrorf(diags, "No Users, Roles, or Groups specified for IAM Policy Attachment %s", name)
-	} else {
-		var userErr, roleErr, groupErr error
-		if users != nil {
-			userErr = attachPolicyToUsers(ctx, conn, users, arn)
-		}
-		if roles != nil {
-			roleErr = attachPolicyToRoles(ctx, conn, roles, arn)
-		}
-		if groups != nil {
-			groupErr = attachPolicyToGroups(ctx, conn, groups, arn)
-		}
-		if userErr != nil || roleErr != nil || groupErr != nil {
-			return composeErrors(fmt.Sprint("attaching policy with IAM Policy Attachment ", name, ":"), userErr, roleErr, groupErr)
-		}
+	policyARN := d.Get("policy_arn").(string)
+	var groups, roles, users []string
+	if v, ok := d.GetOk("groups"); ok && v.(*schema.Set).Len() > 0 {
+		groups = flex.ExpandStringValueSet(v.(*schema.Set))
 	}
+	if v, ok := d.GetOk("roles"); ok && v.(*schema.Set).Len() > 0 {
+		roles = flex.ExpandStringValueSet(v.(*schema.Set))
+	}
+	if v, ok := d.GetOk("users"); ok && v.(*schema.Set).Len() > 0 {
+		users = flex.ExpandStringValueSet(v.(*schema.Set))
+	}
+
+	diags = sdkdiag.AppendFromErr(diags, attachPolicyToGroups(ctx, conn, groups, policyARN))
+	diags = sdkdiag.AppendFromErr(diags, attachPolicyToRoles(ctx, conn, roles, policyARN))
+	diags = sdkdiag.AppendFromErr(diags, attachPolicyToUsers(ctx, conn, users, policyARN))
+
+	if diags.HasError() {
+		return diags
+	}
+
 	d.SetId(d.Get("name").(string))
+
 	return append(diags, resourcePolicyAttachmentRead(ctx, d, meta)...)
 }
 
 func resourcePolicyAttachmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMConn(ctx)
-	arn := d.Get("policy_arn").(string)
-	name := d.Get("name").(string)
 
-	_, err := conn.GetPolicyWithContext(ctx, &iam.GetPolicyInput{
-		PolicyArn: aws.String(arn),
-	})
+	policyARN := d.Get("policy_arn").(string)
+	groups, roles, users, err := findEntitiesForPolicyByARN(ctx, conn, policyARN)
 
-	if err != nil {
-		if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, iam.ErrCodeNoSuchEntityException) {
-			log.Printf("[WARN] IAM Policy Attachment (%s) not found, removing from state", d.Id())
-			d.SetId("")
-			return diags
-		}
-		return sdkdiag.AppendErrorf(diags, "reading IAM Policy Attachment (%s): %s", d.Id(), err)
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] IAM Policy Attachment (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return diags
 	}
 
-	ul := make([]string, 0)
-	rl := make([]string, 0)
-	gl := make([]string, 0)
-
-	args := iam.ListEntitiesForPolicyInput{
-		PolicyArn: aws.String(arn),
-	}
-	err = conn.ListEntitiesForPolicyPagesWithContext(ctx, &args, func(page *iam.ListEntitiesForPolicyOutput, lastPage bool) bool {
-		for _, u := range page.PolicyUsers {
-			ul = append(ul, *u.UserName)
-		}
-
-		for _, r := range page.PolicyRoles {
-			rl = append(rl, *r.RoleName)
-		}
-
-		for _, g := range page.PolicyGroups {
-			gl = append(gl, *g.GroupName)
-		}
-		return true
-	})
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading IAM Policy Attachment (%s): %s", d.Id(), err)
 	}
 
-	userErr := d.Set("users", ul)
-	roleErr := d.Set("roles", rl)
-	groupErr := d.Set("groups", gl)
-
-	if userErr != nil || roleErr != nil || groupErr != nil {
-		return composeErrors(fmt.Sprint("setting user, role, or group list from IAM Policy Attachment ", name, ":"), userErr, roleErr, groupErr)
-	}
+	d.Set("groups", groups)
+	d.Set("roles", roles)
+	d.Set("users", users)
 
 	return diags
 }
@@ -150,213 +122,215 @@ func resourcePolicyAttachmentRead(ctx context.Context, d *schema.ResourceData, m
 func resourcePolicyAttachmentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMConn(ctx)
-	name := d.Get("name").(string)
-	var userErr, roleErr, groupErr error
 
-	if d.HasChange("users") {
-		userErr = updateUsers(ctx, conn, d)
+	if d.HasChange("groups") {
+		diags = sdkdiag.AppendFromErr(diags, updateGroups(ctx, conn, d))
 	}
 	if d.HasChange("roles") {
-		roleErr = updateRoles(ctx, conn, d)
+		diags = sdkdiag.AppendFromErr(diags, updateRoles(ctx, conn, d))
 	}
-	if d.HasChange("groups") {
-		groupErr = updateGroups(ctx, conn, d)
+	if d.HasChange("users") {
+		diags = sdkdiag.AppendFromErr(diags, updateUsers(ctx, conn, d))
 	}
-	if userErr != nil || roleErr != nil || groupErr != nil {
-		return composeErrors(fmt.Sprint("updating user, role, or group list from IAM Policy Attachment ", name, ":"), userErr, roleErr, groupErr)
+
+	if diags.HasError() {
+		return diags
 	}
+
 	return append(diags, resourcePolicyAttachmentRead(ctx, d, meta)...)
 }
 
 func resourcePolicyAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMConn(ctx)
-	name := d.Get("name").(string)
-	arn := d.Get("policy_arn").(string)
-	users := flex.ExpandStringSet(d.Get("users").(*schema.Set))
-	roles := flex.ExpandStringSet(d.Get("roles").(*schema.Set))
-	groups := flex.ExpandStringSet(d.Get("groups").(*schema.Set))
 
-	var userErr, roleErr, groupErr error
-	if len(users) != 0 {
-		userErr = detachPolicyFromUsers(ctx, conn, users, arn)
+	policyARN := d.Get("policy_arn").(string)
+	var groups, roles, users []string
+	if v, ok := d.GetOk("groups"); ok && v.(*schema.Set).Len() > 0 {
+		groups = flex.ExpandStringValueSet(v.(*schema.Set))
 	}
-	if len(roles) != 0 {
-		roleErr = detachPolicyFromRoles(ctx, conn, roles, arn)
+	if v, ok := d.GetOk("roles"); ok && v.(*schema.Set).Len() > 0 {
+		roles = flex.ExpandStringValueSet(v.(*schema.Set))
 	}
-	if len(groups) != 0 {
-		groupErr = detachPolicyFromGroups(ctx, conn, groups, arn)
+	if v, ok := d.GetOk("users"); ok && v.(*schema.Set).Len() > 0 {
+		users = flex.ExpandStringValueSet(v.(*schema.Set))
 	}
-	if userErr != nil || roleErr != nil || groupErr != nil {
-		return append(diags, composeErrors(fmt.Sprint("removing user, role, or group list from IAM Policy Detach ", name, ":"), userErr, roleErr, groupErr)...)
-	}
+
+	diags = sdkdiag.AppendFromErr(diags, detachPolicyFromGroups(ctx, conn, groups, policyARN))
+	diags = sdkdiag.AppendFromErr(diags, detachPolicyFromRoles(ctx, conn, roles, policyARN))
+	diags = sdkdiag.AppendFromErr(diags, detachPolicyFromUsers(ctx, conn, users, policyARN))
+
 	return diags
 }
 
-func composeErrors(desc string, uErr error, rErr error, gErr error) diag.Diagnostics {
-	errMsg := fmt.Sprint(desc)
-	errs := []error{uErr, rErr, gErr}
-	for _, e := range errs {
-		if e != nil {
-			errMsg = errMsg + "\n– " + e.Error()
-		}
+func attachPolicyToGroups(ctx context.Context, conn *iam.IAM, groups []string, policyARN string) error {
+	var errs []error
+
+	for _, group := range groups {
+		errs = append(errs, attachPolicyToGroup(ctx, conn, group, policyARN))
 	}
-	return diag.Errorf(errMsg)
+
+	return errors.Join(errs...)
 }
 
-func attachPolicyToUsers(ctx context.Context, conn *iam.IAM, users []*string, arn string) error {
-	for _, u := range users {
-		input := &iam.AttachUserPolicyInput{
-			UserName:  u,
-			PolicyArn: aws.String(arn),
-		}
-		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (interface{}, error) {
-			return conn.AttachUserPolicyWithContext(ctx, input)
-		}, iam.ErrCodeConcurrentModificationException)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-func attachPolicyToRoles(ctx context.Context, conn *iam.IAM, roles []*string, arn string) error {
-	for _, r := range roles {
-		input := &iam.AttachRolePolicyInput{
-			RoleName:  r,
-			PolicyArn: aws.String(arn),
-		}
-		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (interface{}, error) {
-			return conn.AttachRolePolicyWithContext(ctx, input)
-		}, iam.ErrCodeConcurrentModificationException)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-func attachPolicyToGroups(ctx context.Context, conn *iam.IAM, groups []*string, arn string) error {
-	for _, g := range groups {
-		input := &iam.AttachGroupPolicyInput{
-			GroupName: g,
-			PolicyArn: aws.String(arn),
-		}
-		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (interface{}, error) {
-			return conn.AttachGroupPolicyWithContext(ctx, input)
-		}, iam.ErrCodeConcurrentModificationException)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-func updateUsers(ctx context.Context, conn *iam.IAM, d *schema.ResourceData) error {
-	arn := d.Get("policy_arn").(string)
-	o, n := d.GetChange("users")
-	if o == nil {
-		o = new(schema.Set)
-	}
-	if n == nil {
-		n = new(schema.Set)
-	}
-	os := o.(*schema.Set)
-	ns := n.(*schema.Set)
-	remove := flex.ExpandStringSet(os.Difference(ns))
-	add := flex.ExpandStringSet(ns.Difference(os))
+func attachPolicyToRoles(ctx context.Context, conn *iam.IAM, roles []string, policyARN string) error {
+	var errs []error
 
-	if rErr := detachPolicyFromUsers(ctx, conn, remove, arn); rErr != nil {
-		return rErr
+	for _, role := range roles {
+		errs = append(errs, attachPolicyToRole(ctx, conn, role, policyARN))
 	}
-	if aErr := attachPolicyToUsers(ctx, conn, add, arn); aErr != nil {
-		return aErr
-	}
-	return nil
-}
-func updateRoles(ctx context.Context, conn *iam.IAM, d *schema.ResourceData) error {
-	arn := d.Get("policy_arn").(string)
-	o, n := d.GetChange("roles")
-	if o == nil {
-		o = new(schema.Set)
-	}
-	if n == nil {
-		n = new(schema.Set)
-	}
-	os := o.(*schema.Set)
-	ns := n.(*schema.Set)
-	remove := flex.ExpandStringSet(os.Difference(ns))
-	add := flex.ExpandStringSet(ns.Difference(os))
 
-	if rErr := detachPolicyFromRoles(ctx, conn, remove, arn); rErr != nil {
-		return rErr
-	}
-	if aErr := attachPolicyToRoles(ctx, conn, add, arn); aErr != nil {
-		return aErr
-	}
-	return nil
+	return errors.Join(errs...)
 }
+
+func attachPolicyToUsers(ctx context.Context, conn *iam.IAM, users []string, policyARN string) error {
+	var errs []error
+
+	for _, user := range users {
+		errs = append(errs, attachPolicyToUser(ctx, conn, user, policyARN))
+	}
+
+	return errors.Join(errs...)
+}
+
 func updateGroups(ctx context.Context, conn *iam.IAM, d *schema.ResourceData) error {
-	arn := d.Get("policy_arn").(string)
+	policyARN := d.Get("policy_arn").(string)
 	o, n := d.GetChange("groups")
-	if o == nil {
-		o = new(schema.Set)
-	}
-	if n == nil {
-		n = new(schema.Set)
-	}
-	os := o.(*schema.Set)
-	ns := n.(*schema.Set)
-	remove := flex.ExpandStringSet(os.Difference(ns))
-	add := flex.ExpandStringSet(ns.Difference(os))
+	os, ns := o.(*schema.Set), n.(*schema.Set)
+	add, del := flex.ExpandStringValueSet(ns.Difference(os)), flex.ExpandStringValueSet(os.Difference(ns))
 
-	if rErr := detachPolicyFromGroups(ctx, conn, remove, arn); rErr != nil {
-		return rErr
+	if err := detachPolicyFromGroups(ctx, conn, del, policyARN); err != nil {
+		return err
 	}
-	if aErr := attachPolicyToGroups(ctx, conn, add, arn); aErr != nil {
-		return aErr
+	if err := attachPolicyToGroups(ctx, conn, add, policyARN); err != nil {
+		return err
 	}
+
 	return nil
 }
-func detachPolicyFromUsers(ctx context.Context, conn *iam.IAM, users []*string, arn string) error {
-	for _, u := range users {
-		_, err := conn.DetachUserPolicyWithContext(ctx, &iam.DetachUserPolicyInput{
-			UserName:  u,
-			PolicyArn: aws.String(arn),
-		})
-		if tfawserr.ErrCodeEquals(err, iam.ErrCodeNoSuchEntityException) {
-			continue
-		}
-		if err != nil {
-			return err
-		}
+
+func updateRoles(ctx context.Context, conn *iam.IAM, d *schema.ResourceData) error {
+	policyARN := d.Get("policy_arn").(string)
+	o, n := d.GetChange("roles")
+	os, ns := o.(*schema.Set), n.(*schema.Set)
+	add, del := flex.ExpandStringValueSet(ns.Difference(os)), flex.ExpandStringValueSet(os.Difference(ns))
+
+	if err := detachPolicyFromRoles(ctx, conn, del, policyARN); err != nil {
+		return err
 	}
+	if err := attachPolicyToRoles(ctx, conn, add, policyARN); err != nil {
+		return err
+	}
+
 	return nil
 }
-func detachPolicyFromRoles(ctx context.Context, conn *iam.IAM, roles []*string, arn string) error {
-	for _, r := range roles {
-		_, err := conn.DetachRolePolicyWithContext(ctx, &iam.DetachRolePolicyInput{
-			RoleName:  r,
-			PolicyArn: aws.String(arn),
-		})
-		if tfawserr.ErrCodeEquals(err, iam.ErrCodeNoSuchEntityException) {
-			continue
-		}
-		if err != nil {
-			return err
-		}
+
+func updateUsers(ctx context.Context, conn *iam.IAM, d *schema.ResourceData) error {
+	policyARN := d.Get("policy_arn").(string)
+	o, n := d.GetChange("users")
+	os, ns := o.(*schema.Set), n.(*schema.Set)
+	add, del := flex.ExpandStringValueSet(ns.Difference(os)), flex.ExpandStringValueSet(os.Difference(ns))
+
+	if err := detachPolicyFromUsers(ctx, conn, del, policyARN); err != nil {
+		return err
 	}
+	if err := attachPolicyToUsers(ctx, conn, add, policyARN); err != nil {
+		return err
+	}
+
 	return nil
 }
-func detachPolicyFromGroups(ctx context.Context, conn *iam.IAM, groups []*string, arn string) error {
-	for _, g := range groups {
-		_, err := conn.DetachGroupPolicyWithContext(ctx, &iam.DetachGroupPolicyInput{
-			GroupName: g,
-			PolicyArn: aws.String(arn),
-		})
-		if tfawserr.ErrCodeEquals(err, iam.ErrCodeNoSuchEntityException) {
-			continue
+
+func detachPolicyFromGroups(ctx context.Context, conn *iam.IAM, groups []string, policyARN string) error {
+	var errs []error
+
+	for _, group := range groups {
+		errs = append(errs, detachPolicyFromGroup(ctx, conn, group, policyARN))
+	}
+
+	return errors.Join(errs...)
+}
+
+func detachPolicyFromRoles(ctx context.Context, conn *iam.IAM, roles []string, policyARN string) error {
+	var errs []error
+
+	for _, role := range roles {
+		errs = append(errs, detachPolicyFromRole(ctx, conn, role, policyARN))
+	}
+
+	return errors.Join(errs...)
+}
+
+func detachPolicyFromUsers(ctx context.Context, conn *iam.IAM, users []string, policyARN string) error {
+	var errs []error
+
+	for _, user := range users {
+		errs = append(errs, detachPolicyFromUser(ctx, conn, user, policyARN))
+	}
+
+	return errors.Join(errs...)
+}
+
+func findEntitiesForPolicyByARN(ctx context.Context, conn *iam.IAM, arn string) ([]string, []string, []string, error) {
+	input := &iam.ListEntitiesForPolicyInput{
+		PolicyArn: aws.String(arn),
+	}
+	groups, roles, users, err := findEntitiesForPolicy(ctx, conn, input)
+
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	if len(groups) == 0 && len(roles) == 0 && len(users) == 0 {
+		return nil, nil, nil, tfresource.NewEmptyResultError(input)
+	}
+
+	groupName := tfslices.ApplyToAll(groups, func(v *iam.PolicyGroup) string { return aws.StringValue(v.GroupName) })
+	roleNames := tfslices.ApplyToAll(roles, func(v *iam.PolicyRole) string { return aws.StringValue(v.RoleName) })
+	userNames := tfslices.ApplyToAll(users, func(v *iam.PolicyUser) string { return aws.StringValue(v.UserName) })
+
+	return groupName, roleNames, userNames, nil
+}
+
+func findEntitiesForPolicy(ctx context.Context, conn *iam.IAM, input *iam.ListEntitiesForPolicyInput) ([]*iam.PolicyGroup, []*iam.PolicyRole, []*iam.PolicyUser, error) {
+	var groups []*iam.PolicyGroup
+	var roles []*iam.PolicyRole
+	var users []*iam.PolicyUser
+
+	err := conn.ListEntitiesForPolicyPagesWithContext(ctx, input, func(page *iam.ListEntitiesForPolicyOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
 		}
-		if err != nil {
-			return err
+
+		for _, v := range page.PolicyGroups {
+			if v != nil {
+				groups = append(groups, v)
+			}
+		}
+		for _, v := range page.PolicyRoles {
+			if v != nil {
+				roles = append(roles, v)
+			}
+		}
+		for _, v := range page.PolicyUsers {
+			if v != nil {
+				users = append(users, v)
+			}
+		}
+
+		return !lastPage
+	})
+
+	if tfawserr.ErrCodeEquals(err, iam.ErrCodeNoSuchEntityException) {
+		return nil, nil, nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
 		}
 	}
-	return nil
+
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	return groups, roles, users, nil
 }

--- a/internal/service/iam/policy_attachment.go
+++ b/internal/service/iam/policy_attachment.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 // @SDKResource("aws_iam_policy_attachment")
@@ -29,34 +30,32 @@ func ResourcePolicyAttachment() *schema.Resource {
 		DeleteWithoutTimeout: resourcePolicyAttachmentDelete,
 
 		Schema: map[string]*schema.Schema{
+			"groups": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.NoZeroValues,
 			},
-			"users": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
+			"policy_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidARN,
 			},
 			"roles": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
 			},
-			"groups": {
+			"users": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
-			},
-			"policy_arn": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
 			},
 		},
 	}

--- a/internal/service/iam/policy_attachment.go
+++ b/internal/service/iam/policy_attachment.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 // @SDKResource("aws_iam_policy_attachment")
@@ -206,10 +207,13 @@ func composeErrors(desc string, uErr error, rErr error, gErr error) diag.Diagnos
 
 func attachPolicyToUsers(ctx context.Context, conn *iam.IAM, users []*string, arn string) error {
 	for _, u := range users {
-		_, err := conn.AttachUserPolicyWithContext(ctx, &iam.AttachUserPolicyInput{
+		input := &iam.AttachUserPolicyInput{
 			UserName:  u,
 			PolicyArn: aws.String(arn),
-		})
+		}
+		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (interface{}, error) {
+			return conn.AttachUserPolicyWithContext(ctx, input)
+		}, iam.ErrCodeConcurrentModificationException)
 		if err != nil {
 			return err
 		}
@@ -218,10 +222,13 @@ func attachPolicyToUsers(ctx context.Context, conn *iam.IAM, users []*string, ar
 }
 func attachPolicyToRoles(ctx context.Context, conn *iam.IAM, roles []*string, arn string) error {
 	for _, r := range roles {
-		_, err := conn.AttachRolePolicyWithContext(ctx, &iam.AttachRolePolicyInput{
+		input := &iam.AttachRolePolicyInput{
 			RoleName:  r,
 			PolicyArn: aws.String(arn),
-		})
+		}
+		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (interface{}, error) {
+			return conn.AttachRolePolicyWithContext(ctx, input)
+		}, iam.ErrCodeConcurrentModificationException)
 		if err != nil {
 			return err
 		}
@@ -230,10 +237,13 @@ func attachPolicyToRoles(ctx context.Context, conn *iam.IAM, roles []*string, ar
 }
 func attachPolicyToGroups(ctx context.Context, conn *iam.IAM, groups []*string, arn string) error {
 	for _, g := range groups {
-		_, err := conn.AttachGroupPolicyWithContext(ctx, &iam.AttachGroupPolicyInput{
+		input := &iam.AttachGroupPolicyInput{
 			GroupName: g,
 			PolicyArn: aws.String(arn),
-		})
+		}
+		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (interface{}, error) {
+			return conn.AttachGroupPolicyWithContext(ctx, input)
+		}, iam.ErrCodeConcurrentModificationException)
 		if err != nil {
 			return err
 		}

--- a/internal/service/iam/policy_attachment_test.go
+++ b/internal/service/iam/policy_attachment_test.go
@@ -294,7 +294,7 @@ resource "aws_iam_group" "test3" {
 }
 
 resource "aws_iam_policy" "test" {
-  name       = %[7]q
+  name        = %[7]q
   description = "A test policy"
 
   policy = <<EOF

--- a/internal/service/iam/policy_attachment_test.go
+++ b/internal/service/iam/policy_attachment_test.go
@@ -365,7 +365,7 @@ EOF
 
 resource "aws_iam_policy_attachment" "test" {
   name       = %[3]q
-  policy_arn = aws_iam_policy.policy.arn
+  policy_arn = aws_iam_policy.test.arn
 
   users = aws_iam_user.test[*].name
 }

--- a/internal/service/iam/policy_attachment_test.go
+++ b/internal/service/iam/policy_attachment_test.go
@@ -8,55 +8,75 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func TestAccIAMPolicyAttachment_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	var out iam.ListEntitiesForPolicyOutput
-
-	rString := sdkacctest.RandString(8)
-	userName := fmt.Sprintf("tf-acc-user-pa-basic-%s", rString)
-	userName2 := fmt.Sprintf("tf-acc-user-pa-basic-2-%s", rString)
-	userName3 := fmt.Sprintf("tf-acc-user-pa-basic-3-%s", rString)
-	roleName := fmt.Sprintf("tf-acc-role-pa-basic-%s", rString)
-	roleName2 := fmt.Sprintf("tf-acc-role-pa-basic-2-%s", rString)
-	roleName3 := fmt.Sprintf("tf-acc-role-pa-basic-3-%s", rString)
-	groupName := fmt.Sprintf("tf-acc-group-pa-basic-%s", rString)
-	groupName2 := fmt.Sprintf("tf-acc-group-pa-basic-2-%s", rString)
-	groupName3 := fmt.Sprintf("tf-acc-group-pa-basic-3-%s", rString)
-	policyName := fmt.Sprintf("tf-acc-policy-pa-basic-%s", rString)
-	attachmentName := fmt.Sprintf("tf-acc-attachment-pa-basic-%s", rString)
+	userName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	userName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	roleName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	roleName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	groupName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	groupName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	groupName3 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	attachmentName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_iam_policy_attachment.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, iam.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckPolicyAttachmentDestroy,
+		CheckDestroy:             testAccCheckPolicyAttachmentDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPolicyAttachmentConfig_attach(userName, roleName, groupName, policyName, attachmentName),
+				Config: testAccPolicyAttachmentConfig_attach(userName1, roleName1, roleName2, policyName, attachmentName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPolicyAttachmentExists(ctx, "aws_iam_policy_attachment.test-attach", 3, &out),
-					testAccCheckPolicyAttachmentAttributes([]string{userName}, []string{roleName}, []string{groupName}, &out),
+					testAccCheckPolicyAttachmentExists(ctx, resourceName),
+					testAccCheckPolicyAttachmentCounts(ctx, resourceName, 0, 2, 1),
 				),
 			},
 			{
-				Config: testAccPolicyAttachmentConfig_attachUpdate(userName, userName2, userName3,
-					roleName, roleName2, roleName3,
-					groupName, groupName2, groupName3,
-					policyName, attachmentName),
+				Config: testAccPolicyAttachmentConfig_attachUpdate(userName1, userName2, roleName1, groupName1, groupName2, groupName3, policyName, attachmentName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPolicyAttachmentExists(ctx, "aws_iam_policy_attachment.test-attach", 6, &out),
-					testAccCheckPolicyAttachmentAttributes([]string{userName2, userName3},
-						[]string{roleName2, roleName3}, []string{groupName2, groupName3}, &out),
+					testAccCheckPolicyAttachmentExists(ctx, resourceName),
+					testAccCheckPolicyAttachmentCounts(ctx, resourceName, 3, 1, 2),
 				),
+			},
+		},
+	})
+}
+
+func TestAccIAMPolicyAttachment_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	userName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	roleName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	roleName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	attachmentName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_iam_policy_attachment.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, iam.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPolicyAttachmentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPolicyAttachmentConfig_attach(userName1, roleName1, roleName2, policyName, attachmentName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPolicyAttachmentExists(ctx, resourceName),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfiam.ResourcePolicyAttachment(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -64,209 +84,106 @@ func TestAccIAMPolicyAttachment_basic(t *testing.T) {
 
 func TestAccIAMPolicyAttachment_paginatedEntities(t *testing.T) {
 	ctx := acctest.Context(t)
-	var out iam.ListEntitiesForPolicyOutput
-
-	rString := sdkacctest.RandString(8)
-	userNamePrefix := fmt.Sprintf("tf-acc-user-pa-pe-%s-", rString)
-	policyName := fmt.Sprintf("tf-acc-policy-pa-pe-%s-", rString)
-	attachmentName := fmt.Sprintf("tf-acc-attachment-pa-pe-%s-", rString)
+	userNamePrefix := fmt.Sprintf("%s-%s-", acctest.ResourcePrefix, sdkacctest.RandString(3))
+	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	attachmentName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_iam_policy_attachment.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, iam.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckPolicyAttachmentDestroy,
+		CheckDestroy:             testAccCheckPolicyAttachmentDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccPolicyAttachmentConfig_paginatedAttach(userNamePrefix, policyName, attachmentName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPolicyAttachmentExists(ctx, "aws_iam_policy_attachment.test-paginated-attach", 101, &out),
+					testAccCheckPolicyAttachmentExists(ctx, resourceName),
+					testAccCheckPolicyAttachmentCounts(ctx, resourceName, 0, 0, 101),
 				),
 			},
 		},
 	})
 }
 
-func TestAccIAMPolicyAttachment_Groups_renamedGroup(t *testing.T) {
-	ctx := acctest.Context(t)
-	var out iam.ListEntitiesForPolicyOutput
+func testAccCheckPolicyAttachmentDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMConn(ctx)
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	groupName1 := fmt.Sprintf("%s-1", rName)
-	groupName2 := fmt.Sprintf("%s-2", rName)
-	resourceName := "aws_iam_policy_attachment.test"
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_iam_policy_attachment" {
+				continue
+			}
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, iam.EndpointsID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckPolicyAttachmentDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccPolicyAttachmentConfig_groupsRenamedGroup(rName, groupName1),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPolicyAttachmentExists(ctx, resourceName, 1, &out),
-					testAccCheckPolicyAttachmentAttributes([]string{}, []string{}, []string{groupName1}, &out),
-				),
-			},
-			{
-				Config: testAccPolicyAttachmentConfig_groupsRenamedGroup(rName, groupName2),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPolicyAttachmentExists(ctx, resourceName, 1, &out),
-					testAccCheckPolicyAttachmentAttributes([]string{}, []string{}, []string{groupName2}, &out),
-				),
-			},
-		},
-	})
+			_, _, _, err := tfiam.FindEntitiesForPolicyByARN(ctx, conn, rs.Primary.Attributes["policy_arn"])
+
+			if tfresource.NotFound(err) {
+				continue
+			}
+
+			if err != nil {
+				return err
+			}
+
+			return fmt.Errorf("IAM Policy Attachment %s still exists", rs.Primary.ID)
+		}
+
+		return nil
+	}
 }
 
-func TestAccIAMPolicyAttachment_Roles_renamedRole(t *testing.T) {
-	ctx := acctest.Context(t)
-	var out iam.ListEntitiesForPolicyOutput
-
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	roleName1 := fmt.Sprintf("%s-1", rName)
-	roleName2 := fmt.Sprintf("%s-2", rName)
-	resourceName := "aws_iam_policy_attachment.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, iam.EndpointsID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckPolicyAttachmentDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccPolicyAttachmentConfig_rolesRenamedRole(rName, roleName1),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPolicyAttachmentExists(ctx, resourceName, 1, &out),
-					testAccCheckPolicyAttachmentAttributes([]string{}, []string{roleName1}, []string{}, &out),
-				),
-			},
-			{
-				Config: testAccPolicyAttachmentConfig_rolesRenamedRole(rName, roleName2),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPolicyAttachmentExists(ctx, resourceName, 1, &out),
-					testAccCheckPolicyAttachmentAttributes([]string{}, []string{roleName2}, []string{}, &out),
-				),
-			},
-		},
-	})
-}
-
-func TestAccIAMPolicyAttachment_Users_renamedUser(t *testing.T) {
-	ctx := acctest.Context(t)
-	var out iam.ListEntitiesForPolicyOutput
-
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	userName1 := fmt.Sprintf("%s-1", rName)
-	userName2 := fmt.Sprintf("%s-2", rName)
-	resourceName := "aws_iam_policy_attachment.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, iam.EndpointsID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckPolicyAttachmentDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccPolicyAttachmentConfig_usersRenamedUser(rName, userName1),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPolicyAttachmentExists(ctx, resourceName, 1, &out),
-					testAccCheckPolicyAttachmentAttributes([]string{userName1}, []string{}, []string{}, &out),
-				),
-			},
-			{
-				Config: testAccPolicyAttachmentConfig_usersRenamedUser(rName, userName2),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPolicyAttachmentExists(ctx, resourceName, 1, &out),
-					testAccCheckPolicyAttachmentAttributes([]string{userName2}, []string{}, []string{}, &out),
-				),
-			},
-		},
-	})
-}
-
-func testAccCheckPolicyAttachmentDestroy(s *terraform.State) error {
-	return nil
-}
-
-func testAccCheckPolicyAttachmentExists(ctx context.Context, n string, c int64, out *iam.ListEntitiesForPolicyOutput) resource.TestCheckFunc {
+func testAccCheckPolicyAttachmentExists(ctx context.Context, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No policy name is set")
+		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMConn(ctx)
+
+		_, _, _, err := tfiam.FindEntitiesForPolicyByARN(ctx, conn, rs.Primary.Attributes["policy_arn"])
+
+		return err
+	}
+}
+
+func testAccCheckPolicyAttachmentCounts(ctx context.Context, n string, wantGroups, wantRoles, wantUsers int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMConn(ctx)
-		arn := rs.Primary.Attributes["policy_arn"]
 
-		resp, err := conn.GetPolicyWithContext(ctx, &iam.GetPolicyInput{
-			PolicyArn: aws.String(arn),
-		})
+		groups, roles, users, err := tfiam.FindEntitiesForPolicyByARN(ctx, conn, rs.Primary.Attributes["policy_arn"])
+
 		if err != nil {
-			return fmt.Errorf("Error: Policy (%s) not found", n)
-		}
-		if c != *resp.Policy.AttachmentCount {
-			return fmt.Errorf("Error: Policy (%s) has wrong number of entities attached on initial creation", n)
-		}
-		resp2, err := conn.ListEntitiesForPolicyWithContext(ctx, &iam.ListEntitiesForPolicyInput{
-			PolicyArn: aws.String(arn),
-		})
-		if err != nil {
-			return fmt.Errorf("Error: Failed to get entities for Policy (%s)", arn)
+			return err
 		}
 
-		*out = *resp2
+		if got, want := len(groups), wantGroups; got != want {
+			return fmt.Errorf("GroupPolicyAttachmentCount = %v, want %v", got, want)
+		}
+		if got, want := len(roles), wantRoles; got != want {
+			return fmt.Errorf("RolePolicyAttachmentCount = %v, want %v", got, want)
+		}
+		if got, want := len(users), wantUsers; got != want {
+			return fmt.Errorf("GroupPolicyAttachmentCount = %v, want %v", got, want)
+		}
+
 		return nil
 	}
 }
 
-func testAccCheckPolicyAttachmentAttributes(users []string, roles []string, groups []string, out *iam.ListEntitiesForPolicyOutput) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		uc := len(users)
-		rc := len(roles)
-		gc := len(groups)
-
-		for _, u := range users {
-			for _, pu := range out.PolicyUsers {
-				if u == *pu.UserName {
-					uc--
-				}
-			}
-		}
-		for _, r := range roles {
-			for _, pr := range out.PolicyRoles {
-				if r == *pr.RoleName {
-					rc--
-				}
-			}
-		}
-		for _, g := range groups {
-			for _, pg := range out.PolicyGroups {
-				if g == *pg.GroupName {
-					gc--
-				}
-			}
-		}
-		if uc != 0 || rc != 0 || gc != 0 {
-			return fmt.Errorf("Error: Number of attached users, roles, or groups was incorrect:\n expected %d users and found %d\nexpected %d roles and found %d\nexpected %d groups and found %d", len(users), len(users)-uc, len(roles), len(roles)-rc, len(groups), len(groups)-gc)
-		}
-		return nil
-	}
-}
-
-func testAccPolicyAttachmentConfig_attach(userName, roleName, groupName, policyName, attachmentName string) string {
+func testAccPolicyAttachmentConfig_attach(userName1, roleName1, roleName2, policyName, attachmentName string) string {
 	return fmt.Sprintf(`
-resource "aws_iam_user" "user" {
-  name = "%s"
+resource "aws_iam_user" "test1" {
+  name = %[1]q
 }
 
-resource "aws_iam_role" "role" {
-  name = "%s"
+resource "aws_iam_role" "test1" {
+  name = %[2]q
 
   assume_role_policy = <<EOF
 {
@@ -285,12 +202,28 @@ resource "aws_iam_role" "role" {
 EOF
 }
 
-resource "aws_iam_group" "group" {
-  name = "%s"
+resource "aws_iam_role" "test2" {
+  name = %[3]q
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
 }
 
-resource "aws_iam_policy" "policy" {
-  name        = "%s"
+resource "aws_iam_policy" "test" {
+  name        = %[4]q
   description = "A test policy"
 
   policy = <<EOF
@@ -309,35 +242,27 @@ resource "aws_iam_policy" "policy" {
 EOF
 }
 
-resource "aws_iam_policy_attachment" "test-attach" {
-  name       = "%s"
-  users      = [aws_iam_user.user.name]
-  roles      = [aws_iam_role.role.name]
-  groups     = [aws_iam_group.group.name]
-  policy_arn = aws_iam_policy.policy.arn
+resource "aws_iam_policy_attachment" "test" {
+  name       = %[5]q
+  users      = [aws_iam_user.test1.name]
+  roles      = [aws_iam_role.test1.name, aws_iam_role.test2.name]
+  policy_arn = aws_iam_policy.test.arn
 }
-`, userName, roleName, groupName, policyName, attachmentName)
+`, userName1, roleName1, roleName2, policyName, attachmentName)
 }
 
-func testAccPolicyAttachmentConfig_attachUpdate(userName, userName2, userName3,
-	roleName, roleName2, roleName3,
-	groupName, groupName2, groupName3,
-	policyName, attachmentName string) string {
+func testAccPolicyAttachmentConfig_attachUpdate(userName1, userName2, roleName1, groupName1, groupName2, groupName3, policyName, attachmentName string) string {
 	return fmt.Sprintf(`
-resource "aws_iam_user" "user" {
-  name = "%s"
+resource "aws_iam_user" "test1" {
+  name = %[1]q
 }
 
-resource "aws_iam_user" "user2" {
-  name = "%s"
+resource "aws_iam_user" "test2" {
+  name = %[2]q
 }
 
-resource "aws_iam_user" "user3" {
-  name = "%s"
-}
-
-resource "aws_iam_role" "role" {
-  name = "%s"
+resource "aws_iam_role" "test1" {
+  name = %[3]q
 
   assume_role_policy = <<EOF
 {
@@ -356,60 +281,20 @@ resource "aws_iam_role" "role" {
 EOF
 }
 
-resource "aws_iam_role" "role2" {
-  name = "%s"
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "ec2.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
+resource "aws_iam_group" "test1" {
+  name = %[4]q
 }
 
-resource "aws_iam_role" "role3" {
-  name = "%s"
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "ec2.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
+resource "aws_iam_group" "test2" {
+  name = %[5]q
 }
 
-resource "aws_iam_group" "group" {
-  name = "%s"
+resource "aws_iam_group" "test3" {
+  name = %[6]q
 }
 
-resource "aws_iam_group" "group2" {
-  name = "%s"
-}
-
-resource "aws_iam_group" "group3" {
-  name = "%s"
-}
-
-resource "aws_iam_policy" "policy" {
-  name        = "%s"
+resource "aws_iam_policy" "test" {
+  name       = %[7]q
   description = "A test policy"
 
   policy = <<EOF
@@ -428,41 +313,38 @@ resource "aws_iam_policy" "policy" {
 EOF
 }
 
-resource "aws_iam_policy_attachment" "test-attach" {
-  name = "%s"
+resource "aws_iam_policy_attachment" "test" {
+  name = %[8]q
 
   users = [
-    aws_iam_user.user2.name,
-    aws_iam_user.user3.name,
+    aws_iam_user.test1.name,
+    aws_iam_user.test2.name,
   ]
 
   roles = [
-    aws_iam_role.role2.name,
-    aws_iam_role.role3.name,
+    aws_iam_role.test1.name,
   ]
 
   groups = [
-    aws_iam_group.group2.name,
-    aws_iam_group.group3.name,
+    aws_iam_group.test1.name,
+    aws_iam_group.test2.name,
+    aws_iam_group.test3.name,
   ]
 
-  policy_arn = aws_iam_policy.policy.arn
+  policy_arn = aws_iam_policy.test.arn
 }
-`, userName, userName2, userName3,
-		roleName, roleName2, roleName3,
-		groupName, groupName2, groupName3,
-		policyName, attachmentName)
+`, userName1, userName2, roleName1, groupName1, groupName2, groupName3, policyName, attachmentName)
 }
 
 func testAccPolicyAttachmentConfig_paginatedAttach(userNamePrefix, policyName, attachmentName string) string {
 	return fmt.Sprintf(`
-resource "aws_iam_user" "user" {
+resource "aws_iam_user" "test" {
   count = 101
-  name  = format("%s%%d", count.index + 1)
+  name  = format("%[1]s%%d", count.index + 1)
 }
 
-resource "aws_iam_policy" "policy" {
-  name        = "%s"
+resource "aws_iam_policy" "test" {
+  name        = %[2]q
   description = "A test policy"
 
   policy = <<EOF
@@ -481,225 +363,11 @@ resource "aws_iam_policy" "policy" {
 EOF
 }
 
-resource "aws_iam_policy_attachment" "test-paginated-attach" {
-  name       = "%s"
+resource "aws_iam_policy_attachment" "test" {
+  name       = %[3]q
   policy_arn = aws_iam_policy.policy.arn
 
-  # TODO: Switch back to simple list reference when test configurations are upgraded to 0.12 syntax
-  users = [
-    aws_iam_user.user[0].name,
-    aws_iam_user.user[1].name,
-    aws_iam_user.user[2].name,
-    aws_iam_user.user[3].name,
-    aws_iam_user.user[4].name,
-    aws_iam_user.user[5].name,
-    aws_iam_user.user[6].name,
-    aws_iam_user.user[7].name,
-    aws_iam_user.user[8].name,
-    aws_iam_user.user[9].name,
-    aws_iam_user.user[10].name,
-    aws_iam_user.user[11].name,
-    aws_iam_user.user[12].name,
-    aws_iam_user.user[13].name,
-    aws_iam_user.user[14].name,
-    aws_iam_user.user[15].name,
-    aws_iam_user.user[16].name,
-    aws_iam_user.user[17].name,
-    aws_iam_user.user[18].name,
-    aws_iam_user.user[19].name,
-    aws_iam_user.user[20].name,
-    aws_iam_user.user[21].name,
-    aws_iam_user.user[22].name,
-    aws_iam_user.user[23].name,
-    aws_iam_user.user[24].name,
-    aws_iam_user.user[25].name,
-    aws_iam_user.user[26].name,
-    aws_iam_user.user[27].name,
-    aws_iam_user.user[28].name,
-    aws_iam_user.user[29].name,
-    aws_iam_user.user[30].name,
-    aws_iam_user.user[31].name,
-    aws_iam_user.user[32].name,
-    aws_iam_user.user[33].name,
-    aws_iam_user.user[34].name,
-    aws_iam_user.user[35].name,
-    aws_iam_user.user[36].name,
-    aws_iam_user.user[37].name,
-    aws_iam_user.user[38].name,
-    aws_iam_user.user[39].name,
-    aws_iam_user.user[40].name,
-    aws_iam_user.user[41].name,
-    aws_iam_user.user[42].name,
-    aws_iam_user.user[43].name,
-    aws_iam_user.user[44].name,
-    aws_iam_user.user[45].name,
-    aws_iam_user.user[46].name,
-    aws_iam_user.user[47].name,
-    aws_iam_user.user[48].name,
-    aws_iam_user.user[49].name,
-    aws_iam_user.user[50].name,
-    aws_iam_user.user[51].name,
-    aws_iam_user.user[52].name,
-    aws_iam_user.user[53].name,
-    aws_iam_user.user[54].name,
-    aws_iam_user.user[55].name,
-    aws_iam_user.user[56].name,
-    aws_iam_user.user[57].name,
-    aws_iam_user.user[58].name,
-    aws_iam_user.user[59].name,
-    aws_iam_user.user[60].name,
-    aws_iam_user.user[61].name,
-    aws_iam_user.user[62].name,
-    aws_iam_user.user[63].name,
-    aws_iam_user.user[64].name,
-    aws_iam_user.user[65].name,
-    aws_iam_user.user[66].name,
-    aws_iam_user.user[67].name,
-    aws_iam_user.user[68].name,
-    aws_iam_user.user[69].name,
-    aws_iam_user.user[70].name,
-    aws_iam_user.user[71].name,
-    aws_iam_user.user[72].name,
-    aws_iam_user.user[73].name,
-    aws_iam_user.user[74].name,
-    aws_iam_user.user[75].name,
-    aws_iam_user.user[76].name,
-    aws_iam_user.user[77].name,
-    aws_iam_user.user[78].name,
-    aws_iam_user.user[79].name,
-    aws_iam_user.user[80].name,
-    aws_iam_user.user[81].name,
-    aws_iam_user.user[82].name,
-    aws_iam_user.user[83].name,
-    aws_iam_user.user[84].name,
-    aws_iam_user.user[85].name,
-    aws_iam_user.user[86].name,
-    aws_iam_user.user[87].name,
-    aws_iam_user.user[88].name,
-    aws_iam_user.user[89].name,
-    aws_iam_user.user[90].name,
-    aws_iam_user.user[91].name,
-    aws_iam_user.user[92].name,
-    aws_iam_user.user[93].name,
-    aws_iam_user.user[94].name,
-    aws_iam_user.user[95].name,
-    aws_iam_user.user[96].name,
-    aws_iam_user.user[97].name,
-    aws_iam_user.user[98].name,
-    aws_iam_user.user[99].name,
-    aws_iam_user.user[100].name,
-  ]
+  users = aws_iam_user.test[*].name
 }
 `, userNamePrefix, policyName, attachmentName)
-}
-
-func testAccPolicyAttachmentConfig_groupsRenamedGroup(rName, groupName string) string {
-	return fmt.Sprintf(`
-resource "aws_iam_policy" "test" {
-  name = %[1]q
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "*",
-      "Effect": "Allow",
-      "Resource": "*"
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_group" "test" {
-  name = %[2]q
-}
-
-resource "aws_iam_policy_attachment" "test" {
-  groups     = [aws_iam_group.test.name]
-  name       = %[1]q
-  policy_arn = aws_iam_policy.test.arn
-}
-`, rName, groupName)
-}
-
-func testAccPolicyAttachmentConfig_rolesRenamedRole(rName, roleName string) string {
-	return fmt.Sprintf(`
-resource "aws_iam_policy" "test" {
-  name = %[1]q
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "*",
-      "Effect": "Allow",
-      "Resource": "*"
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_role" "test" {
-  force_detach_policies = true
-  name                  = %[2]q
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "ec2.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_policy_attachment" "test" {
-  name       = %[1]q
-  policy_arn = aws_iam_policy.test.arn
-  roles      = [aws_iam_role.test.name]
-}
-`, rName, roleName)
-}
-
-func testAccPolicyAttachmentConfig_usersRenamedUser(rName, userName string) string {
-	return fmt.Sprintf(`
-resource "aws_iam_policy" "test" {
-  name = %[1]q
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "*",
-      "Effect": "Allow",
-      "Resource": "*"
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_user" "test" {
-  force_destroy = true
-  name          = %[2]q
-}
-
-resource "aws_iam_policy_attachment" "test" {
-  name       = %[1]q
-  policy_arn = aws_iam_policy.test.arn
-  users      = [aws_iam_user.test.name]
-}
-`, rName, userName)
 }

--- a/internal/service/iam/policy_data_source.go
+++ b/internal/service/iam/policy_data_source.go
@@ -87,7 +87,7 @@ func dataSourcePolicyRead(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	// We need to make a call to `iam.GetPolicy` because `iam.ListPolicies` doesn't return all values
-	policy, err := FindPolicyByARN(ctx, conn, arn)
+	policy, err := findPolicyByARN(ctx, conn, arn)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading IAM Policy (%s): %s", arn, err)

--- a/internal/service/iam/role.go
+++ b/internal/service/iam/role.go
@@ -870,16 +870,15 @@ func addRoleInlinePolicies(ctx context.Context, policies []*iam.PutRolePolicyInp
 
 func addRoleManagedPolicies(ctx context.Context, roleName string, policies []*string, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).IAMConn(ctx)
+	var errs []error
 
-	var errs *multierror.Error
 	for _, arn := range policies {
 		if err := attachPolicyToRole(ctx, conn, roleName, aws.StringValue(arn)); err != nil {
-			newErr := fmt.Errorf("attaching managed policy (%s): %w", aws.StringValue(arn), err)
-			errs = multierror.Append(errs, newErr)
+			errs = append(errs, err)
 		}
 	}
 
-	return errs.ErrorOrNil()
+	return errors.Join(errs...)
 }
 
 func readRoleInlinePolicies(ctx context.Context, roleName string, meta interface{}) ([]*iam.PutRolePolicyInput, error) {

--- a/internal/service/iam/role_policy_attachment.go
+++ b/internal/service/iam/role_policy_attachment.go
@@ -138,8 +138,8 @@ func attachPolicyToRole(ctx context.Context, conn *iam.IAM, role, policyARN stri
 func detachPolicyFromRole(ctx context.Context, conn *iam.IAM, role, policyARN string) error {
 	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (interface{}, error) {
 		return conn.DetachRolePolicyWithContext(ctx, &iam.DetachRolePolicyInput{
-			RoleName:  aws.String(role),
 			PolicyArn: aws.String(policyARN),
+			RoleName:  aws.String(role),
 		})
 	}, iam.ErrCodeConcurrentModificationException)
 

--- a/internal/service/iam/role_policy_attachment.go
+++ b/internal/service/iam/role_policy_attachment.go
@@ -157,10 +157,12 @@ func resourceRolePolicyAttachmentImport(ctx context.Context, d *schema.ResourceD
 }
 
 func attachPolicyToRole(ctx context.Context, conn *iam.IAM, role string, arn string) error {
-	_, err := conn.AttachRolePolicyWithContext(ctx, &iam.AttachRolePolicyInput{
-		RoleName:  aws.String(role),
-		PolicyArn: aws.String(arn),
-	})
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (interface{}, error) {
+		return conn.AttachRolePolicyWithContext(ctx, &iam.AttachRolePolicyInput{
+			RoleName:  aws.String(role),
+			PolicyArn: aws.String(arn),
+		})
+	}, iam.ErrCodeConcurrentModificationException)
 	return err
 }
 

--- a/internal/service/iam/role_policy_attachment.go
+++ b/internal/service/iam/role_policy_attachment.go
@@ -18,12 +18,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-// @SDKResource("aws_iam_role_policy_attachment")
-func ResourceRolePolicyAttachment() *schema.Resource {
+// @SDKResource("aws_iam_role_policy_attachment", name="Role Policy Attachment")
+func resourceRolePolicyAttachment() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceRolePolicyAttachmentCreate,
 		ReadWithoutTimeout:   resourceRolePolicyAttachmentRead,
@@ -54,11 +55,10 @@ func resourceRolePolicyAttachmentCreate(ctx context.Context, d *schema.ResourceD
 	conn := meta.(*conns.AWSClient).IAMConn(ctx)
 
 	role := d.Get("role").(string)
-	arn := d.Get("policy_arn").(string)
+	policyARN := d.Get("policy_arn").(string)
 
-	err := attachPolicyToRole(ctx, conn, role, arn)
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "attaching policy %s to IAM Role %s: %v", arn, role, err)
+	if err := attachPolicyToRole(ctx, conn, role, policyARN); err != nil {
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	//lintignore:R016 // Allow legacy unstable ID usage in managed resource
@@ -70,57 +70,25 @@ func resourceRolePolicyAttachmentCreate(ctx context.Context, d *schema.ResourceD
 func resourceRolePolicyAttachmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMConn(ctx)
+
 	role := d.Get("role").(string)
 	policyARN := d.Get("policy_arn").(string)
-	// Human friendly ID for error messages since d.Id() is non-descriptive
+	// Human friendly ID for error messages since d.Id() is non-descriptive.
 	id := fmt.Sprintf("%s:%s", role, policyARN)
 
-	var hasPolicyAttachment bool
+	_, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
+		return findAttachedRolePolicyByTwoPartKey(ctx, conn, role, policyARN)
+	}, d.IsNewResource())
 
-	err := retry.RetryContext(ctx, propagationTimeout, func() *retry.RetryError {
-		var err error
-
-		hasPolicyAttachment, err = RoleHasPolicyARNAttachment(ctx, conn, role, policyARN)
-
-		if d.IsNewResource() && tfawserr.ErrCodeEquals(err, iam.ErrCodeNoSuchEntityException) {
-			return retry.RetryableError(err)
-		}
-
-		if err != nil {
-			return retry.NonRetryableError(err)
-		}
-
-		if d.IsNewResource() && !hasPolicyAttachment {
-			return retry.RetryableError(&retry.NotFoundError{
-				LastError: fmt.Errorf("IAM Role Managed Policy Attachment (%s) not found", id),
-			})
-		}
-
-		return nil
-	})
-
-	if tfresource.TimedOut(err) {
-		hasPolicyAttachment, err = RoleHasPolicyARNAttachment(ctx, conn, role, policyARN)
-	}
-
-	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, iam.ErrCodeNoSuchEntityException) {
-		log.Printf("[WARN] IAM Role Managed Policy Attachment (%s) not found, removing from state", id)
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] IAM Role Policy Attachment (%s) not found, removing from state", id)
 		d.SetId("")
 		return diags
 	}
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "reading IAM Role Managed Policy Attachment (%s): %s", id, err)
+		return sdkdiag.AppendErrorf(diags, "reading IAM Role Policy Attachment (%s): %s", id, err)
 	}
-
-	if !d.IsNewResource() && !hasPolicyAttachment {
-		log.Printf("[WARN] IAM Role Managed Policy Attachment (%s) not found, removing from state", id)
-		d.SetId("")
-		return diags
-	}
-
-	d.Set("policy_arn", policyARN)
-	d.Set("role", role)
 
 	return diags
 }
@@ -128,18 +96,11 @@ func resourceRolePolicyAttachmentRead(ctx context.Context, d *schema.ResourceDat
 func resourceRolePolicyAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMConn(ctx)
-	role := d.Get("role").(string)
-	arn := d.Get("policy_arn").(string)
 
-	err := DetachPolicyFromRole(ctx, conn, role, arn)
-
-	if tfawserr.ErrCodeEquals(err, iam.ErrCodeNoSuchEntityException) {
-		return diags
+	if err := detachPolicyFromRole(ctx, conn, d.Get("role").(string), d.Get("policy_arn").(string)); err != nil {
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "removing policy %s from IAM Role %s: %v", arn, role, err)
-	}
 	return diags
 }
 
@@ -159,40 +120,87 @@ func resourceRolePolicyAttachmentImport(ctx context.Context, d *schema.ResourceD
 	return []*schema.ResourceData{d}, nil
 }
 
-func attachPolicyToRole(ctx context.Context, conn *iam.IAM, role string, arn string) error {
+func attachPolicyToRole(ctx context.Context, conn *iam.IAM, role, policyARN string) error {
 	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (interface{}, error) {
 		return conn.AttachRolePolicyWithContext(ctx, &iam.AttachRolePolicyInput{
+			PolicyArn: aws.String(policyARN),
 			RoleName:  aws.String(role),
-			PolicyArn: aws.String(arn),
 		})
 	}, iam.ErrCodeConcurrentModificationException)
-	return err
-}
 
-func DetachPolicyFromRole(ctx context.Context, conn *iam.IAM, role string, arn string) error {
-	_, err := conn.DetachRolePolicyWithContext(ctx, &iam.DetachRolePolicyInput{
-		RoleName:  aws.String(role),
-		PolicyArn: aws.String(arn),
-	})
-	return err
-}
-
-func RoleHasPolicyARNAttachment(ctx context.Context, conn *iam.IAM, role string, policyARN string) (bool, error) {
-	hasPolicyAttachment := false
-	input := &iam.ListAttachedRolePoliciesInput{
-		RoleName: aws.String(role),
+	if err != nil {
+		return fmt.Errorf("attaching IAM Policy (%s) to IAM Role (%s): %w", policyARN, role, err)
 	}
 
+	return nil
+}
+
+func detachPolicyFromRole(ctx context.Context, conn *iam.IAM, role, policyARN string) error {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (interface{}, error) {
+		return conn.DetachRolePolicyWithContext(ctx, &iam.DetachRolePolicyInput{
+			RoleName:  aws.String(role),
+			PolicyArn: aws.String(policyARN),
+		})
+	}, iam.ErrCodeConcurrentModificationException)
+
+	if tfawserr.ErrCodeEquals(err, iam.ErrCodeNoSuchEntityException) {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("detaching IAM Policy (%s) from IAM Role (%s): %w", policyARN, role, err)
+	}
+
+	return nil
+}
+
+func findAttachedRolePolicyByTwoPartKey(ctx context.Context, conn *iam.IAM, roleName, policyARN string) (*iam.AttachedPolicy, error) {
+	input := &iam.ListAttachedRolePoliciesInput{
+		RoleName: aws.String(roleName),
+	}
+
+	return findAttachedRolePolicy(ctx, conn, input, func(v *iam.AttachedPolicy) bool {
+		return aws.StringValue(v.PolicyArn) == policyARN
+	})
+}
+
+func findAttachedRolePolicy(ctx context.Context, conn *iam.IAM, input *iam.ListAttachedRolePoliciesInput, filter tfslices.Predicate[*iam.AttachedPolicy]) (*iam.AttachedPolicy, error) {
+	output, err := findAttachedRolePolicies(ctx, conn, input, filter)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfresource.AssertSinglePtrResult(output)
+}
+
+func findAttachedRolePolicies(ctx context.Context, conn *iam.IAM, input *iam.ListAttachedRolePoliciesInput, filter tfslices.Predicate[*iam.AttachedPolicy]) ([]*iam.AttachedPolicy, error) {
+	var output []*iam.AttachedPolicy
+
 	err := conn.ListAttachedRolePoliciesPagesWithContext(ctx, input, func(page *iam.ListAttachedRolePoliciesOutput, lastPage bool) bool {
-		for _, p := range page.AttachedPolicies {
-			if aws.StringValue(p.PolicyArn) == policyARN {
-				hasPolicyAttachment = true
-				return false
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, v := range page.AttachedPolicies {
+			if v != nil && filter(v) {
+				output = append(output, v)
 			}
 		}
 
 		return !lastPage
 	})
 
-	return hasPolicyAttachment, err
+	if tfawserr.ErrCodeEquals(err, iam.ErrCodeNoSuchEntityException) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return output, nil
 }

--- a/internal/service/iam/role_policy_attachment.go
+++ b/internal/service/iam/role_policy_attachment.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 // @SDKResource("aws_iam_role_policy_attachment")
@@ -27,17 +28,19 @@ func ResourceRolePolicyAttachment() *schema.Resource {
 		CreateWithoutTimeout: resourceRolePolicyAttachmentCreate,
 		ReadWithoutTimeout:   resourceRolePolicyAttachmentRead,
 		DeleteWithoutTimeout: resourceRolePolicyAttachmentDelete,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceRolePolicyAttachmentImport,
 		},
 
 		Schema: map[string]*schema.Schema{
-			"role": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
 			"policy_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidARN,
+			},
+			"role": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,

--- a/internal/service/iam/role_policy_attachment_test.go
+++ b/internal/service/iam/role_policy_attachment_test.go
@@ -6,28 +6,28 @@ package iam_test
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/iam"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func TestAccIAMRolePolicyAttachment_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	var out iam.ListAttachedRolePoliciesOutput
-	rInt := sdkacctest.RandInt()
-	testPolicy := fmt.Sprintf("tf-acctest-%d", rInt)
-	testPolicy2 := fmt.Sprintf("tf-acctest2-%d", rInt)
-	testPolicy3 := fmt.Sprintf("tf-acctest3-%d", rInt)
+	roleName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	policyName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	policyName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	policyName3 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_iam_role_policy_attachment.test1"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -36,16 +36,16 @@ func TestAccIAMRolePolicyAttachment_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckRolePolicyAttachmentDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRolePolicyAttachmentConfig_attach(rInt),
+				Config: testAccRolePolicyAttachmentConfig_attach(roleName, policyName1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRolePolicyAttachmentExists(ctx, "aws_iam_role_policy_attachment.test-attach", 1, &out),
-					testAccCheckRolePolicyAttachmentAttributes([]string{testPolicy}, &out),
+					testAccCheckRolePolicyAttachmentExists(ctx, resourceName),
+					testAccCheckRolePolicyAttachmentCount(ctx, roleName, 1),
 				),
 			},
 			{
-				ResourceName:      "aws_iam_role_policy_attachment.test-attach",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccRolePolicyAttachmentImportStateIdFunc("aws_iam_role_policy_attachment.test-attach"),
+				ImportStateIdFunc: testAccRolePolicyAttachmentImportStateIdFunc(resourceName),
 				// We do not have a way to align IDs since the Create function uses id.PrefixedUniqueId()
 				// Failed state verification, resource with ID ROLE-POLICYARN not found
 				// ImportStateVerify: true,
@@ -64,10 +64,10 @@ func TestAccIAMRolePolicyAttachment_basic(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccRolePolicyAttachmentConfig_attachUpdate(rInt),
+				Config: testAccRolePolicyAttachmentConfig_attachUpdate(roleName, policyName1, policyName2, policyName3),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRolePolicyAttachmentExists(ctx, "aws_iam_role_policy_attachment.test-attach", 2, &out),
-					testAccCheckRolePolicyAttachmentAttributes([]string{testPolicy2, testPolicy3}, &out),
+					testAccCheckRolePolicyAttachmentExists(ctx, resourceName),
+					testAccCheckRolePolicyAttachmentCount(ctx, roleName, 2),
 				),
 			},
 		},
@@ -76,10 +76,9 @@ func TestAccIAMRolePolicyAttachment_basic(t *testing.T) {
 
 func TestAccIAMRolePolicyAttachment_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	var attachedRolePolicies iam.ListAttachedRolePoliciesOutput
-
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_iam_role_policy_attachment.test"
+	roleName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_iam_role_policy_attachment.test1"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -88,10 +87,10 @@ func TestAccIAMRolePolicyAttachment_disappears(t *testing.T) {
 		CheckDestroy:             testAccCheckRolePolicyAttachmentDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRolePolicyAttachmentConfig_basic(rName),
+				Config: testAccRolePolicyAttachmentConfig_attach(roleName, policyName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRolePolicyAttachmentExists(ctx, resourceName, 1, &attachedRolePolicies),
-					testAccCheckRolePolicyAttachmentDisappears(ctx, resourceName),
+					testAccCheckRolePolicyAttachmentExists(ctx, resourceName),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfiam.ResourceRolePolicyAttachment(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -101,12 +100,10 @@ func TestAccIAMRolePolicyAttachment_disappears(t *testing.T) {
 
 func TestAccIAMRolePolicyAttachment_Disappears_role(t *testing.T) {
 	ctx := acctest.Context(t)
-	var attachedRolePolicies iam.ListAttachedRolePoliciesOutput
-	var role iam.Role
-
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	roleName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_iam_role_policy_attachment.test1"
 	iamRoleResourceName := "aws_iam_role.test"
-	resourceName := "aws_iam_role_policy_attachment.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -115,12 +112,11 @@ func TestAccIAMRolePolicyAttachment_Disappears_role(t *testing.T) {
 		CheckDestroy:             testAccCheckRolePolicyAttachmentDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRolePolicyAttachmentConfig_basic(rName),
+				Config: testAccRolePolicyAttachmentConfig_attach(roleName, policyName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoleExists(ctx, iamRoleResourceName, &role),
-					testAccCheckRolePolicyAttachmentExists(ctx, resourceName, 1, &attachedRolePolicies),
+					testAccCheckRolePolicyAttachmentExists(ctx, resourceName),
 					// DeleteConflict: Cannot delete entity, must detach all policies first.
-					testAccCheckRolePolicyAttachmentDisappears(ctx, resourceName),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfiam.ResourceRolePolicyAttachment(), resourceName),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfiam.ResourceRole(), iamRoleResourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -138,12 +134,9 @@ func testAccCheckRolePolicyAttachmentDestroy(ctx context.Context) resource.TestC
 				continue
 			}
 
-			policyARN := rs.Primary.Attributes["policy_arn"]
-			role := rs.Primary.Attributes["role"]
+			_, err := tfiam.FindAttachedRolePolicyByTwoPartKey(ctx, conn, rs.Primary.Attributes["role"], rs.Primary.Attributes["policy_arn"])
 
-			hasPolicyAttachment, err := tfiam.RoleHasPolicyARNAttachment(ctx, conn, role, policyARN)
-
-			if tfawserr.ErrCodeEquals(err, iam.ErrCodeNoSuchEntityException) {
+			if tfresource.NotFound(err) {
 				continue
 			}
 
@@ -151,78 +144,46 @@ func testAccCheckRolePolicyAttachmentDestroy(ctx context.Context) resource.TestC
 				return err
 			}
 
-			if hasPolicyAttachment {
-				return fmt.Errorf("IAM Role (%s) Policy Attachment (%s) still exists", role, policyARN)
-			}
+			return fmt.Errorf("IAM Role Policy Attachment %s still exists", rs.Primary.ID)
 		}
 
 		return nil
 	}
 }
 
-func testAccCheckRolePolicyAttachmentExists(ctx context.Context, n string, c int, out *iam.ListAttachedRolePoliciesOutput) resource.TestCheckFunc {
+func testAccCheckRolePolicyAttachmentExists(ctx context.Context, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No policy name is set")
-		}
-
 		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMConn(ctx)
-		role := rs.Primary.Attributes["role"]
 
-		attachedPolicies, err := conn.ListAttachedRolePoliciesWithContext(ctx, &iam.ListAttachedRolePoliciesInput{
-			RoleName: aws.String(role),
-		})
+		_, err := tfiam.FindAttachedRolePolicyByTwoPartKey(ctx, conn, rs.Primary.Attributes["role"], rs.Primary.Attributes["policy_arn"])
+
+		return err
+	}
+}
+
+func testAccCheckRolePolicyAttachmentCount(ctx context.Context, roleName string, want int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMConn(ctx)
+
+		input := &iam.ListAttachedRolePoliciesInput{
+			RoleName: aws.String(roleName),
+		}
+		output, err := tfiam.FindAttachedRolePolicies(ctx, conn, input, tfslices.PredicateTrue[*iam.AttachedPolicy]())
+
 		if err != nil {
-			return fmt.Errorf("Error: Failed to get attached policies for role %s (%s)", role, n)
-		}
-		if c != len(attachedPolicies.AttachedPolicies) {
-			return fmt.Errorf("Error: Role (%s) has wrong number of policies attached on initial creation", n)
+			return err
 		}
 
-		*out = *attachedPolicies
-		return nil
-	}
-}
-
-func testAccCheckRolePolicyAttachmentAttributes(policies []string, out *iam.ListAttachedRolePoliciesOutput) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		matched := 0
-
-		for _, p := range policies {
-			for _, ap := range out.AttachedPolicies {
-				// *ap.PolicyArn like arn:aws:iam::111111111111:policy/test-policy
-				parts := strings.Split(*ap.PolicyArn, "/")
-				if len(parts) == 2 && p == parts[1] {
-					matched++
-				}
-			}
-		}
-		if matched != len(policies) || matched != len(out.AttachedPolicies) {
-			return fmt.Errorf("Error: Number of attached policies was incorrect: expected %d matched policies, matched %d of %d", len(policies), matched, len(out.AttachedPolicies))
-		}
-		return nil
-	}
-}
-
-func testAccCheckRolePolicyAttachmentDisappears(ctx context.Context, resourceName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMConn(ctx)
-
-		rs, ok := s.RootModule().Resources[resourceName]
-
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
+		if got := len(output); got != want {
+			return fmt.Errorf("RolePolicyAttachmentCount(%q) = %v, want %v", roleName, got, want)
 		}
 
-		policyARN := rs.Primary.Attributes["policy_arn"]
-		role := rs.Primary.Attributes["role"]
-
-		return tfiam.DetachPolicyFromRole(ctx, conn, role, policyARN)
+		return err
 	}
 }
 
@@ -237,153 +198,8 @@ func testAccRolePolicyAttachmentImportStateIdFunc(resourceName string) resource.
 	}
 }
 
-func testAccRolePolicyAttachmentConfig_attach(rInt int) string {
+func testAccRolePolicyAttachmentConfig_attach(roleName, policyName string) string {
 	return fmt.Sprintf(`
-resource "aws_iam_role" "role" {
-  name = "test-role-%d"
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "ec2.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_policy" "policy" {
-  name        = "tf-acctest-%d"
-  description = "A test policy"
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "iam:ChangePassword"
-      ],
-      "Resource": "*",
-      "Effect": "Allow"
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_role_policy_attachment" "test-attach" {
-  role       = aws_iam_role.role.name
-  policy_arn = aws_iam_policy.policy.arn
-}
-`, rInt, rInt)
-}
-
-func testAccRolePolicyAttachmentConfig_attachUpdate(rInt int) string {
-	return fmt.Sprintf(`
-resource "aws_iam_role" "role" {
-  name = "test-role-%d"
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "ec2.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_policy" "policy" {
-  name        = "tf-acctest-%d"
-  description = "A test policy"
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "iam:ChangePassword"
-      ],
-      "Resource": "*",
-      "Effect": "Allow"
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_policy" "policy2" {
-  name        = "tf-acctest2-%d"
-  description = "A test policy"
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "iam:ChangePassword"
-      ],
-      "Resource": "*",
-      "Effect": "Allow"
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_policy" "policy3" {
-  name        = "tf-acctest3-%d"
-  description = "A test policy"
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "iam:ChangePassword"
-      ],
-      "Resource": "*",
-      "Effect": "Allow"
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_role_policy_attachment" "test-attach" {
-  role       = aws_iam_role.role.name
-  policy_arn = aws_iam_policy.policy2.arn
-}
-
-resource "aws_iam_role_policy_attachment" "test-attach2" {
-  role       = aws_iam_role.role.name
-  policy_arn = aws_iam_policy.policy3.arn
-}
-`, rInt, rInt, rInt, rInt)
-}
-
-func testAccRolePolicyAttachmentConfig_basic(rName string) string {
-	return fmt.Sprintf(`
-data "aws_partition" "current" {}
-
 resource "aws_iam_role" "test" {
   name = %[1]q
 
@@ -404,9 +220,123 @@ resource "aws_iam_role" "test" {
 EOF
 }
 
-resource "aws_iam_role_policy_attachment" "test" {
-  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AdministratorAccess"
-  role       = aws_iam_role.test.name
+resource "aws_iam_policy" "test1" {
+  name        = %[2]q
+  description = "A test policy"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "iam:ChangePassword"
+      ],
+      "Resource": "*",
+      "Effect": "Allow"
+    }
+  ]
 }
-`, rName)
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "test1" {
+  role       = aws_iam_role.test.name
+  policy_arn = aws_iam_policy.test1.arn
+}
+`, roleName, policyName)
+}
+
+func testAccRolePolicyAttachmentConfig_attachUpdate(roleName, policyName1, policyName2, policyName3 string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  name = %[1]q
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "test1" {
+  name        = %[2]q
+  description = "A test policy"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "iam:ChangePassword"
+      ],
+      "Resource": "*",
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "test2" {
+  name        = %[3]q
+  description = "A test policy"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "iam:ChangePassword"
+      ],
+      "Resource": "*",
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "test3" {
+  name        = %[4]q
+  description = "A test policy"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "iam:ChangePassword"
+      ],
+      "Resource": "*",
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "test1" {
+  role       = aws_iam_role.test.name
+  policy_arn = aws_iam_policy.test2.arn
+}
+
+resource "aws_iam_role_policy_attachment" "test2" {
+  role       = aws_iam_role.test.name
+  policy_arn = aws_iam_policy.test3.arn
+}
+`, roleName, policyName1, policyName2, policyName3)
 }

--- a/internal/service/iam/role_policy_attachment_test.go
+++ b/internal/service/iam/role_policy_attachment_test.go
@@ -183,7 +183,7 @@ func testAccCheckRolePolicyAttachmentCount(ctx context.Context, roleName string,
 			return fmt.Errorf("RolePolicyAttachmentCount(%q) = %v, want %v", roleName, got, want)
 		}
 
-		return err
+		return nil
 	}
 }
 

--- a/internal/service/iam/service_package_gen.go
+++ b/internal/service/iam/service_package_gen.go
@@ -125,6 +125,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceGroupPolicyAttachment,
 			TypeName: "aws_iam_group_policy_attachment",
+			Name:     "Group Policy Attachment",
 		},
 		{
 			Factory:  ResourceInstanceProfile,

--- a/internal/service/iam/service_package_gen.go
+++ b/internal/service/iam/service_package_gen.go
@@ -146,8 +146,9 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			Tags:     &types.ServicePackageResourceTags{},
 		},
 		{
-			Factory:  ResourcePolicyAttachment,
+			Factory:  resourcePolicyAttachment,
 			TypeName: "aws_iam_policy_attachment",
+			Name:     "Policy Attachment",
 		},
 		{
 			Factory:  ResourceRole,

--- a/internal/service/iam/service_package_gen.go
+++ b/internal/service/iam/service_package_gen.go
@@ -213,7 +213,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			TypeName: "aws_iam_user_policy",
 		},
 		{
-			Factory:  ResourceUserPolicyAttachment,
+			Factory:  resourceUserPolicyAttachment,
 			TypeName: "aws_iam_user_policy_attachment",
 		},
 		{

--- a/internal/service/iam/service_package_gen.go
+++ b/internal/service/iam/service_package_gen.go
@@ -123,7 +123,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			TypeName: "aws_iam_group_policy",
 		},
 		{
-			Factory:  ResourceGroupPolicyAttachment,
+			Factory:  resourceGroupPolicyAttachment,
 			TypeName: "aws_iam_group_policy_attachment",
 			Name:     "Group Policy Attachment",
 		},

--- a/internal/service/iam/service_package_gen.go
+++ b/internal/service/iam/service_package_gen.go
@@ -160,8 +160,9 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			TypeName: "aws_iam_role_policy",
 		},
 		{
-			Factory:  ResourceRolePolicyAttachment,
+			Factory:  resourceRolePolicyAttachment,
 			TypeName: "aws_iam_role_policy_attachment",
+			Name:     "Role Policy Attachment",
 		},
 		{
 			Factory:  ResourceSAMLProvider,
@@ -215,6 +216,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  resourceUserPolicyAttachment,
 			TypeName: "aws_iam_user_policy_attachment",
+			Name:     "User Policy Attachment",
 		},
 		{
 			Factory:  ResourceUserSSHKey,

--- a/internal/service/iam/sweep.go
+++ b/internal/service/iam/sweep.go
@@ -683,7 +683,7 @@ func sweepUsers(region string) error {
 
 			log.Printf("[DEBUG] Detaching IAM User (%s) attached policy: %s", username, policyARN)
 
-			if err := DetachPolicyFromUser(ctx, conn, username, policyARN); err != nil {
+			if err := detachPolicyFromUser(ctx, conn, username, policyARN); err != nil {
 				sweeperErr := fmt.Errorf("error detaching IAM User (%s) attached policy (%s): %s", username, policyARN, err)
 				log.Printf("[ERROR] %s", sweeperErr)
 				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)

--- a/internal/service/iam/user_policy_attachment.go
+++ b/internal/service/iam/user_policy_attachment.go
@@ -123,8 +123,8 @@ func resourceUserPolicyAttachmentImport(ctx context.Context, d *schema.ResourceD
 func attachPolicyToUser(ctx context.Context, conn *iam.IAM, user, policyARN string) error {
 	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (interface{}, error) {
 		return conn.AttachUserPolicyWithContext(ctx, &iam.AttachUserPolicyInput{
-			UserName:  aws.String(user),
 			PolicyArn: aws.String(policyARN),
+			UserName:  aws.String(user),
 		})
 	}, iam.ErrCodeConcurrentModificationException)
 
@@ -138,8 +138,8 @@ func attachPolicyToUser(ctx context.Context, conn *iam.IAM, user, policyARN stri
 func detachPolicyFromUser(ctx context.Context, conn *iam.IAM, user, policyARN string) error {
 	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (interface{}, error) {
 		return conn.DetachUserPolicyWithContext(ctx, &iam.DetachUserPolicyInput{
-			UserName:  aws.String(user),
 			PolicyArn: aws.String(policyARN),
+			UserName:  aws.String(user),
 		})
 	}, iam.ErrCodeConcurrentModificationException)
 

--- a/internal/service/iam/user_policy_attachment.go
+++ b/internal/service/iam/user_policy_attachment.go
@@ -23,7 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-// @SDKResource("aws_iam_user_policy_attachment")
+// @SDKResource("aws_iam_user_policy_attachment", name="User Policy Attachment")
 func resourceUserPolicyAttachment() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceUserPolicyAttachmentCreate,

--- a/internal/service/iam/user_policy_attachment.go
+++ b/internal/service/iam/user_policy_attachment.go
@@ -153,10 +153,12 @@ func resourceUserPolicyAttachmentImport(ctx context.Context, d *schema.ResourceD
 }
 
 func attachPolicyToUser(ctx context.Context, conn *iam.IAM, user string, arn string) error {
-	_, err := conn.AttachUserPolicyWithContext(ctx, &iam.AttachUserPolicyInput{
-		UserName:  aws.String(user),
-		PolicyArn: aws.String(arn),
-	})
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (interface{}, error) {
+		return conn.AttachUserPolicyWithContext(ctx, &iam.AttachUserPolicyInput{
+			UserName:  aws.String(user),
+			PolicyArn: aws.String(arn),
+		})
+	}, iam.ErrCodeConcurrentModificationException)
 	return err
 }
 

--- a/internal/service/iam/user_policy_attachment.go
+++ b/internal/service/iam/user_policy_attachment.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 // @SDKResource("aws_iam_user_policy_attachment")
@@ -27,20 +28,22 @@ func ResourceUserPolicyAttachment() *schema.Resource {
 		CreateWithoutTimeout: resourceUserPolicyAttachmentCreate,
 		ReadWithoutTimeout:   resourceUserPolicyAttachmentRead,
 		DeleteWithoutTimeout: resourceUserPolicyAttachmentDelete,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceUserPolicyAttachmentImport,
 		},
 
 		Schema: map[string]*schema.Schema{
+			"policy_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidARN,
+			},
 			"user": {
 				Type:     schema.TypeString,
 				ForceNew: true,
 				Required: true,
-			},
-			"policy_arn": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
 			},
 		},
 	}

--- a/internal/service/iam/user_policy_attachment.go
+++ b/internal/service/iam/user_policy_attachment.go
@@ -18,12 +18,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 // @SDKResource("aws_iam_user_policy_attachment")
-func ResourceUserPolicyAttachment() *schema.Resource {
+func resourceUserPolicyAttachment() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceUserPolicyAttachmentCreate,
 		ReadWithoutTimeout:   resourceUserPolicyAttachmentRead,
@@ -54,11 +55,10 @@ func resourceUserPolicyAttachmentCreate(ctx context.Context, d *schema.ResourceD
 	conn := meta.(*conns.AWSClient).IAMConn(ctx)
 
 	user := d.Get("user").(string)
-	arn := d.Get("policy_arn").(string)
+	policyARN := d.Get("policy_arn").(string)
 
-	err := attachPolicyToUser(ctx, conn, user, arn)
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "attaching policy %s to IAM User %s: %v", arn, user, err)
+	if err := attachPolicyToUser(ctx, conn, user, policyARN); err != nil {
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	//lintignore:R016 // Allow legacy unstable ID usage in managed resource
@@ -70,57 +70,24 @@ func resourceUserPolicyAttachmentCreate(ctx context.Context, d *schema.ResourceD
 func resourceUserPolicyAttachmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMConn(ctx)
+
 	user := d.Get("user").(string)
-	arn := d.Get("policy_arn").(string)
-	// Human friendly ID for error messages since d.Id() is non-descriptive
-	id := fmt.Sprintf("%s:%s", user, arn)
+	policyARN := d.Get("policy_arn").(string)
+	// Human friendly ID for error messages since d.Id() is non-descriptive.
+	id := fmt.Sprintf("%s:%s", user, policyARN)
 
-	var attachedPolicy *iam.AttachedPolicy
+	_, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
+		return findAttachedUserPolicyByTwoPartKey(ctx, conn, user, policyARN)
+	}, d.IsNewResource())
 
-	err := retry.RetryContext(ctx, propagationTimeout, func() *retry.RetryError {
-		var err error
-
-		attachedPolicy, err = FindUserAttachedPolicy(ctx, conn, user, arn)
-
-		if d.IsNewResource() && tfawserr.ErrCodeEquals(err, iam.ErrCodeNoSuchEntityException) {
-			return retry.RetryableError(err)
-		}
-
-		if err != nil {
-			return retry.NonRetryableError(err)
-		}
-
-		if d.IsNewResource() && attachedPolicy == nil {
-			return retry.RetryableError(&retry.NotFoundError{
-				LastError: fmt.Errorf("IAM User Managed Policy Attachment (%s) not found", id),
-			})
-		}
-
-		return nil
-	})
-
-	if tfresource.TimedOut(err) {
-		attachedPolicy, err = FindUserAttachedPolicy(ctx, conn, user, arn)
-	}
-
-	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, iam.ErrCodeNoSuchEntityException) {
-		log.Printf("[WARN] IAM User Managed Policy Attachment (%s) not found, removing from state", id)
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] IAM User Policy Attachment (%s) not found, removing from state", id)
 		d.SetId("")
 		return diags
 	}
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "reading IAM User Managed Policy Attachment (%s): %s", id, err)
-	}
-
-	if attachedPolicy == nil {
-		if d.IsNewResource() {
-			return sdkdiag.AppendErrorf(diags, "reading IAM User Managed Policy Attachment (%s): not found after creation", id)
-		}
-
-		log.Printf("[WARN] IAM User Managed Policy Attachment (%s) not found, removing from state", id)
-		d.SetId("")
-		return diags
+		return sdkdiag.AppendErrorf(diags, "reading IAM User Policy Attachment (%s): %s", id, err)
 	}
 
 	return diags
@@ -129,13 +96,11 @@ func resourceUserPolicyAttachmentRead(ctx context.Context, d *schema.ResourceDat
 func resourceUserPolicyAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMConn(ctx)
-	user := d.Get("user").(string)
-	arn := d.Get("policy_arn").(string)
 
-	err := DetachPolicyFromUser(ctx, conn, user, arn)
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "removing policy %s from IAM User %s: %v", arn, user, err)
+	if err := detachPolicyFromUser(ctx, conn, d.Get("user").(string), d.Get("policy_arn").(string)); err != nil {
+		return sdkdiag.AppendFromErr(diags, err)
 	}
+
 	return diags
 }
 
@@ -155,20 +120,87 @@ func resourceUserPolicyAttachmentImport(ctx context.Context, d *schema.ResourceD
 	return []*schema.ResourceData{d}, nil
 }
 
-func attachPolicyToUser(ctx context.Context, conn *iam.IAM, user string, arn string) error {
+func attachPolicyToUser(ctx context.Context, conn *iam.IAM, user, policyARN string) error {
 	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (interface{}, error) {
 		return conn.AttachUserPolicyWithContext(ctx, &iam.AttachUserPolicyInput{
 			UserName:  aws.String(user),
-			PolicyArn: aws.String(arn),
+			PolicyArn: aws.String(policyARN),
 		})
 	}, iam.ErrCodeConcurrentModificationException)
-	return err
+
+	if err != nil {
+		return fmt.Errorf("attaching IAM Policy (%s) to IAM User (%s): %w", policyARN, user, err)
+	}
+
+	return nil
 }
 
-func DetachPolicyFromUser(ctx context.Context, conn *iam.IAM, user string, arn string) error {
-	_, err := conn.DetachUserPolicyWithContext(ctx, &iam.DetachUserPolicyInput{
-		UserName:  aws.String(user),
-		PolicyArn: aws.String(arn),
+func detachPolicyFromUser(ctx context.Context, conn *iam.IAM, user, policyARN string) error {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (interface{}, error) {
+		return conn.DetachUserPolicyWithContext(ctx, &iam.DetachUserPolicyInput{
+			UserName:  aws.String(user),
+			PolicyArn: aws.String(policyARN),
+		})
+	}, iam.ErrCodeConcurrentModificationException)
+
+	if tfawserr.ErrCodeEquals(err, iam.ErrCodeNoSuchEntityException) {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("detaching IAM Policy (%s) from IAM User (%s): %w", policyARN, user, err)
+	}
+
+	return nil
+}
+
+func findAttachedUserPolicyByTwoPartKey(ctx context.Context, conn *iam.IAM, userName, policyARN string) (*iam.AttachedPolicy, error) {
+	input := &iam.ListAttachedUserPoliciesInput{
+		UserName: aws.String(userName),
+	}
+
+	return findAttachedUserPolicy(ctx, conn, input, func(v *iam.AttachedPolicy) bool {
+		return aws.StringValue(v.PolicyArn) == policyARN
 	})
-	return err
+}
+
+func findAttachedUserPolicy(ctx context.Context, conn *iam.IAM, input *iam.ListAttachedUserPoliciesInput, filter tfslices.Predicate[*iam.AttachedPolicy]) (*iam.AttachedPolicy, error) {
+	output, err := findAttachedUserPolicies(ctx, conn, input, filter)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfresource.AssertSinglePtrResult(output)
+}
+
+func findAttachedUserPolicies(ctx context.Context, conn *iam.IAM, input *iam.ListAttachedUserPoliciesInput, filter tfslices.Predicate[*iam.AttachedPolicy]) ([]*iam.AttachedPolicy, error) {
+	var output []*iam.AttachedPolicy
+
+	err := conn.ListAttachedUserPoliciesPagesWithContext(ctx, input, func(page *iam.ListAttachedUserPoliciesOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, v := range page.AttachedPolicies {
+			if v != nil && filter(v) {
+				output = append(output, v)
+			}
+		}
+
+		return !lastPage
+	})
+
+	if tfawserr.ErrCodeEquals(err, iam.ErrCodeNoSuchEntityException) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return output, nil
 }

--- a/internal/service/iam/user_policy_attachment_test.go
+++ b/internal/service/iam/user_policy_attachment_test.go
@@ -156,7 +156,7 @@ func testAccCheckUserPolicyAttachmentCount(ctx context.Context, userName string,
 			return fmt.Errorf("UserPolicyAttachmentCount(%q) = %v, want %v", userName, got, want)
 		}
 
-		return err
+		return nil
 	}
 }
 

--- a/internal/service/iam/user_policy_attachment_test.go
+++ b/internal/service/iam/user_policy_attachment_test.go
@@ -6,7 +6,6 @@ package iam_test
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -17,33 +16,36 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func TestAccIAMUserPolicyAttachment_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	var out iam.ListAttachedUserPoliciesOutput
-	rName := sdkacctest.RandString(10)
-	policyName1 := fmt.Sprintf("test-policy-%s", sdkacctest.RandString(10))
-	policyName2 := fmt.Sprintf("test-policy-%s", sdkacctest.RandString(10))
-	policyName3 := fmt.Sprintf("test-policy-%s", sdkacctest.RandString(10))
+	userName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	policyName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	policyName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	policyName3 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_iam_user_policy_attachment.test1"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, iam.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserPolicyAttachmentDestroy,
+		CheckDestroy:             testAccCheckUserPolicyAttachmentDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserPolicyAttachmentConfig_attach(rName, policyName1),
+				Config: testAccUserPolicyAttachmentConfig_attach(userName, policyName1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserPolicyAttachmentExists(ctx, "aws_iam_user_policy_attachment.test-attach", 1, &out),
-					testAccCheckUserPolicyAttachmentAttributes([]string{policyName1}, &out),
+					testAccCheckUserPolicyAttachmentExists(ctx, resourceName),
+					testAccCheckUserPolicyAttachmentCount(ctx, userName, 1),
 				),
 			},
 			{
-				ResourceName:      "aws_iam_user_policy_attachment.test-attach",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccUserPolicyAttachmentImportStateIdFunc("aws_iam_user_policy_attachment.test-attach"),
+				ImportStateIdFunc: testAccUserPolicyAttachmentImportStateIdFunc(resourceName),
 				// We do not have a way to align IDs since the Create function uses id.PrefixedUniqueId()
 				// Failed state verification, resource with ID USER-POLICYARN not found
 				// ImportStateVerify: true,
@@ -62,66 +64,99 @@ func TestAccIAMUserPolicyAttachment_basic(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccUserPolicyAttachmentConfig_attachUpdate(rName, policyName1, policyName2, policyName3),
+				Config: testAccUserPolicyAttachmentConfig_attachUpdate(userName, policyName1, policyName2, policyName3),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserPolicyAttachmentExists(ctx, "aws_iam_user_policy_attachment.test-attach", 2, &out),
-					testAccCheckUserPolicyAttachmentAttributes([]string{policyName2, policyName3}, &out),
+					testAccCheckUserPolicyAttachmentExists(ctx, resourceName),
+					testAccCheckUserPolicyAttachmentCount(ctx, userName, 2),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckUserPolicyAttachmentDestroy(s *terraform.State) error {
-	return nil
+func TestAccIAMUserPolicyAttachment_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	userName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_iam_user_policy_attachment.test1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, iam.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserPolicyAttachmentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserPolicyAttachmentConfig_attach(userName, policyName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserPolicyAttachmentExists(ctx, resourceName),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfiam.ResourceUserPolicyAttachment(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
 }
 
-func testAccCheckUserPolicyAttachmentExists(ctx context.Context, n string, c int, out *iam.ListAttachedUserPoliciesOutput) resource.TestCheckFunc {
+func testAccCheckUserPolicyAttachmentDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMConn(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_iam_user_policy_attachment" {
+				continue
+			}
+
+			_, err := tfiam.FindAttachedUserPolicyByTwoPartKey(ctx, conn, rs.Primary.Attributes["user"], rs.Primary.Attributes["policy_arn"])
+
+			if tfresource.NotFound(err) {
+				continue
+			}
+
+			if err != nil {
+				return err
+			}
+
+			return fmt.Errorf("IAM User Policy Attachment %s still exists", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckUserPolicyAttachmentExists(ctx context.Context, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No policy name is set")
-		}
-
 		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMConn(ctx)
-		user := rs.Primary.Attributes["user"]
 
-		attachedPolicies, err := conn.ListAttachedUserPoliciesWithContext(ctx, &iam.ListAttachedUserPoliciesInput{
-			UserName: aws.String(user),
-		})
-		if err != nil {
-			return fmt.Errorf("Error: Failed to get attached policies for user %s (%s)", user, n)
-		}
-		if c != len(attachedPolicies.AttachedPolicies) {
-			return fmt.Errorf("Error: User (%s) has wrong number of policies attached on initial creation", n)
-		}
+		_, err := tfiam.FindAttachedUserPolicyByTwoPartKey(ctx, conn, rs.Primary.Attributes["user"], rs.Primary.Attributes["policy_arn"])
 
-		*out = *attachedPolicies
-		return nil
+		return err
 	}
 }
 
-func testAccCheckUserPolicyAttachmentAttributes(policies []string, out *iam.ListAttachedUserPoliciesOutput) resource.TestCheckFunc {
+func testAccCheckUserPolicyAttachmentCount(ctx context.Context, userName string, want int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		matched := 0
+		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMConn(ctx)
 
-		for _, p := range policies {
-			for _, ap := range out.AttachedPolicies {
-				// *ap.PolicyArn like arn:aws:iam::111111111111:policy/test-policy
-				parts := strings.Split(*ap.PolicyArn, "/")
-				if len(parts) == 2 && p == parts[1] {
-					matched++
-				}
-			}
+		input := &iam.ListAttachedUserPoliciesInput{
+			UserName: aws.String(userName),
 		}
-		if matched != len(policies) || matched != len(out.AttachedPolicies) {
-			return fmt.Errorf("Error: Number of attached policies was incorrect: expected %d matched policies, matched %d of %d", len(policies), matched, len(out.AttachedPolicies))
+		output, err := tfiam.FindAttachedUserPolicies(ctx, conn, input, tfslices.PredicateTrue[*iam.AttachedPolicy]())
+
+		if err != nil {
+			return err
 		}
-		return nil
+
+		if got := len(output); got != want {
+			return fmt.Errorf("UserPolicyAttachmentCount(%q) = %v, want %v", userName, got, want)
+		}
+
+		return err
 	}
 }
 
@@ -138,12 +173,12 @@ func testAccUserPolicyAttachmentImportStateIdFunc(resourceName string) resource.
 
 func testAccUserPolicyAttachmentConfig_attach(rName, policyName string) string {
 	return fmt.Sprintf(`
-resource "aws_iam_user" "user" {
-  name = "test-user-%s"
+resource "aws_iam_user" "test" {
+  name = %[1]q
 }
 
-resource "aws_iam_policy" "policy" {
-  name        = "%s"
+resource "aws_iam_policy" "test1" {
+  name        = %[2]q
   description = "A test policy"
 
   policy = <<EOF
@@ -162,21 +197,21 @@ resource "aws_iam_policy" "policy" {
 EOF
 }
 
-resource "aws_iam_user_policy_attachment" "test-attach" {
-  user       = aws_iam_user.user.name
-  policy_arn = aws_iam_policy.policy.arn
+resource "aws_iam_user_policy_attachment" "test1" {
+  user       = aws_iam_user.test.name
+  policy_arn = aws_iam_policy.test1.arn
 }
 `, rName, policyName)
 }
 
 func testAccUserPolicyAttachmentConfig_attachUpdate(rName, policyName1, policyName2, policyName3 string) string {
 	return fmt.Sprintf(`
-resource "aws_iam_user" "user" {
-  name = "test-user-%s"
+resource "aws_iam_user" "test" {
+  name = %[1]q
 }
 
-resource "aws_iam_policy" "policy" {
-  name        = "%s"
+resource "aws_iam_policy" "test1" {
+  name        = %[2]q
   description = "A test policy"
 
   policy = <<EOF
@@ -195,8 +230,8 @@ resource "aws_iam_policy" "policy" {
 EOF
 }
 
-resource "aws_iam_policy" "policy2" {
-  name        = "%s"
+resource "aws_iam_policy" "test2" {
+  name        = %[3]q
   description = "A test policy"
 
   policy = <<EOF
@@ -215,8 +250,8 @@ resource "aws_iam_policy" "policy2" {
 EOF
 }
 
-resource "aws_iam_policy" "policy3" {
-  name        = "%s"
+resource "aws_iam_policy" "test3" {
+  name        = %[4]q
   description = "A test policy"
 
   policy = <<EOF
@@ -235,14 +270,14 @@ resource "aws_iam_policy" "policy3" {
 EOF
 }
 
-resource "aws_iam_user_policy_attachment" "test-attach" {
-  user       = aws_iam_user.user.name
-  policy_arn = aws_iam_policy.policy2.arn
+resource "aws_iam_user_policy_attachment" "test1" {
+  user       = aws_iam_user.test.name
+  policy_arn = aws_iam_policy.test2.arn
 }
 
-resource "aws_iam_user_policy_attachment" "test-attach2" {
-  user       = aws_iam_user.user.name
-  policy_arn = aws_iam_policy.policy3.arn
+resource "aws_iam_user_policy_attachment" "test2" {
+  user       = aws_iam_user.test.name
+  policy_arn = aws_iam_policy.test3.arn
 }
 `, rName, policyName1, policyName2, policyName3)
 }


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Seems like AWS IAM now returns ConcurrentModification when previously this was not a problem.
Just retry the operation like we do in other parts of the code.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #34371

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

<!--
```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
-->