### PR TITLE
Migrate Evidently service to Go SDKv2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/eks v1.33.2
 	github.com/aws/aws-sdk-go-v2/service/emr v1.34.1
 	github.com/aws/aws-sdk-go-v2/service/emrserverless v1.13.4
+	github.com/aws/aws-sdk-go-v2/service/evidently v1.15.3
 	github.com/aws/aws-sdk-go-v2/service/finspace v1.17.1
 	github.com/aws/aws-sdk-go-v2/service/fis v1.19.3
 	github.com/aws/aws-sdk-go-v2/service/glacier v1.18.3

--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,8 @@ github.com/aws/aws-sdk-go-v2/service/emr v1.34.1 h1:AkAncVuiOap3LS/kLs1QdVDY9LZy
 github.com/aws/aws-sdk-go-v2/service/emr v1.34.1/go.mod h1:HCZK6jCgxuYABdZFqiiHE3WT2tvTFVjefMB3ZX9dOxA=
 github.com/aws/aws-sdk-go-v2/service/emrserverless v1.13.4 h1:V5unlj0Ky5ZuvLkndDQlHbYe3vshVJwavUZ7aGne8oo=
 github.com/aws/aws-sdk-go-v2/service/emrserverless v1.13.4/go.mod h1:EC2zElGORkIzy2vPQV5U1qNGXIDzZHjL/KWbpQD6nc0=
+github.com/aws/aws-sdk-go-v2/service/evidently v1.15.3 h1:guFZcKDSE3NoijLu40GeMIs0TXIMdXGCZFEdprOMkcs=
+github.com/aws/aws-sdk-go-v2/service/evidently v1.15.3/go.mod h1:59okKGh8LvG0ZhKMZMCYU++ZendXUT6dqzCufBzfzq4=
 github.com/aws/aws-sdk-go-v2/service/finspace v1.17.1 h1:GcBPj8B8EiVaHOba8Pq+CS+7w7s3q8ndETwPtpleS7A=
 github.com/aws/aws-sdk-go-v2/service/finspace v1.17.1/go.mod h1:waL57h/Nj7KR0Z6HvjdeJrHS7o8E/uQ33YgNQcLcrYE=
 github.com/aws/aws-sdk-go-v2/service/fis v1.19.3 h1:u6/LY1KBbBazaZZGT6NPUyUurwV6e7Fg+guLOVgeI9M=

