### PR TITLE
r/aws_lexv2models_bot_locale: fix `voice_settings.engine` validation 

### DIFF
--- a/.changelog/34532.txt
+++ b/.changelog/34532.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lexv2_bot_locale: Fix `voice_settings.engine` validation, value conversion errors
+```

--- a/internal/service/lexv2models/bot_locale.go
+++ b/internal/service/lexv2models/bot_locale.go
@@ -513,7 +513,7 @@ type resourceBotLocaleData struct {
 
 type voiceSettingsData struct {
 	VoiceId types.String `tfsdk:"voice_id"`
-	Engine  types.String `tfsdk:"voice_engine"`
+	Engine  types.String `tfsdk:"engine"`
 }
 
 var voiceSettingsAttrTypes = map[string]attr.Type{

--- a/internal/service/lexv2models/bot_locale.go
+++ b/internal/service/lexv2models/bot_locale.go
@@ -111,7 +111,7 @@ func (r *resourceBotLocale) Schema(ctx context.Context, req resource.SchemaReque
 							Optional: true,
 							Computed: true,
 							Validators: []validator.String{
-								enum.FrameworkValidate[awstypes.BotType](),
+								enum.FrameworkValidate[awstypes.VoiceEngine](),
 							},
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.UseStateForUnknown(),

--- a/website/docs/r/lexv2models_bot_locale.html.markdown
+++ b/website/docs/r/lexv2models_bot_locale.html.markdown
@@ -16,10 +16,26 @@ Terraform resource for managing an AWS Lex V2 Models Bot Locale.
 
 ```terraform
 resource "aws_lexv2models_bot_locale" "example" {
-  bot_id                           = aws_lexv2models_bot.test.id
+  bot_id                           = aws_lexv2models_bot.example.id
   bot_version                      = "DRAFT"
   locale_id                        = "en_US"
   n_lu_intent_confidence_threshold = 0.70
+}
+```
+
+### Voice Settings
+
+```terraform
+resource "aws_lexv2models_bot_locale" "example" {
+  bot_id                           = aws_lexv2models_bot.example.id
+  bot_version                      = "DRAFT"
+  locale_id                        = "en_US"
+  n_lu_intent_confidence_threshold = 0.70
+
+  voice_settings {
+    voice_id = "Kendra"
+    engine   = "standard"
+  }
 }
 ```
 
@@ -37,17 +53,17 @@ The following arguments are optional:
 * `description` - Description of the bot locale. Use this to help identify the bot locale in lists.
 * `voice_settings` - Amazon Polly voice ID that Amazon Lex uses for voice interaction with the user. See [`voice_settings`](#voice-settings).
 
+### Voice Settings
+
+* `voice_id` - (Required) Identifier of the Amazon Polly voice to use.
+* `engine` - (Optional) Indicates the type of Amazon Polly voice that Amazon Lex should use for voice interaction with the user. Valid values are `standard` and `neural`. If not specified, the default is `standard`.
+
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `id` - Comma-delimited string joining locale ID, bot ID, and bot version.
+* `id` - Comma-delimited string joining `locale_id`, `bot_id`, and `bot_version`.
 * `name` - Specified locale name.
-
-### Voice Settings
-
-* `voice_id` - Identifier of the Amazon Polly voice to use.
-* `engine` - Indicates the type of Amazon Polly voice that Amazon Lex should use for voice interaction with the user. For more information, see the [engine parameter of the SynthesizeSpeech operation](https://docs.aws.amazon.com/polly/latest/dg/API_SynthesizeSpeech.html#polly-SynthesizeSpeech-request-Engine) in the Amazon Polly developer guide. If not specified, the default is `standard`.
 
 ## Timeouts
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Fixes validation of the `voice_settings.engine` argument to use the correct enum values of `standard` and `neural`. Also addresses a value conversion error caused by a typo in the struct tag for the `engine` arguments underlying struct field. Adds an acceptance test and example with the `voice_settings` argument configured.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #34531
Relates #33949 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/lexv2/latest/APIReference/API_VoiceSettings.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=lexv2models TESTS=TestAccLexV2ModelsBotLocale_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lexv2models/... -v -count 1 -parallel 20 -run='TestAccLexV2ModelsBotLocale_'  -timeout 360m

--- PASS: TestAccLexV2ModelsBotLocale_disappears (115.42s)
--- PASS: TestAccLexV2ModelsBotLocale_basic (116.31s)
--- PASS: TestAccLexV2ModelsBotLocale_voiceSettings (117.29s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lexv2models        120.416s
```
