### PR TITLE
Fix vpcinstancetenancyenum

### DIFF
--- a/internal/service/ec2/vpc_.go
+++ b/internal/service/ec2/vpc_.go
@@ -114,7 +114,7 @@ func ResourceVPC() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      types.TenancyDefault,
-				ValidateFunc: validation.StringInSlice(enum.Slice(types.TenancyDefault, types.TenancyDedicated), false),
+				ValidateFunc: validation.StringInSlice(flattenTenancyEnumValues(types.Tenancy("").Values()), false),
 			},
 			"ipv4_ipam_pool_id": {
 				Type:     schema.TypeString,
@@ -737,4 +737,14 @@ func findIPAMPoolAllocationsForVPC(ctx context.Context, conn *ec2.Client, poolID
 	}
 
 	return output, nil
+}
+
+func flattenTenancyEnumValues(t []types.Tenancy) []string {
+	var out []string
+
+	for _, v := range t {
+		out = append(out, string(v))
+	}
+
+	return out
 }

--- a/internal/service/ec2/vpc_.go
+++ b/internal/service/ec2/vpc_.go
@@ -111,10 +111,10 @@ func ResourceVPC() *schema.Resource {
 				Computed: true,
 			},
 			"instance_tenancy": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Default:      types.TenancyDefault,
-				ValidateFunc: validation.StringInSlice(flattenTenancyEnumValues(types.Tenancy("").Values()), false),
+				Type:             schema.TypeString,
+				Optional:         true,
+				Default:          types.TenancyDefault,
+				ValidateDiagFunc: enum.Validate[types.Tenancy](),
 			},
 			"ipv4_ipam_pool_id": {
 				Type:     schema.TypeString,
@@ -737,14 +737,4 @@ func findIPAMPoolAllocationsForVPC(ctx context.Context, conn *ec2.Client, poolID
 	}
 
 	return output, nil
-}
-
-func flattenTenancyEnumValues(t []types.Tenancy) []string {
-	var out []string
-
-	for _, v := range t {
-		out = append(out, string(v))
-	}
-
-	return out
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

instance tenancy param is hardcoded. values option includes a new parameter that was currently missing

```
func (Tenancy) Values() []Tenancy {
	return []Tenancy{
		"default",
		"dedicated",
		"host",
	}
}
```

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccVPC_basic PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPC_basic'  -timeout 360m
=== RUN   TestAccVPC_basic
=== PAUSE TestAccVPC_basic
=== CONT  TestAccVPC_basic
--- PASS: TestAccVPC_basic (38.38s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        40.567s

...
```
