### PR TITLE
r/aws_elasticache_user: Add acceptance test for tagging during out-of-band modification

### DIFF
--- a/.changelog/34396.txt
+++ b/.changelog/34396.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_elasticache_user: Fix `UserNotFound: ... is not available for tagging` errors on resource Read when there is a concurrent update to the user
+```

--- a/internal/service/elasticache/sweep.go
+++ b/internal/service/elasticache/sweep.go
@@ -63,6 +63,11 @@ func RegisterSweepers() {
 			"aws_elasticache_replication_group",
 		},
 	})
+
+	resource.AddTestSweepers("aws_elasticache_user", &resource.Sweeper{
+		Name: "aws_elasticache_user",
+		F:    sweepUsers,
+	})
 }
 
 func sweepClusters(region string) error {
@@ -300,6 +305,57 @@ func sweepSubnetGroups(region string) error {
 		}
 		return fmt.Errorf("Error retrieving ElastiCache Subnet Groups: %w", err)
 	}
+	return nil
+}
+
+func sweepUsers(region string) error {
+	ctx := sweep.Context(region)
+	client, err := sweep.SharedRegionalSweepClient(ctx, region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+	conn := client.ElastiCacheConn(ctx)
+	input := &elasticache.DescribeUsersInput{}
+	sweepResources := make([]sweep.Sweepable, 0)
+
+	err = conn.DescribeUsersPagesWithContext(ctx, input, func(page *elasticache.DescribeUsersOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, v := range page.Users {
+			id := aws.StringValue(v.UserId)
+
+			if id == "default" {
+				log.Printf("[INFO] Skipping ElastiCache User: %s", id)
+				continue
+			}
+
+			r := ResourceUser()
+			d := r.Data(nil)
+			d.SetId(aws.StringValue(v.UserId))
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+
+		return !lastPage
+	})
+
+	if awsv1.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping ElastiCache User sweep for %s: %s", region, err)
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("listing ElastiCache Users (%s): %w", region, err)
+	}
+
+	err = sweep.SweepOrchestrator(ctx, sweepResources)
+
+	if err != nil {
+		return fmt.Errorf("sweeping ElastiCache Users (%s): %w", region, err)
+	}
+
 	return nil
 }
 

--- a/internal/service/elasticache/user_test.go
+++ b/internal/service/elasticache/user_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	// "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -303,6 +304,49 @@ func TestAccElastiCacheUser_disappears(t *testing.T) {
 	})
 }
 
+/*
+// https://github.com/hashicorp/terraform-provider-aws/issues/34002.
+func TestAccElastiCacheUser_oobModify(t *testing.T) {
+	ctx := acctest.Context(t)
+	var user elasticache.User
+	rName := sdkacctest.RandomWithPrefix("tf-acc")
+	resourceName := "aws_elasticache_user.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, elasticache.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserConfig_tags(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists(ctx, resourceName, &user),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			// Start to update the user out-of-band.
+			{
+				Config: testAccUserConfig_tags(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserUpdateOOB(ctx, &user),
+				),
+			},
+			// Update tags.
+			{
+				Config: testAccUserConfig_tags(rName, "key1", "value1updated"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists(ctx, resourceName, &user),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+				),
+			},
+		},
+	})
+}
+*/
+
 func testAccCheckUserDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheConn(ctx)
@@ -353,6 +397,21 @@ func testAccCheckUserExists(ctx context.Context, n string, v *elasticache.User) 
 		return nil
 	}
 }
+
+/*
+func testAccCheckUserUpdateOOB(ctx context.Context, v *elasticache.User) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheConn(ctx)
+
+		_, err := conn.ModifyUserWithContext(ctx, &elasticache.ModifyUserInput{
+			AccessString: aws.String("on ~* +@all"),
+			UserId:       v.UserId,
+		})
+
+		return err
+	}
+}
+*/
 
 func testAccUserConfig_basic(rName string) string {
 	return fmt.Sprintf(`

--- a/internal/service/elasticache/user_test.go
+++ b/internal/service/elasticache/user_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"testing"
 
-	// "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -304,7 +304,6 @@ func TestAccElastiCacheUser_disappears(t *testing.T) {
 	})
 }
 
