### PR TITLE
r/aws_vpc: Add wait_for_ipam_deallocation parameter

### DIFF
--- a/internal/service/ec2/vpc_.go
+++ b/internal/service/ec2/vpc_.go
@@ -161,6 +161,11 @@ func ResourceVPC() *schema.Resource {
 				ConflictsWith: []string{"ipv6_cidr_block"},
 				RequiredWith:  []string{"ipv6_ipam_pool_id"},
 			},
+			"wait_for_ipam_deallocation": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
 			"main_route_table_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -480,7 +485,9 @@ func resourceVPCDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 			ipamPoolID = v.(string)
 		}
 	}
-	if ipamPoolID != "" && ipamPoolID != amazonIPv6PoolID {
+	var wait_for_ipam_deallocation = d.Get("wait_for_ipam_deallocation").(bool)
+	log.Printf("[INFO] Should wait for IPAM: %s", wait_for_ipam_deallocation)
+	if ipamPoolID != "" && ipamPoolID != amazonIPv6PoolID && wait_for_ipam_deallocation {
 		const (
 			timeout = 20 * time.Minute // IPAM eventual consistency
 		)

--- a/internal/service/ec2/vpc_default_vpc.go
+++ b/internal/service/ec2/vpc_default_vpc.go
@@ -139,6 +139,11 @@ func ResourceDefaultVPC() *schema.Resource {
 				ConflictsWith: []string{"ipv6_cidr_block"},
 				RequiredWith:  []string{"ipv6_ipam_pool_id"},
 			},
+			"wait_for_ipam_deallocation": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
 			"main_route_table_id": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/website/docs/r/vpc.html.markdown
+++ b/website/docs/r/vpc.html.markdown
@@ -76,6 +76,7 @@ This resource supports the following arguments:
 * `ipv6_ipam_pool_id` - (Optional) IPAM Pool ID for a IPv6 pool. Conflicts with `assign_generated_ipv6_cidr_block`.
 * `ipv6_netmask_length` - (Optional) Netmask length to request from IPAM Pool. Conflicts with `ipv6_cidr_block`. This can be omitted if IPAM pool as a `allocation_default_netmask_length` set. Valid values: `56`.
 * `ipv6_cidr_block_network_border_group` - (Optional) By default when an IPv6 CIDR is assigned to a VPC a default ipv6_cidr_block_network_border_group will be set to the region of the VPC. This can be changed to restrict advertisement of public addresses to specific Network Border Groups such as LocalZones.
+* `wait_for_ipam_deallocation` - (Optional) A boolean flag to enable/disable waiting for IPAM deallocation on VPC destroy. Defaults to true.
 * `enable_dns_support` - (Optional) A boolean flag to enable/disable DNS support in the VPC. Defaults to true.
 * `enable_network_address_usage_metrics` - (Optional) Indicates whether Network Address Usage metrics are enabled for your VPC. Defaults to false.
 * `enable_dns_hostnames` - (Optional) A boolean flag to enable/disable DNS hostnames in the VPC. Defaults false.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The wait for IPAM pool deallocation was introduced in https://github.com/hashicorp/terraform-provider-aws/pull/30795.
This allows force-recreation of VPC whose CIDR is IPAM-managed to succeed by waiting for IPAM to reach eventual consistency.
Better explanation of the reasoning behind this change can be found here: https://github.com/hashicorp/terraform-provider-aws/issues/31211#issuecomment-1631617273

The problem is that IPAM deallocation takes significant amount of time. For certain use-cases waiting for IPAM can be skipped, like final destroy of the VPC.

This PR introduces a parameter `wait_for_ipam_deallocation` which defaults to `true` (current behavior). Thus, if user thinks the wait just adds up execution time unreasonably, `wait_for_ipam_deallocation = false` could be passed to vpc resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->
Closes #31211
Relates #27571

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
https://github.com/hashicorp/terraform-provider-aws/pull/30795


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```