### PR TITLE
r/aws_s3_bucket_public_access_block: Migrate to AWS SDK for Go v2

### DIFF
--- a/internal/service/s3/bucket_public_access_block.go
+++ b/internal/service/s3/bucket_public_access_block.go
@@ -6,11 +6,11 @@ package s3
 import (
 	"context"
 	"log"
-	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -26,35 +26,32 @@ func ResourceBucketPublicAccessBlock() *schema.Resource {
 		ReadWithoutTimeout:   resourceBucketPublicAccessBlockRead,
 		UpdateWithoutTimeout: resourceBucketPublicAccessBlockUpdate,
 		DeleteWithoutTimeout: resourceBucketPublicAccessBlockDelete,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{
-			"bucket": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-
 			"block_public_acls": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
 			},
-
 			"block_public_policy": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
 			},
-
+			"bucket": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
 			"ignore_public_acls": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
 			},
-
 			"restrict_public_buckets": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -66,12 +63,12 @@ func ResourceBucketPublicAccessBlock() *schema.Resource {
 
 func resourceBucketPublicAccessBlockCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).S3Conn(ctx)
-	bucket := d.Get("bucket").(string)
+	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
+	bucket := d.Get("bucket").(string)
 	input := &s3.PutPublicAccessBlockInput{
 		Bucket: aws.String(bucket),
-		PublicAccessBlockConfiguration: &s3.PublicAccessBlockConfiguration{
+		PublicAccessBlockConfiguration: &types.PublicAccessBlockConfiguration{
 			BlockPublicAcls:       aws.Bool(d.Get("block_public_acls").(bool)),
 			BlockPublicPolicy:     aws.Bool(d.Get("block_public_policy").(bool)),
 			IgnorePublicAcls:      aws.Bool(d.Get("ignore_public_acls").(bool)),
@@ -79,100 +76,59 @@ func resourceBucketPublicAccessBlockCreate(ctx context.Context, d *schema.Resour
 		},
 	}
 
-	log.Printf("[DEBUG] S3 bucket: %s, public access block: %v", bucket, input.PublicAccessBlockConfiguration)
-	err := retry.RetryContext(ctx, 1*time.Minute, func() *retry.RetryError {
-		_, err := conn.PutPublicAccessBlockWithContext(ctx, input)
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, s3BucketPropagationTimeout, func() (interface{}, error) {
+		return conn.PutPublicAccessBlock(ctx, input)
+	}, errCodeNoSuchBucket)
 
-		if tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket) {
-			return retry.RetryableError(err)
-		}
-
-		if err != nil {
-			return retry.NonRetryableError(err)
-		}
-
-		return nil
-	})
-	if tfresource.TimedOut(err) {
-		_, err = conn.PutPublicAccessBlockWithContext(ctx, input)
-	}
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "creating public access block policy for S3 bucket (%s): %s", bucket, err)
+		return sdkdiag.AppendErrorf(diags, "creating S3 Bucket (%s) Public Access Block: %s", bucket, err)
 	}
 
 	d.SetId(bucket)
+
+	_, err = tfresource.RetryWhenNotFound(ctx, s3BucketPropagationTimeout, func() (interface{}, error) {
+		return findPublicAccessBlockConfiguration(ctx, conn, d.Id())
+	})
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "waiting for S3 Bucket Public Access Block (%s) create: %s", d.Id(), err)
+	}
+
 	return append(diags, resourceBucketPublicAccessBlockRead(ctx, d, meta)...)
 }
 
 func resourceBucketPublicAccessBlockRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).S3Conn(ctx)
+	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
-	input := &s3.GetPublicAccessBlockInput{
-		Bucket: aws.String(d.Id()),
-	}
+	pabc, err := findPublicAccessBlockConfiguration(ctx, conn, d.Id())
 
