### PR TITLE
tech debt: Collect diags instead of returning directly - `b` and `c` services

### DIFF
--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,9 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/c[o-z]*
+        - internal/service/code[b-z]*
+        - internal/service/co[g-z]*
+        - internal/service/c[u]*
         - internal/service/[d-z]*
     pattern: diag.FromErr($ERR)
     fix: sdkdiag.AppendFromErr(diags, $ERR)
@@ -15,7 +17,9 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/c[o-z]*
+        - internal/service/code[b-z]*
+        - internal/service/co[g-z]*
+        - internal/service/c[u]*
         - internal/service/[d-z]*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
@@ -26,7 +30,9 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/c[o-z]*
+        - internal/service/code[b-z]*
+        - internal/service/co[g-z]*
+        - internal/service/c[u]*
         - internal/service/[d-z]*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
@@ -48,7 +54,9 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/c[o-z]*
+        - internal/service/code[b-z]*
+        - internal/service/co[g-z]*
+        - internal/service/c[u]*
         - internal/service/[d-z]*
     pattern: create.DiagSettingError($...ARGS)
     fix: create.AppendDiagSettingError(diags, $...ARGS)
@@ -59,7 +67,9 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/c[o-z]*
+        - internal/service/code[b-z]*
+        - internal/service/co[g-z]*
+        - internal/service/c[u]*
         - internal/service/[d-z]*
     patterns:
       - pattern: return $READFN($...ARGS)