-/*
 // https://github.com/hashicorp/terraform-provider-aws/issues/34002.
 func TestAccElastiCacheUser_oobModify(t *testing.T) {
 	ctx := acctest.Context(t)
@@ -332,6 +331,7 @@ func TestAccElastiCacheUser_oobModify(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserUpdateOOB(ctx, &user),
 				),
+				ExpectNonEmptyPlan: true,
 			},
 			// Update tags.
 			{
@@ -345,7 +345,6 @@ func TestAccElastiCacheUser_oobModify(t *testing.T) {
 		},
 	})
 }
-*/
 
 func testAccCheckUserDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -398,7 +397,6 @@ func testAccCheckUserExists(ctx context.Context, n string, v *elasticache.User) 
 	}
 }
 
-/*
 func testAccCheckUserUpdateOOB(ctx context.Context, v *elasticache.User) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheConn(ctx)
@@ -411,7 +409,6 @@ func testAccCheckUserUpdateOOB(ctx context.Context, v *elasticache.User) resourc
 		return err
 	}
 }
-*/
 
 func testAccUserConfig_basic(rName string) string {
 	return fmt.Sprintf(`

--- a/website/docs/r/elasticache_user.html.markdown
+++ b/website/docs/r/elasticache_user.html.markdown
@@ -84,6 +84,7 @@ This resource exports the following attributes in addition to the arguments abov
 [Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
 
 - `create` - (Default `5m`)
+- `read` - (Default `5m`)
 - `update` - (Default `5m`)
 - `delete` - (Default `5m`)
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fix `UserNotFound: ... is not available for tagging` errors on resource Read when there is a concurrent update to the user by waiting for the resource to be in `active` state.

As many stray ElastiCache users were created during testing, sweeper for `aws_elasticache_user` and `aws_elasticache_user_group` have been added.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/34002.

### Acceptance Test Output

```
% make testacc TESTARGS='-run=TestAccElastiCacheUser_' PKG=elasticache ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elasticache/... -v -count 1 -parallel 2  -run=TestAccElastiCacheUser_ -timeout 360m
=== RUN   TestAccElastiCacheUser_basic
=== PAUSE TestAccElastiCacheUser_basic
=== RUN   TestAccElastiCacheUser_password_auth_mode
=== PAUSE TestAccElastiCacheUser_password_auth_mode
=== RUN   TestAccElastiCacheUser_iam_auth_mode
=== PAUSE TestAccElastiCacheUser_iam_auth_mode
=== RUN   TestAccElastiCacheUser_update
=== PAUSE TestAccElastiCacheUser_update
=== RUN   TestAccElastiCacheUser_update_password_auth_mode
=== PAUSE TestAccElastiCacheUser_update_password_auth_mode
=== RUN   TestAccElastiCacheUser_tags
=== PAUSE TestAccElastiCacheUser_tags
=== RUN   TestAccElastiCacheUser_disappears
=== PAUSE TestAccElastiCacheUser_disappears
=== RUN   TestAccElastiCacheUser_oobModify
=== PAUSE TestAccElastiCacheUser_oobModify
=== CONT  TestAccElastiCacheUser_basic
=== CONT  TestAccElastiCacheUser_update_password_auth_mode
--- PASS: TestAccElastiCacheUser_basic (55.65s)
=== CONT  TestAccElastiCacheUser_oobModify
--- PASS: TestAccElastiCacheUser_update_password_auth_mode (181.44s)
=== CONT  TestAccElastiCacheUser_disappears
--- PASS: TestAccElastiCacheUser_oobModify (179.98s)
=== CONT  TestAccElastiCacheUser_tags
--- PASS: TestAccElastiCacheUser_tags (60.51s)
=== CONT  TestAccElastiCacheUser_iam_auth_mode
--- PASS: TestAccElastiCacheUser_iam_auth_mode (68.67s)
=== CONT  TestAccElastiCacheUser_update
--- PASS: TestAccElastiCacheUser_disappears (223.14s)
=== CONT  TestAccElastiCacheUser_password_auth_mode
--- PASS: TestAccElastiCacheUser_password_auth_mode (80.51s)
--- PASS: TestAccElastiCacheUser_update (121.70s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticache	492.314s
```