### PR TITLE
Add Cloudwatch Logs log classes argument

### DIFF
--- a/.changelog/34679.txt
+++ b/.changelog/34679.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/cloudwatch_log_group: Add ability to specify the log class (standard or IA)
+```

--- a/.changelog/34679.txt
+++ b/.changelog/34679.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/cloudwatch_log_group: Add ability to specify the log class (standard or IA)
+resource/aws_cloudwatch_log_group: Add `log_group_class` argument
 ```

--- a/internal/service/logs/group.go
+++ b/internal/service/logs/group.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -45,6 +46,13 @@ func resourceGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"log_group_class": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				Default:          types.LogGroupClassStandard,
+				ValidateDiagFunc: enum.Validate[types.LogGroupClass](),
+			},
 			"name": {
 				Type:          schema.TypeString,
 				Optional:      true,
@@ -60,12 +68,6 @@ func resourceGroup() *schema.Resource {
 				ForceNew:      true,
 				ConflictsWith: []string{"name"},
 				ValidateFunc:  validLogGroupNamePrefix,
-			},
-			"log_group_class": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Default:      "STANDARD",
-				ValidateFunc: validation.StringInSlice([]string{"STANDARD", "INFREQUENT_ACCESS"}, false),
 			},
 			"retention_in_days": {
 				Type:         schema.TypeInt,
@@ -91,9 +93,9 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	name := create.Name(d.Get("name").(string), d.Get("name_prefix").(string))
 	input := &cloudwatchlogs.CreateLogGroupInput{
+		LogGroupClass: types.LogGroupClass(d.Get("log_group_class").(string)),
 		LogGroupName:  aws.String(name),
 		Tags:          getTagsIn(ctx),
-		LogGroupClass: types.LogGroupClass(d.Get("log_group_class").(string)),
 	}
 
 	if v, ok := d.GetOk("kms_key_id"); ok {
@@ -143,6 +145,7 @@ func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interfa
 
 	d.Set("arn", TrimLogGroupARNWildcardSuffix(aws.ToString(lg.Arn)))
 	d.Set("kms_key_id", lg.KmsKeyId)
+	d.Set("log_group_class", lg.LogGroupClass)
 	d.Set("name", lg.LogGroupName)
 	d.Set("name_prefix", create.NamePrefixFromName(aws.ToString(lg.LogGroupName)))
 	d.Set("retention_in_days", lg.RetentionInDays)

--- a/internal/service/logs/group.go
+++ b/internal/service/logs/group.go
@@ -61,6 +61,12 @@ func resourceGroup() *schema.Resource {
 				ConflictsWith: []string{"name"},
 				ValidateFunc:  validLogGroupNamePrefix,
 			},
+			"log_group_class": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "STANDARD",
+				ValidateFunc: validation.StringInSlice([]string{"STANDARD", "INFREQUENT_ACCESS"}, false),
+			},
 			"retention_in_days": {
 				Type:         schema.TypeInt,
 				Optional:     true,
@@ -85,8 +91,9 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	name := create.Name(d.Get("name").(string), d.Get("name_prefix").(string))
 	input := &cloudwatchlogs.CreateLogGroupInput{
-		LogGroupName: aws.String(name),
-		Tags:         getTagsIn(ctx),
+		LogGroupName:  aws.String(name),
+		Tags:          getTagsIn(ctx),
+		LogGroupClass: types.LogGroupClass(d.Get("log_group_class").(string)),
 	}
 
 	if v, ok := d.GetOk("kms_key_id"); ok {

--- a/internal/service/logs/group_test.go
+++ b/internal/service/logs/group_test.go
@@ -36,11 +36,11 @@ func TestAccLogsGroup_basic(t *testing.T) {
 					testAccCheckGroupExists(ctx, t, resourceName, &v),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "logs", fmt.Sprintf("log-group:%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "kms_key_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "log_group_class", "STANDARD"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "name_prefix", ""),
 					resource.TestCheckResourceAttr(resourceName, "retention_in_days", "0"),
 					resource.TestCheckResourceAttr(resourceName, "skip_destroy", "false"),
-					resource.TestCheckResourceAttr(resourceName, "log_group_class", "STANDARD"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
@@ -228,7 +228,7 @@ func TestAccLogsGroup_kmsKey(t *testing.T) {
 	})
 }
 
-func TestAccLogsGroup_logClass(t *testing.T) {
+func TestAccLogsGroup_logGroupClass(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.LogGroup
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -241,14 +241,7 @@ func TestAccLogsGroup_logClass(t *testing.T) {
 		CheckDestroy:             testAccCheckGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGroupConfig_logClass(rName, "STANDARD"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGroupExists(ctx, t, resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "log_group_class", "STANDARD"),
-				),
-			},
-			{
-				Config: testAccGroupConfig_logClass(rName, "INFREQUENT_ACCESS"),
+				Config: testAccGroupConfig_logGroupClass(rName, "INFREQUENT_ACCESS"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGroupExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "log_group_class", "INFREQUENT_ACCESS"),
@@ -491,7 +484,7 @@ resource "aws_cloudwatch_log_group" "test" {
 `, rName, idx)
 }
 
-func testAccGroupConfig_logClass(rName string, val string) string {
+func testAccGroupConfig_logGroupClass(rName string, val string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudwatch_log_group" "test" {
   name            = %[1]q

--- a/website/docs/r/cloudwatch_log_group.html.markdown
+++ b/website/docs/r/cloudwatch_log_group.html.markdown
@@ -30,6 +30,7 @@ This resource supports the following arguments:
 * `name` - (Optional, Forces new resource) The name of the log group. If omitted, Terraform will assign a random, unique name.
 * `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `skip_destroy` - (Optional) Set to true if you do not wish the log group (and any logs it may contain) to be deleted at destroy time, and instead just remove the log group from the Terraform state.
+* `log_group_class` - (Optional) Specified the log class of the log group. Possible values are: `STANDARD` or `INFREQUENT_ACCESS`.
 * `retention_in_days` - (Optional) Specifies the number of days
   you want to retain log events in the specified log group.  Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653, and 0.
   If you select 0, the events in the log group are always retained and never expire.


### PR DESCRIPTION
### Description
This PR adds the [recently announced](https://aws.amazon.com/blogs/aws/new-amazon-cloudwatch-log-class-for-infrequent-access-logs-at-a-reduced-price) Cloudwatch Log Group log classes (`STANDARD` or `INFREQUENT_ACCESS`).

Feature request: https://github.com/hashicorp/terraform-provider-aws/issues/34570

### References
https://aws.amazon.com/blogs/aws/new-amazon-cloudwatch-log-class-for-infrequent-access-logs-at-a-reduced-price
https://github.com/aws/aws-sdk-go/releases/tag/v1.48.4
https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CloudWatch_Logs_Log_Classes.html


### Output from Acceptance Testing
```
❯ make testacc TESTS=TestAccLogsGroup_logClass PKG=logs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/logs/... -v -count 1 -parallel 20 -run='TestAccLogsGroup_logClass'  -timeout 360m
=== RUN   TestAccLogsGroup_logClass
=== PAUSE TestAccLogsGroup_logClass
=== CONT  TestAccLogsGroup_logClass
--- PASS: TestAccLogsGroup_logClass (20.09s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/logs	23.631s
```