### PR TITLE
td/chime service -> sdkv2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/athena v1.34.1
 	github.com/aws/aws-sdk-go-v2/service/auditmanager v1.29.1
 	github.com/aws/aws-sdk-go-v2/service/bedrock v1.3.1
+	github.com/aws/aws-sdk-go-v2/service/chimesdkvoice v1.11.2
 	github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.7.0
 	github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.14.2
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.27.0
@@ -145,7 +146,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.16.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.17.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.19.1 // indirect
-	github.com/aws/smithy-go v1.16.0 // indirect
+	github.com/aws/smithy-go v1.17.0 // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/boombuler/barcode v1.0.1 // indirect
 	github.com/bufbuild/protocompile v0.6.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -146,7 +146,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.16.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.17.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.19.1 // indirect
-	github.com/aws/smithy-go v1.17.0 // indirect
+	github.com/aws/smithy-go v1.16.0 // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/boombuler/barcode v1.0.1 // indirect
 	github.com/bufbuild/protocompile v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/aws/aws-sdk-go-v2/service/auditmanager v1.29.1 h1:qeUpRNt719FxxOv0OIb
 github.com/aws/aws-sdk-go-v2/service/auditmanager v1.29.1/go.mod h1:Ta+K43GimomnNMOSgZBHDy6itNw8zfhcJoSVkLWCPiE=
 github.com/aws/aws-sdk-go-v2/service/bedrock v1.3.1 h1:lAbJ/wQ96QZPbgMGkwy4MkwYBE0fSkHrsCqpdzKB8FA=
 github.com/aws/aws-sdk-go-v2/service/bedrock v1.3.1/go.mod h1:T6sGivDDiUgXY/R3+S9t5oRR0XJiUeKAXyyw3LRdTK4=
+github.com/aws/aws-sdk-go-v2/service/chimesdkvoice v1.11.2 h1:BOhDhkslpSqyye38XkGuYRtKc2K+LUARi40+nLfFZns=
+github.com/aws/aws-sdk-go-v2/service/chimesdkvoice v1.11.2/go.mod h1:ugdoQ39F3IjYNFnWgPqruX04VpJLYlvZ/Ncv/UOT2lM=
 github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.7.0 h1:Tzr0M3HxHIjFtxxPzsKE9xeLOrWCfJXl5HDCgkmiylE=
 github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.7.0/go.mod h1:1uZJJhBfD+zak0t687UE2IQ8t8hugY6bpM67IpLcYK8=
 github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.14.2 h1:wm8zm7z6Gl+5O4K5DbZAm1Q37W2SGX4OrP9VOVPuHvc=
@@ -208,8 +210,8 @@ github.com/aws/aws-sdk-go-v2/service/workspaces v1.33.1 h1:9pj1eIIwWJqGrITnkH6gg
 github.com/aws/aws-sdk-go-v2/service/workspaces v1.33.1/go.mod h1:WpCZtgHZRiYfv0jN6WsgKYvpsGp5H/QxUF+VYnTwmcE=
 github.com/aws/aws-sdk-go-v2/service/xray v1.22.1 h1:EfeYTIUR/HgFijILpqvRh3Xgky0qOW998lOOmMSPqRY=
 github.com/aws/aws-sdk-go-v2/service/xray v1.22.1/go.mod h1:4+g9QRvp2RZko4VZF62ICz59N3t1yUPllfzMy6yg8yg=
-github.com/aws/smithy-go v1.16.0 h1:gJZEH/Fqh+RsvlJ1Zt4tVAtV6bKkp3cC+R6FCZMNzik=
-github.com/aws/smithy-go v1.16.0/go.mod h1:NukqUGpCZIILqqiV0NIjeFh24kd/FAa4beRb6nbIUPE=
+github.com/aws/smithy-go v1.17.0 h1:wWJD7LX6PBV6etBUwO0zElG0nWN9rUhp0WdYeHSHAaI=
+github.com/aws/smithy-go v1.17.0/go.mod h1:NukqUGpCZIILqqiV0NIjeFh24kd/FAa4beRb6nbIUPE=
 github.com/beevik/etree v1.2.0 h1:l7WETslUG/T+xOPs47dtd6jov2Ii/8/OjCldk5fYfQw=
 github.com/beevik/etree v1.2.0/go.mod h1:aiPf89g/1k3AShMVAzriilpcE4R/Vuor90y83zVZWFc=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=

--- a/go.sum
+++ b/go.sum
@@ -210,8 +210,8 @@ github.com/aws/aws-sdk-go-v2/service/workspaces v1.33.1 h1:9pj1eIIwWJqGrITnkH6gg
 github.com/aws/aws-sdk-go-v2/service/workspaces v1.33.1/go.mod h1:WpCZtgHZRiYfv0jN6WsgKYvpsGp5H/QxUF+VYnTwmcE=
 github.com/aws/aws-sdk-go-v2/service/xray v1.22.1 h1:EfeYTIUR/HgFijILpqvRh3Xgky0qOW998lOOmMSPqRY=
 github.com/aws/aws-sdk-go-v2/service/xray v1.22.1/go.mod h1:4+g9QRvp2RZko4VZF62ICz59N3t1yUPllfzMy6yg8yg=
-github.com/aws/smithy-go v1.17.0 h1:wWJD7LX6PBV6etBUwO0zElG0nWN9rUhp0WdYeHSHAaI=
-github.com/aws/smithy-go v1.17.0/go.mod h1:NukqUGpCZIILqqiV0NIjeFh24kd/FAa4beRb6nbIUPE=
+github.com/aws/smithy-go v1.16.0 h1:gJZEH/Fqh+RsvlJ1Zt4tVAtV6bKkp3cC+R6FCZMNzik=
+github.com/aws/smithy-go v1.16.0/go.mod h1:NukqUGpCZIILqqiV0NIjeFh24kd/FAa4beRb6nbIUPE=
 github.com/beevik/etree v1.2.0 h1:l7WETslUG/T+xOPs47dtd6jov2Ii/8/OjCldk5fYfQw=
 github.com/beevik/etree v1.2.0/go.mod h1:aiPf89g/1k3AShMVAzriilpcE4R/Vuor90y83zVZWFc=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=

