### PR TITLE
resource/aws_ami: Fixes eventual consistency errors

### DIFF
--- a/.changelog/34691.txt
+++ b/.changelog/34691.txt
@@ -1,0 +1,11 @@
+```release-note:bug
+resource/aws_ami: Correctly sets `description` on update due to eventual consistency
+```
+
+```release-note:bug
+resource/aws_ami: Correctly sets `deprecation_time` on creation and update due to eventual consistency
+```
+
+```release-note:bug
+resource/aws_ami: Now allows removing `deprecation_time`
+```

--- a/internal/service/ec2/ec2_ami.go
+++ b/internal/service/ec2/ec2_ami.go
@@ -6,7 +6,6 @@ package ec2
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -17,7 +16,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -481,8 +479,14 @@ func resourceAMIUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	if d.HasChange("deprecation_time") {
-		if err := enableImageDeprecation(ctx, conn, d.Id(), d.Get("deprecation_time").(string)); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating EC2 AMI (%s): %s", d.Id(), err)
+		if v := d.Get("deprecation_time").(string); v != "" {
+			if err := enableImageDeprecation(ctx, conn, d.Id(), v); err != nil {
+				return sdkdiag.AppendErrorf(diags, "updating EC2 AMI (%s): %s", d.Id(), err)
+			}
+		} else {
+			if err := disableImageDeprecation(ctx, conn, d.Id()); err != nil {
+				return sdkdiag.AppendErrorf(diags, "updating EC2 AMI (%s):  %s", d.Id(), err)
+			}
 		}
 	}
 
@@ -553,10 +557,30 @@ func enableImageDeprecation(ctx context.Context, conn *ec2.EC2, id string, depre
 		return fmt.Errorf("enabling deprecation: %w", err)
 	}
 
-	_, err = waitImageDeprecationTimeUpdated(ctx, conn, id, deprecateAt)
+	err = waitImageDeprecationTimeUpdated(ctx, conn, id, deprecateAt)
 
 	if err != nil {
 		return fmt.Errorf("enabling deprecation: waiting for completion: %w", err)
+	}
+
+	return nil
+}
+
+func disableImageDeprecation(ctx context.Context, conn *ec2.EC2, id string) error {
+	input := &ec2.DisableImageDeprecationInput{
+		ImageId: aws.String(id),
+	}
+
+	_, err := conn.DisableImageDeprecationWithContext(ctx, input)
+
+	if err != nil {
+		return fmt.Errorf("disabling deprecation: %w", err)
+	}
+
+	err = waitImageDeprecationTimeDisabled(ctx, conn, id)
+
+	if err != nil {
+		return fmt.Errorf("disabling deprecation: waiting for completion: %w", err)
 	}
 
 	return nil
@@ -791,53 +815,62 @@ func flattenBlockDeviceMappingsForAMIEphemeralBlockDevice(apiObjects []*ec2.Bloc
 	return tfList
 }
 
-func waitImageDeprecationTimeUpdated(ctx context.Context, conn *ec2.EC2, imageID, expectedValue string) (*ec2.Image, error) {
-	t, err := time.Parse(time.RFC3339, expectedValue)
+const imageDeprecationPropagationTimeout = 2 * time.Minute
+
+func waitImageDeprecationTimeUpdated(ctx context.Context, conn *ec2.EC2, imageID, expectedValue string) error {
+	expected, err := time.Parse(time.RFC3339, expectedValue)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	rt := t.Round(time.Minute)
-	expectedValue = rt.Format(time.RFC3339)
+	expected = expected.Round(time.Minute)
 
-	stateConf := &retry.StateChangeConf{
-		Target:     []string{expectedValue},
-		Refresh:    statusImageDeprecationTime(ctx, conn, imageID),
-		Timeout:    ec2PropagationTimeout,
-		Delay:      amiRetryDelay,
-		MinTimeout: amiRetryMinTimeout,
-	}
-
-	outputRaw, err := stateConf.WaitForStateContext(ctx)
-
-	if output, ok := outputRaw.(*ec2.Image); ok {
-		if stateReason := output.StateReason; stateReason != nil {
-			tfresource.SetLastError(err, errors.New(aws.StringValue(stateReason.Message)))
-		}
-
-		return output, err
-	}
-
-	return nil, err
-}
-
-func statusImageDeprecationTime(ctx context.Context, conn *ec2.EC2, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		output, err := FindImageByID(ctx, conn, id)
+	return tfresource.WaitUntil(ctx, imageDeprecationPropagationTimeout, func() (bool, error) {
+		output, err := FindImageByID(ctx, conn, imageID)
 
 		if tfresource.NotFound(err) {
-			return nil, "", nil
+			return false, nil
 		}
 
 		if err != nil {
-			return nil, "", err
+			return false, err
 		}
 
-		t, err := time.Parse(time.RFC3339, aws.StringValue(output.DeprecationTime))
+		if output.DeprecationTime == nil {
+			return false, nil
+		}
+
+		dt, err := time.Parse(time.RFC3339, *output.DeprecationTime)
 		if err != nil {
-			return nil, "", err
+			return false, err
 		}
-		rt := t.Round(time.Minute)
+		dt = dt.Round(time.Minute)
 
-		return output, rt.Format(time.RFC3339), nil
-	}
+		return expected.Equal(dt), nil
+	},
+		tfresource.WaitOpts{
+			Delay:      amiRetryDelay,
+			MinTimeout: amiRetryMinTimeout,
+		},
+	)
+}
+
+func waitImageDeprecationTimeDisabled(ctx context.Context, conn *ec2.EC2, imageID string) error {
+	return tfresource.WaitUntil(ctx, imageDeprecationPropagationTimeout, func() (bool, error) {
+		output, err := FindImageByID(ctx, conn, imageID)
+
+		if tfresource.NotFound(err) {
+			return false, nil
+		}
+
+		if err != nil {
+			return false, err
+		}
+
+		return output.DeprecationTime == nil, nil
+	},
+		tfresource.WaitOpts{
+			Delay:      amiRetryDelay,
+			MinTimeout: amiRetryMinTimeout,
+		},
+	)
 }

--- a/internal/service/ec2/ec2_ami_test.go
+++ b/internal/service/ec2/ec2_ami_test.go
@@ -119,6 +119,14 @@ func TestAccEC2AMI_deprecateAt(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "deprecation_time", deprecateAtUpdated),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"manage_ebs_snapshots",
+				},
+			},
 		},
 	})
 }

