### PR TITLE
finspace: Increase kx_cluster create/update and kx_environment delete timeouts

### DIFF
--- a/.changelog/34398.txt
+++ b/.changelog/34398.txt
@@ -1,0 +1,6 @@
+```release-note:enhancement
+resource/aws_finspace_kx_cluster: Increase default create and update timeouts to 4 hours to allow for increased startup times with large volumes of cached data
+```
+```release-note:enhancement
+resource/aws_finspace_kx_environment: Increase default delete timeout to 75 minutes
+```

--- a/internal/service/finspace/kx_cluster.go
+++ b/internal/service/finspace/kx_cluster.go
@@ -42,8 +42,8 @@ func ResourceKxCluster() *schema.Resource {
 		},
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(45 * time.Minute),
-			Update: schema.DefaultTimeout(30 * time.Minute),
+			Create: schema.DefaultTimeout(18 * time.Hour),
+			Update: schema.DefaultTimeout(18 * time.Hour),
 			Delete: schema.DefaultTimeout(60 * time.Minute),
 		},
 

--- a/internal/service/finspace/kx_cluster.go
+++ b/internal/service/finspace/kx_cluster.go
@@ -42,8 +42,8 @@ func ResourceKxCluster() *schema.Resource {
 		},
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(18 * time.Hour),
-			Update: schema.DefaultTimeout(18 * time.Hour),
+			Create: schema.DefaultTimeout(4 * time.Hour),
+			Update: schema.DefaultTimeout(4 * time.Hour),
 			Delete: schema.DefaultTimeout(60 * time.Minute),
 		},
 

--- a/internal/service/finspace/kx_environment.go
+++ b/internal/service/finspace/kx_environment.go
@@ -43,7 +43,7 @@ func ResourceKxEnvironment() *schema.Resource {
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),
 			Update: schema.DefaultTimeout(30 * time.Minute),
-			Delete: schema.DefaultTimeout(45 * time.Minute),
+			Delete: schema.DefaultTimeout(75 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/website/docs/r/finspace_kx_cluster.html.markdown
+++ b/website/docs/r/finspace_kx_cluster.html.markdown
@@ -52,6 +52,13 @@ resource "aws_finspace_kx_cluster" "example" {
     s3_bucket = aws_s3_bucket.test.id
     s3_key    = aws_s3_object.object.key
   }
+  
+  # Depending on the amount of data cached, create/update timeouts 
+  # may need to be increased up to a potential maximum of 18 hours.
+  timeouts {
+    create = "18h"
+    update = "18h"
+  }
 }
 ```
 
@@ -123,6 +130,9 @@ The cache_storage_configuration block supports the following arguments:
     * CACHE_12 - This type provides 12 MB/s disk access throughput.
 * `size` - (Required) Size of cache in Gigabytes.
 
+Please note that create/update timeouts may have to be adjusted from the default 4 hours depending upon the
+volume of data being cached, as noted in the example configuration.
+
 ### code
 
 The code block supports the following arguments:
@@ -177,8 +187,8 @@ This resource exports the following attributes in addition to the arguments abov
 
 [Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
 
-* `create` - (Default `18h`)
-* `update` - (Default `18h`)
+* `create` - (Default `4h`)
+* `update` - (Default `4h`)
 * `delete` - (Default `60m`)
 
 ## Import

--- a/website/docs/r/finspace_kx_cluster.html.markdown
+++ b/website/docs/r/finspace_kx_cluster.html.markdown
@@ -52,7 +52,7 @@ resource "aws_finspace_kx_cluster" "example" {
     s3_bucket = aws_s3_bucket.test.id
     s3_key    = aws_s3_object.object.key
   }
-  
+
   # Depending on the amount of data cached, create/update timeouts 
   # may need to be increased up to a potential maximum of 18 hours.
   timeouts {

--- a/website/docs/r/finspace_kx_cluster.html.markdown
+++ b/website/docs/r/finspace_kx_cluster.html.markdown
@@ -177,8 +177,8 @@ This resource exports the following attributes in addition to the arguments abov
 
 [Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
 
-* `create` - (Default `45m`)
-* `update` - (Default `30m`)
+* `create` - (Default `18h`)
+* `update` - (Default `18h`)
 * `delete` - (Default `60m`)
 
 ## Import

--- a/website/docs/r/finspace_kx_environment.html.markdown
+++ b/website/docs/r/finspace_kx_environment.html.markdown
@@ -173,7 +173,7 @@ This resource exports the following attributes in addition to the arguments abov
 
 * `create` - (Default `30m`)
 * `update` - (Default `30m`)
-* `delete` - (Default `45m`)
+* `delete` - (Default `75m`)
 
 ## Import
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Increases create and update default timeouts of kx_cluster resource to 18 hours to prepare for upcoming changes involving cache warming.

Also increase delete default timeout of kx_environment resource to 75 minutes to prepare for bug fix coming to deletion workflow when environment has deleting clusters (as in acceptance tests).

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #33745 and #31806


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Fix on cluster/environment deletion still in progress for kx_cluster tests, but ran TestAccFinSpaceKxCluster_code after making timeout changes and verified that create and update both worked as expected, along with their checks. Will rerun all cluster tests once deletion bug is fixed.