--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -11,6 +11,7 @@ import (
 	athena_sdkv2 "github.com/aws/aws-sdk-go-v2/service/athena"
 	auditmanager_sdkv2 "github.com/aws/aws-sdk-go-v2/service/auditmanager"
 	bedrock_sdkv2 "github.com/aws/aws-sdk-go-v2/service/bedrock"
+	chimesdkvoice_sdkv2 "github.com/aws/aws-sdk-go-v2/service/chimesdkvoice"
 	cleanrooms_sdkv2 "github.com/aws/aws-sdk-go-v2/service/cleanrooms"
 	cloudcontrol_sdkv2 "github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	cloudwatchlogs_sdkv2 "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
@@ -97,7 +98,6 @@ import (
 	budgets_sdkv1 "github.com/aws/aws-sdk-go/service/budgets"
 	chime_sdkv1 "github.com/aws/aws-sdk-go/service/chime"
 	chimesdkmediapipelines_sdkv1 "github.com/aws/aws-sdk-go/service/chimesdkmediapipelines"
-	chimesdkvoice_sdkv1 "github.com/aws/aws-sdk-go/service/chimesdkvoice"
 	cloud9_sdkv1 "github.com/aws/aws-sdk-go/service/cloud9"
 	cloudformation_sdkv1 "github.com/aws/aws-sdk-go/service/cloudformation"
 	cloudfront_sdkv1 "github.com/aws/aws-sdk-go/service/cloudfront"
@@ -346,8 +346,8 @@ func (c *AWSClient) ChimeSDKMediaPipelinesConn(ctx context.Context) *chimesdkmed
 	return errs.Must(conn[*chimesdkmediapipelines_sdkv1.ChimeSDKMediaPipelines](ctx, c, names.ChimeSDKMediaPipelines))
 }
 
-func (c *AWSClient) ChimeSDKVoiceConn(ctx context.Context) *chimesdkvoice_sdkv1.ChimeSDKVoice {
-	return errs.Must(conn[*chimesdkvoice_sdkv1.ChimeSDKVoice](ctx, c, names.ChimeSDKVoice))
+func (c *AWSClient) ChimeSDKVoiceClient(ctx context.Context) *chimesdkvoice_sdkv2.Client {
+	return errs.Must(client[*chimesdkvoice_sdkv2.Client](ctx, c, names.ChimeSDKVoice))
 }
 
 func (c *AWSClient) CleanRoomsClient(ctx context.Context) *cleanrooms_sdkv2.Client {

--- a/internal/service/chime/generate.go
+++ b/internal/service/chime/generate.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-//go:generate go run ../../generate/tags/main.go -ListTags -ListTagsInIDElem=ResourceARN -ServiceTagsSlice -TagInIDElem=ResourceARN -UpdateTags -AWSSDKServicePackage=chimesdkvoice
+//go:generate go run ../../generate/tags/main.go -AWSSDKVersion=2 -ListTags -ListTagsInIDElem=ResourceARN -ServiceTagsSlice -TagInIDElem=ResourceARN -UpdateTags -AWSSDKServicePackage=chimesdkvoice
 //go:generate go run ../../generate/servicepackage/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/chime/tags_gen.go
+++ b/internal/service/chime/tags_gen.go
@@ -5,9 +5,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
-	"github.com/aws/aws-sdk-go/service/chimesdkvoice/chimesdkvoiceiface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/chimesdkvoice"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/chimesdkvoice/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/logging"
@@ -19,12 +19,12 @@ import (
 // listTags lists chime service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn chimesdkvoiceiface.ChimeSDKVoiceAPI, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *chimesdkvoice.Client, identifier string) (tftags.KeyValueTags, error) {
 	input := &chimesdkvoice.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResourceWithContext(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -36,7 +36,7 @@ func listTags(ctx context.Context, conn chimesdkvoiceiface.ChimeSDKVoiceAPI, ide
 // ListTags lists chime service tags and set them in Context.
 // It is called from outside this package.
 func (p *servicePackage) ListTags(ctx context.Context, meta any, identifier string) error {
-	tags, err := listTags(ctx, meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx), identifier)
+	tags, err := listTags(ctx, meta.(*conns.AWSClient).ChimeSDKVoiceClient(ctx), identifier)
 
 	if err != nil {
 		return err
@@ -52,11 +52,11 @@ func (p *servicePackage) ListTags(ctx context.Context, meta any, identifier stri
 // []*SERVICE.Tag handling
 
 // Tags returns chime service tags.
-func Tags(tags tftags.KeyValueTags) []*chimesdkvoice.Tag {
-	result := make([]*chimesdkvoice.Tag, 0, len(tags))
+func Tags(tags tftags.KeyValueTags) []awstypes.Tag {
+	result := make([]awstypes.Tag, 0, len(tags))
 
 	for k, v := range tags.Map() {
-		tag := &chimesdkvoice.Tag{
+		tag := awstypes.Tag{
 			Key:   aws.String(k),
 			Value: aws.String(v),
 		}
@@ -68,11 +68,11 @@ func Tags(tags tftags.KeyValueTags) []*chimesdkvoice.Tag {
 }
 
 // KeyValueTags creates tftags.KeyValueTags from chimesdkvoice service tags.
-func KeyValueTags(ctx context.Context, tags []*chimesdkvoice.Tag) tftags.KeyValueTags {
+func KeyValueTags(ctx context.Context, tags []awstypes.Tag) tftags.KeyValueTags {
 	m := make(map[string]*string, len(tags))
 
 	for _, tag := range tags {
-		m[aws.StringValue(tag.Key)] = tag.Value
+		m[aws.ToString(tag.Key)] = tag.Value
 	}
 
 	return tftags.New(ctx, m)
@@ -80,7 +80,7 @@ func KeyValueTags(ctx context.Context, tags []*chimesdkvoice.Tag) tftags.KeyValu
 
 // getTagsIn returns chime service tags from Context.
 // nil is returned if there are no input tags.
-func getTagsIn(ctx context.Context) []*chimesdkvoice.Tag {
+func getTagsIn(ctx context.Context) []awstypes.Tag {
 	if inContext, ok := tftags.FromContext(ctx); ok {
 		if tags := Tags(inContext.TagsIn.UnwrapOrDefault()); len(tags) > 0 {
 			return tags
@@ -91,7 +91,7 @@ func getTagsIn(ctx context.Context) []*chimesdkvoice.Tag {
 }
 
 // setTagsOut sets chime service tags in Context.
-func setTagsOut(ctx context.Context, tags []*chimesdkvoice.Tag) {
+func setTagsOut(ctx context.Context, tags []awstypes.Tag) {
 	if inContext, ok := tftags.FromContext(ctx); ok {
 		inContext.TagsOut = types.Some(KeyValueTags(ctx, tags))
 	}
@@ -100,7 +100,7 @@ func setTagsOut(ctx context.Context, tags []*chimesdkvoice.Tag) {
 // updateTags updates chime service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn chimesdkvoiceiface.ChimeSDKVoiceAPI, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *chimesdkvoice.Client, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -111,10 +111,10 @@ func updateTags(ctx context.Context, conn chimesdkvoiceiface.ChimeSDKVoiceAPI, i
 	if len(removedTags) > 0 {
 		input := &chimesdkvoice.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.Keys()),
+			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResourceWithContext(ctx, input)
+		_, err := conn.UntagResource(ctx, input)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -129,7 +129,7 @@ func updateTags(ctx context.Context, conn chimesdkvoiceiface.ChimeSDKVoiceAPI, i
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResourceWithContext(ctx, input)
+		_, err := conn.TagResource(ctx, input)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)
@@ -142,5 +142,5 @@ func updateTags(ctx context.Context, conn chimesdkvoiceiface.ChimeSDKVoiceAPI, i
 // UpdateTags updates chime service tags.
 // It is called from outside this package.
 func (p *servicePackage) UpdateTags(ctx context.Context, meta any, identifier string, oldTags, newTags any) error {
-	return updateTags(ctx, meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx), identifier, oldTags, newTags)
+	return updateTags(ctx, meta.(*conns.AWSClient).ChimeSDKVoiceClient(ctx), identifier, oldTags, newTags)
 }

--- a/internal/service/chime/voice_connector_group.go
+++ b/internal/service/chime/voice_connector_group.go
@@ -7,14 +7,15 @@ import (
 	"context"
 	"log"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/chimesdkvoice"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/chimesdkvoice/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
@@ -61,7 +62,7 @@ func ResourceVoiceConnectorGroup() *schema.Resource {
 }
 
 func resourceVoiceConnectorGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
 	input := &chimesdkvoice.CreateVoiceConnectorGroupInput{
 		Name: aws.String(d.Get("name").(string)),
@@ -71,21 +72,21 @@ func resourceVoiceConnectorGroupCreate(ctx context.Context, d *schema.ResourceDa
 		input.VoiceConnectorItems = expandVoiceConnectorItems(v.(*schema.Set).List())
 	}
 
-	resp, err := conn.CreateVoiceConnectorGroupWithContext(ctx, input)
+	resp, err := conn.CreateVoiceConnectorGroup(ctx, input)
 	if err != nil || resp.VoiceConnectorGroup == nil {
 		return diag.Errorf("creating Chime Voice Connector group: %s", err)
 	}
 
-	d.SetId(aws.StringValue(resp.VoiceConnectorGroup.VoiceConnectorGroupId))
+	d.SetId(aws.ToString(resp.VoiceConnectorGroup.VoiceConnectorGroupId))
 
 	return resourceVoiceConnectorGroupRead(ctx, d, meta)
 }
 
 func resourceVoiceConnectorGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
-	resp, err := FindVoiceConnectorResourceWithRetry(ctx, d.IsNewResource(), func() (*chimesdkvoice.VoiceConnectorGroup, error) {
+	resp, err := FindVoiceConnectorResourceWithRetry(ctx, d.IsNewResource(), func() (*awstypes.VoiceConnectorGroup, error) {
 		return findVoiceConnectorGroupByID(ctx, conn, d.Id())
 	})
 
@@ -113,7 +114,7 @@ func resourceVoiceConnectorGroupRead(ctx context.Context, d *schema.ResourceData
 }
 
 func resourceVoiceConnectorGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
 	input := &chimesdkvoice.UpdateVoiceConnectorGroupInput{
 		Name:                  aws.String(d.Get("name").(string)),
@@ -125,10 +126,10 @@ func resourceVoiceConnectorGroupUpdate(ctx context.Context, d *schema.ResourceDa
 			input.VoiceConnectorItems = expandVoiceConnectorItems(v.(*schema.Set).List())
 		}
 	} else if !d.IsNewResource() {
-		input.VoiceConnectorItems = make([]*chimesdkvoice.VoiceConnectorItem, 0)
+		input.VoiceConnectorItems = make([]awstypes.VoiceConnectorItem, 0)
 	}
 
-	if _, err := conn.UpdateVoiceConnectorGroupWithContext(ctx, input); err != nil {
+	if _, err := conn.UpdateVoiceConnectorGroup(ctx, input); err != nil {
 		return diag.Errorf("updating Chime Voice Connector group (%s): %s", d.Id(), err)
 	}
 
@@ -136,7 +137,7 @@ func resourceVoiceConnectorGroupUpdate(ctx context.Context, d *schema.ResourceDa
 }
 
 func resourceVoiceConnectorGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
 	if v, ok := d.GetOk("connector"); ok && v.(*schema.Set).Len() > 0 {
 		if err := resourceVoiceConnectorGroupUpdate(ctx, d, meta); err != nil {
@@ -148,8 +149,8 @@ func resourceVoiceConnectorGroupDelete(ctx context.Context, d *schema.ResourceDa
 		VoiceConnectorGroupId: aws.String(d.Id()),
 	}
 
-	if _, err := conn.DeleteVoiceConnectorGroupWithContext(ctx, input); err != nil {
-		if tfawserr.ErrCodeEquals(err, chimesdkvoice.ErrCodeNotFoundException) {
+	if _, err := conn.DeleteVoiceConnectorGroup(ctx, input); err != nil {
+		if errs.IsA[*awstypes.NotFoundException](err) {
 			log.Printf("[WARN] Chime Voice conector group %s not found", d.Id())
 			return nil
 		}
@@ -159,41 +160,41 @@ func resourceVoiceConnectorGroupDelete(ctx context.Context, d *schema.ResourceDa
 	return nil
 }
 
-func expandVoiceConnectorItems(data []interface{}) []*chimesdkvoice.VoiceConnectorItem {
-	var connectorsItems []*chimesdkvoice.VoiceConnectorItem
+func expandVoiceConnectorItems(data []interface{}) []awstypes.VoiceConnectorItem {
+	var connectorsItems []awstypes.VoiceConnectorItem
 
 	for _, rItem := range data {
 		item := rItem.(map[string]interface{})
-		connectorsItems = append(connectorsItems, &chimesdkvoice.VoiceConnectorItem{
+		connectorsItems = append(connectorsItems, awstypes.VoiceConnectorItem{
 			VoiceConnectorId: aws.String(item["voice_connector_id"].(string)),
-			Priority:         aws.Int64(int64(item["priority"].(int))),
+			Priority:         aws.Int32(int32(item["priority"].(int))),
 		})
 	}
 
 	return connectorsItems
 }
 
-func flattenVoiceConnectorItems(connectors []*chimesdkvoice.VoiceConnectorItem) []interface{} {
+func flattenVoiceConnectorItems(connectors []awstypes.VoiceConnectorItem) []interface{} {
 	var rawConnectors []interface{}
 
 	for _, c := range connectors {
 		rawC := map[string]interface{}{
-			"priority":           aws.Int64Value(c.Priority),
-			"voice_connector_id": aws.StringValue(c.VoiceConnectorId),
+			"priority":           c.Priority,
+			"voice_connector_id": aws.ToString(c.VoiceConnectorId),
 		}
 		rawConnectors = append(rawConnectors, rawC)
 	}
 	return rawConnectors
 }
 
-func findVoiceConnectorGroupByID(ctx context.Context, conn *chimesdkvoice.ChimeSDKVoice, id string) (*chimesdkvoice.VoiceConnectorGroup, error) {
+func findVoiceConnectorGroupByID(ctx context.Context, conn *chimesdkvoice.Client, id string) (*awstypes.VoiceConnectorGroup, error) {
 	in := &chimesdkvoice.GetVoiceConnectorGroupInput{
 		VoiceConnectorGroupId: aws.String(id),
 	}
 
-	resp, err := conn.GetVoiceConnectorGroupWithContext(ctx, in)
+	resp, err := conn.GetVoiceConnectorGroup(ctx, in)
 
-	if tfawserr.ErrCodeEquals(err, chimesdkvoice.ErrCodeNotFoundException) {
+	if errs.IsA[*awstypes.NotFoundException](err) {
 		return nil, &retry.NotFoundError{
 			LastError:   err,
 			LastRequest: in,

--- a/internal/service/chime/voice_connector_group_test.go
+++ b/internal/service/chime/voice_connector_group_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/chimesdkvoice/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -16,11 +16,12 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfchime "github.com/hashicorp/terraform-provider-aws/internal/service/chime"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func testAccVoiceConnectorGroup_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	var voiceConnectorGroup *chimesdkvoice.VoiceConnectorGroup
+	var voiceConnectorGroup *awstypes.VoiceConnectorGroup
 
 	vcgName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector_group.test"
@@ -30,7 +31,7 @@ func testAccVoiceConnectorGroup_basic(t *testing.T) {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ChimeSDKVoiceEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorGroupDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -54,7 +55,7 @@ func testAccVoiceConnectorGroup_basic(t *testing.T) {
 
 func testAccVoiceConnectorGroup_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	var voiceConnectorGroup *chimesdkvoice.VoiceConnectorGroup
+	var voiceConnectorGroup *awstypes.VoiceConnectorGroup
 
 	vcgName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector_group.test"
@@ -64,7 +65,7 @@ func testAccVoiceConnectorGroup_disappears(t *testing.T) {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ChimeSDKVoiceEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorGroupDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -82,7 +83,7 @@ func testAccVoiceConnectorGroup_disappears(t *testing.T) {
 
 func testAccVoiceConnectorGroup_update(t *testing.T) {
 	ctx := acctest.Context(t)
-	var voiceConnectorGroup *chimesdkvoice.VoiceConnectorGroup
+	var voiceConnectorGroup *awstypes.VoiceConnectorGroup
 
 	vcgName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector_group.test"
@@ -92,7 +93,7 @@ func testAccVoiceConnectorGroup_update(t *testing.T) {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ChimeSDKVoiceEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorGroupDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -156,7 +157,7 @@ resource "aws_chime_voice_connector_group" "test" {
 `, name)
 }
 
-func testAccCheckVoiceConnectorGroupExists(ctx context.Context, name string, vc *chimesdkvoice.VoiceConnectorGroup) resource.TestCheckFunc {
+func testAccCheckVoiceConnectorGroupExists(ctx context.Context, name string, vc *awstypes.VoiceConnectorGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -167,9 +168,9 @@ func testAccCheckVoiceConnectorGroupExists(ctx context.Context, name string, vc 
 			return fmt.Errorf("no Chime voice connector group ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
-		resp, err := tfchime.FindVoiceConnectorResourceWithRetry(ctx, false, func() (*chimesdkvoice.VoiceConnectorGroup, error) {
+		resp, err := tfchime.FindVoiceConnectorResourceWithRetry(ctx, false, func() (*awstypes.VoiceConnectorGroup, error) {
 			return tfchime.FindVoiceConnectorGroupByID(ctx, conn, rs.Primary.ID)
 		})
 
@@ -189,9 +190,9 @@ func testAccCheckVoiceConnectorGroupDestroy(ctx context.Context) resource.TestCh
 			if rs.Type != "aws_chime_voice_connector" {
 				continue
 			}
-			conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+			conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
-			_, err := tfchime.FindVoiceConnectorResourceWithRetry(ctx, false, func() (*chimesdkvoice.VoiceConnectorGroup, error) {
+			_, err := tfchime.FindVoiceConnectorResourceWithRetry(ctx, false, func() (*awstypes.VoiceConnectorGroup, error) {
 				return tfchime.FindVoiceConnectorGroupByID(ctx, conn, rs.Primary.ID)
 			})
 

--- a/internal/service/chime/voice_connector_logging_test.go
+++ b/internal/service/chime/voice_connector_logging_test.go
@@ -8,13 +8,14 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/chimesdkvoice/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfchime "github.com/hashicorp/terraform-provider-aws/internal/service/chime"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func testAccVoiceConnectorLogging_basic(t *testing.T) {
@@ -27,7 +28,7 @@ func testAccVoiceConnectorLogging_basic(t *testing.T) {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ChimeSDKVoiceEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -58,7 +59,7 @@ func testAccVoiceConnectorLogging_disappears(t *testing.T) {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ChimeSDKVoiceEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -84,7 +85,7 @@ func testAccVoiceConnectorLogging_update(t *testing.T) {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ChimeSDKVoiceEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -152,9 +153,9 @@ func testAccCheckVoiceConnectorLoggingExists(ctx context.Context, name string) r
 			return fmt.Errorf("no Chime Voice Connector logging ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
-		_, err := tfchime.FindVoiceConnectorResourceWithRetry(ctx, false, func() (*chimesdkvoice.LoggingConfiguration, error) {
+		_, err := tfchime.FindVoiceConnectorResourceWithRetry(ctx, false, func() (*awstypes.LoggingConfiguration, error) {
 			return tfchime.FindVoiceConnectorLoggingByID(ctx, conn, rs.Primary.ID)
 		})
 

--- a/internal/service/chime/voice_connector_origination.go
+++ b/internal/service/chime/voice_connector_origination.go
@@ -7,14 +7,16 @@ import (
 	"context"
 	"log"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/chimesdkvoice"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/chimesdkvoice/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
@@ -59,9 +61,9 @@ func ResourceVoiceConnectorOrigination() *schema.Resource {
 							ValidateFunc: validation.IntBetween(1, 99),
 						},
 						"protocol": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringInSlice(chimesdkvoice.OriginationRouteProtocol_Values(), false),
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateDiagFunc: enum.Validate[awstypes.OriginationRouteProtocol](),
 						},
 						"weight": {
 							Type:         schema.TypeInt,
@@ -81,13 +83,13 @@ func ResourceVoiceConnectorOrigination() *schema.Resource {
 }
 
 func resourceVoiceConnectorOriginationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
 	vcId := d.Get("voice_connector_id").(string)
 
 	input := &chimesdkvoice.PutVoiceConnectorOriginationInput{
 		VoiceConnectorId: aws.String(vcId),
-		Origination: &chimesdkvoice.Origination{
+		Origination: &awstypes.Origination{
 			Routes: expandOriginationRoutes(d.Get("route").(*schema.Set).List()),
 		},
 	}
@@ -96,7 +98,7 @@ func resourceVoiceConnectorOriginationCreate(ctx context.Context, d *schema.Reso
 		input.Origination.Disabled = aws.Bool(v.(bool))
 	}
 
-	if _, err := conn.PutVoiceConnectorOriginationWithContext(ctx, input); err != nil {
+	if _, err := conn.PutVoiceConnectorOrigination(ctx, input); err != nil {
 		return diag.Errorf("creating Chime Voice Connector (%s) origination: %s", vcId, err)
 	}
 
@@ -106,9 +108,9 @@ func resourceVoiceConnectorOriginationCreate(ctx context.Context, d *schema.Reso
 }
 
 func resourceVoiceConnectorOriginationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
-	resp, err := FindVoiceConnectorResourceWithRetry(ctx, d.IsNewResource(), func() (*chimesdkvoice.Origination, error) {
+	resp, err := FindVoiceConnectorResourceWithRetry(ctx, d.IsNewResource(), func() (*awstypes.Origination, error) {
 		return findVoiceConnectorOriginationByID(ctx, conn, d.Id())
 	})
 
@@ -137,12 +139,12 @@ func resourceVoiceConnectorOriginationRead(ctx context.Context, d *schema.Resour
 }
 
 func resourceVoiceConnectorOriginationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
 	if d.HasChanges("route", "disabled") {
 		input := &chimesdkvoice.PutVoiceConnectorOriginationInput{
 			VoiceConnectorId: aws.String(d.Id()),
-			Origination: &chimesdkvoice.Origination{
+			Origination: &awstypes.Origination{
 				Routes: expandOriginationRoutes(d.Get("route").(*schema.Set).List()),
 			},
 		}
@@ -151,7 +153,7 @@ func resourceVoiceConnectorOriginationUpdate(ctx context.Context, d *schema.Reso
 			input.Origination.Disabled = aws.Bool(v.(bool))
 		}
 
-		_, err := conn.PutVoiceConnectorOriginationWithContext(ctx, input)
+		_, err := conn.PutVoiceConnectorOrigination(ctx, input)
 
 		if err != nil {
 			return diag.Errorf("updating Chime Voice Connector (%s) origination: %s", d.Id(), err)
@@ -162,15 +164,15 @@ func resourceVoiceConnectorOriginationUpdate(ctx context.Context, d *schema.Reso
 }
 
 func resourceVoiceConnectorOriginationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
 	input := &chimesdkvoice.DeleteVoiceConnectorOriginationInput{
 		VoiceConnectorId: aws.String(d.Id()),
 	}
 
-	_, err := conn.DeleteVoiceConnectorOriginationWithContext(ctx, input)
+	_, err := conn.DeleteVoiceConnectorOrigination(ctx, input)
 
-	if tfawserr.ErrCodeEquals(err, chimesdkvoice.ErrCodeNotFoundException) {
+	if errs.IsA[*awstypes.NotFoundException](err) {
 		return nil
 	}
 
@@ -181,33 +183,33 @@ func resourceVoiceConnectorOriginationDelete(ctx context.Context, d *schema.Reso
 	return nil
 }
 
-func expandOriginationRoutes(data []interface{}) []*chimesdkvoice.OriginationRoute {
-	var originationRoutes []*chimesdkvoice.OriginationRoute
+func expandOriginationRoutes(data []interface{}) []awstypes.OriginationRoute {
+	var originationRoutes []awstypes.OriginationRoute
 
 	for _, rItem := range data {
 		item := rItem.(map[string]interface{})
-		originationRoutes = append(originationRoutes, &chimesdkvoice.OriginationRoute{
+		originationRoutes = append(originationRoutes, awstypes.OriginationRoute{
 			Host:     aws.String(item["host"].(string)),
-			Port:     aws.Int64(int64(item["port"].(int))),
-			Priority: aws.Int64(int64(item["priority"].(int))),
-			Protocol: aws.String(item["protocol"].(string)),
-			Weight:   aws.Int64(int64(item["weight"].(int))),
+			Port:     aws.Int32(int32(item["port"].(int))),
+			Priority: aws.Int32(int32(item["priority"].(int))),
+			Protocol: awstypes.OriginationRouteProtocol(item["protocol"].(string)),
+			Weight:   aws.Int32(int32(item["weight"].(int))),
 		})
 	}
 
 	return originationRoutes
 }
 
-func flattenOriginationRoutes(routes []*chimesdkvoice.OriginationRoute) []interface{} {
+func flattenOriginationRoutes(routes []awstypes.OriginationRoute) []interface{} {
 	var rawRoutes []interface{}
 
 	for _, route := range routes {
 		r := map[string]interface{}{
-			"host":     aws.StringValue(route.Host),
-			"port":     aws.Int64Value(route.Port),
-			"priority": aws.Int64Value(route.Priority),
-			"protocol": aws.StringValue(route.Protocol),
-			"weight":   aws.Int64Value(route.Weight),
+			"host":     aws.ToString(route.Host),
+			"port":     aws.ToInt32(route.Port),
+			"priority": aws.ToInt32(route.Priority),
+			"protocol": string(route.Protocol),
+			"weight":   aws.ToInt32(route.Weight),
 		}
 
 		rawRoutes = append(rawRoutes, r)
@@ -216,14 +218,14 @@ func flattenOriginationRoutes(routes []*chimesdkvoice.OriginationRoute) []interf
 	return rawRoutes
 }
 
-func findVoiceConnectorOriginationByID(ctx context.Context, conn *chimesdkvoice.ChimeSDKVoice, id string) (*chimesdkvoice.Origination, error) {
+func findVoiceConnectorOriginationByID(ctx context.Context, conn *chimesdkvoice.Client, id string) (*awstypes.Origination, error) {
 	in := &chimesdkvoice.GetVoiceConnectorOriginationInput{
 		VoiceConnectorId: aws.String(id),
 	}
 
-	resp, err := conn.GetVoiceConnectorOriginationWithContext(ctx, in)
+	resp, err := conn.GetVoiceConnectorOrigination(ctx, in)
 
-	if tfawserr.ErrCodeEquals(err, chimesdkvoice.ErrCodeNotFoundException) {
+	if errs.IsA[*awstypes.NotFoundException](err) {
 		return nil, &retry.NotFoundError{
 			LastError:   err,
 			LastRequest: in,

--- a/internal/service/chime/voice_connector_origination_test.go
+++ b/internal/service/chime/voice_connector_origination_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/chimesdkvoice/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfchime "github.com/hashicorp/terraform-provider-aws/internal/service/chime"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func testAccVoiceConnectorOrigination_basic(t *testing.T) {
@@ -28,7 +29,7 @@ func testAccVoiceConnectorOrigination_basic(t *testing.T) {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ChimeSDKVoiceEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorOriginationDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -62,7 +63,7 @@ func testAccVoiceConnectorOrigination_disappears(t *testing.T) {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ChimeSDKVoiceEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorOriginationDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -88,7 +89,7 @@ func testAccVoiceConnectorOrigination_update(t *testing.T) {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ChimeSDKVoiceEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorOriginationDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -135,9 +136,9 @@ func testAccCheckVoiceConnectorOriginationExists(ctx context.Context, name strin
 			return fmt.Errorf("no Chime voice connector origination ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
-		_, err := tfchime.FindVoiceConnectorResourceWithRetry(ctx, false, func() (*chimesdkvoice.Origination, error) {
+		_, err := tfchime.FindVoiceConnectorResourceWithRetry(ctx, false, func() (*awstypes.Origination, error) {
 			return tfchime.FindVoiceConnectorOriginationByID(ctx, conn, rs.Primary.ID)
 		})
 
@@ -151,9 +152,9 @@ func testAccCheckVoiceConnectorOriginationDestroy(ctx context.Context) resource.
 			if rs.Type != "aws_chime_voice_connector_origination" {
 				continue
 			}
-			conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+			conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
-			_, err := tfchime.FindVoiceConnectorResourceWithRetry(ctx, false, func() (*chimesdkvoice.Origination, error) {
+			_, err := tfchime.FindVoiceConnectorResourceWithRetry(ctx, false, func() (*awstypes.Origination, error) {
 				return tfchime.FindVoiceConnectorOriginationByID(ctx, conn, rs.Primary.ID)
 			})
 

--- a/internal/service/chime/voice_connector_streaming_test.go
+++ b/internal/service/chime/voice_connector_streaming_test.go
@@ -9,16 +9,17 @@ import (
 	"testing"
 
 	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/chime"
-	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/chimesdkvoice"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/chimesdkvoice/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	tfchime "github.com/hashicorp/terraform-provider-aws/internal/service/chime"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func testAccVoiceConnectorStreaming_basic(t *testing.T) {
@@ -31,7 +32,7 @@ func testAccVoiceConnectorStreaming_basic(t *testing.T) {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chime.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ChimeSDKVoiceEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorStreamingDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -63,7 +64,7 @@ func testAccVoiceConnectorStreaming_disappears(t *testing.T) {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chime.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ChimeSDKVoiceEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorStreamingDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -89,7 +90,7 @@ func testAccVoiceConnectorStreaming_update(t *testing.T) {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chime.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ChimeSDKVoiceEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorStreamingDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -213,12 +214,12 @@ func testAccCheckVoiceConnectorStreamingExists(ctx context.Context, name string)
 			return fmt.Errorf("no Chime Voice Connector streaming configuration ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 		input := &chimesdkvoice.GetVoiceConnectorStreamingConfigurationInput{
 			VoiceConnectorId: aws.String(rs.Primary.ID),
 		}
 
-		resp, err := conn.GetVoiceConnectorStreamingConfigurationWithContext(ctx, input)
+		resp, err := conn.GetVoiceConnectorStreamingConfiguration(ctx, input)
 		if err != nil {
 			return err
 		}
@@ -237,13 +238,13 @@ func testAccCheckVoiceConnectorStreamingDestroy(ctx context.Context) resource.Te
 			if rs.Type != "aws_chime_voice_connector_termination" {
 				continue
 			}
-			conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+			conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 			input := &chimesdkvoice.GetVoiceConnectorStreamingConfigurationInput{
 				VoiceConnectorId: aws.String(rs.Primary.ID),
 			}
-			resp, err := conn.GetVoiceConnectorStreamingConfigurationWithContext(ctx, input)
+			resp, err := conn.GetVoiceConnectorStreamingConfiguration(ctx, input)
 
-			if tfawserr.ErrCodeEquals(err, chimesdkvoice.ErrCodeNotFoundException) {
+			if errs.IsA[*awstypes.NotFoundException](err) {
 				continue
 			}
 

--- a/internal/service/chime/voice_connector_termination_credentials_test.go
+++ b/internal/service/chime/voice_connector_termination_credentials_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
+	"github.com/aws/aws-sdk-go-v2/service/chimesdkvoice"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfchime "github.com/hashicorp/terraform-provider-aws/internal/service/chime"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func testAccVoiceConnectorTerminationCredentials_basic(t *testing.T) {
@@ -28,7 +29,7 @@ func testAccVoiceConnectorTerminationCredentials_basic(t *testing.T) {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ChimeSDKVoiceEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorTerminationCredentialsDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -59,7 +60,7 @@ func testAccVoiceConnectorTerminationCredentials_disappears(t *testing.T) {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ChimeSDKVoiceEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorTerminationCredentialsDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -85,7 +86,7 @@ func testAccVoiceConnectorTerminationCredentials_update(t *testing.T) {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ChimeSDKVoiceEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorTerminationCredentialsDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -118,7 +119,7 @@ func testAccCheckVoiceConnectorTerminationCredentialsExists(ctx context.Context,
 			return fmt.Errorf("no Chime Voice Connector termination credentials ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
 		_, err := tfchime.FindVoiceConnectorResourceWithRetry(ctx, false, func() (*chimesdkvoice.ListVoiceConnectorTerminationCredentialsOutput, error) {
 			return tfchime.FindVoiceConnectorTerminationCredentialsByID(ctx, conn, rs.Primary.ID)
@@ -134,7 +135,7 @@ func testAccCheckVoiceConnectorTerminationCredentialsDestroy(ctx context.Context
 			if rs.Type != "aws_chime_voice_connector_termination_credentials" {
 				continue
 			}
-			conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+			conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
 			_, err := tfchime.FindVoiceConnectorResourceWithRetry(ctx, false, func() (*chimesdkvoice.ListVoiceConnectorTerminationCredentialsOutput, error) {
 				return tfchime.FindVoiceConnectorTerminationCredentialsByID(ctx, conn, rs.Primary.ID)

--- a/internal/service/chime/voice_connector_termination_test.go
+++ b/internal/service/chime/voice_connector_termination_test.go
@@ -8,8 +8,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/chimesdkvoice"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/chimesdkvoice/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -17,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfchime "github.com/hashicorp/terraform-provider-aws/internal/service/chime"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func testAccVoiceConnectorTermination_basic(t *testing.T) {
@@ -29,7 +31,7 @@ func testAccVoiceConnectorTermination_basic(t *testing.T) {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ChimeSDKVoiceEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorTerminationDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -62,7 +64,7 @@ func testAccVoiceConnectorTermination_disappears(t *testing.T) {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ChimeSDKVoiceEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorTerminationDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -88,7 +90,7 @@ func testAccVoiceConnectorTermination_update(t *testing.T) {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ChimeSDKVoiceEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorTerminationDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -161,12 +163,12 @@ func testAccCheckVoiceConnectorTerminationExists(ctx context.Context, name strin
 			return fmt.Errorf("no Chime Voice Connector termination ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 		input := &chimesdkvoice.GetVoiceConnectorTerminationInput{
 			VoiceConnectorId: aws.String(rs.Primary.ID),
 		}
 
-		resp, err := conn.GetVoiceConnectorTerminationWithContext(ctx, input)
+		resp, err := conn.GetVoiceConnectorTermination(ctx, input)
 		if err != nil {
 			return err
 		}
@@ -185,9 +187,9 @@ func testAccCheckVoiceConnectorTerminationDestroy(ctx context.Context) resource.
 			if rs.Type != "aws_chime_voice_connector_termination" {
 				continue
 			}
-			conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+			conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
-			_, err := tfchime.FindVoiceConnectorResourceWithRetry(ctx, false, func() (*chimesdkvoice.Termination, error) {
+			_, err := tfchime.FindVoiceConnectorResourceWithRetry(ctx, false, func() (*awstypes.Termination, error) {
 				return tfchime.FindVoiceConnectorTerminationByID(ctx, conn, rs.Primary.ID)
 			})
 

--- a/internal/service/chime/voice_connector_test.go
+++ b/internal/service/chime/voice_connector_test.go
@@ -8,7 +8,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
+	"github.com/aws/aws-sdk-go-v2/service/chimesdkvoice"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/chimesdkvoice/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -16,11 +17,12 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfchime "github.com/hashicorp/terraform-provider-aws/internal/service/chime"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func testAccVoiceConnector_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	var voiceConnector *chimesdkvoice.VoiceConnector
+	var voiceConnector *awstypes.VoiceConnector
 
 	vcName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector.test"
@@ -30,7 +32,7 @@ func testAccVoiceConnector_basic(t *testing.T) {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ChimeSDKVoiceEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -54,7 +56,7 @@ func testAccVoiceConnector_basic(t *testing.T) {
 
 func testAccVoiceConnector_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	var voiceConnector *chimesdkvoice.VoiceConnector
+	var voiceConnector *awstypes.VoiceConnector
 
 	vcName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector.test"
@@ -64,7 +66,7 @@ func testAccVoiceConnector_disappears(t *testing.T) {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ChimeSDKVoiceEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -82,7 +84,7 @@ func testAccVoiceConnector_disappears(t *testing.T) {
 
 func testAccVoiceConnector_update(t *testing.T) {
 	ctx := acctest.Context(t)
-	var voiceConnector *chimesdkvoice.VoiceConnector
+	var voiceConnector *awstypes.VoiceConnector
 
 	vcName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector.test"
@@ -92,7 +94,7 @@ func testAccVoiceConnector_update(t *testing.T) {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ChimeSDKVoiceEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -122,7 +124,7 @@ func testAccVoiceConnector_update(t *testing.T) {
 
 func testAccVoiceConnector_tags(t *testing.T) {
 	ctx := acctest.Context(t)
-	var voiceConnector *chimesdkvoice.VoiceConnector
+	var voiceConnector *awstypes.VoiceConnector
 
 	vcName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chime_voice_connector.test"
@@ -132,7 +134,7 @@ func testAccVoiceConnector_tags(t *testing.T) {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ChimeSDKVoiceEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceConnectorDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -218,7 +220,7 @@ resource "aws_chime_voice_connector" "test" {
 `, name, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccCheckVoiceConnectorExists(ctx context.Context, name string, vc *chimesdkvoice.VoiceConnector) resource.TestCheckFunc {
+func testAccCheckVoiceConnectorExists(ctx context.Context, name string, vc *awstypes.VoiceConnector) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -229,9 +231,9 @@ func testAccCheckVoiceConnectorExists(ctx context.Context, name string, vc *chim
 			return fmt.Errorf("no Chime voice connector ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
-		resp, err := tfchime.FindVoiceConnectorResourceWithRetry(ctx, false, func() (*chimesdkvoice.VoiceConnector, error) {
+		resp, err := tfchime.FindVoiceConnectorResourceWithRetry(ctx, false, func() (*awstypes.VoiceConnector, error) {
 			return tfchime.FindVoiceConnectorByID(ctx, conn, rs.Primary.ID)
 		})
 
@@ -251,9 +253,9 @@ func testAccCheckVoiceConnectorDestroy(ctx context.Context) resource.TestCheckFu
 			if rs.Type != "aws_chime_voice_connector" {
 				continue
 			}
-			conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+			conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
-			_, err := tfchime.FindVoiceConnectorResourceWithRetry(ctx, false, func() (*chimesdkvoice.VoiceConnector, error) {
+			_, err := tfchime.FindVoiceConnectorResourceWithRetry(ctx, false, func() (*awstypes.VoiceConnector, error) {
 				return tfchime.FindVoiceConnectorByID(ctx, conn, rs.Primary.ID)
 			})
 
@@ -273,11 +275,11 @@ func testAccCheckVoiceConnectorDestroy(ctx context.Context) resource.TestCheckFu
 }
 
 func testAccPreCheck(ctx context.Context, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+	conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
 	input := &chimesdkvoice.ListVoiceConnectorsInput{}
 
-	_, err := conn.ListVoiceConnectorsWithContext(ctx, input)
+	_, err := conn.ListVoiceConnectors(ctx, input)
 
 	if acctest.PreCheckSkipError(err) {
 		t.Skipf("skipping acceptance testing: %s", err)

--- a/internal/service/chimesdkvoice/generate.go
+++ b/internal/service/chimesdkvoice/generate.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-//go:generate go run ../../generate/tags/main.go -ListTags -ListTagsInIDElem=ResourceARN -ServiceTagsSlice -TagInIDElem=ResourceARN -UpdateTags
+//go:generate go run ../../generate/tags/main.go -AWSSDKVersion=2 -ListTags -ListTagsInIDElem=ResourceARN -ServiceTagsSlice -TagInIDElem=ResourceARN -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/chimesdkvoice/global_settings.go
+++ b/internal/service/chimesdkvoice/global_settings.go
@@ -9,8 +9,9 @@ import (
 	"log"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/chimesdkvoice"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/chimesdkvoice/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -57,14 +58,14 @@ func ResourceGlobalSettings() *schema.Resource {
 
 func resourceGlobalSettingsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
 	// Include retry handling to allow for propagation of the Global Settings
 	// logging bucket configuration
 	var out *chimesdkvoice.GetGlobalSettingsOutput
 	err := tfresource.Retry(ctx, globalSettingsPropagationTimeout, func() *retry.RetryError {
 		var getErr error
-		out, getErr = conn.GetGlobalSettingsWithContext(ctx, &chimesdkvoice.GetGlobalSettingsInput{})
+		out, getErr = conn.GetGlobalSettings(ctx, &chimesdkvoice.GetGlobalSettingsInput{})
 
 		if getErr != nil {
 			return retry.NonRetryableError(getErr)
@@ -96,14 +97,14 @@ func resourceGlobalSettingsRead(ctx context.Context, d *schema.ResourceData, met
 
 func resourceGlobalSettingsUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
 	if d.HasChange("voice_connector") {
 		input := &chimesdkvoice.UpdateGlobalSettingsInput{
 			VoiceConnector: expandVoiceConnectorSettings(d.Get("voice_connector").([]interface{})),
 		}
 
-		_, err := conn.UpdateGlobalSettingsWithContext(ctx, input)
+		_, err := conn.UpdateGlobalSettings(ctx, input)
 		if err != nil {
 			return append(diags, create.DiagError(names.ChimeSDKVoice, create.ErrActionUpdating, ResNameGlobalSettings, d.Id(), err)...)
 		}
@@ -115,10 +116,10 @@ func resourceGlobalSettingsUpdate(ctx context.Context, d *schema.ResourceData, m
 
 func resourceGlobalSettingsDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
-	_, err := conn.UpdateGlobalSettingsWithContext(ctx, &chimesdkvoice.UpdateGlobalSettingsInput{
-		VoiceConnector: &chimesdkvoice.VoiceConnectorSettings{},
+	_, err := conn.UpdateGlobalSettings(ctx, &chimesdkvoice.UpdateGlobalSettingsInput{
+		VoiceConnector: &awstypes.VoiceConnectorSettings{},
 	})
 	if err != nil {
 		return append(diags, create.DiagError(names.ChimeSDKVoice, create.ErrActionDeleting, ResNameGlobalSettings, d.Id(), err)...)
@@ -127,7 +128,7 @@ func resourceGlobalSettingsDelete(ctx context.Context, d *schema.ResourceData, m
 	return diags
 }
 
-func expandVoiceConnectorSettings(tfList []interface{}) *chimesdkvoice.VoiceConnectorSettings {
+func expandVoiceConnectorSettings(tfList []interface{}) *awstypes.VoiceConnectorSettings {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -137,14 +138,14 @@ func expandVoiceConnectorSettings(tfList []interface{}) *chimesdkvoice.VoiceConn
 		return nil
 	}
 
-	return &chimesdkvoice.VoiceConnectorSettings{
+	return &awstypes.VoiceConnectorSettings{
 		CdrBucket: aws.String(tfMap["cdr_bucket"].(string)),
 	}
 }
 
-func flattenVoiceConnectorSettings(apiObject *chimesdkvoice.VoiceConnectorSettings) []interface{} {
+func flattenVoiceConnectorSettings(apiObject *awstypes.VoiceConnectorSettings) []interface{} {
 	m := map[string]interface{}{
-		"cdr_bucket": aws.StringValue(apiObject.CdrBucket),
+		"cdr_bucket": aws.ToString(apiObject.CdrBucket),
 	}
 	return []interface{}{m}
 }

--- a/internal/service/chimesdkvoice/global_settings_test.go
+++ b/internal/service/chimesdkvoice/global_settings_test.go
@@ -10,8 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
-	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
+	"github.com/aws/aws-sdk-go-v2/service/chimesdkvoice"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -20,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfchimesdkvoice "github.com/hashicorp/terraform-provider-aws/internal/service/chimesdkvoice"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccChimeSDKVoiceGlobalSettings_serial(t *testing.T) {
@@ -42,7 +42,7 @@ func testAccGlobalSettings_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ChimeSDKVoiceEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckGlobalSettingsDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -68,7 +68,7 @@ func testAccGlobalSettings_disappears(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ChimeSDKVoiceEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckGlobalSettingsDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -93,9 +93,9 @@ func testAccGlobalSettings_update(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID) // run test in us-east-1 only since eventual consistency causes intermittent failures in other regions.
+			acctest.PreCheckRegion(t, names.USEast1RegionID) // run test in us-east-1 only since eventual consistency causes intermittent failures in other regions.
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ChimeSDKVoiceEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckGlobalSettingsDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -125,7 +125,7 @@ func testAccCheckGlobalSettingsDestroy(ctx context.Context) resource.TestCheckFu
 				continue
 			}
 
-			conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+			conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 			input := &chimesdkvoice.GetGlobalSettingsInput{}
 
 			const retryTimeout = 10 * time.Second
@@ -133,7 +133,7 @@ func testAccCheckGlobalSettingsDestroy(ctx context.Context) resource.TestCheckFu
 
 			err := tfresource.Retry(ctx, retryTimeout, func() *retry.RetryError {
 				var err error
-				response, err = conn.GetGlobalSettingsWithContext(ctx, input)
+				response, err = conn.GetGlobalSettings(ctx, input)
 				if err == nil && response.VoiceConnector.CdrBucket != nil {
 					return retry.RetryableError(errors.New("error Chime Voice Connector Global settings still exists"))
 				}

--- a/internal/service/chimesdkvoice/service_package_gen.go
+++ b/internal/service/chimesdkvoice/service_package_gen.go
@@ -5,9 +5,8 @@ package chimesdkvoice
 import (
 	"context"
 
-	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
-	session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
-	chimesdkvoice_sdkv1 "github.com/aws/aws-sdk-go/service/chimesdkvoice"
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	chimesdkvoice_sdkv2 "github.com/aws/aws-sdk-go-v2/service/chimesdkvoice"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -61,11 +60,15 @@ func (p *servicePackage) ServicePackageName() string {
 	return names.ChimeSDKVoice
 }
 
-// NewConn returns a new AWS SDK for Go v1 client for this service package's AWS API.
-func (p *servicePackage) NewConn(ctx context.Context, config map[string]any) (*chimesdkvoice_sdkv1.ChimeSDKVoice, error) {
-	sess := config["session"].(*session_sdkv1.Session)
+// NewClient returns a new AWS SDK for Go v2 client for this service package's AWS API.
+func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (*chimesdkvoice_sdkv2.Client, error) {
+	cfg := *(config["aws_sdkv2_config"].(*aws_sdkv2.Config))
 
-	return chimesdkvoice_sdkv1.New(sess.Copy(&aws_sdkv1.Config{Endpoint: aws_sdkv1.String(config["endpoint"].(string))})), nil
+	return chimesdkvoice_sdkv2.NewFromConfig(cfg, func(o *chimesdkvoice_sdkv2.Options) {
+		if endpoint := config["endpoint"].(string); endpoint != "" {
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
+		}
+	}), nil
 }
 
 func ServicePackage(ctx context.Context) conns.ServicePackage {

--- a/internal/service/chimesdkvoice/sip_media_application_test.go
+++ b/internal/service/chimesdkvoice/sip_media_application_test.go
@@ -8,8 +8,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/chime"
-	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/chimesdkvoice/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -17,11 +16,12 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfchimesdkvoice "github.com/hashicorp/terraform-provider-aws/internal/service/chimesdkvoice"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccChimeSDKVoiceSipMediaApplication_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	var chimeSipMediaApplication *chimesdkvoice.SipMediaApplication
+	var chimeSipMediaApplication *awstypes.SipMediaApplication
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chimesdkvoice_sip_media_application.test"
@@ -31,7 +31,7 @@ func TestAccChimeSDKVoiceSipMediaApplication_basic(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ChimeSDKVoiceEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckSipMediaApplicationDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -56,7 +56,7 @@ func TestAccChimeSDKVoiceSipMediaApplication_basic(t *testing.T) {
 
 func TestAccChimeSDKVoiceSipMediaApplication_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	var chimeSipMediaApplication *chimesdkvoice.SipMediaApplication
+	var chimeSipMediaApplication *awstypes.SipMediaApplication
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chimesdkvoice_sip_media_application.test"
@@ -65,7 +65,7 @@ func TestAccChimeSDKVoiceSipMediaApplication_disappears(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chime.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ChimeSDKVoiceEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckSipMediaApplicationDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -83,7 +83,7 @@ func TestAccChimeSDKVoiceSipMediaApplication_disappears(t *testing.T) {
 
 func TestAccChimeSDKVoiceSipMediaApplication_update(t *testing.T) {
 	ctx := acctest.Context(t)
-	var chimeSipMediaApplication *chimesdkvoice.SipMediaApplication
+	var chimeSipMediaApplication *awstypes.SipMediaApplication
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rNameUpdated := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -94,7 +94,7 @@ func TestAccChimeSDKVoiceSipMediaApplication_update(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ChimeSDKVoiceEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckSipMediaApplicationDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -129,7 +129,7 @@ func TestAccChimeSDKVoiceSipMediaApplication_update(t *testing.T) {
 
 func TestAccChimeSDKVoiceSipMediaApplication_tags(t *testing.T) {
 	ctx := acctest.Context(t)
-	var sipMediaApplication *chimesdkvoice.SipMediaApplication
+	var sipMediaApplication *awstypes.SipMediaApplication
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chimesdkvoice_sip_media_application.test"
@@ -138,7 +138,7 @@ func TestAccChimeSDKVoiceSipMediaApplication_tags(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ChimeSDKVoiceEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckSipMediaApplicationDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -179,7 +179,7 @@ func TestAccChimeSDKVoiceSipMediaApplication_tags(t *testing.T) {
 	})
 }
 
-func testAccCheckSipMediaApplicationExists(ctx context.Context, name string, vc *chimesdkvoice.SipMediaApplication) resource.TestCheckFunc {
+func testAccCheckSipMediaApplicationExists(ctx context.Context, name string, vc *awstypes.SipMediaApplication) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -190,9 +190,9 @@ func testAccCheckSipMediaApplicationExists(ctx context.Context, name string, vc 
 			return fmt.Errorf("no ChimeSdkVoice Sip Media Application ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
-		resp, err := tfchimesdkvoice.FindSIPResourceWithRetry(ctx, false, func() (*chimesdkvoice.SipMediaApplication, error) {
+		resp, err := tfchimesdkvoice.FindSIPResourceWithRetry(ctx, false, func() (*awstypes.SipMediaApplication, error) {
 			return tfchimesdkvoice.FindSIPMediaApplicationByID(ctx, conn, rs.Primary.ID)
 		})
 
@@ -212,9 +212,9 @@ func testAccCheckSipMediaApplicationDestroy(ctx context.Context) resource.TestCh
 			if rs.Type != "aws_chimesdkvoice_sip_media_application" {
 				continue
 			}
-			conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+			conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
-			_, err := tfchimesdkvoice.FindSIPResourceWithRetry(ctx, false, func() (*chimesdkvoice.SipMediaApplication, error) {
+			_, err := tfchimesdkvoice.FindSIPResourceWithRetry(ctx, false, func() (*awstypes.SipMediaApplication, error) {
 				return tfchimesdkvoice.FindSIPMediaApplicationByID(ctx, conn, rs.Primary.ID)
 			})
 

--- a/internal/service/chimesdkvoice/sip_rule_test.go
+++ b/internal/service/chimesdkvoice/sip_rule_test.go
@@ -8,8 +8,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/chime"
-	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/chimesdkvoice/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -17,11 +16,12 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfchimesdkvoice "github.com/hashicorp/terraform-provider-aws/internal/service/chimesdkvoice"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccChimeSDKVoiceSipRule_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	var chimeSipRule *chimesdkvoice.SipRule
+	var chimeSipRule *awstypes.SipRule
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chimesdkvoice_sip_rule.test"
@@ -30,7 +30,7 @@ func TestAccChimeSDKVoiceSipRule_basic(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ChimeSDKVoiceEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckSipRuleDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -58,7 +58,7 @@ func TestAccChimeSDKVoiceSipRule_basic(t *testing.T) {
 
 func TestAccChimeSDKVoiceSipRule_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	var chimeSipRule *chimesdkvoice.SipRule
+	var chimeSipRule *awstypes.SipRule
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chimesdkvoice_sip_rule.test"
@@ -67,7 +67,7 @@ func TestAccChimeSDKVoiceSipRule_disappears(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chime.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ChimeSDKVoiceEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckSipRuleDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -85,7 +85,7 @@ func TestAccChimeSDKVoiceSipRule_disappears(t *testing.T) {
 
 func TestAccChimeSDKVoiceSipRule_update(t *testing.T) {
 	ctx := acctest.Context(t)
-	var chimeSipRule *chimesdkvoice.SipRule
+	var chimeSipRule *awstypes.SipRule
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rNameUpdated := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -95,7 +95,7 @@ func TestAccChimeSDKVoiceSipRule_update(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ChimeSDKVoiceEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckSipRuleDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -129,7 +129,7 @@ func TestAccChimeSDKVoiceSipRule_update(t *testing.T) {
 	})
 }
 
-func testAccCheckSipRuleExists(ctx context.Context, name string, sr *chimesdkvoice.SipRule) resource.TestCheckFunc {
+func testAccCheckSipRuleExists(ctx context.Context, name string, sr *awstypes.SipRule) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -140,9 +140,9 @@ func testAccCheckSipRuleExists(ctx context.Context, name string, sr *chimesdkvoi
 			return fmt.Errorf("no ChimeSdkVoice Sip Rule ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
-		resp, err := tfchimesdkvoice.FindSIPResourceWithRetry(ctx, false, func() (*chimesdkvoice.SipRule, error) {
+		resp, err := tfchimesdkvoice.FindSIPResourceWithRetry(ctx, false, func() (*awstypes.SipRule, error) {
 			return tfchimesdkvoice.FindSIPRuleByID(ctx, conn, rs.Primary.ID)
 		})
 
@@ -162,9 +162,9 @@ func testAccCheckSipRuleDestroy(ctx context.Context) resource.TestCheckFunc {
 			if rs.Type != "aws_chimesdkvoice_sip_rule" {
 				continue
 			}
-			conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+			conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
-			_, err := tfchimesdkvoice.FindSIPResourceWithRetry(ctx, false, func() (*chimesdkvoice.SipRule, error) {
+			_, err := tfchimesdkvoice.FindSIPResourceWithRetry(ctx, false, func() (*awstypes.SipRule, error) {
 				return tfchimesdkvoice.FindSIPRuleByID(ctx, conn, rs.Primary.ID)
 			})
 

--- a/internal/service/chimesdkvoice/tags_gen.go
+++ b/internal/service/chimesdkvoice/tags_gen.go
@@ -5,9 +5,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
-	"github.com/aws/aws-sdk-go/service/chimesdkvoice/chimesdkvoiceiface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/chimesdkvoice"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/chimesdkvoice/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/logging"
@@ -19,12 +19,12 @@ import (
 // listTags lists chimesdkvoice service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn chimesdkvoiceiface.ChimeSDKVoiceAPI, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *chimesdkvoice.Client, identifier string) (tftags.KeyValueTags, error) {
 	input := &chimesdkvoice.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResourceWithContext(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -36,7 +36,7 @@ func listTags(ctx context.Context, conn chimesdkvoiceiface.ChimeSDKVoiceAPI, ide
 // ListTags lists chimesdkvoice service tags and set them in Context.
 // It is called from outside this package.
 func (p *servicePackage) ListTags(ctx context.Context, meta any, identifier string) error {
-	tags, err := listTags(ctx, meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx), identifier)
+	tags, err := listTags(ctx, meta.(*conns.AWSClient).ChimeSDKVoiceClient(ctx), identifier)
 
 	if err != nil {
 		return err
@@ -52,11 +52,11 @@ func (p *servicePackage) ListTags(ctx context.Context, meta any, identifier stri
 // []*SERVICE.Tag handling
 
 // Tags returns chimesdkvoice service tags.
-func Tags(tags tftags.KeyValueTags) []*chimesdkvoice.Tag {
-	result := make([]*chimesdkvoice.Tag, 0, len(tags))
+func Tags(tags tftags.KeyValueTags) []awstypes.Tag {
+	result := make([]awstypes.Tag, 0, len(tags))
 
 	for k, v := range tags.Map() {
-		tag := &chimesdkvoice.Tag{
+		tag := awstypes.Tag{
 			Key:   aws.String(k),
 			Value: aws.String(v),
 		}
@@ -68,11 +68,11 @@ func Tags(tags tftags.KeyValueTags) []*chimesdkvoice.Tag {
 }
 
 // KeyValueTags creates tftags.KeyValueTags from chimesdkvoice service tags.
-func KeyValueTags(ctx context.Context, tags []*chimesdkvoice.Tag) tftags.KeyValueTags {
+func KeyValueTags(ctx context.Context, tags []awstypes.Tag) tftags.KeyValueTags {
 	m := make(map[string]*string, len(tags))
 
 	for _, tag := range tags {
-		m[aws.StringValue(tag.Key)] = tag.Value
+		m[aws.ToString(tag.Key)] = tag.Value
 	}
 
 	return tftags.New(ctx, m)
@@ -80,7 +80,7 @@ func KeyValueTags(ctx context.Context, tags []*chimesdkvoice.Tag) tftags.KeyValu
 
 // getTagsIn returns chimesdkvoice service tags from Context.
 // nil is returned if there are no input tags.
-func getTagsIn(ctx context.Context) []*chimesdkvoice.Tag {
+func getTagsIn(ctx context.Context) []awstypes.Tag {
 	if inContext, ok := tftags.FromContext(ctx); ok {
 		if tags := Tags(inContext.TagsIn.UnwrapOrDefault()); len(tags) > 0 {
 			return tags
@@ -91,7 +91,7 @@ func getTagsIn(ctx context.Context) []*chimesdkvoice.Tag {
 }
 
 // setTagsOut sets chimesdkvoice service tags in Context.
-func setTagsOut(ctx context.Context, tags []*chimesdkvoice.Tag) {
+func setTagsOut(ctx context.Context, tags []awstypes.Tag) {
 	if inContext, ok := tftags.FromContext(ctx); ok {
 		inContext.TagsOut = types.Some(KeyValueTags(ctx, tags))
 	}
@@ -100,7 +100,7 @@ func setTagsOut(ctx context.Context, tags []*chimesdkvoice.Tag) {
 // updateTags updates chimesdkvoice service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn chimesdkvoiceiface.ChimeSDKVoiceAPI, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *chimesdkvoice.Client, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -111,10 +111,10 @@ func updateTags(ctx context.Context, conn chimesdkvoiceiface.ChimeSDKVoiceAPI, i
 	if len(removedTags) > 0 {
 		input := &chimesdkvoice.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.Keys()),
+			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResourceWithContext(ctx, input)
+		_, err := conn.UntagResource(ctx, input)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -129,7 +129,7 @@ func updateTags(ctx context.Context, conn chimesdkvoiceiface.ChimeSDKVoiceAPI, i
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResourceWithContext(ctx, input)
+		_, err := conn.TagResource(ctx, input)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)
@@ -142,5 +142,5 @@ func updateTags(ctx context.Context, conn chimesdkvoiceiface.ChimeSDKVoiceAPI, i
 // UpdateTags updates chimesdkvoice service tags.
 // It is called from outside this package.
 func (p *servicePackage) UpdateTags(ctx context.Context, meta any, identifier string, oldTags, newTags any) error {
-	return updateTags(ctx, meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx), identifier, oldTags, newTags)
+	return updateTags(ctx, meta.(*conns.AWSClient).ChimeSDKVoiceClient(ctx), identifier, oldTags, newTags)
 }

--- a/internal/service/chimesdkvoice/voice_profile_domain.go
+++ b/internal/service/chimesdkvoice/voice_profile_domain.go
@@ -99,7 +99,7 @@ func resourceVoiceProfileDomainCreate(ctx context.Context, d *schema.ResourceDat
 	in := &chimesdkvoice.CreateVoiceProfileDomainInput{
 		Name:                              aws.String(d.Get(names.AttrName).(string)),
 		ServerSideEncryptionConfiguration: expandServerSideEncryptionConfiguration(d.Get("server_side_encryption_configuration").([]interface{})),
-		Tags:                              getTagsIn(ctx),
+		//Tags:                              getTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk(names.AttrDescription); ok {

--- a/internal/service/chimesdkvoice/voice_profile_domain.go
+++ b/internal/service/chimesdkvoice/voice_profile_domain.go
@@ -10,15 +10,16 @@ import (
 	"time"
 
 	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/chimesdkvoice"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/chimesdkvoice/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -94,19 +95,19 @@ func ResourceVoiceProfileDomain() *schema.Resource {
 }
 
 func resourceVoiceProfileDomainCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
 	in := &chimesdkvoice.CreateVoiceProfileDomainInput{
 		Name:                              aws.String(d.Get(names.AttrName).(string)),
 		ServerSideEncryptionConfiguration: expandServerSideEncryptionConfiguration(d.Get("server_side_encryption_configuration").([]interface{})),
-		//Tags:                              getTagsIn(ctx),
+		Tags:                              getTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk(names.AttrDescription); ok {
 		in.Description = aws.String(v.(string))
 	}
 
-	out, err := conn.CreateVoiceProfileDomainWithContext(ctx, in)
+	out, err := conn.CreateVoiceProfileDomain(ctx, in)
 	if err != nil {
 		return create.DiagError(names.ChimeSDKVoice, create.ErrActionCreating, ResNameVoiceProfileDomain, d.Get("name").(string), err)
 	}
@@ -115,13 +116,13 @@ func resourceVoiceProfileDomainCreate(ctx context.Context, d *schema.ResourceDat
 		return create.DiagError(names.ChimeSDKVoice, create.ErrActionCreating, ResNameVoiceProfileDomain, d.Get("name").(string), errors.New("empty output"))
 	}
 
-	d.SetId(aws.StringValue(out.VoiceProfileDomain.VoiceProfileDomainId))
+	d.SetId(aws.ToString(out.VoiceProfileDomain.VoiceProfileDomainId))
 
 	return resourceVoiceProfileDomainRead(ctx, d, meta)
 }
 
 func resourceVoiceProfileDomainRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
 	out, err := FindVoiceProfileDomainByID(ctx, conn, d.Id())
 
@@ -135,7 +136,7 @@ func resourceVoiceProfileDomainRead(ctx context.Context, d *schema.ResourceData,
 		return create.DiagError(names.ChimeSDKVoice, create.ErrActionReading, ResNameVoiceProfileDomain, d.Id(), err)
 	}
 
-	d.SetId(aws.StringValue(out.VoiceProfileDomainId))
+	d.SetId(aws.ToString(out.VoiceProfileDomainId))
 	d.Set(names.AttrARN, out.VoiceProfileDomainArn)
 	d.Set(names.AttrName, out.Name)
 	d.Set(names.AttrDescription, out.Description)
@@ -148,7 +149,7 @@ func resourceVoiceProfileDomainRead(ctx context.Context, d *schema.ResourceData,
 }
 
 func resourceVoiceProfileDomainUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
 	if d.HasChanges(names.AttrName, names.AttrDescription) {
 		in := &chimesdkvoice.UpdateVoiceProfileDomainInput{
@@ -160,7 +161,7 @@ func resourceVoiceProfileDomainUpdate(ctx context.Context, d *schema.ResourceDat
 			in.Description = aws.String(v.(string))
 		}
 
-		_, err := conn.UpdateVoiceProfileDomainWithContext(ctx, in)
+		_, err := conn.UpdateVoiceProfileDomain(ctx, in)
 		if err != nil {
 			return create.DiagError(names.ChimeSDKMediaPipelines, create.ErrActionUpdating, ResNameVoiceProfileDomain, d.Id(), err)
 		}
@@ -172,15 +173,15 @@ func resourceVoiceProfileDomainUpdate(ctx context.Context, d *schema.ResourceDat
 }
 
 func resourceVoiceProfileDomainDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
 	log.Printf("[INFO] Deleting ChimeSDKVoice VoiceProfileDomain %s", d.Id())
 
-	_, err := conn.DeleteVoiceProfileDomainWithContext(ctx, &chimesdkvoice.DeleteVoiceProfileDomainInput{
+	_, err := conn.DeleteVoiceProfileDomain(ctx, &chimesdkvoice.DeleteVoiceProfileDomainInput{
 		VoiceProfileDomainId: aws.String(d.Id()),
 	})
 
-	if tfawserr.ErrCodeEquals(err, chimesdkvoice.ErrCodeNotFoundException) {
+	if errs.IsA[*awstypes.NotFoundException](err) {
 		return nil
 	}
 
@@ -191,12 +192,12 @@ func resourceVoiceProfileDomainDelete(ctx context.Context, d *schema.ResourceDat
 	return nil
 }
 
-func FindVoiceProfileDomainByID(ctx context.Context, conn *chimesdkvoice.ChimeSDKVoice, id string) (*chimesdkvoice.VoiceProfileDomain, error) {
+func FindVoiceProfileDomainByID(ctx context.Context, conn *chimesdkvoice.Client, id string) (*awstypes.VoiceProfileDomain, error) {
 	in := &chimesdkvoice.GetVoiceProfileDomainInput{
 		VoiceProfileDomainId: aws.String(id),
 	}
-	out, err := conn.GetVoiceProfileDomainWithContext(ctx, in)
-	if tfawserr.ErrCodeEquals(err, chimesdkvoice.ErrCodeNotFoundException) {
+	out, err := conn.GetVoiceProfileDomain(ctx, in)
+	if errs.IsA[*awstypes.NotFoundException](err) {
 		return nil, &retry.NotFoundError{
 			LastError:   err,
 			LastRequest: in,
@@ -214,7 +215,7 @@ func FindVoiceProfileDomainByID(ctx context.Context, conn *chimesdkvoice.ChimeSD
 	return out.VoiceProfileDomain, nil
 }
 
-func flattenServerSideEncryptionConfiguration(apiObject *chimesdkvoice.ServerSideEncryptionConfiguration) []interface{} {
+func flattenServerSideEncryptionConfiguration(apiObject *awstypes.ServerSideEncryptionConfiguration) []interface{} {
 	if apiObject == nil {
 		return nil
 	}
@@ -224,11 +225,11 @@ func flattenServerSideEncryptionConfiguration(apiObject *chimesdkvoice.ServerSid
 	}}
 }
 
-func expandServerSideEncryptionConfiguration(tfList []interface{}) *chimesdkvoice.ServerSideEncryptionConfiguration {
+func expandServerSideEncryptionConfiguration(tfList []interface{}) *awstypes.ServerSideEncryptionConfiguration {
 	if len(tfList) != 1 {
 		return nil
 	}
-	return &chimesdkvoice.ServerSideEncryptionConfiguration{
+	return &awstypes.ServerSideEncryptionConfiguration{
 		KmsKeyArn: aws.String(tfList[0].(map[string]interface{})["kms_key_arn"].(string)),
 	}
 }

--- a/internal/service/chimesdkvoice/voice_profile_domain_test.go
+++ b/internal/service/chimesdkvoice/voice_profile_domain_test.go
@@ -10,15 +10,16 @@ import (
 	"testing"
 
 	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/chimesdkvoice"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/chimesdkvoice/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	tfchimesdkvoice "github.com/hashicorp/terraform-provider-aws/internal/service/chimesdkvoice"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -40,17 +41,17 @@ func TestAccChimeSDKVoiceVoiceProfileDomain_serial(t *testing.T) {
 
 func testAccVoiceProfileDomain_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	var voiceprofiledomain chimesdkvoice.VoiceProfileDomain
+	var voiceprofiledomain awstypes.VoiceProfileDomain
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chimesdkvoice_voice_profile_domain.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, chimesdkvoice.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.ChimeSDKVoiceEndpointID)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ChimeSDKVoiceEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceProfileDomainDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -75,17 +76,17 @@ func testAccVoiceProfileDomain_basic(t *testing.T) {
 func testAccVoiceProfileDomain_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 
-	var voiceprofiledomain chimesdkvoice.VoiceProfileDomain
+	var voiceprofiledomain awstypes.VoiceProfileDomain
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chimesdkvoice_voice_profile_domain.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, chimesdkvoice.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.ChimeSDKVoiceEndpointID)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ChimeSDKVoiceEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceProfileDomainDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -103,7 +104,7 @@ func testAccVoiceProfileDomain_disappears(t *testing.T) {
 
 func testAccVoiceProfileDomain_update(t *testing.T) {
 	ctx := acctest.Context(t)
-	var v1, v2 chimesdkvoice.VoiceProfileDomain
+	var v1, v2 awstypes.VoiceProfileDomain
 	rName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -112,10 +113,10 @@ func testAccVoiceProfileDomain_update(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, chimesdkvoice.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.ChimeSDKVoiceEndpointID)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ChimeSDKVoiceEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceProfileDomainDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -145,17 +146,17 @@ func testAccVoiceProfileDomain_update(t *testing.T) {
 
 func testAccVoiceProfileDomain_tags(t *testing.T) {
 	ctx := acctest.Context(t)
-	var voiceprofiledomain chimesdkvoice.VoiceProfileDomain
+	var voiceprofiledomain awstypes.VoiceProfileDomain
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chimesdkvoice_voice_profile_domain.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, chimesdkvoice.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.ChimeSDKVoiceEndpointID)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ChimeSDKVoiceEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckVoiceProfileDomainDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -195,7 +196,7 @@ func testAccVoiceProfileDomain_tags(t *testing.T) {
 
 func testAccCheckVoiceProfileDomainDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_chimesdkvoice_voice_profile_domain" {
@@ -204,7 +205,7 @@ func testAccCheckVoiceProfileDomainDestroy(ctx context.Context) resource.TestChe
 
 			_, err := tfchimesdkvoice.FindVoiceProfileDomainByID(ctx, conn, rs.Primary.ID)
 			if err != nil {
-				if tfawserr.ErrCodeEquals(err, chimesdkvoice.ErrCodeNotFoundException) {
+				if errs.IsA[*awstypes.NotFoundException](err) {
 					return nil
 				}
 				return err
@@ -217,7 +218,7 @@ func testAccCheckVoiceProfileDomainDestroy(ctx context.Context) resource.TestChe
 	}
 }
 
-func testAccCheckVoiceProfileDomainExists(ctx context.Context, name string, voiceprofiledomain *chimesdkvoice.VoiceProfileDomain) resource.TestCheckFunc {
+func testAccCheckVoiceProfileDomainExists(ctx context.Context, name string, voiceprofiledomain *awstypes.VoiceProfileDomain) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -228,7 +229,7 @@ func testAccCheckVoiceProfileDomainExists(ctx context.Context, name string, voic
 			return create.Error(names.ChimeSDKVoice, create.ErrActionCheckingExistence, tfchimesdkvoice.ResNameVoiceProfileDomain, name, errors.New("not set"))
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 		resp, err := tfchimesdkvoice.FindVoiceProfileDomainByID(ctx, conn, rs.Primary.ID)
 		if err != nil {
 			return create.Error(names.ChimeSDKVoice, create.ErrActionCheckingExistence, tfchimesdkvoice.ResNameVoiceProfileDomain, rs.Primary.ID, err)
@@ -241,10 +242,10 @@ func testAccCheckVoiceProfileDomainExists(ctx context.Context, name string, voic
 }
 
 func testAccPreCheck(ctx context.Context, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+	conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
 	input := &chimesdkvoice.ListVoiceProfileDomainsInput{}
-	_, err := conn.ListVoiceProfileDomainsWithContext(ctx, input)
+	_, err := conn.ListVoiceProfileDomains(ctx, input)
 
 	if acctest.PreCheckSkipError(err) {
 		t.Skipf("skipping acceptance testing: %s", err)
@@ -255,9 +256,9 @@ func testAccPreCheck(ctx context.Context, t *testing.T) {
 	}
 }
 
-func testAccCheckVoiceProfileDomainNotRecreated(before, after *chimesdkvoice.VoiceProfileDomain) resource.TestCheckFunc {
+func testAccCheckVoiceProfileDomainNotRecreated(before, after *awstypes.VoiceProfileDomain) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if beforeID, afterID := aws.StringValue(before.VoiceProfileDomainId), aws.StringValue(after.VoiceProfileDomainId); beforeID != afterID {
+		if beforeID, afterID := aws.ToString(before.VoiceProfileDomainId), aws.ToString(after.VoiceProfileDomainId); beforeID != afterID {
 			return create.Error(names.ChimeSDKVoice, create.ErrActionCheckingNotRecreated, tfchimesdkvoice.ResNameVoiceProfileDomain, beforeID, errors.New("recreated"))
 		}
 

--- a/names/names.go
+++ b/names/names.go
@@ -33,6 +33,7 @@ const (
 	AthenaEndpointID                     = "athena"
 	AuditManagerEndpointID               = "auditmanager"
 	BedrockEndpointID                    = "bedrock"
+	ChimeSDKVoiceEndpointID              = "voice-chime"
 	CleanRoomsEndpointID                 = "cleanrooms"
 	CloudWatchLogsEndpointID             = "logs"
 	CodeStarConnectionsEndpointID        = "codestar-connections"

--- a/names/names_data.csv
+++ b/names/names_data.csv
@@ -44,7 +44,7 @@ chime-sdk-identity,chimesdkidentity,chimesdkidentity,chimesdkidentity,,chimesdki
 chime-sdk-mediapipelines,chimesdkmediapipelines,chimesdkmediapipelines,chimesdkmediapipelines,,chimesdkmediapipelines,,,ChimeSDKMediaPipelines,ChimeSDKMediaPipelines,,1,,,aws_chimesdkmediapipelines_,,chimesdkmediapipelines_,Chime SDK Media Pipelines,Amazon,,,,,,,
 chime-sdk-meetings,chimesdkmeetings,chimesdkmeetings,chimesdkmeetings,,chimesdkmeetings,,,ChimeSDKMeetings,ChimeSDKMeetings,,1,,,aws_chimesdkmeetings_,,chimesdkmeetings_,Chime SDK Meetings,Amazon,,x,,,,,
 chime-sdk-messaging,chimesdkmessaging,chimesdkmessaging,chimesdkmessaging,,chimesdkmessaging,,,ChimeSDKMessaging,ChimeSDKMessaging,,1,,,aws_chimesdkmessaging_,,chimesdkmessaging_,Chime SDK Messaging,Amazon,,x,,,,,
-chime-sdk-voice,chimesdkvoice,chimesdkvoice,chimesdkvoice,,chimesdkvoice,,,ChimeSDKVoice,ChimeSDKVoice,,1,,,aws_chimesdkvoice_,,chimesdkvoice_,Chime SDK Voice,Amazon,,,,,,,
+chime-sdk-voice,chimesdkvoice,chimesdkvoice,chimesdkvoice,,chimesdkvoice,,,ChimeSDKVoice,ChimeSDKVoice,,,2,,aws_chimesdkvoice_,,chimesdkvoice_,Chime SDK Voice,Amazon,,,,,,,
 cleanrooms,cleanrooms,cleanrooms,cleanrooms,,cleanrooms,,,CleanRooms,CleanRooms,,,2,,aws_cleanrooms_,,cleanrooms_,Clean Rooms,AWS,,,,,,,
 ,,,,,,,,,,,,,,,,,CLI (Command Line Interface),AWS,x,,,,,,No SDK support
 configure,configure,,,,,,,,,,,,,,,,CLI Configure options,AWS,x,,,,,,CLI only


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

covert to AWS SDKv2 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTARGS="-run=TestAccChime_serial" PKG=chime

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/chime/... -v -count 1 -parallel 20  -run=TestAccChime_serial -timeout 360m
--- PASS: TestAccChime_serial (2351.88s)
    --- PASS: TestAccChime_serial/VoiceConnectorTerminationCredentials (428.51s)
        --- PASS: TestAccChime_serial/VoiceConnectorTerminationCredentials/update (200.77s)
        --- PASS: TestAccChime_serial/VoiceConnectorTerminationCredentials/basic (118.63s)
        --- PASS: TestAccChime_serial/VoiceConnectorTerminationCredentials/disappears (109.11s)
    --- PASS: TestAccChime_serial/VoiceConnector (339.00s)
        --- PASS: TestAccChime_serial/VoiceConnector/basic (57.87s)
        --- PASS: TestAccChime_serial/VoiceConnector/disappears (40.84s)
        --- PASS: TestAccChime_serial/VoiceConnector/update (95.73s)
        --- PASS: TestAccChime_serial/VoiceConnector/tags (144.56s)
    --- PASS: TestAccChime_serial/VoiceConnectorGroup (336.43s)
        --- PASS: TestAccChime_serial/VoiceConnectorGroup/basic (93.70s)
        --- PASS: TestAccChime_serial/VoiceConnectorGroup/disappears (85.04s)
        --- PASS: TestAccChime_serial/VoiceConnectorGroup/update (157.69s)
    --- PASS: TestAccChime_serial/VoiceConnectorLogging (319.74s)
        --- PASS: TestAccChime_serial/VoiceConnectorLogging/basic (86.11s)
        --- PASS: TestAccChime_serial/VoiceConnectorLogging/disappears (81.91s)
        --- PASS: TestAccChime_serial/VoiceConnectorLogging/update (151.72s)
    --- PASS: TestAccChime_serial/VoiceConnectorOrigination (312.20s)
        --- PASS: TestAccChime_serial/VoiceConnectorOrigination/basic (85.55s)
        --- PASS: TestAccChime_serial/VoiceConnectorOrigination/disappears (75.27s)
        --- PASS: TestAccChime_serial/VoiceConnectorOrigination/update (151.38s)
    --- PASS: TestAccChime_serial/VoiceConnectorStreaming (324.31s)
        --- PASS: TestAccChime_serial/VoiceConnectorStreaming/basic (60.74s)
        --- PASS: TestAccChime_serial/VoiceConnectorStreaming/disappears (59.79s)
        --- PASS: TestAccChime_serial/VoiceConnectorStreaming/update (203.78s)
    --- PASS: TestAccChime_serial/VoiceConnectorTermination (291.69s)
        --- PASS: TestAccChime_serial/VoiceConnectorTermination/disappears (69.53s)
        --- PASS: TestAccChime_serial/VoiceConnectorTermination/update (141.22s)
        --- PASS: TestAccChime_serial/VoiceConnectorTermination/basic (80.94s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/chime	2355.181s
```

```console
$ make testacc TESTARGS="-run=TestAccChimeSDKVoice" PKG=chimesdkvoice

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/chimesdkvoice/... -v -count 1 -parallel 20  -run=TestAccChimeSDKVoice -timeout 360m
--- PASS: TestAccChimeSDKVoiceSipMediaApplication_disappears (194.39s)
--- PASS: TestAccChimeSDKVoiceSipMediaApplication_basic (208.58s)
    acctest.go:917: skipping tests; AWS_DEFAULT_REGION (us-west-2) not supported. Supported: [us-east-1]
--- PASS: TestAccChimeSDKVoiceGlobalSettings_serial (214.29s)
    --- PASS: TestAccChimeSDKVoiceGlobalSettings_serial/basic (100.88s)
    --- PASS: TestAccChimeSDKVoiceGlobalSettings_serial/disappears (113.41s)
    --- SKIP: TestAccChimeSDKVoiceGlobalSettings_serial/update (0.00s)
--- PASS: TestAccChimeSDKVoiceSipRule_disappears (262.65s)
--- PASS: TestAccChimeSDKVoiceSipRule_basic (284.02s)
--- PASS: TestAccChimeSDKVoiceSipMediaApplication_update (319.63s)
--- PASS: TestAccChimeSDKVoiceSipMediaApplication_tags (409.98s)
--- PASS: TestAccChimeSDKVoiceVoiceProfileDomain_serial (443.59s)
    --- PASS: TestAccChimeSDKVoiceVoiceProfileDomain_serial/VoiceProfileDomain (443.59s)
        --- PASS: TestAccChimeSDKVoiceVoiceProfileDomain_serial/VoiceProfileDomain/basic (95.56s)
        --- PASS: TestAccChimeSDKVoiceVoiceProfileDomain_serial/VoiceProfileDomain/disappears (86.36s)
        --- PASS: TestAccChimeSDKVoiceVoiceProfileDomain_serial/VoiceProfileDomain/update (120.65s)
        --- PASS: TestAccChimeSDKVoiceVoiceProfileDomain_serial/VoiceProfileDomain/tags (141.01s)
--- PASS: TestAccChimeSDKVoiceSipRule_update (448.56s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/chimesdkvoice	451.807s
```