-	// Retry for eventual consistency on creation
-	var output *s3.GetPublicAccessBlockOutput
-	err := retry.RetryContext(ctx, s3BucketPropagationTimeout, func() *retry.RetryError {
-		var err error
-		output, err = conn.GetPublicAccessBlockWithContext(ctx, input)
-
-		if d.IsNewResource() && tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket) {
-			return retry.RetryableError(err)
-		}
-
-		if d.IsNewResource() && tfawserr.ErrCodeEquals(err, ErrCodeNoSuchPublicAccessBlockConfiguration) {
-			return retry.RetryableError(err)
-		}
-
-		if err != nil {
-			return retry.NonRetryableError(err)
-		}
-
-		return nil
-	})
-
-	if tfresource.TimedOut(err) {
-		output, err = conn.GetPublicAccessBlockWithContext(ctx, input)
-	}
-
-	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, ErrCodeNoSuchPublicAccessBlockConfiguration) {
+	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] S3 Bucket Public Access Block (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
 	}
 
-	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket) {
-		log.Printf("[WARN] S3 Bucket (%s) not found, removing from state", d.Id())
-		d.SetId("")
-		return diags
-	}
-
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "reading S3 bucket Public Access Block (%s): %s", d.Id(), err)
-	}
-
-	if output == nil || output.PublicAccessBlockConfiguration == nil {
-		return sdkdiag.AppendErrorf(diags, "reading S3 Bucket Public Access Block (%s): empty response", d.Id())
+		return sdkdiag.AppendErrorf(diags, "reading S3 Bucket Public Access Block (%s): %s", d.Id(), err)
 	}
 
 	d.Set("bucket", d.Id())
-	d.Set("block_public_acls", output.PublicAccessBlockConfiguration.BlockPublicAcls)
-	d.Set("block_public_policy", output.PublicAccessBlockConfiguration.BlockPublicPolicy)
-	d.Set("ignore_public_acls", output.PublicAccessBlockConfiguration.IgnorePublicAcls)
-	d.Set("restrict_public_buckets", output.PublicAccessBlockConfiguration.RestrictPublicBuckets)
+	d.Set("block_public_acls", pabc.BlockPublicAcls)
+	d.Set("block_public_policy", pabc.BlockPublicPolicy)
+	d.Set("ignore_public_acls", pabc.IgnorePublicAcls)
+	d.Set("restrict_public_buckets", pabc.RestrictPublicBuckets)
 
 	return diags
 }
 
 func resourceBucketPublicAccessBlockUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).S3Conn(ctx)
+	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
 	input := &s3.PutPublicAccessBlockInput{
 		Bucket: aws.String(d.Id()),
-		PublicAccessBlockConfiguration: &s3.PublicAccessBlockConfiguration{
+		PublicAccessBlockConfiguration: &types.PublicAccessBlockConfiguration{
 			BlockPublicAcls:       aws.Bool(d.Get("block_public_acls").(bool)),
 			BlockPublicPolicy:     aws.Bool(d.Get("block_public_policy").(bool)),
 			IgnorePublicAcls:      aws.Bool(d.Get("ignore_public_acls").(bool)),
@@ -180,8 +136,8 @@ func resourceBucketPublicAccessBlockUpdate(ctx context.Context, d *schema.Resour
 		},
 	}
 
-	log.Printf("[DEBUG] Updating S3 bucket Public Access Block: %s", input)
-	_, err := conn.PutPublicAccessBlockWithContext(ctx, input)
+	_, err := conn.PutPublicAccessBlock(ctx, input)
+
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "updating S3 Bucket Public Access Block (%s): %s", d.Id(), err)
 	}
@@ -195,26 +151,20 @@ func resourceBucketPublicAccessBlockUpdate(ctx context.Context, d *schema.Resour
 	d.Set("ignore_public_acls", input.PublicAccessBlockConfiguration.IgnorePublicAcls)
 	d.Set("restrict_public_buckets", input.PublicAccessBlockConfiguration.RestrictPublicBuckets)
 
-	// Skip normal Read after Update due to eventual consistency issues
+	// Skip normal Read after Update due to eventual consistency issues.
 	return diags
 }
 
 func resourceBucketPublicAccessBlockDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).S3Conn(ctx)
