### PR TITLE
Fixed docs for data.aws_cloudfront_origin_access_identity

### DIFF
--- a/website/docs/d/cloudfront_origin_access_identity.html.markdown
+++ b/website/docs/d/cloudfront_origin_access_identity.html.markdown
@@ -16,13 +16,13 @@ The following example below creates a CloudFront origin access identity.
 
 ```terraform
 data "aws_cloudfront_origin_access_identity" "example" {
-  id = "EDFDVBD632BHDS5"
+  id = "E1ZAKK699EOLAL"
 }
 ```
 
 ## Argument Reference
 
-* `id` (Required) -  The identifier for the distribution. For example: `EDFDVBD632BHDS5`.
+* `id` (Required) -  The identifier for the origin access identity. For example: `E1ZAKK699EOLAL`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
### Description
Updated description for the `id` attribute of `data.aws_cloudfront_origin_access_identity`. Id should be that of the access identity, not the CLoudfront distribution.


### Relations
Closes #34416

### References
[Cloudfront Access Control](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html) (Legacy OAI at the bottom)

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudfront_origin_access_identity
