### PR TITLE
RDS fixes

### DIFF
--- a/internal/service/rds/cluster_instance.go
+++ b/internal/service/rds/cluster_instance.go
@@ -219,7 +219,7 @@ func ResourceClusterInstance() *schema.Resource {
 			"publicly_accessible": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  false,
+				Computed: true,
 			},
 			"storage_encrypted": {
 				Type:     schema.TypeBool,

--- a/internal/service/rds/cluster_instance.go
+++ b/internal/service/rds/cluster_instance.go
@@ -114,7 +114,7 @@ func ResourceClusterInstance() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: validation.Any(
 					validation.StringMatch(regexache.MustCompile(fmt.Sprintf(`^%s.*$`, InstanceEngineCustomPrefix)), fmt.Sprintf("must begin with %s", InstanceEngineCustomPrefix)),
-					validation.StringInSlice(ClusterEngine_Values(), false),
+					validation.StringInSlice(ClusterInstanceEngine_Values(), false),
 				),
 			},
 			"engine_version": {

--- a/internal/service/rds/cluster_instance_test.go
+++ b/internal/service/rds/cluster_instance_test.go
@@ -381,6 +381,21 @@ func TestAccRDSClusterInstance_publiclyAccessible(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "publicly_accessible", "false"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+				},
+			},
+			{
+				Config: testAccClusterInstanceConfig_publiclyAccessible(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterInstanceExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "publicly_accessible", "true"),
+				),
+			},
 		},
 	})
 }
@@ -1343,14 +1358,53 @@ resource "aws_db_parameter_group" "test" {
 }
 
 func testAccClusterInstanceConfig_publiclyAccessible(rName string, publiclyAccessible bool) string {
-	return acctest.ConfigCompose(testAccClusterInstanceConfig_base(rName, "aurora-mysql"), fmt.Sprintf(`
+	return acctest.ConfigCompose(
+		acctest.ConfigAvailableAZsNoOptInDefaultExclude(),
+		fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+  enable_dns_hostnames = true
+}
+
+resource "aws_subnet" "test" {
+  count = %[2]d
+
+  vpc_id            = aws_vpc.test.id
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)
+}
+`, rName, 2),
+		testAccClusterInstanceConfig_orderableEngineBase("aurora-mysql", false),
+		fmt.Sprintf(`
 resource "aws_rds_cluster_instance" "test" {
   apply_immediately   = true
-  engine              = data.aws_rds_engine_version.default.engine
   cluster_identifier  = aws_rds_cluster.test.id
   identifier          = %[1]q
+  engine              = aws_rds_cluster.test.engine
   instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   publicly_accessible = %[2]t
+
+  depends_on = [aws_internet_gateway.test]
+}
+
+resource "aws_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+}
+
+resource "aws_rds_cluster" "test" {
+  cluster_identifier = %[1]q
+  engine              = data.aws_rds_engine_version.default.engine
+  engine_version      = data.aws_rds_engine_version.default.version
+  database_name       = "mydb"
+  master_username     = "foo"
+  master_password     = "mustbeeightcharacters"
+  skip_final_snapshot = true
+  db_subnet_group_name = aws_db_subnet_group.test.name
+}
+
+resource "aws_db_subnet_group" "test" {
+  name       = %[1]q
+  subnet_ids = aws_subnet.test[*].id
 }
 `, rName, publiclyAccessible))
 }

