### PR TITLE
autoflex: Fix MapValueOf bug

### DIFF
--- a/internal/framework/flex/autoflex_test.go
+++ b/internal/framework/flex/autoflex_test.go
@@ -547,7 +547,7 @@ func TestGenericExpand(t *testing.T) {
 }
 
 type TestFlexTF11 struct {
-	FieldInner fwtypes.MapValueOf[types.String] `tfsdk:"field_inner"`
+	FieldInner fwtypes.MapValueOf[basetypes.StringValue] `tfsdk:"field_inner"`
 }
 
 type TestFlexTF12 struct {
@@ -666,6 +666,24 @@ func TestGenericExpand2(t *testing.T) {
 				FieldInner: map[string]*TestFlexAWS01{
 					"x": {
 						Field1: "a",
+					},
+				},
+			},
+		},
+		{
+			TestName: "nested string map",
+			Source: &TestFlexTF14{
+				FieldOuter: fwtypes.NewListNestedObjectValueOfPtr(ctx, &TestFlexTF11{
+					FieldInner: fwtypes.NewMapValueOf(ctx, map[string]basetypes.StringValue{
+						"x": types.StringValue("y"),
+					}),
+				}),
+			},
+			Target: &TestFlexAWS16{},
+			WantTarget: &TestFlexAWS16{
+				FieldOuter: TestFlexAWS13{
+					FieldInner: map[string]string{
+						"x": "y",
 					},
 				},
 			},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% go test ./internal/framework/flex/... -v -count 1 -parallel 20 -run='TestGenericExpand2'
=== RUN   TestGenericExpand2
=== PAUSE TestGenericExpand2
=== CONT  TestGenericExpand2
=== RUN   TestGenericExpand2/map_string
=== PAUSE TestGenericExpand2/map_string
=== RUN   TestGenericExpand2/object_map
=== PAUSE TestGenericExpand2/object_map
=== RUN   TestGenericExpand2/object_map_ptr_target
=== PAUSE TestGenericExpand2/object_map_ptr_target
=== RUN   TestGenericExpand2/object_map_ptr_source_and_target
=== PAUSE TestGenericExpand2/object_map_ptr_source_and_target
=== RUN   TestGenericExpand2/nested_string_map
=== PAUSE TestGenericExpand2/nested_string_map
=== RUN   TestGenericExpand2/nested_object_map
=== PAUSE TestGenericExpand2/nested_object_map
=== CONT  TestGenericExpand2/map_string
=== CONT  TestGenericExpand2/object_map_ptr_source_and_target
=== CONT  TestGenericExpand2/nested_string_map
=== CONT  TestGenericExpand2/object_map_ptr_target
=== CONT  TestGenericExpand2/nested_object_map
=== CONT  TestGenericExpand2/object_map
--- PASS: TestGenericExpand2 (0.00s)
    --- PASS: TestGenericExpand2/map_string (0.00s)
    --- PASS: TestGenericExpand2/object_map_ptr_source_and_target (0.00s)
    --- PASS: TestGenericExpand2/object_map_ptr_target (0.00s)
    --- PASS: TestGenericExpand2/nested_string_map (0.00s)
    --- PASS: TestGenericExpand2/nested_object_map (0.00s)
    --- PASS: TestGenericExpand2/object_map (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/framework/flex	0.569s
```