### PR TITLE
Adds tests for shared config file parsing

### DIFF
--- a/internal/conns/awsclient.go
+++ b/internal/conns/awsclient.go
@@ -53,6 +53,10 @@ func (client *AWSClient) CredentialsProvider() aws_sdkv2.CredentialsProvider {
 	return client.awsConfig.Credentials
 }
 
+func (client *AWSClient) AwsConfig() aws_sdkv2.Config { // nosemgrep:ci.aws-in-func-name
+	return client.awsConfig.Copy()
+}
+
 // PartitionHostname returns a hostname with the provider domain suffix for the partition
 // e.g. PREFIX.amazonaws.com
 // The prefix should not contain a trailing period.

--- a/internal/provider/provider_config_test.go
+++ b/internal/provider/provider_config_test.go
@@ -60,7 +60,7 @@ region = us-west-2
 			SharedConfigurationFile: `
 	[default]
 	region = us-west-2
-		`,
+		`, //lintignore:AWSAT003
 			Check: func(t *testing.T, meta *conns.AWSClient) {
 				//lintignore:AWSAT003
 				if a, e := meta.Region, "us-west-2"; a != e {
@@ -80,7 +80,7 @@ region = us-west-2
 
 	[profile test]
 	region = us-east-1
-			`,
+			`, //lintignore:AWSAT003
 			Check: func(t *testing.T, meta *conns.AWSClient) {
 				//lintignore:AWSAT003
 				if a, e := meta.Region, "us-east-1"; a != e {
@@ -99,7 +99,7 @@ region = us-west-2
 
 [profile test]
 region = us-east-1
-`,
+`, //lintignore:AWSAT003
 			Check: func(t *testing.T, meta *conns.AWSClient) {
 				//lintignore:AWSAT003
 				if a, e := meta.Region, "us-east-1"; a != e {
@@ -113,7 +113,7 @@ region = us-east-1
 [default]
 region = us-west-2
 sso_start_url = https://d-123456789a.awsapps.com/start#
-`,
+`, //lintignore:AWSAT003
 			Check: func(t *testing.T, meta *conns.AWSClient) {
 				awsConfig := meta.AwsConfig()
 				var ssoStartUrl string

--- a/internal/provider/provider_config_test.go
+++ b/internal/provider/provider_config_test.go
@@ -23,6 +23,8 @@ import (
 
 // TestSharedConfigFileParsing prevents regression in shared config file parsing
 // * https://github.com/aws/aws-sdk-go-v2/issues/2349: indented keys
+// * https://github.com/aws/aws-sdk-go-v2/issues/2363: leading whitespace
+// * https://github.com/aws/aws-sdk-go-v2/issues/2369: trailing `#` in, e.g. SSO Start URLs
 func TestSharedConfigFileParsing(t *testing.T) { //nolint:paralleltest
 	testcases := map[string]struct {
 		Config                  map[string]any

--- a/internal/provider/provider_config_test.go
+++ b/internal/provider/provider_config_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/google/go-cmp/cmp"
 	configtesting "github.com/hashicorp/aws-sdk-go-base/v2/configtesting"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
@@ -17,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"golang.org/x/exp/maps"
 )
 
 // TestSharedConfigFileParsing prevents regression in shared config file parsing
@@ -27,16 +29,101 @@ func TestSharedConfigFileParsing(t *testing.T) { //nolint:paralleltest
 		SharedConfigurationFile string
 		Check                   func(t *testing.T, meta *conns.AWSClient)
 	}{
+		"leading newline": {
+			SharedConfigurationFile: `
+[default]
+region = us-west-2
+`, //lintignore:AWSAT003
+			Check: func(t *testing.T, meta *conns.AWSClient) {
+				//lintignore:AWSAT003
+				if a, e := meta.Region, "us-west-2"; a != e {
+					t.Errorf("expected region %q, got %q", e, a)
+				}
+			},
+		},
+
 		"leading whitespace": {
 			// Do not "fix" indentation!
-			SharedConfigurationFile: `
-	[default]
+			SharedConfigurationFile: `	[default]
 	region = us-west-2
 	`, //lintignore:AWSAT003
 			Check: func(t *testing.T, meta *conns.AWSClient) {
 				//lintignore:AWSAT003
 				if a, e := meta.Region, "us-west-2"; a != e {
 					t.Errorf("expected region %q, got %q", e, a)
+				}
+			},
+		},
+
+		"leading newline and whitespace": {
+			// Do not "fix" indentation!
+			SharedConfigurationFile: `
+	[default]
+	region = us-west-2
+		`,
+			Check: func(t *testing.T, meta *conns.AWSClient) {
+				//lintignore:AWSAT003
+				if a, e := meta.Region, "us-west-2"; a != e {
+					t.Errorf("expected region %q, got %q", e, a)
+				}
+			},
+		},
+
+		"named profile after leading newline and whitespace": {
+			Config: map[string]any{
+				"profile": "test",
+			},
+			// Do not "fix" indentation!
+			SharedConfigurationFile: `
+[default]
+region = us-west-2
+
+	[profile test]
+	region = us-east-1
+			`,
+			Check: func(t *testing.T, meta *conns.AWSClient) {
+				//lintignore:AWSAT003
+				if a, e := meta.Region, "us-east-1"; a != e {
+					t.Errorf("expected region %q, got %q", e, a)
+				}
+			},
+		},
+
+		"named profile": {
+			Config: map[string]any{
+				"profile": "test",
+			},
+			SharedConfigurationFile: `
+[default]
+region = us-west-2
+
+[profile test]
+region = us-east-1
+`,
+			Check: func(t *testing.T, meta *conns.AWSClient) {
+				//lintignore:AWSAT003
+				if a, e := meta.Region, "us-east-1"; a != e {
+					t.Errorf("expected region %q, got %q", e, a)
+				}
+			},
+		},
+
+		"trailing hash": {
+			SharedConfigurationFile: `
+[default]
+region = us-west-2
+sso_start_url = https://d-123456789a.awsapps.com/start#
+`,
+			Check: func(t *testing.T, meta *conns.AWSClient) {
+				awsConfig := meta.AwsConfig()
+				var ssoStartUrl string
+				for _, source := range awsConfig.ConfigSources {
+					if shared, ok := source.(config.SharedConfig); ok {
+						ssoStartUrl = shared.SSOStartURL
+					}
+				}
+				if a, e := ssoStartUrl, "https://d-123456789a.awsapps.com/start#"; a != e {
+					t.Errorf("expected sso_start_url %q, got %q", e, a)
 				}
 			},
 		},
@@ -56,6 +143,8 @@ func TestSharedConfigFileParsing(t *testing.T) { //nolint:paralleltest
 				"skip_credentials_validation": true,
 				"skip_requesting_account_id":  true,
 			}
+
+			maps.Copy(config, tc.Config)
 
 			if tc.SharedConfigurationFile != "" {
 				file, err := os.CreateTemp("", "aws-sdk-go-base-shared-configuration-file")
@@ -101,6 +190,10 @@ func TestSharedConfigFileParsing(t *testing.T) { //nolint:paralleltest
 
 			if diff := cmp.Diff(diags, expected, cmp.Comparer(sdkdiag.Comparer)); diff != "" {
 				t.Errorf("unexpected diagnostics difference: %s", diff)
+			}
+
+			if diags.HasError() {
+				t.FailNow()
 			}
 
 			meta := p.Meta().(*conns.AWSClient)


### PR DESCRIPTION
Adds tests to validate shared config file parsing

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/aws/aws-sdk-go-v2/issues/2369

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% go test ./internal/provider/... -run=TestSharedConfigFileParsing -v

--- PASS: TestSharedConfigFileParsing (0.95s)
    --- PASS: TestSharedConfigFileParsing/named_profile_after_leading_newline_and_whitespace (0.20s)
    --- PASS: TestSharedConfigFileParsing/named_profile (0.13s)
    --- PASS: TestSharedConfigFileParsing/trailing_hash (0.14s)
    --- PASS: TestSharedConfigFileParsing/leading_newline (0.20s)
    --- PASS: TestSharedConfigFileParsing/leading_whitespace (0.13s)
    --- PASS: TestSharedConfigFileParsing/leading_newline_and_whitespace (0.16s)
```
