### PR TITLE
sweeper/aws_dms_replication_subnet_group: Fixes dependencies

### DIFF
--- a/internal/service/dms/sweep.go
+++ b/internal/service/dms/sweep.go
@@ -32,7 +32,6 @@ func RegisterSweepers() {
 		Name: "aws_dms_replication_instance",
 		F:    sweepReplicationInstances,
 		Dependencies: []string{
-			"aws_dms_replication_subnet_group",
 			"aws_dms_replication_task",
 		},
 	})
@@ -40,6 +39,9 @@ func RegisterSweepers() {
 	resource.AddTestSweepers("aws_dms_replication_subnet_group", &resource.Sweeper{
 		Name: "aws_dms_replication_subnet_group",
 		F:    sweepReplicationSubnetGroups,
+		Dependencies: []string{
+			"aws_dms_replication_instance",
+		},
 	})
 
 	resource.AddTestSweepers("aws_dms_replication_task", &resource.Sweeper{

--- a/internal/service/ec2/sweep.go
+++ b/internal/service/ec2/sweep.go
@@ -220,7 +220,7 @@ func RegisterSweepers() {
 			"aws_codestarconnections_host",
 			"aws_db_subnet_group",
 			"aws_directory_service_directory",
-			"aws_dms_replication_instance",
+			"aws_dms_replication_subnet_group",
 			"aws_docdb_subnet_group",
 			"aws_ec2_client_vpn_endpoint",
 			"aws_ec2_instance_connect_endpoint",


### PR DESCRIPTION

### Description

All DMS replication instances must be deleted before subnet groups are deleted

### Output

Previously:

> aws_dms_replication_subnet_group: error sweeping DMS Replication Subnet Groups (us-west-2): 1 error occurred:
>   * deleting DMS Replication Subnet Group (tf-acc-test-7140903143330117603): InvalidResourceStateFault: Cannot delete the subnet group 'tf-acc-test-7140903143330117603' because at least one database instance: tf-acc-test-7140903143330117603 is still using it.

Now:

Sweeper Tests for region (us-west-2) ran successfully:
  - aws_dms_replication_task
  - aws_dms_replication_instance
  - aws_dms_replication_subnet_group
 