### PR TITLE
Regressions notifier: wrap title with toJSON to prevent quoting issues

### DIFF
--- a/.github/workflows/regressions.yml
+++ b/.github/workflows/regressions.yml
@@ -17,7 +17,7 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           EVENT_URL: ${{ github.event.issue.html_url || github.event.pull_request.html_url }}
-          EVENT_TITLE: ${{ github.event.issue.title || github.event.pull_request.title }}
+          EVENT_TITLE: ${{ toJSON(github.event.issue.title || github.event.pull_request.title) }}
         with:
           channel-id: ${{ secrets.SLACK_CHANNEL }}
           payload: |


### PR DESCRIPTION
### Description

This PR fixes an issue where a title with a quote would break the regressions Slack notifier.

### References

- https://github.com/slackapi/slack-github-action/issues/202#issuecomment-1769132156


### Output from Acceptance Testing

N/a, Actions
