### PR TITLE
Fix `ecr_repository_prefix` validation in `aws_ecr_pull_through_cache_rule`

### DIFF
--- a/.changelog/34716.txt
+++ b/.changelog/34716.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_ecr_pull_through_cache_rule: Fix plan time validation for `ecr_repository_prefix`
+```
+
+```release-note:bug
+data-source/aws_ecr_pull_through_cache_rule: Fix plan time validation for `ecr_repository_prefix`
+```

--- a/internal/service/ecr/pull_through_cache_rule.go
+++ b/internal/service/ecr/pull_through_cache_rule.go
@@ -35,10 +35,10 @@ func ResourcePullThroughCacheRule() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 				ValidateFunc: validation.All(
-					validation.StringLenBetween(2, 20),
+					validation.StringLenBetween(2, 30),
 					validation.StringMatch(
-						regexache.MustCompile(`^[0-9a-z]+(?:[._-][0-9a-z]+)*$`),
-						"must only include alphanumeric, underscore, period, or hyphen characters"),
+						regexache.MustCompile(`(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*`),
+						"must only include alphanumeric, underscore, period, hyphen, or slash characters"),
 				),
 			},
 			"registry_id": {

--- a/internal/service/ecr/pull_through_cache_rule_data_source.go
+++ b/internal/service/ecr/pull_through_cache_rule_data_source.go
@@ -24,10 +24,10 @@ func DataSourcePullThroughCacheRule() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 				ValidateFunc: validation.All(
-					validation.StringLenBetween(2, 20),
+					validation.StringLenBetween(2, 30),
 					validation.StringMatch(
-						regexache.MustCompile(`^[0-9a-z]+(?:[._-][0-9a-z]+)*$`),
-						"must only include alphanumeric, underscore, period, or hyphen characters"),
+						regexache.MustCompile(`(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*`),
+						"must only include alphanumeric, underscore, period, hyphen, or slash characters"),
 				),
 			},
 			"registry_id": {

--- a/internal/service/ecr/pull_through_cache_rule_data_source_test.go
+++ b/internal/service/ecr/pull_through_cache_rule_data_source_test.go
@@ -33,7 +33,7 @@ func TestAccECRPullThroughCacheRuleDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccECRPullThroughCacheRuleDataSource_ecrRepositoryPrefixWithSlash(t *testing.T) {
+func TestAccECRPullThroughCacheRuleDataSource_repositoryPrefixWithSlash(t *testing.T) {
 	ctx := acctest.Context(t)
 	repositoryPrefix := "tf-test/" + sdkacctest.RandString(22)
 	dataSource := "data.aws_ecr_pull_through_cache_rule.test"
@@ -45,7 +45,7 @@ func TestAccECRPullThroughCacheRuleDataSource_ecrRepositoryPrefixWithSlash(t *te
 		CheckDestroy:             testAccCheckPullThroughCacheRuleDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPullThroughCacheRuleDataSourceConfig_ecrRepositoryPrefixWithSlash(repositoryPrefix),
+				Config: testAccPullThroughCacheRuleDataSourceConfig_repositoryPrefixWithSlash(repositoryPrefix),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSource, "upstream_registry_url", "public.ecr.aws"),
 					acctest.CheckResourceAttrAccountID(dataSource, "registry_id"),
@@ -68,7 +68,7 @@ data "aws_ecr_pull_through_cache_rule" "test" {
 `
 }
 
-func testAccPullThroughCacheRuleDataSourceConfig_ecrRepositoryPrefixWithSlash(repositoryPrefix string) string {
+func testAccPullThroughCacheRuleDataSourceConfig_repositoryPrefixWithSlash(repositoryPrefix string) string {
 	return fmt.Sprintf(`
 resource "aws_ecr_pull_through_cache_rule" "test" {
   ecr_repository_prefix = %[1]q

--- a/internal/service/ecr/pull_through_cache_rule_data_source_test.go
+++ b/internal/service/ecr/pull_through_cache_rule_data_source_test.go
@@ -4,9 +4,11 @@
 package ecr_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/ecr"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
@@ -31,6 +33,28 @@ func TestAccECRPullThroughCacheRuleDataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccECRPullThroughCacheRuleDataSource_ecrRepositoryPrefixWithSlash(t *testing.T) {
+	ctx := acctest.Context(t)
+	repositoryPrefix := "tf-test/" + sdkacctest.RandString(22)
+	dataSource := "data.aws_ecr_pull_through_cache_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ecr.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPullThroughCacheRuleDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPullThroughCacheRuleDataSourceConfig_ecrRepositoryPrefixWithSlash(repositoryPrefix),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSource, "upstream_registry_url", "public.ecr.aws"),
+					acctest.CheckResourceAttrAccountID(dataSource, "registry_id"),
+				),
+			},
+		},
+	})
+}
+
 func testAccPullThroughCacheRuleDataSourceConfig_basic() string {
 	return `
 resource "aws_ecr_pull_through_cache_rule" "test" {
@@ -42,4 +66,17 @@ data "aws_ecr_pull_through_cache_rule" "test" {
   ecr_repository_prefix = aws_ecr_pull_through_cache_rule.test.ecr_repository_prefix
 }
 `
+}
+
+func testAccPullThroughCacheRuleDataSourceConfig_ecrRepositoryPrefixWithSlash(repositoryPrefix string) string {
+	return fmt.Sprintf(`
+resource "aws_ecr_pull_through_cache_rule" "test" {
+  ecr_repository_prefix = %[1]q
+  upstream_registry_url = "public.ecr.aws"
+}
+
+data "aws_ecr_pull_through_cache_rule" "test" {
+  ecr_repository_prefix = aws_ecr_pull_through_cache_rule.test.ecr_repository_prefix
+}
+`, repositoryPrefix)
 }

--- a/internal/service/ecr/pull_through_cache_rule_test.go
+++ b/internal/service/ecr/pull_through_cache_rule_test.go
@@ -97,7 +97,7 @@ func TestAccECRPullThroughCacheRule_failWhenAlreadyExists(t *testing.T) {
 	})
 }
 
-func TestAccECRPullThroughCacheRule_ecrRepositoryPrefixWithSlash(t *testing.T) {
+func TestAccECRPullThroughCacheRule_repositoryPrefixWithSlash(t *testing.T) {
 	ctx := acctest.Context(t)
 	repositoryPrefix := "tf-test/" + sdkacctest.RandString(22)
 	resourceName := "aws_ecr_pull_through_cache_rule.test"

--- a/internal/service/ecr/pull_through_cache_rule_test.go
+++ b/internal/service/ecr/pull_through_cache_rule_test.go
@@ -97,6 +97,30 @@ func TestAccECRPullThroughCacheRule_failWhenAlreadyExists(t *testing.T) {
 	})
 }
 
+func TestAccECRPullThroughCacheRule_ecrRepositoryPrefixWithSlash(t *testing.T) {
+	ctx := acctest.Context(t)
+	repositoryPrefix := "tf-test/" + sdkacctest.RandString(22)
+	resourceName := "aws_ecr_pull_through_cache_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ecr.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPullThroughCacheRuleDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPullThroughCacheRuleConfig_basic(repositoryPrefix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPullThroughCacheRuleExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "ecr_repository_prefix", repositoryPrefix),
+					testAccCheckPullThroughCacheRuleRegistryID(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "upstream_registry_url", "public.ecr.aws"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckPullThroughCacheRuleDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).ECRConn(ctx)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fixes validation of `ecr_repository_prefix` in `aws_ecr_pull_through_cache_rule`.
Referred to the latest AWS documentation and corrected the string size and regular expression pattern for `ecr_repository_prefix`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #34516

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

- https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_CreatePullThroughCacheRule.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccECRPullThroughCacheRule_ PKG=ecr          
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecr/... -v -count 1 -parallel 20 -run='TestAccECRPullThroughCacheRule_'  -timeout 360m
=== RUN   TestAccECRPullThroughCacheRule_basic
=== PAUSE TestAccECRPullThroughCacheRule_basic
=== RUN   TestAccECRPullThroughCacheRule_disappears
=== PAUSE TestAccECRPullThroughCacheRule_disappears
=== RUN   TestAccECRPullThroughCacheRule_failWhenAlreadyExists
=== PAUSE TestAccECRPullThroughCacheRule_failWhenAlreadyExists
=== RUN   TestAccECRPullThroughCacheRule_ecrRepositoryPrefixWithSlash
=== PAUSE TestAccECRPullThroughCacheRule_ecrRepositoryPrefixWithSlash
=== CONT  TestAccECRPullThroughCacheRule_basic
=== CONT  TestAccECRPullThroughCacheRule_failWhenAlreadyExists
=== CONT  TestAccECRPullThroughCacheRule_disappears
=== CONT  TestAccECRPullThroughCacheRule_ecrRepositoryPrefixWithSlash
--- PASS: TestAccECRPullThroughCacheRule_failWhenAlreadyExists (76.76s)
--- PASS: TestAccECRPullThroughCacheRule_disappears (78.29s)
--- PASS: TestAccECRPullThroughCacheRule_ecrRepositoryPrefixWithSlash (86.24s)
--- PASS: TestAccECRPullThroughCacheRule_basic (89.38s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecr        89.466s
```

```console
% make testacc TESTS=TestAccECRPullThroughCacheRuleDataSource_ PKG=ecr
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecr/... -v -count 1 -parallel 20 -run='TestAccECRPullThroughCacheRuleDataSource_'  -timeout 360m
=== RUN   TestAccECRPullThroughCacheRuleDataSource_basic
=== PAUSE TestAccECRPullThroughCacheRuleDataSource_basic
=== RUN   TestAccECRPullThroughCacheRuleDataSource_ecrRepositoryPrefixWithSlash
=== PAUSE TestAccECRPullThroughCacheRuleDataSource_ecrRepositoryPrefixWithSlash
=== CONT  TestAccECRPullThroughCacheRuleDataSource_basic
=== CONT  TestAccECRPullThroughCacheRuleDataSource_ecrRepositoryPrefixWithSlash
--- PASS: TestAccECRPullThroughCacheRuleDataSource_basic (92.56s)
--- PASS: TestAccECRPullThroughCacheRuleDataSource_ecrRepositoryPrefixWithSlash (92.84s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecr        92.921s
```
