### PR TITLE
r/aws_pipes_pipe: fix zero value vs `null` value on update

### DIFF
--- a/.changelog/34487.txt
+++ b/.changelog/34487.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_pipes_pipe: Fix error when zero value is sent to `source_parameters` on update
+```

--- a/internal/service/pipes/source_parameters.go
+++ b/internal/service/pipes/source_parameters.go
@@ -735,7 +735,7 @@ func expandUpdatePipeSourceActiveMQBrokerParameters(tfMap map[string]interface{}
 
 	apiObject := &types.UpdatePipeSourceActiveMQBrokerParameters{}
 
-	if v, ok := tfMap["batch_size"].(int); ok {
+	if v, ok := tfMap["batch_size"].(int); ok && v != 0 {
 		apiObject.BatchSize = aws.Int32(int32(v))
 	}
 
@@ -815,7 +815,7 @@ func expandUpdatePipeSourceDynamoDBStreamParameters(tfMap map[string]interface{}
 
 	apiObject := &types.UpdatePipeSourceDynamoDBStreamParameters{}
 
-	if v, ok := tfMap["batch_size"].(int); ok {
+	if v, ok := tfMap["batch_size"].(int); ok && v != 0 {
 		apiObject.BatchSize = aws.Int32(int32(v))
 	}
 
@@ -841,7 +841,7 @@ func expandUpdatePipeSourceDynamoDBStreamParameters(tfMap map[string]interface{}
 		apiObject.OnPartialBatchItemFailure = types.OnPartialBatchItemFailureStreams(v)
 	}
 
-	if v, ok := tfMap["parallelization_factor"].(int); ok {
+	if v, ok := tfMap["parallelization_factor"].(int); ok && v != 0 {
 		apiObject.ParallelizationFactor = aws.Int32(int32(v))
 	}
 
@@ -917,7 +917,7 @@ func expandUpdatePipeSourceKinesisStreamParameters(tfMap map[string]interface{})
 
 	apiObject := &types.UpdatePipeSourceKinesisStreamParameters{}
 
-	if v, ok := tfMap["batch_size"].(int); ok {
+	if v, ok := tfMap["batch_size"].(int); ok && v != 0 {
 		apiObject.BatchSize = aws.Int32(int32(v))
 	}
 
@@ -931,7 +931,7 @@ func expandUpdatePipeSourceKinesisStreamParameters(tfMap map[string]interface{})
 		apiObject.MaximumBatchingWindowInSeconds = aws.Int32(int32(v))
 	}
 
-	if v, ok := tfMap["maximum_record_age_in_seconds"].(int); ok {
+	if v, ok := tfMap["maximum_record_age_in_seconds"].(int); ok && v != 0 {
 		apiObject.MaximumRecordAgeInSeconds = aws.Int32(int32(v))
 	}
 
@@ -943,7 +943,7 @@ func expandUpdatePipeSourceKinesisStreamParameters(tfMap map[string]interface{})
 		apiObject.OnPartialBatchItemFailure = types.OnPartialBatchItemFailureStreams(v)
 	}
 
-	if v, ok := tfMap["parallelization_factor"].(int); ok {
+	if v, ok := tfMap["parallelization_factor"].(int); ok && v != 0 {
 		apiObject.ParallelizationFactor = aws.Int32(int32(v))
 	}
 
@@ -991,7 +991,7 @@ func expandUpdatePipeSourceManagedStreamingKafkaParameters(tfMap map[string]inte
 
 	apiObject := &types.UpdatePipeSourceManagedStreamingKafkaParameters{}
 
-	if v, ok := tfMap["batch_size"].(int); ok {
+	if v, ok := tfMap["batch_size"].(int); ok && v != 0 {
 		apiObject.BatchSize = aws.Int32(int32(v))
 	}
 
@@ -1067,7 +1067,7 @@ func expandUpdatePipeSourceRabbitMQBrokerParameters(tfMap map[string]interface{}
 
 	apiObject := &types.UpdatePipeSourceRabbitMQBrokerParameters{}
 
-	if v, ok := tfMap["batch_size"].(int); ok {
+	if v, ok := tfMap["batch_size"].(int); ok && v != 0 {
 		apiObject.BatchSize = aws.Int32(int32(v))
 	}
 
@@ -1243,7 +1243,7 @@ func expandUpdatePipeSourceSQSQueueParameters(tfMap map[string]interface{}) *typ
 
 	apiObject := &types.UpdatePipeSourceSqsQueueParameters{}
 
-	if v, ok := tfMap["batch_size"].(int); ok {
+	if v, ok := tfMap["batch_size"].(int); ok && v != 0 {
 		apiObject.BatchSize = aws.Int32(int32(v))
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #32423

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS="-run=TestAccPipesPipe_" PKG=pipes

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/pipes/... -v -count 1 -parallel 20  -run=TestAccPipesPipe_ -timeout 360m
    acctest.go:89: DependencyViolation errors deleting subnets and security group
--- SKIP: TestAccPipesPipe_mskSourceHTTPTarget (0.00s)
    acctest.go:89: DependencyViolation errors deleting subnets and security group
--- SKIP: TestAccPipesPipe_selfManagedKafkaSourceLambdaFunctionTarget (0.00s)
    acctest.go:89: aws_sagemaker_pipeline resource not yet implemented
--- SKIP: TestAccPipesPipe_SourceSageMakerTarget (0.00s)
    acctest.go:89: ValidationException: [numeric instance is lower than the required minimum (minimum: 1, found: 0)]
--- SKIP: TestAccPipesPipe_sqsSourceECSTaskTarget (0.00s)
--- PASS: TestAccPipesPipe_namePrefix (895.09s)
--- PASS: TestAccPipesPipe_nameGenerated (903.49s)
--- PASS: TestAccPipesPipe_disappears (904.91s)
--- PASS: TestAccPipesPipe_basicSQS (920.71s)
--- PASS: TestAccPipesPipe_dynamoDBSourceCloudWatchLogsTarget (977.85s)
--- PASS: TestAccPipesPipe_sqsSourceRedshiftTarget (1025.94s)
--- PASS: TestAccPipesPipe_kinesisSourceAndTarget (1260.29s)
--- PASS: TestAccPipesPipe_rabbitMQSourceEventBusTarget (1333.86s)
--- PASS: TestAccPipesPipe_roleARN (1406.88s)
--- PASS: TestAccPipesPipe_targetUpdate (1423.21s)
--- PASS: TestAccPipesPipe_enrichmentParameters (1436.48s)
--- PASS: TestAccPipesPipe_sqsSourceBatchJobTarget (1477.89s)
--- PASS: TestAccPipesPipe_tags (1578.62s)
--- PASS: TestAccPipesPipe_targetParameters_inputTemplate (1615.37s)
--- PASS: TestAccPipesPipe_enrichment (1658.46s)
--- PASS: TestAccPipesPipe_desiredState (1750.14s)
--- PASS: TestAccPipesPipe_description (1762.66s)
--- PASS: TestAccPipesPipe_activeMQSourceStepFunctionTarget (1814.93s)
--- PASS: TestAccPipesPipe_sourceParameters_filterCriteria (2039.45s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/pipes	2042.763s
```
