### PR TITLE
r/aws_glue_trigger: handle concurrent modification exceptions

### DIFF
--- a/.changelog/34530.txt
+++ b/.changelog/34530.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_glue_trigger: Fix `ConcurrentModificationException: Workflow <workflowName> was modified while adding trigger <triggerName>` errors
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This change will retry trigger creation when a `ConcurrentModificationException` is received. This can occur when multiple triggers reference a single workflow within the same configuration.

Successfully tested against the example configuration provided in the linked issue.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #21759

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=glue TESTS=TestAccGlueTrigger_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/glue/... -v -count 1 -parallel 20 -run='TestAccGlueTrigger_'  -timeout 360m

=== NAME  TestAccGlueTrigger_crawler
    trigger_test.go:71: Step 1/3 error: Error running apply: exit status 1

        Error: creating Glue Crawler (tf-acc-test-7273293400628501361): InvalidInputException: S3 bucket test_bucket does not exist.
        {
          RespMetadata: {
            StatusCode: 400,
            RequestID: "39b3cb75-eccb-4553-bd75-bb8efd7e0610"
          },
          Message_: "S3 bucket test_bucket does not exist."
        }

          with aws_glue_crawler.test,
          on terraform_plugin_test.tf line 53, in resource "aws_glue_crawler" "test":
          53: resource "aws_glue_crawler" "test" {


        Error: creating Glue Crawler (tf-acc-test-7273293400628501361crawl2): InvalidInputException: S3 bucket test_bucket does not exist.
        {
          RespMetadata: {
            StatusCode: 400,
            RequestID: "8d5bd273-f219-4021-b91b-6c5f2ccc7a5b"
          },
          Message_: "S3 bucket test_bucket does not exist."
        }

          with aws_glue_crawler.test2,
          on terraform_plugin_test.tf line 65, in resource "aws_glue_crawler" "test2":
          65: resource "aws_glue_crawler" "test2" {

--- FAIL: TestAccGlueTrigger_crawler (393.46s)
--- PASS: TestAccGlueTrigger_disappears (469.59s)
--- PASS: TestAccGlueTrigger_basic (484.02s)
--- PASS: TestAccGlueTrigger_Actions_security (521.28s)
--- PASS: TestAccGlueTrigger_startOnCreate (523.61s)
--- PASS: TestAccGlueTrigger_workflowName (527.73s)
--- PASS: TestAccGlueTrigger_description (685.51s)
--- PASS: TestAccGlueTrigger_schedule (705.29s)
--- PASS: TestAccGlueTrigger_eventBatchingCondition (725.09s)
--- PASS: TestAccGlueTrigger_predicate (766.45s)
--- PASS: TestAccGlueTrigger_Actions_notify (808.51s)
--- PASS: TestAccGlueTrigger_tags (808.53s)
--- PASS: TestAccGlueTrigger_onDemandDisable (810.73s)
--- PASS: TestAccGlueTrigger_enabled (844.14s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/glue       847.445s
```

Failure is unrelated to this change (cause is a broader issue affecting all crawler acceptance tests which use S3 targets, including this one which references a crawler test config).