+	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
-	input := &s3.DeletePublicAccessBlockInput{
+	log.Printf("[DEBUG] Deleting S3 Bucket Ownership Controls: %s", d.Id())
+	_, err := conn.DeletePublicAccessBlock(ctx, &s3.DeletePublicAccessBlockInput{
 		Bucket: aws.String(d.Id()),
-	}
+	})
 
-	log.Printf("[DEBUG] S3 bucket: %s, delete public access block", d.Id())
-	_, err := conn.DeletePublicAccessBlockWithContext(ctx, input)
-
-	if tfawserr.ErrCodeEquals(err, ErrCodeNoSuchPublicAccessBlockConfiguration) {
-		return diags
-	}
-
-	if tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket) {
+	if tfawserr.ErrCodeEquals(err, errCodeNoSuchBucket, errCodeNoSuchPublicAccessBlockConfiguration) {
 		return diags
 	}
 
@@ -222,5 +172,38 @@ func resourceBucketPublicAccessBlockDelete(ctx context.Context, d *schema.Resour
 		return sdkdiag.AppendErrorf(diags, "deleting S3 Bucket Public Access Block (%s): %s", d.Id(), err)
 	}
 
+	_, err = tfresource.RetryUntilNotFound(ctx, s3BucketPropagationTimeout, func() (interface{}, error) {
+		return findPublicAccessBlockConfiguration(ctx, conn, d.Id())
+	})
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "waiting for S3 Bucket Public Access Block (%s) delete: %s", d.Id(), err)
+	}
+
 	return diags
+}
+
+func findPublicAccessBlockConfiguration(ctx context.Context, conn *s3.Client, bucket string) (*types.PublicAccessBlockConfiguration, error) {
+	input := &s3.GetPublicAccessBlockInput{
+		Bucket: aws.String(bucket),
+	}
+
+	output, err := conn.GetPublicAccessBlock(ctx, input)
+
+	if tfawserr.ErrCodeEquals(err, errCodeNoSuchBucket, errCodeNoSuchPublicAccessBlockConfiguration) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.PublicAccessBlockConfiguration == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.PublicAccessBlockConfiguration, nil
 }

