### PR TITLE
r/aws_elasticache_replication_group: v2 state upgrader

### DIFF
--- a/.changelog/34600.txt
+++ b/.changelog/34600.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_elaticache_replication_group: Fix regression caused by the introduction of the `auth_token_update_strategy` argument with a default value
+```

--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -73,7 +73,6 @@ func ResourceReplicationGroup() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validation.StringInSlice(elasticache.AuthTokenUpdateStrategyType_Values(), true),
 				Default:      elasticache.AuthTokenUpdateStrategyTypeRotate,
-				RequiredWith: []string{"auth_token"},
 			},
 			"auto_minor_version_upgrade": {
 				Type:         nullable.TypeNullableBool,

--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -349,12 +349,24 @@ func ResourceReplicationGroup() *schema.Resource {
 			},
 		},
 
-		SchemaVersion: 1,
+		SchemaVersion: 2,
 		// SchemaVersion: 1 did not include any state changes via MigrateState.
 		// Perform a no-operation state upgrade for Terraform 0.12 compatibility.
 		// Future state migrations should be performed with StateUpgraders.
 		MigrateState: func(v int, inst *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
 			return inst, nil
+		},
+
+		StateUpgraders: []schema.StateUpgrader{
+			// v5.27.0 introduced the auth_token_update_strategy argument with a default
+			// value required to preserve backward compatibility. In order to prevent
+			// differences and attempted modifications on upgrade, the default value
+			// must be written to state via a state upgrader.
+			{
+				Type:    resourceReplicationGroupConfigV1().CoreConfigSchema().ImpliedType(),
+				Upgrade: replicationGroupStateUpgradeV1,
+				Version: 1,
+			},
 		},
 
 		Timeouts: &schema.ResourceTimeout{

--- a/internal/service/elasticache/replication_group_migrate.go
+++ b/internal/service/elasticache/replication_group_migrate.go
@@ -1,0 +1,330 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package elasticache
+
+import (
+	"context"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/service/elasticache"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/types/nullable"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func replicationGroupStateUpgradeV1(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	if rawState == nil {
+		rawState = map[string]interface{}{}
+	}
+
+	// Set auth_token_update_strategy to new default value
+	rawState["auth_token_update_strategy"] = elasticache.AuthTokenUpdateStrategyTypeRotate
+
+	return rawState, nil
+}
+
+func resourceReplicationGroupConfigV1() *schema.Resource {
+	//lintignore:R011
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"apply_immediately": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"at_rest_encryption_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"auth_token": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Sensitive:     true,
+				ValidateFunc:  validReplicationGroupAuthToken,
+				ConflictsWith: []string{"user_group_ids"},
+			},
+			"auto_minor_version_upgrade": {
+				Type:         nullable.TypeNullableBool,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: nullable.ValidateTypeStringNullableBool,
+			},
+			"automatic_failover_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"cluster_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"configuration_endpoint_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"data_tiering_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+			"engine": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      engineRedis,
+				ValidateFunc: validation.StringInSlice([]string{engineRedis}, true),
+			},
+			"engine_version": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validRedisVersionString,
+			},
+			"engine_version_actual": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"global_replication_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+				ConflictsWith: []string{
+					"num_node_groups",
+					"parameter_group_name",
+					"engine",
+					"engine_version",
+					"node_type",
+					"security_group_names",
+					"transit_encryption_enabled",
+					"at_rest_encryption_enabled",
+					"snapshot_arns",
+					"snapshot_name",
+				},
+			},
+			"ip_discovery": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice(elasticache.IpDiscovery_Values(), false),
+			},
+			"log_delivery_configuration": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				MaxItems: 2,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"destination_type": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(elasticache.DestinationType_Values(), false),
+						},
+						"destination": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"log_format": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(elasticache.LogFormat_Values(), false),
+						},
+						"log_type": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(elasticache.LogType_Values(), false),
+						},
+					},
+				},
+			},
+			"maintenance_window": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				StateFunc: func(val interface{}) string {
+					// ElastiCache always changes the maintenance to lowercase
+					return strings.ToLower(val.(string))
+				},
+				ValidateFunc: verify.ValidOnceAWeekWindowFormat,
+			},
+			"member_clusters": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"multi_az_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"network_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(elasticache.NetworkType_Values(), false),
+			},
+			"node_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"notification_topic_arn": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: verify.ValidARN,
+			},
+			"num_cache_clusters": {
+				Type:          schema.TypeInt,
+				Computed:      true,
+				Optional:      true,
+				ConflictsWith: []string{"num_node_groups"},
+			},
+			"num_node_groups": {
+				Type:          schema.TypeInt,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"num_cache_clusters", "global_replication_group_id"},
+			},
+			"parameter_group_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return strings.HasPrefix(old, "global-datastore-")
+				},
+			},
+			"port": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					// Suppress default Redis ports when not defined
+					if !d.IsNewResource() && new == "0" && old == defaultRedisPort {
+						return true
+					}
+					return false
+				},
+			},
+			"preferred_cache_cluster_azs": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"primary_endpoint_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"reader_endpoint_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"replicas_per_node_group": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"replication_group_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateReplicationGroupID,
+				StateFunc: func(val interface{}) string {
+					return strings.ToLower(val.(string))
+				},
+			},
+			"security_group_names": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"security_group_ids": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"snapshot_arns": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				// Note: Unlike aws_elasticache_cluster, this does not have a limit of 1 item.
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					ValidateFunc: validation.All(
+						verify.ValidARN,
+						validation.StringDoesNotContainAny(","),
+					),
+				},
+				Set: schema.HashString,
+			},
+			"snapshot_retention_limit": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntAtMost(35),
+			},
+			"snapshot_window": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: verify.ValidOnceADayWindowFormat,
+			},
+			"snapshot_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"subnet_group_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			"transit_encryption_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"user_group_ids": {
+				Type:          schema.TypeSet,
+				Optional:      true,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				Set:           schema.HashString,
+				ConflictsWith: []string{"auth_token"},
+			},
+			"kms_key_id": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+			},
+			"final_snapshot_identifier": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This state upgrader resolves issues with the default `auth_token_update_strategy` value, introduced in v5.27.0, which causes a diff upon upgrade and triggers an attempted in-place update. The default value will now instead be written to state by the state upgrader, resulting in no changes on the initial apply.

Before:

```console
% make testacc PKG=elasticache TESTS="TestAccElastiCacheReplicationGroup_stateUpgrade5270"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheReplicationGroup_stateUpgrade5270'  -timeout 360m
=== RUN   TestAccElastiCacheReplicationGroup_stateUpgrade5270
=== PAUSE TestAccElastiCacheReplicationGroup_stateUpgrade5270
=== CONT  TestAccElastiCacheReplicationGroup_stateUpgrade5270
    replication_group_test.go:81: Step 2/2 error: Error running apply: exit status 1

        Error: changing auth_token for ElastiCache Replication Group (tf-acc-test-867954266583441629): InvalidParameterValue: The AUTH token modification is only supported when encryption-in-transit is enabl
