### PR TITLE
Fix domain_name argument formatting

### DIFF
--- a/website/docs/r/sagemaker_domain.html.markdown
+++ b/website/docs/r/sagemaker_domain.html.markdown
@@ -92,7 +92,8 @@ The following arguments are required:
 
 * `auth_mode` - (Required) The mode of authentication that members use to access the domain. Valid values are `IAM` and `SSO`.
 * `default_space_settings` - (Required) The default space settings. See [Default Space Settings](#default_space_settings) below.
-* `default_user_settings` - (Required) The default user settings. See [Default User Settings](#default_user_settings) below.* `domain_name` - (Required) The domain name.
+* `default_user_settings` - (Required) The default user settings. See [Default User Settings](#default_user_settings) below.
+* `domain_name` - (Required) The domain name.
 * `subnet_ids` - (Required) The VPC subnets that Studio uses for communication.
 * `vpc_id` - (Required) The ID of the Amazon Virtual Private Cloud (VPC) that Studio uses for communication.
 


### PR DESCRIPTION
I found a small formatting issue in the [sagemaker_domain](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sagemaker_domain) doc, it looks like this:
<img width="700" alt="Screenshot 2023-11-16 at 11 49 36" src="https://github.com/hashicorp/terraform-provider-aws/assets/41582251/572c871f-7406-499d-b437-db0b7d791cee">
This PR fixeds that