### PR TITLE
sweepers: Fix `RequestLimitExceeded` error when sweeping large number of Subnets

### DIFF
--- a/internal/service/ec2/vpc_network_interface.go
+++ b/internal/service/ec2/vpc_network_interface.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
@@ -1471,6 +1472,8 @@ func flattenIPv6PrefixSpecifications(apiObjects []*ec2.Ipv6PrefixSpecification) 
 // which can prevent security groups and subnets attached to such ENIs from being destroyed
 func deleteLingeringENIs(ctx context.Context, conn *ec2.EC2, filterName, resourceId string, timeout time.Duration) error {
 	var g multierror.Group
+
+	tflog.Trace(ctx, "Checking for lingering ENIs")
 
 	err := multierror.Append(nil, deleteLingeringLambdaENIs(ctx, &g, conn, filterName, resourceId, timeout))
 

--- a/internal/service/ec2/vpc_network_interface.go
+++ b/internal/service/ec2/vpc_network_interface.go
@@ -1475,166 +1475,129 @@ func deleteLingeringENIs(ctx context.Context, conn *ec2.EC2, filterName, resourc
 
 	tflog.Trace(ctx, "Checking for lingering ENIs")
 
-	err := multierror.Append(nil, deleteLingeringLambdaENIs(ctx, &g, conn, filterName, resourceId, timeout))
+	enis, err := FindNetworkInterfaces(ctx, conn, &ec2.DescribeNetworkInterfacesInput{
+		Filters: BuildAttributeFilterList(map[string]string{
+			filterName: resourceId,
+		}),
+	})
+	if err != nil {
+		return fmt.Errorf("listing EC2 Network Interfaces: %w", err)
+	}
 
-	err = multierror.Append(err, deleteLingeringComprehendENIs(ctx, &g, conn, filterName, resourceId, timeout))
+	for _, eni := range enis {
+		eni := eni
 
-	err = multierror.Append(err, deleteLingeringDMSENIs(ctx, &g, conn, filterName, resourceId, timeout))
+		if found := deleteLingeringLambdaENI(ctx, &g, conn, eni, timeout); found {
+			continue
+		}
 
-	return multierror.Append(err, g.Wait()).ErrorOrNil()
+		if found := deleteLingeringComprehendENI(ctx, &g, conn, eni, timeout); found {
+			continue
+		}
+
+		deleteLingeringDMSENI(ctx, &g, conn, eni, timeout)
+	}
+
+	return g.Wait().ErrorOrNil()
 }
 
-func deleteLingeringLambdaENIs(ctx context.Context, g *multierror.Group, conn *ec2.EC2, filterName, resourceId string, timeout time.Duration) error {
+func deleteLingeringLambdaENI(ctx context.Context, g *multierror.Group, conn *ec2.EC2, eni *ec2.NetworkInterface, timeout time.Duration) bool {
 	// AWS Lambda service team confirms P99 deletion time of ~35 minutes. Buffer for safety.
 	if minimumTimeout := 45 * time.Minute; timeout < minimumTimeout {
 		timeout = minimumTimeout
 	}
 
-	networkInterfaces, err := FindNetworkInterfaces(ctx, conn, &ec2.DescribeNetworkInterfacesInput{
-		Filters: BuildAttributeFilterList(map[string]string{
-			filterName:    resourceId,
-			"description": "AWS Lambda VPC ENI*",
-		}),
+	if !strings.HasPrefix(aws.StringValue(eni.Description), "AWS Lambda VPC ENI") {
+		return false
+	}
+
+	g.Go(func() error {
+		networkInterfaceID := aws.StringValue(eni.NetworkInterfaceId)
+
+		if eni.Attachment != nil && aws.StringValue(eni.Attachment.InstanceOwnerId) == "amazon-aws" {
+			networkInterface, err := WaitNetworkInterfaceAvailableAfterUse(ctx, conn, networkInterfaceID, timeout)
+			if tfresource.NotFound(err) {
+				return nil
+			}
+			if err != nil {
+				return fmt.Errorf("waiting for Lambda ENI (%s) to become available for detachment: %w", networkInterfaceID, err)
+			}
+
+			eni = networkInterface
+		}
+
+		if eni.Attachment != nil {
+			if err := DetachNetworkInterface(ctx, conn, networkInterfaceID, aws.StringValue(eni.Attachment.AttachmentId), timeout); err != nil {
+				return fmt.Errorf("detaching Lambda ENI (%s): %w", networkInterfaceID, err)
+			}
+		}
+
+		if err := DeleteNetworkInterface(ctx, conn, networkInterfaceID); err != nil {
+			return fmt.Errorf("deleting Lambda ENI (%s): %w", networkInterfaceID, err)
+		}
+
+		return nil
 	})
 
-	if err != nil {
-		return fmt.Errorf("listing EC2 Network Interfaces: %w", err)
-	}
-
-	for _, v := range networkInterfaces {
-		v := v
-		g.Go(func() error {
-			networkInterfaceID := aws.StringValue(v.NetworkInterfaceId)
-
-			if v.Attachment != nil && aws.StringValue(v.Attachment.InstanceOwnerId) == "amazon-aws" {
-				networkInterface, err := WaitNetworkInterfaceAvailableAfterUse(ctx, conn, networkInterfaceID, timeout)
-
-				if tfresource.NotFound(err) {
-					return nil
-				}
-
-				if err != nil {
-					return fmt.Errorf("waiting for Lambda ENI (%s) to become available for detachment: %w", networkInterfaceID, err)
-				}
-
-				v = networkInterface
-			}
-
-			if v.Attachment != nil {
-				err = DetachNetworkInterface(ctx, conn, networkInterfaceID, aws.StringValue(v.Attachment.AttachmentId), timeout)
-
-				if err != nil {
-					return fmt.Errorf("detaching Lambda ENI (%s): %w", networkInterfaceID, err)
-				}
-			}
-
-			err = DeleteNetworkInterface(ctx, conn, networkInterfaceID)
-
-			if err != nil {
-				return fmt.Errorf("deleting Lambda ENI (%s): %w", networkInterfaceID, err)
-			}
-
-			return nil
-		})
-	}
-
-	return nil
+	return true
 }
 
-func deleteLingeringComprehendENIs(ctx context.Context, g *multierror.Group, conn *ec2.EC2, filterName, resourceId string, timeout time.Duration) error {
+func deleteLingeringComprehendENI(ctx context.Context, g *multierror.Group, conn *ec2.EC2, eni *ec2.NetworkInterface, timeout time.Duration) bool {
 	// Deletion appears to take approximately 5 minutes
 	if minimumTimeout := 10 * time.Minute; timeout < minimumTimeout {
 		timeout = minimumTimeout
 	}
 
-	enis, err := FindNetworkInterfaces(ctx, conn, &ec2.DescribeNetworkInterfacesInput{
-		Filters: BuildAttributeFilterList(map[string]string{
-			filterName: resourceId,
-		}),
-	})
-	if err != nil {
-		return fmt.Errorf("listing EC2 Network Interfaces: %w", err)
+	if !strings.HasSuffix(aws.StringValue(eni.RequesterId), ":Comprehend") {
+		return false
 	}
 
-	networkInterfaces := make([]*ec2.NetworkInterface, 0, len(enis))
-	for _, v := range enis {
-		if strings.HasSuffix(aws.StringValue(v.RequesterId), ":Comprehend") {
-			networkInterfaces = append(networkInterfaces, v)
+	g.Go(func() error {
+		networkInterfaceID := aws.StringValue(eni.NetworkInterfaceId)
+
+		if eni.Attachment != nil {
+			if err := DetachNetworkInterface(ctx, conn, networkInterfaceID, aws.StringValue(eni.Attachment.AttachmentId), timeout); err != nil {
+				return fmt.Errorf("detaching Comprehend ENI (%s): %w", networkInterfaceID, err)
+			}
 		}
-	}
 
-	for _, v := range networkInterfaces {
-		v := v
-		g.Go(func() error {
-			networkInterfaceID := aws.StringValue(v.NetworkInterfaceId)
+		if err := DeleteNetworkInterface(ctx, conn, networkInterfaceID); err != nil {
+			return fmt.Errorf("deleting Comprehend ENI (%s): %w", networkInterfaceID, err)
+		}
 
-			if v.Attachment != nil {
-				err = DetachNetworkInterface(ctx, conn, networkInterfaceID, aws.StringValue(v.Attachment.AttachmentId), timeout)
+		return nil
+	})
 
-				if err != nil {
-					return fmt.Errorf("detaching Comprehend ENI (%s): %w", networkInterfaceID, err)
-				}
-			}
-
-			err := DeleteNetworkInterface(ctx, conn, networkInterfaceID)
-
-			if err != nil {
-				return fmt.Errorf("deleting Comprehend ENI (%s): %w", networkInterfaceID, err)
-			}
-
-			return nil
-		})
-	}
-
-	return nil
+	return true
 }
 
-func deleteLingeringDMSENIs(ctx context.Context, g *multierror.Group, conn *ec2.EC2, filterName, resourceId string, timeout time.Duration) error {
+func deleteLingeringDMSENI(ctx context.Context, g *multierror.Group, conn *ec2.EC2, v *ec2.NetworkInterface, timeout time.Duration) bool {
 	// Deletion appears to take approximately 5 minutes
 	if minimumTimeout := 10 * time.Minute; timeout < minimumTimeout {
 		timeout = minimumTimeout
 	}
 
-	enis, err := FindNetworkInterfaces(ctx, conn, &ec2.DescribeNetworkInterfacesInput{
-		Filters: BuildAttributeFilterList(map[string]string{
-			filterName: resourceId,
-		}),
-	})
-	if err != nil {
-		return fmt.Errorf("listing EC2 Network Interfaces: %w", err)
+	if aws.StringValue(v.Description) != "DMSNetworkInterface" {
+		return false
 	}
 
-	networkInterfaces := make([]*ec2.NetworkInterface, 0, len(enis))
-	for _, v := range enis {
-		if aws.StringValue(v.Description) == "DMSNetworkInterface" {
-			networkInterfaces = append(networkInterfaces, v)
+	g.Go(func() error {
+		networkInterfaceID := aws.StringValue(v.NetworkInterfaceId)
+
+		if v.Attachment != nil {
+			if err := DetachNetworkInterface(ctx, conn, networkInterfaceID, aws.StringValue(v.Attachment.AttachmentId), timeout); err != nil {
+				return fmt.Errorf("detaching DMS ENI (%s): %w", networkInterfaceID, err)
+			}
 		}
-	}
 
-	for _, v := range networkInterfaces {
-		v := v
-		g.Go(func() error {
-			networkInterfaceID := aws.StringValue(v.NetworkInterfaceId)
+		if err := DeleteNetworkInterface(ctx, conn, networkInterfaceID); err != nil {
+			return fmt.Errorf("deleting DMS ENI (%s): %w", networkInterfaceID, err)
+		}
 
-			if v.Attachment != nil {
-				err = DetachNetworkInterface(ctx, conn, networkInterfaceID, aws.StringValue(v.Attachment.AttachmentId), timeout)
+		return nil
+	})
 
-				if err != nil {
-					return fmt.Errorf("detaching Comprehend ENI (%s): %w", networkInterfaceID, err)
-				}
-			}
-
-			err := DeleteNetworkInterface(ctx, conn, networkInterfaceID)
-
-			if err != nil {
-				return fmt.Errorf("deleting Comprehend ENI (%s): %w", networkInterfaceID, err)
-			}
-
-			return nil
-		})
-	}
-
-	return nil
+	return true
 }
 
 // Flattens security group identifiers into a []string, where the elements returned are the GroupIDs

--- a/internal/service/ec2/vpc_subnet.go
+++ b/internal/service/ec2/vpc_subnet.go
@@ -12,11 +12,13 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/logging"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -188,7 +190,6 @@ func resourceSubnetCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		input.OutpostArn = aws.String(v.(string))
 	}
 
-	log.Printf("[DEBUG] Creating EC2 Subnet: %s", input)
 	output, err := conn.CreateSubnetWithContext(ctx, input)
 
 	if err != nil {
@@ -364,7 +365,9 @@ func resourceSubnetDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn(ctx)
 
-	log.Printf("[INFO] Deleting EC2 Subnet: %s", d.Id())
+	ctx = tflog.SetField(ctx, logging.KeyResourceId, d.Id())
+
+	tflog.Info(ctx, "Deleting EC2 Subnet")
 
 	if err := deleteLingeringENIs(ctx, conn, "subnet-id", d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "deleting ENIs for EC2 Subnet (%s): %s", d.Id(), err)

--- a/internal/service/lambda/function_test.go
+++ b/internal/service/lambda/function_test.go
@@ -2525,7 +2525,9 @@ resource "aws_security_group" "test" {
 }
 
 func testAccFunctionConfig_basic(funcName, policyName, roleName, sgName string) string {
-	return fmt.Sprintf(acctest.ConfigLambdaBase(policyName, roleName, sgName)+`
+	return acctest.ConfigCompose(
+		acctest.ConfigLambdaBase(policyName, roleName, sgName),
+		fmt.Sprintf(`
 resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = "%s"
@@ -2533,7 +2535,7 @@ resource "aws_lambda_function" "test" {
   handler       = "exports.example"
   runtime       = "nodejs16.x"
 }
-`, funcName)
+`, funcName))
 }
 
 func testAccFunctionConfig_snapStartEnabled(rName string) string {

--- a/internal/sweep/context.go
+++ b/internal/sweep/context.go
@@ -6,8 +6,6 @@ package sweep
 import (
 	"context"
 
-	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-log/tfsdklog"
 )
 
@@ -17,17 +15,6 @@ func Context(region string) context.Context {
 	ctx = tfsdklog.RegisterStdlogSink(ctx)
 
 	ctx = logger(ctx, "sweeper", region)
-
-	return ctx
-}
-
-func logger(ctx context.Context, loggerName, region string) context.Context {
-	ctx = tfsdklog.NewRootProviderLogger(ctx,
-		tfsdklog.WithLevel(hclog.Debug),
-		tfsdklog.WithLogName(loggerName),
-		tfsdklog.WithoutLocation(),
-	)
-	ctx = tflog.SetField(ctx, "sweeper_region", region)
 
 	return ctx
 }

--- a/internal/sweep/logging.go
+++ b/internal/sweep/logging.go
@@ -1,0 +1,36 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package sweep
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-log/tfsdklog"
+)
+
+const (
+	loggingKeySweeperRegion = "sweeper_region"
+
+	// Copied from:
+	// * https://github.com/hashicorp/terraform-plugin-sdk/blob/ffbf0104398c0aa91aa3a82aff4b67e260677454/internal/logging/keys.go#L29
+	// * https://github.com/hashicorp/terraform-plugin-framework/blob/743126edc3b04e735c05f2ddfa42e990b7231600/internal/logging/keys.go#L29
+	loggingKeyResourceType = "tf_resource_type"
+)
+
+func logger(ctx context.Context, loggerName, region string) context.Context {
+	ctx = tfsdklog.NewRootProviderLogger(ctx,
+		tfsdklog.WithLevel(hclog.Debug),
+		tfsdklog.WithLogName(loggerName),
+		tfsdklog.WithoutLocation(),
+	)
+	ctx = tflog.SetField(ctx, loggingKeySweeperRegion, region)
+
+	return ctx
+}
+
+func logWithResourceType(ctx context.Context, resourceType string) context.Context {
+	return tflog.SetField(ctx, loggingKeyResourceType, resourceType)
+}

--- a/internal/sweep/sweep.go
+++ b/internal/sweep/sweep.go
@@ -147,7 +147,7 @@ func Register(name string, f SweeperFn, dependencies ...string) {
 		Name: name,
 		F: func(region string) error {
 			ctx := Context(region)
-			ctx = tflog.SetField(ctx, "sweeper_name", name)
+			ctx = logWithResourceType(ctx, name)
 
 			client, err := SharedRegionalSweepClient(ctx, region)
 			if err != nil {


### PR DESCRIPTION
### Description

When there is a large number of Subnets in a region, the `aws_subnet` sweeper may fail with an error like

> Error running Sweeper (aws_subnet) in region (us-west-2): error sweeping EC2 Subnets (us-west-2): 73 errors occurred:
	* deleting ENIs for EC2 Subnet (subnet-abc123): 1 error occurred:
	* listing EC2 Network Interfaces: RequestLimitExceeded: Request limit exceeded.

The sweeper is not identifying `RequestLimitExceeded` as a throttling error, and therefore not retrying.

The subnet `Delete` function checks for lingering ENIs in three cases:

* Lambda
* Comprehend
* DMS

For each case, the `DescribeNetworkInterfaces` API is called with appropriate filters, thus three times per subnet.

This PR

1. uses a single call to `DescribeNetworkInterfaces` per subnet,
2. identifies throttling error codes using a list from `aws-sdk-go-v2`, which is a strict superset of the codes used in v1, and
3. adds a pause before retrying throttled requests

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

To test, run

```console
% make sweep SWEEPERS=aws_vpc
```

Previously, if there are 50 VPCs with 3 subnets each, the sweeper would fail, leaving between 80 and 100 subnets behind with an error like above.

Now, the sweeper will succeed without any retries.