--- a/internal/service/ec2/ec2_ami_test.go
+++ b/internal/service/ec2/ec2_ami_test.go
@@ -127,6 +127,21 @@ func TestAccEC2AMI_deprecateAt(t *testing.T) {
 					"manage_ebs_snapshots",
 				},
 			},
+			{
+				Config: testAccAMIConfig_noDeprecateAt(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAMIExists(ctx, resourceName, &ami),
+					resource.TestCheckResourceAttr(resourceName, "deprecation_time", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"manage_ebs_snapshots",
+				},
+			},
 		},
 	})
 }
@@ -615,6 +630,25 @@ resource "aws_ami" "test" {
   }
 }
 `, rName, deprecateAt))
+}
+
+// testAccAMIConfig_noDeprecateAt should stay in sync with testAccAMIConfig_deprecateAt
+func testAccAMIConfig_noDeprecateAt(rName string) string {
+	return acctest.ConfigCompose(
+		testAccAMIConfig_base(rName),
+		fmt.Sprintf(`
+resource "aws_ami" "test" {
+  ena_support         = true
+  name                = %[1]q
+  root_device_name    = "/dev/sda1"
+  virtualization_type = "hvm"
+
+  ebs_block_device {
+    device_name = "/dev/sda1"
+    snapshot_id = aws_ebs_snapshot.test.id
+  }
+}
+`, rName))
 }
 
 func testAccAMIConfig_desc(rName, desc string) string {

--- a/internal/service/ec2/ec2_ami_test.go
+++ b/internal/service/ec2/ec2_ami_test.go
@@ -182,6 +182,14 @@ func TestAccEC2AMI_description(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", descUpdated),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"manage_ebs_snapshots",
+				},
+			},
 		},
 	})
 }

--- a/internal/service/ec2/ec2_ami_test.go
+++ b/internal/service/ec2/ec2_ami_test.go
@@ -87,7 +87,6 @@ func TestAccEC2AMI_deprecateAt(t *testing.T) {
 	ctx := acctest.Context(t)
 	var ami ec2.Image
 	resourceName := "aws_ami.test"
-	snapshotResourceName := "aws_ebs_snapshot.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	deprecateAt := "2027-10-15T13:17:00.000Z"
 	deprecateAtUpdated := "2028-10-15T13:17:00.000Z"
@@ -102,33 +101,7 @@ func TestAccEC2AMI_deprecateAt(t *testing.T) {
 				Config: testAccAMIConfig_deprecateAt(rName, deprecateAt),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAMIExists(ctx, resourceName, &ami),
-					resource.TestCheckResourceAttr(resourceName, "architecture", "x86_64"),
-					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "ec2", regexache.MustCompile(`image/ami-.+`)),
 					resource.TestCheckResourceAttr(resourceName, "deprecation_time", deprecateAt),
-					resource.TestCheckResourceAttr(resourceName, "description", ""),
-					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.#", "1"),
-					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ebs_block_device.*", map[string]string{
-						"delete_on_termination": "true",
-						"device_name":           "/dev/sda1",
-						"encrypted":             "false",
-						"iops":                  "0",
-						"throughput":            "0",
-						"volume_size":           "8",
-						"outpost_arn":           "",
-						"volume_type":           "standard",
-					}),
-					resource.TestCheckTypeSetElemAttrPair(resourceName, "ebs_block_device.*.snapshot_id", snapshotResourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "ena_support", "true"),
-					resource.TestCheckResourceAttr(resourceName, "ephemeral_block_device.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "kernel_id", ""),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					acctest.CheckResourceAttrAccountID(resourceName, "owner_id"),
-					resource.TestCheckResourceAttr(resourceName, "ramdisk_id", ""),
-					resource.TestCheckResourceAttr(resourceName, "root_device_name", "/dev/sda1"),
-					resource.TestCheckResourceAttrPair(resourceName, "root_snapshot_id", snapshotResourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "sriov_net_support", "simple"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
-					resource.TestCheckResourceAttr(resourceName, "virtualization_type", "hvm"),
 				),
 			},
 			{
@@ -143,33 +116,7 @@ func TestAccEC2AMI_deprecateAt(t *testing.T) {
 				Config: testAccAMIConfig_deprecateAt(rName, deprecateAtUpdated),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAMIExists(ctx, resourceName, &ami),
-					resource.TestCheckResourceAttr(resourceName, "architecture", "x86_64"),
-					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "ec2", regexache.MustCompile(`image/ami-.+`)),
 					resource.TestCheckResourceAttr(resourceName, "deprecation_time", deprecateAtUpdated),
-					resource.TestCheckResourceAttr(resourceName, "description", ""),
-					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.#", "1"),
-					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ebs_block_device.*", map[string]string{
-						"delete_on_termination": "true",
-						"device_name":           "/dev/sda1",
-						"encrypted":             "false",
-						"iops":                  "0",
-						"throughput":            "0",
-						"volume_size":           "8",
-						"outpost_arn":           "",
-						"volume_type":           "standard",
-					}),
-					resource.TestCheckTypeSetElemAttrPair(resourceName, "ebs_block_device.*.snapshot_id", snapshotResourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "ena_support", "true"),
-					resource.TestCheckResourceAttr(resourceName, "ephemeral_block_device.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "kernel_id", ""),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					acctest.CheckResourceAttrAccountID(resourceName, "owner_id"),
-					resource.TestCheckResourceAttr(resourceName, "ramdisk_id", ""),
-					resource.TestCheckResourceAttr(resourceName, "root_device_name", "/dev/sda1"),
-					resource.TestCheckResourceAttrPair(resourceName, "root_snapshot_id", snapshotResourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "sriov_net_support", "simple"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
-					resource.TestCheckResourceAttr(resourceName, "virtualization_type", "hvm"),
 				),
 			},
 		},
@@ -180,7 +127,6 @@ func TestAccEC2AMI_description(t *testing.T) {
 	ctx := acctest.Context(t)
 	var ami ec2.Image
 	resourceName := "aws_ami.test"
-	snapshotResourceName := "aws_ebs_snapshot.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	desc := sdkacctest.RandomWithPrefix("desc")
 	descUpdated := sdkacctest.RandomWithPrefix("desc-updated")
@@ -195,32 +141,7 @@ func TestAccEC2AMI_description(t *testing.T) {
 				Config: testAccAMIConfig_desc(rName, desc),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAMIExists(ctx, resourceName, &ami),
-					resource.TestCheckResourceAttr(resourceName, "architecture", "x86_64"),
-					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "ec2", regexache.MustCompile(`image/ami-.+`)),
 					resource.TestCheckResourceAttr(resourceName, "description", desc),
-					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.#", "1"),
-					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ebs_block_device.*", map[string]string{
-						"delete_on_termination": "true",
-						"device_name":           "/dev/sda1",
-						"encrypted":             "false",
-						"iops":                  "0",
-						"throughput":            "0",
-						"volume_size":           "8",
-						"outpost_arn":           "",
-						"volume_type":           "standard",
-					}),
-					resource.TestCheckTypeSetElemAttrPair(resourceName, "ebs_block_device.*.snapshot_id", snapshotResourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "ena_support", "true"),
-					resource.TestCheckResourceAttr(resourceName, "ephemeral_block_device.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "kernel_id", ""),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					acctest.CheckResourceAttrAccountID(resourceName, "owner_id"),
-					resource.TestCheckResourceAttr(resourceName, "ramdisk_id", ""),
-					resource.TestCheckResourceAttr(resourceName, "root_device_name", "/dev/sda1"),
-					resource.TestCheckResourceAttrPair(resourceName, "root_snapshot_id", snapshotResourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "sriov_net_support", "simple"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
-					resource.TestCheckResourceAttr(resourceName, "virtualization_type", "hvm"),
 				),
 			},
 			{
@@ -235,32 +156,7 @@ func TestAccEC2AMI_description(t *testing.T) {
 				Config: testAccAMIConfig_desc(rName, descUpdated),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAMIExists(ctx, resourceName, &ami),
-					resource.TestCheckResourceAttr(resourceName, "architecture", "x86_64"),
-					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "ec2", regexache.MustCompile(`image/ami-.+`)),
 					resource.TestCheckResourceAttr(resourceName, "description", descUpdated),
-					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.#", "1"),
-					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ebs_block_device.*", map[string]string{
-						"delete_on_termination": "true",
-						"device_name":           "/dev/sda1",
-						"encrypted":             "false",
-						"iops":                  "0",
-						"throughput":            "0",
-						"volume_size":           "8",
-						"outpost_arn":           "",
-						"volume_type":           "standard",
-					}),
-					resource.TestCheckTypeSetElemAttrPair(resourceName, "ebs_block_device.*.snapshot_id", snapshotResourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "ena_support", "true"),
-					resource.TestCheckResourceAttr(resourceName, "ephemeral_block_device.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "kernel_id", ""),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					acctest.CheckResourceAttrAccountID(resourceName, "owner_id"),
-					resource.TestCheckResourceAttr(resourceName, "ramdisk_id", ""),
-					resource.TestCheckResourceAttr(resourceName, "root_device_name", "/dev/sda1"),
-					resource.TestCheckResourceAttrPair(resourceName, "root_snapshot_id", snapshotResourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "sriov_net_support", "simple"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
-					resource.TestCheckResourceAttr(resourceName, "virtualization_type", "hvm"),
 				),
 			},
 		},


### PR DESCRIPTION
### Description

The parameters `description` and `deprecation_time` are set or modified using eventually consistent operations. This was causing them to not be updated in Terraform state.

Also affects `aws_ami_from_instance` and `aws_ami_copy`

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=ec2 TESTS='TestAccEC2AMI_|TestAccEC2AMICopy_|TestAccEC2AMIFromInstance_'

--- PASS: TestAccEC2AMI_ephemeralBlockDevices (1049.53s)
--- PASS: TestAccEC2AMI_gp3BlockDevice (1058.41s)
--- PASS: TestAccEC2AMI_imdsSupport (1066.79s)
--- PASS: TestAccEC2AMI_tpmSupport (1071.75s)
--- PASS: TestAccEC2AMI_disappears (1074.21s)
--- PASS: TestAccEC2AMI_boot (1075.10s)
--- PASS: TestAccEC2AMI_basic (1086.15s)
--- PASS: TestAccEC2AMIFromInstance_basic (1140.95s)
--- PASS: TestAccEC2AMIFromInstance_disappears (1155.93s)
--- PASS: TestAccEC2AMICopy_basic (1173.47s)
--- PASS: TestAccEC2AMICopy_enaSupport (1175.05s)
--- PASS: TestAccEC2AMI_description (1243.46s)
--- PASS: TestAccEC2AMI_tags (1359.69s)
--- PASS: TestAccEC2AMICopy_description (1366.41s)
--- PASS: TestAccEC2AMI_deprecateAt (1378.52s)
--- PASS: TestAccEC2AMIFromInstance_tags (1396.37s)
--- PASS: TestAccEC2AMICopy_tags (1473.40s)
```
