### PR TITLE
fix broken example in dms_replication_config.html.markdown

### DIFF
--- a/website/docs/r/dms_replication_config.html.markdown
+++ b/website/docs/r/dms_replication_config.html.markdown
@@ -23,7 +23,7 @@ resource "aws_dms_replication_config" "name" {
   target_endpoint_arn           = aws_dms_endpoint.target.endpoint_arn
   table_mappings                = <<EOF
   {
-    "rules":[{"rule-type":"selection","rule-id":"1","rule-name":"1","object-locator":{"schema-name":"%%","table-name":"%%", "rule-action":"include"}]
+    "rules":[{"rule-type":"selection","rule-id":"1","rule-name":"1","rule-action":"include","object-locator":{"schema-name":"%%","table-name":"%%"}}]
   }
 EOF
 


### PR DESCRIPTION

### Description
Fixing a broken example for the aws_dms_replication_config resource docs


### Relations
n/a

### References
n/a


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