--- a/internal/service/s3/bucket_public_access_block_test.go
+++ b/internal/service/s3/bucket_public_access_block_test.go
@@ -7,38 +7,36 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfs3 "github.com/hashicorp/terraform-provider-aws/internal/service/s3"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccS3BucketPublicAccessBlock_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	var config s3.PublicAccessBlockConfiguration
-	name := fmt.Sprintf("tf-test-bucket-%d", sdkacctest.RandInt())
-	resourceName := "aws_s3_bucket_public_access_block.bucket"
+	var config types.PublicAccessBlockConfiguration
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_public_access_block.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, s3.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3EndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBucketDestroy(ctx),
+		CheckDestroy:             testAccCheckBucketPublicAccessBlockDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBucketPublicAccessBlockConfig_basic(name, "false", "false", "false", "false"),
+				Config: testAccBucketPublicAccessBlockConfig_basic(rName, false, false, false, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBucketExists(ctx, "aws_s3_bucket.bucket"),
+					testAccCheckBucketExists(ctx, "aws_s3_bucket.test"),
 					testAccCheckBucketPublicAccessBlockExists(ctx, resourceName, &config),
-					resource.TestCheckResourceAttr(resourceName, "bucket", name),
+					resource.TestCheckResourceAttr(resourceName, "bucket", rName),
 					resource.TestCheckResourceAttr(resourceName, "block_public_acls", "false"),
 					resource.TestCheckResourceAttr(resourceName, "block_public_policy", "false"),
 					resource.TestCheckResourceAttr(resourceName, "ignore_public_acls", "false"),
@@ -56,21 +54,21 @@ func TestAccS3BucketPublicAccessBlock_basic(t *testing.T) {
 
 func TestAccS3BucketPublicAccessBlock_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	var config s3.PublicAccessBlockConfiguration
-	name := fmt.Sprintf("tf-test-bucket-%d", sdkacctest.RandInt())
-	resourceName := "aws_s3_bucket_public_access_block.bucket"
+	var config types.PublicAccessBlockConfiguration
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_public_access_block.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, s3.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3EndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBucketDestroy(ctx),
+		CheckDestroy:             testAccCheckBucketPublicAccessBlockDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBucketPublicAccessBlockConfig_basic(name, "false", "false", "false", "false"),
+				Config: testAccBucketPublicAccessBlockConfig_basic(rName, false, false, false, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketPublicAccessBlockExists(ctx, resourceName, &config),
-					testAccCheckBucketPublicAccessBlockDisappears(ctx, resourceName),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfs3.ResourceBucketPublicAccessBlock(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -80,19 +78,19 @@ func TestAccS3BucketPublicAccessBlock_disappears(t *testing.T) {
 
 func TestAccS3BucketPublicAccessBlock_Disappears_bucket(t *testing.T) {
 	ctx := acctest.Context(t)
-	var config s3.PublicAccessBlockConfiguration
-	name := fmt.Sprintf("tf-test-bucket-%d", sdkacctest.RandInt())
-	resourceName := "aws_s3_bucket_public_access_block.bucket"
-	bucketResourceName := "aws_s3_bucket.bucket"
+	var config types.PublicAccessBlockConfiguration
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_public_access_block.test"
+	bucketResourceName := "aws_s3_bucket.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, s3.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3EndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBucketDestroy(ctx),
+		CheckDestroy:             testAccCheckBucketPublicAccessBlockDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBucketPublicAccessBlockConfig_basic(name, "false", "false", "false", "false"),
+				Config: testAccBucketPublicAccessBlockConfig_basic(rName, false, false, false, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketPublicAccessBlockExists(ctx, resourceName, &config),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfs3.ResourceBucket(), bucketResourceName),
@@ -105,20 +103,20 @@ func TestAccS3BucketPublicAccessBlock_Disappears_bucket(t *testing.T) {
 
 func TestAccS3BucketPublicAccessBlock_blockPublicACLs(t *testing.T) {
 	ctx := acctest.Context(t)
-	var config1, config2, config3 s3.PublicAccessBlockConfiguration
-	name := fmt.Sprintf("tf-test-bucket-%d", sdkacctest.RandInt())
-	resourceName := "aws_s3_bucket_public_access_block.bucket"
+	var config types.PublicAccessBlockConfiguration
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_public_access_block.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, s3.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3EndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBucketDestroy(ctx),
+		CheckDestroy:             testAccCheckBucketPublicAccessBlockDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBucketPublicAccessBlockConfig_basic(name, "true", "false", "false", "false"),
+				Config: testAccBucketPublicAccessBlockConfig_basic(rName, true, false, false, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBucketPublicAccessBlockExists(ctx, resourceName, &config1),
+					testAccCheckBucketPublicAccessBlockExists(ctx, resourceName, &config),
 					resource.TestCheckResourceAttr(resourceName, "block_public_acls", "true"),
 				),
 			},
@@ -128,16 +126,16 @@ func TestAccS3BucketPublicAccessBlock_blockPublicACLs(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccBucketPublicAccessBlockConfig_basic(name, "false", "false", "false", "false"),
+				Config: testAccBucketPublicAccessBlockConfig_basic(rName, false, false, false, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBucketPublicAccessBlockExists(ctx, resourceName, &config2),
+					testAccCheckBucketPublicAccessBlockExists(ctx, resourceName, &config),
 					resource.TestCheckResourceAttr(resourceName, "block_public_acls", "false"),
 				),
 			},
 			{
-				Config: testAccBucketPublicAccessBlockConfig_basic(name, "true", "false", "false", "false"),
+				Config: testAccBucketPublicAccessBlockConfig_basic(rName, true, false, false, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBucketPublicAccessBlockExists(ctx, resourceName, &config3),
+					testAccCheckBucketPublicAccessBlockExists(ctx, resourceName, &config),
 					resource.TestCheckResourceAttr(resourceName, "block_public_acls", "true"),
 				),
 			},
@@ -147,20 +145,20 @@ func TestAccS3BucketPublicAccessBlock_blockPublicACLs(t *testing.T) {
 
 func TestAccS3BucketPublicAccessBlock_blockPublicPolicy(t *testing.T) {
 	ctx := acctest.Context(t)
-	var config1, config2, config3 s3.PublicAccessBlockConfiguration
-	name := fmt.Sprintf("tf-test-bucket-%d", sdkacctest.RandInt())
-	resourceName := "aws_s3_bucket_public_access_block.bucket"
+	var config types.PublicAccessBlockConfiguration
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_public_access_block.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, s3.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3EndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBucketDestroy(ctx),
+		CheckDestroy:             testAccCheckBucketPublicAccessBlockDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBucketPublicAccessBlockConfig_basic(name, "false", "true", "false", "false"),
+				Config: testAccBucketPublicAccessBlockConfig_basic(rName, false, true, false, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBucketPublicAccessBlockExists(ctx, resourceName, &config1),
+					testAccCheckBucketPublicAccessBlockExists(ctx, resourceName, &config),
 					resource.TestCheckResourceAttr(resourceName, "block_public_policy", "true"),
 				),
 			},
@@ -170,16 +168,16 @@ func TestAccS3BucketPublicAccessBlock_blockPublicPolicy(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccBucketPublicAccessBlockConfig_basic(name, "false", "false", "false", "false"),
+				Config: testAccBucketPublicAccessBlockConfig_basic(rName, false, false, false, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBucketPublicAccessBlockExists(ctx, resourceName, &config2),
+					testAccCheckBucketPublicAccessBlockExists(ctx, resourceName, &config),
 					resource.TestCheckResourceAttr(resourceName, "block_public_policy", "false"),
 				),
 			},
 			{
-				Config: testAccBucketPublicAccessBlockConfig_basic(name, "false", "true", "false", "false"),
+				Config: testAccBucketPublicAccessBlockConfig_basic(rName, false, true, false, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBucketPublicAccessBlockExists(ctx, resourceName, &config3),
+					testAccCheckBucketPublicAccessBlockExists(ctx, resourceName, &config),
 					resource.TestCheckResourceAttr(resourceName, "block_public_policy", "true"),
 				),
 			},
@@ -189,20 +187,20 @@ func TestAccS3BucketPublicAccessBlock_blockPublicPolicy(t *testing.T) {
 
 func TestAccS3BucketPublicAccessBlock_ignorePublicACLs(t *testing.T) {
 	ctx := acctest.Context(t)
-	var config1, config2, config3 s3.PublicAccessBlockConfiguration
-	name := fmt.Sprintf("tf-test-bucket-%d", sdkacctest.RandInt())
-	resourceName := "aws_s3_bucket_public_access_block.bucket"
+	var config types.PublicAccessBlockConfiguration
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_public_access_block.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, s3.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3EndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBucketDestroy(ctx),
+		CheckDestroy:             testAccCheckBucketPublicAccessBlockDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBucketPublicAccessBlockConfig_basic(name, "false", "false", "true", "false"),
+				Config: testAccBucketPublicAccessBlockConfig_basic(rName, false, false, true, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBucketPublicAccessBlockExists(ctx, resourceName, &config1),
+					testAccCheckBucketPublicAccessBlockExists(ctx, resourceName, &config),
 					resource.TestCheckResourceAttr(resourceName, "ignore_public_acls", "true"),
 				),
 			},
@@ -212,16 +210,16 @@ func TestAccS3BucketPublicAccessBlock_ignorePublicACLs(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccBucketPublicAccessBlockConfig_basic(name, "false", "false", "false", "false"),
+				Config: testAccBucketPublicAccessBlockConfig_basic(rName, false, false, false, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBucketPublicAccessBlockExists(ctx, resourceName, &config2),
+					testAccCheckBucketPublicAccessBlockExists(ctx, resourceName, &config),
 					resource.TestCheckResourceAttr(resourceName, "ignore_public_acls", "false"),
 				),
 			},
 			{
-				Config: testAccBucketPublicAccessBlockConfig_basic(name, "false", "false", "true", "false"),
+				Config: testAccBucketPublicAccessBlockConfig_basic(rName, false, false, true, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBucketPublicAccessBlockExists(ctx, resourceName, &config3),
+					testAccCheckBucketPublicAccessBlockExists(ctx, resourceName, &config),
 					resource.TestCheckResourceAttr(resourceName, "ignore_public_acls", "true"),
 				),
 			},
@@ -231,20 +229,20 @@ func TestAccS3BucketPublicAccessBlock_ignorePublicACLs(t *testing.T) {
 
 func TestAccS3BucketPublicAccessBlock_restrictPublicBuckets(t *testing.T) {
 	ctx := acctest.Context(t)
-	var config1, config2, config3 s3.PublicAccessBlockConfiguration
-	name := fmt.Sprintf("tf-test-bucket-%d", sdkacctest.RandInt())
-	resourceName := "aws_s3_bucket_public_access_block.bucket"
+	var config types.PublicAccessBlockConfiguration
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_public_access_block.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, s3.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3EndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBucketDestroy(ctx),
+		CheckDestroy:             testAccCheckBucketPublicAccessBlockDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBucketPublicAccessBlockConfig_basic(name, "false", "false", "false", "true"),
+				Config: testAccBucketPublicAccessBlockConfig_basic(rName, false, false, false, true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBucketPublicAccessBlockExists(ctx, resourceName, &config1),
+					testAccCheckBucketPublicAccessBlockExists(ctx, resourceName, &config),
 					resource.TestCheckResourceAttr(resourceName, "restrict_public_buckets", "true"),
 				),
 			},
@@ -254,16 +252,16 @@ func TestAccS3BucketPublicAccessBlock_restrictPublicBuckets(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccBucketPublicAccessBlockConfig_basic(name, "false", "false", "false", "false"),
+				Config: testAccBucketPublicAccessBlockConfig_basic(rName, false, false, false, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBucketPublicAccessBlockExists(ctx, resourceName, &config2),
+					testAccCheckBucketPublicAccessBlockExists(ctx, resourceName, &config),
 					resource.TestCheckResourceAttr(resourceName, "restrict_public_buckets", "false"),
 				),
 			},
 			{
-				Config: testAccBucketPublicAccessBlockConfig_basic(name, "false", "false", "false", "true"),
+				Config: testAccBucketPublicAccessBlockConfig_basic(rName, false, false, false, true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBucketPublicAccessBlockExists(ctx, resourceName, &config3),
+					testAccCheckBucketPublicAccessBlockExists(ctx, resourceName, &config),
 					resource.TestCheckResourceAttr(resourceName, "restrict_public_buckets", "true"),
 				),
 			},
@@ -271,111 +269,66 @@ func TestAccS3BucketPublicAccessBlock_restrictPublicBuckets(t *testing.T) {
 	})
 }
 
-func testAccCheckBucketPublicAccessBlockExists(ctx context.Context, n string, config *s3.PublicAccessBlockConfiguration) resource.TestCheckFunc {
+func testAccCheckBucketPublicAccessBlockDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
+		conn := acctest.Provider.Meta().(*conns.AWSClient).S3Client(ctx)
 
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No S3 Bucket ID is set")
-		}
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_s3_bucket_public_access_block" {
+				continue
+			}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).S3Conn(ctx)
+			_, err := tfs3.FindPublicAccessBlockConfiguration(ctx, conn, rs.Primary.ID)
 
-		input := &s3.GetPublicAccessBlockInput{
-			Bucket: aws.String(rs.Primary.ID),
-		}
-
-		var output *s3.GetPublicAccessBlockOutput
-		err := retry.RetryContext(ctx, 1*time.Minute, func() *retry.RetryError {
-			var err error
-			output, err = conn.GetPublicAccessBlockWithContext(ctx, input)
-
-			if tfawserr.ErrCodeEquals(err, tfs3.ErrCodeNoSuchPublicAccessBlockConfiguration) {
-				return retry.RetryableError(err)
+			if tfresource.NotFound(err) {
+				continue
 			}
 
 			if err != nil {
-				return retry.NonRetryableError(err)
+				return err
 			}
 
-			return nil
-		})
-
-		if err != nil {
-			return err
+			return fmt.Errorf("S3 Bucket Public Access Block %s still exists", rs.Primary.ID)
 		}
-
-		if output == nil || output.PublicAccessBlockConfiguration == nil {
-			return fmt.Errorf("S3 Bucket Public Access Block not found")
-		}
-
-		*config = *output.PublicAccessBlockConfiguration
 
 		return nil
 	}
 }
 
-func testAccCheckBucketPublicAccessBlockDisappears(ctx context.Context, n string) resource.TestCheckFunc {
+func testAccCheckBucketPublicAccessBlockExists(ctx context.Context, n string, v *types.PublicAccessBlockConfiguration) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No S3 Bucket ID is set")
-		}
+		conn := acctest.Provider.Meta().(*conns.AWSClient).S3Client(ctx)
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).S3Conn(ctx)
+		output, err := tfs3.FindPublicAccessBlockConfiguration(ctx, conn, rs.Primary.ID)
 
-		deleteInput := &s3.DeletePublicAccessBlockInput{
-			Bucket: aws.String(rs.Primary.ID),
-		}
-
-		if _, err := conn.DeletePublicAccessBlockWithContext(ctx, deleteInput); err != nil {
+		if err != nil {
 			return err
 		}
 
-		getInput := &s3.GetPublicAccessBlockInput{
-			Bucket: aws.String(rs.Primary.ID),
-		}
+		*v = *output
 
-		return retry.RetryContext(ctx, 1*time.Minute, func() *retry.RetryError {
-			_, err := conn.GetPublicAccessBlockWithContext(ctx, getInput)
-
-			if tfawserr.ErrCodeEquals(err, tfs3.ErrCodeNoSuchPublicAccessBlockConfiguration) {
-				return nil
-			}
-
-			if err != nil {
-				return retry.NonRetryableError(err)
-			}
-
-			return retry.RetryableError(fmt.Errorf("S3 Bucket Public Access Block (%s) still exists", rs.Primary.ID))
-		})
+		return nil
 	}
 }
 
-func testAccBucketPublicAccessBlockConfig_basic(bucketName, blockPublicAcls, blockPublicPolicy, ignorePublicAcls, restrictPublicBuckets string) string {
+func testAccBucketPublicAccessBlockConfig_basic(bucketName string, blockPublicAcls, blockPublicPolicy, ignorePublicAcls, restrictPublicBuckets bool) string {
 	return fmt.Sprintf(`
-resource "aws_s3_bucket" "bucket" {
+resource "aws_s3_bucket" "test" {
   bucket = %[1]q
-
-  tags = {
-    TestName = %[1]q
-  }
 }
 
-resource "aws_s3_bucket_public_access_block" "bucket" {
-  bucket = aws_s3_bucket.bucket.bucket
+resource "aws_s3_bucket_public_access_block" "test" {
+  bucket = aws_s3_bucket.test.bucket
 
-  block_public_acls       = %[2]q
-  block_public_policy     = %[3]q
-  ignore_public_acls      = %[4]q
-  restrict_public_buckets = %[5]q
+  block_public_acls       = %[2]t
+  block_public_policy     = %[3]t
+  ignore_public_acls      = %[4]t
+  restrict_public_buckets = %[5]t
 }
 `, bucketName, blockPublicAcls, blockPublicPolicy, ignorePublicAcls, restrictPublicBuckets)
 }

--- a/internal/service/s3/errors.go
+++ b/internal/service/s3/errors.go
@@ -19,7 +19,7 @@ const (
 	errCodeNoSuchCORSConfiguration              = "NoSuchCORSConfiguration"
 	errCodeNoSuchLifecycleConfiguration         = "NoSuchLifecycleConfiguration"
 	errCodeNoSuchKey                            = "NoSuchKey"
-	ErrCodeNoSuchPublicAccessBlockConfiguration = "NoSuchPublicAccessBlockConfiguration"
+	errCodeNoSuchPublicAccessBlockConfiguration = "NoSuchPublicAccessBlockConfiguration"
 	errCodeNoSuchTagSet                         = "NoSuchTagSet"
 	errCodeNoSuchTagSetError                    = "NoSuchTagSetError"
 	errCodeNoSuchWebsiteConfiguration           = "NoSuchWebsiteConfiguration"

--- a/internal/service/s3/exports_test.go
+++ b/internal/service/s3/exports_test.go
@@ -25,6 +25,7 @@ var (
 	FindObjectByBucketAndKey              = findObjectByBucketAndKey
 	FindObjectLockConfiguration           = findObjectLockConfiguration
 	FindOwnershipControls                 = findOwnershipControls
+	FindPublicAccessBlockConfiguration    = findPublicAccessBlockConfiguration
 	FindReplicationConfiguration          = findReplicationConfiguration
 	FindServerSideEncryptionConfiguration = findServerSideEncryptionConfiguration
 	SDKv1CompatibleCleanKey               = sdkv1CompatibleCleanKey


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Migrates the `aws_s3_bucket_public_access_block` resource to AWS SDK for Go v2.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/33654.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/32976.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccS3BucketPublicAccessBlock_' PKG=s3 ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 2  -run=TestAccS3BucketPublicAccessBlock_ -timeout 360m
=== RUN   TestAccS3BucketPublicAccessBlock_basic
=== PAUSE TestAccS3BucketPublicAccessBlock_basic
=== RUN   TestAccS3BucketPublicAccessBlock_disappears
=== PAUSE TestAccS3BucketPublicAccessBlock_disappears
=== RUN   TestAccS3BucketPublicAccessBlock_Disappears_bucket
=== PAUSE TestAccS3BucketPublicAccessBlock_Disappears_bucket
=== RUN   TestAccS3BucketPublicAccessBlock_blockPublicACLs
=== PAUSE TestAccS3BucketPublicAccessBlock_blockPublicACLs
=== RUN   TestAccS3BucketPublicAccessBlock_blockPublicPolicy
=== PAUSE TestAccS3BucketPublicAccessBlock_blockPublicPolicy
=== RUN   TestAccS3BucketPublicAccessBlock_ignorePublicACLs
=== PAUSE TestAccS3BucketPublicAccessBlock_ignorePublicACLs
=== RUN   TestAccS3BucketPublicAccessBlock_restrictPublicBuckets
=== PAUSE TestAccS3BucketPublicAccessBlock_restrictPublicBuckets
=== CONT  TestAccS3BucketPublicAccessBlock_basic
=== CONT  TestAccS3BucketPublicAccessBlock_blockPublicPolicy
--- PASS: TestAccS3BucketPublicAccessBlock_basic (84.18s)
=== CONT  TestAccS3BucketPublicAccessBlock_restrictPublicBuckets
--- PASS: TestAccS3BucketPublicAccessBlock_blockPublicPolicy (160.01s)
=== CONT  TestAccS3BucketPublicAccessBlock_ignorePublicACLs
--- PASS: TestAccS3BucketPublicAccessBlock_restrictPublicBuckets (150.94s)
=== CONT  TestAccS3BucketPublicAccessBlock_Disappears_bucket
--- PASS: TestAccS3BucketPublicAccessBlock_Disappears_bucket (51.08s)
=== CONT  TestAccS3BucketPublicAccessBlock_blockPublicACLs
--- PASS: TestAccS3BucketPublicAccessBlock_ignorePublicACLs (144.94s)
=== CONT  TestAccS3BucketPublicAccessBlock_disappears
--- PASS: TestAccS3BucketPublicAccessBlock_disappears (28.44s)
--- PASS: TestAccS3BucketPublicAccessBlock_blockPublicACLs (91.53s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	393.673s
```