@@ -76,7 +86,9 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/c[o-z]*
+        - internal/service/code[b-z]*
+        - internal/service/co[g-z]*
+        - internal/service/c[u]*
         - internal/service/[d-z]*
     patterns:
       - pattern: return nil

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,7 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/code[g-z]*
+        - internal/service/code[p-z]*
         - internal/service/co[g-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
@@ -17,7 +17,7 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/code[g-z]*
+        - internal/service/code[p-z]*
         - internal/service/co[g-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
@@ -30,7 +30,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/code[g-z]*
+        - internal/service/code[p-z]*
         - internal/service/co[g-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
@@ -57,7 +57,7 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/code[g-z]*
+        - internal/service/code[p-z]*
         - internal/service/co[g-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
@@ -70,7 +70,7 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/code[g-z]*
+        - internal/service/code[p-z]*
         - internal/service/co[g-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
@@ -89,7 +89,7 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/code[g-z]*
+        - internal/service/code[p-z]*
         - internal/service/co[g-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -5,7 +5,7 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/c[h-z]*
+        - internal/service/c[l-z]*
         - internal/service/[d-z]*
     patterns:
       - pattern: diag.FromErr($ERR)
@@ -19,24 +19,32 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/c[h-z]*
+        - internal/service/c[l-z]*
         - internal/service/[d-z]*
     patterns:
       - pattern: diag.Errorf(...)
     severity: WARNING
 
-  - id: avoid-create_DiagError
-    fix-regex:
-      regex: create\.DiagError\((.*)\)
-      replacement: create.AppendDiagError(diags, \1)
+  - id: avoid-return-create_DiagError
     languages: [go]
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/c[h-z]*
+        - internal/service/c[l-z]*
         - internal/service/[d-z]*
-    patterns:
-      - pattern: create.DiagError(...)
+    pattern: return create.DiagError($...ARGS)
+    fix: return create.AppendDiagError(diags, $...ARGS)
+    severity: WARNING
+
+  - id: avoid-append-create_DiagError
+    languages: [go]
+    message: Prefer `create.AppendDiagError` to `create.DiagError`
+    paths:
+      exclude:
+        - internal/service/c[l-z]*
+        - internal/service/[d-z]*
+    pattern: append(diags, create.DiagError($...ARGS)...)
+    fix: create.AppendDiagError(diags, $...ARGS)
     severity: WARNING
 
   - id: avoid-create_DiagSettingError
@@ -47,7 +55,7 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/c[h-z]*
+        - internal/service/c[l-z]*
         - internal/service/[d-z]*
     patterns:
       - pattern: create.DiagSettingError(...)
@@ -61,7 +69,7 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/c[h-z]*
+        - internal/service/c[l-z]*
         - internal/service/[d-z]*
     patterns:
       - pattern: return $READFN(...)
@@ -80,7 +88,7 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/c[h-z]*
+        - internal/service/c[l-z]*
         - internal/service/[d-z]*
     patterns:
       - pattern: return nil

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,8 +4,8 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/code[s-z]*
-        - internal/service/co[g-z]*
+        - internal/service/cognitoidp
+        - internal/service/co[m-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
     pattern: diag.FromErr($ERR)
@@ -17,8 +17,8 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/code[s-z]*
-        - internal/service/co[g-z]*
+        - internal/service/cognitoidp
+        - internal/service/co[m-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
     pattern: diag.Errorf($...ARGS)
@@ -30,8 +30,8 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/code[s-z]*
-        - internal/service/co[g-z]*
+        - internal/service/cognitoidp
+        - internal/service/co[m-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
     pattern: return create.DiagError($...ARGS)
@@ -43,9 +43,8 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/codecommit
-        - internal/service/code[g-z]*
-        - internal/service/co[g-z]*
+        - internal/service/cognitoidp
+        - internal/service/co[m-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
@@ -57,8 +56,8 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/code[s-z]*
-        - internal/service/co[g-z]*
+        - internal/service/cognitoidp
+        - internal/service/co[m-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
     pattern: create.DiagSettingError($...ARGS)
@@ -70,8 +69,8 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/code[s-z]*
-        - internal/service/co[g-z]*
+        - internal/service/cognitoidp
+        - internal/service/co[m-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
     patterns:
@@ -93,8 +92,8 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/code[s-z]*
-        - internal/service/co[g-z]*
+        - internal/service/cognitoidp
+        - internal/service/co[m-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
     patterns:

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,8 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/code[c-z]*
+        - internal/service/codecommit
+        - internal/service/code[g-z]*
         - internal/service/co[g-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
@@ -17,7 +18,8 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/code[c-z]*
+        - internal/service/codecommit
+        - internal/service/code[g-z]*
         - internal/service/co[g-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
@@ -30,7 +32,8 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/code[c-z]*
+        - internal/service/codecommit
+        - internal/service/code[g-z]*
         - internal/service/co[g-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
@@ -43,7 +46,10 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/c[l-z]*
+        - internal/service/codecommit
+        - internal/service/code[g-z]*
+        - internal/service/co[g-z]*
+        - internal/service/c[u]*
         - internal/service/[d-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
     fix: create.AppendDiagError(diags, $...ARGS)
@@ -54,7 +60,8 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/code[c-z]*
+        - internal/service/codecommit
+        - internal/service/code[g-z]*
         - internal/service/co[g-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
@@ -67,7 +74,8 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/code[c-z]*
+        - internal/service/codecommit
+        - internal/service/code[g-z]*
         - internal/service/co[g-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
@@ -86,7 +94,8 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/code[c-z]*
+        - internal/service/codecommit
+        - internal/service/code[g-z]*
         - internal/service/co[g-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -1,28 +1,26 @@
 rules:
   - id: avoid-diag_FromErr
-    fix: sdkdiag.AppendFromErr(diags, $ERR)
     languages: [go]
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/c[l-z]*
+        - internal/service/cl[o-z]*
+        - internal/service/c[m-z]*
         - internal/service/[d-z]*
-    patterns:
-      - pattern: diag.FromErr($ERR)
+    pattern: diag.FromErr($ERR)
+    fix: sdkdiag.AppendFromErr(diags, $ERR)
     severity: WARNING
 
   - id: avoid-diag_Errorf
-    fix-regex:
-      regex: diag\.Errorf\((.*)\)
-      replacement: sdkdiag.AppendErrorf(diags, \1)
     languages: [go]
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/c[l-z]*
+        - internal/service/cl[o-z]*
+        - internal/service/c[m-z]*
         - internal/service/[d-z]*
-    patterns:
-      - pattern: diag.Errorf(...)
+    pattern: diag.Errorf($...ARGS)
+    fix: sdkdiag.AppendErrorf(diags, $...ARGS)
     severity: WARNING
 
   - id: avoid-return-create_DiagError
@@ -30,7 +28,8 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/c[l-z]*
+        - internal/service/cl[o-z]*
+        - internal/service/c[m-z]*
         - internal/service/[d-z]*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
@@ -48,47 +47,42 @@ rules:
     severity: WARNING
 
   - id: avoid-create_DiagSettingError
-    fix-regex:
-      regex: create\.DiagSettingError\((.*)\)
-      replacement: create.AppendDiagSettingError(diags, \1)
     languages: [go]
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/c[l-z]*
+        - internal/service/cl[o-z]*
+        - internal/service/c[m-z]*
         - internal/service/[d-z]*
-    patterns:
-      - pattern: create.DiagSettingError(...)
+    pattern: create.DiagSettingError($...ARGS)
+    fix: create.AppendDiagSettingError(diags, $...ARGS)
     severity: WARNING
 
   - id: append-Read-to-diags
-    fix-regex:
-      regex: return (resource\w+Read\(.*\))
-      replacement: return append(diags, \1...)
     languages: [go]
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/c[l-z]*
+        - internal/service/cl[o-z]*
+        - internal/service/c[m-z]*
         - internal/service/[d-z]*
     patterns:
-      - pattern: return $READFN(...)
+      - pattern: return $READFN($...ARGS)
       - metavariable-regex:
           metavariable: "$READFN"
           regex: resource\w+Read
+    fix: return append(diags, $READFN($...ARGS)...)
     severity: WARNING
 
   - id: return-diags-not-nil
-    fix-regex:
-      regex: return nil
-      replacement: return diags
     languages: [go]
     message: Return diags instead of nil
     paths:
       include:
         - internal/service
       exclude:
-        - internal/service/c[l-z]*
+        - internal/service/cl[o-z]*
+        - internal/service/c[m-z]*
         - internal/service/[d-z]*
     patterns:
       - pattern: return nil
@@ -100,4 +94,5 @@ rules:
           func $F(...) diag.Diagnostics {
             ...
           }
+    fix: return diags
     severity: WARNING

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,7 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/code[b-z]*
+        - internal/service/code[c-z]*
         - internal/service/co[g-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
@@ -17,7 +17,7 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/code[b-z]*
+        - internal/service/code[c-z]*
         - internal/service/co[g-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
@@ -30,7 +30,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/code[b-z]*
+        - internal/service/code[c-z]*
         - internal/service/co[g-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
@@ -54,7 +54,7 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/code[b-z]*
+        - internal/service/code[c-z]*
         - internal/service/co[g-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
@@ -67,7 +67,7 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/code[b-z]*
+        - internal/service/code[c-z]*
         - internal/service/co[g-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
@@ -86,7 +86,7 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/code[b-z]*
+        - internal/service/code[c-z]*
         - internal/service/co[g-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -5,7 +5,7 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/[b-z]*
+        - internal/service/[c-z]*
     patterns:
       - pattern: diag.FromErr($ERR)
     severity: WARNING
@@ -18,7 +18,7 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/[b-z]*
+        - internal/service/[c-z]*
     patterns:
       - pattern: diag.Errorf(...)
     severity: WARNING
@@ -31,7 +31,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/[b-z]*
+        - internal/service/[c-z]*
     patterns:
       - pattern: create.DiagError(...)
     severity: WARNING
@@ -44,7 +44,7 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/[b-z]*
+        - internal/service/[c-z]*
     patterns:
       - pattern: create.DiagSettingError(...)
     severity: WARNING
@@ -57,7 +57,7 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/[b-z]*
+        - internal/service/[c-z]*
     patterns:
       - pattern: return $READFN(...)
       - metavariable-regex:
@@ -75,7 +75,7 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/[b-z]*
+        - internal/service/[c-z]*
     patterns:
       - pattern: return nil
       - pattern-not-inside: |

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,6 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/codecommit
         - internal/service/code[g-z]*
         - internal/service/co[g-z]*
         - internal/service/c[u]*
@@ -18,7 +17,6 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/codecommit
         - internal/service/code[g-z]*
         - internal/service/co[g-z]*
         - internal/service/c[u]*
@@ -32,7 +30,6 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/codecommit
         - internal/service/code[g-z]*
         - internal/service/co[g-z]*
         - internal/service/c[u]*
@@ -60,7 +57,6 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/codecommit
         - internal/service/code[g-z]*
         - internal/service/co[g-z]*
         - internal/service/c[u]*
@@ -74,7 +70,6 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/codecommit
         - internal/service/code[g-z]*
         - internal/service/co[g-z]*
         - internal/service/c[u]*
@@ -94,7 +89,6 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/codecommit
         - internal/service/code[g-z]*
         - internal/service/co[g-z]*
         - internal/service/c[u]*

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,8 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/cloud[f-z]*
+        - internal/service/cloudf[r-z]*
+        - internal/service/cloud[g-z]*
         - internal/service/c[m-z]*
         - internal/service/[d-z]*
     pattern: diag.FromErr($ERR)
@@ -16,7 +17,8 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/cloud[f-z]*
+        - internal/service/cloudf[r-z]*
+        - internal/service/cloud[g-z]*
         - internal/service/c[m-z]*
         - internal/service/[d-z]*
     pattern: diag.Errorf($...ARGS)
@@ -28,7 +30,8 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/cloud[f-z]*
+        - internal/service/cloudf[r-z]*
+        - internal/service/cloud[g-z]*
         - internal/service/c[m-z]*
         - internal/service/[d-z]*
     pattern: return create.DiagError($...ARGS)
@@ -51,7 +54,8 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/cloud[f-z]*
+        - internal/service/cloudf[r-z]*
+        - internal/service/cloud[g-z]*
         - internal/service/c[m-z]*
         - internal/service/[d-z]*
     pattern: create.DiagSettingError($...ARGS)
@@ -63,7 +67,8 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/cloud[f-z]*
+        - internal/service/cloudf[r-z]*
+        - internal/service/cloud[g-z]*
         - internal/service/c[m-z]*
         - internal/service/[d-z]*
     patterns:
@@ -81,7 +86,8 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/cloud[f-z]*
+        - internal/service/cloudf[r-z]*
+        - internal/service/cloud[g-z]*
         - internal/service/c[m-z]*
         - internal/service/[d-z]*
     patterns:

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,7 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/co[m-z]*
+        - internal/service/co[n-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
     pattern: diag.FromErr($ERR)
@@ -16,7 +16,7 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/co[m-z]*
+        - internal/service/co[n-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
     pattern: diag.Errorf($...ARGS)
@@ -28,7 +28,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/co[m-z]*
+        - internal/service/co[n-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
     pattern: return create.DiagError($...ARGS)
@@ -53,7 +53,7 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/co[m-z]*
+        - internal/service/co[n-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
     pattern: create.DiagSettingError($...ARGS)
@@ -65,7 +65,7 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/co[m-z]*
+        - internal/service/co[n-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
     patterns:
@@ -87,7 +87,7 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/co[m-z]*
+        - internal/service/co[n-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
     patterns:

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,6 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/cloudf[r-z]*
         - internal/service/cloud[g-z]*
         - internal/service/c[m-z]*
         - internal/service/[d-z]*
@@ -17,7 +16,6 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/cloudf[r-z]*
         - internal/service/cloud[g-z]*
         - internal/service/c[m-z]*
         - internal/service/[d-z]*
@@ -30,7 +28,6 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/cloudf[r-z]*
         - internal/service/cloud[g-z]*
         - internal/service/c[m-z]*
         - internal/service/[d-z]*
@@ -54,7 +51,6 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/cloudf[r-z]*
         - internal/service/cloud[g-z]*
         - internal/service/c[m-z]*
         - internal/service/[d-z]*
@@ -67,7 +63,6 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/cloudf[r-z]*
         - internal/service/cloud[g-z]*
         - internal/service/c[m-z]*
         - internal/service/[d-z]*
@@ -86,7 +81,6 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/cloudf[r-z]*
         - internal/service/cloud[g-z]*
         - internal/service/c[m-z]*
         - internal/service/[d-z]*

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,8 +4,7 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/cloud[w-z]*
-        - internal/service/c[m-z]*
+        - internal/service/c[o-z]*
         - internal/service/[d-z]*
     pattern: diag.FromErr($ERR)
     fix: sdkdiag.AppendFromErr(diags, $ERR)
@@ -16,8 +15,7 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/cloud[w-z]*
-        - internal/service/c[m-z]*
+        - internal/service/c[o-z]*
         - internal/service/[d-z]*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
@@ -28,8 +26,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/cloud[w-z]*
-        - internal/service/c[m-z]*
+        - internal/service/c[o-z]*
         - internal/service/[d-z]*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
@@ -51,8 +48,7 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/cloud[w-z]*
-        - internal/service/c[m-z]*
+        - internal/service/c[o-z]*
         - internal/service/[d-z]*
     pattern: create.DiagSettingError($...ARGS)
     fix: create.AppendDiagSettingError(diags, $...ARGS)
@@ -63,8 +59,7 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/cloud[w-z]*
-        - internal/service/c[m-z]*
+        - internal/service/c[o-z]*
         - internal/service/[d-z]*
     patterns:
       - pattern: return $READFN($...ARGS)
@@ -81,8 +76,7 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/cloud[w-z]*
-        - internal/service/c[m-z]*
+        - internal/service/c[o-z]*
         - internal/service/[d-z]*
     patterns:
       - pattern: return nil

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -5,7 +5,8 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/[c-z]*
+        - internal/service/c[h-z]*
+        - internal/service/[d-z]*
     patterns:
       - pattern: diag.FromErr($ERR)
     severity: WARNING
@@ -18,7 +19,8 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/[c-z]*
+        - internal/service/c[h-z]*
+        - internal/service/[d-z]*
     patterns:
       - pattern: diag.Errorf(...)
     severity: WARNING
@@ -31,7 +33,8 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/[c-z]*
+        - internal/service/c[h-z]*
+        - internal/service/[d-z]*
     patterns:
       - pattern: create.DiagError(...)
     severity: WARNING
@@ -44,7 +47,8 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/[c-z]*
+        - internal/service/c[h-z]*
+        - internal/service/[d-z]*
     patterns:
       - pattern: create.DiagSettingError(...)
     severity: WARNING
@@ -57,7 +61,8 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/[c-z]*
+        - internal/service/c[h-z]*
+        - internal/service/[d-z]*
     patterns:
       - pattern: return $READFN(...)
       - metavariable-regex:
@@ -75,7 +80,8 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/[c-z]*
+        - internal/service/c[h-z]*
+        - internal/service/[d-z]*
     patterns:
       - pattern: return nil
       - pattern-not-inside: |

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,6 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/connect
         - internal/service/connectcases
         - internal/service/controltower
         - internal/service/cur
@@ -19,7 +18,6 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/connect
         - internal/service/connectcases
         - internal/service/controltower
         - internal/service/cur
@@ -33,7 +31,6 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/connect
         - internal/service/connectcases
         - internal/service/controltower
         - internal/service/cur
@@ -61,7 +58,6 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/connect
         - internal/service/connectcases
         - internal/service/controltower
         - internal/service/cur
@@ -75,7 +71,6 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/connect
         - internal/service/connectcases
         - internal/service/controltower
         - internal/service/cur
@@ -99,7 +94,6 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/connect
         - internal/service/connectcases
         - internal/service/controltower
         - internal/service/cur

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,8 +4,11 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/co[n-z]*
-        - internal/service/c[u]*
+        - internal/service/connect
+        - internal/service/connectcases
+        - internal/service/controltower
+        - internal/service/cur
+        - internal/service/customerprofiles
         - internal/service/[d-z]*
     pattern: diag.FromErr($ERR)
     fix: sdkdiag.AppendFromErr(diags, $ERR)
@@ -16,8 +19,10 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/co[n-z]*
-        - internal/service/c[u]*
+        - internal/service/connect
+        - internal/service/connectcases
+        - internal/service/controltower
+        - internal/service/cur
         - internal/service/[d-z]*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
@@ -28,8 +33,10 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/co[n-z]*
-        - internal/service/c[u]*
+        - internal/service/connect
+        - internal/service/connectcases
+        - internal/service/controltower
+        - internal/service/cur
         - internal/service/[d-z]*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
@@ -40,9 +47,10 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/cognitoidp
-        - internal/service/co[m-z]*
-        - internal/service/c[u]*
+        - internal/service/connect
+        - internal/service/connectcases
+        - internal/service/controltower
+        - internal/service/cur
         - internal/service/[d-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
     fix: create.AppendDiagError(diags, $...ARGS)
@@ -53,8 +61,10 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/co[n-z]*
-        - internal/service/c[u]*
+        - internal/service/connect
+        - internal/service/connectcases
+        - internal/service/controltower
+        - internal/service/cur
         - internal/service/[d-z]*
     pattern: create.DiagSettingError($...ARGS)
     fix: create.AppendDiagSettingError(diags, $...ARGS)
@@ -65,8 +75,10 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/co[n-z]*
-        - internal/service/c[u]*
+        - internal/service/connect
+        - internal/service/connectcases
+        - internal/service/controltower
+        - internal/service/cur
         - internal/service/[d-z]*
     patterns:
       - pattern: return $READFN($...ARGS)
@@ -87,8 +99,10 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/co[n-z]*
-        - internal/service/c[u]*
+        - internal/service/connect
+        - internal/service/connectcases
+        - internal/service/controltower
+        - internal/service/cur
         - internal/service/[d-z]*
     patterns:
       - pattern: return nil

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,7 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/code[p-z]*
+        - internal/service/code[s-z]*
         - internal/service/co[g-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
@@ -17,7 +17,7 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/code[p-z]*
+        - internal/service/code[s-z]*
         - internal/service/co[g-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
@@ -30,7 +30,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/code[p-z]*
+        - internal/service/code[s-z]*
         - internal/service/co[g-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
@@ -57,7 +57,7 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/code[p-z]*
+        - internal/service/code[s-z]*
         - internal/service/co[g-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
@@ -70,7 +70,7 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/code[p-z]*
+        - internal/service/code[s-z]*
         - internal/service/co[g-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
@@ -79,6 +79,10 @@ rules:
       - metavariable-regex:
           metavariable: "$READFN"
           regex: resource\w+Read
+      - pattern-not-inside: |
+          func $UPDATEFN(...) {
+            return $READFN($...ARGS)
+          }
     fix: return append(diags, $READFN($...ARGS)...)
     severity: WARNING
 
@@ -89,7 +93,7 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/code[p-z]*
+        - internal/service/code[s-z]*
         - internal/service/co[g-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,10 +4,6 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/connectcases
-        - internal/service/controltower
-        - internal/service/cur
-        - internal/service/customerprofiles
         - internal/service/[d-z]*
     pattern: diag.FromErr($ERR)
     fix: sdkdiag.AppendFromErr(diags, $ERR)
@@ -18,9 +14,6 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/connectcases
-        - internal/service/controltower
-        - internal/service/cur
         - internal/service/[d-z]*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
@@ -31,9 +24,6 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/connectcases
-        - internal/service/controltower
-        - internal/service/cur
         - internal/service/[d-z]*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
@@ -58,9 +48,6 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/connectcases
-        - internal/service/controltower
-        - internal/service/cur
         - internal/service/[d-z]*
     pattern: create.DiagSettingError($...ARGS)
     fix: create.AppendDiagSettingError(diags, $...ARGS)
@@ -71,9 +58,6 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/connectcases
-        - internal/service/controltower
-        - internal/service/cur
         - internal/service/[d-z]*
     patterns:
       - pattern: return $READFN($...ARGS)
@@ -94,9 +78,6 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/connectcases
-        - internal/service/controltower
-        - internal/service/cur
         - internal/service/[d-z]*
     patterns:
       - pattern: return nil

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,7 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/cloud[g-z]*
+        - internal/service/cloud[w-z]*
         - internal/service/c[m-z]*
         - internal/service/[d-z]*
     pattern: diag.FromErr($ERR)
@@ -16,7 +16,7 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/cloud[g-z]*
+        - internal/service/cloud[w-z]*
         - internal/service/c[m-z]*
         - internal/service/[d-z]*
     pattern: diag.Errorf($...ARGS)
@@ -28,7 +28,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/cloud[g-z]*
+        - internal/service/cloud[w-z]*
         - internal/service/c[m-z]*
         - internal/service/[d-z]*
     pattern: return create.DiagError($...ARGS)
@@ -51,7 +51,7 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/cloud[g-z]*
+        - internal/service/cloud[w-z]*
         - internal/service/c[m-z]*
         - internal/service/[d-z]*
     pattern: create.DiagSettingError($...ARGS)
@@ -63,7 +63,7 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/cloud[g-z]*
+        - internal/service/cloud[w-z]*
         - internal/service/c[m-z]*
         - internal/service/[d-z]*
     patterns:
@@ -81,7 +81,7 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/cloud[g-z]*
+        - internal/service/cloud[w-z]*
         - internal/service/c[m-z]*
         - internal/service/[d-z]*
     patterns:

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,7 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/cl[o-z]*
+        - internal/service/cloud[f-z]*
         - internal/service/c[m-z]*
         - internal/service/[d-z]*
     pattern: diag.FromErr($ERR)
@@ -16,7 +16,7 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/cl[o-z]*
+        - internal/service/cloud[f-z]*
         - internal/service/c[m-z]*
         - internal/service/[d-z]*
     pattern: diag.Errorf($...ARGS)
@@ -28,7 +28,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/cl[o-z]*
+        - internal/service/cloud[f-z]*
         - internal/service/c[m-z]*
         - internal/service/[d-z]*
     pattern: return create.DiagError($...ARGS)
@@ -51,7 +51,7 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/cl[o-z]*
+        - internal/service/cloud[f-z]*
         - internal/service/c[m-z]*
         - internal/service/[d-z]*
     pattern: create.DiagSettingError($...ARGS)
@@ -63,7 +63,7 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/cl[o-z]*
+        - internal/service/cloud[f-z]*
         - internal/service/c[m-z]*
         - internal/service/[d-z]*
     patterns:
@@ -81,7 +81,7 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/cl[o-z]*
+        - internal/service/cloud[f-z]*
         - internal/service/c[m-z]*
         - internal/service/[d-z]*
     patterns:

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,6 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/cognitoidp
         - internal/service/co[m-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
@@ -17,7 +16,6 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/cognitoidp
         - internal/service/co[m-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
@@ -30,7 +28,6 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/cognitoidp
         - internal/service/co[m-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
@@ -56,7 +53,6 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/cognitoidp
         - internal/service/co[m-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
@@ -69,7 +65,6 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/cognitoidp
         - internal/service/co[m-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*
@@ -92,7 +87,6 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/cognitoidp
         - internal/service/co[m-z]*
         - internal/service/c[u]*
         - internal/service/[d-z]*

--- a/internal/service/apprunner/auto_scaling_configuration_version.go
+++ b/internal/service/apprunner/auto_scaling_configuration_version.go
@@ -168,7 +168,7 @@ func resourceAutoScalingConfigurationRead(ctx context.Context, d *schema.Resourc
 
 func resourceAutoScalingConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	// Tags only.
-	return resourceAutoScalingConfigurationRead(ctx, d, meta) // nosemgrep:ci.semgrep.pluginsdk.append-Read-to-diags
+	return resourceAutoScalingConfigurationRead(ctx, d, meta)
 }
 
 func resourceAutoScalingConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/service/apprunner/connection.go
+++ b/internal/service/apprunner/connection.go
@@ -116,7 +116,7 @@ func resourceConnectionRead(ctx context.Context, d *schema.ResourceData, meta in
 
 func resourceConnectionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	// Tags only.
-	return resourceConnectionRead(ctx, d, meta) // nosemgrep:ci.semgrep.pluginsdk.append-Read-to-diags
+	return resourceConnectionRead(ctx, d, meta)
 }
 
 func resourceConnectionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/service/apprunner/observability_configuration.go
+++ b/internal/service/apprunner/observability_configuration.go
@@ -142,7 +142,7 @@ func resourceObservabilityConfigurationRead(ctx context.Context, d *schema.Resou
 
 func resourceObservabilityConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	// Tags only.
-	return resourceObservabilityConfigurationRead(ctx, d, meta) // nosemgrep:ci.semgrep.pluginsdk.append-Read-to-diags
+	return resourceObservabilityConfigurationRead(ctx, d, meta)
 }
 
 func resourceObservabilityConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/service/apprunner/vpc_connector.go
+++ b/internal/service/apprunner/vpc_connector.go
@@ -135,7 +135,7 @@ func resourceVPCConnectorRead(ctx context.Context, d *schema.ResourceData, meta 
 
 func resourceVPCConnectorUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	// Tags only.
-	return resourceVPCConnectorRead(ctx, d, meta) // nosemgrep:ci.semgrep.pluginsdk.append-Read-to-diags
+	return resourceVPCConnectorRead(ctx, d, meta)
 }
 
 func resourceVPCConnectorDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/service/apprunner/vpc_ingress_connection.go
+++ b/internal/service/apprunner/vpc_ingress_connection.go
@@ -146,7 +146,7 @@ func resourceVPCIngressConnectionRead(ctx context.Context, d *schema.ResourceDat
 
 func resourceVPCIngressConnectionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	// Tags only.
-	return resourceVPCIngressConnectionRead(ctx, d, meta) // nosemgrep:ci.semgrep.pluginsdk.append-Read-to-diags
+	return resourceVPCIngressConnectionRead(ctx, d, meta)
 }
 
 func resourceVPCIngressConnectionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/service/appstream/image_builder.go
+++ b/internal/service/appstream/image_builder.go
@@ -300,7 +300,7 @@ func resourceImageBuilderRead(ctx context.Context, d *schema.ResourceData, meta 
 
 func resourceImageBuilderUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	// Tags only.
-	return resourceImageBuilderRead(ctx, d, meta) // nosemgrep:ci.semgrep.pluginsdk.append-Read-to-diags
+	return resourceImageBuilderRead(ctx, d, meta)
 }
 
 func resourceImageBuilderDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/service/batch/scheduling_policy.go
+++ b/internal/service/batch/scheduling_policy.go
@@ -101,6 +101,8 @@ func ResourceSchedulingPolicy() *schema.Resource {
 }
 
 func resourceSchedulingPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).BatchConn(ctx)
 
 	name := d.Get("name").(string)
@@ -113,16 +115,17 @@ func resourceSchedulingPolicyCreate(ctx context.Context, d *schema.ResourceData,
 	output, err := conn.CreateSchedulingPolicyWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating Batch Scheduling Policy (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "creating Batch Scheduling Policy (%s): %s", name, err)
 	}
 
 	d.SetId(aws.StringValue(output.Arn))
 
-	return resourceSchedulingPolicyRead(ctx, d, meta)
+	return append(diags, resourceSchedulingPolicyRead(ctx, d, meta)...)
 }
 
 func resourceSchedulingPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).BatchConn(ctx)
 
 	sp, err := FindSchedulingPolicyByARN(ctx, conn, d.Id())
@@ -149,6 +152,8 @@ func resourceSchedulingPolicyRead(ctx context.Context, d *schema.ResourceData, m
 }
 
 func resourceSchedulingPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).BatchConn(ctx)
 
 	if d.HasChange("fair_share_policy") {
@@ -160,14 +165,16 @@ func resourceSchedulingPolicyUpdate(ctx context.Context, d *schema.ResourceData,
 		_, err := conn.UpdateSchedulingPolicyWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("updating Batch Scheduling Policy (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating Batch Scheduling Policy (%s): %s", d.Id(), err)
 		}
 	}
 
-	return resourceSchedulingPolicyRead(ctx, d, meta)
+	return append(diags, resourceSchedulingPolicyRead(ctx, d, meta)...)
 }
 
 func resourceSchedulingPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).BatchConn(ctx)
 
 	log.Printf("[DEBUG] Deleting Batch Scheduling Policy: %s", d.Id())
@@ -176,10 +183,10 @@ func resourceSchedulingPolicyDelete(ctx context.Context, d *schema.ResourceData,
 	})
 
 	if err != nil {
-		return diag.Errorf("deleting Batch Scheduling Policy (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Batch Scheduling Policy (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func FindSchedulingPolicyByARN(ctx context.Context, conn *batch.Batch, arn string) (*batch.SchedulingPolicyDetail, error) {

--- a/internal/service/budgets/budget.go
+++ b/internal/service/budgets/budget.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -289,12 +290,14 @@ func ResourceBudget() *schema.Resource {
 }
 
 func resourceBudgetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).BudgetsConn(ctx)
 
 	budget, err := expandBudgetUnmarshal(d)
 
 	if err != nil {
-		return diag.Errorf("expandBudgetUnmarshal: %s", err)
+		return sdkdiag.AppendErrorf(diags, "expandBudgetUnmarshal: %s", err)
 	}
 
 	name := create.Name(d.Get("name").(string), d.Get("name_prefix").(string))
@@ -311,7 +314,7 @@ func resourceBudgetCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	})
 
 	if err != nil {
-		return diag.Errorf("creating Budget (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "creating Budget (%s): %s", name, err)
 	}
 
 	d.SetId(BudgetCreateResourceID(accountID, aws.StringValue(budget.BudgetName)))
@@ -322,19 +325,21 @@ func resourceBudgetCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	err = createBudgetNotifications(ctx, conn, notifications, subscribers, *budget.BudgetName, accountID)
 
 	if err != nil {
-		return diag.Errorf("creating Budget (%s) notifications: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "creating Budget (%s) notifications: %s", d.Id(), err)
 	}
 
-	return resourceBudgetRead(ctx, d, meta)
+	return append(diags, resourceBudgetRead(ctx, d, meta)...)
 }
 
 func resourceBudgetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).BudgetsConn(ctx)
 
 	accountID, budgetName, err := BudgetParseResourceID(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	budget, err := FindBudgetByTwoPartKey(ctx, conn, accountID, budgetName)
@@ -342,11 +347,11 @@ func resourceBudgetRead(ctx context.Context, d *schema.ResourceData, meta interf
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Budget (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Budget (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Budget (%s): %s", d.Id(), err)
 	}
 
 	d.Set("account_id", accountID)
@@ -360,13 +365,13 @@ func resourceBudgetRead(ctx context.Context, d *schema.ResourceData, meta interf
 	d.Set("budget_type", budget.BudgetType)
 
 	if err := d.Set("cost_filter", convertCostFiltersToMap(budget.CostFilters)); err != nil {
-		return diag.Errorf("setting cost_filter: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting cost_filter: %s", err)
 	}
 	if err := d.Set("cost_types", flattenCostTypes(budget.CostTypes)); err != nil {
-		return diag.Errorf("setting cost_types: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting cost_types: %s", err)
 	}
 	if err := d.Set("auto_adjust_data", flattenAutoAdjustData(budget.AutoAdjustData)); err != nil {
-		return diag.Errorf("setting auto_adjust_data: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting auto_adjust_data: %s", err)
 	}
 
 	if budget.BudgetLimit != nil {
@@ -378,7 +383,7 @@ func resourceBudgetRead(ctx context.Context, d *schema.ResourceData, meta interf
 	d.Set("name_prefix", create.NamePrefixFromName(aws.StringValue(budget.BudgetName)))
 
 	if err := d.Set("planned_limit", convertPlannedBudgetLimitsToSet(budget.PlannedBudgetLimits)); err != nil {
-		return diag.Errorf("setting planned_limit: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting planned_limit: %s", err)
 	}
 
 	if budget.TimePeriod != nil {
@@ -391,11 +396,11 @@ func resourceBudgetRead(ctx context.Context, d *schema.ResourceData, meta interf
 	notifications, err := findNotifications(ctx, conn, accountID, budgetName)
 
 	if tfresource.NotFound(err) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Budget (%s) notifications: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Budget (%s) notifications: %s", d.Id(), err)
 	}
 
 	var tfList []interface{}
@@ -423,7 +428,7 @@ func resourceBudgetRead(ctx context.Context, d *schema.ResourceData, meta interf
 		}
 
 		if err != nil {
-			return diag.Errorf("reading Budget (%s) subscribers: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "reading Budget (%s) subscribers: %s", d.Id(), err)
 		}
 
 		var emailSubscribers []string
@@ -444,25 +449,27 @@ func resourceBudgetRead(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	if err := d.Set("notification", tfList); err != nil {
-		return diag.Errorf("setting notification: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting notification: %s", err)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceBudgetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).BudgetsConn(ctx)
 
 	accountID, _, err := BudgetParseResourceID(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	budget, err := expandBudgetUnmarshal(d)
 
 	if err != nil {
-		return diag.Errorf("expandBudgetUnmarshal: %s", err)
+		return sdkdiag.AppendErrorf(diags, "expandBudgetUnmarshal: %s", err)
 	}
 
 	_, err = conn.UpdateBudgetWithContext(ctx, &budgets.UpdateBudgetInput{
@@ -471,25 +478,27 @@ func resourceBudgetUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	})
 
 	if err != nil {
-		return diag.Errorf("updating Budget (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "updating Budget (%s): %s", d.Id(), err)
 	}
 
 	err = updateBudgetNotifications(ctx, conn, d)
 
 	if err != nil {
-		return diag.Errorf("updating Budget (%s) notifications: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "updating Budget (%s) notifications: %s", d.Id(), err)
 	}
 
-	return resourceBudgetRead(ctx, d, meta)
+	return append(diags, resourceBudgetRead(ctx, d, meta)...)
 }
 
 func resourceBudgetDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).BudgetsConn(ctx)
 
 	accountID, budgetName, err := BudgetParseResourceID(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	log.Printf("[DEBUG] Deleting Budget: %s", d.Id())
@@ -499,14 +508,14 @@ func resourceBudgetDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	})
 
 	if tfawserr.ErrCodeEquals(err, budgets.ErrCodeNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting Budget (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Budget (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 const budgetResourceIDSeparator = ":"

--- a/internal/service/budgets/budget_action.go
+++ b/internal/service/budgets/budget_action.go
@@ -274,7 +274,7 @@ func resourceBudgetActionRead(ctx context.Context, d *schema.ResourceData, meta 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Budget Action (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
@@ -378,7 +378,7 @@ func resourceBudgetActionDelete(ctx context.Context, d *schema.ResourceData, met
 	}, budgets.ErrCodeResourceLockedException)
 
 	if tfawserr.ErrCodeEquals(err, budgets.ErrCodeNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {

--- a/internal/service/ce/anomaly_monitor.go
+++ b/internal/service/ce/anomaly_monitor.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -75,6 +76,8 @@ func ResourceAnomalyMonitor() *schema.Resource {
 }
 
 func resourceAnomalyMonitorCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).CEConn(ctx)
 
 	input := &costexplorer.CreateAnomalyMonitorInput{
@@ -89,38 +92,40 @@ func resourceAnomalyMonitorCreate(ctx context.Context, d *schema.ResourceData, m
 		if v, ok := d.GetOk("monitor_dimension"); ok {
 			input.AnomalyMonitor.MonitorDimension = aws.String(v.(string))
 		} else {
-			return diag.Errorf("If Monitor Type is %s, dimension attrribute is required", costexplorer.MonitorTypeDimensional)
+			return sdkdiag.AppendErrorf(diags, "If Monitor Type is %s, dimension attrribute is required", costexplorer.MonitorTypeDimensional)
 		}
 	case costexplorer.MonitorTypeCustom:
 		if v, ok := d.GetOk("monitor_specification"); ok {
 			expression := costexplorer.Expression{}
 
 			if err := json.Unmarshal([]byte(v.(string)), &expression); err != nil {
-				return diag.Errorf("parsing specification: %s", err)
+				return sdkdiag.AppendErrorf(diags, "parsing specification: %s", err)
 			}
 
 			input.AnomalyMonitor.MonitorSpecification = &expression
 		} else {
-			return diag.Errorf("If Monitor Type is %s, dimension attrribute is required", costexplorer.MonitorTypeCustom)
+			return sdkdiag.AppendErrorf(diags, "If Monitor Type is %s, dimension attrribute is required", costexplorer.MonitorTypeCustom)
 		}
 	}
 
 	resp, err := conn.CreateAnomalyMonitorWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating Anomaly Monitor: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating Anomaly Monitor: %s", err)
 	}
 
 	if resp == nil || resp.MonitorArn == nil {
-		return diag.Errorf("creating Cost Explorer Anomaly Monitor resource (%s): empty output", d.Get("name").(string))
+		return sdkdiag.AppendErrorf(diags, "creating Cost Explorer Anomaly Monitor resource (%s): empty output", d.Get("name").(string))
 	}
 
 	d.SetId(aws.StringValue(resp.MonitorArn))
 
-	return resourceAnomalyMonitorRead(ctx, d, meta)
+	return append(diags, resourceAnomalyMonitorRead(ctx, d, meta)...)
 }
 
 func resourceAnomalyMonitorRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).CEConn(ctx)
 
 	monitor, err := FindAnomalyMonitorByARN(ctx, conn, d.Id())
@@ -128,22 +133,22 @@ func resourceAnomalyMonitorRead(ctx context.Context, d *schema.ResourceData, met
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		create.LogNotFoundRemoveState(names.CE, create.ErrActionReading, ResNameAnomalyMonitor, d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.CE, create.ErrActionReading, ResNameAnomalyMonitor, d.Id(), err)
+		return create.AppendDiagError(diags, names.CE, create.ErrActionReading, ResNameAnomalyMonitor, d.Id(), err)
 	}
 
 	if monitor.MonitorSpecification != nil {
 		specificationToJson, err := json.Marshal(monitor.MonitorSpecification)
 		if err != nil {
-			return diag.Errorf("parsing specification response: %s", err)
+			return sdkdiag.AppendErrorf(diags, "parsing specification response: %s", err)
 		}
 		specificationToSet, err := structure.NormalizeJsonString(string(specificationToJson))
 
 		if err != nil {
-			return diag.Errorf("Specification (%s) is invalid JSON: %s", specificationToSet, err)
+			return sdkdiag.AppendErrorf(diags, "Specification (%s) is invalid JSON: %s", specificationToSet, err)
 		}
 
 		d.Set("monitor_specification", specificationToSet)
@@ -154,10 +159,12 @@ func resourceAnomalyMonitorRead(ctx context.Context, d *schema.ResourceData, met
 	d.Set("name", monitor.MonitorName)
 	d.Set("monitor_type", monitor.MonitorType)
 
-	return nil
+	return diags
 }
 
 func resourceAnomalyMonitorUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).CEConn(ctx)
 	requestUpdate := false
 
@@ -174,25 +181,27 @@ func resourceAnomalyMonitorUpdate(ctx context.Context, d *schema.ResourceData, m
 		_, err := conn.UpdateAnomalyMonitorWithContext(ctx, input)
 
 		if err != nil {
-			return create.DiagError(names.CE, create.ErrActionUpdating, ResNameAnomalyMonitor, d.Id(), err)
+			return create.AppendDiagError(diags, names.CE, create.ErrActionUpdating, ResNameAnomalyMonitor, d.Id(), err)
 		}
 	}
 
-	return resourceAnomalyMonitorRead(ctx, d, meta)
+	return append(diags, resourceAnomalyMonitorRead(ctx, d, meta)...)
 }
 
 func resourceAnomalyMonitorDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).CEConn(ctx)
 
 	_, err := conn.DeleteAnomalyMonitorWithContext(ctx, &costexplorer.DeleteAnomalyMonitorInput{MonitorArn: aws.String(d.Id())})
 
 	if err != nil && tfawserr.ErrCodeEquals(err, costexplorer.ErrCodeUnknownMonitorException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.CE, create.ErrActionDeleting, ResNameAnomalyMonitor, d.Id(), err)
+		return create.AppendDiagError(diags, names.CE, create.ErrActionDeleting, ResNameAnomalyMonitor, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/ce/cost_category_data_source.go
+++ b/internal/service/ce/cost_category_data_source.go
@@ -317,13 +317,15 @@ func DataSourceCostCategory() *schema.Resource {
 }
 
 func dataSourceCostCategoryRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).CEConn(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	costCategory, err := FindCostCategoryByARN(ctx, conn, d.Get("cost_category_arn").(string))
 
 	if err != nil {
-		return create.DiagError(names.CE, create.ErrActionReading, ResNameCostCategory, d.Id(), err)
+		return create.AppendDiagError(diags, names.CE, create.ErrActionReading, ResNameCostCategory, d.Id(), err)
 	}
 
 	d.Set("default_value", costCategory.DefaultValue)
@@ -331,11 +333,11 @@ func dataSourceCostCategoryRead(ctx context.Context, d *schema.ResourceData, met
 	d.Set("effective_start", costCategory.EffectiveStart)
 	d.Set("name", costCategory.Name)
 	if err = d.Set("rule", flattenCostCategoryRules(costCategory.Rules)); err != nil {
-		return create.DiagError(names.CE, "setting rule", ResNameCostCategory, d.Id(), err)
+		return create.AppendDiagError(diags, names.CE, "setting rule", ResNameCostCategory, d.Id(), err)
 	}
 	d.Set("rule_version", costCategory.RuleVersion)
 	if err = d.Set("split_charge_rule", flattenCostCategorySplitChargeRules(costCategory.SplitChargeRules)); err != nil {
-		return create.DiagError(names.CE, "setting split_charge_rule", ResNameCostCategory, d.Id(), err)
+		return create.AppendDiagError(diags, names.CE, "setting split_charge_rule", ResNameCostCategory, d.Id(), err)
 	}
 
 	d.SetId(aws.StringValue(costCategory.CostCategoryArn))
@@ -343,12 +345,12 @@ func dataSourceCostCategoryRead(ctx context.Context, d *schema.ResourceData, met
 	tags, err := listTags(ctx, conn, d.Id())
 
 	if err != nil {
-		return create.DiagError(names.CE, "listing tags", ResNameCostCategory, d.Id(), err)
+		return create.AppendDiagError(diags, names.CE, "listing tags", ResNameCostCategory, d.Id(), err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return create.DiagError(names.CE, "setting tags", ResNameCostCategory, d.Id(), err)
+		return create.AppendDiagError(diags, names.CE, "setting tags", ResNameCostCategory, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/ce/tags_data_source.go
+++ b/internal/service/ce/tags_data_source.go
@@ -92,6 +92,8 @@ func DataSourceTags() *schema.Resource {
 }
 
 func dataSourceTagsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).CEConn(ctx)
 
 	input := &costexplorer.GetTagsInput{
@@ -117,14 +119,14 @@ func dataSourceTagsRead(ctx context.Context, d *schema.ResourceData, meta interf
 	resp, err := conn.GetTagsWithContext(ctx, input)
 
 	if err != nil {
-		return create.DiagError(names.CE, create.ErrActionReading, DSNameTags, d.Id(), err)
+		return create.AppendDiagError(diags, names.CE, create.ErrActionReading, DSNameTags, d.Id(), err)
 	}
 
 	d.Set("tags", flex.FlattenStringList(resp.Tags))
 
 	d.SetId(meta.(*conns.AWSClient).AccountID)
 
-	return nil
+	return diags
 }
 
 func expandTagsSortBys(tfList []interface{}) []*costexplorer.SortDefinition {

--- a/internal/service/chime/voice_connector_group.go
+++ b/internal/service/chime/voice_connector_group.go
@@ -62,6 +62,8 @@ func ResourceVoiceConnectorGroup() *schema.Resource {
 }
 
 func resourceVoiceConnectorGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
 	input := &chimesdkvoice.CreateVoiceConnectorGroupInput{
@@ -74,12 +76,12 @@ func resourceVoiceConnectorGroupCreate(ctx context.Context, d *schema.ResourceDa
 
 	resp, err := conn.CreateVoiceConnectorGroup(ctx, input)
 	if err != nil || resp.VoiceConnectorGroup == nil {
-		return diag.Errorf("creating Chime Voice Connector group: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating Chime Voice Connector group: %s", err)
 	}
 
 	d.SetId(aws.ToString(resp.VoiceConnectorGroup.VoiceConnectorGroupId))
 
-	return resourceVoiceConnectorGroupRead(ctx, d, meta)
+	return append(diags, resourceVoiceConnectorGroupRead(ctx, d, meta)...)
 }
 
 func resourceVoiceConnectorGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -97,7 +99,7 @@ func resourceVoiceConnectorGroupRead(ctx context.Context, d *schema.ResourceData
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Chime Voice conector group %s not found", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
@@ -110,10 +112,12 @@ func resourceVoiceConnectorGroupRead(ctx context.Context, d *schema.ResourceData
 		return sdkdiag.AppendErrorf(diags, "setting Chime Voice Connector group items (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceVoiceConnectorGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
 	input := &chimesdkvoice.UpdateVoiceConnectorGroupInput{
@@ -130,13 +134,15 @@ func resourceVoiceConnectorGroupUpdate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if _, err := conn.UpdateVoiceConnectorGroup(ctx, input); err != nil {
-		return diag.Errorf("updating Chime Voice Connector group (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "updating Chime Voice Connector group (%s): %s", d.Id(), err)
 	}
 
-	return resourceVoiceConnectorGroupRead(ctx, d, meta)
+	return append(diags, resourceVoiceConnectorGroupRead(ctx, d, meta)...)
 }
 
 func resourceVoiceConnectorGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
 	if v, ok := d.GetOk("connector"); ok && v.(*schema.Set).Len() > 0 {
@@ -152,12 +158,12 @@ func resourceVoiceConnectorGroupDelete(ctx context.Context, d *schema.ResourceDa
 	if _, err := conn.DeleteVoiceConnectorGroup(ctx, input); err != nil {
 		if errs.IsA[*awstypes.NotFoundException](err) {
 			log.Printf("[WARN] Chime Voice conector group %s not found", d.Id())
-			return nil
+			return diags
 		}
-		return diag.Errorf("deleting Chime Voice Connector group (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Chime Voice Connector group (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func expandVoiceConnectorItems(data []interface{}) []awstypes.VoiceConnectorItem {

--- a/internal/service/chimesdkvoice/global_settings.go
+++ b/internal/service/chimesdkvoice/global_settings.go
@@ -86,7 +86,7 @@ func resourceGlobalSettingsRead(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	if err != nil {
-		return append(diags, create.DiagError(names.ChimeSDKVoice, create.ErrActionReading, ResNameGlobalSettings, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.ChimeSDKVoice, create.ErrActionReading, ResNameGlobalSettings, d.Id(), err)
 	}
 
 	d.SetId(meta.(*conns.AWSClient).AccountID)
@@ -106,7 +106,7 @@ func resourceGlobalSettingsUpdate(ctx context.Context, d *schema.ResourceData, m
 
 		_, err := conn.UpdateGlobalSettings(ctx, input)
 		if err != nil {
-			return append(diags, create.DiagError(names.ChimeSDKVoice, create.ErrActionUpdating, ResNameGlobalSettings, d.Id(), err)...)
+			return create.AppendDiagError(diags, names.ChimeSDKVoice, create.ErrActionUpdating, ResNameGlobalSettings, d.Id(), err)
 		}
 	}
 	d.SetId(meta.(*conns.AWSClient).AccountID)
@@ -122,7 +122,7 @@ func resourceGlobalSettingsDelete(ctx context.Context, d *schema.ResourceData, m
 		VoiceConnector: &awstypes.VoiceConnectorSettings{},
 	})
 	if err != nil {
-		return append(diags, create.DiagError(names.ChimeSDKVoice, create.ErrActionDeleting, ResNameGlobalSettings, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.ChimeSDKVoice, create.ErrActionDeleting, ResNameGlobalSettings, d.Id(), err)
 	}
 
 	return diags

--- a/internal/service/chimesdkvoice/voice_profile_domain.go
+++ b/internal/service/chimesdkvoice/voice_profile_domain.go
@@ -95,6 +95,8 @@ func ResourceVoiceProfileDomain() *schema.Resource {
 }
 
 func resourceVoiceProfileDomainCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
 	in := &chimesdkvoice.CreateVoiceProfileDomainInput{
@@ -109,19 +111,21 @@ func resourceVoiceProfileDomainCreate(ctx context.Context, d *schema.ResourceDat
 
 	out, err := conn.CreateVoiceProfileDomain(ctx, in)
 	if err != nil {
-		return create.DiagError(names.ChimeSDKVoice, create.ErrActionCreating, ResNameVoiceProfileDomain, d.Get("name").(string), err)
+		return create.AppendDiagError(diags, names.ChimeSDKVoice, create.ErrActionCreating, ResNameVoiceProfileDomain, d.Get("name").(string), err)
 	}
 
 	if out == nil || out.VoiceProfileDomain == nil {
-		return create.DiagError(names.ChimeSDKVoice, create.ErrActionCreating, ResNameVoiceProfileDomain, d.Get("name").(string), errors.New("empty output"))
+		return create.AppendDiagError(diags, names.ChimeSDKVoice, create.ErrActionCreating, ResNameVoiceProfileDomain, d.Get("name").(string), errors.New("empty output"))
 	}
 
 	d.SetId(aws.ToString(out.VoiceProfileDomain.VoiceProfileDomainId))
 
-	return resourceVoiceProfileDomainRead(ctx, d, meta)
+	return append(diags, resourceVoiceProfileDomainRead(ctx, d, meta)...)
 }
 
 func resourceVoiceProfileDomainRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
 	out, err := FindVoiceProfileDomainByID(ctx, conn, d.Id())
@@ -129,11 +133,11 @@ func resourceVoiceProfileDomainRead(ctx context.Context, d *schema.ResourceData,
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] ChimeSDKVoice VoiceProfileDomain (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.ChimeSDKVoice, create.ErrActionReading, ResNameVoiceProfileDomain, d.Id(), err)
+		return create.AppendDiagError(diags, names.ChimeSDKVoice, create.ErrActionReading, ResNameVoiceProfileDomain, d.Id(), err)
 	}
 
 	d.SetId(aws.ToString(out.VoiceProfileDomainId))
@@ -142,13 +146,15 @@ func resourceVoiceProfileDomainRead(ctx context.Context, d *schema.ResourceData,
 	d.Set(names.AttrDescription, out.Description)
 
 	if err := d.Set("server_side_encryption_configuration", flattenServerSideEncryptionConfiguration(out.ServerSideEncryptionConfiguration)); err != nil {
-		return create.DiagError(names.ChimeSDKVoice, create.ErrActionSetting, ResNameVoiceProfileDomain, d.Id(), err)
+		return create.AppendDiagError(diags, names.ChimeSDKVoice, create.ErrActionSetting, ResNameVoiceProfileDomain, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceVoiceProfileDomainUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
 	if d.HasChanges(names.AttrName, names.AttrDescription) {
@@ -163,16 +169,18 @@ func resourceVoiceProfileDomainUpdate(ctx context.Context, d *schema.ResourceDat
 
 		_, err := conn.UpdateVoiceProfileDomain(ctx, in)
 		if err != nil {
-			return create.DiagError(names.ChimeSDKMediaPipelines, create.ErrActionUpdating, ResNameVoiceProfileDomain, d.Id(), err)
+			return create.AppendDiagError(diags, names.ChimeSDKMediaPipelines, create.ErrActionUpdating, ResNameVoiceProfileDomain, d.Id(), err)
 		}
 
-		return resourceVoiceProfileDomainRead(ctx, d, meta)
+		return append(diags, resourceVoiceProfileDomainRead(ctx, d, meta)...)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceVoiceProfileDomainDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ChimeSDKVoiceClient(ctx)
 
 	log.Printf("[INFO] Deleting ChimeSDKVoice VoiceProfileDomain %s", d.Id())
@@ -182,14 +190,14 @@ func resourceVoiceProfileDomainDelete(ctx context.Context, d *schema.ResourceDat
 	})
 
 	if errs.IsA[*awstypes.NotFoundException](err) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.ChimeSDKVoice, create.ErrActionDeleting, ResNameVoiceProfileDomain, d.Id(), err)
+		return create.AppendDiagError(diags, names.ChimeSDKVoice, create.ErrActionDeleting, ResNameVoiceProfileDomain, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func FindVoiceProfileDomainByID(ctx context.Context, conn *chimesdkvoice.Client, id string) (*awstypes.VoiceProfileDomain, error) {

--- a/internal/service/cloudcontrol/resource_data_source.go
+++ b/internal/service/cloudcontrol/resource_data_source.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 )
 
 // @SDKDataSource("aws_cloudcontrolapi_resource")
@@ -46,6 +47,8 @@ func DataSourceResource() *schema.Resource {
 }
 
 func dataSourceResourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).CloudControlClient(ctx)
 
 	identifier := d.Get("identifier").(string)
@@ -58,12 +61,12 @@ func dataSourceResourceRead(ctx context.Context, d *schema.ResourceData, meta in
 	)
 
 	if err != nil {
-		return diag.Errorf("reading Cloud Control API (%s) Resource (%s): %s", typeName, identifier, err)
+		return sdkdiag.AppendErrorf(diags, "reading Cloud Control API (%s) Resource (%s): %s", typeName, identifier, err)
 	}
 
 	d.SetId(aws.ToString(resourceDescription.Identifier))
 
 	d.Set("properties", resourceDescription.Properties)
 
-	return nil
+	return diags
 }

--- a/internal/service/cloudformation/type_data_source.go
+++ b/internal/service/cloudformation/type_data_source.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 )
 
 // @SDKDataSource("aws_cloudformation_type")
@@ -110,6 +111,8 @@ func DataSourceType() *schema.Resource {
 }
 
 func dataSourceTypeRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).CloudFormationConn(ctx)
 
 	input := &cloudformation.DescribeTypeInput{}
@@ -133,11 +136,11 @@ func dataSourceTypeRead(ctx context.Context, d *schema.ResourceData, meta interf
 	output, err := conn.DescribeTypeWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("reading CloudFormation Type: %s", err)
+		return sdkdiag.AppendErrorf(diags, "reading CloudFormation Type: %s", err)
 	}
 
 	if output == nil {
-		return diag.Errorf("reading CloudFormation Type: empty response")
+		return sdkdiag.AppendErrorf(diags, "reading CloudFormation Type: empty response")
 	}
 
 	d.SetId(aws.StringValue(output.Arn))
@@ -151,7 +154,7 @@ func dataSourceTypeRead(ctx context.Context, d *schema.ResourceData, meta interf
 	d.Set("is_default_version", output.IsDefaultVersion)
 	if output.LoggingConfig != nil {
 		if err := d.Set("logging_config", []interface{}{flattenLoggingConfig(output.LoggingConfig)}); err != nil {
-			return diag.Errorf("setting logging_config: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting logging_config: %s", err)
 		}
 	} else {
 		d.Set("logging_config", nil)
@@ -163,5 +166,5 @@ func dataSourceTypeRead(ctx context.Context, d *schema.ResourceData, meta interf
 	d.Set("type_name", output.TypeName)
 	d.Set("visibility", output.Visibility)
 
-	return nil
+	return diags
 }

--- a/internal/service/cloudfront/origin_access_identity.go
+++ b/internal/service/cloudfront/origin_access_identity.go
@@ -69,7 +69,7 @@ func resourceOriginAccessIdentityCreate(ctx context.Context, d *schema.ResourceD
 
 	resp, err := conn.CreateCloudFrontOriginAccessIdentityWithContext(ctx, params)
 	if err != nil {
-		return create.DiagError(names.CloudFront, create.ErrActionReading, ResNameOriginAccessIdentity, d.Id(), err)
+		return create.AppendDiagError(diags, names.CloudFront, create.ErrActionReading, ResNameOriginAccessIdentity, d.Id(), err)
 	}
 	d.SetId(aws.StringValue(resp.CloudFrontOriginAccessIdentity.Id))
 	return append(diags, resourceOriginAccessIdentityRead(ctx, d, meta)...)
@@ -90,7 +90,7 @@ func resourceOriginAccessIdentityRead(ctx context.Context, d *schema.ResourceDat
 	}
 
 	if err != nil {
-		return create.DiagError(names.CloudFront, create.ErrActionReading, ResNameOriginAccessIdentity, d.Id(), err)
+		return create.AppendDiagError(diags, names.CloudFront, create.ErrActionReading, ResNameOriginAccessIdentity, d.Id(), err)
 	}
 
 	// Update attributes from DistributionConfig
@@ -120,7 +120,7 @@ func resourceOriginAccessIdentityUpdate(ctx context.Context, d *schema.ResourceD
 	}
 	_, err := conn.UpdateCloudFrontOriginAccessIdentityWithContext(ctx, params)
 	if err != nil {
-		return create.DiagError(names.CloudFront, create.ErrActionUpdating, ResNameOriginAccessIdentity, d.Id(), err)
+		return create.AppendDiagError(diags, names.CloudFront, create.ErrActionUpdating, ResNameOriginAccessIdentity, d.Id(), err)
 	}
 
 	return append(diags, resourceOriginAccessIdentityRead(ctx, d, meta)...)
@@ -135,7 +135,7 @@ func resourceOriginAccessIdentityDelete(ctx context.Context, d *schema.ResourceD
 	}
 
 	if _, err := conn.DeleteCloudFrontOriginAccessIdentityWithContext(ctx, params); err != nil {
-		return create.DiagError(names.CloudFront, create.ErrActionDeleting, ResNameOriginAccessIdentity, d.Id(), err)
+		return create.AppendDiagError(diags, names.CloudFront, create.ErrActionDeleting, ResNameOriginAccessIdentity, d.Id(), err)
 	}
 	return diags
 }

--- a/internal/service/cloudwatch/dashboard.go
+++ b/internal/service/cloudwatch/dashboard.go
@@ -80,7 +80,7 @@ func resourceDashboardRead(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	if err != nil {
-		return create.DiagError(names.CloudWatch, create.ErrActionReading, ResNameDashboard, d.Id(), err)
+		return create.AppendDiagError(diags, names.CloudWatch, create.ErrActionReading, ResNameDashboard, d.Id(), err)
 	}
 
 	d.Set("dashboard_arn", resp.DashboardArn)

--- a/internal/service/cloudwatch/metric_alarm.go
+++ b/internal/service/cloudwatch/metric_alarm.go
@@ -377,7 +377,7 @@ func resourceMetricAlarmRead(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	if err != nil {
-		return diag.Errorf("reading CloudWatch Metric Alarm (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading CloudWatch Metric Alarm (%s): %s", d.Id(), err)
 	}
 
 	d.Set("actions_enabled", alarm.ActionsEnabled)

--- a/internal/service/codeartifact/domain.go
+++ b/internal/service/codeartifact/domain.go
@@ -110,7 +110,7 @@ func resourceDomainRead(ctx context.Context, d *schema.ResourceData, meta interf
 
 	domainOwner, domainName, err := DecodeDomainID(d.Id())
 	if err != nil {
-		return create.DiagError(names.CodeArtifact, create.ErrActionReading, ResNameDomain, d.Id(), err)
+		return create.AppendDiagError(diags, names.CodeArtifact, create.ErrActionReading, ResNameDomain, d.Id(), err)
 	}
 
 	sm, err := conn.DescribeDomainWithContext(ctx, &codeartifact.DescribeDomainInput{
@@ -124,7 +124,7 @@ func resourceDomainRead(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	if err != nil {
-		return create.DiagError(names.CodeArtifact, create.ErrActionReading, ResNameDomain, d.Id(), err)
+		return create.AppendDiagError(diags, names.CodeArtifact, create.ErrActionReading, ResNameDomain, d.Id(), err)
 	}
 
 	arn := aws.StringValue(sm.Domain.Arn)

--- a/internal/service/codeartifact/domain_permissions_policy.go
+++ b/internal/service/codeartifact/domain_permissions_policy.go
@@ -109,7 +109,7 @@ func resourceDomainPermissionsPolicyRead(ctx context.Context, d *schema.Resource
 
 	domainOwner, domainName, err := DecodeDomainID(d.Id())
 	if err != nil {
-		return create.DiagError(names.CodeArtifact, create.ErrActionReading, ResNameDomainPermissionsPolicy, d.Id(), err)
+		return create.AppendDiagError(diags, names.CodeArtifact, create.ErrActionReading, ResNameDomainPermissionsPolicy, d.Id(), err)
 	}
 
 	dm, err := conn.GetDomainPermissionsPolicyWithContext(ctx, &codeartifact.GetDomainPermissionsPolicyInput{
@@ -123,7 +123,7 @@ func resourceDomainPermissionsPolicyRead(ctx context.Context, d *schema.Resource
 	}
 
 	if err != nil {
-		return create.DiagError(names.CodeArtifact, create.ErrActionReading, ResNameDomainPermissionsPolicy, d.Id(), err)
+		return create.AppendDiagError(diags, names.CodeArtifact, create.ErrActionReading, ResNameDomainPermissionsPolicy, d.Id(), err)
 	}
 
 	d.Set("domain", domainName)

--- a/internal/service/codeartifact/repository.go
+++ b/internal/service/codeartifact/repository.go
@@ -161,7 +161,7 @@ func resourceRepositoryRead(ctx context.Context, d *schema.ResourceData, meta in
 
 	owner, domain, repo, err := DecodeRepositoryID(d.Id())
 	if err != nil {
-		return create.DiagError(names.CodeArtifact, create.ErrActionReading, ResNameRepository, d.Id(), err)
+		return create.AppendDiagError(diags, names.CodeArtifact, create.ErrActionReading, ResNameRepository, d.Id(), err)
 	}
 	sm, err := conn.DescribeRepositoryWithContext(ctx, &codeartifact.DescribeRepositoryInput{
 		Repository:  aws.String(repo),
@@ -175,7 +175,7 @@ func resourceRepositoryRead(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	if err != nil {
-		return create.DiagError(names.CodeArtifact, create.ErrActionReading, ResNameRepository, d.Id(), err)
+		return create.AppendDiagError(diags, names.CodeArtifact, create.ErrActionReading, ResNameRepository, d.Id(), err)
 	}
 
 	arn := aws.StringValue(sm.Repository.Arn)

--- a/internal/service/codeartifact/repository_permissions_policy.go
+++ b/internal/service/codeartifact/repository_permissions_policy.go
@@ -115,7 +115,7 @@ func resourceRepositoryPermissionsPolicyRead(ctx context.Context, d *schema.Reso
 
 	domainOwner, domainName, repoName, err := DecodeRepositoryID(d.Id())
 	if err != nil {
-		return create.DiagError(names.CodeArtifact, create.ErrActionReading, ResNameRepositoryPermissionsPolicy, d.Id(), err)
+		return create.AppendDiagError(diags, names.CodeArtifact, create.ErrActionReading, ResNameRepositoryPermissionsPolicy, d.Id(), err)
 	}
 
 	dm, err := conn.GetRepositoryPermissionsPolicyWithContext(ctx, &codeartifact.GetRepositoryPermissionsPolicyInput{
@@ -130,7 +130,7 @@ func resourceRepositoryPermissionsPolicyRead(ctx context.Context, d *schema.Reso
 	}
 
 	if err != nil {
-		return create.DiagError(names.CodeArtifact, create.ErrActionReading, ResNameRepositoryPermissionsPolicy, d.Id(), err)
+		return create.AppendDiagError(diags, names.CodeArtifact, create.ErrActionReading, ResNameRepositoryPermissionsPolicy, d.Id(), err)
 	}
 
 	d.Set("domain", domainName)

--- a/internal/service/codebuild/report_group.go
+++ b/internal/service/codebuild/report_group.go
@@ -148,7 +148,7 @@ func resourceReportGroupRead(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	if err != nil {
-		return create.DiagError(names.CodeBuild, create.ErrActionReading, ResNameReportGroup, d.Id(), err)
+		return create.AppendDiagError(diags, names.CodeBuild, create.ErrActionReading, ResNameReportGroup, d.Id(), err)
 	}
 
 	if !d.IsNewResource() && reportGroup == nil {
@@ -158,7 +158,7 @@ func resourceReportGroupRead(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	if reportGroup == nil {
-		return create.DiagError(names.CodeBuild, create.ErrActionReading, ResNameReportGroup, d.Id(), errors.New("not found after creation"))
+		return create.AppendDiagError(diags, names.CodeBuild, create.ErrActionReading, ResNameReportGroup, d.Id(), errors.New("not found after creation"))
 	}
 
 	d.Set("arn", reportGroup.Arn)

--- a/internal/service/codebuild/webhook.go
+++ b/internal/service/codebuild/webhook.go
@@ -181,11 +181,11 @@ func resourceWebhookRead(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	if err != nil {
-		return create.DiagError(names.CodeBuild, create.ErrActionReading, ResNameWebhook, d.Id(), err)
+		return create.AppendDiagError(diags, names.CodeBuild, create.ErrActionReading, ResNameWebhook, d.Id(), err)
 	}
 
 	if d.IsNewResource() && len(resp.Projects) == 0 {
-		return create.DiagError(names.CodeBuild, create.ErrActionReading, ResNameWebhook, d.Id(), errors.New("no project found after create"))
+		return create.AppendDiagError(diags, names.CodeBuild, create.ErrActionReading, ResNameWebhook, d.Id(), errors.New("no project found after create"))
 	}
 
 	if !d.IsNewResource() && len(resp.Projects) == 0 {
@@ -197,7 +197,7 @@ func resourceWebhookRead(ctx context.Context, d *schema.ResourceData, meta inter
 	project := resp.Projects[0]
 
 	if d.IsNewResource() && project.Webhook == nil {
-		return create.DiagError(names.CodeBuild, create.ErrActionReading, ResNameWebhook, d.Id(), errors.New("no webhook after creation"))
+		return create.AppendDiagError(diags, names.CodeBuild, create.ErrActionReading, ResNameWebhook, d.Id(), errors.New("no webhook after creation"))
 	}
 
 	if !d.IsNewResource() && project.Webhook == nil {

--- a/internal/service/codecatalyst/dev_environment.go
+++ b/internal/service/codecatalyst/dev_environment.go
@@ -152,17 +152,17 @@ func resourceDevEnvironmentCreate(ctx context.Context, d *schema.ResourceData, m
 	out, err := conn.CreateDevEnvironment(ctx, in)
 
 	if err != nil {
-		return append(diags, create.DiagError(names.CodeCatalyst, create.ErrActionCreating, ResNameDevEnvironment, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.CodeCatalyst, create.ErrActionCreating, ResNameDevEnvironment, d.Id(), err)
 	}
 
 	if out == nil {
-		return append(diags, create.DiagError(names.CodeCatalyst, create.ErrActionCreating, ResNameDevEnvironment, d.Id(), errors.New("empty output"))...)
+		return create.AppendDiagError(diags, names.CodeCatalyst, create.ErrActionCreating, ResNameDevEnvironment, d.Id(), errors.New("empty output"))
 	}
 
 	d.SetId(aws.ToString(out.Id))
 
 	if _, err := waitDevEnvironmentCreated(ctx, conn, d.Id(), out.SpaceName, out.ProjectName, d.Timeout(schema.TimeoutCreate)); err != nil {
-		return append(diags, create.DiagError(names.CodeCatalyst, create.ErrActionWaitingForCreation, ResNameDevEnvironment, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.CodeCatalyst, create.ErrActionWaitingForCreation, ResNameDevEnvironment, d.Id(), err)
 	}
 
 	return append(diags, resourceDevEnvironmentRead(ctx, d, meta)...)
@@ -185,7 +185,7 @@ func resourceDevEnvironmentRead(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	if err != nil {
-		return append(diags, create.DiagError(names.CodeCatalyst, create.ErrActionReading, ResNameDevEnvironment, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.CodeCatalyst, create.ErrActionReading, ResNameDevEnvironment, d.Id(), err)
 	}
 
 	d.Set("alias", out.Alias)
@@ -196,11 +196,11 @@ func resourceDevEnvironmentRead(ctx context.Context, d *schema.ResourceData, met
 	d.Set("persistent_storage", flattenPersistentStorage(out.PersistentStorage))
 
 	if err := d.Set("ides", flattenIdes(out.Ides)); err != nil {
-		return append(diags, create.DiagError(names.CodeCatalyst, create.ErrActionSetting, ResNameDevEnvironment, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.CodeCatalyst, create.ErrActionSetting, ResNameDevEnvironment, d.Id(), err)
 	}
 
 	if err := d.Set("repositories", flattenRepositories(out.Repositories)); err != nil {
-		return append(diags, create.DiagError(names.CodeCatalyst, create.ErrActionSetting, ResNameDevEnvironment, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.CodeCatalyst, create.ErrActionSetting, ResNameDevEnvironment, d.Id(), err)
 	}
 
 	return diags
@@ -233,11 +233,11 @@ func resourceDevEnvironmentUpdate(ctx context.Context, d *schema.ResourceData, m
 	log.Printf("[DEBUG] Updating Codecatalyst DevEnvironment (%s): %#v", d.Id(), in)
 	out, err := conn.UpdateDevEnvironment(ctx, in)
 	if err != nil {
-		return append(diags, create.DiagError(names.CodeCatalyst, create.ErrActionUpdating, ResNameDevEnvironment, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.CodeCatalyst, create.ErrActionUpdating, ResNameDevEnvironment, d.Id(), err)
 	}
 
 	if _, err := waitDevEnvironmentUpdated(ctx, conn, aws.ToString(out.Id), out.SpaceName, out.ProjectName, d.Timeout(schema.TimeoutUpdate)); err != nil {
-		return append(diags, create.DiagError(names.CodeCatalyst, create.ErrActionWaitingForUpdate, ResNameDevEnvironment, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.CodeCatalyst, create.ErrActionWaitingForUpdate, ResNameDevEnvironment, d.Id(), err)
 	}
 
 	return append(diags, resourceDevEnvironmentRead(ctx, d, meta)...)
@@ -260,7 +260,7 @@ func resourceDevEnvironmentDelete(ctx context.Context, d *schema.ResourceData, m
 		return diags
 	}
 	if err != nil {
-		return append(diags, create.DiagError(names.CodeCatalyst, create.ErrActionDeleting, ResNameDevEnvironment, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.CodeCatalyst, create.ErrActionDeleting, ResNameDevEnvironment, d.Id(), err)
 	}
 
 	return diags

--- a/internal/service/codecatalyst/dev_environment_data_source.go
+++ b/internal/service/codecatalyst/dev_environment_data_source.go
@@ -128,7 +128,7 @@ func dataSourceDevEnvironmentRead(ctx context.Context, d *schema.ResourceData, m
 
 	out, err := findDevEnvironmentByID(ctx, conn, env_id, spaceName, projectName)
 	if err != nil {
-		return append(diags, create.DiagError(names.CodeCatalyst, create.ErrActionReading, DSNameDevEnvironment, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.CodeCatalyst, create.ErrActionReading, DSNameDevEnvironment, d.Id(), err)
 	}
 
 	d.SetId(aws.ToString(out.Id))
@@ -145,11 +145,11 @@ func dataSourceDevEnvironmentRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set("status_reason", out.StatusReason)
 
 	if err := d.Set("ides", flattenIdes(out.Ides)); err != nil {
-		return append(diags, create.DiagError(names.CodeCatalyst, create.ErrActionSetting, ResNameDevEnvironment, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.CodeCatalyst, create.ErrActionSetting, ResNameDevEnvironment, d.Id(), err)
 	}
 
 	if err := d.Set("repositories", flattenRepositories(out.Repositories)); err != nil {
-		return append(diags, create.DiagError(names.CodeCatalyst, create.ErrActionSetting, ResNameDevEnvironment, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.CodeCatalyst, create.ErrActionSetting, ResNameDevEnvironment, d.Id(), err)
 	}
 
 	return diags

--- a/internal/service/codecatalyst/source_repository.go
+++ b/internal/service/codecatalyst/source_repository.go
@@ -79,16 +79,16 @@ func resourceSourceRepositoryCreate(ctx context.Context, d *schema.ResourceData,
 
 	out, err := conn.CreateSourceRepository(ctx, in)
 	if err != nil {
-		return append(diags, create.DiagError(names.CodeCatalyst, create.ErrActionCreating, ResNameSourceRepository, d.Get("name").(string), err)...)
+		return create.AppendDiagError(diags, names.CodeCatalyst, create.ErrActionCreating, ResNameSourceRepository, d.Get("name").(string), err)
 	}
 
 	if out == nil || out.Name == nil {
-		return append(diags, create.DiagError(names.CodeCatalyst, create.ErrActionCreating, ResNameSourceRepository, d.Get("name").(string), errors.New("empty output"))...)
+		return create.AppendDiagError(diags, names.CodeCatalyst, create.ErrActionCreating, ResNameSourceRepository, d.Get("name").(string), errors.New("empty output"))
 	}
 
 	d.SetId(aws.ToString(out.Name))
 
-	return resourceSourceRepositoryRead(ctx, d, meta)
+	return append(diags, resourceSourceRepositoryRead(ctx, d, meta)...)
 }
 
 func resourceSourceRepositoryRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -107,7 +107,7 @@ func resourceSourceRepositoryRead(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if err != nil {
-		return append(diags, create.DiagError(names.CodeCatalyst, create.ErrActionReading, ResNameSourceRepository, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.CodeCatalyst, create.ErrActionReading, ResNameSourceRepository, d.Id(), err)
 	}
 
 	d.Set("name", out.Name)
@@ -135,7 +135,7 @@ func resourceSourceRepositoryDelete(ctx context.Context, d *schema.ResourceData,
 		return diags
 	}
 	if err != nil {
-		return append(diags, create.DiagError(names.CodeCatalyst, create.ErrActionDeleting, ResNameSourceRepository, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.CodeCatalyst, create.ErrActionDeleting, ResNameSourceRepository, d.Id(), err)
 	}
 
 	return diags

--- a/internal/service/codecommit/repository.go
+++ b/internal/service/codecommit/repository.go
@@ -125,7 +125,7 @@ func resourceRepositoryRead(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	if err != nil {
-		return create.DiagError(names.CodeCommit, create.ErrActionReading, ResNameRepository, d.Id(), err)
+		return create.AppendDiagError(diags, names.CodeCommit, create.ErrActionReading, ResNameRepository, d.Id(), err)
 	}
 
 	d.Set("repository_id", out.RepositoryMetadata.RepositoryId)

--- a/internal/service/codepipeline/webhook.go
+++ b/internal/service/codepipeline/webhook.go
@@ -168,7 +168,7 @@ func resourceWebhookRead(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	if err != nil {
-		return create.DiagError(names.CodePipeline, create.ErrActionReading, ResNameWebhook, d.Id(), err)
+		return create.AppendDiagError(diags, names.CodePipeline, create.ErrActionReading, ResNameWebhook, d.Id(), err)
 	}
 
 	webhookDef := webhook.Definition

--- a/internal/service/cognitoidentity/pool.go
+++ b/internal/service/cognitoidentity/pool.go
@@ -181,7 +181,7 @@ func resourcePoolRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	}
 
 	if err != nil {
-		return create.DiagError(names.CognitoIdentity, create.ErrActionReading, ResNamePool, d.Id(), err)
+		return create.AppendDiagError(diags, names.CognitoIdentity, create.ErrActionReading, ResNamePool, d.Id(), err)
 	}
 
 	arn := arn.ARN{

--- a/internal/service/cognitoidentity/pool_data_source.go
+++ b/internal/service/cognitoidentity/pool_data_source.go
@@ -107,7 +107,7 @@ func dataSourcePoolRead(ctx context.Context, d *schema.ResourceData, meta interf
 
 	ip, err := findPoolByName(ctx, conn, name)
 	if err != nil {
-		return append(diags, create.DiagError(names.CognitoIdentity, create.ErrActionReading, DSNamePool, name, err)...)
+		return create.AppendDiagError(diags, names.CognitoIdentity, create.ErrActionReading, DSNamePool, name, err)
 	}
 
 	d.SetId(aws.StringValue(ip.IdentityPoolId))

--- a/internal/service/cognitoidentity/pool_provider_principal_tag.go
+++ b/internal/service/cognitoidentity/pool_provider_principal_tag.go
@@ -102,7 +102,7 @@ func resourcePoolProviderPrincipalTagRead(ctx context.Context, d *schema.Resourc
 	poolId, providerName, err := DecodePoolProviderPrincipalTagsID(d.Id())
 
 	if err != nil {
-		return create.DiagError(names.CognitoIdentity, create.ErrActionReading, ResNamePoolProviderPrincipalTag, d.Id(), err)
+		return create.AppendDiagError(diags, names.CognitoIdentity, create.ErrActionReading, ResNamePoolProviderPrincipalTag, d.Id(), err)
 	}
 
 	ret, err := conn.GetPrincipalTagAttributeMapWithContext(ctx, &cognitoidentity.GetPrincipalTagAttributeMapInput{
@@ -117,7 +117,7 @@ func resourcePoolProviderPrincipalTagRead(ctx context.Context, d *schema.Resourc
 	}
 
 	if err != nil {
-		return create.DiagError(names.CognitoIdentity, create.ErrActionReading, ResNamePoolProviderPrincipalTag, d.Id(), err)
+		return create.AppendDiagError(diags, names.CognitoIdentity, create.ErrActionReading, ResNamePoolProviderPrincipalTag, d.Id(), err)
 	}
 
 	d.Set("identity_pool_id", ret.IdentityPoolId)

--- a/internal/service/cognitoidentity/pool_roles_attachment.go
+++ b/internal/service/cognitoidentity/pool_roles_attachment.go
@@ -161,7 +161,7 @@ func resourcePoolRolesAttachmentRead(ctx context.Context, d *schema.ResourceData
 	}
 
 	if err != nil {
-		return create.DiagError(names.CognitoIdentity, create.ErrActionReading, ResNamePoolRolesAttachment, d.Id(), err)
+		return create.AppendDiagError(diags, names.CognitoIdentity, create.ErrActionReading, ResNamePoolRolesAttachment, d.Id(), err)
 	}
 
 	d.Set("identity_pool_id", ip.IdentityPoolId)

--- a/internal/service/cognitoidp/identity_provider.go
+++ b/internal/service/cognitoidp/identity_provider.go
@@ -133,7 +133,7 @@ func resourceIdentityProviderRead(ctx context.Context, d *schema.ResourceData, m
 
 	userPoolID, providerName, err := DecodeIdentityProviderID(d.Id())
 	if err != nil {
-		return create.DiagError(names.CognitoIDP, create.ErrActionReading, ResNameIdentityProvider, d.Id(), err)
+		return create.AppendDiagError(diags, names.CognitoIDP, create.ErrActionReading, ResNameIdentityProvider, d.Id(), err)
 	}
 
 	ret, err := conn.DescribeIdentityProviderWithContext(ctx, &cognitoidentityprovider.DescribeIdentityProviderInput{
@@ -148,7 +148,7 @@ func resourceIdentityProviderRead(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if err != nil {
-		return create.DiagError(names.CognitoIDP, create.ErrActionReading, ResNameIdentityProvider, d.Id(), err)
+		return create.AppendDiagError(diags, names.CognitoIDP, create.ErrActionReading, ResNameIdentityProvider, d.Id(), err)
 	}
 
 	if !d.IsNewResource() && (ret == nil || ret.IdentityProvider == nil) {
@@ -158,7 +158,7 @@ func resourceIdentityProviderRead(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if d.IsNewResource() && (ret == nil || ret.IdentityProvider == nil) {
-		return create.DiagError(names.CognitoIDP, create.ErrActionReading, ResNameIdentityProvider, d.Id(), errors.New("not found after creation"))
+		return create.AppendDiagError(diags, names.CognitoIDP, create.ErrActionReading, ResNameIdentityProvider, d.Id(), errors.New("not found after creation"))
 	}
 
 	ip := ret.IdentityProvider

--- a/internal/service/cognitoidp/resource_server.go
+++ b/internal/service/cognitoidp/resource_server.go
@@ -118,7 +118,7 @@ func resourceResourceServerRead(ctx context.Context, d *schema.ResourceData, met
 
 	userPoolID, identifier, err := DecodeResourceServerID(d.Id())
 	if err != nil {
-		return create.DiagError(names.CognitoIDP, create.ErrActionReading, ResNameResourceServer, d.Id(), err)
+		return create.AppendDiagError(diags, names.CognitoIDP, create.ErrActionReading, ResNameResourceServer, d.Id(), err)
 	}
 
 	params := &cognitoidentityprovider.DescribeResourceServerInput{
@@ -137,7 +137,7 @@ func resourceResourceServerRead(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	if err != nil {
-		return create.DiagError(names.CognitoIDP, create.ErrActionReading, ResNameResourceServer, d.Id(), err)
+		return create.AppendDiagError(diags, names.CognitoIDP, create.ErrActionReading, ResNameResourceServer, d.Id(), err)
 	}
 
 	if !d.IsNewResource() && (resp == nil || resp.ResourceServer == nil) {
@@ -147,7 +147,7 @@ func resourceResourceServerRead(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	if d.IsNewResource() && (resp == nil || resp.ResourceServer == nil) {
-		return create.DiagError(names.CognitoIDP, create.ErrActionReading, ResNameResourceServer, d.Id(), errors.New("not found after creation"))
+		return create.AppendDiagError(diags, names.CognitoIDP, create.ErrActionReading, ResNameResourceServer, d.Id(), errors.New("not found after creation"))
 	}
 
 	d.Set("identifier", resp.ResourceServer.Identifier)

--- a/internal/service/cognitoidp/user.go
+++ b/internal/service/cognitoidp/user.go
@@ -240,7 +240,7 @@ func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	}
 
 	if err != nil {
-		return create.DiagError(names.CognitoIDP, create.ErrActionReading, ResNameUser, d.Get("username").(string), err)
+		return create.AppendDiagError(diags, names.CognitoIDP, create.ErrActionReading, ResNameUser, d.Get("username").(string), err)
 	}
 
 	if err := d.Set("attributes", flattenUserAttributes(user.UserAttributes)); err != nil {

--- a/internal/service/cognitoidp/user_group.go
+++ b/internal/service/cognitoidp/user_group.go
@@ -119,7 +119,7 @@ func resourceUserGroupRead(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	if err != nil {
-		return create.DiagError(names.CognitoIDP, create.ErrActionReading, ResNameUserGroup, d.Get("name").(string), err)
+		return create.AppendDiagError(diags, names.CognitoIDP, create.ErrActionReading, ResNameUserGroup, d.Get("name").(string), err)
 	}
 
 	d.Set("description", resp.Group.Description)

--- a/internal/service/cognitoidp/user_pool.go
+++ b/internal/service/cognitoidp/user_pool.go
@@ -862,7 +862,7 @@ func resourceUserPoolRead(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if err != nil {
-		return create.DiagError(names.CognitoIDP, create.ErrActionReading, ResNameUserPool, d.Id(), err)
+		return create.AppendDiagError(diags, names.CognitoIDP, create.ErrActionReading, ResNameUserPool, d.Id(), err)
 	}
 
 	userPool := resp.UserPool
@@ -955,7 +955,7 @@ func resourceUserPoolRead(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if err != nil {
-		return create.DiagError(names.CognitoIDP, create.ErrActionReading, ResNameUserPool, d.Id(), err)
+		return create.AppendDiagError(diags, names.CognitoIDP, create.ErrActionReading, ResNameUserPool, d.Id(), err)
 	}
 
 	d.Set("mfa_configuration", output.MfaConfiguration)

--- a/internal/service/configservice/aggregate_authorization.go
+++ b/internal/service/configservice/aggregate_authorization.go
@@ -87,7 +87,7 @@ func resourceAggregateAuthorizationRead(ctx context.Context, d *schema.ResourceD
 
 	accountId, region, err := AggregateAuthorizationParseID(d.Id())
 	if err != nil {
-		return create.DiagError(names.ConfigService, create.ErrActionReading, ResNameAggregateAuthorization, d.Id(), err)
+		return create.AppendDiagError(diags, names.ConfigService, create.ErrActionReading, ResNameAggregateAuthorization, d.Id(), err)
 	}
 
 	d.Set("account_id", accountId)
@@ -101,7 +101,7 @@ func resourceAggregateAuthorizationRead(ctx context.Context, d *schema.ResourceD
 	}
 
 	if err != nil {
-		return create.DiagError(names.ConfigService, create.ErrActionReading, ResNameAggregateAuthorization, d.Id(), err)
+		return create.AppendDiagError(diags, names.ConfigService, create.ErrActionReading, ResNameAggregateAuthorization, d.Id(), err)
 	}
 
 	var aggregationAuthorization *configservice.AggregationAuthorization
@@ -119,7 +119,7 @@ func resourceAggregateAuthorizationRead(ctx context.Context, d *schema.ResourceD
 	}
 
 	if d.IsNewResource() && aggregationAuthorization == nil {
-		return create.DiagError(names.ConfigService, create.ErrActionReading, ResNameAggregateAuthorization, d.Id(), errors.New("not found after creation"))
+		return create.AppendDiagError(diags, names.ConfigService, create.ErrActionReading, ResNameAggregateAuthorization, d.Id(), errors.New("not found after creation"))
 	}
 
 	d.Set("arn", aggregationAuthorization.AggregationAuthorizationArn)

--- a/internal/service/configservice/config_rule.go
+++ b/internal/service/configservice/config_rule.go
@@ -256,7 +256,7 @@ func resourceRulePutConfig(ctx context.Context, d *schema.ResourceData, meta int
 		_, err = conn.PutConfigRuleWithContext(ctx, &input)
 	}
 	if err != nil {
-		return append(diags, create.DiagError(names.ConfigService, create.ErrActionUpdating, ResNameConfigRule, name, err)...)
+		return create.AppendDiagError(diags, names.ConfigService, create.ErrActionUpdating, ResNameConfigRule, name, err)
 	}
 
 	d.SetId(name)
@@ -276,7 +276,7 @@ func resourceConfigRuleRead(ctx context.Context, d *schema.ResourceData, meta in
 		return diags
 	}
 	if err != nil {
-		return append(diags, create.DiagError(names.ConfigService, create.ErrActionReading, ResNameConfigRule, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.ConfigService, create.ErrActionReading, ResNameConfigRule, d.Id(), err)
 	}
 
 	arn := aws.StringValue(rule.ConfigRuleArn)
@@ -322,11 +322,11 @@ func resourceConfigRuleDelete(ctx context.Context, d *schema.ResourceData, meta 
 		_, err = conn.DeleteConfigRuleWithContext(ctx, input)
 	}
 	if err != nil {
-		return append(diags, create.DiagError(names.ConfigService, create.ErrActionDeleting, ResNameConfigRule, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.ConfigService, create.ErrActionDeleting, ResNameConfigRule, d.Id(), err)
 	}
 
 	if _, err := waitRuleDeleted(ctx, conn, d.Id()); err != nil {
-		return append(diags, create.DiagError(names.ConfigService, create.ErrActionWaitingForDeletion, ResNameConfigRule, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.ConfigService, create.ErrActionWaitingForDeletion, ResNameConfigRule, d.Id(), err)
 	}
 
 	return diags

--- a/internal/service/configservice/configuration_aggregator.go
+++ b/internal/service/configservice/configuration_aggregator.go
@@ -169,7 +169,7 @@ func resourceConfigurationAggregatorRead(ctx context.Context, d *schema.Resource
 	}
 
 	if err != nil {
-		return create.DiagError(names.ConfigService, create.ErrActionReading, ResNameConfigurationAggregator, d.Id(), err)
+		return create.AppendDiagError(diags, names.ConfigService, create.ErrActionReading, ResNameConfigurationAggregator, d.Id(), err)
 	}
 
 	if !d.IsNewResource() && (res == nil || len(res.ConfigurationAggregators) == 0) {
@@ -179,7 +179,7 @@ func resourceConfigurationAggregatorRead(ctx context.Context, d *schema.Resource
 	}
 
 	if d.IsNewResource() && (res == nil || len(res.ConfigurationAggregators) == 0) {
-		return create.DiagError(names.ConfigService, create.ErrActionReading, ResNameConfigurationAggregator, d.Id(), errors.New("not found after creation"))
+		return create.AppendDiagError(diags, names.ConfigService, create.ErrActionReading, ResNameConfigurationAggregator, d.Id(), errors.New("not found after creation"))
 	}
 
 	aggregator := res.ConfigurationAggregators[0]

--- a/internal/service/configservice/configuration_recorder_status.go
+++ b/internal/service/configservice/configuration_recorder_status.go
@@ -96,7 +96,7 @@ func resourceConfigurationRecorderStatusRead(ctx context.Context, d *schema.Reso
 	}
 
 	if err != nil {
-		return create.DiagError(names.ConfigService, create.ErrActionReading, ResNameConfigurationRecorderStatus, d.Id(), err)
+		return create.AppendDiagError(diags, names.ConfigService, create.ErrActionReading, ResNameConfigurationRecorderStatus, d.Id(), err)
 	}
 
 	numberOfStatuses := len(statusOut.ConfigurationRecordersStatus)
@@ -107,7 +107,7 @@ func resourceConfigurationRecorderStatusRead(ctx context.Context, d *schema.Reso
 	}
 
 	if d.IsNewResource() && numberOfStatuses < 1 {
-		return create.DiagError(names.ConfigService, create.ErrActionReading, ResNameConfigurationRecorderStatus, d.Id(), errors.New("not found after creation"))
+		return create.AppendDiagError(diags, names.ConfigService, create.ErrActionReading, ResNameConfigurationRecorderStatus, d.Id(), errors.New("not found after creation"))
 	}
 
 	if numberOfStatuses > 1 {

--- a/internal/service/configservice/delivery_channel.go
+++ b/internal/service/configservice/delivery_channel.go
@@ -152,7 +152,7 @@ func resourceDeliveryChannelRead(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	if err != nil {
-		return create.DiagError(names.ConfigService, create.ErrActionReading, ResNameDeliveryChannel, d.Id(), err)
+		return create.AppendDiagError(diags, names.ConfigService, create.ErrActionReading, ResNameDeliveryChannel, d.Id(), err)
 	}
 
 	if !d.IsNewResource() && len(out.DeliveryChannels) < 1 {
@@ -162,7 +162,7 @@ func resourceDeliveryChannelRead(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	if d.IsNewResource() && len(out.DeliveryChannels) < 1 {
-		return create.DiagError(names.ConfigService, create.ErrActionReading, ResNameDeliveryChannel, d.Id(), errors.New("not found after creation"))
+		return create.AppendDiagError(diags, names.ConfigService, create.ErrActionReading, ResNameDeliveryChannel, d.Id(), errors.New("not found after creation"))
 	}
 
 	if len(out.DeliveryChannels) > 1 {

--- a/internal/service/configservice/organization_custom_rule.go
+++ b/internal/service/configservice/organization_custom_rule.go
@@ -174,13 +174,13 @@ func resourceOrganizationCustomRuleCreate(ctx context.Context, d *schema.Resourc
 	_, err := conn.PutOrganizationConfigRuleWithContext(ctx, input)
 
 	if err != nil {
-		return create.DiagError(names.ConfigService, create.ErrActionCreating, ResNameOrganizationCustomRule, name, err)
+		return create.AppendDiagError(diags, names.ConfigService, create.ErrActionCreating, ResNameOrganizationCustomRule, name, err)
 	}
 
 	d.SetId(name)
 
 	if err := waitForOrganizationRuleStatusCreateSuccessful(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return create.DiagError(names.ConfigService, create.ErrActionWaitingForCreation, ResNameOrganizationCustomRule, d.Id(), err)
+		return create.AppendDiagError(diags, names.ConfigService, create.ErrActionWaitingForCreation, ResNameOrganizationCustomRule, d.Id(), err)
 	}
 
 	return append(diags, resourceOrganizationCustomRuleRead(ctx, d, meta)...)
@@ -199,7 +199,7 @@ func resourceOrganizationCustomRuleRead(ctx context.Context, d *schema.ResourceD
 	}
 
 	if err != nil {
-		return create.DiagError(names.ConfigService, create.ErrActionReading, ResNameOrganizationCustomRule, d.Id(), err)
+		return create.AppendDiagError(diags, names.ConfigService, create.ErrActionReading, ResNameOrganizationCustomRule, d.Id(), err)
 	}
 
 	if !d.IsNewResource() && rule == nil {
@@ -209,26 +209,26 @@ func resourceOrganizationCustomRuleRead(ctx context.Context, d *schema.ResourceD
 	}
 
 	if d.IsNewResource() && rule == nil {
-		return create.DiagError(names.ConfigService, create.ErrActionReading, ResNameOrganizationCustomRule, d.Id(), errors.New("empty rule after creation"))
+		return create.AppendDiagError(diags, names.ConfigService, create.ErrActionReading, ResNameOrganizationCustomRule, d.Id(), errors.New("empty rule after creation"))
 	}
 
 	if rule.OrganizationCustomPolicyRuleMetadata != nil {
-		return create.DiagError(names.ConfigService, create.ErrActionReading, ResNameOrganizationCustomRule, d.Id(), errors.New("expected Organization Custom Rule, found Organization Custom Policy Rule"))
+		return create.AppendDiagError(diags, names.ConfigService, create.ErrActionReading, ResNameOrganizationCustomRule, d.Id(), errors.New("expected Organization Custom Rule, found Organization Custom Policy Rule"))
 	}
 
 	if rule.OrganizationManagedRuleMetadata != nil {
-		return create.DiagError(names.ConfigService, create.ErrActionReading, ResNameOrganizationCustomRule, d.Id(), errors.New("expected Organization Custom Rule, found Organization Managed Rule"))
+		return create.AppendDiagError(diags, names.ConfigService, create.ErrActionReading, ResNameOrganizationCustomRule, d.Id(), errors.New("expected Organization Custom Rule, found Organization Managed Rule"))
 	}
 
 	if rule.OrganizationCustomRuleMetadata == nil {
-		return create.DiagError(names.ConfigService, create.ErrActionReading, ResNameOrganizationCustomRule, d.Id(), errors.New("empty metadata"))
+		return create.AppendDiagError(diags, names.ConfigService, create.ErrActionReading, ResNameOrganizationCustomRule, d.Id(), errors.New("empty metadata"))
 	}
 
 	d.Set("arn", rule.OrganizationConfigRuleArn)
 	d.Set("description", rule.OrganizationCustomRuleMetadata.Description)
 
 	if err := d.Set("excluded_accounts", aws.StringValueSlice(rule.ExcludedAccounts)); err != nil {
-		return create.DiagError(names.ConfigService, create.ErrActionSetting, ResNameOrganizationCustomRule, d.Id(), err)
+		return create.AppendDiagError(diags, names.ConfigService, create.ErrActionSetting, ResNameOrganizationCustomRule, d.Id(), err)
 	}
 
 	d.Set("input_parameters", rule.OrganizationCustomRuleMetadata.InputParameters)
@@ -238,14 +238,14 @@ func resourceOrganizationCustomRuleRead(ctx context.Context, d *schema.ResourceD
 	d.Set("resource_id_scope", rule.OrganizationCustomRuleMetadata.ResourceIdScope)
 
 	if err := d.Set("resource_types_scope", aws.StringValueSlice(rule.OrganizationCustomRuleMetadata.ResourceTypesScope)); err != nil {
-		return create.DiagError(names.ConfigService, create.ErrActionSetting, ResNameOrganizationCustomRule, d.Id(), err)
+		return create.AppendDiagError(diags, names.ConfigService, create.ErrActionSetting, ResNameOrganizationCustomRule, d.Id(), err)
 	}
 
 	d.Set("tag_key_scope", rule.OrganizationCustomRuleMetadata.TagKeyScope)
 	d.Set("tag_value_scope", rule.OrganizationCustomRuleMetadata.TagValueScope)
 
 	if err := d.Set("trigger_types", aws.StringValueSlice(rule.OrganizationCustomRuleMetadata.OrganizationConfigRuleTriggerTypes)); err != nil {
-		return create.DiagError(names.ConfigService, create.ErrActionSetting, ResNameOrganizationCustomRule, d.Id(), err)
+		return create.AppendDiagError(diags, names.ConfigService, create.ErrActionSetting, ResNameOrganizationCustomRule, d.Id(), err)
 	}
 
 	return diags
@@ -298,11 +298,11 @@ func resourceOrganizationCustomRuleUpdate(ctx context.Context, d *schema.Resourc
 	_, err := conn.PutOrganizationConfigRuleWithContext(ctx, input)
 
 	if err != nil {
-		return create.DiagError(names.ConfigService, create.ErrActionUpdating, ResNameOrganizationCustomRule, d.Id(), err)
+		return create.AppendDiagError(diags, names.ConfigService, create.ErrActionUpdating, ResNameOrganizationCustomRule, d.Id(), err)
 	}
 
 	if err := waitForOrganizationRuleStatusUpdateSuccessful(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-		return create.DiagError(names.ConfigService, create.ErrActionWaitingForUpdate, ResNameOrganizationCustomRule, d.Id(), err)
+		return create.AppendDiagError(diags, names.ConfigService, create.ErrActionWaitingForUpdate, ResNameOrganizationCustomRule, d.Id(), err)
 	}
 
 	return append(diags, resourceOrganizationCustomRuleRead(ctx, d, meta)...)
@@ -319,11 +319,11 @@ func resourceOrganizationCustomRuleDelete(ctx context.Context, d *schema.Resourc
 	_, err := conn.DeleteOrganizationConfigRuleWithContext(ctx, input)
 
 	if err != nil {
-		return create.DiagError(names.ConfigService, create.ErrActionDeleting, ResNameOrganizationCustomRule, d.Id(), err)
+		return create.AppendDiagError(diags, names.ConfigService, create.ErrActionDeleting, ResNameOrganizationCustomRule, d.Id(), err)
 	}
 
 	if err := waitForOrganizationRuleStatusDeleteSuccessful(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return create.DiagError(names.ConfigService, create.ErrActionWaitingForDeletion, ResNameOrganizationCustomRule, d.Id(), err)
+		return create.AppendDiagError(diags, names.ConfigService, create.ErrActionWaitingForDeletion, ResNameOrganizationCustomRule, d.Id(), err)
 	}
 
 	return diags

--- a/internal/service/configservice/organization_managed_rule.go
+++ b/internal/service/configservice/organization_managed_rule.go
@@ -195,7 +195,7 @@ func resourceOrganizationManagedRuleRead(ctx context.Context, d *schema.Resource
 	}
 
 	if d.IsNewResource() && rule == nil {
-		return create.DiagError(names.ConfigService, create.ErrActionReading, ResNameOrganizationManagedRule, d.Id(), errors.New("empty rule after creation"))
+		return create.AppendDiagError(diags, names.ConfigService, create.ErrActionReading, ResNameOrganizationManagedRule, d.Id(), errors.New("empty rule after creation"))
 	}
 
 	if rule.OrganizationCustomPolicyRuleMetadata != nil {

--- a/internal/service/configservice/remediation_configuration.go
+++ b/internal/service/configservice/remediation_configuration.go
@@ -189,7 +189,7 @@ func resourceRemediationConfigurationPut(ctx context.Context, d *schema.Resource
 	log.Printf("[DEBUG] Creating AWSConfig remediation configuration: %s", inputs)
 	_, err := conn.PutRemediationConfigurationsWithContext(ctx, &inputs)
 	if err != nil {
-		return create.DiagError(names.ConfigService, create.ErrActionCreating, ResNameRemediationConfiguration, fmt.Sprintf("%+v", inputs), err)
+		return create.AppendDiagError(diags, names.ConfigService, create.ErrActionCreating, ResNameRemediationConfiguration, fmt.Sprintf("%+v", inputs), err)
 	}
 
 	d.SetId(name)
@@ -213,7 +213,7 @@ func resourceRemediationConfigurationRead(ctx context.Context, d *schema.Resourc
 	}
 
 	if err != nil {
-		return create.DiagError(names.ConfigService, create.ErrActionReading, ResNameRemediationConfiguration, d.Id(), err)
+		return create.AppendDiagError(diags, names.ConfigService, create.ErrActionReading, ResNameRemediationConfiguration, d.Id(), err)
 	}
 
 	numberOfRemediationConfigurations := len(out.RemediationConfigurations)
@@ -224,7 +224,7 @@ func resourceRemediationConfigurationRead(ctx context.Context, d *schema.Resourc
 	}
 
 	if d.IsNewResource() && numberOfRemediationConfigurations < 1 {
-		return create.DiagError(names.ConfigService, create.ErrActionReading, ResNameRemediationConfiguration, d.Id(), errors.New("none found after creation"))
+		return create.AppendDiagError(diags, names.ConfigService, create.ErrActionReading, ResNameRemediationConfiguration, d.Id(), errors.New("none found after creation"))
 	}
 
 	log.Printf("[DEBUG] AWS Config remediation configurations received: %s", out)
@@ -242,11 +242,11 @@ func resourceRemediationConfigurationRead(ctx context.Context, d *schema.Resourc
 	d.Set("maximum_automatic_attempts", remediationConfiguration.MaximumAutomaticAttempts)
 
 	if err := d.Set("execution_controls", flattenExecutionControls(remediationConfiguration.ExecutionControls)); err != nil {
-		return create.DiagError(names.ConfigService, create.ErrActionReading, ResNameRemediationConfiguration, d.Id(), err)
+		return create.AppendDiagError(diags, names.ConfigService, create.ErrActionReading, ResNameRemediationConfiguration, d.Id(), err)
 	}
 
 	if err := d.Set("parameter", flattenRemediationParameterValues(remediationConfiguration.Parameters)); err != nil {
-		return create.DiagError(names.ConfigService, create.ErrActionReading, ResNameRemediationConfiguration, d.Id(), err)
+		return create.AppendDiagError(diags, names.ConfigService, create.ErrActionReading, ResNameRemediationConfiguration, d.Id(), err)
 	}
 
 	return diags
@@ -286,7 +286,7 @@ func resourceRemediationConfigurationDelete(ctx context.Context, d *schema.Resou
 	}
 
 	if err != nil {
-		return create.DiagError(names.ConfigService, create.ErrActionDeleting, ResNameRemediationConfiguration, d.Id(), err)
+		return create.AppendDiagError(diags, names.ConfigService, create.ErrActionDeleting, ResNameRemediationConfiguration, d.Id(), err)
 	}
 
 	return diags

--- a/internal/service/connect/bot_association.go
+++ b/internal/service/connect/bot_association.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
@@ -78,6 +79,8 @@ func ResourceBotAssociation() *schema.Resource {
 }
 
 func resourceBotAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ConnectConn(ctx)
 
 	instanceId := d.Get("instance_id").(string)
@@ -116,21 +119,23 @@ func resourceBotAssociationCreate(ctx context.Context, d *schema.ResourceData, m
 	lbaId := BotV1AssociationCreateResourceID(instanceId, aws.StringValue(input.LexBot.Name), aws.StringValue(input.LexBot.LexRegion))
 
 	if err != nil {
-		return diag.Errorf("creating Connect Bot Association (%s): %s", lbaId, err)
+		return sdkdiag.AppendErrorf(diags, "creating Connect Bot Association (%s): %s", lbaId, err)
 	}
 
 	d.SetId(lbaId)
 
-	return resourceBotAssociationRead(ctx, d, meta)
+	return append(diags, resourceBotAssociationRead(ctx, d, meta)...)
 }
 
 func resourceBotAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ConnectConn(ctx)
 
 	instanceId, name, region, err := BotV1AssociationParseResourceID(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	lexBot, err := FindBotAssociationV1ByNameAndRegionWithContext(ctx, conn, instanceId, name, region)
@@ -138,32 +143,34 @@ func resourceBotAssociationRead(ctx context.Context, d *schema.ResourceData, met
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Connect Bot Association (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Connect Bot Association (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Connect Bot Association (%s): %s", d.Id(), err)
 	}
 
 	if lexBot == nil {
-		return diag.Errorf("reading Connect Bot Association (%s): empty output", d.Id())
+		return sdkdiag.AppendErrorf(diags, "reading Connect Bot Association (%s): empty output", d.Id())
 	}
 
 	d.Set("instance_id", instanceId)
 	if err := d.Set("lex_bot", flattenLexBot(lexBot)); err != nil {
-		return diag.Errorf("setting lex_bot: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting lex_bot: %s", err)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceBotAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ConnectConn(ctx)
 
 	instanceID, name, region, err := BotV1AssociationParseResourceID(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	lexBot := &connect.LexBot{
@@ -179,14 +186,14 @@ func resourceBotAssociationDelete(ctx context.Context, d *schema.ResourceData, m
 	_, err = conn.DisassociateBotWithContext(ctx, input)
 
 	if tfawserr.ErrCodeEquals(err, connect.ErrCodeResourceNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting Connect Bot Association (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Connect Bot Association (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func expandLexBot(l []interface{}) *connect.LexBot {

--- a/internal/service/connect/bot_association_data_source.go
+++ b/internal/service/connect/bot_association_data_source.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 )
 
 // @SDKDataSource("aws_connect_bot_association")
@@ -46,6 +47,8 @@ func DataSourceBotAssociation() *schema.Resource {
 }
 
 func dataSourceBotAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ConnectConn(ctx)
 
 	instanceID := d.Get("instance_id").(string)
@@ -59,19 +62,19 @@ func dataSourceBotAssociationRead(ctx context.Context, d *schema.ResourceData, m
 
 	lexBot, err := FindBotAssociationV1ByNameAndRegionWithContext(ctx, conn, instanceID, name, region)
 	if err != nil {
-		return diag.Errorf("finding Connect Bot Association (%s,%s): %s", instanceID, name, err)
+		return sdkdiag.AppendErrorf(diags, "finding Connect Bot Association (%s,%s): %s", instanceID, name, err)
 	}
 
 	if lexBot == nil {
-		return diag.Errorf("finding Connect Bot Association (%s,%s) : not found", instanceID, name)
+		return sdkdiag.AppendErrorf(diags, "finding Connect Bot Association (%s,%s) : not found", instanceID, name)
 	}
 
 	d.SetId(meta.(*conns.AWSClient).Region)
 
 	d.Set("instance_id", instanceID)
 	if err := d.Set("lex_bot", flattenLexBot(lexBot)); err != nil {
-		return diag.Errorf("setting lex_bot: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting lex_bot: %s", err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/connect/instance_storage_config.go
+++ b/internal/service/connect/instance_storage_config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
@@ -177,6 +178,8 @@ func ResourceInstanceStorageConfig() *schema.Resource {
 }
 
 func resourceInstanceStorageConfigCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ConnectConn(ctx)
 
 	instanceId := d.Get("instance_id").(string)
@@ -192,25 +195,27 @@ func resourceInstanceStorageConfigCreate(ctx context.Context, d *schema.Resource
 	output, err := conn.AssociateInstanceStorageConfigWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating Connect Instance Storage Config for Connect Instance (%s,%s): %s", instanceId, resourceType, err)
+		return sdkdiag.AppendErrorf(diags, "creating Connect Instance Storage Config for Connect Instance (%s,%s): %s", instanceId, resourceType, err)
 	}
 
 	if output == nil || output.AssociationId == nil {
-		return diag.Errorf("creating Connect Instance Storage Config for Connect Instance (%s,%s): empty output", instanceId, resourceType)
+		return sdkdiag.AppendErrorf(diags, "creating Connect Instance Storage Config for Connect Instance (%s,%s): empty output", instanceId, resourceType)
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s:%s", instanceId, aws.StringValue(output.AssociationId), resourceType))
 
-	return resourceInstanceStorageConfigRead(ctx, d, meta)
+	return append(diags, resourceInstanceStorageConfigRead(ctx, d, meta)...)
 }
 
 func resourceInstanceStorageConfigRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ConnectConn(ctx)
 
 	instanceId, associationId, resourceType, err := InstanceStorageConfigParseId(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	resp, err := conn.DescribeInstanceStorageConfigWithContext(ctx, &connect.DescribeInstanceStorageConfigInput{
@@ -222,15 +227,15 @@ func resourceInstanceStorageConfigRead(ctx context.Context, d *schema.ResourceDa
 	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, connect.ErrCodeResourceNotFoundException) {
 		log.Printf("[WARN] Connect Instance Storage Config (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("getting Connect Instance Storage Config (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "getting Connect Instance Storage Config (%s): %s", d.Id(), err)
 	}
 
 	if resp == nil || resp.StorageConfig == nil {
-		return diag.Errorf("getting Connect Instance Storage Config (%s): empty response", d.Id())
+		return sdkdiag.AppendErrorf(diags, "getting Connect Instance Storage Config (%s): empty response", d.Id())
 	}
 
 	storageConfig := resp.StorageConfig
@@ -240,19 +245,21 @@ func resourceInstanceStorageConfigRead(ctx context.Context, d *schema.ResourceDa
 	d.Set("resource_type", resourceType)
 
 	if err := d.Set("storage_config", flattenStorageConfig(storageConfig)); err != nil {
-		return diag.Errorf("setting storage_config: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting storage_config: %s", err)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceInstanceStorageConfigUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ConnectConn(ctx)
 
 	instanceId, associationId, resourceType, err := InstanceStorageConfigParseId(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	input := &connect.UpdateInstanceStorageConfigInput{
@@ -268,19 +275,21 @@ func resourceInstanceStorageConfigUpdate(ctx context.Context, d *schema.Resource
 	_, err = conn.UpdateInstanceStorageConfigWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("updating Instance Storage Config (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "updating Instance Storage Config (%s): %s", d.Id(), err)
 	}
 
-	return resourceInstanceStorageConfigRead(ctx, d, meta)
+	return append(diags, resourceInstanceStorageConfigRead(ctx, d, meta)...)
 }
 
 func resourceInstanceStorageConfigDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ConnectConn(ctx)
 
 	instanceId, associationId, resourceType, err := InstanceStorageConfigParseId(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	_, err = conn.DisassociateInstanceStorageConfigWithContext(ctx, &connect.DisassociateInstanceStorageConfigInput{
@@ -290,10 +299,10 @@ func resourceInstanceStorageConfigDelete(ctx context.Context, d *schema.Resource
 	})
 
 	if err != nil {
-		return diag.Errorf("deleting InstanceStorageConfig (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting InstanceStorageConfig (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func InstanceStorageConfigParseId(id string) (string, string, string, error) {

--- a/internal/service/connect/instance_storage_config_data_source.go
+++ b/internal/service/connect/instance_storage_config_data_source.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 )
 
 // @SDKDataSource("aws_connect_instance_storage_config")
@@ -140,6 +141,8 @@ func DataSourceInstanceStorageConfig() *schema.Resource {
 }
 
 func dataSourceInstanceStorageConfigRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ConnectConn(ctx)
 
 	associationId := d.Get("association_id").(string)
@@ -155,20 +158,20 @@ func dataSourceInstanceStorageConfigRead(ctx context.Context, d *schema.Resource
 	resp, err := conn.DescribeInstanceStorageConfigWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("getting Connect Instance Storage Config for Connect Instance (%s,%s,%s): %s", associationId, instanceId, resourceType, err)
+		return sdkdiag.AppendErrorf(diags, "getting Connect Instance Storage Config for Connect Instance (%s,%s,%s): %s", associationId, instanceId, resourceType, err)
 	}
 
 	if resp == nil || resp.StorageConfig == nil {
-		return diag.Errorf("getting Connect Instance Storage Config: empty response")
+		return sdkdiag.AppendErrorf(diags, "getting Connect Instance Storage Config: empty response")
 	}
 
 	storageConfig := resp.StorageConfig
 
 	if err := d.Set("storage_config", flattenStorageConfig(storageConfig)); err != nil {
-		return diag.Errorf("setting storage_config: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting storage_config: %s", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s:%s", instanceId, associationId, resourceType))
 
-	return nil
+	return diags
 }

--- a/internal/service/connect/lambda_function_association.go
+++ b/internal/service/connect/lambda_function_association.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
@@ -43,6 +44,8 @@ func ResourceLambdaFunctionAssociation() *schema.Resource {
 }
 
 func resourceLambdaFunctionAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ConnectConn(ctx)
 
 	instanceId := d.Get("instance_id").(string)
@@ -55,21 +58,23 @@ func resourceLambdaFunctionAssociationCreate(ctx context.Context, d *schema.Reso
 
 	_, err := conn.AssociateLambdaFunctionWithContext(ctx, input)
 	if err != nil {
-		return diag.Errorf("creating Connect Lambda Function Association (%s,%s): %s", instanceId, functionArn, err)
+		return sdkdiag.AppendErrorf(diags, "creating Connect Lambda Function Association (%s,%s): %s", instanceId, functionArn, err)
 	}
 
 	d.SetId(LambdaFunctionAssociationCreateResourceID(instanceId, functionArn))
 
-	return resourceLambdaFunctionAssociationRead(ctx, d, meta)
+	return append(diags, resourceLambdaFunctionAssociationRead(ctx, d, meta)...)
 }
 
 func resourceLambdaFunctionAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ConnectConn(ctx)
 
 	instanceID, functionArn, err := LambdaFunctionAssociationParseResourceID(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	lfaArn, err := FindLambdaFunctionAssociationByARNWithContext(ctx, conn, instanceID, functionArn)
@@ -77,25 +82,27 @@ func resourceLambdaFunctionAssociationRead(ctx context.Context, d *schema.Resour
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Connect Lambda Function Association (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("finding Connect Lambda Function Association by Function ARN (%s): %s", functionArn, err)
+		return sdkdiag.AppendErrorf(diags, "finding Connect Lambda Function Association by Function ARN (%s): %s", functionArn, err)
 	}
 
 	d.Set("function_arn", lfaArn)
 	d.Set("instance_id", instanceID)
 
-	return nil
+	return diags
 }
 
 func resourceLambdaFunctionAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ConnectConn(ctx)
 
 	instanceID, functionArn, err := LambdaFunctionAssociationParseResourceID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	input := &connect.DisassociateLambdaFunctionInput{
@@ -106,12 +113,12 @@ func resourceLambdaFunctionAssociationDelete(ctx context.Context, d *schema.Reso
 	_, err = conn.DisassociateLambdaFunctionWithContext(ctx, input)
 
 	if tfawserr.ErrCodeEquals(err, connect.ErrCodeResourceNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting Connect Lambda Function Association (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Connect Lambda Function Association (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/connect/lambda_function_association_data_source.go
+++ b/internal/service/connect/lambda_function_association_data_source.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
@@ -31,22 +32,24 @@ func DataSourceLambdaFunctionAssociation() *schema.Resource {
 }
 
 func dataSourceLambdaFunctionAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ConnectConn(ctx)
 	functionArn := d.Get("function_arn")
 	instanceID := d.Get("instance_id")
 
 	lfaArn, err := FindLambdaFunctionAssociationByARNWithContext(ctx, conn, instanceID.(string), functionArn.(string))
 	if err != nil {
-		return diag.Errorf("finding Connect Lambda Function Association by ARN (%s): %s", functionArn, err)
+		return sdkdiag.AppendErrorf(diags, "finding Connect Lambda Function Association by ARN (%s): %s", functionArn, err)
 	}
 
 	if lfaArn == "" {
-		return diag.Errorf("finding Connect Lambda Function Association by ARN (%s): not found", functionArn)
+		return sdkdiag.AppendErrorf(diags, "finding Connect Lambda Function Association by ARN (%s): not found", functionArn)
 	}
 
 	d.SetId(meta.(*conns.AWSClient).Region)
 	d.Set("function_arn", functionArn)
 	d.Set("instance_id", instanceID)
 
-	return nil
+	return diags
 }

--- a/internal/service/connect/phone_number.go
+++ b/internal/service/connect/phone_number.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -98,6 +99,8 @@ func ResourcePhoneNumber() *schema.Resource {
 }
 
 func resourcePhoneNumberCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ConnectConn(ctx)
 
 	targetArn := d.Get("target_arn").(string)
@@ -117,18 +120,18 @@ func resourcePhoneNumberCreate(ctx context.Context, d *schema.ResourceData, meta
 	output, err := conn.SearchAvailablePhoneNumbersWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("searching Connect Phone Number for Connect Instance (%s,%s): %s", targetArn, phoneNumberType, err)
+		return sdkdiag.AppendErrorf(diags, "searching Connect Phone Number for Connect Instance (%s,%s): %s", targetArn, phoneNumberType, err)
 	}
 
 	if output == nil || output.AvailableNumbersList == nil || len(output.AvailableNumbersList) == 0 {
-		return diag.Errorf("searching Connect Phone Number for Connect Instance (%s,%s): empty output", targetArn, phoneNumberType)
+		return sdkdiag.AppendErrorf(diags, "searching Connect Phone Number for Connect Instance (%s,%s): empty output", targetArn, phoneNumberType)
 	}
 
 	phoneNumber := output.AvailableNumbersList[0].PhoneNumber
 
 	uuid, err := uuid.GenerateUUID()
 	if err != nil {
-		return diag.Errorf("generating uuid for ClientToken for Connect Instance (%s,%s): %s", targetArn, aws.StringValue(phoneNumber), err)
+		return sdkdiag.AppendErrorf(diags, "generating uuid for ClientToken for Connect Instance (%s,%s): %s", targetArn, aws.StringValue(phoneNumber), err)
 	}
 
 	input2 := &connect.ClaimPhoneNumberInput{
@@ -146,24 +149,26 @@ func resourcePhoneNumberCreate(ctx context.Context, d *schema.ResourceData, meta
 	output2, err2 := conn.ClaimPhoneNumberWithContext(ctx, input2)
 
 	if err2 != nil {
-		return diag.Errorf("creating Connect Phone Number for Connect Instance (%s,%s): %s", targetArn, aws.StringValue(phoneNumber), err2)
+		return sdkdiag.AppendErrorf(diags, "creating Connect Phone Number for Connect Instance (%s,%s): %s", targetArn, aws.StringValue(phoneNumber), err2)
 	}
 
 	if output2 == nil || output2.PhoneNumberId == nil {
-		return diag.Errorf("creating Connect Phone Number for Connect Instance (%s,%s): empty output", targetArn, aws.StringValue(phoneNumber))
+		return sdkdiag.AppendErrorf(diags, "creating Connect Phone Number for Connect Instance (%s,%s): empty output", targetArn, aws.StringValue(phoneNumber))
 	}
 
 	phoneNumberId := output2.PhoneNumberId
 	d.SetId(aws.StringValue(phoneNumberId))
 
 	if _, err := waitPhoneNumberCreated(ctx, conn, d.Timeout(schema.TimeoutCreate), d.Id()); err != nil {
-		return diag.Errorf("waiting for Phone Number (%s) creation: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Phone Number (%s) creation: %s", d.Id(), err)
 	}
 
-	return resourcePhoneNumberRead(ctx, d, meta)
+	return append(diags, resourcePhoneNumberRead(ctx, d, meta)...)
 }
 
 func resourcePhoneNumberRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ConnectConn(ctx)
 
 	phoneNumberId := d.Id()
@@ -175,15 +180,15 @@ func resourcePhoneNumberRead(ctx context.Context, d *schema.ResourceData, meta i
 	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, connect.ErrCodeResourceNotFoundException) {
 		log.Printf("[WARN] Connect Phone Number (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("getting Connect Phone Number (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "getting Connect Phone Number (%s): %s", d.Id(), err)
 	}
 
 	if resp == nil || resp.ClaimedPhoneNumberSummary == nil {
-		return diag.Errorf("getting Connect Phone Number (%s): empty response", d.Id())
+		return sdkdiag.AppendErrorf(diags, "getting Connect Phone Number (%s): empty response", d.Id())
 	}
 
 	phoneNumberSummary := resp.ClaimedPhoneNumberSummary
@@ -196,22 +201,24 @@ func resourcePhoneNumberRead(ctx context.Context, d *schema.ResourceData, meta i
 	d.Set("target_arn", phoneNumberSummary.TargetArn)
 
 	if err := d.Set("status", flattenPhoneNumberStatus(phoneNumberSummary.PhoneNumberStatus)); err != nil {
-		return diag.Errorf("setting status: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting status: %s", err)
 	}
 
 	setTagsOut(ctx, resp.ClaimedPhoneNumberSummary.Tags)
 
-	return nil
+	return diags
 }
 
 func resourcePhoneNumberUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ConnectConn(ctx)
 
 	phoneNumberId := d.Id()
 
 	uuid, err := uuid.GenerateUUID()
 	if err != nil {
-		return diag.Errorf("generating uuid for ClientToken for Phone Number %s: %s", phoneNumberId, err)
+		return sdkdiag.AppendErrorf(diags, "generating uuid for ClientToken for Phone Number %s: %s", phoneNumberId, err)
 	}
 
 	if d.HasChange("target_arn") {
@@ -222,25 +229,27 @@ func resourcePhoneNumberUpdate(ctx context.Context, d *schema.ResourceData, meta
 		})
 
 		if err != nil {
-			return diag.Errorf("updating Phone Number (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating Phone Number (%s): %s", d.Id(), err)
 		}
 	}
 
 	if _, err := waitPhoneNumberUpdated(ctx, conn, d.Timeout(schema.TimeoutCreate), d.Id()); err != nil {
-		return diag.Errorf("waiting for Phone Number (%s) update: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Phone Number (%s) update: %s", d.Id(), err)
 	}
 
-	return resourcePhoneNumberRead(ctx, d, meta)
+	return append(diags, resourcePhoneNumberRead(ctx, d, meta)...)
 }
 
 func resourcePhoneNumberDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ConnectConn(ctx)
 
 	phoneNumberId := d.Id()
 
 	uuid, err := uuid.GenerateUUID()
 	if err != nil {
-		return diag.Errorf("generating uuid for ClientToken for Phone Number %s: %s", phoneNumberId, err)
+		return sdkdiag.AppendErrorf(diags, "generating uuid for ClientToken for Phone Number %s: %s", phoneNumberId, err)
 	}
 
 	_, err = conn.ReleasePhoneNumberWithContext(ctx, &connect.ReleasePhoneNumberInput{
@@ -249,14 +258,14 @@ func resourcePhoneNumberDelete(ctx context.Context, d *schema.ResourceData, meta
 	})
 
 	if err != nil {
-		return diag.Errorf("deleting PhoneNumber (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting PhoneNumber (%s): %s", d.Id(), err)
 	}
 
 	if _, err := waitPhoneNumberDeleted(ctx, conn, d.Timeout(schema.TimeoutCreate), phoneNumberId); err != nil {
-		return diag.Errorf("waiting for Phone Number (%s) deletion: %s", phoneNumberId, err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Phone Number (%s) deletion: %s", phoneNumberId, err)
 	}
 
-	return nil
+	return diags
 }
 
 func flattenPhoneNumberStatus(apiObject *connect.PhoneNumberStatus) []interface{} {

--- a/internal/service/connect/prompt_data_source.go
+++ b/internal/service/connect/prompt_data_source.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 )
 
 // @SDKDataSource("aws_connect_prompt")
@@ -40,6 +41,8 @@ func DataSourcePrompt() *schema.Resource {
 }
 
 func dataSourcePromptRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ConnectConn(ctx)
 
 	instanceID := d.Get("instance_id").(string)
@@ -48,11 +51,11 @@ func dataSourcePromptRead(ctx context.Context, d *schema.ResourceData, meta inte
 	promptSummary, err := dataSourceGetPromptSummaryByName(ctx, conn, instanceID, name)
 
 	if err != nil {
-		return diag.Errorf("finding Connect Prompt Summary by name (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "finding Connect Prompt Summary by name (%s): %s", name, err)
 	}
 
 	if promptSummary == nil {
-		return diag.Errorf("finding Connect Prompt Summary by name (%s): not found", name)
+		return sdkdiag.AppendErrorf(diags, "finding Connect Prompt Summary by name (%s): not found", name)
 	}
 
 	d.Set("arn", promptSummary.Arn)
@@ -62,7 +65,7 @@ func dataSourcePromptRead(ctx context.Context, d *schema.ResourceData, meta inte
 
 	d.SetId(fmt.Sprintf("%s:%s", instanceID, aws.StringValue(promptSummary.Id)))
 
-	return nil
+	return diags
 }
 
 func dataSourceGetPromptSummaryByName(ctx context.Context, conn *connect.Connect, instanceID, name string) (*connect.PromptSummary, error) {

--- a/internal/service/connect/routing_profile.go
+++ b/internal/service/connect/routing_profile.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -132,6 +133,8 @@ func ResourceRoutingProfile() *schema.Resource {
 }
 
 func resourceRoutingProfileCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ConnectConn(ctx)
 
 	instanceID := d.Get("instance_id").(string)
@@ -153,11 +156,11 @@ func resourceRoutingProfileCreate(ctx context.Context, d *schema.ResourceData, m
 	output, err := conn.CreateRoutingProfileWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating Connect Routing Profile (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "creating Connect Routing Profile (%s): %s", name, err)
 	}
 
 	if output == nil {
-		return diag.Errorf("creating Connect Routing Profile (%s): empty output", name)
+		return sdkdiag.AppendErrorf(diags, "creating Connect Routing Profile (%s): empty output", name)
 	}
 
 	// call the batched association API if the number of queues to associate with the routing profile is > CreateRoutingProfileQueuesMaxItems
@@ -166,22 +169,24 @@ func resourceRoutingProfileCreate(ctx context.Context, d *schema.ResourceData, m
 		err = updateQueueConfigs(ctx, conn, instanceID, aws.StringValue(output.RoutingProfileId), v.(*schema.Set).List(), queueConfigsUpdateRemove)
 
 		if err != nil {
-			return diag.FromErr(err)
+			return sdkdiag.AppendFromErr(diags, err)
 		}
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s", instanceID, aws.StringValue(output.RoutingProfileId)))
 
-	return resourceRoutingProfileRead(ctx, d, meta)
+	return append(diags, resourceRoutingProfileRead(ctx, d, meta)...)
 }
 
 func resourceRoutingProfileRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ConnectConn(ctx)
 
 	instanceID, routingProfileID, err := RoutingProfileParseID(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	resp, err := conn.DescribeRoutingProfileWithContext(ctx, &connect.DescribeRoutingProfileInput{
@@ -192,21 +197,21 @@ func resourceRoutingProfileRead(ctx context.Context, d *schema.ResourceData, met
 	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, connect.ErrCodeResourceNotFoundException) {
 		log.Printf("[WARN] Connect Routing Profile (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("getting Connect Routing Profile (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "getting Connect Routing Profile (%s): %s", d.Id(), err)
 	}
 
 	if resp == nil || resp.RoutingProfile == nil {
-		return diag.Errorf("getting Connect Routing Profile (%s): empty response", d.Id())
+		return sdkdiag.AppendErrorf(diags, "getting Connect Routing Profile (%s): empty response", d.Id())
 	}
 
 	routingProfile := resp.RoutingProfile
 
 	if err := d.Set("media_concurrencies", flattenRoutingProfileMediaConcurrencies(routingProfile.MediaConcurrencies)); err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	d.Set("arn", routingProfile.RoutingProfileArn)
@@ -221,23 +226,25 @@ func resourceRoutingProfileRead(ctx context.Context, d *schema.ResourceData, met
 	queueConfigs, err := getRoutingProfileQueueConfigs(ctx, conn, instanceID, routingProfileID)
 
 	if err != nil {
-		return diag.Errorf("finding Connect Routing Profile Queue Configs Summary by Routing Profile ID (%s): %s", routingProfileID, err)
+		return sdkdiag.AppendErrorf(diags, "finding Connect Routing Profile Queue Configs Summary by Routing Profile ID (%s): %s", routingProfileID, err)
 	}
 
 	d.Set("queue_configs", queueConfigs)
 
 	setTagsOut(ctx, resp.RoutingProfile.Tags)
 
-	return nil
+	return diags
 }
 
 func resourceRoutingProfileUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ConnectConn(ctx)
 
 	instanceID, routingProfileID, err := RoutingProfileParseID(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	// RoutingProfile has 4 update APIs
@@ -257,7 +264,7 @@ func resourceRoutingProfileUpdate(ctx context.Context, d *schema.ResourceData, m
 		inputConcurrency.MediaConcurrencies = mediaConcurrencies
 		_, err = conn.UpdateRoutingProfileConcurrencyWithContext(ctx, inputConcurrency)
 		if err != nil {
-			return diag.Errorf("updating RoutingProfile Media Concurrency (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating RoutingProfile Media Concurrency (%s): %s", d.Id(), err)
 		}
 	}
 
@@ -272,7 +279,7 @@ func resourceRoutingProfileUpdate(ctx context.Context, d *schema.ResourceData, m
 		_, err = conn.UpdateRoutingProfileDefaultOutboundQueueWithContext(ctx, inputDefaultOutboundQueue)
 
 		if err != nil {
-			return diag.Errorf("updating RoutingProfile Default Outbound Queue ID (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating RoutingProfile Default Outbound Queue ID (%s): %s", d.Id(), err)
 		}
 	}
 
@@ -288,7 +295,7 @@ func resourceRoutingProfileUpdate(ctx context.Context, d *schema.ResourceData, m
 		_, err = conn.UpdateRoutingProfileNameWithContext(ctx, inputNameDesc)
 
 		if err != nil {
-			return diag.Errorf("updating RoutingProfile Name (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating RoutingProfile Name (%s): %s", d.Id(), err)
 		}
 	}
 
@@ -317,11 +324,11 @@ func resourceRoutingProfileUpdate(ctx context.Context, d *schema.ResourceData, m
 		err = updateQueueConfigs(ctx, conn, instanceID, routingProfileID, queueConfigsUpdateAdd, queueConfigsUpdateRemove)
 
 		if err != nil {
-			return diag.FromErr(err)
+			return sdkdiag.AppendFromErr(diags, err)
 		}
 	}
 
-	return resourceRoutingProfileRead(ctx, d, meta)
+	return append(diags, resourceRoutingProfileRead(ctx, d, meta)...)
 }
 
 func updateQueueConfigs(ctx context.Context, conn *connect.Connect, instanceID, routingProfileID string, queueConfigsUpdateAdd, queueConfigsUpdateRemove []interface{}) error {
@@ -372,12 +379,14 @@ func updateQueueConfigs(ctx context.Context, conn *connect.Connect, instanceID, 
 }
 
 func resourceRoutingProfileDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ConnectConn(ctx)
 
 	instanceID, routingProfileID, err := RoutingProfileParseID(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	_, err = conn.DeleteRoutingProfileWithContext(ctx, &connect.DeleteRoutingProfileInput{
@@ -386,10 +395,10 @@ func resourceRoutingProfileDelete(ctx context.Context, d *schema.ResourceData, m
 	})
 
 	if err != nil {
-		return diag.Errorf("deleting RoutingProfile (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting RoutingProfile (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func expandRoutingProfileMediaConcurrencies(mediaConcurrencies []interface{}) []*connect.MediaConcurrency {

--- a/internal/service/connect/security_profile.go
+++ b/internal/service/connect/security_profile.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -78,6 +79,8 @@ func ResourceSecurityProfile() *schema.Resource {
 }
 
 func resourceSecurityProfileCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ConnectConn(ctx)
 
 	instanceID := d.Get("instance_id").(string)
@@ -100,25 +103,27 @@ func resourceSecurityProfileCreate(ctx context.Context, d *schema.ResourceData, 
 	output, err := conn.CreateSecurityProfileWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating Connect Security Profile (%s): %s", securityProfileName, err)
+		return sdkdiag.AppendErrorf(diags, "creating Connect Security Profile (%s): %s", securityProfileName, err)
 	}
 
 	if output == nil {
-		return diag.Errorf("creating Connect Security Profile (%s): empty output", securityProfileName)
+		return sdkdiag.AppendErrorf(diags, "creating Connect Security Profile (%s): empty output", securityProfileName)
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s", instanceID, aws.StringValue(output.SecurityProfileId)))
 
-	return resourceSecurityProfileRead(ctx, d, meta)
+	return append(diags, resourceSecurityProfileRead(ctx, d, meta)...)
 }
 
 func resourceSecurityProfileRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ConnectConn(ctx)
 
 	instanceID, securityProfileID, err := SecurityProfileParseID(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	resp, err := conn.DescribeSecurityProfileWithContext(ctx, &connect.DescribeSecurityProfileInput{
@@ -129,15 +134,15 @@ func resourceSecurityProfileRead(ctx context.Context, d *schema.ResourceData, me
 	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, connect.ErrCodeResourceNotFoundException) {
 		log.Printf("[WARN] Connect Security Profile (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("getting Connect Security Profile (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "getting Connect Security Profile (%s): %s", d.Id(), err)
 	}
 
 	if resp == nil || resp.SecurityProfile == nil {
-		return diag.Errorf("getting Connect Security Profile (%s): empty response", d.Id())
+		return sdkdiag.AppendErrorf(diags, "getting Connect Security Profile (%s): empty response", d.Id())
 	}
 
 	d.Set("arn", resp.SecurityProfile.Arn)
@@ -151,7 +156,7 @@ func resourceSecurityProfileRead(ctx context.Context, d *schema.ResourceData, me
 	permissions, err := getSecurityProfilePermissions(ctx, conn, instanceID, securityProfileID)
 
 	if err != nil {
-		return diag.Errorf("finding Connect Security Profile Permissions for Security Profile (%s): %s", securityProfileID, err)
+		return sdkdiag.AppendErrorf(diags, "finding Connect Security Profile Permissions for Security Profile (%s): %s", securityProfileID, err)
 	}
 
 	if permissions != nil {
@@ -160,16 +165,18 @@ func resourceSecurityProfileRead(ctx context.Context, d *schema.ResourceData, me
 
 	setTagsOut(ctx, resp.SecurityProfile.Tags)
 
-	return nil
+	return diags
 }
 
 func resourceSecurityProfileUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ConnectConn(ctx)
 
 	instanceID, securityProfileID, err := SecurityProfileParseID(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	input := &connect.UpdateSecurityProfileInput{
@@ -188,19 +195,21 @@ func resourceSecurityProfileUpdate(ctx context.Context, d *schema.ResourceData, 
 	_, err = conn.UpdateSecurityProfileWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("updating SecurityProfile (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "updating SecurityProfile (%s): %s", d.Id(), err)
 	}
 
-	return resourceSecurityProfileRead(ctx, d, meta)
+	return append(diags, resourceSecurityProfileRead(ctx, d, meta)...)
 }
 
 func resourceSecurityProfileDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ConnectConn(ctx)
 
 	instanceID, securityProfileID, err := SecurityProfileParseID(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	_, err = conn.DeleteSecurityProfileWithContext(ctx, &connect.DeleteSecurityProfileInput{
@@ -209,10 +218,10 @@ func resourceSecurityProfileDelete(ctx context.Context, d *schema.ResourceData, 
 	})
 
 	if err != nil {
-		return diag.Errorf("deleting SecurityProfile (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting SecurityProfile (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func SecurityProfileParseID(id string) (string, string, error) {

--- a/internal/service/connect/user_hierarchy_structure_data_source.go
+++ b/internal/service/connect/user_hierarchy_structure_data_source.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 )
 
 // @SDKDataSource("aws_connect_user_hierarchy_structure")
@@ -81,6 +82,8 @@ func userHierarchyLevelDataSourceSchema() *schema.Schema {
 }
 
 func dataSourceUserHierarchyStructureRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ConnectConn(ctx)
 
 	instanceID := d.Get("instance_id").(string)
@@ -90,18 +93,18 @@ func dataSourceUserHierarchyStructureRead(ctx context.Context, d *schema.Resourc
 	})
 
 	if err != nil {
-		return diag.Errorf("getting Connect User Hierarchy Structure for Connect Instance (%s): %s", instanceID, err)
+		return sdkdiag.AppendErrorf(diags, "getting Connect User Hierarchy Structure for Connect Instance (%s): %s", instanceID, err)
 	}
 
 	if resp == nil || resp.HierarchyStructure == nil {
-		return diag.Errorf("getting Connect User Hierarchy Structure for Connect Instance (%s): empty response", instanceID)
+		return sdkdiag.AppendErrorf(diags, "getting Connect User Hierarchy Structure for Connect Instance (%s): empty response", instanceID)
 	}
 
 	if err := d.Set("hierarchy_structure", flattenUserHierarchyStructure(resp.HierarchyStructure)); err != nil {
-		return diag.Errorf("setting Connect User Hierarchy Structure for Connect Instance: (%s)", instanceID)
+		return sdkdiag.AppendErrorf(diags, "setting Connect User Hierarchy Structure for Connect Instance: (%s)", instanceID)
 	}
 
 	d.SetId(instanceID)
 
-	return nil
+	return diags
 }

--- a/internal/service/connect/vocabulary.go
+++ b/internal/service/connect/vocabulary.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -99,6 +100,8 @@ func ResourceVocabulary() *schema.Resource {
 }
 
 func resourceVocabularyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ConnectConn(ctx)
 
 	instanceID := d.Get("instance_id").(string)
@@ -116,11 +119,11 @@ func resourceVocabularyCreate(ctx context.Context, d *schema.ResourceData, meta 
 	output, err := conn.CreateVocabularyWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating Connect Vocabulary (%s): %s", vocabularyName, err)
+		return sdkdiag.AppendErrorf(diags, "creating Connect Vocabulary (%s): %s", vocabularyName, err)
 	}
 
 	if output == nil {
-		return diag.Errorf("creating Connect Vocabulary (%s): empty output", vocabularyName)
+		return sdkdiag.AppendErrorf(diags, "creating Connect Vocabulary (%s): empty output", vocabularyName)
 	}
 
 	vocabularyID := aws.StringValue(output.VocabularyId)
@@ -129,19 +132,21 @@ func resourceVocabularyCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 	// waiter since the status changes from CREATION_IN_PROGRESS to either ACTIVE or CREATION_FAILED
 	if _, err := waitVocabularyCreated(ctx, conn, d.Timeout(schema.TimeoutCreate), instanceID, vocabularyID); err != nil {
-		return diag.Errorf("waiting for Vocabulary (%s) creation: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Vocabulary (%s) creation: %s", d.Id(), err)
 	}
 
-	return resourceVocabularyRead(ctx, d, meta)
+	return append(diags, resourceVocabularyRead(ctx, d, meta)...)
 }
 
 func resourceVocabularyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ConnectConn(ctx)
 
 	instanceID, vocabularyID, err := VocabularyParseID(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	resp, err := conn.DescribeVocabularyWithContext(ctx, &connect.DescribeVocabularyInput{
@@ -152,15 +157,15 @@ func resourceVocabularyRead(ctx context.Context, d *schema.ResourceData, meta in
 	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, connect.ErrCodeResourceNotFoundException) {
 		log.Printf("[WARN] Connect Vocabulary (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("getting Connect Vocabulary (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "getting Connect Vocabulary (%s): %s", d.Id(), err)
 	}
 
 	if resp == nil || resp.Vocabulary == nil {
-		return diag.Errorf("getting Connect Vocabulary (%s): empty response", d.Id())
+		return sdkdiag.AppendErrorf(diags, "getting Connect Vocabulary (%s): empty response", d.Id())
 	}
 
 	vocabulary := resp.Vocabulary
@@ -177,7 +182,7 @@ func resourceVocabularyRead(ctx context.Context, d *schema.ResourceData, meta in
 
 	setTagsOut(ctx, resp.Vocabulary.Tags)
 
-	return nil
+	return diags
 }
 
 func resourceVocabularyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -186,12 +191,14 @@ func resourceVocabularyUpdate(ctx context.Context, d *schema.ResourceData, meta 
 }
 
 func resourceVocabularyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ConnectConn(ctx)
 
 	instanceID, vocabularyID, err := VocabularyParseID(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	_, err = conn.DeleteVocabularyWithContext(ctx, &connect.DeleteVocabularyInput{
@@ -200,14 +207,14 @@ func resourceVocabularyDelete(ctx context.Context, d *schema.ResourceData, meta 
 	})
 
 	if err != nil {
-		return diag.Errorf("deleting Vocabulary (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Vocabulary (%s): %s", d.Id(), err)
 	}
 
 	if _, err := waitVocabularyDeleted(ctx, conn, d.Timeout(schema.TimeoutDelete), instanceID, vocabularyID); err != nil {
-		return diag.Errorf("waiting for Vocabulary (%s) deletion: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Vocabulary (%s) deletion: %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func VocabularyParseID(id string) (string, string, error) {


### PR DESCRIPTION
### Description

Collects diagnostics in `diags` instead of returning error diagnostic directly. Ensures that warning diagnostics are not accidentally dropped.

Covers services starting with `b` and `c`