ed.
                status code: 400, request id: de789aa8-0cf8-4e3d-a20f-d1252d7e5c28

          with aws_elasticache_replication_group.test,
          on terraform_plugin_test.tf line 2, in resource "aws_elasticache_replication_group" "test":
           2: resource "aws_elasticache_replication_group" "test" {

--- FAIL: TestAccElastiCacheReplicationGroup_stateUpgrade5270 (856.84s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        860.110s
```

After: 

```console
% make testacc PKG=elasticache TESTS="TestAccElastiCacheReplicationGroup_stateUpgrade5270"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheReplicationGroup_stateUpgrade5270'  -timeout 360m
=== RUN   TestAccElastiCacheReplicationGroup_stateUpgrade5270
=== PAUSE TestAccElastiCacheReplicationGroup_stateUpgrade5270
=== CONT  TestAccElastiCacheReplicationGroup_stateUpgrade5270
--- PASS: TestAccElastiCacheReplicationGroup_stateUpgrade5270 (892.26s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        895.558s
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #34589
Closes #34592
Relates #34460 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=elasticache TESTS="TestAccElastiCacheReplicationGroup_stateUpgrade5270"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheReplicationGroup_stateUpgrade5270'  -timeout 360m
=== RUN   TestAccElastiCacheReplicationGroup_stateUpgrade5270
=== PAUSE TestAccElastiCacheReplicationGroup_stateUpgrade5270
=== CONT  TestAccElastiCacheReplicationGroup_stateUpgrade5270
--- PASS: TestAccElastiCacheReplicationGroup_stateUpgrade5270 (892.26s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        895.558s
```