--- a/internal/service/rds/cluster_instance_test.go
+++ b/internal/service/rds/cluster_instance_test.go
@@ -1362,7 +1362,7 @@ func testAccClusterInstanceConfig_publiclyAccessible(rName string, publiclyAcces
 		acctest.ConfigAvailableAZsNoOptInDefaultExclude(),
 		fmt.Sprintf(`
 resource "aws_vpc" "test" {
-  cidr_block = "10.0.0.0/16"
+  cidr_block           = "10.0.0.0/16"
   enable_dns_hostnames = true
 }
 
@@ -1392,13 +1392,13 @@ resource "aws_internet_gateway" "test" {
 }
 
 resource "aws_rds_cluster" "test" {
-  cluster_identifier = %[1]q
-  engine              = data.aws_rds_engine_version.default.engine
-  engine_version      = data.aws_rds_engine_version.default.version
-  database_name       = "mydb"
-  master_username     = "foo"
-  master_password     = "mustbeeightcharacters"
-  skip_final_snapshot = true
+  cluster_identifier   = %[1]q
+  engine               = data.aws_rds_engine_version.default.engine
+  engine_version       = data.aws_rds_engine_version.default.version
+  database_name        = "mydb"
+  master_username      = "foo"
+  master_password      = "mustbeeightcharacters"
+  skip_final_snapshot  = true
   db_subnet_group_name = aws_db_subnet_group.test.name
 }
 

--- a/internal/service/rds/consts.go
+++ b/internal/service/rds/consts.go
@@ -140,6 +140,13 @@ func ClusterEngine_Values() []string {
 	}
 }
 
+func ClusterInstanceEngine_Values() []string {
+	return []string{
+		ClusterEngineAuroraMySQL,
+		ClusterEngineAuroraPostgreSQL,
+	}
+}
+
 const (
 	GlobalClusterEngineAurora           = "aurora"
 	GlobalClusterEngineAuroraMySQL      = "aurora-mysql"

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -2209,7 +2209,7 @@ func TestAccRDSInstance_ReplicateSourceDB_parameterGroupTwoStep(t *testing.T) {
 					resource.TestCheckResourceAttr(sourceResourceName, "parameter_group_name", "default.oracle-ee-19"),
 					testAccCheckInstanceExists(ctx, resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "replica_mode", "open-read-only"),
-					resource.TestCheckResourceAttrPair(resourceName, "parameter_group_name", parameterGroupResourceName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "parameter_group_name", parameterGroupResourceName, "name"),
 					testAccCheckInstanceParameterApplyStatusInSync(&dbInstance),
 					testAccCheckInstanceParameterApplyStatusInSync(&sourceDbInstance),
 				),
@@ -4856,7 +4856,7 @@ func TestAccRDSInstance_BlueGreenDeployment_updateParameterGroup(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(ctx, resourceName, &v2),
 					testAccCheckDBInstanceRecreated(&v1, &v2),
-					resource.TestCheckResourceAttrPair(resourceName, "parameter_group_name", parameterGroupResourceName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "parameter_group_name", parameterGroupResourceName, "name"),
 					resource.TestCheckResourceAttr(resourceName, "blue_green_update.0.enabled", "true"),
 				),
 			},
@@ -8700,7 +8700,7 @@ resource "aws_db_instance" "source" {
   engine_version          = data.aws_rds_orderable_db_instance.test.engine_version
   identifier              = "%[1]s-source"
   instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
-  parameter_group_name    = aws_db_parameter_group.test.id
+  parameter_group_name    = aws_db_parameter_group.test.name
   password                = "avoid-plaintext-passwords"
   username                = "tfacctest"
   skip_final_snapshot     = true
@@ -8709,7 +8709,7 @@ resource "aws_db_instance" "source" {
 resource "aws_db_instance" "test" {
   identifier           = %[1]q
   instance_class       = aws_db_instance.source.instance_class
-  parameter_group_name = aws_db_parameter_group.test.id
+  parameter_group_name = aws_db_parameter_group.test.name
   replicate_source_db  = aws_db_instance.source.identifier
   skip_final_snapshot  = true
 }
@@ -8723,7 +8723,7 @@ func testAccInstanceConfig_ReplicateSourceDB_ParameterGroupName_differentSetOnBo
 resource "aws_db_instance" "test" {
   identifier           = %[1]q
   instance_class       = aws_db_instance.source.instance_class
-  parameter_group_name = aws_db_parameter_group.test.id
+  parameter_group_name = aws_db_parameter_group.test.name
   replicate_source_db  = aws_db_instance.source.identifier
   skip_final_snapshot  = true
 }
@@ -8745,7 +8745,7 @@ resource "aws_db_instance" "source" {
   engine_version          = data.aws_rds_orderable_db_instance.test.engine_version
   identifier              = "%[1]s-source"
   instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
-  parameter_group_name    = aws_db_parameter_group.source.id
+  parameter_group_name    = aws_db_parameter_group.source.name
   password                = "avoid-plaintext-passwords"
   username                = "tfacctest"
   skip_final_snapshot     = true
@@ -8784,7 +8784,7 @@ resource "aws_db_instance" "source" {
   engine_version          = data.aws_rds_orderable_db_instance.test.engine_version
   identifier              = "%[1]s-source"
   instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
-  parameter_group_name    = aws_db_parameter_group.test.id
+  parameter_group_name    = aws_db_parameter_group.test.name
   password                = "avoid-plaintext-passwords"
   username                = "tfacctest"
   skip_final_snapshot     = true
@@ -8828,7 +8828,7 @@ resource "aws_db_instance" "source" {
 resource "aws_db_instance" "test" {
   identifier           = %[1]q
   instance_class       = aws_db_instance.source.instance_class
-  parameter_group_name = aws_db_parameter_group.test.id
+  parameter_group_name = aws_db_parameter_group.test.name
   replicate_source_db  = aws_db_instance.source.identifier
   skip_final_snapshot  = true
 }
@@ -9009,7 +9009,7 @@ resource "aws_db_instance" "test" {
   skip_final_snapshot = true
   apply_immediately   = true
 
-  parameter_group_name = aws_db_parameter_group.test.id
+  parameter_group_name = aws_db_parameter_group.test.name
   ca_cert_identifier   = "rds-ca-2019"
 
   timeouts {
@@ -9907,7 +9907,7 @@ resource "aws_db_snapshot" "test" {
 resource "aws_db_instance" "test" {
   identifier           = %[1]q
   instance_class       = aws_db_instance.source.instance_class
-  parameter_group_name = aws_db_parameter_group.test.id
+  parameter_group_name = aws_db_parameter_group.test.name
   snapshot_identifier  = aws_db_snapshot.test.id
   skip_final_snapshot  = true
 }
@@ -10663,7 +10663,7 @@ resource "aws_db_instance" "test" {
   engine_version          = data.aws_rds_orderable_db_instance.test.engine_version
   instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   db_name                 = "test"
-  parameter_group_name    = aws_db_parameter_group.test.id
+  parameter_group_name    = aws_db_parameter_group.test.name
   skip_final_snapshot     = true
   password                = "avoid-plaintext-passwords"
   username                = "tfacctest"

--- a/website/docs/r/rds_cluster_instance.html.markdown
+++ b/website/docs/r/rds_cluster_instance.html.markdown
@@ -63,7 +63,8 @@ This argument supports the following arguments:
 * `db_parameter_group_name` - (Optional) Name of the DB parameter group to associate with this instance.
 * `db_subnet_group_name` - (Required if `publicly_accessible = false`, Optional otherwise, Forces new resource) DB subnet group to associate with this DB instance. **NOTE:** This must match the `db_subnet_group_name` of the attached [`aws_rds_cluster`](/docs/providers/aws/r/rds_cluster.html).
 * `engine_version` - (Optional) Database engine version.
-* `engine` - (Required, Forces new resource) Name of the database engine to be used for the RDS instance. Valid Values: `aurora-mysql`, `aurora-postgresql`, `mysql`, `postgres`.
+* `engine` - (Required, Forces new resource) Name of the database engine to be used for the RDS cluster instance.
+  Valid Values: `aurora-mysql`, `aurora-postgresql`.
 * `identifier_prefix` - (Optional, Forces new resource) Creates a unique identifier beginning with the specified prefix. Conflicts with `identifier`.
 * `identifier` - (Optional, Forces new resource) Identifier for the RDS instance, if omitted, Terraform will assign a random, unique identifier.
 * `instance_class` - (Required) Instance class to use. For details on CPU and memory, see [Scaling Aurora DB Instances][4]. Aurora uses `db.*` instance classes/types. Please see [AWS Documentation][7] for currently available instance classes and complete details.


### PR DESCRIPTION
### Description

* Only allows Aurora engine types in `aws_rds_cluster_instance` validation
* Allows correctly setting `publicly_accessible` on `aws_rds_cluster_instance`
* Uses `name` instead of `id` for references to `aws_rds_parameter_group`

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=rds TESTS='TestAccRDSClusterInstance_|TestAccRDSInstance_'

--- PASS: TestAccRDSInstance_FinalSnapshotIdentifier_skipFinalSnapshot (1037.35s)
--- PASS: TestAccRDSInstance_storageTypePostgres (1078.46s)
--- PASS: TestAccRDSInstance_EnabledCloudWatchLogsExports_msSQL (1167.32s)
--- PASS: TestAccRDSInstance_storageChangeIOPSThroughput (1300.45s)
--- PASS: TestAccRDSInstance_newIdentifier (1398.97s)
--- PASS: TestAccRDSInstance_storageChangeIOPS (1458.30s)
--- PASS: TestAccRDSInstance_gp3Postgres (1494.03s)
--- PASS: TestAccRDSInstance_storageChangeThroughput (1520.72s)
--- PASS: TestAccRDSInstance_storageThroughputSSE (1688.34s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_basic (1706.79s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_port (1760.37s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_namePrefix (1777.02s)
--- PASS: TestAccRDSInstance_gp3SQLServer (1793.33s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_vpcSecurityGroupIDs (2066.23s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_ManagedMasterPasswordKMSKey (2185.95s)
--- PASS: TestAccRDSClusterInstance_basic (2208.95s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSetOnReplica (2217.57s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_caCertificateIdentifier (2247.06s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameReplicaCopiesValue (1886.48s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameDifferentSetOnBoth (1940.81s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_networkType (1724.53s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSameSetOnBoth (1958.26s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_maxAllocatedStorage (1758.05s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_iamDatabaseAuthenticationEnabled (1594.32s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_maintenanceWindow (1691.26s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_monitoring (1907.33s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_monitoring_sourceAlreadyExists (1951.41s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_replicaMode (3474.01s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_backupWindow (1726.80s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_availabilityZone (1601.67s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_autoMinorVersionUpgrade (1585.81s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupTwoStep (3799.21s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_multiAZ (2434.11s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_allowMajorVersionUpgrade (1656.09s)
--- PASS: TestAccRDSInstance_ManagedMasterPassword_managed (471.02s)
--- PASS: TestAccRDSInstance_ReplicateSourceDBDBSubnetGroupName_vpcSecurityGroupIDs (2166.14s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName (2183.55s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_backupRetentionPeriod (1973.93s)
--- PASS: TestAccRDSInstance_ManagedMasterPassword_managedSpecificKMSKey (666.59s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_allocatedStorageAndIops (1833.98s)
--- PASS: TestAccRDSInstance_ManagedMasterPassword_convertToManaged (853.70s)
--- PASS: TestAccRDSInstance_password (877.05s)
--- PASS: TestAccRDSInstance_isAlreadyBeingDeleted (750.75s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_addLater (1662.58s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_allocatedStorage (1742.16s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_iops (1838.49s)
--- PASS: TestAccRDSInstance_maxAllocatedStorage (1253.08s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_nameGenerated (1653.26s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_deletionProtectionBypassesBlueGreen (1076.44s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_namePrefix (1698.00s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_passwordBypassesBlueGreen (1213.69s)
--- PASS: TestAccRDSInstance_gp3MySQL (1275.61s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_tags (1111.32s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_basic (2147.36s)
--- PASS: TestAccRDSInstance_NoNationalCharacterSet_oracle (952.67s)
--- PASS: TestAccRDSInstance_license (1420.07s)
--- PASS: TestAccRDSInstance_caCertificateIdentifier (717.22s)
--- PASS: TestAccRDSInstance_NationalCharacterSet_oracle (1028.72s)
--- PASS: TestAccRDSInstance_PerformanceInsightsEnabled_enabledToDisabled (1136.03s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_performanceInsightsEnabled (1791.45s)
--- PASS: TestAccRDSInstance_RestoreToPointInTime_sourceIdentifier (1649.45s)
--- PASS: TestAccRDSInstance_deletionProtection (809.78s)
--- PASS: TestAccRDSInstance_performanceInsightsRetentionPeriod (1417.14s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateInstanceClass (2531.61s)
--- PASS: TestAccRDSInstance_performanceInsightsKMSKeyID (1454.23s)
--- PASS: TestAccRDSInstance_PerformanceInsightsEnabled_disabledToEnabled (956.62s)
--- PASS: TestAccRDSInstance_noDeleteAutomatedBackups (906.71s)
--- PASS: TestAccRDSInstance_RestoreToPointInTime_ManagedMasterPassword (1925.19s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateParameterGroup (2629.48s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateWithDeletionProtection (2904.31s)
--- PASS: TestAccRDSInstance_RestoreToPointInTime_monitoring (1988.94s)
--- PASS: TestAccRDSInstance_finalSnapshotIdentifier (1261.34s)
--- PASS: TestAccRDSInstance_EnabledCloudWatchLogsExports_postgresql (668.78s)
--- PASS: TestAccRDSInstance_RestoreToPointInTime_sourceResourceID (2025.94s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateAndEnableBackups (3020.43s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_performanceInsightsEnabled (1863.82s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateEngineVersion (2871.58s)
--- PASS: TestAccRDSInstance_DBSubnetGroupName_vpcSecurityGroupIDs (825.85s)
--- PASS: TestAccRDSInstance_minorVersion (551.70s)
--- PASS: TestAccRDSInstance_dbSubnetGroupName (701.41s)
--- PASS: TestAccRDSClusterInstance_kmsKey (1773.05s)
--- PASS: TestAccRDSInstance_iamAuth (695.95s)
--- PASS: TestAccRDSInstance_allowMajorVersionUpgrade (799.70s)
--- PASS: TestAccRDSInstance_cloudWatchLogsExport (818.32s)
--- PASS: TestAccRDSInstance_optionGroup (774.03s)
--- PASS: TestAccRDSInstance_EnabledCloudWatchLogsExports_oracle (1052.05s)
--- PASS: TestAccRDSInstance_kmsKey (719.06s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateAndPromoteReplica (3968.81s)
--- PASS: TestAccRDSInstance_onlyMajorVersion (682.87s)
--- PASS: TestAccRDSInstance_portUpdate (1010.32s)
--- PASS: TestAccRDSInstance_networkType (1214.47s)
--- PASS: TestAccRDSInstance_MonitoringRoleARN_removedToEnabled (939.88s)
--- PASS: TestAccRDSInstance_disappears (643.48s)
--- PASS: TestAccRDSInstance_EnabledCloudWatchLogsExports_mySQL (1633.11s)
--- PASS: TestAccRDSInstance_tags (830.05s)
--- PASS: TestAccRDSInstance_subnetGroup (1462.00s)
--- PASS: TestAccRDSInstance_separateIopsUpdate (1123.64s)
--- PASS: TestAccRDSInstance_MonitoringRoleARN_enabledToRemoved (1117.87s)
--- PASS: TestAccRDSInstance_identifierGenerated (652.31s)
--- PASS: TestAccRDSInstance_identifierPrefix (665.44s)
--- PASS: TestAccRDSInstance_manage_password (677.41s)
--- PASS: TestAccRDSInstance_MonitoringRoleARN_enabledToDisabled (1246.86s)
--- PASS: TestAccRDSInstance_MySQL_snapshotRestoreWithEngineVersion (2015.06s)
--- PASS: TestAccRDSInstance_basic (627.84s)
--- PASS: TestAccRDSInstance_MSSQL_tz (1971.76s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDsTags (1447.14s)
--- PASS: TestAccRDSInstance_monitoringInterval (1752.07s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDs (1513.41s)
--- PASS: TestAccRDSClusterInstance_PerformanceInsightsKMSKeyIDAuroraPostgresql_defaultKeyToCustomKey (1364.08s)
--- PASS: TestAccRDSClusterInstance_PerformanceInsightsKMSKeyID_auroraPostgresql (1353.41s)
--- PASS: TestAccRDSClusterInstance_PerformanceInsightsKMSKeyIDAuroraMySQL1_defaultKeyToCustomKey (1438.53s)
--- PASS: TestAccRDSClusterInstance_PerformanceInsightsKMSKeyID_auroraMySQL1 (1381.13s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_tags (1335.31s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_port (1506.95s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_backupWindow (1510.00s)
--- PASS: TestAccRDSInstance_MSSQL_domainSnapshotRestore (3434.46s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_parameterGroupName (1686.69s)
--- PASS: TestAccRDSClusterInstance_MonitoringRoleARN_enabledToDisabled (2220.86s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_monitoring (1625.86s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_maxAllocatedStorage (1527.67s)
--- PASS: TestAccRDSClusterInstance_performanceInsightsRetentionPeriod (2188.39s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_maintenanceWindow (1356.57s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_iamDatabaseAuthenticationEnabled (1447.79s)
--- FAIL: TestAccRDSInstance_customIAMInstanceProfile (3971.13s)
--- PASS: TestAccRDSInstance_MSSQL_domain (4115.47s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_multiAZ (2248.38s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_deletionProtection (1585.82s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameVPCSecurityGroupIDs (1605.76s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupName (1571.37s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_multiAZSQLServer (4810.00s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_allowMajorVersionUpgrade (1872.14s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodOverride (1858.69s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_availabilityZone (1640.48s)
--- PASS: TestAccRDSClusterInstance_PerformanceInsightsEnabled_auroraMySQL1 (1507.07s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_autoMinorVersionUpgrade (1722.65s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodUnset (2209.29s)
--- PASS: TestAccRDSClusterInstance_az (1866.31s)
--- PASS: TestAccRDSClusterInstance_caCertificateIdentifier (1873.54s)
--- PASS: TestAccRDSClusterInstance_copyTagsToSnapshot (1961.26s)
--- PASS: TestAccRDSClusterInstance_MonitoringRoleARN_removedToEnabled (2232.34s)
--- PASS: TestAccRDSClusterInstance_identifierPrefix (1760.93s)
--- PASS: TestAccRDSClusterInstance_isAlreadyBeingDeleted (1632.96s)
--- PASS: TestAccRDSClusterInstance_identifierGenerated (1758.33s)
--- PASS: TestAccRDSClusterInstance_disappears (1784.42s)
--- PASS: TestAccRDSClusterInstance_tags (1987.63s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_allocatedStorage (1770.85s)
--- PASS: TestAccRDSClusterInstance_MonitoringRoleARN_enabledToRemoved (2104.03s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_io1Storage (1768.92s)
--- PASS: TestAccRDSClusterInstance_publiclyAccessible (2621.71s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_AssociationRemoved (1539.57s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_nameGenerated (1458.10s)
--- PASS: TestAccRDSClusterInstance_PerformanceInsightsEnabled_auroraPostgresql (1551.68s)
--- PASS: TestAccRDSClusterInstance_monitoringInterval (2974.39s)
```

The failure in `TestAccRDSInstance_customIAMInstanceProfile` is unrelated to these changes