### PR TITLE
MSK configuration data source should accept longer name

### DIFF
--- a/internal/service/kafka/configuration_data_source.go
+++ b/internal/service/kafka/configuration_data_source.go
@@ -43,7 +43,7 @@ func DataSourceConfiguration() *schema.Resource {
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.StringLenBetween(1, 64),
+				ValidateFunc: validation.StringLenBetween(1, 128),
 			},
 			"server_properties": {
 				Type:     schema.TypeString,

--- a/internal/service/kafka/configuration_data_source_test.go
+++ b/internal/service/kafka/configuration_data_source_test.go
@@ -5,6 +5,7 @@ package kafka_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/kafka"
@@ -16,6 +17,34 @@ import (
 func TestAccKafkaConfigurationDataSource_name(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_msk_configuration.test"
+	resourceName := "aws_msk_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, kafka.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckConfigurationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigurationDataSourceConfig_name(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "description", dataSourceName, "description"),
+					resource.TestCheckResourceAttrPair(resourceName, "kafka_versions.#", dataSourceName, "kafka_versions.#"),
+					resource.TestCheckResourceAttrPair(resourceName, "latest_revision", dataSourceName, "latest_revision"),
+					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "server_properties", dataSourceName, "server_properties"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKafkaConfigurationDataSource_longestName(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName = rName + strings.Repeat("a", 128-len(rName)) // make configuration name 128 characters
 	dataSourceName := "data.aws_msk_configuration.test"
 	resourceName := "aws_msk_configuration.test"
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

We created some MSK configs longer than 64 characters. But when we tried to read them via data source, errors occurred: `Error: expected length of name to be in the range (1 - 64)`. I've verified that the longest name for configuration should be `128`.

<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccKafkaConfigurationDataSource_longestName PKG=kafka
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/kafka/... -v -count 1 -parallel 20 -run='TestAccKafkaConfigurationDataSource_longestName'  -timeout 360m
=== RUN   TestAccKafkaConfigurationDataSource_longestName
=== PAUSE TestAccKafkaConfigurationDataSource_longestName
=== CONT  TestAccKafkaConfigurationDataSource_longestName
--- PASS: TestAccKafkaConfigurationDataSource_longestName (25.83s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kafka	30.466s

...
```
