### PR TITLE
r/aws_neptune_parameter_group: Add name_prefix argument

### DIFF
--- a/.changelog/34500.txt
+++ b/.changelog/34500.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_neptune_parameter_group: Add name_prefix argument
+```

--- a/internal/service/neptune/parameter_group.go
+++ b/internal/service/neptune/parameter_group.go
@@ -5,7 +5,6 @@ package neptune
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"log"
 	"time"
 
@@ -17,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"

--- a/internal/service/neptune/parameter_group_test.go
+++ b/internal/service/neptune/parameter_group_test.go
@@ -6,13 +6,13 @@ package neptune_test
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"testing"
 
 	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/neptune"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

r/aws_neptune_parameter_group: Add name_prefix argument

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #34499

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
 % make testacc TESTS=TestAccNeptuneParameterGroup PKG=neptune
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/neptune/... -v -count 1 -parallel 20 -run='TestAccNeptuneParameterGroup'  -timeout 360m
=== RUN   TestAccNeptuneParameterGroup_basic
=== PAUSE TestAccNeptuneParameterGroup_basic
=== RUN   TestAccNeptuneParameterGroup_nameGenerated
=== PAUSE TestAccNeptuneParameterGroup_nameGenerated
=== RUN   TestAccNeptuneParameterGroup_namePrefix
=== PAUSE TestAccNeptuneParameterGroup_namePrefix
=== RUN   TestAccNeptuneParameterGroup_description
=== PAUSE TestAccNeptuneParameterGroup_description
=== RUN   TestAccNeptuneParameterGroup_parameter
=== PAUSE TestAccNeptuneParameterGroup_parameter
=== RUN   TestAccNeptuneParameterGroup_tags
=== PAUSE TestAccNeptuneParameterGroup_tags
=== CONT  TestAccNeptuneParameterGroup_basic
=== CONT  TestAccNeptuneParameterGroup_description
=== CONT  TestAccNeptuneParameterGroup_tags
=== CONT  TestAccNeptuneParameterGroup_nameGenerated
=== CONT  TestAccNeptuneParameterGroup_parameter
=== CONT  TestAccNeptuneParameterGroup_namePrefix
--- PASS: TestAccNeptuneParameterGroup_namePrefix (158.83s)
--- PASS: TestAccNeptuneParameterGroup_basic (160.74s)
--- PASS: TestAccNeptuneParameterGroup_description (161.48s)
--- PASS: TestAccNeptuneParameterGroup_nameGenerated (162.31s)
--- PASS: TestAccNeptuneParameterGroup_parameter (238.21s)
--- PASS: TestAccNeptuneParameterGroup_tags (271.48s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/neptune    275.308s
...
```
