### PR TITLE
r/chimesdkvoice service: fix eventual consistency errors

### DIFF
--- a/.changelog/34426.txt
+++ b/.changelog/34426.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_chimesdkvoice_sip_rule: Fix eventual consistency errors when not using `us-east-1`
+```
+
+```release-note:bug
+resource/aws_chimesdkvoice_sip_media_application: Fix eventual consistency errors when not using `us-east-1`
+```

--- a/internal/service/chimesdkvoice/exports_test.go
+++ b/internal/service/chimesdkvoice/exports_test.go
@@ -6,4 +6,5 @@ package chimesdkvoice
 // Exports for use in tests only.
 var (
 	FindSIPMediaApplicationByID = findSIPMediaApplicationByID
+	FindSIPRuleByID             = findSIPRuleByID
 )

--- a/internal/service/chimesdkvoice/exports_test.go
+++ b/internal/service/chimesdkvoice/exports_test.go
@@ -1,0 +1,9 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package chimesdkvoice
+
+// Exports for use in tests only.
+var (
+	FindSIPMediaApplicationByID = findSIPMediaApplicationByID
+)

--- a/internal/service/chimesdkvoice/find..go
+++ b/internal/service/chimesdkvoice/find..go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package chimesdkvoice
 
 import (

--- a/internal/service/chimesdkvoice/find..go
+++ b/internal/service/chimesdkvoice/find..go
@@ -1,0 +1,32 @@
+package chimesdkvoice
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+const (
+	sipResourcePropagationTimeout = 1 * time.Minute
+)
+
+func FindSIPResourceWithRetry[T any](ctx context.Context, isNewResource bool, f func() (T, error)) (T, error) {
+	var resp T
+	err := tfresource.Retry(ctx, sipResourcePropagationTimeout, func() *retry.RetryError {
+		var err error
+		resp, err = f()
+		if isNewResource && tfresource.NotFound(err) {
+			return retry.RetryableError(err)
+		}
+
+		if err != nil {
+			return retry.NonRetryableError(err)
+		}
+
+		return nil
+	}, tfresource.WithDelay(5*time.Second))
+
+	return resp, err
+}

--- a/internal/service/chimesdkvoice/sip_rule.go
+++ b/internal/service/chimesdkvoice/sip_rule.go
@@ -11,10 +11,12 @@ import (
 	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 // @SDKResource("aws_chimesdkvoice_sip_rule", name="Sip Rule")
@@ -107,26 +109,21 @@ func resourceSipRuleRead(ctx context.Context, d *schema.ResourceData, meta inter
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
 
-	getInput := &chimesdkvoice.GetSipRuleInput{
-		SipRuleId: aws.String(d.Id()),
-	}
+	resp, err := FindSIPResourceWithRetry(ctx, d.IsNewResource(), func() (*chimesdkvoice.SipRule, error) {
+		return findSIPRuleByID(ctx, conn, d.Id())
+	})
 
-	resp, err := conn.GetSipRuleWithContext(ctx, getInput)
-	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, chimesdkvoice.ErrCodeNotFoundException) {
+	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] ChimeSDKVoice Sip Rule %s not found", d.Id())
 		d.SetId("")
 		return diags
 	}
 
-	if err != nil || resp.SipRule == nil {
-		return sdkdiag.AppendErrorf(diags, "getting Sip Rule (%s): %s", d.Id(), err)
-	}
-
-	d.Set("name", resp.SipRule.Name)
-	d.Set("disabled", resp.SipRule.Disabled)
-	d.Set("trigger_type", resp.SipRule.TriggerType)
-	d.Set("trigger_value", resp.SipRule.TriggerValue)
-	d.Set("target_applications", flattenSipRuleTargetApplications(resp.SipRule.TargetApplications))
+	d.Set("name", resp.Name)
+	d.Set("disabled", resp.Disabled)
+	d.Set("trigger_type", resp.TriggerType)
+	d.Set("trigger_value", resp.TriggerValue)
+	d.Set("target_applications", flattenSipRuleTargetApplications(resp.TargetApplications))
 	return diags
 }
 
@@ -203,4 +200,29 @@ func flattenSipRuleTargetApplications(apiObject []*chimesdkvoice.SipRuleTargetAp
 		rawSipRuleTargetApplications = append(rawSipRuleTargetApplications, rawTargetApplication)
 	}
 	return rawSipRuleTargetApplications
+}
+
+func findSIPRuleByID(ctx context.Context, conn *chimesdkvoice.ChimeSDKVoice, id string) (*chimesdkvoice.SipRule, error) {
+	in := &chimesdkvoice.GetSipRuleInput{
+		SipRuleId: aws.String(id),
+	}
+
+	resp, err := conn.GetSipRuleWithContext(ctx, in)
+
+	if tfawserr.ErrCodeEquals(err, chimesdkvoice.ErrCodeNotFoundException) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: in,
+		}
+	}
+
+	if resp == nil || resp.SipRule == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.SipRule, nil
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Test are successful in regions other than `us-east-1`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #32678

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTARGS="-run=TestAccChimeSDKVoiceSipMediaApplication_" PKG=chimesdkvoice

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/chimesdkvoice/... -v -count 1 -parallel 20  -run=TestAccChimeSDKVoiceSipMediaApplication_ -timeout 360m
--- PASS: TestAccChimeSDKVoiceSipMediaApplication_disappears (129.17s)
--- PASS: TestAccChimeSDKVoiceSipMediaApplication_basic (145.59s)
--- PASS: TestAccChimeSDKVoiceSipMediaApplication_update (254.78s)
--- PASS: TestAccChimeSDKVoiceSipMediaApplication_tags (352.36s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/chimesdkvoice	355.659s
```

```console
$ make testacc TESTARGS="-run=TestAccChimeSDKVoiceSipRule_" PKG=chimesdkvoice

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/chimesdkvoice/... -v -count 1 -parallel 20  -run=TestAccChimeSDKVoiceSipRule_ -timeout 360m
--- PASS: TestAccChimeSDKVoiceSipRule_disappears (201.51s)
--- PASS: TestAccChimeSDKVoiceSipRule_basic (207.11s)
--- PASS: TestAccChimeSDKVoiceSipRule_update (356.54s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/chimesdkvoice	359.815s
 ```
