### PR TITLE
r/aws_lexv2models_bot: support explicit type argument on create and update

### DIFF
--- a/.changelog/34524.txt
+++ b/.changelog/34524.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lexv2models_bot: Properly send `type` argument on create and update when configured
+```

--- a/internal/service/lexv2models/bot.go
+++ b/internal/service/lexv2models/bot.go
@@ -77,12 +77,12 @@ func (r *resourceBot) Schema(ctx context.Context, req resource.SchemaRequest, re
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			names.AttrTags:    tftags.TagsAttribute(),
-			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
 			"role_arn": schema.StringAttribute{
 				CustomType: fwtypes.ARNType,
 				Required:   true,
 			},
+			names.AttrTags:    tftags.TagsAttribute(),
+			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
 			"test_bot_alias_tags": schema.MapAttribute{
 				ElementType: types.StringType,
 				Optional:    true,
@@ -178,6 +178,10 @@ func (r *resourceBot) Create(ctx context.Context, req resource.CreateRequest, re
 	if !plan.Members.IsNull() {
 		bmInput := expandMembers(ctx, bm)
 		in.BotMembers = bmInput
+	}
+
+	if !plan.Type.IsNull() {
+		in.BotType = awstypes.BotType(plan.Type.ValueString())
 	}
 
 	out, err := conn.CreateBot(ctx, &in)
@@ -314,6 +318,10 @@ func (r *resourceBot) Update(ctx context.Context, req resource.UpdateRequest, re
 			if resp.Diagnostics.HasError() {
 				return
 			}
+		}
+
+		if !plan.Type.IsNull() {
+			in.BotType = awstypes.BotType(plan.Type.ValueString())
 		}
 
 		_, err := conn.UpdateBot(ctx, &in)


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Previously, explicitly configured values for the `type` argument were not sent during create or update operations, resulting in the default `Bot` type in all cases. These operations will now send the `type` value when set.

Note: An acceptance test using the `BotNetwork` bot type could not be written at this time, as it is dependent on the `aws_lexv2models_bot_alias` resource which is not yet available.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #33475 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=lexv2models TESTS=TestAccLexV2ModelsBot_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lexv2models/... -v -count 1 -parallel 20 -run='TestAccLexV2ModelsBot_'  -timeout 360m

--- PASS: TestAccLexV2ModelsBot_disappears (103.22s)
--- PASS: TestAccLexV2ModelsBot_type (104.00s)
--- PASS: TestAccLexV2ModelsBot_basic (104.32s)
--- PASS: TestAccLexV2ModelsBot_tags (210.73s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lexv2models        214.070s
```
