### PR TITLE
resource/aws_cloudwatch_event_rule: Adds `state` parameter

### DIFF
--- a/.changelog/34510.txt
+++ b/.changelog/34510.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cloudwatch_event_rule: Add `state` parameter and deprecate `is_enabled` parameter
+```

--- a/internal/service/events/rule.go
+++ b/internal/service/events/rule.go
@@ -236,7 +236,7 @@ func resourceRuleRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	default:
 		d.Set("is_enabled", false)
 	}
-	d.Set("state", aws.StringValue(output.State))
+	d.Set("state", output.State)
 	d.Set("name", output.Name)
 	d.Set("name_prefix", create.NamePrefixFromName(aws.StringValue(output.Name)))
 	d.Set("role_arn", output.RoleArn)

--- a/internal/service/events/rule.go
+++ b/internal/service/events/rule.go
@@ -91,6 +91,9 @@ func ResourceRule() *schema.Resource {
 					rawIsEnabled := rawPlan.GetAttr("is_enabled")
 					return rawIsEnabled.IsKnown() && rawIsEnabled.IsNull()
 				},
+				ConflictsWith: []string{
+					"state",
+				},
 			},
 			"name": {
 				Type:          schema.TypeString,
@@ -131,6 +134,9 @@ func ResourceRule() *schema.Resource {
 						return true
 					}
 					return false
+				},
+				ConflictsWith: []string{
+					"is_enabled",
 				},
 			},
 			names.AttrTags:    tftags.TagsSchema(),

--- a/internal/service/events/rule_migrate.go
+++ b/internal/service/events/rule_migrate.go
@@ -1,0 +1,94 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package events
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/service/eventbridge"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func resourceRuleV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"event_bus_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  DefaultEventBusName,
+			},
+			"event_pattern": {
+				Type:     schema.TypeString,
+				Optional: true,
+				StateFunc: func(v interface{}) string {
+					json, _ := RuleEventPatternJSONDecoder(v.(string))
+					return json
+				},
+			},
+			"is_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name_prefix": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"role_arn": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: verify.ValidARN,
+			},
+			"schedule_expression": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+		},
+	}
+}
+
+func resourceRuleUpgradeV0(ctx context.Context, rawState map[string]any, meta any) (map[string]any, error) {
+	if rawState == nil {
+		rawState = map[string]any{}
+	}
+
+	tflog.Debug(ctx, "Upgrading resource", map[string]any{
+		"from_version": 0,
+		"to_version":   1,
+	})
+
+	if rawState["is_enabled"].(bool) {
+		rawState["state"] = eventbridge.RuleStateEnabled
+	} else {
+		rawState["state"] = eventbridge.RuleStateDisabled
+	}
+
+	return rawState, nil
+}

--- a/internal/service/events/rule_test.go
+++ b/internal/service/events/rule_test.go
@@ -677,7 +677,7 @@ func TestAccEventsRule_migrateV0(t *testing.T) {
 		},
 	}
 
-	for name, testcase := range testcases {
+	for name, testcase := range testcases { //nolint:paralleltest
 		testcase := testcase
 
 		t.Run(name, func(t *testing.T) {
@@ -749,7 +749,7 @@ func TestAccEventsRule_migrateV0_Equivalent(t *testing.T) {
 		},
 	}
 
-	for name, testcase := range testcases {
+	for name, testcase := range testcases { //nolint:paralleltest
 		testcase := testcase
 
 		t.Run(name, func(t *testing.T) {

--- a/internal/service/events/rule_test.go
+++ b/internal/service/events/rule_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -83,7 +84,7 @@ func TestAccEventsRule_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRuleConfig_basic(rName1),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRuleExists(ctx, resourceName, &v1),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "events", regexache.MustCompile(fmt.Sprintf(`rule/%s$`, rName1))),
 					resource.TestCheckResourceAttr(resourceName, "name", rName1),
@@ -95,6 +96,7 @@ func TestAccEventsRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "role_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "is_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "state", "ENABLED"),
 					testAccCheckRuleEnabled(ctx, resourceName, "ENABLED"),
 				),
 			},
@@ -111,7 +113,7 @@ func TestAccEventsRule_basic(t *testing.T) {
 			},
 			{
 				Config: testAccRuleConfig_basic(rName2),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRuleExists(ctx, resourceName, &v2),
 					testAccCheckRuleRecreated(&v1, &v2),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "events", regexache.MustCompile(fmt.Sprintf(`rule/%s$`, rName2))),
@@ -121,12 +123,13 @@ func TestAccEventsRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "role_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "is_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "state", "ENABLED"),
 					testAccCheckRuleEnabled(ctx, resourceName, "ENABLED"),
 				),
 			},
 			{
 				Config: testAccRuleConfig_defaultBusName(rName2),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRuleExists(ctx, resourceName, &v3),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "events", regexache.MustCompile(fmt.Sprintf(`rule/%s$`, rName2))),
 					testAccCheckRuleNotRecreated(&v2, &v3),
@@ -155,7 +158,7 @@ func TestAccEventsRule_eventBusName(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRuleConfig_busName(rName1, busName1, "description 1"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRuleExists(ctx, resourceName, &v1),
 					resource.TestCheckResourceAttr(resourceName, "name", rName1),
 					resource.TestCheckResourceAttr(resourceName, "event_bus_name", busName1),
@@ -169,7 +172,7 @@ func TestAccEventsRule_eventBusName(t *testing.T) {
 			},
 			{
 				Config: testAccRuleConfig_busName(rName1, busName1, "description 2"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRuleExists(ctx, resourceName, &v2),
 					testAccCheckRuleNotRecreated(&v1, &v2),
 					resource.TestCheckResourceAttr(resourceName, "name", rName1),
@@ -178,7 +181,7 @@ func TestAccEventsRule_eventBusName(t *testing.T) {
 			},
 			{
 				Config: testAccRuleConfig_busName(rName2, busName2, "description 2"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRuleExists(ctx, resourceName, &v3),
 					testAccCheckRuleRecreated(&v2, &v3),
 					resource.TestCheckResourceAttr(resourceName, "name", rName2),
@@ -205,7 +208,7 @@ func TestAccEventsRule_role(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRuleConfig_role(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRuleExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttrPair(resourceName, "role_arn", iamRoleResourceName, "arn"),
@@ -234,7 +237,7 @@ func TestAccEventsRule_description(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRuleConfig_description(rName, "description1"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRuleExists(ctx, resourceName, &v1),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "description", "description1"),
@@ -247,7 +250,7 @@ func TestAccEventsRule_description(t *testing.T) {
 			},
 			{
 				Config: testAccRuleConfig_description(rName, "description2"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRuleExists(ctx, resourceName, &v2),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "description", "description2"),
@@ -271,7 +274,7 @@ func TestAccEventsRule_pattern(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRuleConfig_pattern(rName, "{\"source\":[\"aws.ec2\"]}"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRuleExists(ctx, resourceName, &v1),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "schedule_expression", ""),
@@ -285,7 +288,7 @@ func TestAccEventsRule_pattern(t *testing.T) {
 			},
 			{
 				Config: testAccRuleConfig_pattern(rName, "{\"source\":[\"aws.lambda\"]}"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRuleExists(ctx, resourceName, &v2),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					acctest.CheckResourceAttrEquivalentJSON(resourceName, "event_pattern", "{\"source\":[\"aws.lambda\"]}"),
@@ -309,7 +312,7 @@ func TestAccEventsRule_patternJSONEncoder(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRuleConfig_patternJSONEncoder(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRuleExists(ctx, resourceName, &v1),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "schedule_expression", ""),
@@ -334,7 +337,7 @@ func TestAccEventsRule_scheduleAndPattern(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRuleConfig_scheduleAndPattern(rName, "{\"source\":[\"aws.ec2\"]}"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRuleExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "schedule_expression", "rate(1 hour)"),
@@ -364,7 +367,7 @@ func TestAccEventsRule_namePrefix(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRuleConfig_namePrefix(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRuleExists(ctx, resourceName, &v),
 					acctest.CheckResourceAttrNameFromPrefix(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "name_prefix", rName),
@@ -392,7 +395,7 @@ func TestAccEventsRule_Name_generated(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRuleConfig_nameGenerated,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRuleExists(ctx, resourceName, &v),
 					acctest.CheckResourceAttrNameGenerated(resourceName, "name"),
 					resource.TestCheckResourceAttr(resourceName, "name_prefix", "terraform-"),
@@ -421,7 +424,7 @@ func TestAccEventsRule_tags(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRuleConfig_tags1(rName, "key1", "value1"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRuleExists(ctx, resourceName, &v1),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
@@ -434,7 +437,7 @@ func TestAccEventsRule_tags(t *testing.T) {
 			},
 			{
 				Config: testAccRuleConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRuleExists(ctx, resourceName, &v2),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
@@ -443,7 +446,7 @@ func TestAccEventsRule_tags(t *testing.T) {
 			},
 			{
 				Config: testAccRuleConfig_tags1(rName, "key2", "value2"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRuleExists(ctx, resourceName, &v3),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
@@ -467,9 +470,10 @@ func TestAccEventsRule_isEnabled(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRuleConfig_isEnabled(rName, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRuleExists(ctx, resourceName, &v1),
 					resource.TestCheckResourceAttr(resourceName, "is_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "state", "DISABLED"),
 					testAccCheckRuleEnabled(ctx, resourceName, "DISABLED"),
 				),
 			},
@@ -480,17 +484,67 @@ func TestAccEventsRule_isEnabled(t *testing.T) {
 			},
 			{
 				Config: testAccRuleConfig_isEnabled(rName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRuleExists(ctx, resourceName, &v2),
 					resource.TestCheckResourceAttr(resourceName, "is_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "state", "ENABLED"),
 					testAccCheckRuleEnabled(ctx, resourceName, "ENABLED"),
 				),
 			},
 			{
 				Config: testAccRuleConfig_isEnabled(rName, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRuleExists(ctx, resourceName, &v3),
 					resource.TestCheckResourceAttr(resourceName, "is_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "state", "DISABLED"),
+					testAccCheckRuleEnabled(ctx, resourceName, "DISABLED"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEventsRule_state(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v1, v2, v3 eventbridge.DescribeRuleOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_cloudwatch_event_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, eventbridge.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRuleDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRuleConfig_isEnabled(rName, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRuleExists(ctx, resourceName, &v1),
+					resource.TestCheckResourceAttr(resourceName, "is_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "state", "DISABLED"),
+					testAccCheckRuleEnabled(ctx, resourceName, "DISABLED"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccRuleConfig_isEnabled(rName, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRuleExists(ctx, resourceName, &v2),
+					resource.TestCheckResourceAttr(resourceName, "is_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "state", "ENABLED"),
+					testAccCheckRuleEnabled(ctx, resourceName, "ENABLED"),
+				),
+			},
+			{
+				Config: testAccRuleConfig_isEnabled(rName, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRuleExists(ctx, resourceName, &v3),
+					resource.TestCheckResourceAttr(resourceName, "is_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "state", "DISABLED"),
 					testAccCheckRuleEnabled(ctx, resourceName, "DISABLED"),
 				),
 			},
@@ -518,13 +572,14 @@ func TestAccEventsRule_partnerEventBus(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRuleConfig_partnerBus(rName, busName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRuleExists(ctx, resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "events", regexache.MustCompile(fmt.Sprintf(`rule/%s/%s$`, busName, rName))),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttr(resourceName, "event_bus_name", busName),
 					acctest.CheckResourceAttrEquivalentJSON(resourceName, "event_pattern", "{\"source\":[\"aws.ec2\"]}"),
 					resource.TestCheckResourceAttr(resourceName, "is_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "state", "ENABLED"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "role_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "schedule_expression", ""),
@@ -555,13 +610,14 @@ func TestAccEventsRule_eventBusARN(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRuleConfig_busARN(rName, eventBusName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRuleExists(ctx, resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "events", regexache.MustCompile(fmt.Sprintf(`rule/%s/%s$`, eventBusName, rName))),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "event_bus_name", "aws_cloudwatch_event_bus.test", "arn"),
 					acctest.CheckResourceAttrEquivalentJSON(resourceName, "event_pattern", "{\"source\":[\"aws.ec2\"]}"),
 					resource.TestCheckResourceAttr(resourceName, "is_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "state", "ENABLED"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "role_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "schedule_expression", ""),
@@ -575,6 +631,86 @@ func TestAccEventsRule_eventBusARN(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccEventsRule_migrateV0(t *testing.T) {
+	const resourceName = "aws_cloudwatch_event_rule.test"
+
+	t.Parallel()
+
+	testcases := map[string]struct {
+		config            string
+		expectedIsEnabled string
+		expectedState     string
+	}{
+		"basic": {
+			config:            testAccRuleConfig_basic(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)),
+			expectedIsEnabled: "true",
+			expectedState:     "ENABLED",
+		},
+
+		"enabled": {
+			config:            testAccRuleConfig_isEnabled(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix), true),
+			expectedIsEnabled: "true",
+			expectedState:     "ENABLED",
+		},
+
+		"disabled": {
+			config:            testAccRuleConfig_isEnabled(sdkacctest.RandomWithPrefix(acctest.ResourcePrefix), false),
+			expectedIsEnabled: "false",
+			expectedState:     "DISABLED",
+		},
+	}
+
+	for name, testcase := range testcases {
+		testcase := testcase
+
+		t.Run(name, func(t *testing.T) {
+			ctx := acctest.Context(t)
+			var v eventbridge.DescribeRuleOutput
+
+			resource.ParallelTest(t, resource.TestCase{
+				PreCheck:     func() { acctest.PreCheck(ctx, t) },
+				ErrorCheck:   acctest.ErrorCheck(t, eventbridge.EndpointsID),
+				CheckDestroy: testAccCheckRuleDestroy(ctx),
+				Steps: []resource.TestStep{
+					{
+						ExternalProviders: map[string]resource.ExternalProvider{
+							"aws": {
+								Source:            "hashicorp/aws",
+								VersionConstraint: "5.26.0",
+							},
+						},
+						Config: testcase.config,
+						Check: resource.ComposeAggregateTestCheckFunc(
+							testAccCheckRuleExists(ctx, resourceName, &v),
+							resource.TestCheckResourceAttr(resourceName, "is_enabled", testcase.expectedIsEnabled),
+							testAccCheckRuleEnabled(ctx, resourceName, testcase.expectedState),
+						),
+					},
+					{
+						ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+						Config:                   testcase.config,
+						PlanOnly:                 true,
+					},
+					{
+						ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+						Config:                   testcase.config,
+						ConfigPlanChecks: resource.ConfigPlanChecks{
+							PreApply: []plancheck.PlanCheck{
+								plancheck.ExpectEmptyPlan(),
+							},
+						},
+						Check: resource.ComposeAggregateTestCheckFunc(
+							resource.TestCheckResourceAttr(resourceName, "is_enabled", testcase.expectedIsEnabled),
+							resource.TestCheckResourceAttr(resourceName, "state", testcase.expectedState),
+							testAccCheckRuleEnabled(ctx, resourceName, testcase.expectedState),
+						),
+					},
+				},
+			})
+		})
+	}
 }
 
 func testAccCheckRuleExists(ctx context.Context, n string, v *eventbridge.DescribeRuleOutput) resource.TestCheckFunc {

--- a/website/docs/r/cloudwatch_event_rule.html.markdown
+++ b/website/docs/r/cloudwatch_event_rule.html.markdown
@@ -68,7 +68,15 @@ This resource supports the following arguments:
 * `event_pattern` - (Optional) The event pattern described a JSON object. At least one of `schedule_expression` or `event_pattern` is required. See full documentation of [Events and Event Patterns in EventBridge](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html) for details. **Note**: The event pattern size is 2048 by default but it is adjustable up to 4096 characters by submitting a service quota increase request. See [Amazon EventBridge quotas](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-quota.html) for details.
 * `description` - (Optional) The description of the rule.
 * `role_arn` - (Optional) The Amazon Resource Name (ARN) associated with the role that is used for target invocation.
-* `is_enabled` - (Optional) Whether the rule should be enabled (defaults to `true`).
+* `is_enabled` - (Optional, **Deprecated** Use `state` instead) Whether the rule should be enabled.
+  Defaults to `true`.
+  Conflicts with `state`.
+* `state` - (Optional) State of the rule.
+  Valid values are `DISABLED`, `ENABLED`, and `ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS`.
+  When state is `ENABLED`, the rule is enabled for all events except those delivered by CloudTrail.
+  To also enable the rule for events delivered by CloudTrail, set `state` to `ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS`.
+  Defaults to `ENABLED`.
+  Conflicts with `is_enabled`.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attribute Reference


### PR DESCRIPTION
### Description

Previously, the provider used the boolean parameter `is_enabled` to configure the AWS API parameter `State` with values `ENABLED` and `DISABLED`. Recently, AWS added the value `ENABLED_WITH_CLOUDTRAIL_READ_ONLY_EVENTS` to `State`.

Adds the parameter `state` and deprecates `is_enabled`.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=events TESTS=TestAccEventsRule_

--- PASS: TestAccEventsRule_patternJSONEncoder (202.70s)
--- PASS: TestAccEventsRule_Name_generated (219.52s)
--- PASS: TestAccEventsRule_scheduleAndPattern (228.14s)
--- PASS: TestAccEventsRule_namePrefix (228.40s)
--- PASS: TestAccEventsRule_migrateV0 (0.00s)
    --- PASS: TestAccEventsRule_migrateV0/enabled (241.41s)
    --- PASS: TestAccEventsRule_migrateV0/disabled (241.48s)
    --- PASS: TestAccEventsRule_migrateV0/basic (244.05s)
--- PASS: TestAccEventsRule_migrateV0_Equivalent (0.00s)
    --- PASS: TestAccEventsRule_migrateV0_Equivalent/enabled (238.40s)
    --- PASS: TestAccEventsRule_migrateV0_Equivalent/disabled (244.46s)
--- PASS: TestAccEventsRule_eventBusARN (281.94s)
--- PASS: TestAccEventsRule_role (286.05s)
--- PASS: TestAccEventsRule_description (294.10s)
--- PASS: TestAccEventsRule_pattern (294.93s)
--- PASS: TestAccEventsRule_tags (329.01s)
--- PASS: TestAccEventsRule_basic (329.56s)
--- PASS: TestAccEventsRule_isEnabled (331.36s)
--- PASS: TestAccEventsRule_state (335.21s)
--- PASS: TestAccEventsRule_eventBusName (379.52s)
```
