### PR TITLE
[New Data Source]: `aws_emr_supported_instance_types`

### DIFF
--- a/.changelog/34481.txt
+++ b/.changelog/34481.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_emr_supported_instance_types
+```

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/docdbelastic v1.5.3
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.137.0
 	github.com/aws/aws-sdk-go-v2/service/eks v1.33.2
+	github.com/aws/aws-sdk-go-v2/service/emr v1.34.1
 	github.com/aws/aws-sdk-go-v2/service/emrserverless v1.13.4
 	github.com/aws/aws-sdk-go-v2/service/finspace v1.17.1
 	github.com/aws/aws-sdk-go-v2/service/fis v1.19.3

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,8 @@ github.com/aws/aws-sdk-go-v2/service/ec2 v1.137.0 h1:XCaAqb6eTyyzEKhLTXDmQRJyIIg
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.137.0/go.mod h1:hrBzQzlQQRmiaeYRQPr0SdSx6fdqP+5YcGhb97LCt8M=
 github.com/aws/aws-sdk-go-v2/service/eks v1.33.2 h1:V31GdxyniIKfST6Dlfan7zvl0V64pdYbhA/A3+1sIYM=
 github.com/aws/aws-sdk-go-v2/service/eks v1.33.2/go.mod h1:DInudKNZjEy7SJ0KfRh4VxaqY04B52Lq2+QRuvObfNQ=
+github.com/aws/aws-sdk-go-v2/service/emr v1.34.1 h1:AkAncVuiOap3LS/kLs1QdVDY9LZyYHOMzCRybLtlxJU=
+github.com/aws/aws-sdk-go-v2/service/emr v1.34.1/go.mod h1:HCZK6jCgxuYABdZFqiiHE3WT2tvTFVjefMB3ZX9dOxA=
 github.com/aws/aws-sdk-go-v2/service/emrserverless v1.13.4 h1:V5unlj0Ky5ZuvLkndDQlHbYe3vshVJwavUZ7aGne8oo=
 github.com/aws/aws-sdk-go-v2/service/emrserverless v1.13.4/go.mod h1:EC2zElGORkIzy2vPQV5U1qNGXIDzZHjL/KWbpQD6nc0=
 github.com/aws/aws-sdk-go-v2/service/finspace v1.17.1 h1:GcBPj8B8EiVaHOba8Pq+CS+7w7s3q8ndETwPtpleS7A=

--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -29,6 +29,7 @@ import (
 	docdbelastic_sdkv2 "github.com/aws/aws-sdk-go-v2/service/docdbelastic"
 	ec2_sdkv2 "github.com/aws/aws-sdk-go-v2/service/ec2"
 	eks_sdkv2 "github.com/aws/aws-sdk-go-v2/service/eks"
+	emr_sdkv2 "github.com/aws/aws-sdk-go-v2/service/emr"
 	emrserverless_sdkv2 "github.com/aws/aws-sdk-go-v2/service/emrserverless"
 	finspace_sdkv2 "github.com/aws/aws-sdk-go-v2/service/finspace"
 	fis_sdkv2 "github.com/aws/aws-sdk-go-v2/service/fis"
@@ -552,6 +553,10 @@ func (c *AWSClient) ELBV2Conn(ctx context.Context) *elbv2_sdkv1.ELBV2 {
 
 func (c *AWSClient) EMRConn(ctx context.Context) *emr_sdkv1.EMR {
 	return errs.Must(conn[*emr_sdkv1.EMR](ctx, c, names.EMR))
+}
+
+func (c *AWSClient) EMRClient(ctx context.Context) *emr_sdkv2.Client {
+	return errs.Must(client[*emr_sdkv2.Client](ctx, c, names.EMR))
 }
 
 func (c *AWSClient) EMRContainersConn(ctx context.Context) *emrcontainers_sdkv1.EMRContainers {

--- a/internal/framework/flex/float.go
+++ b/internal/framework/flex/float.go
@@ -25,3 +25,19 @@ func Float64ToFramework(ctx context.Context, v *float64) types.Float64 {
 func Float64ToFrameworkLegacy(_ context.Context, v *float64) types.Float64 {
 	return types.Float64Value(aws.ToFloat64(v))
 }
+
+// Float32ToFramework converts a float32 pointer to a Framework Float64 value.
+// A nil float32 pointer is converted to a null Float64.
+func Float32ToFramework(ctx context.Context, v *float32) types.Float64 {
+	var output types.Float64
+
+	panicOnError(Flatten(ctx, v, &output))
+
+	return output
+}
+
+// Float32ToFrameworkLegacy converts a float32 pointer to a Framework Float64 value.
+// A nil float32 pointer is converted to a zero float64.
+func Float32ToFrameworkLegacy(_ context.Context, v *float32) types.Float64 {
+	return types.Float64Value(float64(aws.ToFloat32(v)))
+}

--- a/internal/framework/flex/float_test.go
+++ b/internal/framework/flex/float_test.go
@@ -57,15 +57,15 @@ func TestFloat64ToFrameworkLegacy(t *testing.T) {
 		expected types.Float64
 	}
 	tests := map[string]testCase{
-		"valid int64": {
+		"valid float64": {
 			input:    aws.Float64(42.1),
 			expected: types.Float64Value(42.1),
 		},
-		"zero int64": {
+		"zero float64": {
 			input:    aws.Float64(0),
 			expected: types.Float64Value(0),
 		},
-		"nil int64": {
+		"nil float64": {
 			input:    nil,
 			expected: types.Float64Value(0),
 		},
@@ -77,6 +77,78 @@ func TestFloat64ToFrameworkLegacy(t *testing.T) {
 			t.Parallel()
 
 			got := flex.Float64ToFrameworkLegacy(context.Background(), test.input)
+
+			if diff := cmp.Diff(got, test.expected); diff != "" {
+				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}
+
+func TestFloat32ToFramework(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input    *float32
+		expected types.Float64
+	}
+	tests := map[string]testCase{
+		"valid float32": {
+			input:    aws.Float32(42.0),
+			expected: types.Float64Value(42.0),
+		},
+		"zero float32": {
+			input:    aws.Float32(0),
+			expected: types.Float64Value(0),
+		},
+		"nil float32": {
+			input:    nil,
+			expected: types.Float64Null(),
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := flex.Float32ToFramework(context.Background(), test.input)
+
+			if diff := cmp.Diff(got, test.expected); diff != "" {
+				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}
+
+func TestFloat32ToFrameworkLegacy(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input    *float32
+		expected types.Float64
+	}
+	tests := map[string]testCase{
+		"valid float32": {
+			input:    aws.Float32(42.0),
+			expected: types.Float64Value(42.0),
+		},
+		"zero float32": {
+			input:    aws.Float32(0),
+			expected: types.Float64Value(0),
+		},
+		"nil float32": {
+			input:    nil,
+			expected: types.Float64Value(0),
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := flex.Float32ToFrameworkLegacy(context.Background(), test.input)
 
 			if diff := cmp.Diff(got, test.expected); diff != "" {
 				t.Errorf("unexpected diff (+wanted, -got): %s", diff)

--- a/internal/service/emr/service_package_gen.go
+++ b/internal/service/emr/service_package_gen.go
@@ -5,6 +5,8 @@ package emr
 import (
 	"context"
 
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	emr_sdkv2 "github.com/aws/aws-sdk-go-v2/service/emr"
 	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
 	session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
 	emr_sdkv1 "github.com/aws/aws-sdk-go/service/emr"
@@ -16,7 +18,12 @@ import (
 type servicePackage struct{}
 
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.ServicePackageFrameworkDataSource {
-	return []*types.ServicePackageFrameworkDataSource{}
+	return []*types.ServicePackageFrameworkDataSource{
+		{
+			Factory: newDataSourceSupportedInstanceTypes,
+			Name:    "Supported Instance Types",
+		},
+	}
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.ServicePackageFrameworkResource {
@@ -86,6 +93,17 @@ func (p *servicePackage) NewConn(ctx context.Context, config map[string]any) (*e
 	sess := config["session"].(*session_sdkv1.Session)
 
 	return emr_sdkv1.New(sess.Copy(&aws_sdkv1.Config{Endpoint: aws_sdkv1.String(config["endpoint"].(string))})), nil
+}
+
+// NewClient returns a new AWS SDK for Go v2 client for this service package's AWS API.
+func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (*emr_sdkv2.Client, error) {
+	cfg := *(config["aws_sdkv2_config"].(*aws_sdkv2.Config))
+
+	return emr_sdkv2.NewFromConfig(cfg, func(o *emr_sdkv2.Options) {
+		if endpoint := config["endpoint"].(string); endpoint != "" {
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
+		}
+	}), nil
 }
 
 func ServicePackage(ctx context.Context) conns.ServicePackage {

--- a/internal/service/emr/supported_instance_types_data_source.go
+++ b/internal/service/emr/supported_instance_types_data_source.go
@@ -1,0 +1,179 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package emr
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/emr"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/emr/types"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource(name="Supported Instance Types")
+func newDataSourceSupportedInstanceTypes(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &dataSourceSupportedInstanceTypes{}, nil
+}
+
+const (
+	DSNameSupportedInstanceTypes = "Supported Instance Types Data Source"
+)
+
+type dataSourceSupportedInstanceTypes struct {
+	framework.DataSourceWithConfigure
+}
+
+func (d *dataSourceSupportedInstanceTypes) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) { // nosemgrep:ci.meta-in-func-name
+	resp.TypeName = "aws_emr_supported_instance_types"
+}
+
+func (d *dataSourceSupportedInstanceTypes) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": framework.IDAttribute(),
+			"release_label": schema.StringAttribute{
+				Required: true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"supported_instance_types": schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"architecture": schema.StringAttribute{
+							Computed: true,
+						},
+						"ebs_optimized_available": schema.BoolAttribute{
+							Computed: true,
+						},
+						"ebs_optimized_by_default": schema.BoolAttribute{
+							Computed: true,
+						},
+						"ebs_storage_only": schema.BoolAttribute{
+							Computed: true,
+						},
+						"instance_family_id": schema.StringAttribute{
+							Computed: true,
+						},
+						"is_64_bits_only": schema.BoolAttribute{
+							Computed: true,
+						},
+						"memory_gb": schema.Float64Attribute{
+							Computed: true,
+						},
+						"number_of_disks": schema.Int64Attribute{
+							Computed: true,
+						},
+						"storage_gb": schema.Int64Attribute{
+							Computed: true,
+						},
+						"type": schema.StringAttribute{
+							Computed: true,
+						},
+						"vcpu": schema.Int64Attribute{
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+func (d *dataSourceSupportedInstanceTypes) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	conn := d.Meta().EMRClient(ctx)
+
+	var data dataSourceSupportedInstanceTypesData
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	data.ID = types.StringValue(data.ReleaseLabel.ValueString())
+
+	input := &emr.ListSupportedInstanceTypesInput{
+		ReleaseLabel: aws.String(data.ReleaseLabel.ValueString()),
+	}
+
+	var results []awstypes.SupportedInstanceType
+	paginator := emr.NewListSupportedInstanceTypesPaginator(conn, input)
+	for paginator.HasMorePages() {
+		output, err := paginator.NextPage(ctx)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.EMR, create.ErrActionReading, DSNameSupportedInstanceTypes, data.ID.String(), err),
+				err.Error(),
+			)
+			return
+		}
+		results = append(results, output.SupportedInstanceTypes...)
+	}
+
+	supportedInstanceTypes, diag := flattenSupportedInstanceTypes(ctx, results)
+	resp.Diagnostics.Append(diag...)
+	data.SupportedInstanceTypes = supportedInstanceTypes
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+type dataSourceSupportedInstanceTypesData struct {
+	ID                     types.String `tfsdk:"id"`
+	ReleaseLabel           types.String `tfsdk:"release_label"`
+	SupportedInstanceTypes types.List   `tfsdk:"supported_instance_types"`
+}
+
+var supportedInstanceTypeAttrTypes = map[string]attr.Type{
+	"architecture":             types.StringType,
+	"ebs_optimized_available":  types.BoolType,
+	"ebs_optimized_by_default": types.BoolType,
+	"ebs_storage_only":         types.BoolType,
+	"instance_family_id":       types.StringType,
+	"is_64_bits_only":          types.BoolType,
+	"memory_gb":                types.Float64Type,
+	"number_of_disks":          types.Int64Type,
+	"storage_gb":               types.Int64Type,
+	"type":                     types.StringType,
+	"vcpu":                     types.Int64Type,
+}
+
+func flattenSupportedInstanceTypes(ctx context.Context, apiObjects []awstypes.SupportedInstanceType) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	elemType := types.ObjectType{AttrTypes: supportedInstanceTypeAttrTypes}
+
+	if len(apiObjects) == 0 {
+		return types.ListNull(elemType), diags
+	}
+
+	elems := []attr.Value{}
+	for _, apiObject := range apiObjects {
+		obj := map[string]attr.Value{
+			"architecture":             flex.StringToFramework(ctx, apiObject.Architecture),
+			"ebs_optimized_available":  flex.BoolToFramework(ctx, apiObject.EbsOptimizedAvailable),
+			"ebs_optimized_by_default": flex.BoolToFramework(ctx, apiObject.EbsOptimizedByDefault),
+			"ebs_storage_only":         flex.BoolToFramework(ctx, apiObject.EbsStorageOnly),
+			"instance_family_id":       flex.StringToFramework(ctx, apiObject.InstanceFamilyId),
+			"is_64_bits_only":          flex.BoolToFramework(ctx, apiObject.Is64BitsOnly),
+			"memory_gb":                flex.Float32ToFramework(ctx, apiObject.MemoryGB),
+			"number_of_disks":          flex.Int32ToFramework(ctx, apiObject.NumberOfDisks),
+			"storage_gb":               flex.Int32ToFramework(ctx, apiObject.StorageGB),
+			"type":                     flex.StringToFramework(ctx, apiObject.Type),
+			"vcpu":                     flex.Int32ToFramework(ctx, apiObject.VCPU),
+		}
+		objVal, d := types.ObjectValue(supportedInstanceTypeAttrTypes, obj)
+		diags.Append(d...)
+
+		elems = append(elems, objVal)
+	}
+
+	listVal, d := types.ListValue(elemType, elems)
+	diags.Append(d...)
+
+	return listVal, diags
+}

--- a/internal/service/emr/supported_instance_types_data_source_test.go
+++ b/internal/service/emr/supported_instance_types_data_source_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package emr_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccEMRSupportedInstanceTypesDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_emr_supported_instance_types.test"
+	releaseLabel := "emr-6.15.0"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.EMREndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.EMREndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSupportedInstanceTypesDataSourceConfig_basic(releaseLabel),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "release_label", releaseLabel),
+					// Verify a known supported type is included in the output
+					resource.TestCheckTypeSetElemNestedAttrs(dataSourceName, "supported_instance_types.*", map[string]string{
+						"type": "m5.xlarge",
+					}),
+				),
+			},
+		},
+	})
+}
+
+func testAccSupportedInstanceTypesDataSourceConfig_basic(releaseLabel string) string {
+	return fmt.Sprintf(`
+data "aws_emr_supported_instance_types" "test" {
+  release_label = %[1]q
+}
+`, releaseLabel)
+}

--- a/names/names.go
+++ b/names/names.go
@@ -45,6 +45,7 @@ const (
 	ComputeOptimizerEndpointID           = "computeoptimizer"
 	DSEndpointID                         = "ds"
 	EKSEndpointID                        = "eks"
+	EMREndpointID                        = "elasticmapreduce"
 	EMRServerlessEndpointID              = "emrserverless"
 	GlacierEndpointID                    = "glacier"
 	IdentityStoreEndpointID              = "identitystore"

--- a/names/names_data.csv
+++ b/names/names_data.csv
@@ -149,7 +149,7 @@ mediastore,mediastore,mediastore,mediastore,,mediastore,,,MediaStore,MediaStore,
 mediastore-data,mediastoredata,mediastoredata,mediastoredata,,mediastoredata,,,MediaStoreData,MediaStoreData,,1,,,aws_mediastoredata_,,mediastoredata_,Elemental MediaStore Data,AWS,,x,,,,,
 mediatailor,mediatailor,mediatailor,mediatailor,,mediatailor,,,MediaTailor,MediaTailor,,1,,,aws_mediatailor_,,media_tailor_,Elemental MediaTailor,AWS,,x,,,,,
 ,,,,,,,,,,,,,,,,,Elemental On-Premises,AWS,x,,,,,,No SDK support
-emr,emr,emr,emr,,emr,,,EMR,EMR,,1,,,aws_emr_,,emr_,EMR,Amazon,,,,,,,
+emr,emr,emr,emr,,emr,,,EMR,EMR,,1,2,,aws_emr_,,emr_,EMR,Amazon,,,,,,,
 emr-containers,emrcontainers,emrcontainers,emrcontainers,,emrcontainers,,,EMRContainers,EMRContainers,,1,,,aws_emrcontainers_,,emrcontainers_,EMR Containers,Amazon,,,,,,,
 emr-serverless,emrserverless,emrserverless,emrserverless,,emrserverless,,,EMRServerless,EMRServerless,,,2,,aws_emrserverless_,,emrserverless_,EMR Serverless,Amazon,,,,,,,
 ,,,,,,,,,,,,,,,,,End-of-Support Migration Program (EMP) for Windows Server,AWS,x,,,,,,No SDK support

--- a/website/docs/d/emr_supported_instance_types.html.markdown
+++ b/website/docs/d/emr_supported_instance_types.html.markdown
@@ -1,0 +1,47 @@
+---
+subcategory: "EMR"
+layout: "aws"
+page_title: "AWS: aws_emr_supported_instance_types"
+description: |-
+  Terraform data source for managing AWS EMR Supported Instance Types.
+---
+
+# Data Source: aws_emr_supported_instance_types
+
+Terraform data source for managing AWS EMR Supported Instance Types.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_emr_supported_instance_types" "example" {
+  release_label = "ebs-6.15.0"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `release_label` - (Required) Amazon EMR release label. For more information about Amazon EMR releases and their included application versions and features, see the [Amazon EMR Release Guide](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-release-components.html).
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `supported_instance_types` - List of supported instance types. See [`supported_instance_types`](#supported_instance_types-attribute-reference) below.
+
+### `supported_instance_types` Attribute Reference
+
+* `architecture` - CPU architecture.
+* `ebs_optimized_available` - Indicates whether the instance type supports Amazon EBS optimization.
+* `ebs_optimized_by_default` - Indicates whether the instance type uses Amazon EBS optimization by default.
+* `ebs_storage_only` - Indicates whether the instance type only supports Amazon EBS.
+* `instance_family_id` - The Amazon EC2 family and generation for the instance type.
+* `is_64_bits_only` - Indicates whether the instance type only supports 64-bit architecture.
+* `memory_gb` - Memory that is available to Amazon EMR from the instance type.
+* `number_of_disks` - Number of disks for the instance type.
+* `storage_gb` - Storage capacity of the instance type.
+* `type` - Amazon EC2 instance type. For example, `m5.xlarge`.
+* `vcpu` - The number of vCPUs available for the instance type.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Returns a list of supported instance types for the provided release label (ie. `emr-6.15.0`).

Also adds a V2 EMR service client and `flex` flatteners to support `float32` builtin type conversions to framework `Float64` types.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #34438
Relates #33998

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/emr/latest/APIReference/API_ListSupportedInstanceTypes.html
- https://docs.aws.amazon.com/emr/latest/APIReference/API_SupportedInstanceType.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=emr TESTS=TestAccEMRSupportedInstanceTypesDataSource_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/emr/... -v -count 1 -parallel 20 -run='TestAccEMRSupportedInstanceTypesDataSource_'  -timeout 360m
=== RUN   TestAccEMRSupportedInstanceTypesDataSource_basic
=== PAUSE TestAccEMRSupportedInstanceTypesDataSource_basic
=== CONT  TestAccEMRSupportedInstanceTypesDataSource_basic
--- PASS: TestAccEMRSupportedInstanceTypesDataSource_basic (31.85s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/emr        35.082s
```
