### PR TITLE
aws_lightsail_container_service_deployment_version ports is required

### DIFF
--- a/website/docs/r/lightsail_container_service_deployment_version.html.markdown
+++ b/website/docs/r/lightsail_container_service_deployment_version.html.markdown
@@ -69,7 +69,7 @@ The `container` configuration block supports the following arguments:
 * `image` - (Required) The name of the image used for the container. Container images sourced from your Lightsail container service, that are registered and stored on your service, start with a colon (`:`). For example, `:container-service-1.mystaticwebsite.1`. Container images sourced from a public registry like Docker Hub don't start with a colon. For example, `nginx:latest` or `nginx`.
 * `command` - (Optional) The launch command for the container. A list of string.
 * `environment` - (Optional) A key-value map of the environment variables of the container.
-* `ports` - (Optional) A key-value map of the open firewall ports of the container. Valid values: `HTTP`, `HTTPS`, `TCP`, `UDP`.
+* `ports` - (`Required`) A key-value map of the open firewall ports of the container. Valid values: `HTTP`, `HTTPS`, `TCP`, `UDP`.
 
 ### `public_endpoint`
 


### PR DESCRIPTION
If you don't include “ports” when configuring a lightsail deployment version, you will hit the following error

`InvalidInputException: Invalid port specified. You must specify a port that is in the list of ports of the specified container.`

Updated to be a "Required" input