### PR TITLE
r/aws_evidently_feature: check error correctly

### DIFF
--- a/internal/service/evidently/feature.go
+++ b/internal/service/evidently/feature.go
@@ -15,13 +15,12 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/evidently"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/evidently/types"
-	"github.com/aws/aws-sdk-go/service/cloudwatchevidently"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -344,7 +343,7 @@ func resourceFeatureDelete(ctx context.Context, d *schema.ResourceData, meta int
 		Project: aws.String(project),
 	})
 
-	if tfawserr.ErrCodeEquals(err, cloudwatchevidently.ErrCodeResourceNotFoundException) {
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return nil
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Check SDKv2 error correctly.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS="-run=TestAccEvidentlyFeature_" PKG=evidently

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/evidently/... -v -count 1 -parallel 20  -run=TestAccEvidentlyFeature_ -timeout 360m
--- PASS: TestAccEvidentlyFeature_disappears (127.92s)
--- PASS: TestAccEvidentlyFeature_basic (127.94s)
--- PASS: TestAccEvidentlyFeature_updateVariationsLongValue (202.04s)
--- PASS: TestAccEvidentlyFeature_updateDefaultVariation (203.14s)
--- PASS: TestAccEvidentlyFeature_updateVariationsBoolValue (204.20s)
--- PASS: TestAccEvidentlyFeature_updateEvaluationStrategy (204.31s)
--- PASS: TestAccEvidentlyFeature_updateDescription (204.77s)
--- PASS: TestAccEvidentlyFeature_updateEntityOverrides (204.77s)
--- PASS: TestAccEvidentlyFeature_updateVariationsDoubleValue (206.22s)
--- PASS: TestAccEvidentlyFeature_tags (242.93s)
--- PASS: TestAccEvidentlyFeature_updateVariationsStringValue (243.50s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/evidently	246.798s
```