--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -31,6 +31,7 @@ import (
 	eks_sdkv2 "github.com/aws/aws-sdk-go-v2/service/eks"
 	emr_sdkv2 "github.com/aws/aws-sdk-go-v2/service/emr"
 	emrserverless_sdkv2 "github.com/aws/aws-sdk-go-v2/service/emrserverless"
+	evidently_sdkv2 "github.com/aws/aws-sdk-go-v2/service/evidently"
 	finspace_sdkv2 "github.com/aws/aws-sdk-go-v2/service/finspace"
 	fis_sdkv2 "github.com/aws/aws-sdk-go-v2/service/fis"
 	glacier_sdkv2 "github.com/aws/aws-sdk-go-v2/service/glacier"
@@ -107,7 +108,6 @@ import (
 	cloudsearch_sdkv1 "github.com/aws/aws-sdk-go/service/cloudsearch"
 	cloudtrail_sdkv1 "github.com/aws/aws-sdk-go/service/cloudtrail"
 	cloudwatch_sdkv1 "github.com/aws/aws-sdk-go/service/cloudwatch"
-	cloudwatchevidently_sdkv1 "github.com/aws/aws-sdk-go/service/cloudwatchevidently"
 	cloudwatchrum_sdkv1 "github.com/aws/aws-sdk-go/service/cloudwatchrum"
 	codeartifact_sdkv1 "github.com/aws/aws-sdk-go/service/codeartifact"
 	codebuild_sdkv1 "github.com/aws/aws-sdk-go/service/codebuild"
@@ -587,8 +587,8 @@ func (c *AWSClient) EventsConn(ctx context.Context) *eventbridge_sdkv1.EventBrid
 	return errs.Must(conn[*eventbridge_sdkv1.EventBridge](ctx, c, names.Events))
 }
 
-func (c *AWSClient) EvidentlyConn(ctx context.Context) *cloudwatchevidently_sdkv1.CloudWatchEvidently {
-	return errs.Must(conn[*cloudwatchevidently_sdkv1.CloudWatchEvidently](ctx, c, names.Evidently))
+func (c *AWSClient) EvidentlyClient(ctx context.Context) *evidently_sdkv2.Client {
+	return errs.Must(client[*evidently_sdkv2.Client](ctx, c, names.Evidently))
 }
 
 func (c *AWSClient) FISClient(ctx context.Context) *fis_sdkv2.Client {

--- a/internal/flex/flex.go
+++ b/internal/flex/flex.go
@@ -122,6 +122,13 @@ func ExpandInt64Map(m map[string]interface{}) map[string]*int64 {
 	})
 }
 
+// ExpandInt64ValueMap expands a map of string to interface to a map of string to int64
+func ExpandInt64ValueMap(m map[string]interface{}) map[string]int64 {
+	return tfmaps.ApplyToAllValues(m, func(v any) int64 {
+		return int64(v.(int))
+	})
+}
+
 // Expands a map of string to interface to a map of string to *string
 func ExpandStringMap(m map[string]interface{}) map[string]*string {
 	return tfmaps.ApplyToAllValues(m, func(v any) *string {

--- a/internal/service/evidently/feature.go
+++ b/internal/service/evidently/feature.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 	"time"
 
@@ -448,11 +449,11 @@ func flattenValue(apiObject awstypes.VariableValue) []interface{} {
 	// only one of these values should be set at a time
 	switch v := apiObject.(type) {
 	case *awstypes.VariableValueMemberBoolValue:
-		m["bool_value"] = v.Value
+		m["bool_value"] = strconv.FormatBool(v.Value)
 	case *awstypes.VariableValueMemberLongValue:
-		m["long_value"] = v.Value
+		m["long_value"] = strconv.FormatInt(v.Value, 10)
 	case *awstypes.VariableValueMemberDoubleValue:
-		m["double_value"] = v.Value
+		m["double_value"] = strconv.FormatFloat(v.Value, 'f', -1, 64)
 	case *awstypes.VariableValueMemberStringValue:
 		m["string_value"] = v.Value
 	}

--- a/internal/service/evidently/feature.go
+++ b/internal/service/evidently/feature.go
@@ -7,18 +7,20 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/evidently"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/evidently/types"
 	"github.com/aws/aws-sdk-go/service/cloudwatchevidently"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -96,10 +98,10 @@ func ResourceFeature() *schema.Resource {
 				},
 			},
 			"evaluation_strategy": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.StringInSlice(cloudwatchevidently.FeatureEvaluationStrategy_Values(), false),
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				ValidateDiagFunc: enum.Validate[awstypes.FeatureEvaluationStrategy](),
 			},
 			"last_updated_time": {
 				Type:     schema.TypeString,
@@ -199,11 +201,11 @@ func ResourceFeature() *schema.Resource {
 }
 
 func resourceFeatureCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).EvidentlyConn(ctx)
+	conn := meta.(*conns.AWSClient).EvidentlyClient(ctx)
 
 	name := d.Get("name").(string)
 	project := d.Get("project").(string)
-	input := &cloudwatchevidently.CreateFeatureInput{
+	input := &evidently.CreateFeatureInput{
 		Name:       aws.String(name),
 		Project:    aws.String(project),
 		Tags:       getTagsIn(ctx),
@@ -219,14 +221,14 @@ func resourceFeatureCreate(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	if v := d.Get("entity_overrides").(map[string]interface{}); len(v) > 0 {
-		input.EntityOverrides = flex.ExpandStringMap(v)
+		input.EntityOverrides = flex.ExpandStringValueMap(v)
 	}
 
 	if v, ok := d.GetOk("evaluation_strategy"); ok {
-		input.EvaluationStrategy = aws.String(v.(string))
+		input.EvaluationStrategy = awstypes.FeatureEvaluationStrategy(v.(string))
 	}
 
-	output, err := conn.CreateFeatureWithContext(ctx, input)
+	output, err := conn.CreateFeature(ctx, input)
 
 	if err != nil {
 		return diag.Errorf("creating CloudWatch Evidently Feature (%s) for Project (%s): %s", name, project, err)
@@ -234,7 +236,7 @@ func resourceFeatureCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 	// the GetFeature API call uses the Feature name and Project ARN
 	// concat Feature name and Project Name or ARN to be used in Read for imports
-	d.SetId(fmt.Sprintf("%s:%s", aws.StringValue(output.Feature.Name), aws.StringValue(output.Feature.Project)))
+	d.SetId(fmt.Sprintf("%s:%s", aws.ToString(output.Feature.Name), aws.ToString(output.Feature.Project)))
 
 	if _, err := waitFeatureCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
 		return diag.Errorf("waiting for CloudWatch Evidently Feature (%s) for Project (%s) creation: %s", name, project, err)
@@ -244,7 +246,7 @@ func resourceFeatureCreate(ctx context.Context, d *schema.ResourceData, meta int
 }
 
 func resourceFeatureRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).EvidentlyConn(ctx)
+	conn := meta.(*conns.AWSClient).EvidentlyClient(ctx)
 
 	featureName, projectNameOrARN, err := FeatureParseID(d.Id())
 
@@ -273,12 +275,12 @@ func resourceFeatureRead(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	d.Set("arn", feature.Arn)
-	d.Set("created_time", aws.TimeValue(feature.CreatedTime).Format(time.RFC3339))
+	d.Set("created_time", aws.ToTime(feature.CreatedTime).Format(time.RFC3339))
 	d.Set("default_variation", feature.DefaultVariation)
 	d.Set("description", feature.Description)
-	d.Set("entity_overrides", aws.StringValueMap(feature.EntityOverrides))
+	d.Set("entity_overrides", feature.EntityOverrides)
 	d.Set("evaluation_strategy", feature.EvaluationStrategy)
-	d.Set("last_updated_time", aws.TimeValue(feature.LastUpdatedTime).Format(time.RFC3339))
+	d.Set("last_updated_time", aws.ToTime(feature.LastUpdatedTime).Format(time.RFC3339))
 	d.Set("name", feature.Name)
 	d.Set("project", feature.Project)
 	d.Set("status", feature.Status)
@@ -290,17 +292,17 @@ func resourceFeatureRead(ctx context.Context, d *schema.ResourceData, meta inter
 }
 
 func resourceFeatureUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).EvidentlyConn(ctx)
+	conn := meta.(*conns.AWSClient).EvidentlyClient(ctx)
 
 	if d.HasChanges("default_variation", "description", "entity_overrides", "evaluation_strategy", "variations") {
 		name := d.Get("name").(string)
 		project := d.Get("project").(string)
 
-		input := &cloudwatchevidently.UpdateFeatureInput{
+		input := &evidently.UpdateFeatureInput{
 			DefaultVariation:   aws.String(d.Get("default_variation").(string)),
 			Description:        aws.String(d.Get("description").(string)),
-			EntityOverrides:    flex.ExpandStringMap(d.Get("entity_overrides").(map[string]interface{})),
-			EvaluationStrategy: aws.String(d.Get("evaluation_strategy").(string)),
+			EntityOverrides:    flex.ExpandStringValueMap(d.Get("entity_overrides").(map[string]interface{})),
+			EvaluationStrategy: awstypes.FeatureEvaluationStrategy(d.Get("evaluation_strategy").(string)),
 			Feature:            aws.String(name),
 			Project:            aws.String(project),
 		}
@@ -315,7 +317,7 @@ func resourceFeatureUpdate(ctx context.Context, d *schema.ResourceData, meta int
 			input.AddOrUpdateVariations = toAddOrUpdate
 			input.RemoveVariations = toRemove
 		}
-		_, err := conn.UpdateFeatureWithContext(ctx, input)
+		_, err := conn.UpdateFeature(ctx, input)
 
 		if err != nil {
 			return diag.Errorf("updating CloudWatch Evidently Feature (%s) for Project (%s): %s", name, project, err)
@@ -330,13 +332,13 @@ func resourceFeatureUpdate(ctx context.Context, d *schema.ResourceData, meta int
 }
 
 func resourceFeatureDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).EvidentlyConn(ctx)
+	conn := meta.(*conns.AWSClient).EvidentlyClient(ctx)
 
 	name := d.Get("name").(string)
 	project := d.Get("project").(string)
 
 	log.Printf("[DEBUG] Deleting CloudWatch Evidently Feature: %s", d.Id())
-	_, err := conn.DeleteFeatureWithContext(ctx, &cloudwatchevidently.DeleteFeatureInput{
+	_, err := conn.DeleteFeature(ctx, &evidently.DeleteFeatureInput{
 		Feature: aws.String(name),
 		Project: aws.String(project),
 	})
@@ -366,12 +368,12 @@ func FeatureParseID(id string) (string, string, error) {
 	return featureName, projectNameOrARN, nil
 }
 
-func expandVariations(variations []interface{}) []*cloudwatchevidently.VariationConfig {
+func expandVariations(variations []interface{}) []awstypes.VariationConfig {
 	if len(variations) == 0 {
 		return nil
 	}
 
-	variationsFormatted := make([]*cloudwatchevidently.VariationConfig, len(variations))
+	variationsFormatted := make([]awstypes.VariationConfig, len(variations))
 
 	for i, variation := range variations {
 		variationsFormatted[i] = expandVariation(variation.(map[string]interface{}))
@@ -380,14 +382,14 @@ func expandVariations(variations []interface{}) []*cloudwatchevidently.Variation
 	return variationsFormatted
 }
 
-func expandVariation(variation map[string]interface{}) *cloudwatchevidently.VariationConfig {
-	return &cloudwatchevidently.VariationConfig{
+func expandVariation(variation map[string]interface{}) awstypes.VariationConfig {
+	return awstypes.VariationConfig{
 		Name:  aws.String(variation["name"].(string)),
 		Value: expandValue(variation["value"].([]interface{})),
 	}
 }
 
-func expandValue(value []interface{}) *cloudwatchevidently.VariableValue {
+func expandValue(value []interface{}) awstypes.VariableValue {
 	if len(value) == 0 || value[0] == nil {
 		return nil
 	}
@@ -397,22 +399,30 @@ func expandValue(value []interface{}) *cloudwatchevidently.VariableValue {
 		return nil
 	}
 
-	result := &cloudwatchevidently.VariableValue{}
+	var result awstypes.VariableValue
 
 	// Only one of these values can be set at a time
 	if val, null, _ := nullable.Bool(tfMap["bool_value"].(string)).Value(); !null {
-		result.BoolValue = aws.Bool(val)
+		result = &awstypes.VariableValueMemberBoolValue{
+			Value: val,
+		}
 	} else if v, null, _ := nullable.Int(tfMap["long_value"].(string)).Value(); !null {
-		result.LongValue = aws.Int64(v)
+		result = &awstypes.VariableValueMemberLongValue{
+			Value: v,
+		}
 	} else if v, null, _ := nullable.Float(tfMap["double_value"].(string)).Value(); !null {
-		result.DoubleValue = aws.Float64(v)
+		result = &awstypes.VariableValueMemberDoubleValue{
+			Value: v,
+		}
 	} else if v, ok := tfMap["string_value"].(string); ok {
-		result.StringValue = aws.String(v)
+		result = &awstypes.VariableValueMemberStringValue{
+			Value: v,
+		}
 	}
 	return result
 }
 
-func flattenVariations(apiObject []*cloudwatchevidently.Variation) []interface{} {
+func flattenVariations(apiObject []awstypes.Variation) []interface{} {
 	if apiObject == nil {
 		return []interface{}{}
 	}
@@ -420,7 +430,7 @@ func flattenVariations(apiObject []*cloudwatchevidently.Variation) []interface{}
 	variationsFormatted := []interface{}{}
 	for _, variation := range apiObject {
 		variationFormatted := map[string]interface{}{
-			"name":  aws.StringValue(variation.Name),
+			"name":  aws.ToString(variation.Name),
 			"value": flattenValue(variation.Value),
 		}
 		variationsFormatted = append(variationsFormatted, variationFormatted)
@@ -428,7 +438,7 @@ func flattenVariations(apiObject []*cloudwatchevidently.Variation) []interface{}
 	return variationsFormatted
 }
 
-func flattenValue(apiObject *cloudwatchevidently.VariableValue) []interface{} {
+func flattenValue(apiObject awstypes.VariableValue) []interface{} {
 	if apiObject == nil {
 		return []interface{}{}
 	}
@@ -436,20 +446,21 @@ func flattenValue(apiObject *cloudwatchevidently.VariableValue) []interface{} {
 	m := map[string]interface{}{}
 
 	// only one of these values should be set at a time
-	if v := apiObject.BoolValue; v != nil {
-		m["bool_value"] = strconv.FormatBool(aws.BoolValue(v))
-	} else if v := apiObject.LongValue; v != nil {
-		m["long_value"] = strconv.FormatInt(aws.Int64Value(v), 10)
-	} else if v := apiObject.DoubleValue; v != nil {
-		m["double_value"] = strconv.FormatFloat(aws.Float64Value(v), 'f', -1, 64)
-	} else {
-		m["string_value"] = aws.StringValue(apiObject.StringValue)
+	switch v := apiObject.(type) {
+	case *awstypes.VariableValueMemberBoolValue:
+		m["bool_value"] = v.Value
+	case *awstypes.VariableValueMemberLongValue:
+		m["long_value"] = v.Value
+	case *awstypes.VariableValueMemberDoubleValue:
+		m["double_value"] = v.Value
+	case *awstypes.VariableValueMemberStringValue:
+		m["string_value"] = v.Value
 	}
 
 	return []interface{}{m}
 }
 
-func flattenEvaluationRules(apiObject []*cloudwatchevidently.EvaluationRule) []interface{} {
+func flattenEvaluationRules(apiObject []awstypes.EvaluationRule) []interface{} {
 	if apiObject == nil {
 		return []interface{}{}
 	}
@@ -457,15 +468,15 @@ func flattenEvaluationRules(apiObject []*cloudwatchevidently.EvaluationRule) []i
 	evaluationRulesFormatted := []interface{}{}
 	for _, evaluationRule := range apiObject {
 		evaluationRuleFormatted := map[string]interface{}{
-			"name": aws.StringValue(evaluationRule.Name),
-			"type": aws.StringValue(evaluationRule.Type),
+			"name": aws.ToString(evaluationRule.Name),
+			"type": aws.ToString(evaluationRule.Type),
 		}
 		evaluationRulesFormatted = append(evaluationRulesFormatted, evaluationRuleFormatted)
 	}
 	return evaluationRulesFormatted
 }
 
-func VariationChanges(o, n interface{}) (remove []*string, addOrUpdate []*cloudwatchevidently.VariationConfig) {
+func VariationChanges(o, n interface{}) (remove []string, addOrUpdate []awstypes.VariationConfig) {
 	if o == nil {
 		o = new(schema.Set)
 	}
@@ -476,12 +487,12 @@ func VariationChanges(o, n interface{}) (remove []*string, addOrUpdate []*cloudw
 	os := o.(*schema.Set)
 	ns := n.(*schema.Set)
 
-	om := make(map[string]*cloudwatchevidently.VariationConfig, os.Len())
+	om := make(map[string]awstypes.VariationConfig, os.Len())
 	for _, raw := range os.List() {
 		param := raw.(map[string]interface{})
 		om[param["name"].(string)] = expandVariation(param)
 	}
-	nm := make(map[string]*cloudwatchevidently.VariationConfig, len(addOrUpdate))
+	nm := make(map[string]awstypes.VariationConfig, len(addOrUpdate))
 	for _, raw := range ns.List() {
 		param := raw.(map[string]interface{})
 		nm[param["name"].(string)] = expandVariation(param)
@@ -496,16 +507,16 @@ func VariationChanges(o, n interface{}) (remove []*string, addOrUpdate []*cloudw
 	// 	}
 	// }
 	// remove is a list of strings
-	remove = make([]*string, 0)
+	remove = make([]string, 0)
 	for k := range om {
 		k := k
 		if _, ok := nm[k]; !ok {
-			remove = append(remove, &k)
+			remove = append(remove, k)
 		}
 	}
 
 	// Add or Update: key is in new, but not in old or has changed value
-	addOrUpdate = make([]*cloudwatchevidently.VariationConfig, 0, ns.Len())
+	addOrUpdate = make([]awstypes.VariationConfig, 0, ns.Len())
 	for k, nv := range nm {
 		ov, ok := om[k]
 		if !ok {
@@ -513,13 +524,7 @@ func VariationChanges(o, n interface{}) (remove []*string, addOrUpdate []*cloudw
 			addOrUpdate = append(addOrUpdate, nm[k])
 		} else {
 			// updates to existing variations
-			if nv.Value.StringValue != nil && aws.StringValue(nv.Value.StringValue) != aws.StringValue(ov.Value.StringValue) {
-				addOrUpdate = append(addOrUpdate, nm[k])
-			} else if nv.Value.BoolValue != nil && aws.BoolValue(nv.Value.BoolValue) != aws.BoolValue(ov.Value.BoolValue) {
-				addOrUpdate = append(addOrUpdate, nm[k])
-			} else if nv.Value.LongValue != nil && aws.Int64Value(nv.Value.LongValue) != aws.Int64Value(ov.Value.LongValue) {
-				addOrUpdate = append(addOrUpdate, nm[k])
-			} else if nv.Value.DoubleValue != nil && aws.Float64Value(nv.Value.DoubleValue) != aws.Float64Value(ov.Value.DoubleValue) {
+			if nv.Value != nil && nv.Value != ov.Value {
 				addOrUpdate = append(addOrUpdate, nm[k])
 			}
 		}

--- a/internal/service/evidently/feature_test.go
+++ b/internal/service/evidently/feature_test.go
@@ -619,7 +619,7 @@ func TestAccEvidentlyFeature_disappears(t *testing.T) {
 
 func testAccCheckFeatureDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).EvidentlyConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).EvidentlyClient(ctx)
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_evidently_feature" {
 				continue

--- a/internal/service/evidently/feature_test.go
+++ b/internal/service/evidently/feature_test.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/cloudwatchevidently"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/evidently/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -17,11 +17,12 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfcloudwatchevidently "github.com/hashicorp/terraform-provider-aws/internal/service/evidently"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccEvidentlyFeature_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	var feature cloudwatchevidently.Feature
+	var feature awstypes.Feature
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -30,9 +31,9 @@ func TestAccEvidentlyFeature_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, cloudwatchevidently.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.EvidentlyEndpointID)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.EvidentlyEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckFeatureDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -45,13 +46,13 @@ func TestAccEvidentlyFeature_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "default_variation", "Variation1"),
 					resource.TestCheckResourceAttr(resourceName, "entity_overrides.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "evaluation_rules.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "evaluation_strategy", cloudwatchevidently.FeatureEvaluationStrategyAllRules),
+					resource.TestCheckResourceAttr(resourceName, "evaluation_strategy", string(awstypes.FeatureEvaluationStrategyAllRules)),
 					resource.TestCheckResourceAttrSet(resourceName, "last_updated_time"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName2),
 					resource.TestCheckResourceAttrPair(resourceName, "project", "aws_evidently_project.test", "arn"),
-					resource.TestCheckResourceAttr(resourceName, "status", cloudwatchevidently.FeatureStatusAvailable),
+					resource.TestCheckResourceAttr(resourceName, "status", string(awstypes.FeatureStatusAvailable)),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
-					resource.TestCheckResourceAttr(resourceName, "value_type", cloudwatchevidently.VariationValueTypeString),
+					resource.TestCheckResourceAttr(resourceName, "value_type", string(awstypes.VariationValueTypeString)),
 					resource.TestCheckResourceAttr(resourceName, "variations.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "variations.*", map[string]string{
 						"name":                 "Variation1",
@@ -71,7 +72,7 @@ func TestAccEvidentlyFeature_basic(t *testing.T) {
 
 func TestAccEvidentlyFeature_updateDefaultVariation(t *testing.T) {
 	ctx := acctest.Context(t)
-	var feature cloudwatchevidently.Feature
+	var feature awstypes.Feature
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -82,9 +83,9 @@ func TestAccEvidentlyFeature_updateDefaultVariation(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, cloudwatchevidently.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.EvidentlyEndpointID)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.EvidentlyEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckFeatureDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -113,7 +114,7 @@ func TestAccEvidentlyFeature_updateDefaultVariation(t *testing.T) {
 
 func TestAccEvidentlyFeature_updateDescription(t *testing.T) {
 	ctx := acctest.Context(t)
-	var feature cloudwatchevidently.Feature
+	var feature awstypes.Feature
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -124,9 +125,9 @@ func TestAccEvidentlyFeature_updateDescription(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, cloudwatchevidently.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.EvidentlyEndpointID)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.EvidentlyEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckFeatureDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -155,7 +156,7 @@ func TestAccEvidentlyFeature_updateDescription(t *testing.T) {
 
 func TestAccEvidentlyFeature_updateEntityOverrides(t *testing.T) {
 	ctx := acctest.Context(t)
-	var feature cloudwatchevidently.Feature
+	var feature awstypes.Feature
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -166,9 +167,9 @@ func TestAccEvidentlyFeature_updateEntityOverrides(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, cloudwatchevidently.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.EvidentlyEndpointID)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.EvidentlyEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckFeatureDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -220,20 +221,20 @@ func TestAccEvidentlyFeature_updateEntityOverrides(t *testing.T) {
 
 func TestAccEvidentlyFeature_updateEvaluationStrategy(t *testing.T) {
 	ctx := acctest.Context(t)
-	var feature cloudwatchevidently.Feature
+	var feature awstypes.Feature
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	originalEvaluationStategy := cloudwatchevidently.FeatureEvaluationStrategyAllRules
-	updatedEvaluationStategy := cloudwatchevidently.FeatureEvaluationStrategyDefaultVariation
+	originalEvaluationStategy := string(awstypes.FeatureEvaluationStrategyAllRules)
+	updatedEvaluationStategy := string(awstypes.FeatureEvaluationStrategyDefaultVariation)
 	resourceName := "aws_evidently_feature.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, cloudwatchevidently.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.EvidentlyEndpointID)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.EvidentlyEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckFeatureDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -262,7 +263,7 @@ func TestAccEvidentlyFeature_updateEvaluationStrategy(t *testing.T) {
 
 func TestAccEvidentlyFeature_updateVariationsBoolValue(t *testing.T) {
 	ctx := acctest.Context(t)
-	var feature cloudwatchevidently.Feature
+	var feature awstypes.Feature
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -277,9 +278,9 @@ func TestAccEvidentlyFeature_updateVariationsBoolValue(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, cloudwatchevidently.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.EvidentlyEndpointID)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.EvidentlyEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckFeatureDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -288,7 +289,7 @@ func TestAccEvidentlyFeature_updateVariationsBoolValue(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFeatureExists(ctx, resourceName, &feature),
 					resource.TestCheckResourceAttr(resourceName, "default_variation", originalVariationName1),
-					resource.TestCheckResourceAttr(resourceName, "value_type", cloudwatchevidently.VariationValueTypeBoolean),
+					resource.TestCheckResourceAttr(resourceName, "value_type", string(awstypes.VariationValueTypeBoolean)),
 					resource.TestCheckResourceAttr(resourceName, "variations.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "variations.*", map[string]string{
 						"name":               originalVariationName1,
@@ -307,7 +308,7 @@ func TestAccEvidentlyFeature_updateVariationsBoolValue(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFeatureExists(ctx, resourceName, &feature),
 					resource.TestCheckResourceAttr(resourceName, "default_variation", variationName2), // update default_variation since the first variation is deleted
-					resource.TestCheckResourceAttr(resourceName, "value_type", cloudwatchevidently.VariationValueTypeBoolean),
+					resource.TestCheckResourceAttr(resourceName, "value_type", string(awstypes.VariationValueTypeBoolean)),
 					resource.TestCheckResourceAttr(resourceName, "variations.#", "2"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "variations.*", map[string]string{
 						"name":               updatedVariationName1,
@@ -327,7 +328,7 @@ func TestAccEvidentlyFeature_updateVariationsBoolValue(t *testing.T) {
 
 func TestAccEvidentlyFeature_updateVariationsDoubleValue(t *testing.T) {
 	ctx := acctest.Context(t)
-	var feature cloudwatchevidently.Feature
+	var feature awstypes.Feature
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -342,9 +343,9 @@ func TestAccEvidentlyFeature_updateVariationsDoubleValue(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, cloudwatchevidently.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.EvidentlyEndpointID)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.EvidentlyEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckFeatureDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -353,7 +354,7 @@ func TestAccEvidentlyFeature_updateVariationsDoubleValue(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFeatureExists(ctx, resourceName, &feature),
 					resource.TestCheckResourceAttr(resourceName, "default_variation", originalVariationName1),
-					resource.TestCheckResourceAttr(resourceName, "value_type", cloudwatchevidently.VariationValueTypeDouble),
+					resource.TestCheckResourceAttr(resourceName, "value_type", string(awstypes.VariationValueTypeDouble)),
 					resource.TestCheckResourceAttr(resourceName, "variations.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "variations.*", map[string]string{
 						"name":                 originalVariationName1,
@@ -372,7 +373,7 @@ func TestAccEvidentlyFeature_updateVariationsDoubleValue(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFeatureExists(ctx, resourceName, &feature),
 					resource.TestCheckResourceAttr(resourceName, "default_variation", variationName2), // update default_variation since the first variation is deleted
-					resource.TestCheckResourceAttr(resourceName, "value_type", cloudwatchevidently.VariationValueTypeDouble),
+					resource.TestCheckResourceAttr(resourceName, "value_type", string(awstypes.VariationValueTypeDouble)),
 					resource.TestCheckResourceAttr(resourceName, "variations.#", "2"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "variations.*", map[string]string{
 						"name":                 updatedVariationName1,
@@ -392,7 +393,7 @@ func TestAccEvidentlyFeature_updateVariationsDoubleValue(t *testing.T) {
 
 func TestAccEvidentlyFeature_updateVariationsLongValue(t *testing.T) {
 	ctx := acctest.Context(t)
-	var feature cloudwatchevidently.Feature
+	var feature awstypes.Feature
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -407,9 +408,9 @@ func TestAccEvidentlyFeature_updateVariationsLongValue(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, cloudwatchevidently.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.EvidentlyEndpointID)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.EvidentlyEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckFeatureDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -418,7 +419,7 @@ func TestAccEvidentlyFeature_updateVariationsLongValue(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFeatureExists(ctx, resourceName, &feature),
 					resource.TestCheckResourceAttr(resourceName, "default_variation", originalVariationName1),
-					resource.TestCheckResourceAttr(resourceName, "value_type", cloudwatchevidently.VariationValueTypeLong),
+					resource.TestCheckResourceAttr(resourceName, "value_type", string(awstypes.VariationValueTypeLong)),
 					resource.TestCheckResourceAttr(resourceName, "variations.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "variations.*", map[string]string{
 						"name":               originalVariationName1,
@@ -437,7 +438,7 @@ func TestAccEvidentlyFeature_updateVariationsLongValue(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFeatureExists(ctx, resourceName, &feature),
 					resource.TestCheckResourceAttr(resourceName, "default_variation", variationName2), // update default_variation since the first variation is deleted
-					resource.TestCheckResourceAttr(resourceName, "value_type", cloudwatchevidently.VariationValueTypeLong),
+					resource.TestCheckResourceAttr(resourceName, "value_type", string(awstypes.VariationValueTypeLong)),
 					resource.TestCheckResourceAttr(resourceName, "variations.#", "2"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "variations.*", map[string]string{
 						"name":               updatedVariationName1,
@@ -457,7 +458,7 @@ func TestAccEvidentlyFeature_updateVariationsLongValue(t *testing.T) {
 
 func TestAccEvidentlyFeature_updateVariationsStringValue(t *testing.T) {
 	ctx := acctest.Context(t)
-	var feature cloudwatchevidently.Feature
+	var feature awstypes.Feature
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -473,9 +474,9 @@ func TestAccEvidentlyFeature_updateVariationsStringValue(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, cloudwatchevidently.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.EvidentlyEndpointID)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.EvidentlyEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckFeatureDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -484,7 +485,7 @@ func TestAccEvidentlyFeature_updateVariationsStringValue(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFeatureExists(ctx, resourceName, &feature),
 					resource.TestCheckResourceAttr(resourceName, "default_variation", originalVariationName1),
-					resource.TestCheckResourceAttr(resourceName, "value_type", cloudwatchevidently.VariationValueTypeString),
+					resource.TestCheckResourceAttr(resourceName, "value_type", string(awstypes.VariationValueTypeString)),
 					resource.TestCheckResourceAttr(resourceName, "variations.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "variations.*", map[string]string{
 						"name":                 originalVariationName1,
@@ -503,7 +504,7 @@ func TestAccEvidentlyFeature_updateVariationsStringValue(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFeatureExists(ctx, resourceName, &feature),
 					resource.TestCheckResourceAttr(resourceName, "default_variation", variationName2), // update default_variation since the first variation is deleted
-					resource.TestCheckResourceAttr(resourceName, "value_type", cloudwatchevidently.VariationValueTypeString),
+					resource.TestCheckResourceAttr(resourceName, "value_type", string(awstypes.VariationValueTypeString)),
 					resource.TestCheckResourceAttr(resourceName, "variations.#", "2"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "variations.*", map[string]string{
 						"name":                 updatedVariationName1,
@@ -522,7 +523,7 @@ func TestAccEvidentlyFeature_updateVariationsStringValue(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFeatureExists(ctx, resourceName, &feature),
 					resource.TestCheckResourceAttr(resourceName, "default_variation", variationName2), // update default_variation since the first variation is deleted
-					resource.TestCheckResourceAttr(resourceName, "value_type", cloudwatchevidently.VariationValueTypeString),
+					resource.TestCheckResourceAttr(resourceName, "value_type", string(awstypes.VariationValueTypeString)),
 					resource.TestCheckResourceAttr(resourceName, "variations.#", "2"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "variations.*", map[string]string{
 						"name":                 updatedVariationName1,
@@ -542,7 +543,7 @@ func TestAccEvidentlyFeature_updateVariationsStringValue(t *testing.T) {
 
 func TestAccEvidentlyFeature_tags(t *testing.T) {
 	ctx := acctest.Context(t)
-	var feature cloudwatchevidently.Feature
+	var feature awstypes.Feature
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -551,9 +552,9 @@ func TestAccEvidentlyFeature_tags(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, cloudwatchevidently.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.EvidentlyEndpointID)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.EvidentlyEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckFeatureDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -593,7 +594,7 @@ func TestAccEvidentlyFeature_tags(t *testing.T) {
 
 func TestAccEvidentlyFeature_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	var feature cloudwatchevidently.Feature
+	var feature awstypes.Feature
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -601,7 +602,7 @@ func TestAccEvidentlyFeature_disappears(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.EvidentlyEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckFeatureDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -648,7 +649,7 @@ func testAccCheckFeatureDestroy(ctx context.Context) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckFeatureExists(ctx context.Context, n string, v *cloudwatchevidently.Feature) resource.TestCheckFunc {
+func testAccCheckFeatureExists(ctx context.Context, n string, v *awstypes.Feature) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 
@@ -666,7 +667,7 @@ func testAccCheckFeatureExists(ctx context.Context, n string, v *cloudwatchevide
 			return err
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).EvidentlyConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).EvidentlyClient(ctx)
 
 		output, err := tfcloudwatchevidently.FindFeatureWithProjectNameorARN(ctx, conn, featureName, projectNameOrARN)
 

--- a/internal/service/evidently/find.go
+++ b/internal/service/evidently/find.go
@@ -6,9 +6,9 @@ package evidently
 import (
 	"context"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/evidently"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/evidently/types"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"

--- a/internal/service/evidently/find.go
+++ b/internal/service/evidently/find.go
@@ -68,14 +68,14 @@ func FindLaunchWithProjectNameorARN(ctx context.Context, conn *evidently.Client,
 	return output.Launch, nil
 }
 
-func FindProjectByNameOrARN(ctx context.Context, conn *cloudwatchevidently.CloudWatchEvidently, nameOrARN string) (*cloudwatchevidently.Project, error) {
-	input := &cloudwatchevidently.GetProjectInput{
+func FindProjectByNameOrARN(ctx context.Context, conn *evidently.Client, nameOrARN string) (*awstypes.Project, error) {
+	input := &evidently.GetProjectInput{
 		Project: aws.String(nameOrARN),
 	}
 
-	output, err := conn.GetProjectWithContext(ctx, input)
+	output, err := conn.GetProject(ctx, input)
 
-	if tfawserr.ErrCodeEquals(err, cloudwatchevidently.ErrCodeResourceNotFoundException) {
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return nil, &retry.NotFoundError{
 			LastError:   err,
 			LastRequest: input,

--- a/internal/service/evidently/find.go
+++ b/internal/service/evidently/find.go
@@ -6,6 +6,8 @@ package evidently
 import (
 	"context"
 
+	"github.com/aws/aws-sdk-go-v2/service/evidently"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/evidently/types"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatchevidently"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
@@ -13,13 +15,13 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func FindFeatureWithProjectNameorARN(ctx context.Context, conn *cloudwatchevidently.CloudWatchEvidently, featureName, projectNameOrARN string) (*cloudwatchevidently.Feature, error) {
-	input := &cloudwatchevidently.GetFeatureInput{
+func FindFeatureWithProjectNameorARN(ctx context.Context, conn *evidently.Client, featureName, projectNameOrARN string) (*awstypes.Feature, error) {
+	input := &evidently.GetFeatureInput{
 		Feature: aws.String(featureName),
 		Project: aws.String(projectNameOrARN),
 	}
 
-	output, err := conn.GetFeatureWithContext(ctx, input)
+	output, err := conn.GetFeature(ctx, input)
 
 	if tfawserr.ErrCodeEquals(err, cloudwatchevidently.ErrCodeResourceNotFoundException) {
 		return nil, &retry.NotFoundError{

--- a/internal/service/evidently/find.go
+++ b/internal/service/evidently/find.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudwatchevidently"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
@@ -23,7 +24,7 @@ func FindFeatureWithProjectNameorARN(ctx context.Context, conn *evidently.Client
 
 	output, err := conn.GetFeature(ctx, input)
 
-	if tfawserr.ErrCodeEquals(err, cloudwatchevidently.ErrCodeResourceNotFoundException) {
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return nil, &retry.NotFoundError{
 			LastError:   err,
 			LastRequest: input,
@@ -41,15 +42,15 @@ func FindFeatureWithProjectNameorARN(ctx context.Context, conn *evidently.Client
 	return output.Feature, nil
 }
 
-func FindLaunchWithProjectNameorARN(ctx context.Context, conn *cloudwatchevidently.CloudWatchEvidently, launchName, projectNameOrARN string) (*cloudwatchevidently.Launch, error) {
-	input := &cloudwatchevidently.GetLaunchInput{
+func FindLaunchWithProjectNameorARN(ctx context.Context, conn *evidently.Client, launchName, projectNameOrARN string) (*awstypes.Launch, error) {
+	input := &evidently.GetLaunchInput{
 		Launch:  aws.String(launchName),
 		Project: aws.String(projectNameOrARN),
 	}
 
-	output, err := conn.GetLaunchWithContext(ctx, input)
+	output, err := conn.GetLaunch(ctx, input)
 
-	if tfawserr.ErrCodeEquals(err, cloudwatchevidently.ErrCodeResourceNotFoundException) {
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return nil, &retry.NotFoundError{
 			LastError:   err,
 			LastRequest: input,

--- a/internal/service/evidently/find.go
+++ b/internal/service/evidently/find.go
@@ -9,8 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/evidently"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/evidently/types"
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/cloudwatchevidently"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -93,14 +91,14 @@ func FindProjectByNameOrARN(ctx context.Context, conn *evidently.Client, nameOrA
 	return output.Project, nil
 }
 
-func FindSegmentByNameOrARN(ctx context.Context, conn *cloudwatchevidently.CloudWatchEvidently, nameOrARN string) (*cloudwatchevidently.Segment, error) {
-	input := &cloudwatchevidently.GetSegmentInput{
+func FindSegmentByNameOrARN(ctx context.Context, conn *evidently.Client, nameOrARN string) (*awstypes.Segment, error) {
+	input := &evidently.GetSegmentInput{
 		Segment: aws.String(nameOrARN),
 	}
 
-	output, err := conn.GetSegmentWithContext(ctx, input)
+	output, err := conn.GetSegment(ctx, input)
 
-	if tfawserr.ErrCodeEquals(err, cloudwatchevidently.ErrCodeResourceNotFoundException) {
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return nil, &retry.NotFoundError{
 			LastError:   err,
 			LastRequest: input,

--- a/internal/service/evidently/generate.go
+++ b/internal/service/evidently/generate.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-//go:generate go run ../../generate/tags/main.go -ServiceTagsMap -UpdateTags
+//go:generate go run ../../generate/tags/main.go -AWSSDKVersion=2 -ServiceTagsMap -KVTValues -SkipTypesImp -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/evidently/launch.go
+++ b/internal/service/evidently/launch.go
@@ -11,14 +11,15 @@ import (
 	"time"
 
 	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/cloudwatchevidently"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/evidently"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/evidently/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -297,11 +298,11 @@ func ResourceLaunch() *schema.Resource {
 }
 
 func resourceLaunchCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).EvidentlyConn(ctx)
+	conn := meta.(*conns.AWSClient).EvidentlyClient(ctx)
 
 	name := d.Get("name").(string)
 	project := d.Get("project").(string)
-	input := &cloudwatchevidently.CreateLaunchInput{
+	input := &evidently.CreateLaunchInput{
 		Name:    aws.String(name),
 		Project: aws.String(project),
 		Groups:  expandGroups(d.Get("groups").([]interface{})),
@@ -324,7 +325,7 @@ func resourceLaunchCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		input.ScheduledSplitsConfig = expandScheduledSplitsConfig(v.([]interface{}))
 	}
 
-	output, err := conn.CreateLaunchWithContext(ctx, input)
+	output, err := conn.CreateLaunch(ctx, input)
 
 	if err != nil {
 		return diag.Errorf("creating CloudWatch Evidently Launch (%s) for Project (%s): %s", name, project, err)
@@ -332,7 +333,7 @@ func resourceLaunchCreate(ctx context.Context, d *schema.ResourceData, meta inte
 
 	// the GetLaunch API call uses the Launch name and Project ARN
 	// concat Launch name and Project Name or ARN to be used in Read for imports
-	d.SetId(fmt.Sprintf("%s:%s", aws.StringValue(output.Launch.Name), aws.StringValue(output.Launch.Project)))
+	d.SetId(fmt.Sprintf("%s:%s", aws.ToString(output.Launch.Name), aws.ToString(output.Launch.Project)))
 
 	if _, err := waitLaunchCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
 		return diag.Errorf("waiting for CloudWatch Evidently Launch (%s) for Project (%s) creation: %s", name, project, err)
@@ -342,7 +343,7 @@ func resourceLaunchCreate(ctx context.Context, d *schema.ResourceData, meta inte
 }
 
 func resourceLaunchRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).EvidentlyConn(ctx)
+	conn := meta.(*conns.AWSClient).EvidentlyClient(ctx)
 
 	launchName, projectNameOrARN, err := LaunchParseID(d.Id())
 
@@ -379,9 +380,9 @@ func resourceLaunchRead(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	d.Set("arn", launch.Arn)
-	d.Set("created_time", aws.TimeValue(launch.CreatedTime).Format(time.RFC3339))
+	d.Set("created_time", aws.ToTime(launch.CreatedTime).Format(time.RFC3339))
 	d.Set("description", launch.Description)
-	d.Set("last_updated_time", aws.TimeValue(launch.LastUpdatedTime).Format(time.RFC3339))
+	d.Set("last_updated_time", aws.ToTime(launch.LastUpdatedTime).Format(time.RFC3339))
 	d.Set("name", launch.Name)
 	d.Set("project", launch.Project)
 	d.Set("randomization_salt", launch.RandomizationSalt)
@@ -395,13 +396,13 @@ func resourceLaunchRead(ctx context.Context, d *schema.ResourceData, meta interf
 }
 
 func resourceLaunchUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).EvidentlyConn(ctx)
+	conn := meta.(*conns.AWSClient).EvidentlyClient(ctx)
 
 	if d.HasChanges("description", "groups", "metric_monitors", "randomization_salt", "scheduled_splits_config") {
 		name := d.Get("name").(string)
 		project := d.Get("project").(string)
 
-		input := &cloudwatchevidently.UpdateLaunchInput{
+		input := &evidently.UpdateLaunchInput{
 			Description:           aws.String(d.Get("description").(string)),
 			Groups:                expandGroups(d.Get("groups").([]interface{})),
 			Launch:                aws.String(name),
@@ -411,7 +412,7 @@ func resourceLaunchUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			ScheduledSplitsConfig: expandScheduledSplitsConfig(d.Get("scheduled_splits_config").([]interface{})),
 		}
 
-		_, err := conn.UpdateLaunchWithContext(ctx, input)
+		_, err := conn.UpdateLaunch(ctx, input)
 
 		if err != nil {
 			return diag.Errorf("updating CloudWatch Evidently Launch (%s) for Project (%s): %s", name, project, err)
@@ -426,18 +427,18 @@ func resourceLaunchUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 }
 
 func resourceLaunchDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).EvidentlyConn(ctx)
+	conn := meta.(*conns.AWSClient).EvidentlyClient(ctx)
 
 	name := d.Get("name").(string)
 	project := d.Get("project").(string)
 
 	log.Printf("[DEBUG] Deleting CloudWatch Evidently Launch: %s", d.Id())
-	_, err := conn.DeleteLaunchWithContext(ctx, &cloudwatchevidently.DeleteLaunchInput{
+	_, err := conn.DeleteLaunch(ctx, &evidently.DeleteLaunchInput{
 		Launch:  aws.String(name),
 		Project: aws.String(project),
 	})
 
-	if tfawserr.ErrCodeEquals(err, cloudwatchevidently.ErrCodeResourceNotFoundException) {
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return nil
 	}
 
@@ -462,8 +463,8 @@ func LaunchParseID(id string) (string, string, error) {
 	return launchName, projectNameOrARN, nil
 }
 
-func expandGroups(tfMaps []interface{}) []*cloudwatchevidently.LaunchGroupConfig {
-	apiObjects := make([]*cloudwatchevidently.LaunchGroupConfig, 0, len(tfMaps))
+func expandGroups(tfMaps []interface{}) []awstypes.LaunchGroupConfig {
+	apiObjects := make([]awstypes.LaunchGroupConfig, 0, len(tfMaps))
 
 	for _, tfMap := range tfMaps {
 		apiObjects = append(apiObjects, expandGroup(tfMap.(map[string]interface{})))
@@ -472,8 +473,8 @@ func expandGroups(tfMaps []interface{}) []*cloudwatchevidently.LaunchGroupConfig
 	return apiObjects
 }
 
-func expandGroup(tfMap map[string]interface{}) *cloudwatchevidently.LaunchGroupConfig {
-	apiObject := &cloudwatchevidently.LaunchGroupConfig{
+func expandGroup(tfMap map[string]interface{}) awstypes.LaunchGroupConfig {
+	apiObject := awstypes.LaunchGroupConfig{
 		Feature:   aws.String(tfMap["feature"].(string)),
 		Name:      aws.String(tfMap["name"].(string)),
 		Variation: aws.String(tfMap["variation"].(string)),
@@ -486,8 +487,8 @@ func expandGroup(tfMap map[string]interface{}) *cloudwatchevidently.LaunchGroupC
 	return apiObject
 }
 
-func expandMetricMonitors(tfMaps []interface{}) []*cloudwatchevidently.MetricMonitorConfig {
-	apiObjects := make([]*cloudwatchevidently.MetricMonitorConfig, 0, len(tfMaps))
+func expandMetricMonitors(tfMaps []interface{}) []awstypes.MetricMonitorConfig {
+	apiObjects := make([]awstypes.MetricMonitorConfig, 0, len(tfMaps))
 
 	for _, tfMap := range tfMaps {
 		apiObjects = append(apiObjects, expandMetricMonitor(tfMap.(map[string]interface{})))
@@ -496,22 +497,22 @@ func expandMetricMonitors(tfMaps []interface{}) []*cloudwatchevidently.MetricMon
 	return apiObjects
 }
 
-func expandMetricMonitor(tfMap map[string]interface{}) *cloudwatchevidently.MetricMonitorConfig {
-	apiObject := &cloudwatchevidently.MetricMonitorConfig{
+func expandMetricMonitor(tfMap map[string]interface{}) awstypes.MetricMonitorConfig {
+	apiObject := awstypes.MetricMonitorConfig{
 		MetricDefinition: expandMetricDefinition(tfMap["metric_definition"].([]interface{})),
 	}
 
 	return apiObject
 }
 
-func expandMetricDefinition(tfList []interface{}) *cloudwatchevidently.MetricDefinitionConfig {
+func expandMetricDefinition(tfList []interface{}) *awstypes.MetricDefinitionConfig {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
 	tfMap := tfList[0].(map[string]interface{})
 
-	apiObject := &cloudwatchevidently.MetricDefinitionConfig{
+	apiObject := &awstypes.MetricDefinitionConfig{
 		EntityIdKey: aws.String(tfMap["entity_id_key"].(string)),
 		Name:        aws.String(tfMap["name"].(string)),
 		ValueKey:    aws.String(tfMap["value_key"].(string)),
@@ -528,22 +529,22 @@ func expandMetricDefinition(tfList []interface{}) *cloudwatchevidently.MetricDef
 	return apiObject
 }
 
-func expandScheduledSplitsConfig(tfList []interface{}) *cloudwatchevidently.ScheduledSplitsLaunchConfig {
+func expandScheduledSplitsConfig(tfList []interface{}) *awstypes.ScheduledSplitsLaunchConfig {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
 	tfMap := tfList[0].(map[string]interface{})
 
-	apiObject := &cloudwatchevidently.ScheduledSplitsLaunchConfig{
+	apiObject := &awstypes.ScheduledSplitsLaunchConfig{
 		Steps: expandSteps(tfMap["steps"].([]interface{})),
 	}
 
 	return apiObject
 }
 
-func expandSteps(tfMaps []interface{}) []*cloudwatchevidently.ScheduledSplitConfig {
-	apiObjects := make([]*cloudwatchevidently.ScheduledSplitConfig, 0, len(tfMaps))
+func expandSteps(tfMaps []interface{}) []awstypes.ScheduledSplitConfig {
+	apiObjects := make([]awstypes.ScheduledSplitConfig, 0, len(tfMaps))
 
 	for _, tfMap := range tfMaps {
 		apiObjects = append(apiObjects, expandStep(tfMap.(map[string]interface{})))
@@ -552,12 +553,12 @@ func expandSteps(tfMaps []interface{}) []*cloudwatchevidently.ScheduledSplitConf
 	return apiObjects
 }
 
-func expandStep(tfMap map[string]interface{}) *cloudwatchevidently.ScheduledSplitConfig {
+func expandStep(tfMap map[string]interface{}) awstypes.ScheduledSplitConfig {
 	t, _ := time.Parse(time.RFC3339, tfMap["start_time"].(string))
 	startTime := aws.Time(t)
 
-	apiObject := &cloudwatchevidently.ScheduledSplitConfig{
-		GroupWeights:     flex.ExpandInt64Map(tfMap["group_weights"].(map[string]interface{})),
+	apiObject := awstypes.ScheduledSplitConfig{
+		GroupWeights:     flex.ExpandInt64ValueMap(tfMap["group_weights"].(map[string]interface{})),
 		SegmentOverrides: expandSegmentOverrides(tfMap["segment_overrides"].([]interface{})),
 		StartTime:        startTime,
 	}
@@ -565,8 +566,8 @@ func expandStep(tfMap map[string]interface{}) *cloudwatchevidently.ScheduledSpli
 	return apiObject
 }
 
-func expandSegmentOverrides(tfMaps []interface{}) []*cloudwatchevidently.SegmentOverride {
-	apiObjects := make([]*cloudwatchevidently.SegmentOverride, 0, len(tfMaps))
+func expandSegmentOverrides(tfMaps []interface{}) []awstypes.SegmentOverride {
+	apiObjects := make([]awstypes.SegmentOverride, 0, len(tfMaps))
 
 	for _, tfMap := range tfMaps {
 		apiObjects = append(apiObjects, expandSegmentOverride(tfMap.(map[string]interface{})))
@@ -575,17 +576,17 @@ func expandSegmentOverrides(tfMaps []interface{}) []*cloudwatchevidently.Segment
 	return apiObjects
 }
 
-func expandSegmentOverride(tfMap map[string]interface{}) *cloudwatchevidently.SegmentOverride {
-	apiObject := &cloudwatchevidently.SegmentOverride{
+func expandSegmentOverride(tfMap map[string]interface{}) awstypes.SegmentOverride {
+	apiObject := awstypes.SegmentOverride{
 		EvaluationOrder: aws.Int64(int64(tfMap["evaluation_order"].(int))),
 		Segment:         aws.String(tfMap["segment"].(string)),
-		Weights:         flex.ExpandInt64Map(tfMap["weights"].(map[string]interface{})),
+		Weights:         flex.ExpandInt64ValueMap(tfMap["weights"].(map[string]interface{})),
 	}
 
 	return apiObject
 }
 
-func flattenExecution(apiObjects *cloudwatchevidently.LaunchExecution) []interface{} {
+func flattenExecution(apiObjects *awstypes.LaunchExecution) []interface{} {
 	if apiObjects == nil {
 		return nil
 	}
@@ -593,17 +594,17 @@ func flattenExecution(apiObjects *cloudwatchevidently.LaunchExecution) []interfa
 	values := map[string]interface{}{}
 
 	if apiObjects.EndedTime != nil {
-		values["ended_time"] = aws.TimeValue(apiObjects.EndedTime).Format(time.RFC3339)
+		values["ended_time"] = aws.ToTime(apiObjects.EndedTime).Format(time.RFC3339)
 	}
 
 	if apiObjects.StartedTime != nil {
-		values["started_time"] = aws.TimeValue(apiObjects.StartedTime).Format(time.RFC3339)
+		values["started_time"] = aws.ToTime(apiObjects.StartedTime).Format(time.RFC3339)
 	}
 
 	return []interface{}{values}
 }
 
-func flattenGroups(apiObjects []*cloudwatchevidently.LaunchGroup) []interface{} {
+func flattenGroups(apiObjects []awstypes.LaunchGroup) []interface{} {
 	if len(apiObjects) == 0 {
 		return nil
 	}
@@ -611,7 +612,7 @@ func flattenGroups(apiObjects []*cloudwatchevidently.LaunchGroup) []interface{} 
 	var tfList []interface{}
 
 	for _, apiObject := range apiObjects {
-		if apiObject == nil {
+		if apiObject.Name == nil {
 			continue
 		}
 
@@ -621,28 +622,28 @@ func flattenGroups(apiObjects []*cloudwatchevidently.LaunchGroup) []interface{} 
 	return tfList
 }
 
-func flattenGroup(apiObject *cloudwatchevidently.LaunchGroup) map[string]interface{} {
-	if apiObject == nil {
+func flattenGroup(apiObject awstypes.LaunchGroup) map[string]interface{} {
+	if apiObject.Name == nil {
 		return nil
 	}
 
 	tfMap := map[string]interface{}{
-		"name": aws.StringValue(apiObject.Name),
+		"name": aws.ToString(apiObject.Name),
 	}
 
 	for feature, variation := range apiObject.FeatureVariations {
 		tfMap["feature"] = feature
-		tfMap["variation"] = aws.StringValue(variation)
+		tfMap["variation"] = variation
 	}
 
 	if v := apiObject.Description; v != nil {
-		tfMap["description"] = aws.StringValue(v)
+		tfMap["description"] = aws.ToString(v)
 	}
 
 	return tfMap
 }
 
-func flattenMetricMonitors(apiObjects []*cloudwatchevidently.MetricMonitor) []interface{} {
+func flattenMetricMonitors(apiObjects []awstypes.MetricMonitor) []interface{} {
 	if len(apiObjects) == 0 {
 		return nil
 	}
@@ -650,7 +651,7 @@ func flattenMetricMonitors(apiObjects []*cloudwatchevidently.MetricMonitor) []in
 	var tfList []interface{}
 
 	for _, apiObject := range apiObjects {
-		if apiObject == nil {
+		if apiObject == (awstypes.MetricMonitor{}) {
 			continue
 		}
 
@@ -660,8 +661,8 @@ func flattenMetricMonitors(apiObjects []*cloudwatchevidently.MetricMonitor) []in
 	return tfList
 }
 
-func flattenMetricMonitor(apiObject *cloudwatchevidently.MetricMonitor) map[string]interface{} {
-	if apiObject == nil {
+func flattenMetricMonitor(apiObject awstypes.MetricMonitor) map[string]interface{} {
+	if apiObject == (awstypes.MetricMonitor{}) {
 		return nil
 	}
 
@@ -672,29 +673,29 @@ func flattenMetricMonitor(apiObject *cloudwatchevidently.MetricMonitor) map[stri
 	return tfMap
 }
 
-func flattenMetricMonitorDefinition(apiObject *cloudwatchevidently.MetricDefinition) []interface{} {
+func flattenMetricMonitorDefinition(apiObject *awstypes.MetricDefinition) []interface{} {
 	if apiObject == nil {
 		return nil
 	}
 
 	tfMap := map[string]interface{}{
-		"entity_id_key": aws.StringValue(apiObject.EntityIdKey),
-		"name":          aws.StringValue(apiObject.Name),
-		"value_key":     aws.StringValue(apiObject.ValueKey),
+		"entity_id_key": aws.ToString(apiObject.EntityIdKey),
+		"name":          aws.ToString(apiObject.Name),
+		"value_key":     aws.ToString(apiObject.ValueKey),
 	}
 
 	if v := apiObject.EventPattern; v != nil {
-		tfMap["event_pattern"] = aws.StringValue(v)
+		tfMap["event_pattern"] = aws.ToString(v)
 	}
 
 	if v := apiObject.UnitLabel; v != nil {
-		tfMap["unit_label"] = aws.StringValue(v)
+		tfMap["unit_label"] = aws.ToString(v)
 	}
 
 	return []interface{}{tfMap}
 }
 
-func flattenScheduledSplitsDefinition(apiObject *cloudwatchevidently.ScheduledSplitsLaunchDefinition) []interface{} {
+func flattenScheduledSplitsDefinition(apiObject *awstypes.ScheduledSplitsLaunchDefinition) []interface{} {
 	if apiObject == nil {
 		return nil
 	}
@@ -706,7 +707,7 @@ func flattenScheduledSplitsDefinition(apiObject *cloudwatchevidently.ScheduledSp
 	return []interface{}{tfMap}
 }
 
-func flattenSteps(apiObjects []*cloudwatchevidently.ScheduledSplit) []interface{} {
+func flattenSteps(apiObjects []awstypes.ScheduledSplit) []interface{} {
 	if len(apiObjects) == 0 {
 		return nil
 	}
@@ -714,7 +715,7 @@ func flattenSteps(apiObjects []*cloudwatchevidently.ScheduledSplit) []interface{
 	var tfList []interface{}
 
 	for _, apiObject := range apiObjects {
-		if apiObject == nil {
+		if apiObject.StartTime == nil {
 			continue
 		}
 
@@ -724,14 +725,14 @@ func flattenSteps(apiObjects []*cloudwatchevidently.ScheduledSplit) []interface{
 	return tfList
 }
 
-func flattenStep(apiObject *cloudwatchevidently.ScheduledSplit) map[string]interface{} {
-	if apiObject == nil {
+func flattenStep(apiObject awstypes.ScheduledSplit) map[string]interface{} {
+	if apiObject.StartTime == nil {
 		return nil
 	}
 
 	tfMap := map[string]interface{}{
-		"group_weights": aws.Int64ValueMap(apiObject.GroupWeights),
-		"start_time":    aws.TimeValue(apiObject.StartTime).Format(time.RFC3339),
+		"group_weights": apiObject.GroupWeights,
+		"start_time":    aws.ToTime(apiObject.StartTime).Format(time.RFC3339),
 	}
 
 	if v := apiObject.SegmentOverrides; v != nil {
@@ -741,7 +742,7 @@ func flattenStep(apiObject *cloudwatchevidently.ScheduledSplit) map[string]inter
 	return tfMap
 }
 
-func flattenSegmentOverrides(apiObjects []*cloudwatchevidently.SegmentOverride) []interface{} {
+func flattenSegmentOverrides(apiObjects []awstypes.SegmentOverride) []interface{} {
 	if len(apiObjects) == 0 {
 		return nil
 	}
@@ -749,7 +750,7 @@ func flattenSegmentOverrides(apiObjects []*cloudwatchevidently.SegmentOverride) 
 	var tfList []interface{}
 
 	for _, apiObject := range apiObjects {
-		if apiObject == nil {
+		if apiObject.EvaluationOrder == nil {
 			continue
 		}
 
@@ -759,15 +760,15 @@ func flattenSegmentOverrides(apiObjects []*cloudwatchevidently.SegmentOverride) 
 	return tfList
 }
 
-func flattenSegmentOverride(apiObject *cloudwatchevidently.SegmentOverride) map[string]interface{} {
-	if apiObject == nil {
+func flattenSegmentOverride(apiObject awstypes.SegmentOverride) map[string]interface{} {
+	if apiObject.EvaluationOrder == nil {
 		return nil
 	}
 
 	tfMap := map[string]interface{}{
-		"evaluation_order": aws.Int64Value(apiObject.EvaluationOrder),
-		"segment":          aws.StringValue(apiObject.Segment),
-		"weights":          aws.Int64ValueMap(apiObject.Weights),
+		"evaluation_order": aws.ToInt64(apiObject.EvaluationOrder),
+		"segment":          aws.ToString(apiObject.Segment),
+		"weights":          apiObject.Weights,
 	}
 
 	return tfMap

--- a/internal/service/evidently/launch_test.go
+++ b/internal/service/evidently/launch_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/service/cloudwatchevidently"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/evidently/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -17,11 +17,12 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfcloudwatchevidently "github.com/hashicorp/terraform-provider-aws/internal/service/evidently"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccEvidentlyLaunch_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	var launch cloudwatchevidently.Launch
+	var launch awstypes.Launch
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -32,9 +33,9 @@ func TestAccEvidentlyLaunch_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, cloudwatchevidently.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.EvidentlyEndpointID)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.EvidentlyEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckLaunchDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -60,8 +61,8 @@ func TestAccEvidentlyLaunch_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.group_weights.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.group_weights.Variation1", "0"),
 					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.start_time", startTime),
-					resource.TestCheckResourceAttr(resourceName, "status", cloudwatchevidently.LaunchStatusCreated),
-					resource.TestCheckResourceAttr(resourceName, "type", cloudwatchevidently.LaunchTypeAwsEvidentlySplits),
+					resource.TestCheckResourceAttr(resourceName, "status", string(awstypes.LaunchStatusCreated)),
+					resource.TestCheckResourceAttr(resourceName, "type", string(awstypes.LaunchTypeScheduledSplitsLaunch)),
 				),
 			},
 			{
@@ -75,7 +76,7 @@ func TestAccEvidentlyLaunch_basic(t *testing.T) {
 
 func TestAccEvidentlyLaunch_updateDescription(t *testing.T) {
 	ctx := acctest.Context(t)
-	var launch cloudwatchevidently.Launch
+	var launch awstypes.Launch
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -88,9 +89,9 @@ func TestAccEvidentlyLaunch_updateDescription(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, cloudwatchevidently.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.EvidentlyEndpointID)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.EvidentlyEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckLaunchDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -119,7 +120,7 @@ func TestAccEvidentlyLaunch_updateDescription(t *testing.T) {
 
 func TestAccEvidentlyLaunch_updateGroups(t *testing.T) {
 	ctx := acctest.Context(t)
-	var launch cloudwatchevidently.Launch
+	var launch awstypes.Launch
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -132,9 +133,9 @@ func TestAccEvidentlyLaunch_updateGroups(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, cloudwatchevidently.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.EvidentlyEndpointID)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.EvidentlyEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckLaunchDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -203,7 +204,7 @@ func TestAccEvidentlyLaunch_updateGroups(t *testing.T) {
 
 func TestAccEvidentlyLaunch_updateMetricMonitors(t *testing.T) {
 	ctx := acctest.Context(t)
-	var launch cloudwatchevidently.Launch
+	var launch awstypes.Launch
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -214,9 +215,9 @@ func TestAccEvidentlyLaunch_updateMetricMonitors(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, cloudwatchevidently.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.EvidentlyEndpointID)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.EvidentlyEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckLaunchDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -293,7 +294,7 @@ func TestAccEvidentlyLaunch_updateMetricMonitors(t *testing.T) {
 
 func TestAccEvidentlyLaunch_updateRandomizationSalt(t *testing.T) {
 	ctx := acctest.Context(t)
-	var launch cloudwatchevidently.Launch
+	var launch awstypes.Launch
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -306,9 +307,9 @@ func TestAccEvidentlyLaunch_updateRandomizationSalt(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, cloudwatchevidently.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.EvidentlyEndpointID)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.EvidentlyEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckLaunchDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -337,7 +338,7 @@ func TestAccEvidentlyLaunch_updateRandomizationSalt(t *testing.T) {
 
 func TestAccEvidentlyLaunch_scheduledSplitsConfig_updateSteps(t *testing.T) {
 	ctx := acctest.Context(t)
-	var launch cloudwatchevidently.Launch
+	var launch awstypes.Launch
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -352,9 +353,9 @@ func TestAccEvidentlyLaunch_scheduledSplitsConfig_updateSteps(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, cloudwatchevidently.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.EvidentlyEndpointID)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.EvidentlyEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckLaunchDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -427,7 +428,7 @@ func TestAccEvidentlyLaunch_scheduledSplitsConfig_updateSteps(t *testing.T) {
 
 func TestAccEvidentlyLaunch_scheduledSplitsConfig_steps_updateSegmentOverrides(t *testing.T) {
 	ctx := acctest.Context(t)
-	var launch cloudwatchevidently.Launch
+	var launch awstypes.Launch
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -441,9 +442,9 @@ func TestAccEvidentlyLaunch_scheduledSplitsConfig_steps_updateSegmentOverrides(t
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, cloudwatchevidently.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.EvidentlyEndpointID)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.EvidentlyEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckLaunchDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -537,7 +538,7 @@ func TestAccEvidentlyLaunch_scheduledSplitsConfig_steps_updateSegmentOverrides(t
 
 func TestAccEvidentlyLaunch_tags(t *testing.T) {
 	ctx := acctest.Context(t)
-	var launch cloudwatchevidently.Launch
+	var launch awstypes.Launch
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -548,9 +549,9 @@ func TestAccEvidentlyLaunch_tags(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, cloudwatchevidently.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.EvidentlyEndpointID)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.EvidentlyEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckLaunchDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -590,7 +591,7 @@ func TestAccEvidentlyLaunch_tags(t *testing.T) {
 
 func TestAccEvidentlyLaunch_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	var launch cloudwatchevidently.Launch
+	var launch awstypes.Launch
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -600,7 +601,7 @@ func TestAccEvidentlyLaunch_disappears(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.EvidentlyEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckLaunchDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -618,7 +619,7 @@ func TestAccEvidentlyLaunch_disappears(t *testing.T) {
 
 func testAccCheckLaunchDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).EvidentlyConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).EvidentlyClient(ctx)
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_evidently_launch" {
 				continue
@@ -647,7 +648,7 @@ func testAccCheckLaunchDestroy(ctx context.Context) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckLaunchExists(ctx context.Context, n string, v *cloudwatchevidently.Launch) resource.TestCheckFunc {
+func testAccCheckLaunchExists(ctx context.Context, n string, v *awstypes.Launch) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 
@@ -665,7 +666,7 @@ func testAccCheckLaunchExists(ctx context.Context, n string, v *cloudwatcheviden
 			return err
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).EvidentlyConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).EvidentlyClient(ctx)
 
 		output, err := tfcloudwatchevidently.FindLaunchWithProjectNameorARN(ctx, conn, launchName, projectNameOrARN)
 

--- a/internal/service/evidently/project.go
+++ b/internal/service/evidently/project.go
@@ -9,13 +9,14 @@ import (
 	"time"
 
 	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/cloudwatchevidently"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/evidently"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/evidently/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -158,10 +159,10 @@ func ResourceProject() *schema.Resource {
 }
 
 func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).EvidentlyConn(ctx)
+	conn := meta.(*conns.AWSClient).EvidentlyClient(ctx)
 
 	name := d.Get("name").(string)
-	input := &cloudwatchevidently.CreateProjectInput{
+	input := &evidently.CreateProjectInput{
 		Name: aws.String(name),
 		Tags: getTagsIn(ctx),
 	}
@@ -174,13 +175,13 @@ func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, meta int
 		input.DataDelivery = expandDataDelivery(v.([]interface{}))
 	}
 
-	output, err := conn.CreateProjectWithContext(ctx, input)
+	output, err := conn.CreateProject(ctx, input)
 
 	if err != nil {
 		return diag.Errorf("creating CloudWatch Evidently Project (%s): %s", name, err)
 	}
 
-	d.SetId(aws.StringValue(output.Project.Name))
+	d.SetId(aws.ToString(output.Project.Name))
 
 	if _, err := waitProjectCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
 		return diag.Errorf("waiting for CloudWatch Evidently Project (%s) creation: %s", d.Id(), err)
@@ -190,7 +191,7 @@ func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, meta int
 }
 
 func resourceProjectRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).EvidentlyConn(ctx)
+	conn := meta.(*conns.AWSClient).EvidentlyClient(ctx)
 
 	project, err := FindProjectByNameOrARN(ctx, conn, d.Id())
 
@@ -211,11 +212,11 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set("active_experiment_count", project.ActiveExperimentCount)
 	d.Set("active_launch_count", project.ActiveLaunchCount)
 	d.Set("arn", project.Arn)
-	d.Set("created_time", aws.TimeValue(project.CreatedTime).Format(time.RFC3339))
+	d.Set("created_time", aws.ToTime(project.CreatedTime).Format(time.RFC3339))
 	d.Set("description", project.Description)
 	d.Set("experiment_count", project.ExperimentCount)
 	d.Set("feature_count", project.FeatureCount)
-	d.Set("last_updated_time", aws.TimeValue(project.LastUpdatedTime).Format(time.RFC3339))
+	d.Set("last_updated_time", aws.ToTime(project.LastUpdatedTime).Format(time.RFC3339))
 	d.Set("launch_count", project.LaunchCount)
 	d.Set("name", project.Name)
 	d.Set("status", project.Status)
@@ -226,14 +227,14 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, meta inter
 }
 
 func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).EvidentlyConn(ctx)
+	conn := meta.(*conns.AWSClient).EvidentlyClient(ctx)
 
 	// Project has 2 update APIs
 	// UpdateProjectWithContext: Updates the description of an existing project.
 	// UpdateProjectDataDeliveryWithContext: Updates the data storage options for this project.
 
 	if d.HasChanges("description") {
-		_, err := conn.UpdateProjectWithContext(ctx, &cloudwatchevidently.UpdateProjectInput{
+		_, err := conn.UpdateProject(ctx, &evidently.UpdateProjectInput{
 			Description: aws.String(d.Get("description").(string)),
 			Project:     aws.String(d.Id()),
 		})
@@ -248,7 +249,7 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	if d.HasChange("data_delivery") {
-		input := &cloudwatchevidently.UpdateProjectDataDeliveryInput{
+		input := &evidently.UpdateProjectDataDeliveryInput{
 			Project: aws.String(d.Id()),
 		}
 
@@ -269,7 +270,7 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, meta int
 			input.S3Destination = expandS3Destination(v.([]interface{}))
 		}
 
-		_, err := conn.UpdateProjectDataDeliveryWithContext(ctx, input)
+		_, err := conn.UpdateProjectDataDelivery(ctx, input)
 
 		if err != nil {
 			return diag.Errorf("updating CloudWatch Evidently Project (%s) data delivery: %s", d.Id(), err)
@@ -284,14 +285,14 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, meta int
 }
 
 func resourceProjectDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).EvidentlyConn(ctx)
+	conn := meta.(*conns.AWSClient).EvidentlyClient(ctx)
 
 	log.Printf("[DEBUG] Deleting CloudWatch Evidently Project: %s", d.Id())
-	_, err := conn.DeleteProjectWithContext(ctx, &cloudwatchevidently.DeleteProjectInput{
+	_, err := conn.DeleteProject(ctx, &evidently.DeleteProjectInput{
 		Project: aws.String(d.Id()),
 	})
 
-	if tfawserr.ErrCodeEquals(err, cloudwatchevidently.ErrCodeResourceNotFoundException) {
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return nil
 	}
 
@@ -306,7 +307,7 @@ func resourceProjectDelete(ctx context.Context, d *schema.ResourceData, meta int
 	return nil
 }
 
-func expandDataDelivery(dataDelivery []interface{}) *cloudwatchevidently.ProjectDataDeliveryConfig {
+func expandDataDelivery(dataDelivery []interface{}) *awstypes.ProjectDataDeliveryConfig {
 	if len(dataDelivery) == 0 || dataDelivery[0] == nil {
 		return nil
 	}
@@ -316,7 +317,7 @@ func expandDataDelivery(dataDelivery []interface{}) *cloudwatchevidently.Project
 		return nil
 	}
 
-	result := &cloudwatchevidently.ProjectDataDeliveryConfig{}
+	result := &awstypes.ProjectDataDeliveryConfig{}
 
 	if v, ok := tfMap["cloudwatch_logs"]; ok && len(v.([]interface{})) > 0 {
 		result.CloudWatchLogs = expandCloudWatchLogs(v.([]interface{}))
@@ -329,7 +330,7 @@ func expandDataDelivery(dataDelivery []interface{}) *cloudwatchevidently.Project
 	return result
 }
 
-func expandCloudWatchLogs(cloudWatchLogs []interface{}) *cloudwatchevidently.CloudWatchLogsDestinationConfig {
+func expandCloudWatchLogs(cloudWatchLogs []interface{}) *awstypes.CloudWatchLogsDestinationConfig {
 	if len(cloudWatchLogs) == 0 || cloudWatchLogs[0] == nil {
 		return nil
 	}
@@ -339,7 +340,7 @@ func expandCloudWatchLogs(cloudWatchLogs []interface{}) *cloudwatchevidently.Clo
 		return nil
 	}
 
-	result := &cloudwatchevidently.CloudWatchLogsDestinationConfig{}
+	result := &awstypes.CloudWatchLogsDestinationConfig{}
 
 	if v, ok := tfMap["log_group"].(string); ok && v != "" {
 		result.LogGroup = aws.String(v)
@@ -348,7 +349,7 @@ func expandCloudWatchLogs(cloudWatchLogs []interface{}) *cloudwatchevidently.Clo
 	return result
 }
 
-func expandS3Destination(s3Destination []interface{}) *cloudwatchevidently.S3DestinationConfig {
+func expandS3Destination(s3Destination []interface{}) *awstypes.S3DestinationConfig {
 	if len(s3Destination) == 0 || s3Destination[0] == nil {
 		return nil
 	}
@@ -358,7 +359,7 @@ func expandS3Destination(s3Destination []interface{}) *cloudwatchevidently.S3Des
 		return nil
 	}
 
-	result := &cloudwatchevidently.S3DestinationConfig{}
+	result := &awstypes.S3DestinationConfig{}
 
 	if v, ok := tfMap["bucket"].(string); ok && v != "" {
 		result.Bucket = aws.String(v)
@@ -371,7 +372,7 @@ func expandS3Destination(s3Destination []interface{}) *cloudwatchevidently.S3Des
 	return result
 }
 
-func flattenDataDelivery(dataDelivery *cloudwatchevidently.ProjectDataDelivery) []interface{} {
+func flattenDataDelivery(dataDelivery *awstypes.ProjectDataDelivery) []interface{} {
 	if dataDelivery == nil {
 		return []interface{}{}
 	}
@@ -389,7 +390,7 @@ func flattenDataDelivery(dataDelivery *cloudwatchevidently.ProjectDataDelivery) 
 	return []interface{}{values}
 }
 
-func flattenCloudWatchLogs(cloudWatchLogs *cloudwatchevidently.CloudWatchLogsDestination) []interface{} {
+func flattenCloudWatchLogs(cloudWatchLogs *awstypes.CloudWatchLogsDestination) []interface{} {
 	if cloudWatchLogs == nil || cloudWatchLogs.LogGroup == nil {
 		return []interface{}{}
 	}
@@ -397,13 +398,13 @@ func flattenCloudWatchLogs(cloudWatchLogs *cloudwatchevidently.CloudWatchLogsDes
 	values := map[string]interface{}{}
 
 	if cloudWatchLogs.LogGroup != nil {
-		values["log_group"] = aws.StringValue(cloudWatchLogs.LogGroup)
+		values["log_group"] = aws.ToString(cloudWatchLogs.LogGroup)
 	}
 
 	return []interface{}{values}
 }
 
-func flattenS3Destination(s3Destination *cloudwatchevidently.S3Destination) []interface{} {
+func flattenS3Destination(s3Destination *awstypes.S3Destination) []interface{} {
 	if s3Destination == nil || s3Destination.Bucket == nil {
 		return []interface{}{}
 	}
@@ -411,11 +412,11 @@ func flattenS3Destination(s3Destination *cloudwatchevidently.S3Destination) []in
 	values := map[string]interface{}{}
 
 	if s3Destination.Bucket != nil {
-		values["bucket"] = aws.StringValue(s3Destination.Bucket)
+		values["bucket"] = aws.ToString(s3Destination.Bucket)
 	}
 
 	if s3Destination.Prefix != nil {
-		values["prefix"] = aws.StringValue(s3Destination.Prefix)
+		values["prefix"] = aws.ToString(s3Destination.Prefix)
 	}
 
 	return []interface{}{values}

--- a/internal/service/evidently/project_test.go
+++ b/internal/service/evidently/project_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/cloudwatchevidently"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/evidently/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -16,11 +16,12 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfcloudwatchevidently "github.com/hashicorp/terraform-provider-aws/internal/service/evidently"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccEvidentlyProject_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	var project cloudwatchevidently.Project
+	var project awstypes.Project
 
 	rName := sdkacctest.RandomWithPrefix("resource-test-terraform")
 	originalDescription := "original description"
@@ -30,9 +31,9 @@ func TestAccEvidentlyProject_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, cloudwatchevidently.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.EvidentlyEndpointID)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.EvidentlyEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckProjectDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -50,7 +51,7 @@ func TestAccEvidentlyProject_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "last_updated_time"),
 					resource.TestCheckResourceAttrSet(resourceName, "launch_count"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "status", cloudwatchevidently.ProjectStatusAvailable),
+					resource.TestCheckResourceAttr(resourceName, "status", string(awstypes.ProjectStatusAvailable)),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "Test Project"),
 				),
@@ -84,7 +85,7 @@ func TestAccEvidentlyProject_basic(t *testing.T) {
 
 func TestAccEvidentlyProject_tags(t *testing.T) {
 	ctx := acctest.Context(t)
-	var project cloudwatchevidently.Project
+	var project awstypes.Project
 
 	rName := sdkacctest.RandomWithPrefix("resource-test-terraform")
 	description := "example description"
@@ -93,9 +94,9 @@ func TestAccEvidentlyProject_tags(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, cloudwatchevidently.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.EvidentlyEndpointID)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.EvidentlyEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckProjectDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -142,7 +143,7 @@ func TestAccEvidentlyProject_tags(t *testing.T) {
 
 func TestAccEvidentlyProject_updateDataDeliveryCloudWatchLogGroup(t *testing.T) {
 	ctx := acctest.Context(t)
-	var project cloudwatchevidently.Project
+	var project awstypes.Project
 
 	rName := sdkacctest.RandomWithPrefix("tf-test-bucket")
 	rName2 := sdkacctest.RandomWithPrefix("tf-test-bucket")
@@ -154,9 +155,9 @@ func TestAccEvidentlyProject_updateDataDeliveryCloudWatchLogGroup(t *testing.T) 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, cloudwatchevidently.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.EvidentlyEndpointID)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.EvidentlyEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckProjectDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -187,7 +188,7 @@ func TestAccEvidentlyProject_updateDataDeliveryCloudWatchLogGroup(t *testing.T) 
 
 func TestAccEvidentlyProject_updateDataDeliveryS3Bucket(t *testing.T) {
 	ctx := acctest.Context(t)
-	var project cloudwatchevidently.Project
+	var project awstypes.Project
 
 	rName := sdkacctest.RandomWithPrefix("tf-test-bucket")
 	rName2 := sdkacctest.RandomWithPrefix("tf-test-bucket")
@@ -200,9 +201,9 @@ func TestAccEvidentlyProject_updateDataDeliveryS3Bucket(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, cloudwatchevidently.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.EvidentlyEndpointID)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.EvidentlyEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckProjectDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -237,7 +238,7 @@ func TestAccEvidentlyProject_updateDataDeliveryS3Bucket(t *testing.T) {
 
 func TestAccEvidentlyProject_updateDataDeliveryS3Prefix(t *testing.T) {
 	ctx := acctest.Context(t)
-	var project cloudwatchevidently.Project
+	var project awstypes.Project
 
 	rName := sdkacctest.RandomWithPrefix("tf-test-bucket")
 	rName2 := sdkacctest.RandomWithPrefix("tf-test-bucket")
@@ -251,9 +252,9 @@ func TestAccEvidentlyProject_updateDataDeliveryS3Prefix(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, cloudwatchevidently.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.EvidentlyEndpointID)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.EvidentlyEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckProjectDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -288,7 +289,7 @@ func TestAccEvidentlyProject_updateDataDeliveryS3Prefix(t *testing.T) {
 
 func TestAccEvidentlyProject_updateDataDeliveryCloudWatchToS3(t *testing.T) {
 	ctx := acctest.Context(t)
-	var project cloudwatchevidently.Project
+	var project awstypes.Project
 
 	rName := sdkacctest.RandomWithPrefix("tf-test-bucket")
 	rName2 := sdkacctest.RandomWithPrefix("tf-test-bucket")
@@ -301,9 +302,9 @@ func TestAccEvidentlyProject_updateDataDeliveryCloudWatchToS3(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, cloudwatchevidently.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.EvidentlyEndpointID)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.EvidentlyEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckProjectDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -336,7 +337,7 @@ func TestAccEvidentlyProject_updateDataDeliveryCloudWatchToS3(t *testing.T) {
 
 func TestAccEvidentlyProject_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	var project cloudwatchevidently.Project
+	var project awstypes.Project
 
 	rName := sdkacctest.RandomWithPrefix("resource-test-terraform")
 	description := "disappears"
@@ -344,7 +345,7 @@ func TestAccEvidentlyProject_disappears(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.EvidentlyEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckProjectDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -362,7 +363,7 @@ func TestAccEvidentlyProject_disappears(t *testing.T) {
 
 func testAccCheckProjectDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).EvidentlyConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).EvidentlyClient(ctx)
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_evidently_project" {
 				continue
@@ -385,7 +386,7 @@ func testAccCheckProjectDestroy(ctx context.Context) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckProjectExists(ctx context.Context, n string, v *cloudwatchevidently.Project) resource.TestCheckFunc {
+func testAccCheckProjectExists(ctx context.Context, n string, v *awstypes.Project) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 
@@ -397,7 +398,7 @@ func testAccCheckProjectExists(ctx context.Context, n string, v *cloudwatchevide
 			return fmt.Errorf("No CloudWatch Evidently Project ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).EvidentlyConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).EvidentlyClient(ctx)
 
 		output, err := tfcloudwatchevidently.FindProjectByNameOrARN(ctx, conn, rs.Primary.ID)
 

--- a/internal/service/evidently/segment.go
+++ b/internal/service/evidently/segment.go
@@ -9,14 +9,15 @@ import (
 	"time"
 
 	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/cloudwatchevidently"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/evidently"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/evidently/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -95,10 +96,10 @@ func ResourceSegment() *schema.Resource {
 }
 
 func resourceSegmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).EvidentlyConn(ctx)
+	conn := meta.(*conns.AWSClient).EvidentlyClient(ctx)
 
 	name := d.Get("name").(string)
-	input := &cloudwatchevidently.CreateSegmentInput{
+	input := &evidently.CreateSegmentInput{
 		Name:    aws.String(name),
 		Pattern: aws.String(d.Get("pattern").(string)),
 		Tags:    getTagsIn(ctx),
@@ -108,19 +109,19 @@ func resourceSegmentCreate(ctx context.Context, d *schema.ResourceData, meta int
 		input.Description = aws.String(v.(string))
 	}
 
-	output, err := conn.CreateSegmentWithContext(ctx, input)
+	output, err := conn.CreateSegment(ctx, input)
 
 	if err != nil {
 		return diag.Errorf("creating CloudWatch Evidently Segment (%s): %s", name, err)
 	}
 
-	d.SetId(aws.StringValue(output.Segment.Arn))
+	d.SetId(aws.ToString(output.Segment.Arn))
 
 	return resourceSegmentRead(ctx, d, meta)
 }
 
 func resourceSegmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).EvidentlyConn(ctx)
+	conn := meta.(*conns.AWSClient).EvidentlyClient(ctx)
 
 	segment, err := FindSegmentByNameOrARN(ctx, conn, d.Id())
 
@@ -135,10 +136,10 @@ func resourceSegmentRead(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	d.Set("arn", segment.Arn)
-	d.Set("created_time", aws.TimeValue(segment.CreatedTime).Format(time.RFC3339))
+	d.Set("created_time", aws.ToTime(segment.CreatedTime).Format(time.RFC3339))
 	d.Set("description", segment.Description)
 	d.Set("experiment_count", segment.ExperimentCount)
-	d.Set("last_updated_time", aws.TimeValue(segment.LastUpdatedTime).Format(time.RFC3339))
+	d.Set("last_updated_time", aws.ToTime(segment.LastUpdatedTime).Format(time.RFC3339))
 	d.Set("launch_count", segment.LaunchCount)
 	d.Set("name", segment.Name)
 	d.Set("pattern", segment.Pattern)
@@ -154,14 +155,14 @@ func resourceSegmentUpdate(ctx context.Context, d *schema.ResourceData, meta int
 }
 
 func resourceSegmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).EvidentlyConn(ctx)
+	conn := meta.(*conns.AWSClient).EvidentlyClient(ctx)
 
 	log.Printf("[DEBUG] Deleting CloudWatch Evidently Segment: %s", d.Id())
-	_, err := conn.DeleteSegmentWithContext(ctx, &cloudwatchevidently.DeleteSegmentInput{
+	_, err := conn.DeleteSegment(ctx, &evidently.DeleteSegmentInput{
 		Segment: aws.String(d.Id()),
 	})
 
-	if tfawserr.ErrCodeEquals(err, cloudwatchevidently.ErrCodeResourceNotFoundException) {
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return nil
 	}
 

--- a/internal/service/evidently/segment_test.go
+++ b/internal/service/evidently/segment_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/cloudwatchevidently"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/evidently/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -16,11 +16,12 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfcloudwatchevidently "github.com/hashicorp/terraform-provider-aws/internal/service/evidently"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccEvidentlySegment_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	var segment cloudwatchevidently.Segment
+	var segment awstypes.Segment
 
 	rName := sdkacctest.RandomWithPrefix("resource-test-terraform")
 	resourceName := "aws_evidently_segment.test"
@@ -29,9 +30,9 @@ func TestAccEvidentlySegment_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, cloudwatchevidently.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.EvidentlyEndpointID)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.EvidentlyEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckSegmentDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -60,7 +61,7 @@ func TestAccEvidentlySegment_basic(t *testing.T) {
 
 func TestAccEvidentlySegment_description(t *testing.T) {
 	ctx := acctest.Context(t)
-	var segment cloudwatchevidently.Segment
+	var segment awstypes.Segment
 
 	rName := sdkacctest.RandomWithPrefix("resource-test-terraform")
 	description := "example description"
@@ -69,9 +70,9 @@ func TestAccEvidentlySegment_description(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, cloudwatchevidently.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.EvidentlyEndpointID)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.EvidentlyEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckSegmentDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -93,7 +94,7 @@ func TestAccEvidentlySegment_description(t *testing.T) {
 
 func TestAccEvidentlySegment_patternJSON(t *testing.T) {
 	ctx := acctest.Context(t)
-	var segment cloudwatchevidently.Segment
+	var segment awstypes.Segment
 
 	rName := sdkacctest.RandomWithPrefix("resource-test-terraform")
 	resourceName := "aws_evidently_segment.test"
@@ -102,9 +103,9 @@ func TestAccEvidentlySegment_patternJSON(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, cloudwatchevidently.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.EvidentlyEndpointID)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.EvidentlyEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckSegmentDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -126,7 +127,7 @@ func TestAccEvidentlySegment_patternJSON(t *testing.T) {
 
 func TestAccEvidentlySegment_tags(t *testing.T) {
 	ctx := acctest.Context(t)
-	var segment cloudwatchevidently.Segment
+	var segment awstypes.Segment
 
 	rName := sdkacctest.RandomWithPrefix("resource-test-terraform")
 	resourceName := "aws_evidently_segment.test"
@@ -134,9 +135,9 @@ func TestAccEvidentlySegment_tags(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, cloudwatchevidently.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.EvidentlyEndpointID)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.EvidentlyEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckSegmentDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -181,7 +182,7 @@ func TestAccEvidentlySegment_tags(t *testing.T) {
 
 func TestAccEvidentlySegment_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	var segment cloudwatchevidently.Segment
+	var segment awstypes.Segment
 
 	rName := sdkacctest.RandomWithPrefix("resource-test-terraform")
 	pattern := "{\"Price\":[{\"numeric\":[\">\",10,\"<=\",20]}]}"
@@ -189,7 +190,7 @@ func TestAccEvidentlySegment_disappears(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.EvidentlyEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckSegmentDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -207,7 +208,7 @@ func TestAccEvidentlySegment_disappears(t *testing.T) {
 
 func testAccCheckSegmentDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).EvidentlyConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).EvidentlyClient(ctx)
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_evidently_segment" {
 				continue
@@ -230,7 +231,7 @@ func testAccCheckSegmentDestroy(ctx context.Context) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckSegmentExists(ctx context.Context, n string, v *cloudwatchevidently.Segment) resource.TestCheckFunc {
+func testAccCheckSegmentExists(ctx context.Context, n string, v *awstypes.Segment) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 
@@ -242,7 +243,7 @@ func testAccCheckSegmentExists(ctx context.Context, n string, v *cloudwatchevide
 			return fmt.Errorf("No CloudWatch Evidently Segment ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).EvidentlyConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).EvidentlyClient(ctx)
 
 		output, err := tfcloudwatchevidently.FindSegmentByNameOrARN(ctx, conn, rs.Primary.ID)
 

--- a/internal/service/evidently/service_package_gen.go
+++ b/internal/service/evidently/service_package_gen.go
@@ -5,9 +5,8 @@ package evidently
 import (
 	"context"
 
-	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
-	session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
-	cloudwatchevidently_sdkv1 "github.com/aws/aws-sdk-go/service/cloudwatchevidently"
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	evidently_sdkv2 "github.com/aws/aws-sdk-go-v2/service/evidently"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -68,11 +67,15 @@ func (p *servicePackage) ServicePackageName() string {
 	return names.Evidently
 }
 
-// NewConn returns a new AWS SDK for Go v1 client for this service package's AWS API.
-func (p *servicePackage) NewConn(ctx context.Context, config map[string]any) (*cloudwatchevidently_sdkv1.CloudWatchEvidently, error) {
-	sess := config["session"].(*session_sdkv1.Session)
+// NewClient returns a new AWS SDK for Go v2 client for this service package's AWS API.
+func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (*evidently_sdkv2.Client, error) {
+	cfg := *(config["aws_sdkv2_config"].(*aws_sdkv2.Config))
 
-	return cloudwatchevidently_sdkv1.New(sess.Copy(&aws_sdkv1.Config{Endpoint: aws_sdkv1.String(config["endpoint"].(string))})), nil
+	return evidently_sdkv2.NewFromConfig(cfg, func(o *evidently_sdkv2.Options) {
+		if endpoint := config["endpoint"].(string); endpoint != "" {
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
+		}
+	}), nil
 }
 
 func ServicePackage(ctx context.Context) conns.ServicePackage {

--- a/internal/service/evidently/status.go
+++ b/internal/service/evidently/status.go
@@ -6,8 +6,8 @@ package evidently
 import (
 	"context"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/evidently"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatchevidently"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -35,7 +35,7 @@ func statusFeature(ctx context.Context, conn *evidently.Client, id string) retry
 	}
 }
 
-func statusLaunch(ctx context.Context, conn *cloudwatchevidently.CloudWatchEvidently, id string) retry.StateRefreshFunc {
+func statusLaunch(ctx context.Context, conn *evidently.Client, id string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		launchName, projectNameOrARN, err := LaunchParseID(id)
 
@@ -53,7 +53,7 @@ func statusLaunch(ctx context.Context, conn *cloudwatchevidently.CloudWatchEvide
 			return nil, "", err
 		}
 
-		return output, aws.StringValue(output.Status), nil
+		return output, string(output.Status), nil
 	}
 }
 
@@ -69,6 +69,6 @@ func statusProject(ctx context.Context, conn *cloudwatchevidently.CloudWatchEvid
 			return nil, "", err
 		}
 
-		return output, aws.StringValue(output.Status), nil
+		return output, aws.ToString(output.Status), nil
 	}
 }

--- a/internal/service/evidently/status.go
+++ b/internal/service/evidently/status.go
@@ -6,13 +6,14 @@ package evidently
 import (
 	"context"
 
+	"github.com/aws/aws-sdk-go-v2/service/evidently"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatchevidently"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func statusFeature(ctx context.Context, conn *cloudwatchevidently.CloudWatchEvidently, id string) retry.StateRefreshFunc {
+func statusFeature(ctx context.Context, conn *evidently.Client, id string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		featureName, projectNameOrARN, err := FeatureParseID(id)
 
@@ -30,7 +31,7 @@ func statusFeature(ctx context.Context, conn *cloudwatchevidently.CloudWatchEvid
 			return nil, "", err
 		}
 
-		return output, aws.StringValue(output.Status), nil
+		return output, string(output.Status), nil
 	}
 }
 

--- a/internal/service/evidently/status.go
+++ b/internal/service/evidently/status.go
@@ -6,9 +6,7 @@ package evidently
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/evidently"
-	"github.com/aws/aws-sdk-go/service/cloudwatchevidently"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
@@ -57,7 +55,7 @@ func statusLaunch(ctx context.Context, conn *evidently.Client, id string) retry.
 	}
 }
 
-func statusProject(ctx context.Context, conn *cloudwatchevidently.CloudWatchEvidently, id string) retry.StateRefreshFunc {
+func statusProject(ctx context.Context, conn *evidently.Client, id string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		output, err := FindProjectByNameOrARN(ctx, conn, id)
 
@@ -69,6 +67,6 @@ func statusProject(ctx context.Context, conn *cloudwatchevidently.CloudWatchEvid
 			return nil, "", err
 		}
 
-		return output, aws.ToString(output.Status), nil
+		return output, string(output.Status), nil
 	}
 }

--- a/internal/service/evidently/sweep.go
+++ b/internal/service/evidently/sweep.go
@@ -7,12 +7,12 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/cloudwatchevidently"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/evidently"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
-	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv1"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
 )
 
 func RegisterSweepers() {
@@ -28,34 +28,27 @@ func sweepProject(region string) error {
 	if err != nil {
 		return fmt.Errorf("Error getting client: %w", err)
 	}
-	conn := client.EvidentlyConn(ctx)
-	input := &cloudwatchevidently.ListProjectsInput{}
+	conn := client.EvidentlyClient(ctx)
+	input := &evidently.ListProjectsInput{}
 	var sweeperErrs *multierror.Error
 	sweepResources := make([]sweep.Sweepable, 0)
 
-	err = conn.ListProjectsPagesWithContext(ctx, input, func(page *cloudwatchevidently.ListProjectsOutput, lastPage bool) bool {
-		if page == nil {
-			return !lastPage
+	pages := evidently.NewListProjectsPaginator(conn, input)
+
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+		if awsv2.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping Evidently Project sweep for %s: %s", region, err)
+			return nil
 		}
 
 		for _, project := range page.Projects {
 			r := ResourceProject()
 			d := r.Data(nil)
-			d.SetId(aws.StringValue(project.Name))
+			d.SetId(aws.ToString(project.Name))
 
 			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 		}
-
-		return !lastPage
-	})
-
-	if awsv1.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping Evidently Project sweep for %s: %s", region, err)
-		return sweeperErrs.ErrorOrNil()
-	}
-
-	if err != nil {
-		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing Evidently Projects for %s: %w", region, err))
 	}
 
 	if err := sweep.SweepOrchestrator(ctx, sweepResources); err != nil {

--- a/internal/service/evidently/tags_gen.go
+++ b/internal/service/evidently/tags_gen.go
@@ -5,9 +5,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/cloudwatchevidently"
-	"github.com/aws/aws-sdk-go/service/cloudwatchevidently/cloudwatchevidentlyiface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/evidently"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/logging"
@@ -16,21 +15,21 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// map[string]*string handling
+// map[string]string handling
 
 // Tags returns evidently service tags.
-func Tags(tags tftags.KeyValueTags) map[string]*string {
-	return aws.StringMap(tags.Map())
+func Tags(tags tftags.KeyValueTags) map[string]string {
+	return tags.Map()
 }
 
 // KeyValueTags creates tftags.KeyValueTags from evidently service tags.
-func KeyValueTags(ctx context.Context, tags map[string]*string) tftags.KeyValueTags {
+func KeyValueTags(ctx context.Context, tags map[string]string) tftags.KeyValueTags {
 	return tftags.New(ctx, tags)
 }
 
 // getTagsIn returns evidently service tags from Context.
 // nil is returned if there are no input tags.
-func getTagsIn(ctx context.Context) map[string]*string {
+func getTagsIn(ctx context.Context) map[string]string {
 	if inContext, ok := tftags.FromContext(ctx); ok {
 		if tags := Tags(inContext.TagsIn.UnwrapOrDefault()); len(tags) > 0 {
 			return tags
@@ -41,7 +40,7 @@ func getTagsIn(ctx context.Context) map[string]*string {
 }
 
 // setTagsOut sets evidently service tags in Context.
-func setTagsOut(ctx context.Context, tags map[string]*string) {
+func setTagsOut(ctx context.Context, tags map[string]string) {
 	if inContext, ok := tftags.FromContext(ctx); ok {
 		inContext.TagsOut = types.Some(KeyValueTags(ctx, tags))
 	}
@@ -50,7 +49,7 @@ func setTagsOut(ctx context.Context, tags map[string]*string) {
 // updateTags updates evidently service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn cloudwatchevidentlyiface.CloudWatchEvidentlyAPI, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *evidently.Client, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -59,12 +58,12 @@ func updateTags(ctx context.Context, conn cloudwatchevidentlyiface.CloudWatchEvi
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Evidently)
 	if len(removedTags) > 0 {
-		input := &cloudwatchevidently.UntagResourceInput{
+		input := &evidently.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.Keys()),
+			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResourceWithContext(ctx, input)
+		_, err := conn.UntagResource(ctx, input)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -74,12 +73,12 @@ func updateTags(ctx context.Context, conn cloudwatchevidentlyiface.CloudWatchEvi
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Evidently)
 	if len(updatedTags) > 0 {
-		input := &cloudwatchevidently.TagResourceInput{
+		input := &evidently.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResourceWithContext(ctx, input)
+		_, err := conn.TagResource(ctx, input)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)
@@ -92,5 +91,5 @@ func updateTags(ctx context.Context, conn cloudwatchevidentlyiface.CloudWatchEvi
 // UpdateTags updates evidently service tags.
 // It is called from outside this package.
 func (p *servicePackage) UpdateTags(ctx context.Context, meta any, identifier string, oldTags, newTags any) error {
-	return updateTags(ctx, meta.(*conns.AWSClient).EvidentlyConn(ctx), identifier, oldTags, newTags)
+	return updateTags(ctx, meta.(*conns.AWSClient).EvidentlyClient(ctx), identifier, oldTags, newTags)
 }

--- a/internal/service/evidently/wait.go
+++ b/internal/service/evidently/wait.go
@@ -131,41 +131,41 @@ func waitLaunchDeleted(ctx context.Context, conn *evidently.Client, id string, t
 	return nil, err
 }
 
-func waitProjectCreated(ctx context.Context, conn *cloudwatchevidently.CloudWatchEvidently, nameOrARN string, timeout time.Duration) (*cloudwatchevidently.Project, error) {
+func waitProjectCreated(ctx context.Context, conn *evidently.Client, nameOrARN string, timeout time.Duration) (*awstypes.Project, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{},
-		Target:  []string{cloudwatchevidently.ProjectStatusAvailable},
+		Target:  enum.Slice(awstypes.ProjectStatusAvailable),
 		Refresh: statusProject(ctx, conn, nameOrARN),
 		Timeout: timeout,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
-	if output, ok := outputRaw.(*cloudwatchevidently.Project); ok {
+	if output, ok := outputRaw.(*awstypes.Project); ok {
 		return output, err
 	}
 
 	return nil, err
 }
 
-func waitProjectUpdated(ctx context.Context, conn *cloudwatchevidently.CloudWatchEvidently, nameOrARN string, timeout time.Duration) (*cloudwatchevidently.Project, error) { //nolint:unparam
+func waitProjectUpdated(ctx context.Context, conn *evidently.Client, nameOrARN string, timeout time.Duration) (*awstypes.Project, error) { //nolint:unparam
 	stateConf := &retry.StateChangeConf{
-		Pending: []string{cloudwatchevidently.ProjectStatusUpdating},
-		Target:  []string{cloudwatchevidently.ProjectStatusAvailable},
+		Pending: enum.Slice(awstypes.ProjectStatusUpdating),
+		Target:  enum.Slice(awstypes.ProjectStatusAvailable),
 		Refresh: statusProject(ctx, conn, nameOrARN),
 		Timeout: timeout,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
-	if output, ok := outputRaw.(*cloudwatchevidently.Project); ok {
+	if output, ok := outputRaw.(*awstypes.Project); ok {
 		return output, err
 	}
 
 	return nil, err
 }
 
-func waitProjectDeleted(ctx context.Context, conn *cloudwatchevidently.CloudWatchEvidently, nameOrARN string, timeout time.Duration) (*cloudwatchevidently.Project, error) {
+func waitProjectDeleted(ctx context.Context, conn *evidently.Client, nameOrARN string, timeout time.Duration) (*awstypes.Project, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{cloudwatchevidently.ProjectStatusAvailable},
 		Target:  []string{},
@@ -175,7 +175,7 @@ func waitProjectDeleted(ctx context.Context, conn *cloudwatchevidently.CloudWatc
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
-	if output, ok := outputRaw.(*cloudwatchevidently.Project); ok {
+	if output, ok := outputRaw.(*awstypes.Project); ok {
 		return output, err
 	}
 

--- a/internal/service/evidently/wait.go
+++ b/internal/service/evidently/wait.go
@@ -8,10 +8,12 @@ import (
 	"errors"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/evidently"
-	"github.com/aws/aws-sdk-go/aws"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/evidently/types"
 	"github.com/aws/aws-sdk-go/service/cloudwatchevidently"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
@@ -66,18 +68,18 @@ func waitFeatureDeleted(ctx context.Context, conn *evidently.Client, id string, 
 	return nil, err
 }
 
-func waitLaunchCreated(ctx context.Context, conn *cloudwatchevidently.CloudWatchEvidently, id string, timeout time.Duration) (*cloudwatchevidently.Launch, error) {
+func waitLaunchCreated(ctx context.Context, conn *evidently.Client, id string, timeout time.Duration) (*awstypes.Launch, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{},
-		Target:  []string{cloudwatchevidently.LaunchStatusCreated},
+		Target:  enum.Slice(awstypes.LaunchStatusCreated),
 		Refresh: statusLaunch(ctx, conn, id),
 		Timeout: timeout,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
-	if output, ok := outputRaw.(*cloudwatchevidently.Launch); ok {
-		if v := aws.StringValue(output.StatusReason); v != "" {
+	if output, ok := outputRaw.(*awstypes.Launch); ok {
+		if v := aws.ToString(output.StatusReason); v != "" {
 			tfresource.SetLastError(err, errors.New(v))
 		}
 
@@ -87,18 +89,18 @@ func waitLaunchCreated(ctx context.Context, conn *cloudwatchevidently.CloudWatch
 	return nil, err
 }
 
-func waitLaunchUpdated(ctx context.Context, conn *cloudwatchevidently.CloudWatchEvidently, id string, timeout time.Duration) (*cloudwatchevidently.Launch, error) {
+func waitLaunchUpdated(ctx context.Context, conn *evidently.Client, id string, timeout time.Duration) (*awstypes.Launch, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending: []string{cloudwatchevidently.LaunchStatusUpdating},
-		Target:  []string{cloudwatchevidently.LaunchStatusCreated, cloudwatchevidently.LaunchStatusRunning},
+		Pending: enum.Slice(awstypes.LaunchStatusUpdating),
+		Target:  enum.Slice(awstypes.LaunchStatusCreated, awstypes.LaunchStatusRunning),
 		Refresh: statusLaunch(ctx, conn, id),
 		Timeout: timeout,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
-	if output, ok := outputRaw.(*cloudwatchevidently.Launch); ok {
-		if v := aws.StringValue(output.StatusReason); v != "" {
+	if output, ok := outputRaw.(*awstypes.Launch); ok {
+		if v := aws.ToString(output.StatusReason); v != "" {
 			tfresource.SetLastError(err, errors.New(v))
 		}
 
@@ -108,9 +110,9 @@ func waitLaunchUpdated(ctx context.Context, conn *cloudwatchevidently.CloudWatch
 	return nil, err
 }
 
-func waitLaunchDeleted(ctx context.Context, conn *cloudwatchevidently.CloudWatchEvidently, id string, timeout time.Duration) (*cloudwatchevidently.Launch, error) {
+func waitLaunchDeleted(ctx context.Context, conn *evidently.Client, id string, timeout time.Duration) (*awstypes.Launch, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending: []string{cloudwatchevidently.LaunchStatusCreated, cloudwatchevidently.LaunchStatusCompleted, cloudwatchevidently.LaunchStatusRunning, cloudwatchevidently.LaunchStatusCancelled, cloudwatchevidently.LaunchStatusUpdating},
+		Pending: enum.Slice(awstypes.LaunchStatusCreated, awstypes.LaunchStatusCompleted, awstypes.LaunchStatusRunning, awstypes.LaunchStatusCancelled, awstypes.LaunchStatusUpdating),
 		Target:  []string{},
 		Refresh: statusLaunch(ctx, conn, id),
 		Timeout: timeout,
@@ -118,8 +120,8 @@ func waitLaunchDeleted(ctx context.Context, conn *cloudwatchevidently.CloudWatch
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
-	if output, ok := outputRaw.(*cloudwatchevidently.Launch); ok {
-		if v := aws.StringValue(output.StatusReason); v != "" {
+	if output, ok := outputRaw.(*awstypes.Launch); ok {
+		if v := aws.ToString(output.StatusReason); v != "" {
 			tfresource.SetLastError(err, errors.New(v))
 		}
 

--- a/internal/service/evidently/wait.go
+++ b/internal/service/evidently/wait.go
@@ -8,13 +8,14 @@ import (
 	"errors"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/service/evidently"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatchevidently"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func waitFeatureCreated(ctx context.Context, conn *cloudwatchevidently.CloudWatchEvidently, id string, timeout time.Duration) (*cloudwatchevidently.Feature, error) {
+func waitFeatureCreated(ctx context.Context, conn *evidently.Client, id string, timeout time.Duration) (*cloudwatchevidently.Feature, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{},
 		Target:  []string{cloudwatchevidently.FeatureStatusAvailable},
@@ -31,7 +32,7 @@ func waitFeatureCreated(ctx context.Context, conn *cloudwatchevidently.CloudWatc
 	return nil, err
 }
 
-func waitFeatureUpdated(ctx context.Context, conn *cloudwatchevidently.CloudWatchEvidently, id string, timeout time.Duration) (*cloudwatchevidently.Feature, error) {
+func waitFeatureUpdated(ctx context.Context, conn *evidently.Client, id string, timeout time.Duration) (*cloudwatchevidently.Feature, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{cloudwatchevidently.FeatureStatusUpdating},
 		Target:  []string{cloudwatchevidently.FeatureStatusAvailable},
@@ -48,7 +49,7 @@ func waitFeatureUpdated(ctx context.Context, conn *cloudwatchevidently.CloudWatc
 	return nil, err
 }
 
-func waitFeatureDeleted(ctx context.Context, conn *cloudwatchevidently.CloudWatchEvidently, id string, timeout time.Duration) (*cloudwatchevidently.Feature, error) {
+func waitFeatureDeleted(ctx context.Context, conn *evidently.Client, id string, timeout time.Duration) (*cloudwatchevidently.Feature, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{cloudwatchevidently.FeatureStatusAvailable},
 		Target:  []string{},

--- a/names/names.go
+++ b/names/names.go
@@ -47,6 +47,7 @@ const (
 	EKSEndpointID                        = "eks"
 	EMREndpointID                        = "elasticmapreduce"
 	EMRServerlessEndpointID              = "emrserverless"
+	EvidentlyEndpointID                  = "evidently"
 	GlacierEndpointID                    = "glacier"
 	IdentityStoreEndpointID              = "identitystore"
 	Inspector2EndpointID                 = "inspector2"

--- a/names/names_data.csv
+++ b/names/names_data.csv
@@ -68,7 +68,7 @@ cloudsearchdomain,cloudsearchdomain,cloudsearchdomain,cloudsearchdomain,,cloudse
 cloudtrail,cloudtrail,cloudtrail,cloudtrail,,cloudtrail,,,CloudTrail,CloudTrail,,1,,aws_cloudtrail,aws_cloudtrail_,,cloudtrail,CloudTrail,AWS,,,,,,,
 cloudwatch,cloudwatch,cloudwatch,cloudwatch,,cloudwatch,,,CloudWatch,CloudWatch,,1,,aws_cloudwatch_(?!(event_|log_|query_)),aws_cloudwatch_,,cloudwatch_dashboard;cloudwatch_metric_;cloudwatch_composite_,CloudWatch,Amazon,,,,,,,
 application-insights,applicationinsights,applicationinsights,applicationinsights,,applicationinsights,,,ApplicationInsights,ApplicationInsights,,1,,,aws_applicationinsights_,,applicationinsights_,CloudWatch Application Insights,Amazon,,,,,,,
-evidently,evidently,cloudwatchevidently,evidently,,evidently,,cloudwatchevidently,Evidently,CloudWatchEvidently,,1,,,aws_evidently_,,evidently_,CloudWatch Evidently,Amazon,,,,,,,
+evidently,evidently,cloudwatchevidently,evidently,,evidently,,cloudwatchevidently,Evidently,CloudWatchEvidently,,,2,,aws_evidently_,,evidently_,CloudWatch Evidently,Amazon,,,,,,,
 internetmonitor,internetmonitor,internetmonitor,internetmonitor,,internetmonitor,,,InternetMonitor,InternetMonitor,,,2,,aws_internetmonitor_,,internetmonitor_,CloudWatch Internet Monitor,Amazon,,,,,,,
 logs,logs,cloudwatchlogs,cloudwatchlogs,,logs,,cloudwatchlog;cloudwatchlogs,Logs,CloudWatchLogs,,,2,aws_cloudwatch_(log_|query_),aws_logs_,,cloudwatch_log_;cloudwatch_query_,CloudWatch Logs,Amazon,,,,,,,
 rum,rum,cloudwatchrum,rum,,rum,,cloudwatchrum,RUM,CloudWatchRUM,,1,,,aws_rum_,,rum_,CloudWatch RUM,Amazon,,,,,,,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS="-run=TestAccEvidently" PKG=evidently

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/evidently/... -v -count 1 -parallel 20  -run=TestAccEvidently -timeout 360m
--- PASS: TestAccEvidentlyProject_disappears (129.74s)
--- PASS: TestAccEvidentlySegment_description (157.78s)
--- PASS: TestAccEvidentlyFeature_basic (250.65s)
--- PASS: TestAccEvidentlyProject_basic (268.45s)
--- PASS: TestAccEvidentlySegment_basic (159.27s)
--- PASS: TestAccEvidentlyProject_tags (387.44s)
--- PASS: TestAccEvidentlyLaunch_disappears (391.11s)
--- PASS: TestAccEvidentlyLaunch_basic (396.27s)
--- PASS: TestAccEvidentlySegment_disappears (129.65s)
--- PASS: TestAccEvidentlyFeature_updateDescription (429.05s)
--- PASS: TestAccEvidentlyFeature_updateEvaluationStrategy (439.02s)
--- PASS: TestAccEvidentlySegment_patternJSON (158.10s)
--- PASS: TestAccEvidentlyFeature_updateVariationsStringValue (608.82s)
--- PASS: TestAccEvidentlySegment_tags (393.31s)
--- PASS: TestAccEvidentlyFeature_disappears (247.04s)
--- PASS: TestAccEvidentlyLaunch_updateRandomizationSalt (679.31s)
--- PASS: TestAccEvidentlyLaunch_updateDescription (687.79s)
--- PASS: TestAccEvidentlyProject_updateDataDeliveryS3Bucket (721.14s)
--- PASS: TestAccEvidentlyProject_updateDataDeliveryCloudWatchLogGroup (721.38s)
--- PASS: TestAccEvidentlyProject_updateDataDeliveryCloudWatchToS3 (722.25s)
--- PASS: TestAccEvidentlyFeature_updateDefaultVariation (411.29s)
--- PASS: TestAccEvidentlyProject_updateDataDeliveryS3Prefix (729.97s)
--- PASS: TestAccEvidentlyFeature_updateVariationsBoolValue (369.93s)
--- PASS: TestAccEvidentlyFeature_updateVariationsDoubleValue (378.96s)
--- PASS: TestAccEvidentlyFeature_updateVariationsLongValue (374.16s)
--- PASS: TestAccEvidentlyFeature_updateEntityOverrides (344.75s)
--- PASS: TestAccEvidentlyLaunch_tags (809.83s)
--- PASS: TestAccEvidentlyFeature_tags (324.91s)
--- PASS: TestAccEvidentlyLaunch_updateMetricMonitors (894.57s)
--- PASS: TestAccEvidentlyLaunch_scheduledSplitsConfig_updateSteps (916.61s)
--- PASS: TestAccEvidentlyLaunch_updateGroups (965.53s)
--- PASS: TestAccEvidentlyLaunch_scheduledSplitsConfig_steps_updateSegmentOverrides (943.01s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/evidently	1076.113s
```
