### PR TITLE
Best Practices - Updated access keys in documentation examples

### DIFF
--- a/website/docs/cdktf/python/r/lightsail_bucket_access_key.html.markdown
+++ b/website/docs/cdktf/python/r/lightsail_bucket_access_key.html.markdown
@@ -71,7 +71,7 @@ class MyConvertedCode(TerraformStack):
 Using `terraform import`, import `aws_lightsail_bucket_access_key` using the `id` attribute. For example:
 
 ```console
-% terraform import aws_lightsail_bucket_access_key.test example-bucket,AKIA47VOQ2KPR7LLRZ6D
+% terraform import aws_lightsail_bucket_access_key.test example-bucket,AKIAIOSFODNN7EXAMPLE
 ```
 
 <!-- cache-key: cdktf-0.19.0 input-4987b702ac9d88a7d12a903a50c895eccdf400c8ee70bccc957c21e050e1eb7f -->

--- a/website/docs/cdktf/typescript/r/lightsail_bucket_access_key.html.markdown
+++ b/website/docs/cdktf/typescript/r/lightsail_bucket_access_key.html.markdown
@@ -77,7 +77,7 @@ class MyConvertedCode extends TerraformStack {
 Using `terraform import`, import `awsLightsailBucketAccessKey` using the `id` attribute. For example:
 
 ```console
-% terraform import aws_lightsail_bucket_access_key.test example-bucket,AKIA47VOQ2KPR7LLRZ6D
+% terraform import aws_lightsail_bucket_access_key.test example-bucket,AKIAIOSFODNN7EXAMPLE
 ```
 
 <!-- cache-key: cdktf-0.19.0 input-4987b702ac9d88a7d12a903a50c895eccdf400c8ee70bccc957c21e050e1eb7f -->

--- a/website/docs/r/lightsail_bucket_access_key.html.markdown
+++ b/website/docs/r/lightsail_bucket_access_key.html.markdown
@@ -46,12 +46,12 @@ In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashico
 ```terraform
 import {
   to = aws_lightsail_bucket_access_key.test
-  id = "example-bucket,AKIA47VOQ2KPR7LLRZ6D"
+  id = "example-bucket,AKIAIOSFODNN7EXAMPLE"
 }
 ```
 
 Using `terraform import`, import `aws_lightsail_bucket_access_key` using the `id` attribute. For example:
 
 ```console
-% terraform import aws_lightsail_bucket_access_key.test example-bucket,AKIA47VOQ2KPR7LLRZ6D
+% terraform import aws_lightsail_bucket_access_key.test example-bucket,AKIAIOSFODNN7EXAMPLE
 ```


### PR DESCRIPTION

### Description

Replaced access keys in lightsail_bucket documentation with safe names.



### Relations


### References
https://alpha.www.docs.aws.a2z.com/awsstyleguide/latest/styleguide/safenames.html


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
