### PR TITLE
Amend destination argument config for kinesis_firehose_delivery_stream resource docs

### DIFF
--- a/.changelog/34598.txt
+++ b/.changelog/34598.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/kinesis_firehose_delivery_stream: Fix docs for `destination` argument values.
+```

--- a/.changelog/34598.txt
+++ b/.changelog/34598.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-resource/kinesis_firehose_delivery_stream: Fix docs for `destination` argument values.
-```

--- a/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
+++ b/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
@@ -602,7 +602,7 @@ This resource supports the following arguments:
 * `msk_source_configuration` - (Optional) The configuration for the Amazon MSK cluster to be used as the source for a delivery stream. More details are given below.
 * `server_side_encryption` - (Optional) Encrypt at rest options.
 Server-side encryption should not be enabled when a kinesis stream is configured as the source of the firehose delivery stream.
-* `destination` – (Required) This is the destination to where the data is delivered. The only options are `s3` (Deprecated, use `extended_s3` instead), `extended_s3`, `redshift`, `elasticsearch`, `splunk`, `http_endpoint`, `opensearch` and `opensearchserverless`. More details are given below.
+* `destination` – (Required) This is the destination to where the data is delivered. The only options are `s3` (Deprecated, use `extended_s3` instead), `extended_s3`, `redshift`, `elasticsearch`, `splunk`, `http_endpoint`, `opensearch` and `opensearchserverless`.
 * `elasticsearch_configuration` - (Optional) Configuration options when `destination` is `elasticsearch`. More details are given below.
 * `extended_s3_configuration` - (Optional, only Required when `destination` is `extended_s3`) Enhanced configuration options for the s3 destination. More details are given below.
 * `http_endpoint_configuration` - (Optional) Configuration options when `destination` is `http_endpoint`. Requires the user to also specify an `s3_configuration` block.  More details are given below.

--- a/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
+++ b/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
@@ -602,8 +602,7 @@ This resource supports the following arguments:
 * `msk_source_configuration` - (Optional) The configuration for the Amazon MSK cluster to be used as the source for a delivery stream. More details are given below.
 * `server_side_encryption` - (Optional) Encrypt at rest options.
 Server-side encryption should not be enabled when a kinesis stream is configured as the source of the firehose delivery stream.
-* `destination` – (Required) This is the destination to where the data is delivered. The only options are `s3` (Deprecated, use `extended_s3` instead), `extended_s3`, `redshift`, `elasticsearch`, `splunk`, `http_endpoint`, `opensearch` and `opensearchserverless`.
-is redshift). More details are given below.
+* `destination` – (Required) This is the destination to where the data is delivered. The only options are `s3` (Deprecated, use `extended_s3` instead), `extended_s3`, `redshift`, `elasticsearch`, `splunk`, `http_endpoint`, `opensearch` and `opensearchserverless`. More details are given below.
 * `elasticsearch_configuration` - (Optional) Configuration options when `destination` is `elasticsearch`. More details are given below.
 * `extended_s3_configuration` - (Optional, only Required when `destination` is `extended_s3`) Enhanced configuration options for the s3 destination. More details are given below.
 * `http_endpoint_configuration` - (Optional) Configuration options when `destination` is `http_endpoint`. Requires the user to also specify an `s3_configuration` block.  More details are given below.


### PR DESCRIPTION
### Description
Fixes an issue with the `kinesis_firehose_delivery_stream` resource documentation. An extra sentence appeared in the `destination` argument values from a previous revision. The two sentences are correctly revised now.

### Relations
Closes #34598 


