### PR TITLE
internal/framework/flex: generic set/list of string value flatteners

### DIFF
--- a/internal/framework/flex/autoflex.go
+++ b/internal/framework/flex/autoflex.go
@@ -975,10 +975,9 @@ func (flattener autoFlattener) slice(ctx context.Context, vFrom reflect.Value, t
 				return diags
 			}
 
-			from := vFrom.Interface().([]string)
-			elements := make([]attr.Value, len(from))
-			for i, v := range from {
-				elements[i] = types.StringValue(v)
+			elements := make([]attr.Value, vFrom.Len())
+			for i := 0; i < vFrom.Len(); i++ {
+				elements[i] = types.StringValue(vFrom.Index(i).String())
 			}
 			list, d := types.ListValue(types.StringType, elements)
 			diags.Append(d...)
@@ -1004,10 +1003,9 @@ func (flattener autoFlattener) slice(ctx context.Context, vFrom reflect.Value, t
 				return diags
 			}
 
-			from := vFrom.Interface().([]string)
-			elements := make([]attr.Value, len(from))
-			for i, v := range from {
-				elements[i] = types.StringValue(v)
+			elements := make([]attr.Value, vFrom.Len())
+			for i := 0; i < vFrom.Len(); i++ {
+				elements[i] = types.StringValue(vFrom.Index(i).String())
 			}
 			set, d := types.SetValue(types.StringType, elements)
 			diags.Append(d...)

--- a/internal/framework/flex/list.go
+++ b/internal/framework/flex/list.go
@@ -60,7 +60,7 @@ func FlattenFrameworkStringListLegacy(_ context.Context, vs []*string) types.Lis
 //
 // A nil slice is converted to a null List.
 // An empty slice is converted to a null List.
-func FlattenFrameworkStringValueList(ctx context.Context, v []string) types.List {
+func FlattenFrameworkStringValueList[T ~string](ctx context.Context, v []T) types.List {
 	if len(v) == 0 {
 		return types.ListNull(types.StringType)
 	}
@@ -74,11 +74,11 @@ func FlattenFrameworkStringValueList(ctx context.Context, v []string) types.List
 
 // FlattenFrameworkStringValueListLegacy is the Plugin Framework variant of FlattenStringValueList.
 // A nil slice is converted to an empty (non-null) List.
-func FlattenFrameworkStringValueListLegacy(_ context.Context, vs []string) types.List {
+func FlattenFrameworkStringValueListLegacy[T ~string](_ context.Context, vs []T) types.List {
 	elems := make([]attr.Value, len(vs))
 
 	for i, v := range vs {
-		elems[i] = types.StringValue(v)
+		elems[i] = types.StringValue(string(v))
 	}
 
 	return types.ListValueMust(types.StringType, elems)

--- a/internal/framework/flex/list_test.go
+++ b/internal/framework/flex/list_test.go
@@ -193,20 +193,23 @@ func TestFlattenFrameworkStringListLegacy(t *testing.T) {
 func TestFlattenFrameworkStringValueList(t *testing.T) {
 	t.Parallel()
 
+	// AWS enums use custom types with an underlying string type
+	type custom string
+
 	type testCase struct {
-		input    []string
+		input    []custom
 		expected types.List
 	}
 	tests := map[string]testCase{
 		"two elements": {
-			input: []string{"GET", "HEAD"},
+			input: []custom{"GET", "HEAD"},
 			expected: types.ListValueMust(types.StringType, []attr.Value{
 				types.StringValue("GET"),
 				types.StringValue("HEAD"),
 			}),
 		},
 		"zero elements": {
-			input:    []string{},
+			input:    []custom{},
 			expected: types.ListNull(types.StringType),
 		},
 		"nil array": {
@@ -232,20 +235,23 @@ func TestFlattenFrameworkStringValueList(t *testing.T) {
 func TestFlattenFrameworkStringValueListLegacy(t *testing.T) {
 	t.Parallel()
 
+	// AWS enums use custom types with an underlying string type
+	type custom string
+
 	type testCase struct {
-		input    []string
+		input    []custom
 		expected types.List
 	}
 	tests := map[string]testCase{
 		"two elements": {
-			input: []string{"GET", "HEAD"},
+			input: []custom{"GET", "HEAD"},
 			expected: types.ListValueMust(types.StringType, []attr.Value{
 				types.StringValue("GET"),
 				types.StringValue("HEAD"),
 			}),
 		},
 		"zero elements": {
-			input:    []string{},
+			input:    []custom{},
 			expected: types.ListValueMust(types.StringType, []attr.Value{}),
 		},
 		"nil array": {

--- a/internal/framework/flex/set.go
+++ b/internal/framework/flex/set.go
@@ -61,7 +61,7 @@ func FlattenFrameworkStringSetLegacy(_ context.Context, vs []*string) types.Set 
 //
 // A nil slice is converted to a null Set.
 // An empty slice is converted to a null Set.
-func FlattenFrameworkStringValueSet(ctx context.Context, v []string) types.Set {
+func FlattenFrameworkStringValueSet[T ~string](ctx context.Context, v []T) types.Set {
 	if len(v) == 0 {
 		return types.SetNull(types.StringType)
 	}
@@ -75,11 +75,11 @@ func FlattenFrameworkStringValueSet(ctx context.Context, v []string) types.Set {
 
 // FlattenFrameworkStringValueSetLegacy is the Plugin Framework variant of FlattenStringValueSet.
 // A nil slice is converted to an empty (non-null) Set.
-func FlattenFrameworkStringValueSetLegacy(_ context.Context, vs []string) types.Set {
+func FlattenFrameworkStringValueSetLegacy[T ~string](_ context.Context, vs []T) types.Set {
 	elems := make([]attr.Value, len(vs))
 
 	for i, v := range vs {
-		elems[i] = types.StringValue(v)
+		elems[i] = types.StringValue(string(v))
 	}
 
 	return types.SetValueMust(types.StringType, elems)

--- a/internal/framework/flex/set_test.go
+++ b/internal/framework/flex/set_test.go
@@ -115,20 +115,23 @@ func TestExpandFrameworkStringValueSet(t *testing.T) {
 func TestFlattenFrameworkStringValueSet(t *testing.T) {
 	t.Parallel()
 
+	// AWS enums use custom types with an underlying string type
+	type custom string
+
 	type testCase struct {
-		input    []string
+		input    []custom
 		expected types.Set
 	}
 	tests := map[string]testCase{
 		"two elements": {
-			input: []string{"GET", "HEAD"},
+			input: []custom{"GET", "HEAD"},
 			expected: types.SetValueMust(types.StringType, []attr.Value{
 				types.StringValue("GET"),
 				types.StringValue("HEAD"),
 			}),
 		},
 		"zero elements": {
-			input:    []string{},
+			input:    []custom{},
 			expected: types.SetNull(types.StringType),
 		},
 		"nil array": {
@@ -154,20 +157,23 @@ func TestFlattenFrameworkStringValueSet(t *testing.T) {
 func TestFlattenFrameworkStringValueSetLegacy(t *testing.T) {
 	t.Parallel()
 
+	// AWS enums use custom types with an underlying string type
+	type custom string
+
 	type testCase struct {
-		input    []string
+		input    []custom
 		expected types.Set
 	}
 	tests := map[string]testCase{
 		"two elements": {
-			input: []string{"GET", "HEAD"},
+			input: []custom{"GET", "HEAD"},
 			expected: types.SetValueMust(types.StringType, []attr.Value{
 				types.StringValue("GET"),
 				types.StringValue("HEAD"),
 			}),
 		},
 		"zero elements": {
-			input:    []string{},
+			input:    []custom{},
 			expected: types.SetValueMust(types.StringType, []attr.Value{}),
 		},
 		"nil array": {

--- a/internal/service/bedrock/foundation_model_data_source.go
+++ b/internal/service/bedrock/foundation_model_data_source.go
@@ -120,18 +120,9 @@ func (data *foundationModel) refreshFromOutput(ctx context.Context, model *bedro
 	data.ModelID = flex.StringToFramework(ctx, model.ModelDetails.ModelId)
 	data.ModelName = flex.StringToFramework(ctx, model.ModelDetails.ModelName)
 	data.ProviderName = flex.StringToFramework(ctx, model.ModelDetails.ProviderName)
-	data.CustomizationsSupported = flex.FlattenFrameworkStringValueSet(ctx, toStringSlice(model.ModelDetails.CustomizationsSupported))
-	data.InferenceTypesSupported = flex.FlattenFrameworkStringValueSet(ctx, toStringSlice(model.ModelDetails.InferenceTypesSupported))
-	data.InputModalities = flex.FlattenFrameworkStringValueSet(ctx, toStringSlice(model.ModelDetails.InputModalities))
-	data.OutputModalities = flex.FlattenFrameworkStringValueSet(ctx, toStringSlice(model.ModelDetails.OutputModalities))
+	data.CustomizationsSupported = flex.FlattenFrameworkStringValueSet(ctx, model.ModelDetails.CustomizationsSupported)
+	data.InferenceTypesSupported = flex.FlattenFrameworkStringValueSet(ctx, model.ModelDetails.InferenceTypesSupported)
+	data.InputModalities = flex.FlattenFrameworkStringValueSet(ctx, model.ModelDetails.InputModalities)
+	data.OutputModalities = flex.FlattenFrameworkStringValueSet(ctx, model.ModelDetails.OutputModalities)
 	data.ResponseStreamingSupported = flex.BoolToFramework(ctx, model.ModelDetails.ResponseStreamingSupported)
-}
-
-// toStringSlice converts a slice of custom string types to a slice of strings
-func toStringSlice[T ~string](values []T) []string {
-	var out []string
-	for _, v := range values {
-		out = append(out, string(v))
-	}
-	return out
 }

--- a/internal/service/bedrock/foundation_models_data_source.go
+++ b/internal/service/bedrock/foundation_models_data_source.go
@@ -184,10 +184,10 @@ func flattenFoundationModelSummaries(ctx context.Context, models []awstypes.Foun
 		attr["model_name"] = flex.StringToFramework(ctx, model.ModelName)
 		attr["provider_name"] = flex.StringToFramework(ctx, model.ProviderName)
 
-		attr["customizations_supported"] = flex.FlattenFrameworkStringValueSet(ctx, toStringSlice(model.CustomizationsSupported))
-		attr["inference_types_supported"] = flex.FlattenFrameworkStringValueSet(ctx, toStringSlice(model.InferenceTypesSupported))
-		attr["input_modalities"] = flex.FlattenFrameworkStringValueSet(ctx, toStringSlice(model.InputModalities))
-		attr["output_modalities"] = flex.FlattenFrameworkStringValueSet(ctx, toStringSlice(model.OutputModalities))
+		attr["customizations_supported"] = flex.FlattenFrameworkStringValueSet(ctx, model.CustomizationsSupported)
+		attr["inference_types_supported"] = flex.FlattenFrameworkStringValueSet(ctx, model.InferenceTypesSupported)
+		attr["input_modalities"] = flex.FlattenFrameworkStringValueSet(ctx, model.InputModalities)
+		attr["output_modalities"] = flex.FlattenFrameworkStringValueSet(ctx, model.OutputModalities)
 		attr["response_streaming_supported"] = flex.BoolToFramework(ctx, model.ResponseStreamingSupported)
 
 		val := types.ObjectValueMust(attributeTypes, attr)


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This will allow the `FlattenFrameworkStringValue[List|Set]*` functions to be used with lists and sets of AWS enum types, implemented as custom string types.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #34148 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% go test -count=1 ./internal/framework/flex/...
ok      github.com/hashicorp/terraform-provider-aws/internal/framework/flex     0.223s
```

The regions data source utilizes the `flex.FlattenFrameworkStringValueSetLegacy` function.
```console
% make testacc PKG=meta TESTS=TestAccMetaRegionsDataSource_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/meta/... -v -count 1 -parallel 20 -run='TestAccMetaRegionsDataSource_'  -timeout 360m

--- PASS: TestAccMetaRegionsDataSource_allRegions (33.47s)
--- PASS: TestAccMetaRegionsDataSource_filter (33.64s)
--- PASS: TestAccMetaRegionsDataSource_basic (33.75s)
--- PASS: TestAccMetaRegionsDataSource_nonExistentRegion (33.90s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/meta       37.214s
```

These data sources uncovered the need for handling sets of custom types:
```console
% make testacc PKG=bedrock TESTS=TestAccBedrockFoundationModel
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/bedrock/... -v -count 1 -parallel 20 -run='TestAccBedrockFoundationModel'  -timeout 360m

--- PASS: TestAccBedrockFoundationModelsDataSource_byOutputModality (35.61s)
--- PASS: TestAccBedrockFoundationModelsDataSource_basic (35.89s)
--- PASS: TestAccBedrockFoundationModelsDataSource_byCustomizationType (36.09s)
--- PASS: TestAccBedrockFoundationModelsDataSource_byInferenceType (36.12s)
--- PASS: TestAccBedrockFoundationModelDataSource_basic (49.35s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/bedrock    52.612s
```