### PR TITLE
Added aws_cloudfront_origin_access_control data source

### DIFF
--- a/internal/service/cloudfront/origin_access_control_data_source.go
+++ b/internal/service/cloudfront/origin_access_control_data_source.go
@@ -1,0 +1,78 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cloudfront
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+)
+
+// @SDKDataSource("aws_cloudfront_origin_access_control")
+func DataSourceOriginAccessControl() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceOriginAccessControlRead,
+
+		Schema: map[string]*schema.Schema{
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Default:  nil,
+			},
+			"etag": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"origin_access_control_origin_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"signing_behavior": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"signing_protocol": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceOriginAccessControlRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).CloudFrontConn(ctx)
+	id := d.Get("id").(string)
+	params := &cloudfront.GetOriginAccessControlInput{
+		Id: aws.String(id),
+	}
+
+	resp, err := conn.GetOriginAccessControlWithContext(ctx, params)
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading CloudFront Origin Access Control (%s): %s", id, err)
+	}
+
+	// Update other attributes outside of DistributionConfig
+	d.SetId(aws.StringValue(resp.OriginAccessControl.Id))
+	d.Set("etag", resp.ETag)
+	d.Set("description", *resp.OriginAccessControl.OriginAccessControlConfig.Description)
+	d.Set("name", resp.OriginAccessControl.OriginAccessControlConfig.Name)
+	d.Set("origin_access_control_origin_type", resp.OriginAccessControl.OriginAccessControlConfig.OriginAccessControlOriginType)
+	d.Set("signing_behavior", resp.OriginAccessControl.OriginAccessControlConfig.SigningBehavior)
+	d.Set("signing_protocol", resp.OriginAccessControl.OriginAccessControlConfig.SigningProtocol)
+	return diags
+}

--- a/internal/service/cloudfront/origin_access_control_data_source_test.go
+++ b/internal/service/cloudfront/origin_access_control_data_source_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cloudfront_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccCloudFrontOriginAccessControlDataSource_description(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_cloudfront_origin_access_control.test"
+	resourceName := "aws_cloudfront_origin_access_control.test1"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, cloudfront.EndpointsID) },
+		ErrorCheck:               acctest.ErrorCheck(t, cloudfront.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckOriginAccessControlDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOriginAccessControlDataSourceConfig_description(rName, "Acceptance Test 1"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "etag"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "id", resourceName, "id"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "origin_access_control_origin_type", resourceName, "origin_access_control_origin_type"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "signing_behavior", resourceName, "signing_behavior"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "signing_protocol", resourceName, "signing_protocol"),
+				),
+			},
+		},
+	})
+}
+
+func testAccOriginAccessControlDataSourceConfig_description(rName, description string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudfront_origin_access_control" "test1" {
+  name                              = %[1]q
+  description                       = %[2]q
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+data "aws_cloudfront_origin_access_control" "test" {
+	id = aws_cloudfront_origin_access_control.test1.id
+}
+`, rName, description)
+}

--- a/internal/service/cloudfront/service_package_gen.go
+++ b/internal/service/cloudfront/service_package_gen.go
@@ -47,6 +47,10 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 			TypeName: "aws_cloudfront_log_delivery_canonical_user_id",
 		},
 		{
+			Factory:  DataSourceOriginAccessControl,
+			TypeName: "aws_cloudfront_origin_access_control",
+		},
+		{
 			Factory:  DataSourceOriginAccessIdentities,
 			TypeName: "aws_cloudfront_origin_access_identities",
 		},

--- a/website/docs/d/cloudfront_origin_access_control.html.markdown
+++ b/website/docs/d/cloudfront_origin_access_control.html.markdown
@@ -1,0 +1,55 @@
+---
+subcategory: "CloudFront"
+layout: "aws"
+page_title: "AWS: aws_cloudfront_origin_access_control"
+description: |-
+  Use this data source to retrieve information for an Amazon CloudFront origin access control config.
+---
+
+# Data Source: aws_cloudfront_origin_access_control
+
+Use this data source to retrieve information for an Amazon CloudFront origin access control config.
+
+## Example Usage
+
+The below example retrivies a CloudFront origin access control config.
+
+```terraform
+data "aws_cloudfront_origin_access_identity" "example" {
+  id = "E2T5VTFBZJ3BJB"
+}
+```
+
+## Argument Reference
+
+* `id` (Required) -  The identifier for the origin access control settings. For example: `E2T5VTFBZJ3BJB`.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `id` - The unique identifier of the origin access control.
+* `description` - A description of the origin access control.
+* `etag` - Current version of the origin access control's information.
+   For example: `E2QWRUHAPOMQZL`.
+* `name` - A name to identify the origin access control.
+* `origin_access_control_origin_type` - The type of origin that this origin access control is for.
+* `signing_behavior` - Specifies which requests CloudFront signs. See [Signing Behavior](#signing-behavior) for more information.
+* `signing_protocol` - The signing protocol of the origin access control, which determines how CloudFront signs (authenticates) requests.
+  The only valid value is `sigv4`.
+
+### Signing Behavior
+
+Specify always for the most common use case. For more information, see origin access control
+advanced settings in the Amazon CloudFront Developer Guide.
+
+This field can have one of the following values:
+
+* `always` – CloudFront signs all origin requests, overwriting the Authorization header from the viewer request if one exists.
+* `never` – CloudFront doesn't sign any origin requests. This value turns off origin access control for all origins in all
+  distributions that use this origin access control.
+* `no-override` – If the viewer request doesn't contain the Authorization header, then CloudFront signs the origin request.
+  If the viewer request contains the Authorization header, then CloudFront doesn't sign the origin request and instead passes
+  along the Authorization header from the viewer request. WARNING: To pass along the `Authorization` header from the viewer
+  request, you *must* add the `Authorization` header to a cache policy for all cache behaviors that use origins associated with
+  this origin access control. See https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html


### PR DESCRIPTION
### Description
Added a data source for aws_cloudfront_origin_access_control. Used the v1 sdk because there wasn't a v2 cloudfront service configured yet, but could add that as well.

### Relations
Closes #34489

### References
[OAC Docs](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html)

### Output from Acceptance Testing
```console
% make testacc TESTS=TestAccCloudFrontOriginAccessControlDataSource PKG=cloudfront
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudfront/... -v -count 1 -parallel 20 -run='TestAccCloudFrontOriginAccessControlDataSource'  -timeout 360m
=== RUN   TestAccCloudFrontOriginAccessControlDataSource_description
=== PAUSE TestAccCloudFrontOriginAccessControlDataSource_description
=== CONT  TestAccCloudFrontOriginAccessControlDataSource_description
--- PASS: TestAccCloudFrontOriginAccessControlDataSource_description (16.45s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront 16.625s
...
```
