### PR TITLE
d/aws_sfn_state_machines: Add data source for listing all State Machines

### DIFF
--- a/internal/service/sfn/service_package_gen.go
+++ b/internal/service/sfn/service_package_gen.go
@@ -41,6 +41,10 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 			Factory:  DataSourceStateMachineVersions,
 			TypeName: "aws_sfn_state_machine_versions",
 		},
+		{
+			Factory:  DataSourceStateMachines,
+			TypeName: "aws_sfn_state_machines",
+		},
 	}
 }
 

--- a/internal/service/sfn/state_machines_data_source.go
+++ b/internal/service/sfn/state_machines_data_source.go
@@ -1,0 +1,75 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package sfn
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sfn"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+const (
+	DSNameStateMachines = "State Machines Data Source"
+)
+
+// @SDKDataSource("aws_sfn_state_machines")
+func DataSourceStateMachines() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceStateMachinesV2,
+
+		Schema: map[string]*schema.Schema{
+			"arns": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"names": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceStateMachinesV2(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).SFNConn(ctx)
+
+	input := &sfn.ListStateMachinesInput{}
+
+	var arns []string
+	var state_machine_names []string
+
+	err := conn.ListStateMachinesPagesWithContext(ctx, input, func(page *sfn.ListStateMachinesOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, stateMachine := range page.StateMachines {
+			if stateMachine == nil {
+				continue
+			}
+
+			arns = append(arns, aws.StringValue(stateMachine.StateMachineArn))
+			state_machine_names = append(state_machine_names, aws.StringValue(stateMachine.Name))
+		}
+
+		return !lastPage
+	})
+	if err != nil {
+		return create.DiagError(names.SFN, create.ErrActionReading, DSNameStateMachines, "", err)
+	}
+
+	d.SetId(meta.(*conns.AWSClient).Region)
+	d.Set("arns", arns)
+	d.Set("names", state_machine_names)
+
+	return nil
+}

--- a/website/docs/d/sfn_state_machines.html.markdown
+++ b/website/docs/d/sfn_state_machines.html.markdown
@@ -1,0 +1,44 @@
+---
+subcategory: "SFN (Step Functions)"
+layout: "aws"
+page_title: "AWS: aws_sfn_state_machines"
+description: |-
+  Terraform data source for managing an AWS SFN (Step Functions) State Machines.
+---
+
+# Data Source: aws_sfn_state_machines
+
+Terraform data source for managing an AWS SFN (Step Functions) State Machines.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_sfn_state_machines" "example" {
+}
+```
+
+```terraform
+# Get all State Machines
+data "aws_sfn_state_machines" "all" {
+}
+
+# Get more detailed information about each State Machine
+data "aws_sfn_state_machine" "detailed" {
+  for_each = data.aws_sfn_state_machines.all.name
+
+  name = each.value
+}
+```
+
+## Argument Reference
+
+This data source does not accept any arguments.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `arns` - List of ARNs of the State Machines.
+* `names` - List of Names of the State Machines.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

Adds a data source for listing all State Machines in Step Functions.

This can be combined with the `data.aws_sfn_state_machine` data source to get detailed information about each resource via the `arns` and `names` attributes in a for_each loop.

I tried following the skaff-procedure as detailed in https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/add-a-new-datasource.md but couldn't find any reference implementations from services I already know about/use, so I decided to follow the code used in e.g. the RDS Clusters data source instead.

I've tested overriding the provider locally and I got the expected output, but I'll try to provide the acceptance tests as well.


### Relations


### References



### Output from Acceptance Testing

I was not able to add acceptance tests because I'm not quite sure how to ensure a resource exists while testing a data source only, and looking at the singular `data.aws_sfn_state_machine` it seemed like that just expects 1 to exist, which doesn't work when I try the same. If you have any pointers on how to add acceptance tests for a data source fetching multiple items I'd love that, but I'll keep playing around to try to get them done. :)

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
