### PR TITLE
tech debt: Collect diags instead of returning directly - `e`, `f`, `g`, `i`, and `k` services

### DIFF
--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,7 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/e[k-v]*
+        - internal/service/e[l-v]*
         - internal/service/[f-z]*
     pattern: return diag.FromErr($ERR)
     fix: return sdkdiag.AppendFromErr(diags, $ERR)
@@ -27,7 +27,7 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/e[k-v]*
+        - internal/service/e[l-v]*
         - internal/service/[f-z]*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
@@ -38,7 +38,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/e[k-v]*
+        - internal/service/e[l-v]*
         - internal/service/[f-z]*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
@@ -49,7 +49,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/e[k-v]*
+        - internal/service/e[l-v]*
         - internal/service/[f-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
     fix: create.AppendDiagError(diags, $...ARGS)
@@ -60,7 +60,7 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/e[k-v]*
+        - internal/service/e[l-v]*
         - internal/service/[f-z]*
     pattern: create.DiagSettingError($...ARGS)
     fix: create.AppendDiagSettingError(diags, $...ARGS)
@@ -71,7 +71,7 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/e[k-v]*
+        - internal/service/e[l-v]*
         - internal/service/[f-z]*
     patterns:
       - pattern: return $READFN($...ARGS)
@@ -90,7 +90,7 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/e[k-v]*
+        - internal/service/e[l-v]*
         - internal/service/[f-z]*
     patterns:
       - pattern: return $UPDATEFN($...ARGS)
@@ -107,7 +107,7 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/e[k-v]*
+        - internal/service/e[l-v]*
         - internal/service/[f-z]*
     patterns:
       - pattern: return nil

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,7 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/e[f-v]*
+        - internal/service/e[k-v]*
         - internal/service/[f-z]*
     pattern: return diag.FromErr($ERR)
     fix: return sdkdiag.AppendFromErr(diags, $ERR)
@@ -27,7 +27,7 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/e[f-v]*
+        - internal/service/e[k-v]*
         - internal/service/[f-z]*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
@@ -38,7 +38,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/e[f-v]*
+        - internal/service/e[k-v]*
         - internal/service/[f-z]*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
@@ -49,7 +49,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/e[f-v]*
+        - internal/service/e[k-v]*
         - internal/service/[f-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
     fix: create.AppendDiagError(diags, $...ARGS)
@@ -60,7 +60,7 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/e[f-v]*
+        - internal/service/e[k-v]*
         - internal/service/[f-z]*
     pattern: create.DiagSettingError($...ARGS)
     fix: create.AppendDiagSettingError(diags, $...ARGS)
@@ -71,7 +71,7 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/e[f-v]*
+        - internal/service/e[k-v]*
         - internal/service/[f-z]*
     patterns:
       - pattern: return $READFN($...ARGS)
@@ -90,7 +90,7 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/e[f-v]*
+        - internal/service/e[k-v]*
         - internal/service/[f-z]*
     patterns:
       - pattern: return $UPDATEFN($...ARGS)
@@ -107,7 +107,7 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/e[f-v]*
+        - internal/service/e[k-v]*
         - internal/service/[f-z]*
     patterns:
       - pattern: return nil

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,6 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/keyspaces
         - internal/service/k[i-z]*
         - internal/service/[l-z]*
     pattern: return diag.FromErr($ERR)
@@ -16,7 +15,6 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/keyspaces
         - internal/service/k[i-z]*
         - internal/service/[l-z]*
     pattern: append(diags, diag.FromErr($ERR)...)
@@ -28,7 +26,6 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/keyspaces
         - internal/service/k[i-z]*
         - internal/service/[l-z]*
     pattern: diag.Errorf($...ARGS)
@@ -40,7 +37,6 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/keyspaces
         - internal/service/k[i-z]*
         - internal/service/[l-z]*
     pattern: return create.DiagError($...ARGS)
@@ -52,7 +48,6 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/keyspaces
         - internal/service/k[i-z]*
         - internal/service/[l-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
@@ -64,7 +59,6 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/keyspaces
         - internal/service/k[i-z]*
         - internal/service/[l-z]*
     pattern: create.DiagSettingError($...ARGS)
@@ -76,7 +70,6 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/keyspaces
         - internal/service/k[i-z]*
         - internal/service/[l-z]*
     patterns:
@@ -96,7 +89,6 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/keyspaces
         - internal/service/k[i-z]*
         - internal/service/[l-z]*
     patterns:
@@ -114,7 +106,6 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/keyspaces
         - internal/service/k[i-z]*
         - internal/service/[l-z]*
     patterns:

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,8 +4,6 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/glue
-        - internal/service/g[ru]
         - internal/service/[h-z]*
     pattern: return diag.FromErr($ERR)
     fix: return sdkdiag.AppendFromErr(diags, $ERR)
@@ -16,8 +14,6 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/glue
-        - internal/service/g[ru]
         - internal/service/[h-z]*
     pattern: append(diags, diag.FromErr($ERR)...)
     fix: sdkdiag.AppendFromErr(diags, $ERR)
@@ -28,8 +24,6 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/glue
-        - internal/service/g[ru]
         - internal/service/[h-z]*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
@@ -40,8 +34,6 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/glue
-        - internal/service/g[ru]
         - internal/service/[h-z]*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
@@ -52,8 +44,6 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/glue
-        - internal/service/g[ru]
         - internal/service/[h-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
     fix: create.AppendDiagError(diags, $...ARGS)
@@ -64,8 +54,6 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/glue
-        - internal/service/g[ru]
         - internal/service/[h-z]*
     pattern: create.DiagSettingError($...ARGS)
     fix: create.AppendDiagSettingError(diags, $...ARGS)
@@ -76,8 +64,6 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/glue
-        - internal/service/g[ru]
         - internal/service/[h-z]*
     patterns:
       - pattern: return $READFN($...ARGS)
@@ -96,8 +82,6 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/glue
-        - internal/service/g[ru]
         - internal/service/[h-z]*
     patterns:
       - pattern: return $UPDATEFN($...ARGS)
@@ -114,8 +98,6 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/glue
-        - internal/service/g[ru]
         - internal/service/[h-z]*
     patterns:
       - pattern: return nil

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,6 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/kafkaconnect
         - internal/service/k[e-z]*
         - internal/service/[l-z]*
     pattern: return diag.FromErr($ERR)
@@ -16,7 +15,6 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/kafkaconnect
         - internal/service/k[e-z]*
         - internal/service/[l-z]*
     pattern: append(diags, diag.FromErr($ERR)...)
@@ -28,7 +26,6 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/kafkaconnect
         - internal/service/k[e-z]*
         - internal/service/[l-z]*
     pattern: diag.Errorf($...ARGS)
@@ -40,7 +37,6 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/kafkaconnect
         - internal/service/k[e-z]*
         - internal/service/[l-z]*
     pattern: return create.DiagError($...ARGS)
@@ -52,7 +48,6 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/kafkaconnect
         - internal/service/k[e-z]*
         - internal/service/[l-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
@@ -64,7 +59,6 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/kafkaconnect
         - internal/service/k[e-z]*
         - internal/service/[l-z]*
     pattern: create.DiagSettingError($...ARGS)
@@ -76,7 +70,6 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/kafkaconnect
         - internal/service/k[e-z]*
         - internal/service/[l-z]*
     patterns:
@@ -96,7 +89,6 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/kafkaconnect
         - internal/service/k[e-z]*
         - internal/service/[l-z]*
     patterns:
@@ -114,7 +106,6 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/kafkaconnect
         - internal/service/k[e-z]*
         - internal/service/[l-z]*
     patterns:

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,6 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/e[v]*
         - internal/service/[f-z]*
     pattern: return diag.FromErr($ERR)
     fix: return sdkdiag.AppendFromErr(diags, $ERR)
@@ -15,8 +14,6 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/ec[r-s]*
-        - internal/service/e[f-v]*
         - internal/service/[f-z]*
     pattern: append(diags, diag.FromErr($ERR)...)
     fix: sdkdiag.AppendFromErr(diags, $ERR)
@@ -27,7 +24,6 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/e[v]*
         - internal/service/[f-z]*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
@@ -38,7 +34,6 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/e[v]*
         - internal/service/[f-z]*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
@@ -49,7 +44,6 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/e[v]*
         - internal/service/[f-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
     fix: create.AppendDiagError(diags, $...ARGS)
@@ -60,7 +54,6 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/e[v]*
         - internal/service/[f-z]*
     pattern: create.DiagSettingError($...ARGS)
     fix: create.AppendDiagSettingError(diags, $...ARGS)
@@ -71,7 +64,6 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/e[v]*
         - internal/service/[f-z]*
     patterns:
       - pattern: return $READFN($...ARGS)
@@ -90,7 +82,6 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/e[v]*
         - internal/service/[f-z]*
     patterns:
       - pattern: return $UPDATEFN($...ARGS)
@@ -107,7 +98,6 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/e[v]*
         - internal/service/[f-z]*
     patterns:
       - pattern: return nil

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,6 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/f[ms]*
         - internal/service/[g-z]*
     pattern: return diag.FromErr($ERR)
     fix: return sdkdiag.AppendFromErr(diags, $ERR)
@@ -15,8 +14,6 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/fi[rs]*
-        - internal/service/f[ms]*
         - internal/service/[g-z]*
     pattern: append(diags, diag.FromErr($ERR)...)
     fix: sdkdiag.AppendFromErr(diags, $ERR)
@@ -27,7 +24,6 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/f[ms]*
         - internal/service/[g-z]*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
@@ -38,7 +34,6 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/f[ms]*
         - internal/service/[g-z]*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
@@ -49,7 +44,6 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/f[ms]*
         - internal/service/[g-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
     fix: create.AppendDiagError(diags, $...ARGS)
@@ -60,7 +54,6 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/f[ms]*
         - internal/service/[g-z]*
     pattern: create.DiagSettingError($...ARGS)
     fix: create.AppendDiagSettingError(diags, $...ARGS)
@@ -71,7 +64,6 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/f[ms]*
         - internal/service/[g-z]*
     patterns:
       - pattern: return $READFN($...ARGS)
@@ -90,7 +82,6 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/f[ms]*
         - internal/service/[g-z]*
     patterns:
       - pattern: return $UPDATEFN($...ARGS)
@@ -107,7 +98,6 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/f[ms]*
         - internal/service/[g-z]*
     patterns:
       - pattern: return nil

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,7 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/fi[rs]*
+        - internal/service/fis
         - internal/service/f[ms]*
         - internal/service/[g-z]*
     pattern: return diag.FromErr($ERR)
@@ -28,7 +28,7 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/fi[rs]*
+        - internal/service/fis
         - internal/service/f[ms]*
         - internal/service/[g-z]*
     pattern: diag.Errorf($...ARGS)
@@ -40,7 +40,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/fi[rs]*
+        - internal/service/fis
         - internal/service/f[ms]*
         - internal/service/[g-z]*
     pattern: return create.DiagError($...ARGS)
@@ -52,7 +52,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/fi[rs]*
+        - internal/service/fis
         - internal/service/f[ms]*
         - internal/service/[g-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
@@ -64,7 +64,7 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/fi[rs]*
+        - internal/service/fis
         - internal/service/f[ms]*
         - internal/service/[g-z]*
     pattern: create.DiagSettingError($...ARGS)
@@ -76,7 +76,7 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/fi[rs]*
+        - internal/service/fis
         - internal/service/f[ms]*
         - internal/service/[g-z]*
     patterns:
@@ -96,7 +96,7 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/fi[rs]*
+        - internal/service/fis
         - internal/service/f[ms]*
         - internal/service/[g-z]*
     patterns:
@@ -114,7 +114,7 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/fi[rs]*
+        - internal/service/fis
         - internal/service/f[ms]*
         - internal/service/[g-z]*
     patterns:

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,7 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/i[d-z]*
+        - internal/service/i[m-z]*
         - internal/service/[k-z]*
     pattern: return diag.FromErr($ERR)
     fix: return sdkdiag.AppendFromErr(diags, $ERR)
@@ -26,7 +26,7 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/i[d-z]*
+        - internal/service/i[m-z]*
         - internal/service/[k-z]*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
@@ -37,7 +37,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/i[d-z]*
+        - internal/service/i[m-z]*
         - internal/service/[k-z]*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
@@ -48,7 +48,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/i[d-z]*
+        - internal/service/i[m-z]*
         - internal/service/[k-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
     fix: create.AppendDiagError(diags, $...ARGS)
@@ -59,7 +59,7 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/i[d-z]*
+        - internal/service/i[m-z]*
         - internal/service/[k-z]*
     pattern: create.DiagSettingError($...ARGS)
     fix: create.AppendDiagSettingError(diags, $...ARGS)
@@ -70,7 +70,7 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/i[d-z]*
+        - internal/service/i[m-z]*
         - internal/service/[k-z]*
     patterns:
       - pattern: return $READFN($...ARGS)
@@ -89,7 +89,7 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/i[d-z]*
+        - internal/service/i[m-z]*
         - internal/service/[k-z]*
     patterns:
       - pattern: return $UPDATEFN($...ARGS)
@@ -106,7 +106,7 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/i[d-z]*
+        - internal/service/i[m-z]*
         - internal/service/[k-z]*
     patterns:
       - pattern: return nil

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,7 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/e[m-v]*
+        - internal/service/e[v]*
         - internal/service/[f-z]*
     pattern: return diag.FromErr($ERR)
     fix: return sdkdiag.AppendFromErr(diags, $ERR)
@@ -27,7 +27,7 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/e[m-v]*
+        - internal/service/e[v]*
         - internal/service/[f-z]*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
@@ -38,7 +38,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/e[m-v]*
+        - internal/service/e[v]*
         - internal/service/[f-z]*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
@@ -49,7 +49,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/e[m-v]*
+        - internal/service/e[v]*
         - internal/service/[f-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
     fix: create.AppendDiagError(diags, $...ARGS)
@@ -60,7 +60,7 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/e[m-v]*
+        - internal/service/e[v]*
         - internal/service/[f-z]*
     pattern: create.DiagSettingError($...ARGS)
     fix: create.AppendDiagSettingError(diags, $...ARGS)
@@ -71,7 +71,7 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/e[m-v]*
+        - internal/service/e[v]*
         - internal/service/[f-z]*
     patterns:
       - pattern: return $READFN($...ARGS)
@@ -90,7 +90,7 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/e[m-v]*
+        - internal/service/e[v]*
         - internal/service/[f-z]*
     patterns:
       - pattern: return $UPDATEFN($...ARGS)
@@ -107,7 +107,7 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/e[m-v]*
+        - internal/service/e[v]*
         - internal/service/[f-z]*
     patterns:
       - pattern: return nil

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,8 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/k[e-z]*
+        - internal/service/keyspaces
+        - internal/service/k[i-z]*
         - internal/service/[l-z]*
     pattern: return diag.FromErr($ERR)
     fix: return sdkdiag.AppendFromErr(diags, $ERR)
@@ -15,7 +16,8 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/k[e-z]*
+        - internal/service/keyspaces
+        - internal/service/k[i-z]*
         - internal/service/[l-z]*
     pattern: append(diags, diag.FromErr($ERR)...)
     fix: sdkdiag.AppendFromErr(diags, $ERR)
@@ -26,7 +28,8 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/k[e-z]*
+        - internal/service/keyspaces
+        - internal/service/k[i-z]*
         - internal/service/[l-z]*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
@@ -37,7 +40,8 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/k[e-z]*
+        - internal/service/keyspaces
+        - internal/service/k[i-z]*
         - internal/service/[l-z]*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
@@ -48,7 +52,8 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/k[e-z]*
+        - internal/service/keyspaces
+        - internal/service/k[i-z]*
         - internal/service/[l-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
     fix: create.AppendDiagError(diags, $...ARGS)
@@ -59,7 +64,8 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/k[e-z]*
+        - internal/service/keyspaces
+        - internal/service/k[i-z]*
         - internal/service/[l-z]*
     pattern: create.DiagSettingError($...ARGS)
     fix: create.AppendDiagSettingError(diags, $...ARGS)
@@ -70,7 +76,8 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/k[e-z]*
+        - internal/service/keyspaces
+        - internal/service/k[i-z]*
         - internal/service/[l-z]*
     patterns:
       - pattern: return $READFN($...ARGS)
@@ -89,7 +96,8 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/k[e-z]*
+        - internal/service/keyspaces
+        - internal/service/k[i-z]*
         - internal/service/[l-z]*
     patterns:
       - pattern: return $UPDATEFN($...ARGS)
@@ -106,7 +114,8 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/k[e-z]*
+        - internal/service/keyspaces
+        - internal/service/k[i-z]*
         - internal/service/[l-z]*
     patterns:
       - pattern: return nil

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,6 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/ivschat
         - internal/service/[k-z]*
     pattern: return diag.FromErr($ERR)
     fix: return sdkdiag.AppendFromErr(diags, $ERR)
@@ -15,7 +14,6 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/i[d-z]*
         - internal/service/[k-z]*
     pattern: append(diags, diag.FromErr($ERR)...)
     fix: sdkdiag.AppendFromErr(diags, $ERR)
@@ -26,7 +24,6 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/ivschat
         - internal/service/[k-z]*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
@@ -37,7 +34,6 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/ivschat
         - internal/service/[k-z]*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
@@ -48,7 +44,6 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/ivschat
         - internal/service/[k-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
     fix: create.AppendDiagError(diags, $...ARGS)
@@ -59,7 +54,6 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/ivschat
         - internal/service/[k-z]*
     pattern: create.DiagSettingError($...ARGS)
     fix: create.AppendDiagSettingError(diags, $...ARGS)
@@ -70,7 +64,6 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/ivschat
         - internal/service/[k-z]*
     patterns:
       - pattern: return $READFN($...ARGS)
@@ -89,7 +82,6 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/ivschat
         - internal/service/[k-z]*
     patterns:
       - pattern: return $UPDATEFN($...ARGS)
@@ -106,7 +98,6 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/ivschat
         - internal/service/[k-z]*
     patterns:
       - pattern: return nil

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,6 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/k[i-z]*
         - internal/service/[l-z]*
     pattern: return diag.FromErr($ERR)
     fix: return sdkdiag.AppendFromErr(diags, $ERR)
@@ -15,7 +14,6 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/k[i-z]*
         - internal/service/[l-z]*
     pattern: append(diags, diag.FromErr($ERR)...)
     fix: sdkdiag.AppendFromErr(diags, $ERR)
@@ -26,7 +24,6 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/k[i-z]*
         - internal/service/[l-z]*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
@@ -37,7 +34,6 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/k[i-z]*
         - internal/service/[l-z]*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
@@ -48,7 +44,6 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/k[i-z]*
         - internal/service/[l-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
     fix: create.AppendDiagError(diags, $...ARGS)
@@ -59,7 +54,6 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/k[i-z]*
         - internal/service/[l-z]*
     pattern: create.DiagSettingError($...ARGS)
     fix: create.AppendDiagSettingError(diags, $...ARGS)
@@ -70,7 +64,6 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/k[i-z]*
         - internal/service/[l-z]*
     patterns:
       - pattern: return $READFN($...ARGS)
@@ -89,7 +82,6 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/k[i-z]*
         - internal/service/[l-z]*
     patterns:
       - pattern: return $UPDATEFN($...ARGS)
@@ -106,7 +98,6 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/k[i-z]*
         - internal/service/[l-z]*
     patterns:
       - pattern: return nil

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,7 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/ec[r-s]*
+        - internal/service/ecs*
         - internal/service/e[f-v]*
         - internal/service/[f-z]*
     pattern: return diag.FromErr($ERR)
@@ -28,7 +28,7 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/ec[r-s]*
+        - internal/service/ecs*
         - internal/service/e[f-v]*
         - internal/service/[f-z]*
     pattern: diag.Errorf($...ARGS)
@@ -40,7 +40,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/ec[r-s]*
+        - internal/service/ecs*
         - internal/service/e[f-v]*
         - internal/service/[f-z]*
     pattern: return create.DiagError($...ARGS)
@@ -52,7 +52,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/ec[r-s]*
+        - internal/service/ecs*
         - internal/service/e[f-v]*
         - internal/service/[f-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
@@ -64,7 +64,7 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/ec[r-s]*
+        - internal/service/ecs*
         - internal/service/e[f-v]*
         - internal/service/[f-z]*
     pattern: create.DiagSettingError($...ARGS)
@@ -76,7 +76,7 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/ec[r-s]*
+        - internal/service/ecs*
         - internal/service/e[f-v]*
         - internal/service/[f-z]*
     patterns:
@@ -96,7 +96,7 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/ec[r-s]*
+        - internal/service/ecs*
         - internal/service/e[f-v]*
         - internal/service/[f-z]*
     patterns:
@@ -114,7 +114,7 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/ec[r-s]*
+        - internal/service/ecs*
         - internal/service/e[f-v]*
         - internal/service/[f-z]*
     patterns:

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,7 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/i[v-z]*
+        - internal/service/ivschat
         - internal/service/[k-z]*
     pattern: return diag.FromErr($ERR)
     fix: return sdkdiag.AppendFromErr(diags, $ERR)
@@ -26,7 +26,7 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/i[v-z]*
+        - internal/service/ivschat
         - internal/service/[k-z]*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
@@ -37,7 +37,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/i[v-z]*
+        - internal/service/ivschat
         - internal/service/[k-z]*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
@@ -48,7 +48,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/i[v-z]*
+        - internal/service/ivschat
         - internal/service/[k-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
     fix: create.AppendDiagError(diags, $...ARGS)
@@ -59,7 +59,7 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/i[v-z]*
+        - internal/service/ivschat
         - internal/service/[k-z]*
     pattern: create.DiagSettingError($...ARGS)
     fix: create.AppendDiagSettingError(diags, $...ARGS)
@@ -70,7 +70,7 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/i[v-z]*
+        - internal/service/ivschat
         - internal/service/[k-z]*
     patterns:
       - pattern: return $READFN($...ARGS)
@@ -89,7 +89,7 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/i[v-z]*
+        - internal/service/ivschat
         - internal/service/[k-z]*
     patterns:
       - pattern: return $UPDATEFN($...ARGS)
@@ -106,7 +106,7 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/i[v-z]*
+        - internal/service/ivschat
         - internal/service/[k-z]*
     patterns:
       - pattern: return nil

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,7 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/e[l-v]*
+        - internal/service/e[m-v]*
         - internal/service/[f-z]*
     pattern: return diag.FromErr($ERR)
     fix: return sdkdiag.AppendFromErr(diags, $ERR)
@@ -27,7 +27,7 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/e[l-v]*
+        - internal/service/e[m-v]*
         - internal/service/[f-z]*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
@@ -38,7 +38,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/e[l-v]*
+        - internal/service/e[m-v]*
         - internal/service/[f-z]*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
@@ -49,7 +49,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/e[l-v]*
+        - internal/service/e[m-v]*
         - internal/service/[f-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
     fix: create.AppendDiagError(diags, $...ARGS)
@@ -60,7 +60,7 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/e[l-v]*
+        - internal/service/e[m-v]*
         - internal/service/[f-z]*
     pattern: create.DiagSettingError($...ARGS)
     fix: create.AppendDiagSettingError(diags, $...ARGS)
@@ -71,7 +71,7 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/e[l-v]*
+        - internal/service/e[m-v]*
         - internal/service/[f-z]*
     patterns:
       - pattern: return $READFN($...ARGS)
@@ -90,7 +90,7 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/e[l-v]*
+        - internal/service/e[m-v]*
         - internal/service/[f-z]*
     patterns:
       - pattern: return $UPDATEFN($...ARGS)
@@ -107,7 +107,7 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/e[l-v]*
+        - internal/service/e[m-v]*
         - internal/service/[f-z]*
     patterns:
       - pattern: return nil

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,6 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/fis
         - internal/service/f[ms]*
         - internal/service/[g-z]*
     pattern: return diag.FromErr($ERR)
@@ -28,7 +27,6 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/fis
         - internal/service/f[ms]*
         - internal/service/[g-z]*
     pattern: diag.Errorf($...ARGS)
@@ -40,7 +38,6 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/fis
         - internal/service/f[ms]*
         - internal/service/[g-z]*
     pattern: return create.DiagError($...ARGS)
@@ -52,7 +49,6 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/fis
         - internal/service/f[ms]*
         - internal/service/[g-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
@@ -64,7 +60,6 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/fis
         - internal/service/f[ms]*
         - internal/service/[g-z]*
     pattern: create.DiagSettingError($...ARGS)
@@ -76,7 +71,6 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/fis
         - internal/service/f[ms]*
         - internal/service/[g-z]*
     patterns:
@@ -96,7 +90,6 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/fis
         - internal/service/f[ms]*
         - internal/service/[g-z]*
     patterns:
@@ -114,7 +107,6 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/fis
         - internal/service/f[ms]*
         - internal/service/[g-z]*
     patterns:

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,6 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/ecs*
         - internal/service/e[f-v]*
         - internal/service/[f-z]*
     pattern: return diag.FromErr($ERR)
@@ -28,7 +27,6 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/ecs*
         - internal/service/e[f-v]*
         - internal/service/[f-z]*
     pattern: diag.Errorf($...ARGS)
@@ -40,7 +38,6 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/ecs*
         - internal/service/e[f-v]*
         - internal/service/[f-z]*
     pattern: return create.DiagError($...ARGS)
@@ -52,7 +49,6 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/ecs*
         - internal/service/e[f-v]*
         - internal/service/[f-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
@@ -64,7 +60,6 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/ecs*
         - internal/service/e[f-v]*
         - internal/service/[f-z]*
     pattern: create.DiagSettingError($...ARGS)
@@ -76,7 +71,6 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/ecs*
         - internal/service/e[f-v]*
         - internal/service/[f-z]*
     patterns:
@@ -96,7 +90,6 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/ecs*
         - internal/service/e[f-v]*
         - internal/service/[f-z]*
     patterns:
@@ -114,7 +107,6 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/ecs*
         - internal/service/e[f-v]*
         - internal/service/[f-z]*
     patterns:

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,8 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/[h-z]*
+        - internal/service/i[d-z]*
+        - internal/service/[k-z]*
     pattern: return diag.FromErr($ERR)
     fix: return sdkdiag.AppendFromErr(diags, $ERR)
     severity: WARNING
@@ -14,7 +15,8 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/[h-z]*
+        - internal/service/i[d-z]*
+        - internal/service/[k-z]*
     pattern: append(diags, diag.FromErr($ERR)...)
     fix: sdkdiag.AppendFromErr(diags, $ERR)
     severity: WARNING
@@ -24,7 +26,8 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/[h-z]*
+        - internal/service/i[d-z]*
+        - internal/service/[k-z]*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
     severity: WARNING
@@ -34,7 +37,8 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/[h-z]*
+        - internal/service/i[d-z]*
+        - internal/service/[k-z]*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
     severity: WARNING
@@ -44,7 +48,8 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/[h-z]*
+        - internal/service/i[d-z]*
+        - internal/service/[k-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
     fix: create.AppendDiagError(diags, $...ARGS)
     severity: WARNING
@@ -54,7 +59,8 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/[h-z]*
+        - internal/service/i[d-z]*
+        - internal/service/[k-z]*
     pattern: create.DiagSettingError($...ARGS)
     fix: create.AppendDiagSettingError(diags, $...ARGS)
     severity: WARNING
@@ -64,7 +70,8 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/[h-z]*
+        - internal/service/i[d-z]*
+        - internal/service/[k-z]*
     patterns:
       - pattern: return $READFN($...ARGS)
       - metavariable-regex:
@@ -82,7 +89,8 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/[h-z]*
+        - internal/service/i[d-z]*
+        - internal/service/[k-z]*
     patterns:
       - pattern: return $UPDATEFN($...ARGS)
       - metavariable-regex:
@@ -98,7 +106,8 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/[h-z]*
+        - internal/service/i[d-z]*
+        - internal/service/[k-z]*
     patterns:
       - pattern: return nil
       - pattern-not-inside: |

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,9 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/[f-z]*
+        - internal/service/fi[rs]*
+        - internal/service/f[ms]*
+        - internal/service/[g-z]*
     pattern: return diag.FromErr($ERR)
     fix: return sdkdiag.AppendFromErr(diags, $ERR)
     severity: WARNING
@@ -14,7 +16,9 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/[f-z]*
+        - internal/service/fi[rs]*
+        - internal/service/f[ms]*
+        - internal/service/[g-z]*
     pattern: append(diags, diag.FromErr($ERR)...)
     fix: sdkdiag.AppendFromErr(diags, $ERR)
     severity: WARNING
@@ -24,7 +28,9 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/[f-z]*
+        - internal/service/fi[rs]*
+        - internal/service/f[ms]*
+        - internal/service/[g-z]*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
     severity: WARNING
@@ -34,7 +40,9 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/[f-z]*
+        - internal/service/fi[rs]*
+        - internal/service/f[ms]*
+        - internal/service/[g-z]*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
     severity: WARNING
@@ -44,7 +52,9 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/[f-z]*
+        - internal/service/fi[rs]*
+        - internal/service/f[ms]*
+        - internal/service/[g-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
     fix: create.AppendDiagError(diags, $...ARGS)
     severity: WARNING
@@ -54,7 +64,9 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/[f-z]*
+        - internal/service/fi[rs]*
+        - internal/service/f[ms]*
+        - internal/service/[g-z]*
     pattern: create.DiagSettingError($...ARGS)
     fix: create.AppendDiagSettingError(diags, $...ARGS)
     severity: WARNING
@@ -64,7 +76,9 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/[f-z]*
+        - internal/service/fi[rs]*
+        - internal/service/f[ms]*
+        - internal/service/[g-z]*
     patterns:
       - pattern: return $READFN($...ARGS)
       - metavariable-regex:
@@ -82,7 +96,9 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/[f-z]*
+        - internal/service/fi[rs]*
+        - internal/service/f[ms]*
+        - internal/service/[g-z]*
     patterns:
       - pattern: return $UPDATEFN($...ARGS)
       - metavariable-regex:
@@ -98,7 +114,9 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/[f-z]*
+        - internal/service/fi[rs]*
+        - internal/service/f[ms]*
+        - internal/service/[g-z]*
     patterns:
       - pattern: return nil
       - pattern-not-inside: |

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,9 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/[k-z]*
+        - internal/service/kafkaconnect
+        - internal/service/k[e-z]*
+        - internal/service/[l-z]*
     pattern: return diag.FromErr($ERR)
     fix: return sdkdiag.AppendFromErr(diags, $ERR)
     severity: WARNING
@@ -14,7 +16,9 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/[k-z]*
+        - internal/service/kafkaconnect
+        - internal/service/k[e-z]*
+        - internal/service/[l-z]*
     pattern: append(diags, diag.FromErr($ERR)...)
     fix: sdkdiag.AppendFromErr(diags, $ERR)
     severity: WARNING
@@ -24,7 +28,9 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/[k-z]*
+        - internal/service/kafkaconnect
+        - internal/service/k[e-z]*
+        - internal/service/[l-z]*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
     severity: WARNING
@@ -34,7 +40,9 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/[k-z]*
+        - internal/service/kafkaconnect
+        - internal/service/k[e-z]*
+        - internal/service/[l-z]*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
     severity: WARNING
@@ -44,7 +52,9 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/[k-z]*
+        - internal/service/kafkaconnect
+        - internal/service/k[e-z]*
+        - internal/service/[l-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
     fix: create.AppendDiagError(diags, $...ARGS)
     severity: WARNING
@@ -54,7 +64,9 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/[k-z]*
+        - internal/service/kafkaconnect
+        - internal/service/k[e-z]*
+        - internal/service/[l-z]*
     pattern: create.DiagSettingError($...ARGS)
     fix: create.AppendDiagSettingError(diags, $...ARGS)
     severity: WARNING
@@ -64,7 +76,9 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/[k-z]*
+        - internal/service/kafkaconnect
+        - internal/service/k[e-z]*
+        - internal/service/[l-z]*
     patterns:
       - pattern: return $READFN($...ARGS)
       - metavariable-regex:
@@ -82,7 +96,9 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/[k-z]*
+        - internal/service/kafkaconnect
+        - internal/service/k[e-z]*
+        - internal/service/[l-z]*
     patterns:
       - pattern: return $UPDATEFN($...ARGS)
       - metavariable-regex:
@@ -98,7 +114,9 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/[k-z]*
+        - internal/service/kafkaconnect
+        - internal/service/k[e-z]*
+        - internal/service/[l-z]*
     patterns:
       - pattern: return nil
       - pattern-not-inside: |

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,7 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/i[m-z]*
+        - internal/service/i[o-z]*
         - internal/service/[k-z]*
     pattern: return diag.FromErr($ERR)
     fix: return sdkdiag.AppendFromErr(diags, $ERR)
@@ -26,7 +26,7 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/i[m-z]*
+        - internal/service/i[o-z]*
         - internal/service/[k-z]*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
@@ -37,7 +37,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/i[m-z]*
+        - internal/service/i[o-z]*
         - internal/service/[k-z]*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
@@ -48,7 +48,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/i[m-z]*
+        - internal/service/i[o-z]*
         - internal/service/[k-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
     fix: create.AppendDiagError(diags, $...ARGS)
@@ -59,7 +59,7 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/i[m-z]*
+        - internal/service/i[o-z]*
         - internal/service/[k-z]*
     pattern: create.DiagSettingError($...ARGS)
     fix: create.AppendDiagSettingError(diags, $...ARGS)
@@ -70,7 +70,7 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/i[m-z]*
+        - internal/service/i[o-z]*
         - internal/service/[k-z]*
     patterns:
       - pattern: return $READFN($...ARGS)
@@ -89,7 +89,7 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/i[m-z]*
+        - internal/service/i[o-z]*
         - internal/service/[k-z]*
     patterns:
       - pattern: return $UPDATEFN($...ARGS)
@@ -106,7 +106,7 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/i[m-z]*
+        - internal/service/i[o-z]*
         - internal/service/[k-z]*
     patterns:
       - pattern: return nil

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,9 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/[g-z]*
+        - internal/service/glue
+        - internal/service/g[ru]
+        - internal/service/[h-z]*
     pattern: return diag.FromErr($ERR)
     fix: return sdkdiag.AppendFromErr(diags, $ERR)
     severity: WARNING
@@ -14,7 +16,9 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/[g-z]*
+        - internal/service/glue
+        - internal/service/g[ru]
+        - internal/service/[h-z]*
     pattern: append(diags, diag.FromErr($ERR)...)
     fix: sdkdiag.AppendFromErr(diags, $ERR)
     severity: WARNING
@@ -24,7 +28,9 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/[g-z]*
+        - internal/service/glue
+        - internal/service/g[ru]
+        - internal/service/[h-z]*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
     severity: WARNING
@@ -34,7 +40,9 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/[g-z]*
+        - internal/service/glue
+        - internal/service/g[ru]
+        - internal/service/[h-z]*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
     severity: WARNING
@@ -44,7 +52,9 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/[g-z]*
+        - internal/service/glue
+        - internal/service/g[ru]
+        - internal/service/[h-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
     fix: create.AppendDiagError(diags, $...ARGS)
     severity: WARNING
@@ -54,7 +64,9 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/[g-z]*
+        - internal/service/glue
+        - internal/service/g[ru]
+        - internal/service/[h-z]*
     pattern: create.DiagSettingError($...ARGS)
     fix: create.AppendDiagSettingError(diags, $...ARGS)
     severity: WARNING
@@ -64,7 +76,9 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/[g-z]*
+        - internal/service/glue
+        - internal/service/g[ru]
+        - internal/service/[h-z]*
     patterns:
       - pattern: return $READFN($...ARGS)
       - metavariable-regex:
@@ -82,7 +96,9 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/[g-z]*
+        - internal/service/glue
+        - internal/service/g[ru]
+        - internal/service/[h-z]*
     patterns:
       - pattern: return $UPDATEFN($...ARGS)
       - metavariable-regex:
@@ -98,7 +114,9 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/[g-z]*
+        - internal/service/glue
+        - internal/service/g[ru]
+        - internal/service/[h-z]*
     patterns:
       - pattern: return nil
       - pattern-not-inside: |

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,7 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/i[o-z]*
+        - internal/service/i[v-z]*
         - internal/service/[k-z]*
     pattern: return diag.FromErr($ERR)
     fix: return sdkdiag.AppendFromErr(diags, $ERR)
@@ -26,7 +26,7 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/i[o-z]*
+        - internal/service/i[v-z]*
         - internal/service/[k-z]*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
@@ -37,7 +37,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/i[o-z]*
+        - internal/service/i[v-z]*
         - internal/service/[k-z]*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
@@ -48,7 +48,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/i[o-z]*
+        - internal/service/i[v-z]*
         - internal/service/[k-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
     fix: create.AppendDiagError(diags, $...ARGS)
@@ -59,7 +59,7 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/i[o-z]*
+        - internal/service/i[v-z]*
         - internal/service/[k-z]*
     pattern: create.DiagSettingError($...ARGS)
     fix: create.AppendDiagSettingError(diags, $...ARGS)
@@ -70,7 +70,7 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/i[o-z]*
+        - internal/service/i[v-z]*
         - internal/service/[k-z]*
     patterns:
       - pattern: return $READFN($...ARGS)
@@ -89,7 +89,7 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/i[o-z]*
+        - internal/service/i[v-z]*
         - internal/service/[k-z]*
     patterns:
       - pattern: return $UPDATEFN($...ARGS)
@@ -106,7 +106,7 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/i[o-z]*
+        - internal/service/i[v-z]*
         - internal/service/[k-z]*
     patterns:
       - pattern: return nil

--- a/internal/service/ecr/pull_through_cache_rule_data_source.go
+++ b/internal/service/ecr/pull_through_cache_rule_data_source.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 )
 
 // @SDKDataSource("aws_ecr_pull_through_cache_rule")
@@ -43,6 +44,8 @@ func DataSourcePullThroughCacheRule() *schema.Resource {
 }
 
 func dataSourcePullThroughCacheRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ECRConn(ctx)
 
 	repositoryPrefix := d.Get("ecr_repository_prefix").(string)
@@ -50,7 +53,7 @@ func dataSourcePullThroughCacheRuleRead(ctx context.Context, d *schema.ResourceD
 	rule, err := FindPullThroughCacheRuleByRepositoryPrefix(ctx, conn, repositoryPrefix)
 
 	if err != nil {
-		return diag.Errorf("reading ECR Pull Through Cache Rule (%s): %s", repositoryPrefix, err)
+		return sdkdiag.AppendErrorf(diags, "reading ECR Pull Through Cache Rule (%s): %s", repositoryPrefix, err)
 	}
 
 	d.SetId(aws.StringValue(rule.EcrRepositoryPrefix))
@@ -58,5 +61,5 @@ func dataSourcePullThroughCacheRuleRead(ctx context.Context, d *schema.ResourceD
 	d.Set("registry_id", rule.RegistryId)
 	d.Set("upstream_registry_url", rule.UpstreamRegistryUrl)
 
-	return nil
+	return diags
 }

--- a/internal/service/ecs/cluster.go
+++ b/internal/service/ecs/cluster.go
@@ -260,6 +260,8 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
 }
 
 func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ECSConn(ctx)
 
 	if d.HasChanges("configuration", "service_connect_defaults", "setting") {
@@ -282,15 +284,15 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		_, err := conn.UpdateClusterWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("updating ECS Cluster (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating ECS Cluster (%s): %s", d.Id(), err)
 		}
 
 		if _, err := waitClusterAvailable(ctx, conn, d.Id()); err != nil {
-			return diag.Errorf("waiting for ECS Cluster (%s) update: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "waiting for ECS Cluster (%s) update: %s", d.Id(), err)
 		}
 	}
 
-	return nil
+	return diags
 }
 
 func FindClusterByNameOrARN(ctx context.Context, conn *ecs.ECS, nameOrARN string) (*ecs.Cluster, error) {

--- a/internal/service/ecs/cluster_capacity_providers.go
+++ b/internal/service/ecs/cluster_capacity_providers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
@@ -76,6 +77,8 @@ func ResourceClusterCapacityProviders() *schema.Resource {
 }
 
 func resourceClusterCapacityProvidersPut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ECSConn(ctx)
 
 	clusterName := d.Get("cluster_name").(string)
@@ -88,7 +91,7 @@ func resourceClusterCapacityProvidersPut(ctx context.Context, d *schema.Resource
 	err := retryClusterCapacityProvidersPut(ctx, conn, input)
 
 	if err != nil {
-		return diag.Errorf("updating ECS Cluster Capacity Providers (%s): %s", clusterName, err)
+		return sdkdiag.AppendErrorf(diags, "updating ECS Cluster Capacity Providers (%s): %s", clusterName, err)
 	}
 
 	if d.IsNewResource() {
@@ -96,39 +99,43 @@ func resourceClusterCapacityProvidersPut(ctx context.Context, d *schema.Resource
 	}
 
 	if _, err := waitClusterAvailable(ctx, conn, clusterName); err != nil {
-		return diag.Errorf("waiting for ECS Cluster Capacity Providers (%s) update: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for ECS Cluster Capacity Providers (%s) update: %s", d.Id(), err)
 	}
 
-	return resourceClusterCapacityProvidersRead(ctx, d, meta)
+	return append(diags, resourceClusterCapacityProvidersRead(ctx, d, meta)...)
 }
 
 func resourceClusterCapacityProvidersRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ECSConn(ctx)
 
 	cluster, err := FindClusterByNameOrARN(ctx, conn, d.Id())
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
-		diag.Errorf("[WARN] ECS Cluster (%s) not found, removing from state", d.Id())
+		sdkdiag.AppendErrorf(diags, "[WARN] ECS Cluster (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading ECS Cluster (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading ECS Cluster (%s): %s", d.Id(), err)
 	}
 
 	if err := d.Set("capacity_providers", aws.StringValueSlice(cluster.CapacityProviders)); err != nil {
-		return diag.Errorf("setting capacity_providers: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting capacity_providers: %s", err)
 	}
 	d.Set("cluster_name", cluster.ClusterName)
 	if err := d.Set("default_capacity_provider_strategy", flattenCapacityProviderStrategy(cluster.DefaultCapacityProviderStrategy)); err != nil {
-		return diag.Errorf("setting default_capacity_provider_strategy: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting default_capacity_provider_strategy: %s", err)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceClusterCapacityProvidersDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ECSConn(ctx)
 
 	input := &ecs.PutClusterCapacityProvidersInput{
@@ -141,18 +148,18 @@ func resourceClusterCapacityProvidersDelete(ctx context.Context, d *schema.Resou
 	err := retryClusterCapacityProvidersPut(ctx, conn, input)
 
 	if tfawserr.ErrCodeEquals(err, ecs.ErrCodeClusterNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting ECS Cluster Capacity Providers (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting ECS Cluster Capacity Providers (%s): %s", d.Id(), err)
 	}
 
 	if _, err := waitClusterAvailable(ctx, conn, d.Id()); err != nil {
-		return diag.Errorf("waiting for ECS Cluster Capacity Providers (%s) delete: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for ECS Cluster Capacity Providers (%s) delete: %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func retryClusterCapacityProvidersPut(ctx context.Context, conn *ecs.ECS, input *ecs.PutClusterCapacityProvidersInput) error {

--- a/internal/service/ecs/task_execution_data_source.go
+++ b/internal/service/ecs/task_execution_data_source.go
@@ -319,14 +319,14 @@ func dataSourceTaskExecutionRead(ctx context.Context, d *schema.ResourceData, me
 	if v, ok := d.GetOk("placement_constraints"); ok {
 		pc, err := expandPlacementConstraints(v.(*schema.Set).List())
 		if err != nil {
-			return create.DiagError(names.ECS, create.ErrActionCreating, DSNameTaskExecution, d.Id(), err)
+			return create.AppendDiagError(diags, names.ECS, create.ErrActionCreating, DSNameTaskExecution, d.Id(), err)
 		}
 		input.PlacementConstraints = pc
 	}
 	if v, ok := d.GetOk("placement_strategy"); ok {
 		ps, err := expandPlacementStrategy(v.([]interface{}))
 		if err != nil {
-			return create.DiagError(names.ECS, create.ErrActionCreating, DSNameTaskExecution, d.Id(), err)
+			return create.AppendDiagError(diags, names.ECS, create.ErrActionCreating, DSNameTaskExecution, d.Id(), err)
 		}
 		input.PlacementStrategy = ps
 	}
@@ -345,10 +345,10 @@ func dataSourceTaskExecutionRead(ctx context.Context, d *schema.ResourceData, me
 
 	out, err := conn.RunTaskWithContext(ctx, &input)
 	if err != nil {
-		return create.DiagError(names.ECS, create.ErrActionCreating, DSNameTaskExecution, d.Id(), err)
+		return create.AppendDiagError(diags, names.ECS, create.ErrActionCreating, DSNameTaskExecution, d.Id(), err)
 	}
 	if out == nil || len(out.Tasks) == 0 {
-		return create.DiagError(names.ECS, create.ErrActionCreating, DSNameTaskExecution, d.Id(), tfresource.NewEmptyResultError(input))
+		return create.AppendDiagError(diags, names.ECS, create.ErrActionCreating, DSNameTaskExecution, d.Id(), tfresource.NewEmptyResultError(input))
 	}
 
 	var taskArns []*string

--- a/internal/service/eks/addon.go
+++ b/internal/service/eks/addon.go
@@ -212,7 +212,7 @@ func resourceAddonRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] EKS Add-On (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {

--- a/internal/service/eks/addon_data_source.go
+++ b/internal/service/eks/addon_data_source.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 )
 
@@ -60,6 +61,8 @@ func dataSourceAddon() *schema.Resource {
 }
 
 func dataSourceAddonRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).EKSClient(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
@@ -70,7 +73,7 @@ func dataSourceAddonRead(ctx context.Context, d *schema.ResourceData, meta inter
 	addon, err := findAddonByTwoPartKey(ctx, conn, clusterName, addonName)
 
 	if err != nil {
-		return diag.Errorf("reading EKS Add-On (%s): %s", id, err)
+		return sdkdiag.AppendErrorf(diags, "reading EKS Add-On (%s): %s", id, err)
 	}
 
 	d.SetId(id)
@@ -82,8 +85,8 @@ func dataSourceAddonRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set("service_account_role_arn", addon.ServiceAccountRoleArn)
 
 	if err := d.Set("tags", KeyValueTags(ctx, addon.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/eks/addon_version_data_source.go
+++ b/internal/service/eks/addon_version_data_source.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
@@ -46,6 +47,8 @@ func dataSourceAddonVersion() *schema.Resource {
 }
 
 func dataSourceAddonVersionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).EKSClient(ctx)
 
 	addonName := d.Get("addon_name").(string)
@@ -54,7 +57,7 @@ func dataSourceAddonVersionRead(ctx context.Context, d *schema.ResourceData, met
 	versionInfo, err := findAddonVersionByTwoPartKey(ctx, conn, addonName, kubernetesVersion, mostRecent)
 
 	if err != nil {
-		return diag.Errorf("reading EKS Add-On version info (%s, %s): %s", addonName, kubernetesVersion, err)
+		return sdkdiag.AppendErrorf(diags, "reading EKS Add-On version info (%s, %s): %s", addonName, kubernetesVersion, err)
 	}
 
 	d.SetId(addonName)
@@ -63,7 +66,7 @@ func dataSourceAddonVersionRead(ctx context.Context, d *schema.ResourceData, met
 	d.Set("most_recent", mostRecent)
 	d.Set("version", versionInfo.AddonVersion)
 
-	return nil
+	return diags
 }
 
 func findAddonVersionByTwoPartKey(ctx context.Context, conn *eks.Client, addonName, kubernetesVersion string, mostRecent bool) (*types.AddonVersionInfo, error) {

--- a/internal/service/eks/cluster_data_source.go
+++ b/internal/service/eks/cluster_data_source.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 )
 
@@ -189,6 +190,8 @@ func dataSourceCluster() *schema.Resource {
 }
 
 func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).EKSClient(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
@@ -196,13 +199,13 @@ func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta int
 	cluster, err := findClusterByName(ctx, conn, name)
 
 	if err != nil {
-		return diag.Errorf("reading EKS Cluster (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "reading EKS Cluster (%s): %s", name, err)
 	}
 
 	d.SetId(name)
 	d.Set("arn", cluster.Arn)
 	if err := d.Set("certificate_authority", flattenCertificate(cluster.CertificateAuthority)); err != nil {
-		return diag.Errorf("setting certificate_authority: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting certificate_authority: %s", err)
 	}
 	// cluster_id is only relevant for clusters on Outposts.
 	if cluster.OutpostConfig != nil {
@@ -210,30 +213,30 @@ func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta int
 	}
 	d.Set("created_at", aws.ToTime(cluster.CreatedAt).String())
 	if err := d.Set("enabled_cluster_log_types", flattenLogging(cluster.Logging)); err != nil {
-		return diag.Errorf("setting enabled_cluster_log_types: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting enabled_cluster_log_types: %s", err)
 	}
 	d.Set("endpoint", cluster.Endpoint)
 	if err := d.Set("identity", flattenIdentity(cluster.Identity)); err != nil {
-		return diag.Errorf("setting identity: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting identity: %s", err)
 	}
 	if err := d.Set("kubernetes_network_config", flattenKubernetesNetworkConfigResponse(cluster.KubernetesNetworkConfig)); err != nil {
-		return diag.Errorf("setting kubernetes_network_config: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting kubernetes_network_config: %s", err)
 	}
 	d.Set("name", cluster.Name)
 	if err := d.Set("outpost_config", flattenOutpostConfigResponse(cluster.OutpostConfig)); err != nil {
-		return diag.Errorf("setting outpost_config: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting outpost_config: %s", err)
 	}
 	d.Set("platform_version", cluster.PlatformVersion)
 	d.Set("role_arn", cluster.RoleArn)
 	d.Set("status", cluster.Status)
 	d.Set("version", cluster.Version)
 	if err := d.Set("vpc_config", flattenVPCConfigResponse(cluster.ResourcesVpcConfig)); err != nil {
-		return diag.Errorf("setting vpc_config: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting vpc_config: %s", err)
 	}
 
 	if err := d.Set("tags", KeyValueTags(ctx, cluster.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/eks/node_group_data_source.go
+++ b/internal/service/eks/node_group_data_source.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 )
 
@@ -183,6 +184,8 @@ func dataSourceNodeGroup() *schema.Resource {
 }
 
 func dataSourceNodeGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).EKSClient(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
@@ -192,7 +195,7 @@ func dataSourceNodeGroupRead(ctx context.Context, d *schema.ResourceData, meta i
 	nodeGroup, err := findNodegroupByTwoPartKey(ctx, conn, clusterName, nodeGroupName)
 
 	if err != nil {
-		return diag.Errorf("reading EKS Node Group (%s): %s", id, err)
+		return sdkdiag.AppendErrorf(diags, "reading EKS Node Group (%s): %s", id, err)
 	}
 
 	d.SetId(id)
@@ -204,20 +207,20 @@ func dataSourceNodeGroupRead(ctx context.Context, d *schema.ResourceData, meta i
 	d.Set("instance_types", nodeGroup.InstanceTypes)
 	d.Set("labels", nodeGroup.Labels)
 	if err := d.Set("launch_template", flattenLaunchTemplateSpecification(nodeGroup.LaunchTemplate)); err != nil {
-		return diag.Errorf("setting launch_template: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting launch_template: %s", err)
 	}
 	d.Set("node_group_name", nodeGroup.NodegroupName)
 	d.Set("node_role_arn", nodeGroup.NodeRole)
 	d.Set("release_version", nodeGroup.ReleaseVersion)
 	if err := d.Set("remote_access", flattenRemoteAccessConfig(nodeGroup.RemoteAccess)); err != nil {
-		return diag.Errorf("setting remote_access: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting remote_access: %s", err)
 	}
 	if err := d.Set("resources", flattenNodeGroupResources(nodeGroup.Resources)); err != nil {
-		return diag.Errorf("setting resources: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting resources: %s", err)
 	}
 	if nodeGroup.ScalingConfig != nil {
 		if err := d.Set("scaling_config", []interface{}{flattenNodeGroupScalingConfig(nodeGroup.ScalingConfig)}); err != nil {
-			return diag.Errorf("setting scaling_config: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting scaling_config: %s", err)
 		}
 	} else {
 		d.Set("scaling_config", nil)
@@ -225,13 +228,13 @@ func dataSourceNodeGroupRead(ctx context.Context, d *schema.ResourceData, meta i
 	d.Set("status", nodeGroup.Status)
 	d.Set("subnet_ids", nodeGroup.Subnets)
 	if err := d.Set("taints", flattenTaints(nodeGroup.Taints)); err != nil {
-		return diag.Errorf("setting taints: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting taints: %s", err)
 	}
 	d.Set("version", nodeGroup.Version)
 
 	if err := d.Set("tags", KeyValueTags(ctx, nodeGroup.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/elasticache/global_replication_group.go
+++ b/internal/service/elasticache/global_replication_group.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"golang.org/x/exp/slices"
 )
@@ -272,6 +273,8 @@ func paramGroupNameRequiresMajorVersionUpgrade(diff changeDiffer) error {
 }
 
 func resourceGlobalReplicationGroupCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ElastiCacheConn(ctx)
 
 	id := d.Get("global_replication_group_id_suffix").(string)
@@ -286,18 +289,18 @@ func resourceGlobalReplicationGroupCreate(ctx context.Context, d *schema.Resourc
 
 	output, err := conn.CreateGlobalReplicationGroupWithContext(ctx, input)
 	if err != nil {
-		return diag.Errorf("creating ElastiCache Global Replication Group (%s): %s", id, err)
+		return sdkdiag.AppendErrorf(diags, "creating ElastiCache Global Replication Group (%s): %s", id, err)
 	}
 
 	if output == nil || output.GlobalReplicationGroup == nil {
-		return diag.Errorf("creating ElastiCache Global Replication Group (%s): empty result", id)
+		return sdkdiag.AppendErrorf(diags, "creating ElastiCache Global Replication Group (%s): empty result", id)
 	}
 
 	d.SetId(aws.StringValue(output.GlobalReplicationGroup.GlobalReplicationGroupId))
 
 	globalReplicationGroup, err := waitGlobalReplicationGroupAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate))
 	if err != nil {
-		return diag.Errorf("waiting for ElastiCache Global Replication Group (%s) creation: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for ElastiCache Global Replication Group (%s) creation: %s", d.Id(), err)
 	}
 
 	if v, ok := d.GetOk("automatic_failover_enabled"); ok {
@@ -305,7 +308,7 @@ func resourceGlobalReplicationGroupCreate(ctx context.Context, d *schema.Resourc
 			log.Printf("[DEBUG] Not updating ElastiCache Global Replication Group (%s) automatic failover: no change from %t", d.Id(), v)
 		} else {
 			if err := updateGlobalReplicationGroup(ctx, conn, d.Id(), globalReplicationAutomaticFailoverUpdater(v), d.Timeout(schema.TimeoutCreate)); err != nil {
-				return diag.Errorf("updating ElastiCache Global Replication Group (%s) automatic failover on creation: %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "updating ElastiCache Global Replication Group (%s) automatic failover on creation: %s", d.Id(), err)
 			}
 		}
 	}
@@ -315,7 +318,7 @@ func resourceGlobalReplicationGroupCreate(ctx context.Context, d *schema.Resourc
 			log.Printf("[DEBUG] Not updating ElastiCache Global Replication Group (%s) node type: no change from %q", d.Id(), v)
 		} else {
 			if err := updateGlobalReplicationGroup(ctx, conn, d.Id(), globalReplicationGroupNodeTypeUpdater(v.(string)), d.Timeout(schema.TimeoutCreate)); err != nil {
-				return diag.Errorf("updating ElastiCache Global Replication Group (%s) node type on creation: %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "updating ElastiCache Global Replication Group (%s) node type on creation: %s", d.Id(), err)
 			}
 		}
 	}
@@ -325,13 +328,13 @@ func resourceGlobalReplicationGroupCreate(ctx context.Context, d *schema.Resourc
 
 		engineVersion, err := gversion.NewVersion(aws.StringValue(globalReplicationGroup.EngineVersion))
 		if err != nil {
-			return diag.Errorf("updating ElastiCache Global Replication Group (%s) engine version on creation: error reading engine version: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating ElastiCache Global Replication Group (%s) engine version on creation: error reading engine version: %s", d.Id(), err)
 		}
 
 		diff := diffVersion(requestedVersion, engineVersion)
 
 		if diff[0] == -1 || diff[1] == -1 { // Ignore patch version downgrade
-			return diag.Errorf("updating ElastiCache Global Replication Group (%s) engine version on creation: cannot downgrade version when creating, is %s, want %s", d.Id(), engineVersion.String(), requestedVersion.String())
+			return sdkdiag.AppendErrorf(diags, "updating ElastiCache Global Replication Group (%s) engine version on creation: cannot downgrade version when creating, is %s, want %s", d.Id(), engineVersion.String(), requestedVersion.String())
 		}
 
 		p := d.Get("parameter_group_name").(string)
@@ -339,16 +342,16 @@ func resourceGlobalReplicationGroupCreate(ctx context.Context, d *schema.Resourc
 		if diff[0] == 1 {
 			err := updateGlobalReplicationGroup(ctx, conn, d.Id(), globalReplicationGroupEngineVersionMajorUpdater(v.(string), p), d.Timeout(schema.TimeoutCreate))
 			if err != nil {
-				return diag.Errorf("updating ElastiCache Global Replication Group (%s) engine version on creation: %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "updating ElastiCache Global Replication Group (%s) engine version on creation: %s", d.Id(), err)
 			}
 		} else if diff[1] == 1 {
 			if p != "" {
-				return diag.Errorf("cannot change parameter group name on minor engine version upgrade, upgrading from %s to %s", engineVersion.String(), requestedVersion.String())
+				return sdkdiag.AppendErrorf(diags, "cannot change parameter group name on minor engine version upgrade, upgrading from %s to %s", engineVersion.String(), requestedVersion.String())
 			}
 			if t, _ := regexp.MatchString(`[6-9]\.x`, v.(string)); !t {
 				err := updateGlobalReplicationGroup(ctx, conn, d.Id(), globalReplicationGroupEngineVersionMinorUpdater(v.(string)), d.Timeout(schema.TimeoutCreate))
 				if err != nil {
-					return diag.Errorf("updating ElastiCache Global Replication Group (%s) engine version on creation: %s", d.Id(), err)
+					return sdkdiag.AppendErrorf(diags, "updating ElastiCache Global Replication Group (%s) engine version on creation: %s", d.Id(), err)
 				}
 			}
 		}
@@ -362,7 +365,7 @@ func resourceGlobalReplicationGroupCreate(ctx context.Context, d *schema.Resourc
 			if requested > current {
 				err := globalReplcationGroupNodeGroupIncrease(ctx, conn, d.Id(), requested)
 				if err != nil {
-					return diag.Errorf("updating ElastiCache Global Replication Group (%s) node groups on creation: %s", d.Id(), err)
+					return sdkdiag.AppendErrorf(diags, "updating ElastiCache Global Replication Group (%s) node groups on creation: %s", d.Id(), err)
 				}
 			} else if requested < current {
 				var ids []string
@@ -371,36 +374,38 @@ func resourceGlobalReplicationGroupCreate(ctx context.Context, d *schema.Resourc
 				}
 				err := globalReplicationGroupNodeGroupDecrease(ctx, conn, d.Id(), requested, ids)
 				if err != nil {
-					return diag.Errorf("updating ElastiCache Global Replication Group (%s) node groups on creation: %s", d.Id(), err)
+					return sdkdiag.AppendErrorf(diags, "updating ElastiCache Global Replication Group (%s) node groups on creation: %s", d.Id(), err)
 				}
 			}
 
 			if _, err := waitGlobalReplicationGroupAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-				return diag.Errorf("updating ElastiCache Global Replication Group (%s) node groups on creation: waiting for completion: %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "updating ElastiCache Global Replication Group (%s) node groups on creation: waiting for completion: %s", d.Id(), err)
 			}
 		}
 	}
 
-	return resourceGlobalReplicationGroupRead(ctx, d, meta)
+	return append(diags, resourceGlobalReplicationGroupRead(ctx, d, meta)...)
 }
 
 func resourceGlobalReplicationGroupRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ElastiCacheConn(ctx)
 
 	globalReplicationGroup, err := FindGlobalReplicationGroupByID(ctx, conn, d.Id())
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] ElastiCache Global Replication Group (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 	if err != nil {
-		return diag.Errorf("reading ElastiCache Replication Group (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading ElastiCache Replication Group (%s): %s", d.Id(), err)
 	}
 
 	if !d.IsNewResource() && (aws.StringValue(globalReplicationGroup.Status) == "deleting" || aws.StringValue(globalReplicationGroup.Status) == "deleted") {
 		log.Printf("[WARN] ElastiCache Global Replication Group (%s) in deleted state (%s), removing from state", d.Id(), aws.StringValue(globalReplicationGroup.Status))
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	d.Set("arn", globalReplicationGroup.ARN)
@@ -414,35 +419,37 @@ func resourceGlobalReplicationGroupRead(ctx context.Context, d *schema.ResourceD
 	d.Set("transit_encryption_enabled", globalReplicationGroup.TransitEncryptionEnabled)
 
 	if err := setEngineVersionRedis(d, globalReplicationGroup.EngineVersion); err != nil {
-		return diag.Errorf("reading ElastiCache Replication Group (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading ElastiCache Replication Group (%s): %s", d.Id(), err)
 	}
 
 	if err := d.Set("global_node_groups", flattenGlobalNodeGroups(globalReplicationGroup.GlobalNodeGroups)); err != nil {
-		return diag.Errorf("setting global_node_groups: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting global_node_groups: %s", err)
 	}
 	d.Set("num_node_groups", len(globalReplicationGroup.GlobalNodeGroups))
 	d.Set("automatic_failover_enabled", flattenGlobalReplicationGroupAutomaticFailoverEnabled(globalReplicationGroup.Members))
 
 	d.Set("primary_replication_group_id", flattenGlobalReplicationGroupPrimaryGroupID(globalReplicationGroup.Members))
 
-	return nil
+	return diags
 }
 
 type globalReplicationGroupUpdater func(input *elasticache.ModifyGlobalReplicationGroupInput)
 
 func resourceGlobalReplicationGroupUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ElastiCacheConn(ctx)
 
 	// Only one field can be changed per request
 	if d.HasChange("cache_node_type") {
 		if err := updateGlobalReplicationGroup(ctx, conn, d.Id(), globalReplicationGroupNodeTypeUpdater(d.Get("cache_node_type").(string)), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return diag.Errorf("updating ElastiCache Global Replication Group (%s) node type: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating ElastiCache Global Replication Group (%s) node type: %s", d.Id(), err)
 		}
 	}
 
 	if d.HasChange("automatic_failover_enabled") {
 		if err := updateGlobalReplicationGroup(ctx, conn, d.Id(), globalReplicationAutomaticFailoverUpdater(d.Get("automatic_failover_enabled").(bool)), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return diag.Errorf("updating ElastiCache Global Replication Group (%s) automatic failover: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating ElastiCache Global Replication Group (%s) automatic failover: %s", d.Id(), err)
 		}
 	}
 
@@ -457,19 +464,19 @@ func resourceGlobalReplicationGroupUpdate(ctx context.Context, d *schema.Resourc
 			p := d.Get("parameter_group_name").(string)
 			err := updateGlobalReplicationGroup(ctx, conn, d.Id(), globalReplicationGroupEngineVersionMajorUpdater(n.(string), p), d.Timeout(schema.TimeoutUpdate))
 			if err != nil {
-				return diag.Errorf("updating ElastiCache Global Replication Group (%s): %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "updating ElastiCache Global Replication Group (%s): %s", d.Id(), err)
 			}
 		} else if diff[1] == 1 {
 			err := updateGlobalReplicationGroup(ctx, conn, d.Id(), globalReplicationGroupEngineVersionMinorUpdater(n.(string)), d.Timeout(schema.TimeoutUpdate))
 			if err != nil {
-				return diag.Errorf("updating ElastiCache Global Replication Group (%s): %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "updating ElastiCache Global Replication Group (%s): %s", d.Id(), err)
 			}
 		}
 	}
 
 	if d.HasChange("global_replication_group_description") {
 		if err := updateGlobalReplicationGroup(ctx, conn, d.Id(), globalReplicationGroupDescriptionUpdater(d.Get("global_replication_group_description").(string)), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return diag.Errorf("updating ElastiCache Global Replication Group (%s) description: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating ElastiCache Global Replication Group (%s) description: %s", d.Id(), err)
 		}
 	}
 
@@ -482,7 +489,7 @@ func resourceGlobalReplicationGroupUpdate(ctx context.Context, d *schema.Resourc
 			if requested > current {
 				err := globalReplcationGroupNodeGroupIncrease(ctx, conn, d.Id(), requested)
 				if err != nil {
-					return diag.Errorf("updating ElastiCache Global Replication Group (%s) node groups: %s", d.Id(), err)
+					return sdkdiag.AppendErrorf(diags, "updating ElastiCache Global Replication Group (%s) node groups: %s", d.Id(), err)
 				}
 			} else if requested < current {
 				var ids []string
@@ -492,17 +499,17 @@ func resourceGlobalReplicationGroupUpdate(ctx context.Context, d *schema.Resourc
 				}
 				err := globalReplicationGroupNodeGroupDecrease(ctx, conn, d.Id(), requested, ids)
 				if err != nil {
-					return diag.Errorf("updating ElastiCache Global Replication Group (%s) node groups: %s", d.Id(), err)
+					return sdkdiag.AppendErrorf(diags, "updating ElastiCache Global Replication Group (%s) node groups: %s", d.Id(), err)
 				}
 			}
 
 			if _, err := waitGlobalReplicationGroupAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-				return diag.Errorf("updating ElastiCache Global Replication Group (%s) node groups: waiting for completion: %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "updating ElastiCache Global Replication Group (%s) node groups: waiting for completion: %s", d.Id(), err)
 			}
 		}
 	}
 
-	return resourceGlobalReplicationGroupRead(ctx, d, meta)
+	return append(diags, resourceGlobalReplicationGroupRead(ctx, d, meta)...)
 }
 
 func globalReplicationGroupDescriptionUpdater(description string) globalReplicationGroupUpdater {
@@ -555,15 +562,17 @@ func updateGlobalReplicationGroup(ctx context.Context, conn *elasticache.ElastiC
 }
 
 func resourceGlobalReplicationGroupDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ElastiCacheConn(ctx)
 
 	// Using Update timeout because the Global Replication Group could be in the middle of an update operation
 	err := deleteGlobalReplicationGroup(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate), d.Timeout(schema.TimeoutDelete))
 	if err != nil {
-		return diag.Errorf("deleting ElastiCache Global Replication Group: %s", err)
+		return sdkdiag.AppendErrorf(diags, "deleting ElastiCache Global Replication Group: %s", err)
 	}
 
-	return nil
+	return diags
 }
 
 func deleteGlobalReplicationGroup(ctx context.Context, conn *elasticache.ElastiCache, id string, readyTimeout, deleteTimeout time.Duration) error {

--- a/internal/service/elasticbeanstalk/application.go
+++ b/internal/service/elasticbeanstalk/application.go
@@ -135,7 +135,7 @@ func resourceApplicationRead(ctx context.Context, d *schema.ResourceData, meta i
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Elastic Beanstalk Application (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {

--- a/internal/service/elasticbeanstalk/environment.go
+++ b/internal/service/elasticbeanstalk/environment.go
@@ -314,7 +314,7 @@ func resourceEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta i
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Elastic Beanstalk Environment (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
@@ -595,7 +595,7 @@ func resourceEnvironmentDelete(ctx context.Context, d *schema.ResourceData, meta
 	})
 
 	if tfawserr.ErrMessageContains(err, "InvalidParameterValue", "No Environment found") {
-		return nil
+		return diags
 	}
 
 	if err != nil {

--- a/internal/service/elasticsearch/vpc_endpoint.go
+++ b/internal/service/elasticsearch/vpc_endpoint.go
@@ -128,7 +128,7 @@ func resourceVPCEndpointRead(ctx context.Context, d *schema.ResourceData, meta i
 	d.Set("endpoint", endpoint.Endpoint)
 	if endpoint.VpcOptions != nil {
 		if err := d.Set("vpc_options", []interface{}{flattenVPCDerivedInfo(endpoint.VpcOptions)}); err != nil {
-			return diag.Errorf("setting vpc_options: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting vpc_options: %s", err)
 		}
 	} else {
 		d.Set("vpc_options", nil)

--- a/internal/service/elbv2/listener_certificate.go
+++ b/internal/service/elbv2/listener_certificate.go
@@ -91,7 +91,7 @@ func resourceListenerCertificateCreate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if err != nil {
-		return create.DiagError(names.ELBV2, create.ErrActionCreating, ResNameListenerCertificate, d.Id(), err)
+		return create.AppendDiagError(diags, names.ELBV2, create.ErrActionCreating, ResNameListenerCertificate, d.Id(), err)
 	}
 
 	d.SetId(listenerCertificateCreateID(listenerArn, certificateArn))
@@ -105,7 +105,7 @@ func resourceListenerCertificateRead(ctx context.Context, d *schema.ResourceData
 
 	listenerArn, certificateArn, err := listenerCertificateParseID(d.Id())
 	if err != nil {
-		return create.DiagError(names.ELBV2, create.ErrActionReading, ResNameListenerCertificate, d.Id(), err)
+		return create.AppendDiagError(diags, names.ELBV2, create.ErrActionReading, ResNameListenerCertificate, d.Id(), err)
 	}
 
 	log.Printf("[DEBUG] Reading certificate: %s of listener: %s", certificateArn, listenerArn)
@@ -130,11 +130,11 @@ func resourceListenerCertificateRead(ctx context.Context, d *schema.ResourceData
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		create.LogNotFoundRemoveState(names.ELBV2, create.ErrActionReading, ResNameListenerCertificate, d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.ELBV2, create.ErrActionReading, ResNameListenerCertificate, d.Id(), err)
+		return create.AppendDiagError(diags, names.ELBV2, create.ErrActionReading, ResNameListenerCertificate, d.Id(), err)
 	}
 
 	d.Set("certificate_arn", certificateArn)
@@ -168,7 +168,7 @@ func resourceListenerCertificateDelete(ctx context.Context, d *schema.ResourceDa
 			return diags
 		}
 
-		return create.DiagError(names.ELBV2, create.ErrActionDeleting, ResNameListenerCertificate, d.Id(), err)
+		return create.AppendDiagError(diags, names.ELBV2, create.ErrActionDeleting, ResNameListenerCertificate, d.Id(), err)
 	}
 
 	return diags

--- a/internal/service/elbv2/load_balancers_data_source.go
+++ b/internal/service/elbv2/load_balancers_data_source.go
@@ -37,13 +37,15 @@ const (
 )
 
 func dataSourceLoadBalancersRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).ELBV2Conn(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	results, err := FindLoadBalancers(ctx, conn, &elbv2.DescribeLoadBalancersInput{})
 
 	if err != nil {
-		return create.DiagError(names.ELBV2, create.ErrActionReading, DSNameLoadBalancers, "", err)
+		return create.AppendDiagError(diags, names.ELBV2, create.ErrActionReading, DSNameLoadBalancers, "", err)
 	}
 
 	tagsToMatch := tftags.New(ctx, d.Get("tags").(map[string]interface{})).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
@@ -59,7 +61,7 @@ func dataSourceLoadBalancersRead(ctx context.Context, d *schema.ResourceData, me
 			}
 
 			if err != nil {
-				return create.DiagError(names.ELBV2, "listing tags", DSNameLoadBalancers, arn, err)
+				return create.AppendDiagError(diags, names.ELBV2, "listing tags", DSNameLoadBalancers, arn, err)
 			}
 			if !tags.ContainsAll(tagsToMatch) {
 				continue
@@ -79,5 +81,5 @@ func dataSourceLoadBalancersRead(ctx context.Context, d *schema.ResourceData, me
 	d.SetId(meta.(*conns.AWSClient).Region)
 	d.Set("arns", loadBalancerARNs)
 
-	return nil
+	return diags
 }

--- a/internal/service/emr/block_public_access_configuration.go
+++ b/internal/service/emr/block_public_access_configuration.go
@@ -64,6 +64,8 @@ const (
 )
 
 func resourceBlockPublicAccessConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).EMRConn(ctx)
 
 	blockPublicAccessConfiguration := &emr.BlockPublicAccessConfiguration{}
@@ -80,31 +82,35 @@ func resourceBlockPublicAccessConfigurationCreate(ctx context.Context, d *schema
 
 	_, err := conn.PutBlockPublicAccessConfigurationWithContext(ctx, in)
 	if err != nil {
-		return create.DiagError(names.EMR, create.ErrActionCreating, ResNameBlockPublicAccessConfiguration, d.Id(), err)
+		return create.AppendDiagError(diags, names.EMR, create.ErrActionCreating, ResNameBlockPublicAccessConfiguration, d.Id(), err)
 	}
 	d.SetId(dummyIDBlockPublicAccessConfiguration)
 
-	return resourceBlockPublicAccessConfigurationRead(ctx, d, meta)
+	return append(diags, resourceBlockPublicAccessConfigurationRead(ctx, d, meta)...)
 }
 
 func resourceBlockPublicAccessConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).EMRConn(ctx)
 
 	out, err := FindBlockPublicAccessConfiguration(ctx, conn)
 
 	if err != nil {
-		return create.DiagError(names.EMR, create.ErrActionReading, ResNameBlockPublicAccessConfiguration, d.Id(), err)
+		return create.AppendDiagError(diags, names.EMR, create.ErrActionReading, ResNameBlockPublicAccessConfiguration, d.Id(), err)
 	}
 
 	d.Set("block_public_security_group_rules", out.BlockPublicAccessConfiguration.BlockPublicSecurityGroupRules)
 	if err := d.Set("permitted_public_security_group_rule_range", flattenPermittedPublicSecurityGroupRuleRanges(out.BlockPublicAccessConfiguration.PermittedPublicSecurityGroupRuleRanges)); err != nil {
-		return create.DiagError(names.EMR, create.ErrActionSetting, ResNameBlockPublicAccessConfiguration, d.Id(), err)
+		return create.AppendDiagError(diags, names.EMR, create.ErrActionSetting, ResNameBlockPublicAccessConfiguration, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceBlockPublicAccessConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).EMRConn(ctx)
 
 	log.Print("[INFO] Restoring EMR Block Public Access Configuration to default settings")
@@ -116,10 +122,10 @@ func resourceBlockPublicAccessConfigurationDelete(ctx context.Context, d *schema
 
 	_, err := conn.PutBlockPublicAccessConfigurationWithContext(ctx, in)
 	if err != nil {
-		return create.DiagError(names.EMR, create.ErrActionDeleting, ResNameBlockPublicAccessConfiguration, d.Id(), err)
+		return create.AppendDiagError(diags, names.EMR, create.ErrActionDeleting, ResNameBlockPublicAccessConfiguration, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func findDefaultBlockPublicAccessConfiguration() *emr.BlockPublicAccessConfiguration {

--- a/internal/service/emr/release_labels_data_source.go
+++ b/internal/service/emr/release_labels_data_source.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 )
 
 // @SDKDataSource("aws_emr_release_labels")
@@ -47,6 +48,8 @@ func DataSourceReleaseLabels() *schema.Resource {
 }
 
 func dataSourceReleaseLabelsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).EMRConn(ctx)
 
 	input := &emr.ListReleaseLabelsInput{}
@@ -58,7 +61,7 @@ func dataSourceReleaseLabelsRead(ctx context.Context, d *schema.ResourceData, me
 	output, err := findReleaseLabels(ctx, conn, input)
 
 	if err != nil {
-		return diag.Errorf("reading EMR Release Labels: %s", err)
+		return sdkdiag.AppendErrorf(diags, "reading EMR Release Labels: %s", err)
 	}
 
 	releaseLabels := aws.StringValueSlice(output)
@@ -70,7 +73,7 @@ func dataSourceReleaseLabelsRead(ctx context.Context, d *schema.ResourceData, me
 	}
 	d.Set("release_labels", releaseLabels)
 
-	return nil
+	return diags
 }
 
 func expandReleaseLabelsFilters(filters []interface{}) *emr.ReleaseLabelFilter {

--- a/internal/service/emrcontainers/virtual_cluster_data_source.go
+++ b/internal/service/emrcontainers/virtual_cluster_data_source.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 )
 
@@ -81,6 +82,8 @@ func DataSourceVirtualCluster() *schema.Resource {
 }
 
 func dataSourceVirtualClusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).EMRContainersConn(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
@@ -88,14 +91,14 @@ func dataSourceVirtualClusterRead(ctx context.Context, d *schema.ResourceData, m
 	vc, err := FindVirtualClusterByID(ctx, conn, id)
 
 	if err != nil {
-		return diag.Errorf("reading EMR Containers Virtual Cluster (%s): %s", id, err)
+		return sdkdiag.AppendErrorf(diags, "reading EMR Containers Virtual Cluster (%s): %s", id, err)
 	}
 
 	d.SetId(aws.StringValue(vc.Id))
 	d.Set("arn", vc.Arn)
 	if vc.ContainerProvider != nil {
 		if err := d.Set("container_provider", []interface{}{flattenContainerProvider(vc.ContainerProvider)}); err != nil {
-			return diag.Errorf("setting container_provider: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting container_provider: %s", err)
 		}
 	} else {
 		d.Set("container_provider", nil)
@@ -106,8 +109,8 @@ func dataSourceVirtualClusterRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set("virtual_cluster_id", vc.Id)
 
 	if err := d.Set("tags", KeyValueTags(ctx, vc.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/events/endpoint.go
+++ b/internal/service/events/endpoint.go
@@ -193,7 +193,7 @@ func resourceEndpointRead(ctx context.Context, d *schema.ResourceData, meta inte
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] EventBridge Global Endpoint (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {

--- a/internal/service/finspace/kx_cluster.go
+++ b/internal/service/finspace/kx_cluster.go
@@ -370,7 +370,7 @@ func resourceKxClusterCreate(ctx context.Context, d *schema.ResourceData, meta i
 	}
 	rID, err := flex.FlattenResourceId(idParts, kxClusterIDPartCount, false)
 	if err != nil {
-		return append(diags, create.DiagError(names.FinSpace, create.ErrActionFlatteningResourceId, ResNameKxCluster, d.Get("name").(string), err)...)
+		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionFlatteningResourceId, ResNameKxCluster, d.Get("name").(string), err)
 	}
 	d.SetId(rID)
 
@@ -431,15 +431,15 @@ func resourceKxClusterCreate(ctx context.Context, d *schema.ResourceData, meta i
 
 	out, err := conn.CreateKxCluster(ctx, in)
 	if err != nil {
-		return append(diags, create.DiagError(names.FinSpace, create.ErrActionCreating, ResNameKxCluster, d.Get("name").(string), err)...)
+		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionCreating, ResNameKxCluster, d.Get("name").(string), err)
 	}
 
 	if out == nil {
-		return append(diags, create.DiagError(names.FinSpace, create.ErrActionCreating, ResNameKxCluster, d.Get("name").(string), errors.New("empty output"))...)
+		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionCreating, ResNameKxCluster, d.Get("name").(string), errors.New("empty output"))
 	}
 
 	if _, err := waitKxClusterCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return append(diags, create.DiagError(names.FinSpace, create.ErrActionWaitingForCreation, ResNameKxCluster, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionWaitingForCreation, ResNameKxCluster, d.Id(), err)
 	}
 
 	return append(diags, resourceKxClusterRead(ctx, d, meta)...)
@@ -457,7 +457,7 @@ func resourceKxClusterRead(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	if err != nil {
-		return append(diags, create.DiagError(names.FinSpace, create.ErrActionReading, ResNameKxCluster, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionReading, ResNameKxCluster, d.Id(), err)
 	}
 
 	d.Set("status", out.Status)
@@ -474,47 +474,47 @@ func resourceKxClusterRead(ctx context.Context, d *schema.ResourceData, meta int
 	d.Set("initialization_script", out.InitializationScript)
 
 	if err := d.Set("capacity_configuration", flattenCapacityConfiguration(out.CapacityConfiguration)); err != nil {
-		return append(diags, create.DiagError(names.FinSpace, create.ErrActionSetting, ResNameKxCluster, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionSetting, ResNameKxCluster, d.Id(), err)
 	}
 
 	if err := d.Set("vpc_configuration", flattenVPCConfiguration(out.VpcConfiguration)); err != nil {
-		return append(diags, create.DiagError(names.FinSpace, create.ErrActionSetting, ResNameKxCluster, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionSetting, ResNameKxCluster, d.Id(), err)
 	}
 
 	if err := d.Set("code", flattenCode(out.Code)); err != nil {
-		return append(diags, create.DiagError(names.FinSpace, create.ErrActionSetting, ResNameKxCluster, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionSetting, ResNameKxCluster, d.Id(), err)
 	}
 
 	if err := d.Set("auto_scaling_configuration", flattenAutoScalingConfiguration(out.AutoScalingConfiguration)); err != nil {
-		return append(diags, create.DiagError(names.FinSpace, create.ErrActionSetting, ResNameKxCluster, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionSetting, ResNameKxCluster, d.Id(), err)
 	}
 
 	if err := d.Set("savedown_storage_configuration", flattenSavedownStorageConfiguration(
 		out.SavedownStorageConfiguration)); err != nil {
-		return append(diags, create.DiagError(names.FinSpace, create.ErrActionSetting, ResNameKxCluster, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionSetting, ResNameKxCluster, d.Id(), err)
 	}
 
 	if err := d.Set("cache_storage_configurations", flattenCacheStorageConfigurations(
 		out.CacheStorageConfigurations)); err != nil {
-		return append(diags, create.DiagError(names.FinSpace, create.ErrActionSetting, ResNameKxCluster, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionSetting, ResNameKxCluster, d.Id(), err)
 	}
 
 	if err := d.Set("database", flattenDatabases(out.Databases)); err != nil {
-		return append(diags, create.DiagError(names.FinSpace, create.ErrActionSetting, ResNameKxCluster, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionSetting, ResNameKxCluster, d.Id(), err)
 	}
 
 	if err := d.Set("command_line_arguments", flattenCommandLineArguments(out.CommandLineArguments)); err != nil {
-		return append(diags, create.DiagError(names.FinSpace, create.ErrActionSetting, ResNameKxCluster, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionSetting, ResNameKxCluster, d.Id(), err)
 	}
 
 	// compose cluster ARN using environment ARN
 	parts, err := flex.ExpandResourceId(d.Id(), kxUserIDPartCount, false)
 	if err != nil {
-		return append(diags, create.DiagError(names.FinSpace, create.ErrActionSetting, ResNameKxCluster, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionSetting, ResNameKxCluster, d.Id(), err)
 	}
 	env, err := findKxEnvironmentByID(ctx, conn, parts[0])
 	if err != nil {
-		return append(diags, create.DiagError(names.FinSpace, create.ErrActionSetting, ResNameKxCluster, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionSetting, ResNameKxCluster, d.Id(), err)
 	}
 	arn := fmt.Sprintf("%s/kxCluster/%s", aws.ToString(env.EnvironmentArn), aws.ToString(out.ClusterName))
 	d.Set("arn", arn)
@@ -565,20 +565,20 @@ func resourceKxClusterUpdate(ctx context.Context, d *schema.ResourceData, meta i
 	if updateDb {
 		log.Printf("[DEBUG] Updating FinSpace KxClusterDatabases (%s): %#v", d.Id(), DatabaseConfigIn)
 		if _, err := conn.UpdateKxClusterDatabases(ctx, DatabaseConfigIn); err != nil {
-			return append(diags, create.DiagError(names.FinSpace, create.ErrActionUpdating, ResNameKxCluster, d.Id(), err)...)
+			return create.AppendDiagError(diags, names.FinSpace, create.ErrActionUpdating, ResNameKxCluster, d.Id(), err)
 		}
 		if _, err := waitKxClusterUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return append(diags, create.DiagError(names.FinSpace, create.ErrActionUpdating, ResNameKxCluster, d.Id(), err)...)
+			return create.AppendDiagError(diags, names.FinSpace, create.ErrActionUpdating, ResNameKxCluster, d.Id(), err)
 		}
 	}
 
 	if updateCode {
 		log.Printf("[DEBUG] Updating FinSpace KxClusterCodeConfiguration (%s): %#v", d.Id(), CodeConfigIn)
 		if _, err := conn.UpdateKxClusterCodeConfiguration(ctx, CodeConfigIn); err != nil {
-			return append(diags, create.DiagError(names.FinSpace, create.ErrActionUpdating, ResNameKxCluster, d.Id(), err)...)
+			return create.AppendDiagError(diags, names.FinSpace, create.ErrActionUpdating, ResNameKxCluster, d.Id(), err)
 		}
 		if _, err := waitKxClusterUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return append(diags, create.DiagError(names.FinSpace, create.ErrActionUpdating, ResNameKxCluster, d.Id(), err)...)
+			return create.AppendDiagError(diags, names.FinSpace, create.ErrActionUpdating, ResNameKxCluster, d.Id(), err)
 		}
 	}
 
@@ -603,12 +603,12 @@ func resourceKxClusterDelete(ctx context.Context, d *schema.ResourceData, meta i
 			return diags
 		}
 
-		return append(diags, create.DiagError(names.FinSpace, create.ErrActionDeleting, ResNameKxCluster, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionDeleting, ResNameKxCluster, d.Id(), err)
 	}
 
 	_, err = waitKxClusterDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete))
 	if err != nil && !tfresource.NotFound(err) {
-		return append(diags, create.DiagError(names.FinSpace, create.ErrActionWaitingForDeletion, ResNameKxCluster, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionWaitingForDeletion, ResNameKxCluster, d.Id(), err)
 	}
 
 	return diags

--- a/internal/service/finspace/kx_database.go
+++ b/internal/service/finspace/kx_database.go
@@ -106,11 +106,11 @@ func resourceKxDatabaseCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 	out, err := conn.CreateKxDatabase(ctx, in)
 	if err != nil {
-		return append(diags, create.DiagError(names.FinSpace, create.ErrActionCreating, ResNameKxDatabase, d.Get("name").(string), err)...)
+		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionCreating, ResNameKxDatabase, d.Get("name").(string), err)
 	}
 
 	if out == nil || out.DatabaseArn == nil {
-		return append(diags, create.DiagError(names.FinSpace, create.ErrActionCreating, ResNameKxDatabase, d.Get("name").(string), errors.New("empty output"))...)
+		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionCreating, ResNameKxDatabase, d.Get("name").(string), errors.New("empty output"))
 	}
 
 	idParts := []string{
@@ -119,7 +119,7 @@ func resourceKxDatabaseCreate(ctx context.Context, d *schema.ResourceData, meta 
 	}
 	id, err := flex.FlattenResourceId(idParts, kxDatabaseIDPartCount, false)
 	if err != nil {
-		return append(diags, create.DiagError(names.FinSpace, create.ErrActionFlatteningResourceId, ResNameKxDatabase, d.Get("name").(string), err)...)
+		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionFlatteningResourceId, ResNameKxDatabase, d.Get("name").(string), err)
 	}
 
 	d.SetId(id)
@@ -139,7 +139,7 @@ func resourceKxDatabaseRead(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	if err != nil {
-		return append(diags, create.DiagError(names.FinSpace, create.ErrActionReading, ResNameKxDatabase, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionReading, ResNameKxDatabase, d.Id(), err)
 	}
 
 	d.Set("arn", out.DatabaseArn)
@@ -165,7 +165,7 @@ func resourceKxDatabaseUpdate(ctx context.Context, d *schema.ResourceData, meta 
 
 		_, err := conn.UpdateKxDatabase(ctx, in)
 		if err != nil {
-			return append(diags, create.DiagError(names.FinSpace, create.ErrActionUpdating, ResNameKxDatabase, d.Id(), err)...)
+			return create.AppendDiagError(diags, names.FinSpace, create.ErrActionUpdating, ResNameKxDatabase, d.Id(), err)
 		}
 	}
 
@@ -189,7 +189,7 @@ func resourceKxDatabaseDelete(ctx context.Context, d *schema.ResourceData, meta 
 			return diags
 		}
 
-		return append(diags, create.DiagError(names.FinSpace, create.ErrActionDeleting, ResNameKxDatabase, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionDeleting, ResNameKxDatabase, d.Id(), err)
 	}
 
 	return diags

--- a/internal/service/finspace/kx_environment.go
+++ b/internal/service/finspace/kx_environment.go
@@ -225,27 +225,27 @@ func resourceKxEnvironmentCreate(ctx context.Context, d *schema.ResourceData, me
 
 	out, err := conn.CreateKxEnvironment(ctx, in)
 	if err != nil {
-		return append(diags, create.DiagError(names.FinSpace, create.ErrActionCreating, ResNameKxEnvironment, d.Get("name").(string), err)...)
+		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionCreating, ResNameKxEnvironment, d.Get("name").(string), err)
 	}
 
 	if out == nil || out.EnvironmentId == nil {
-		return append(diags, create.DiagError(names.FinSpace, create.ErrActionCreating, ResNameKxEnvironment, d.Get("name").(string), errors.New("empty output"))...)
+		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionCreating, ResNameKxEnvironment, d.Get("name").(string), errors.New("empty output"))
 	}
 
 	d.SetId(aws.ToString(out.EnvironmentId))
 
 	if _, err := waitKxEnvironmentCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return append(diags, create.DiagError(names.FinSpace, create.ErrActionWaitingForCreation, ResNameKxEnvironment, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionWaitingForCreation, ResNameKxEnvironment, d.Id(), err)
 	}
 
 	if err := updateKxEnvironmentNetwork(ctx, d, conn); err != nil {
-		return append(diags, create.DiagError(names.FinSpace, create.ErrActionCreating, ResNameKxEnvironment, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionCreating, ResNameKxEnvironment, d.Id(), err)
 	}
 
 	// The CreateKxEnvironment API currently fails to tag the environment when the
 	// Tags field is set. Until the API is fixed, tag after creation instead.
 	if err := createTags(ctx, conn, aws.ToString(out.EnvironmentArn), getTagsIn(ctx)); err != nil {
-		return append(diags, create.DiagError(names.FinSpace, create.ErrActionCreating, ResNameKxEnvironment, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionCreating, ResNameKxEnvironment, d.Id(), err)
 	}
 
 	return append(diags, resourceKxEnvironmentRead(ctx, d, meta)...)
@@ -264,7 +264,7 @@ func resourceKxEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if err != nil {
-		return append(diags, create.DiagError(names.FinSpace, create.ErrActionReading, ResNameKxEnvironment, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionReading, ResNameKxEnvironment, d.Id(), err)
 	}
 
 	d.Set("id", out.EnvironmentId)
@@ -279,11 +279,11 @@ func resourceKxEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set("last_modified_timestamp", out.UpdateTimestamp.String())
 
 	if err := d.Set("transit_gateway_configuration", flattenTransitGatewayConfiguration(out.TransitGatewayConfiguration)); err != nil {
-		return append(diags, create.DiagError(names.FinSpace, create.ErrActionSetting, ResNameKxEnvironment, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionSetting, ResNameKxEnvironment, d.Id(), err)
 	}
 
 	if err := d.Set("custom_dns_configuration", flattenCustomDNSConfigurations(out.CustomDNSConfiguration)); err != nil {
-		return append(diags, create.DiagError(names.FinSpace, create.ErrActionSetting, ResNameKxEnvironment, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionSetting, ResNameKxEnvironment, d.Id(), err)
 	}
 
 	return diags
@@ -309,14 +309,14 @@ func resourceKxEnvironmentUpdate(ctx context.Context, d *schema.ResourceData, me
 		log.Printf("[DEBUG] Updating FinSpace KxEnvironment (%s): %#v", d.Id(), in)
 		_, err := conn.UpdateKxEnvironment(ctx, in)
 		if err != nil {
-			return append(diags, create.DiagError(names.FinSpace, create.ErrActionUpdating, ResNameKxEnvironment, d.Id(), err)...)
+			return create.AppendDiagError(diags, names.FinSpace, create.ErrActionUpdating, ResNameKxEnvironment, d.Id(), err)
 		}
 	}
 
 	if d.HasChanges("transit_gateway_configuration") || d.HasChanges("custom_dns_configuration") {
 		update = true
 		if err := updateKxEnvironmentNetwork(ctx, d, conn); err != nil {
-			return append(diags, create.DiagError(names.FinSpace, create.ErrActionUpdating, ResNameKxEnvironment, d.Id(), err)...)
+			return create.AppendDiagError(diags, names.FinSpace, create.ErrActionUpdating, ResNameKxEnvironment, d.Id(), err)
 		}
 	}
 
@@ -342,11 +342,11 @@ func resourceKxEnvironmentDelete(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	if err != nil {
-		return append(diags, create.DiagError(names.FinSpace, create.ErrActionDeleting, ResNameKxEnvironment, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionDeleting, ResNameKxEnvironment, d.Id(), err)
 	}
 
 	if _, err := waitKxEnvironmentDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return append(diags, create.DiagError(names.FinSpace, create.ErrActionWaitingForDeletion, ResNameKxEnvironment, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionWaitingForDeletion, ResNameKxEnvironment, d.Id(), err)
 	}
 
 	return diags

--- a/internal/service/finspace/kx_user.go
+++ b/internal/service/finspace/kx_user.go
@@ -92,11 +92,11 @@ func resourceKxUserCreate(ctx context.Context, d *schema.ResourceData, meta inte
 
 	out, err := client.CreateKxUser(ctx, in)
 	if err != nil {
-		return append(diags, create.DiagError(names.FinSpace, create.ErrActionCreating, ResNameKxUser, d.Get("name").(string), err)...)
+		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionCreating, ResNameKxUser, d.Get("name").(string), err)
 	}
 
 	if out == nil {
-		return append(diags, create.DiagError(names.FinSpace, create.ErrActionCreating, ResNameKxUser, d.Get("name").(string), errors.New("empty output"))...)
+		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionCreating, ResNameKxUser, d.Get("name").(string), errors.New("empty output"))
 	}
 
 	idParts := []string{
@@ -105,7 +105,7 @@ func resourceKxUserCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 	id, err := flex.FlattenResourceId(idParts, kxUserIDPartCount, false)
 	if err != nil {
-		return append(diags, create.DiagError(names.FinSpace, create.ErrActionFlatteningResourceId, ResNameKxUser, d.Get("name").(string), err)...)
+		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionFlatteningResourceId, ResNameKxUser, d.Get("name").(string), err)
 	}
 	d.SetId(id)
 
@@ -124,7 +124,7 @@ func resourceKxUserRead(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	if err != nil {
-		return append(diags, create.DiagError(names.FinSpace, create.ErrActionReading, ResNameKxUser, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionReading, ResNameKxUser, d.Id(), err)
 	}
 
 	d.Set("arn", out.UserArn)
@@ -148,7 +148,7 @@ func resourceKxUserUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 
 		_, err := conn.UpdateKxUser(ctx, in)
 		if err != nil {
-			return append(diags, create.DiagError(names.FinSpace, create.ErrActionUpdating, ResNameKxUser, d.Id(), err)...)
+			return create.AppendDiagError(diags, names.FinSpace, create.ErrActionUpdating, ResNameKxUser, d.Id(), err)
 		}
 	}
 
@@ -169,10 +169,10 @@ func resourceKxUserDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	if err != nil {
 		var nfe *types.ResourceNotFoundException
 		if errors.As(err, &nfe) {
-			return nil
+			return diags
 		}
 
-		return append(diags, create.DiagError(names.FinSpace, create.ErrActionDeleting, ResNameKxUser, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionDeleting, ResNameKxUser, d.Id(), err)
 	}
 
 	return diags

--- a/internal/service/firehose/delivery_stream.go
+++ b/internal/service/firehose/delivery_stream.go
@@ -1297,7 +1297,7 @@ func resourceDeliveryStreamRead(ctx context.Context, d *schema.ResourceData, met
 		}
 		if v := v.MSKSourceDescription; v != nil {
 			if err := d.Set("msk_source_configuration", []interface{}{flattenMSKSourceDescription(v)}); err != nil {
-				return diag.Errorf("setting msk_source_configuration: %s", err)
+				return sdkdiag.AppendErrorf(diags, "setting msk_source_configuration: %s", err)
 			}
 		}
 	}

--- a/internal/service/fsx/ontap_volume.go
+++ b/internal/service/fsx/ontap_volume.go
@@ -383,7 +383,7 @@ func resourceONTAPVolumeRead(ctx context.Context, d *schema.ResourceData, meta i
 	d.Set("size_in_megabytes", ontapConfig.SizeInMegabytes)
 	if ontapConfig.SnaplockConfiguration != nil {
 		if err := d.Set("snaplock_configuration", []interface{}{flattenSnaplockConfiguration(ontapConfig.SnaplockConfiguration)}); err != nil {
-			return diag.Errorf("setting snaplock_configuration: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting snaplock_configuration: %s", err)
 		}
 	} else {
 		d.Set("snaplock_configuration", nil)
@@ -393,7 +393,7 @@ func resourceONTAPVolumeRead(ctx context.Context, d *schema.ResourceData, meta i
 	d.Set("storage_virtual_machine_id", ontapConfig.StorageVirtualMachineId)
 	if ontapConfig.TieringPolicy != nil {
 		if err := d.Set("tiering_policy", []interface{}{flattenTieringPolicy(ontapConfig.TieringPolicy)}); err != nil {
-			return diag.Errorf("setting tiering_policy: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting tiering_policy: %s", err)
 		}
 	} else {
 		d.Set("tiering_policy", nil)

--- a/internal/service/fsx/windows_file_system_data_source.go
+++ b/internal/service/fsx/windows_file_system_data_source.go
@@ -216,5 +216,5 @@ func dataSourceWindowsFileSystemRead(ctx context.Context, d *schema.ResourceData
 		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/globalaccelerator/custom_routing_accelerator.go
+++ b/internal/service/globalaccelerator/custom_routing_accelerator.go
@@ -294,7 +294,7 @@ func resourceCustomRoutingAcceleratorDelete(ctx context.Context, d *schema.Resou
 	_, err := conn.UpdateCustomRoutingAcceleratorWithContext(ctx, input)
 
 	if tfawserr.ErrCodeEquals(err, globalaccelerator.ErrCodeAcceleratorNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
@@ -311,7 +311,7 @@ func resourceCustomRoutingAcceleratorDelete(ctx context.Context, d *schema.Resou
 	})
 
 	if tfawserr.ErrCodeEquals(err, globalaccelerator.ErrCodeAcceleratorNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {

--- a/internal/service/globalaccelerator/custom_routing_endpoint_group.go
+++ b/internal/service/globalaccelerator/custom_routing_endpoint_group.go
@@ -200,7 +200,7 @@ func resourceCustomRoutingEndpointGroupDelete(ctx context.Context, d *schema.Res
 	})
 
 	if tfawserr.ErrCodeEquals(err, globalaccelerator.ErrCodeEndpointGroupNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {

--- a/internal/service/globalaccelerator/custom_routing_listener.go
+++ b/internal/service/globalaccelerator/custom_routing_listener.go
@@ -162,7 +162,7 @@ func resourceCustomRoutingListenerDelete(ctx context.Context, d *schema.Resource
 	})
 
 	if tfawserr.ErrCodeEquals(err, globalaccelerator.ErrCodeListenerNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {

--- a/internal/service/glue/data_catalog_encryption_settings_data_source.go
+++ b/internal/service/glue/data_catalog_encryption_settings_data_source.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 )
 
 // @SDKDataSource("aws_glue_data_catalog_encryption_settings")
@@ -67,6 +68,8 @@ func DataSourceDataCatalogEncryptionSettings() *schema.Resource {
 }
 
 func dataSourceDataCatalogEncryptionSettingsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).GlueConn(ctx)
 
 	catalogID := d.Get("catalog_id").(string)
@@ -75,18 +78,18 @@ func dataSourceDataCatalogEncryptionSettingsRead(ctx context.Context, d *schema.
 	})
 
 	if err != nil {
-		return diag.Errorf("reading Glue Data Catalog Encryption Settings (%s): %s", catalogID, err)
+		return sdkdiag.AppendErrorf(diags, "reading Glue Data Catalog Encryption Settings (%s): %s", catalogID, err)
 	}
 
 	d.SetId(catalogID)
 	d.Set("catalog_id", d.Id())
 	if output.DataCatalogEncryptionSettings != nil {
 		if err := d.Set("data_catalog_encryption_settings", []interface{}{flattenDataCatalogEncryptionSettings(output.DataCatalogEncryptionSettings)}); err != nil {
-			return diag.Errorf("setting data_catalog_encryption_settings: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting data_catalog_encryption_settings: %s", err)
 		}
 	} else {
 		d.Set("data_catalog_encryption_settings", nil)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/iam/access_keys_data_source.go
+++ b/internal/service/iam/access_keys_data_source.go
@@ -54,22 +54,24 @@ const (
 )
 
 func dataSourceAccessKeysRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).IAMConn(ctx)
 
 	username := d.Get("user").(string)
 	out, err := FindAccessKeys(ctx, conn, username)
 
 	if err != nil {
-		return create.DiagError(names.IAM, create.ErrActionReading, DSNameAccessKeys, username, err)
+		return create.AppendDiagError(diags, names.IAM, create.ErrActionReading, DSNameAccessKeys, username, err)
 	}
 
 	d.SetId(username)
 
 	if err := d.Set("access_keys", flattenAccessKeys(out)); err != nil {
-		return create.DiagError(names.IAM, create.ErrActionSetting, DSNameAccessKeys, d.Id(), err)
+		return create.AppendDiagError(diags, names.IAM, create.ErrActionSetting, DSNameAccessKeys, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func flattenAccessKeys(apiObjects []*iam.AccessKeyMetadata) []interface{} {

--- a/internal/service/iam/instance_profiles_data_source.go
+++ b/internal/service/iam/instance_profiles_data_source.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 )
 
 // @SDKDataSource("aws_iam_instance_profiles")
@@ -46,13 +47,15 @@ func DataSourceInstanceProfiles() *schema.Resource {
 }
 
 func dataSourceInstanceProfilesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).IAMConn(ctx)
 
 	roleName := d.Get("role_name").(string)
 	instanceProfiles, err := findInstanceProfilesForRole(ctx, conn, roleName)
 
 	if err != nil {
-		return diag.Errorf("reading IAM Instance Profiles for Role (%s): %s", roleName, err)
+		return sdkdiag.AppendErrorf(diags, "reading IAM Instance Profiles for Role (%s): %s", roleName, err)
 	}
 
 	var arns, names, paths []string
@@ -68,7 +71,7 @@ func dataSourceInstanceProfilesRead(ctx context.Context, d *schema.ResourceData,
 	d.Set("names", names)
 	d.Set("paths", paths)
 
-	return nil
+	return diags
 }
 
 func findInstanceProfilesForRole(ctx context.Context, conn *iam.IAM, roleName string) ([]*iam.InstanceProfile, error) {

--- a/internal/service/iam/saml_provider.go
+++ b/internal/service/iam/saml_provider.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -68,6 +69,8 @@ func ResourceSAMLProvider() *schema.Resource {
 }
 
 func resourceSAMLProviderCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).IAMConn(ctx)
 
 	name := d.Get("name").(string)
@@ -87,7 +90,7 @@ func resourceSAMLProviderCreate(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	if err != nil {
-		return diag.Errorf("creating IAM SAML Provider (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "creating IAM SAML Provider (%s): %s", name, err)
 	}
 
 	d.SetId(aws.StringValue(output.SAMLProviderArn))
@@ -98,18 +101,20 @@ func resourceSAMLProviderCreate(ctx context.Context, d *schema.ResourceData, met
 
 		// If default tags only, continue. Otherwise, error.
 		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]interface{})) == 0) && errs.IsUnsupportedOperationInPartitionError(conn.PartitionID, err) {
-			return resourceSAMLProviderRead(ctx, d, meta)
+			return append(diags, resourceSAMLProviderRead(ctx, d, meta)...)
 		}
 
 		if err != nil {
-			return diag.Errorf("setting IAM SAML Provider (%s) tags: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "setting IAM SAML Provider (%s) tags: %s", d.Id(), err)
 		}
 	}
 
-	return resourceSAMLProviderRead(ctx, d, meta)
+	return append(diags, resourceSAMLProviderRead(ctx, d, meta)...)
 }
 
 func resourceSAMLProviderRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).IAMConn(ctx)
 
 	output, err := FindSAMLProviderByARN(ctx, conn, d.Id())
@@ -117,17 +122,17 @@ func resourceSAMLProviderRead(ctx context.Context, d *schema.ResourceData, meta 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] IAM SAML Provider %s not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading IAM SAML Provider (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading IAM SAML Provider (%s): %s", d.Id(), err)
 	}
 
 	name, err := nameFromSAMLProviderARN(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	d.Set("arn", d.Id())
@@ -141,10 +146,12 @@ func resourceSAMLProviderRead(ctx context.Context, d *schema.ResourceData, meta 
 
 	setTagsOut(ctx, output.Tags)
 
-	return nil
+	return diags
 }
 
 func resourceSAMLProviderUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).IAMConn(ctx)
 
 	if d.HasChangesExcept("tags", "tags_all") {
@@ -156,7 +163,7 @@ func resourceSAMLProviderUpdate(ctx context.Context, d *schema.ResourceData, met
 		_, err := conn.UpdateSAMLProviderWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("updating IAM SAML Provider (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating IAM SAML Provider (%s): %s", d.Id(), err)
 		}
 	}
 
@@ -167,18 +174,20 @@ func resourceSAMLProviderUpdate(ctx context.Context, d *schema.ResourceData, met
 
 		// Some partitions (e.g. ISO) may not support tagging.
 		if errs.IsUnsupportedOperationInPartitionError(conn.PartitionID, err) {
-			return resourceSAMLProviderRead(ctx, d, meta)
+			return append(diags, resourceSAMLProviderRead(ctx, d, meta)...)
 		}
 
 		if err != nil {
-			return diag.Errorf("updating tags for IAM SAML Provider (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating tags for IAM SAML Provider (%s): %s", d.Id(), err)
 		}
 	}
 
-	return resourceSAMLProviderRead(ctx, d, meta)
+	return append(diags, resourceSAMLProviderRead(ctx, d, meta)...)
 }
 
 func resourceSAMLProviderDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).IAMConn(ctx)
 
 	log.Printf("[DEBUG] Deleting IAM SAML Provider: %s", d.Id())
@@ -187,14 +196,14 @@ func resourceSAMLProviderDelete(ctx context.Context, d *schema.ResourceData, met
 	})
 
 	if tfawserr.ErrCodeEquals(err, iam.ErrCodeNoSuchEntityException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting IAM SAML Provider (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting IAM SAML Provider (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func FindSAMLProviderByARN(ctx context.Context, conn *iam.IAM, arn string) (*iam.GetSAMLProviderOutput, error) {

--- a/internal/service/iam/saml_provider_data_source.go
+++ b/internal/service/iam/saml_provider_data_source.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
@@ -48,6 +49,8 @@ func DataSourceSAMLProvider() *schema.Resource {
 }
 
 func dataSourceSAMLProviderRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).IAMConn(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
@@ -55,13 +58,13 @@ func dataSourceSAMLProviderRead(ctx context.Context, d *schema.ResourceData, met
 	output, err := FindSAMLProviderByARN(ctx, conn, arn)
 
 	if err != nil {
-		return diag.Errorf("reading IAM SAML Provider (%s): %s", arn, err)
+		return sdkdiag.AppendErrorf(diags, "reading IAM SAML Provider (%s): %s", arn, err)
 	}
 
 	name, err := nameFromSAMLProviderARN(arn)
 
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	d.SetId(arn)
@@ -82,8 +85,8 @@ func dataSourceSAMLProviderRead(ctx context.Context, d *schema.ResourceData, met
 
 	//lintignore:AWSR002
 	if err := d.Set("tags", tags.Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/identitystore/group.go
+++ b/internal/service/identitystore/group.go
@@ -83,6 +83,8 @@ const (
 )
 
 func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).IdentityStoreClient(ctx)
 
 	identityStoreId := d.Get("identity_store_id").(string)
@@ -101,24 +103,26 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	out, err := conn.CreateGroup(ctx, input)
 	if err != nil {
-		return create.DiagError(names.IdentityStore, create.ErrActionCreating, ResNameGroup, d.Get("identity_store_id").(string), err)
+		return create.AppendDiagError(diags, names.IdentityStore, create.ErrActionCreating, ResNameGroup, d.Get("identity_store_id").(string), err)
 	}
 
 	if out == nil || out.GroupId == nil {
-		return create.DiagError(names.IdentityStore, create.ErrActionCreating, ResNameGroup, d.Get("identity_store_id").(string), errors.New("empty output"))
+		return create.AppendDiagError(diags, names.IdentityStore, create.ErrActionCreating, ResNameGroup, d.Get("identity_store_id").(string), errors.New("empty output"))
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", aws.ToString(out.IdentityStoreId), aws.ToString(out.GroupId)))
 
-	return resourceGroupRead(ctx, d, meta)
+	return append(diags, resourceGroupRead(ctx, d, meta)...)
 }
 
 func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).IdentityStoreClient(ctx)
 
 	identityStoreId, groupId, err := resourceGroupParseID(d.Id())
 	if err != nil {
-		return create.DiagError(names.IdentityStore, create.ErrActionReading, ResNameGroup, d.Id(), err)
+		return create.AppendDiagError(diags, names.IdentityStore, create.ErrActionReading, ResNameGroup, d.Id(), err)
 	}
 
 	out, err := FindGroupByTwoPartKey(ctx, conn, identityStoreId, groupId)
@@ -126,25 +130,27 @@ func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] IdentityStore Group (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.IdentityStore, create.ErrActionReading, ResNameGroup, d.Id(), err)
+		return create.AppendDiagError(diags, names.IdentityStore, create.ErrActionReading, ResNameGroup, d.Id(), err)
 	}
 
 	d.Set("description", out.Description)
 	d.Set("display_name", out.DisplayName)
 	if err := d.Set("external_ids", flattenExternalIds(out.ExternalIds)); err != nil {
-		return create.DiagError(names.IdentityStore, create.ErrActionSetting, ResNameGroup, d.Id(), err)
+		return create.AppendDiagError(diags, names.IdentityStore, create.ErrActionSetting, ResNameGroup, d.Id(), err)
 	}
 	d.Set("group_id", out.GroupId)
 	d.Set("identity_store_id", out.IdentityStoreId)
 
-	return nil
+	return diags
 }
 
 func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).IdentityStoreClient(ctx)
 
 	in := &identitystore.UpdateGroupInput{
@@ -170,13 +176,15 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 	_, err := conn.UpdateGroup(ctx, in)
 
 	if err != nil {
-		return create.DiagError(names.IdentityStore, create.ErrActionUpdating, ResNameGroup, d.Id(), err)
+		return create.AppendDiagError(diags, names.IdentityStore, create.ErrActionUpdating, ResNameGroup, d.Id(), err)
 	}
 
-	return resourceGroupRead(ctx, d, meta)
+	return append(diags, resourceGroupRead(ctx, d, meta)...)
 }
 
 func resourceGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).IdentityStoreClient(ctx)
 
 	log.Printf("[INFO] Deleting IdentityStore Group %s", d.Id())
@@ -186,14 +194,14 @@ func resourceGroupDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	})
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.IdentityStore, create.ErrActionDeleting, ResNameGroup, d.Id(), err)
+		return create.AppendDiagError(diags, names.IdentityStore, create.ErrActionDeleting, ResNameGroup, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func FindGroupByTwoPartKey(ctx context.Context, conn *identitystore.Client, identityStoreID, groupID string) (*identitystore.DescribeGroupOutput, error) {

--- a/internal/service/inspector/assessment_template.go
+++ b/internal/service/inspector/assessment_template.go
@@ -119,7 +119,7 @@ func resourceAssessmentTemplateCreate(ctx context.Context, d *schema.ResourceDat
 		input := expandEventSubscriptions(v.(*schema.Set).List(), output.AssessmentTemplateArn)
 
 		if err := subscribeToEvents(ctx, conn, input); err != nil {
-			return create.DiagError(names.Inspector, create.ErrActionCreating, ResNameAssessmentTemplate, d.Id(), err)
+			return create.AppendDiagError(diags, names.Inspector, create.ErrActionCreating, ResNameAssessmentTemplate, d.Id(), err)
 		}
 	}
 
@@ -155,11 +155,11 @@ func resourceAssessmentTemplateRead(ctx context.Context, d *schema.ResourceData,
 	output, err := findSubscriptionsByAssessmentTemplateARN(ctx, conn, arn)
 
 	if err != nil {
-		return create.DiagError(names.Inspector, create.ErrActionReading, ResNameAssessmentTemplate, d.Id(), err)
+		return create.AppendDiagError(diags, names.Inspector, create.ErrActionReading, ResNameAssessmentTemplate, d.Id(), err)
 	}
 
 	if err := d.Set("event_subscription", flattenSubscriptions(output)); err != nil {
-		return create.DiagError(names.Inspector, create.ErrActionSetting, ResNameAssessmentTemplate, d.Id(), err)
+		return create.AppendDiagError(diags, names.Inspector, create.ErrActionSetting, ResNameAssessmentTemplate, d.Id(), err)
 	}
 
 	return diags
@@ -183,11 +183,11 @@ func resourceAssessmentTemplateUpdate(ctx context.Context, d *schema.ResourceDat
 		removeEventSubscriptionsInput := expandEventSubscriptions(eventSubscriptionsToRemove.List(), templateId)
 
 		if err := subscribeToEvents(ctx, conn, addEventSubscriptionsInput); err != nil {
-			return create.DiagError(names.Inspector, create.ErrActionUpdating, ResNameAssessmentTemplate, d.Id(), err)
+			return create.AppendDiagError(diags, names.Inspector, create.ErrActionUpdating, ResNameAssessmentTemplate, d.Id(), err)
 		}
 
 		if err := unsubscribeFromEvents(ctx, conn, removeEventSubscriptionsInput); err != nil {
-			return create.DiagError(names.Inspector, create.ErrActionUpdating, ResNameAssessmentTemplate, d.Id(), err)
+			return create.AppendDiagError(diags, names.Inspector, create.ErrActionUpdating, ResNameAssessmentTemplate, d.Id(), err)
 		}
 	}
 

--- a/internal/service/inspector2/delegated_admin_account.go
+++ b/internal/service/inspector2/delegated_admin_account.go
@@ -60,6 +60,8 @@ const (
 )
 
 func resourceDelegatedAdminAccountCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).Inspector2Client(ctx)
 
 	in := &inspector2.EnableDelegatedAdminAccountInput{
@@ -70,23 +72,25 @@ func resourceDelegatedAdminAccountCreate(ctx context.Context, d *schema.Resource
 	out, err := conn.EnableDelegatedAdminAccount(ctx, in)
 
 	if err != nil && !errs.MessageContains(err, "ConflictException", "already enabled") {
-		return create.DiagError(names.Inspector2, create.ErrActionCreating, ResNameDelegatedAdminAccount, d.Get("account_id").(string), err)
+		return create.AppendDiagError(diags, names.Inspector2, create.ErrActionCreating, ResNameDelegatedAdminAccount, d.Get("account_id").(string), err)
 	}
 
 	if err == nil && (out == nil || out.DelegatedAdminAccountId == nil) {
-		return create.DiagError(names.Inspector2, create.ErrActionCreating, ResNameDelegatedAdminAccount, d.Get("account_id").(string), errors.New("empty output"))
+		return create.AppendDiagError(diags, names.Inspector2, create.ErrActionCreating, ResNameDelegatedAdminAccount, d.Get("account_id").(string), errors.New("empty output"))
 	}
 
 	d.SetId(d.Get("account_id").(string))
 
 	if err := WaitDelegatedAdminAccountEnabled(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return create.DiagError(names.Inspector2, create.ErrActionWaitingForCreation, ResNameDelegatedAdminAccount, d.Id(), err)
+		return create.AppendDiagError(diags, names.Inspector2, create.ErrActionWaitingForCreation, ResNameDelegatedAdminAccount, d.Id(), err)
 	}
 
-	return resourceDelegatedAdminAccountRead(ctx, d, meta)
+	return append(diags, resourceDelegatedAdminAccountRead(ctx, d, meta)...)
 }
 
 func resourceDelegatedAdminAccountRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).Inspector2Client(ctx)
 
 	st, ai, err := FindDelegatedAdminAccountStatusID(ctx, conn, d.Id())
@@ -94,20 +98,22 @@ func resourceDelegatedAdminAccountRead(ctx context.Context, d *schema.ResourceDa
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Inspector Delegated Admin Account (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.Inspector2, create.ErrActionReading, ResNameDelegatedAdminAccount, d.Id(), err)
+		return create.AppendDiagError(diags, names.Inspector2, create.ErrActionReading, ResNameDelegatedAdminAccount, d.Id(), err)
 	}
 
 	d.Set("account_id", ai)
 	d.Set("relationship_status", st)
 
-	return nil
+	return diags
 }
 
 func resourceDelegatedAdminAccountDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).Inspector2Client(ctx)
 
 	log.Printf("[INFO] Deleting Inspector DelegatedAdminAccount %s", d.Id())
@@ -119,17 +125,17 @@ func resourceDelegatedAdminAccountDelete(ctx context.Context, d *schema.Resource
 	if err != nil {
 		var nfe *types.ResourceNotFoundException
 		if errors.As(err, &nfe) {
-			return nil
+			return diags
 		}
 
-		return create.DiagError(names.Inspector2, create.ErrActionDeleting, ResNameDelegatedAdminAccount, d.Id(), err)
+		return create.AppendDiagError(diags, names.Inspector2, create.ErrActionDeleting, ResNameDelegatedAdminAccount, d.Id(), err)
 	}
 
 	if err := WaitDelegatedAdminAccountDisabled(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return create.DiagError(names.Inspector2, create.ErrActionWaitingForDeletion, ResNameDelegatedAdminAccount, d.Id(), err)
+		return create.AppendDiagError(diags, names.Inspector2, create.ErrActionWaitingForDeletion, ResNameDelegatedAdminAccount, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 type DelegatedAccountStatus string

--- a/internal/service/inspector2/enabler.go
+++ b/internal/service/inspector2/enabler.go
@@ -156,14 +156,14 @@ func resourceEnablerCreate(ctx context.Context, d *schema.ResourceData, meta int
 		out, err = conn.Enable(ctx, in)
 	}
 	if err != nil {
-		return append(diags, create.DiagError(names.Inspector2, create.ErrActionCreating, ResNameEnabler, id, err)...)
+		return create.AppendDiagError(diags, names.Inspector2, create.ErrActionCreating, ResNameEnabler, id, err)
 	}
 
 	d.SetId(id)
 
 	st, err := waitEnabled(ctx, conn, accountIDs, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
-		return append(diags, create.DiagError(names.Inspector2, create.ErrActionWaitingForCreation, ResNameEnabler, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.Inspector2, create.ErrActionWaitingForCreation, ResNameEnabler, d.Id(), err)
 	}
 
 	var disableAccountIDs []string
@@ -181,14 +181,14 @@ func resourceEnablerCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 			_, err := conn.Disable(ctx, in)
 			if err != nil {
-				return append(diags, create.DiagError(names.Inspector2, create.ErrActionUpdating, ResNameEnabler, id, err)...)
+				return create.AppendDiagError(diags, names.Inspector2, create.ErrActionUpdating, ResNameEnabler, id, err)
 			}
 		}
 	}
 
 	if len(disableAccountIDs) > 0 {
 		if _, err := waitEnabled(ctx, conn, disableAccountIDs, d.Timeout(schema.TimeoutCreate)); err != nil {
-			return append(diags, create.DiagError(names.Inspector2, create.ErrActionWaitingForUpdate, ResNameEnabler, id, err)...)
+			return create.AppendDiagError(diags, names.Inspector2, create.ErrActionWaitingForUpdate, ResNameEnabler, id, err)
 		}
 	}
 
@@ -201,18 +201,18 @@ func resourceEnablerRead(ctx context.Context, d *schema.ResourceData, meta inter
 
 	accountIDs, _, err := parseEnablerID(d.Id())
 	if err != nil {
-		return append(diags, create.DiagError(names.Inspector2, create.ErrActionReading, ResNameEnabler, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.Inspector2, create.ErrActionReading, ResNameEnabler, d.Id(), err)
 	}
 
 	s, err := AccountStatuses(ctx, conn, accountIDs)
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Inspector2 Enabler (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return append(diags, create.DiagError(names.Inspector2, create.ErrActionReading, ResNameEnabler, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.Inspector2, create.ErrActionReading, ResNameEnabler, d.Id(), err)
 	}
 
 	var enabledAccounts []string
@@ -232,10 +232,10 @@ func resourceEnablerRead(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	if err := d.Set("account_ids", flex.FlattenStringValueSet(enabledAccounts)); err != nil {
-		return append(diags, create.DiagError(names.Inspector2, create.ErrActionReading, ResNameEnabler, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.Inspector2, create.ErrActionReading, ResNameEnabler, d.Id(), err)
 	}
 	if err := d.Set("resource_types", flex.FlattenStringValueSet(enum.Slice(resourceTypes...))); err != nil {
-		return append(diags, create.DiagError(names.Inspector2, create.ErrActionReading, ResNameEnabler, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.Inspector2, create.ErrActionReading, ResNameEnabler, d.Id(), err)
 	}
 
 	return diags
@@ -279,19 +279,19 @@ func resourceEnablerUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 			out, err := conn.Enable(ctx, in)
 			if err != nil {
-				return append(diags, create.DiagError(names.Inspector2, create.ErrActionUpdating, ResNameEnabler, id, err)...)
+				return create.AppendDiagError(diags, names.Inspector2, create.ErrActionUpdating, ResNameEnabler, id, err)
 			}
 
 			if out == nil {
-				return append(diags, create.DiagError(names.Inspector2, create.ErrActionUpdating, ResNameEnabler, id, tfresource.NewEmptyResultError(nil))...)
+				return create.AppendDiagError(diags, names.Inspector2, create.ErrActionUpdating, ResNameEnabler, id, tfresource.NewEmptyResultError(nil))
 			}
 
 			if len(out.FailedAccounts) > 0 {
-				return append(diags, create.DiagError(names.Inspector2, create.ErrActionUpdating, ResNameEnabler, id, errors.New("failed accounts"))...)
+				return create.AppendDiagError(diags, names.Inspector2, create.ErrActionUpdating, ResNameEnabler, id, errors.New("failed accounts"))
 			}
 
 			if _, err := waitEnabled(ctx, conn, acctEnable, d.Timeout(schema.TimeoutCreate)); err != nil {
-				return append(diags, create.DiagError(names.Inspector2, create.ErrActionWaitingForUpdate, ResNameEnabler, id, err)...)
+				return create.AppendDiagError(diags, names.Inspector2, create.ErrActionWaitingForUpdate, ResNameEnabler, id, err)
 			}
 		}
 
@@ -303,11 +303,11 @@ func resourceEnablerUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 			_, err := conn.Disable(ctx, in)
 			if err != nil {
-				return append(diags, create.DiagError(names.Inspector2, create.ErrActionUpdating, ResNameEnabler, id, err)...)
+				return create.AppendDiagError(diags, names.Inspector2, create.ErrActionUpdating, ResNameEnabler, id, err)
 			}
 
 			if _, err := waitEnabled(ctx, conn, acctEnable, d.Timeout(schema.TimeoutCreate)); err != nil {
-				return append(diags, create.DiagError(names.Inspector2, create.ErrActionWaitingForUpdate, ResNameEnabler, id, err)...)
+				return create.AppendDiagError(diags, names.Inspector2, create.ErrActionWaitingForUpdate, ResNameEnabler, id, err)
 			}
 		}
 	}
@@ -358,10 +358,10 @@ func disableAccounts(ctx context.Context, conn *inspector2.Client, d *schema.Res
 
 	out, err := conn.Disable(ctx, in)
 	if err != nil {
-		return append(diags, create.DiagError(names.Inspector2, create.ErrActionDeleting, ResNameEnabler, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.Inspector2, create.ErrActionDeleting, ResNameEnabler, d.Id(), err)
 	}
 	if out == nil {
-		return append(diags, create.DiagError(names.Inspector2, create.ErrActionDeleting, ResNameEnabler, d.Id(), tfresource.NewEmptyResultError(nil))...)
+		return create.AppendDiagError(diags, names.Inspector2, create.ErrActionDeleting, ResNameEnabler, d.Id(), tfresource.NewEmptyResultError(nil))
 	}
 
 	for _, acct := range out.FailedAccounts {
@@ -370,11 +370,11 @@ func disableAccounts(ctx context.Context, conn *inspector2.Client, d *schema.Res
 		}
 	}
 	if err != nil {
-		return append(diags, create.DiagError(names.Inspector2, create.ErrActionDeleting, ResNameEnabler, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.Inspector2, create.ErrActionDeleting, ResNameEnabler, d.Id(), err)
 	}
 
 	if err := waitDisabled(ctx, conn, accountIDs, d.Timeout(schema.TimeoutDelete)); err != nil {
-		return append(diags, create.DiagError(names.Inspector2, create.ErrActionWaitingForDeletion, ResNameEnabler, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.Inspector2, create.ErrActionWaitingForDeletion, ResNameEnabler, d.Id(), err)
 	}
 
 	return diags

--- a/internal/service/inspector2/member_association.go
+++ b/internal/service/inspector2/member_association.go
@@ -94,7 +94,7 @@ func resourceMemberAssociationRead(ctx context.Context, d *schema.ResourceData, 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Amazon Inspector Member Association (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {

--- a/internal/service/iot/ca_certificate.go
+++ b/internal/service/iot/ca_certificate.go
@@ -196,14 +196,14 @@ func resourceCACertificateRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set("generation_id", certificateDescription.GenerationId)
 	if output.RegistrationConfig != nil {
 		if err := d.Set("registration_config", []interface{}{flattenRegistrationConfig(output.RegistrationConfig)}); err != nil {
-			return diag.Errorf("setting registration_config: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting registration_config: %s", err)
 		}
 	} else {
 		d.Set("registration_config", nil)
 	}
 	if certificateDescription.Validity != nil {
 		if err := d.Set("validity", []interface{}{flattenCertificateValidity(certificateDescription.Validity)}); err != nil {
-			return diag.Errorf("setting validity: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting validity: %s", err)
 		}
 	} else {
 		d.Set("validity", nil)

--- a/internal/service/iot/domain_configuration.go
+++ b/internal/service/iot/domain_configuration.go
@@ -188,7 +188,7 @@ func resourceDomainConfigurationRead(ctx context.Context, d *schema.ResourceData
 	d.Set("arn", output.DomainConfigurationArn)
 	if output.AuthorizerConfig != nil {
 		if err := d.Set("authorizer_config", []interface{}{flattenAuthorizerConfig(output.AuthorizerConfig)}); err != nil {
-			return diag.Errorf("setting authorizer_config: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting authorizer_config: %s", err)
 		}
 	} else {
 		d.Set("authorizer_config", nil)
@@ -203,7 +203,7 @@ func resourceDomainConfigurationRead(ctx context.Context, d *schema.ResourceData
 	d.Set("status", output.DomainConfigurationStatus)
 	if output.TlsConfig != nil {
 		if err := d.Set("tls_config", []interface{}{flattenTlsConfig(output.TlsConfig)}); err != nil {
-			return diag.Errorf("setting tls_config: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting tls_config: %s", err)
 		}
 	} else {
 		d.Set("tls_config", nil)

--- a/internal/service/iot/logging_options.go
+++ b/internal/service/iot/logging_options.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
@@ -44,6 +45,8 @@ func ResourceLoggingOptions() *schema.Resource {
 }
 
 func resourceLoggingOptionsPut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).IoTConn(ctx)
 
 	input := &iot.SetV2LoggingOptionsInput{}
@@ -68,26 +71,28 @@ func resourceLoggingOptionsPut(ctx context.Context, d *schema.ResourceData, meta
 	)
 
 	if err != nil {
-		return diag.Errorf("setting IoT logging options: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting IoT logging options: %s", err)
 	}
 
 	d.SetId(meta.(*conns.AWSClient).Region)
 
-	return resourceLoggingOptionsRead(ctx, d, meta)
+	return append(diags, resourceLoggingOptionsRead(ctx, d, meta)...)
 }
 
 func resourceLoggingOptionsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).IoTConn(ctx)
 
 	output, err := conn.GetV2LoggingOptionsWithContext(ctx, &iot.GetV2LoggingOptionsInput{})
 
 	if err != nil {
-		return diag.Errorf("reading IoT logging options: %s", err)
+		return sdkdiag.AppendErrorf(diags, "reading IoT logging options: %s", err)
 	}
 
 	d.Set("default_log_level", output.DefaultLogLevel)
 	d.Set("disable_all_logs", output.DisableAllLogs)
 	d.Set("role_arn", output.RoleArn)
 
-	return nil
+	return diags
 }

--- a/internal/service/iot/policy_attachment.go
+++ b/internal/service/iot/policy_attachment.go
@@ -80,7 +80,7 @@ func resourcePolicyAttachmentRead(ctx context.Context, d *schema.ResourceData, m
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] IoT Policy Attachment (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {

--- a/internal/service/iot/thing_type.go
+++ b/internal/service/iot/thing_type.go
@@ -143,7 +143,7 @@ func resourceThingTypeRead(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	if err != nil {
-		return diag.Errorf("reading IoT Thing Type (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading IoT Thing Type (%s): %s", d.Id(), err)
 	}
 
 	d.Set("arn", output.ThingTypeArn)
@@ -187,7 +187,7 @@ func resourceThingTypeDelete(ctx context.Context, d *schema.ResourceData, meta i
 	})
 
 	if tfawserr.ErrCodeEquals(err, iot.ErrCodeResourceNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
@@ -202,7 +202,7 @@ func resourceThingTypeDelete(ctx context.Context, d *schema.ResourceData, meta i
 	}, iot.ErrCodeInvalidRequestException, "Please wait for 5 minutes after deprecation and then retry")
 
 	if tfawserr.ErrCodeEquals(err, iot.ErrCodeResourceNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {

--- a/internal/service/iot/topic_rule_destination.go
+++ b/internal/service/iot/topic_rule_destination.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -87,6 +88,8 @@ func ResourceTopicRuleDestination() *schema.Resource {
 }
 
 func resourceTopicRuleDestinationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).IoTConn(ctx)
 
 	input := &iot.CreateTopicRuleDestinationInput{
@@ -113,13 +116,13 @@ func resourceTopicRuleDestinationCreate(ctx context.Context, d *schema.ResourceD
 	)
 
 	if err != nil {
-		return diag.Errorf("creating IoT Topic Rule Destination: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating IoT Topic Rule Destination: %s", err)
 	}
 
 	d.SetId(aws.StringValue(outputRaw.(*iot.CreateTopicRuleDestinationOutput).TopicRuleDestination.Arn))
 
 	if _, err := waitTopicRuleDestinationCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return diag.Errorf("waiting for IoT Topic Rule Destination (%s) create: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for IoT Topic Rule Destination (%s) create: %s", d.Id(), err)
 	}
 
 	if _, ok := d.GetOk("enabled"); !ok {
@@ -129,18 +132,20 @@ func resourceTopicRuleDestinationCreate(ctx context.Context, d *schema.ResourceD
 		})
 
 		if err != nil {
-			return diag.Errorf("disabling IoT Topic Rule Destination (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "disabling IoT Topic Rule Destination (%s): %s", d.Id(), err)
 		}
 
 		if _, err := waitTopicRuleDestinationDisabled(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-			return diag.Errorf("waiting for IoT Topic Rule Destination (%s) disable: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "waiting for IoT Topic Rule Destination (%s) disable: %s", d.Id(), err)
 		}
 	}
 
-	return resourceTopicRuleDestinationRead(ctx, d, meta)
+	return append(diags, resourceTopicRuleDestinationRead(ctx, d, meta)...)
 }
 
 func resourceTopicRuleDestinationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).IoTConn(ctx)
 
 	output, err := FindTopicRuleDestinationByARN(ctx, conn, d.Id())
@@ -148,27 +153,29 @@ func resourceTopicRuleDestinationRead(ctx context.Context, d *schema.ResourceDat
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] IoT Topic Rule Destination %s not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading IoT Topic Rule Destination (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading IoT Topic Rule Destination (%s): %s", d.Id(), err)
 	}
 
 	d.Set("arn", output.Arn)
 	d.Set("enabled", aws.StringValue(output.Status) == iot.TopicRuleDestinationStatusEnabled)
 	if output.VpcProperties != nil {
 		if err := d.Set("vpc_configuration", []interface{}{flattenVPCDestinationProperties(output.VpcProperties)}); err != nil {
-			return diag.Errorf("setting vpc_configuration: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting vpc_configuration: %s", err)
 		}
 	} else {
 		d.Set("vpc_configuration", nil)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceTopicRuleDestinationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).IoTConn(ctx)
 
 	if d.HasChange("enabled") {
@@ -186,18 +193,20 @@ func resourceTopicRuleDestinationUpdate(ctx context.Context, d *schema.ResourceD
 		_, err := conn.UpdateTopicRuleDestinationWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("updating IoT Topic Rule Destination (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating IoT Topic Rule Destination (%s): %s", d.Id(), err)
 		}
 
 		if _, err := waiter(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-			return diag.Errorf("waiting for IoT Topic Rule Destination (%s) update: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "waiting for IoT Topic Rule Destination (%s) update: %s", d.Id(), err)
 		}
 	}
 
-	return resourceTopicRuleDestinationRead(ctx, d, meta)
+	return append(diags, resourceTopicRuleDestinationRead(ctx, d, meta)...)
 }
 
 func resourceTopicRuleDestinationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).IoTConn(ctx)
 
 	log.Printf("[INFO] Deleting IoT Topic Rule Destination: %s", d.Id())
@@ -206,14 +215,14 @@ func resourceTopicRuleDestinationDelete(ctx context.Context, d *schema.ResourceD
 	})
 
 	if err != nil {
-		return diag.Errorf("deleting IoT Topic Rule Destination: %s", err)
+		return sdkdiag.AppendErrorf(diags, "deleting IoT Topic Rule Destination: %s", err)
 	}
 
 	if _, err := waitTopicRuleDestinationDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return diag.Errorf("waiting for IoT Topic Rule Destination (%s) delete: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for IoT Topic Rule Destination (%s) delete: %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func expandVPCDestinationConfiguration(tfMap map[string]interface{}) *iot.VpcDestinationConfiguration {

--- a/internal/service/ivs/stream_key_data_source.go
+++ b/internal/service/ivs/stream_key_data_source.go
@@ -42,13 +42,15 @@ const (
 )
 
 func dataSourceStreamKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).IVSConn(ctx)
 
 	channelArn := d.Get("channel_arn").(string)
 
 	out, err := FindStreamKeyByChannelID(ctx, conn, channelArn)
 	if err != nil {
-		return create.DiagError(names.IVS, create.ErrActionReading, DSNameStreamKey, channelArn, err)
+		return create.AppendDiagError(diags, names.IVS, create.ErrActionReading, DSNameStreamKey, channelArn, err)
 	}
 
 	d.SetId(aws.StringValue(out.Arn))
@@ -61,8 +63,8 @@ func dataSourceStreamKeyRead(ctx context.Context, d *schema.ResourceData, meta i
 
 	//lintignore:AWSR002
 	if err := d.Set("tags", KeyValueTags(ctx, out.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return create.DiagError(names.IVS, create.ErrActionSetting, DSNameStreamKey, d.Id(), err)
+		return create.AppendDiagError(diags, names.IVS, create.ErrActionSetting, DSNameStreamKey, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/ivschat/room.go
+++ b/internal/service/ivschat/room.go
@@ -107,6 +107,8 @@ const (
 )
 
 func resourceRoomCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).IVSChatClient(ctx)
 
 	in := &ivschat.CreateRoomInput{
@@ -135,23 +137,25 @@ func resourceRoomCreate(ctx context.Context, d *schema.ResourceData, meta interf
 
 	out, err := conn.CreateRoom(ctx, in)
 	if err != nil {
-		return create.DiagError(names.IVSChat, create.ErrActionCreating, ResNameRoom, d.Get("name").(string), err)
+		return create.AppendDiagError(diags, names.IVSChat, create.ErrActionCreating, ResNameRoom, d.Get("name").(string), err)
 	}
 
 	if out == nil {
-		return create.DiagError(names.IVSChat, create.ErrActionCreating, ResNameRoom, d.Get("name").(string), errors.New("empty output"))
+		return create.AppendDiagError(diags, names.IVSChat, create.ErrActionCreating, ResNameRoom, d.Get("name").(string), errors.New("empty output"))
 	}
 
 	d.SetId(aws.ToString(out.Arn))
 
 	if _, err := waitRoomCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return create.DiagError(names.IVSChat, create.ErrActionWaitingForCreation, ResNameRoom, d.Id(), err)
+		return create.AppendDiagError(diags, names.IVSChat, create.ErrActionWaitingForCreation, ResNameRoom, d.Id(), err)
 	}
 
-	return resourceRoomRead(ctx, d, meta)
+	return append(diags, resourceRoomRead(ctx, d, meta)...)
 }
 
 func resourceRoomRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).IVSChatClient(ctx)
 
 	out, err := findRoomByID(ctx, conn, d.Id())
@@ -159,32 +163,34 @@ func resourceRoomRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] IVSChat Room (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.IVSChat, create.ErrActionReading, ResNameRoom, d.Id(), err)
+		return create.AppendDiagError(diags, names.IVSChat, create.ErrActionReading, ResNameRoom, d.Id(), err)
 	}
 
 	d.Set("arn", out.Arn)
 
 	if err := d.Set("logging_configuration_identifiers", flex.FlattenStringValueList(out.LoggingConfigurationIdentifiers)); err != nil {
-		return create.DiagError(names.IVSChat, create.ErrActionSetting, ResNameRoom, d.Id(), err)
+		return create.AppendDiagError(diags, names.IVSChat, create.ErrActionSetting, ResNameRoom, d.Id(), err)
 	}
 
 	d.Set("maximum_message_length", out.MaximumMessageLength)
 	d.Set("maximum_message_rate_per_second", out.MaximumMessageRatePerSecond)
 
 	if err := d.Set("message_review_handler", flattenMessageReviewHandler(out.MessageReviewHandler)); err != nil {
-		return create.DiagError(names.IVSChat, create.ErrActionSetting, ResNameRoom, d.Id(), err)
+		return create.AppendDiagError(diags, names.IVSChat, create.ErrActionSetting, ResNameRoom, d.Id(), err)
 	}
 
 	d.Set("name", out.Name)
 
-	return nil
+	return diags
 }
 
 func resourceRoomUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).IVSChatClient(ctx)
 
 	update := false
@@ -219,23 +225,25 @@ func resourceRoomUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	if !update {
-		return nil
+		return diags
 	}
 
 	log.Printf("[DEBUG] Updating IVSChat Room (%s): %#v", d.Id(), in)
 	out, err := conn.UpdateRoom(ctx, in)
 	if err != nil {
-		return create.DiagError(names.IVSChat, create.ErrActionUpdating, ResNameRoom, d.Id(), err)
+		return create.AppendDiagError(diags, names.IVSChat, create.ErrActionUpdating, ResNameRoom, d.Id(), err)
 	}
 
 	if _, err := waitRoomUpdated(ctx, conn, aws.ToString(out.Arn), d.Timeout(schema.TimeoutUpdate), in); err != nil {
-		return create.DiagError(names.IVSChat, create.ErrActionWaitingForUpdate, ResNameRoom, d.Id(), err)
+		return create.AppendDiagError(diags, names.IVSChat, create.ErrActionWaitingForUpdate, ResNameRoom, d.Id(), err)
 	}
 
-	return resourceRoomRead(ctx, d, meta)
+	return append(diags, resourceRoomRead(ctx, d, meta)...)
 }
 
 func resourceRoomDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).IVSChatClient(ctx)
 
 	log.Printf("[INFO] Deleting IVSChat Room %s", d.Id())
@@ -247,17 +255,17 @@ func resourceRoomDelete(ctx context.Context, d *schema.ResourceData, meta interf
 	if err != nil {
 		var nfe *types.ResourceNotFoundException
 		if errors.As(err, &nfe) {
-			return nil
+			return diags
 		}
 
-		return create.DiagError(names.IVSChat, create.ErrActionDeleting, ResNameRoom, d.Id(), err)
+		return create.AppendDiagError(diags, names.IVSChat, create.ErrActionDeleting, ResNameRoom, d.Id(), err)
 	}
 
 	if _, err := waitRoomDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return create.DiagError(names.IVSChat, create.ErrActionWaitingForDeletion, ResNameRoom, d.Id(), err)
+		return create.AppendDiagError(diags, names.IVSChat, create.ErrActionWaitingForDeletion, ResNameRoom, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func flattenMessageReviewHandler(apiObject *types.MessageReviewHandler) []interface{} {

--- a/internal/service/kafka/replicator.go
+++ b/internal/service/kafka/replicator.go
@@ -250,17 +250,17 @@ func resourceReplicatorCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 	out, err := conn.CreateReplicator(ctx, in)
 	if err != nil {
-		return append(diags, create.DiagError(names.Kafka, create.ErrActionCreating, ResNameReplicator, d.Get("replicator_name").(string), err)...)
+		return create.AppendDiagError(diags, names.Kafka, create.ErrActionCreating, ResNameReplicator, d.Get("replicator_name").(string), err)
 	}
 
 	if out == nil {
-		return append(diags, create.DiagError(names.Kafka, create.ErrActionCreating, ResNameReplicator, d.Get("replicator_name").(string), errors.New("empty output"))...)
+		return create.AppendDiagError(diags, names.Kafka, create.ErrActionCreating, ResNameReplicator, d.Get("replicator_name").(string), errors.New("empty output"))
 	}
 
 	d.SetId(aws.ToString(out.ReplicatorArn))
 
 	if _, err := waitReplicatorCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return append(diags, create.DiagError(names.Kafka, create.ErrActionWaitingForCreation, ResNameReplicator, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.Kafka, create.ErrActionWaitingForCreation, ResNameReplicator, d.Id(), err)
 	}
 
 	return append(diags, resourceReplicatorRead(ctx, d, meta)...)
@@ -280,7 +280,7 @@ func resourceReplicatorRead(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	if err != nil {
-		return append(diags, create.DiagError(names.Kafka, create.ErrActionReading, ResNameReplicator, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.Kafka, create.ErrActionReading, ResNameReplicator, d.Id(), err)
 	}
 
 	sourceAlias := out.ReplicationInfoList[0].SourceKafkaClusterAlias
@@ -342,11 +342,11 @@ func resourceReplicatorUpdate(ctx context.Context, d *schema.ResourceData, meta 
 		out, err := conn.UpdateReplicationInfo(ctx, in)
 
 		if err != nil {
-			return append(diags, create.DiagError(names.Kafka, create.ErrActionUpdating, ResNameReplicator, d.Id(), err)...)
+			return create.AppendDiagError(diags, names.Kafka, create.ErrActionUpdating, ResNameReplicator, d.Id(), err)
 		}
 
 		if _, err := waitReplicatorUpdated(ctx, conn, aws.ToString(out.ReplicatorArn), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return append(diags, create.DiagError(names.Kafka, create.ErrActionWaitingForUpdate, ResNameReplicator, d.Id(), err)...)
+			return create.AppendDiagError(diags, names.Kafka, create.ErrActionWaitingForUpdate, ResNameReplicator, d.Id(), err)
 		}
 	}
 
@@ -367,11 +367,11 @@ func resourceReplicatorDelete(ctx context.Context, d *schema.ResourceData, meta 
 		return diags
 	}
 	if err != nil {
-		return append(diags, create.DiagError(names.Kafka, create.ErrActionDeleting, ResNameReplicator, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.Kafka, create.ErrActionDeleting, ResNameReplicator, d.Id(), err)
 	}
 
 	if _, err := waitReplicatorDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return append(diags, create.DiagError(names.Kafka, create.ErrActionWaitingForDeletion, ResNameReplicator, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.Kafka, create.ErrActionWaitingForDeletion, ResNameReplicator, d.Id(), err)
 	}
 
 	return diags

--- a/internal/service/kafkaconnect/connector.go
+++ b/internal/service/kafkaconnect/connector.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -386,6 +387,8 @@ func ResourceConnector() *schema.Resource {
 }
 
 func resourceConnectorCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).KafkaConnectConn(ctx)
 
 	name := d.Get("name").(string)
@@ -417,7 +420,7 @@ func resourceConnectorCreate(ctx context.Context, d *schema.ResourceData, meta i
 	output, err := conn.CreateConnectorWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating MSK Connect Connector (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "creating MSK Connect Connector (%s): %s", name, err)
 	}
 
 	d.SetId(aws.StringValue(output.ConnectorArn))
@@ -425,13 +428,15 @@ func resourceConnectorCreate(ctx context.Context, d *schema.ResourceData, meta i
 	_, err = waitConnectorCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate))
 
 	if err != nil {
-		return diag.Errorf("waiting for MSK Connect Connector (%s) create: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for MSK Connect Connector (%s) create: %s", d.Id(), err)
 	}
 
-	return resourceConnectorRead(ctx, d, meta)
+	return append(diags, resourceConnectorRead(ctx, d, meta)...)
 }
 
 func resourceConnectorRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).KafkaConnectConn(ctx)
 
 	connector, err := FindConnectorByARN(ctx, conn, d.Id())
@@ -439,17 +444,17 @@ func resourceConnectorRead(ctx context.Context, d *schema.ResourceData, meta int
 	if tfresource.NotFound(err) && !d.IsNewResource() {
 		log.Printf("[WARN] MSK Connect Connector (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading MSK Connect Connector (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading MSK Connect Connector (%s): %s", d.Id(), err)
 	}
 
 	d.Set("arn", connector.ConnectorArn)
 	if connector.Capacity != nil {
 		if err := d.Set("capacity", []interface{}{flattenCapacityDescription(connector.Capacity)}); err != nil {
-			return diag.Errorf("setting capacity: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting capacity: %s", err)
 		}
 	} else {
 		d.Set("capacity", nil)
@@ -458,21 +463,21 @@ func resourceConnectorRead(ctx context.Context, d *schema.ResourceData, meta int
 	d.Set("description", connector.ConnectorDescription)
 	if connector.KafkaCluster != nil {
 		if err := d.Set("kafka_cluster", []interface{}{flattenClusterDescription(connector.KafkaCluster)}); err != nil {
-			return diag.Errorf("setting kafka_cluster: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting kafka_cluster: %s", err)
 		}
 	} else {
 		d.Set("kafka_cluster", nil)
 	}
 	if connector.KafkaClusterClientAuthentication != nil {
 		if err := d.Set("kafka_cluster_client_authentication", []interface{}{flattenClusterClientAuthenticationDescription(connector.KafkaClusterClientAuthentication)}); err != nil {
-			return diag.Errorf("setting kafka_cluster_client_authentication: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting kafka_cluster_client_authentication: %s", err)
 		}
 	} else {
 		d.Set("kafka_cluster_client_authentication", nil)
 	}
 	if connector.KafkaClusterEncryptionInTransit != nil {
 		if err := d.Set("kafka_cluster_encryption_in_transit", []interface{}{flattenClusterEncryptionInTransitDescription(connector.KafkaClusterEncryptionInTransit)}); err != nil {
-			return diag.Errorf("setting kafka_cluster_encryption_in_transit: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting kafka_cluster_encryption_in_transit: %s", err)
 		}
 	} else {
 		d.Set("kafka_cluster_encryption_in_transit", nil)
@@ -480,29 +485,31 @@ func resourceConnectorRead(ctx context.Context, d *schema.ResourceData, meta int
 	d.Set("kafkaconnect_version", connector.KafkaConnectVersion)
 	if connector.LogDelivery != nil {
 		if err := d.Set("log_delivery", []interface{}{flattenLogDeliveryDescription(connector.LogDelivery)}); err != nil {
-			return diag.Errorf("setting log_delivery: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting log_delivery: %s", err)
 		}
 	} else {
 		d.Set("log_delivery", nil)
 	}
 	d.Set("name", connector.ConnectorName)
 	if err := d.Set("plugin", flattenPluginDescriptions(connector.Plugins)); err != nil {
-		return diag.Errorf("setting plugin: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting plugin: %s", err)
 	}
 	d.Set("service_execution_role_arn", connector.ServiceExecutionRoleArn)
 	d.Set("version", connector.CurrentVersion)
 	if connector.WorkerConfiguration != nil {
 		if err := d.Set("worker_configuration", []interface{}{flattenWorkerConfigurationDescription(connector.WorkerConfiguration)}); err != nil {
-			return diag.Errorf("setting worker_configuration: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting worker_configuration: %s", err)
 		}
 	} else {
 		d.Set("worker_configuration", nil)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceConnectorUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).KafkaConnectConn(ctx)
 
 	input := &kafkaconnect.UpdateConnectorInput{
@@ -515,19 +522,21 @@ func resourceConnectorUpdate(ctx context.Context, d *schema.ResourceData, meta i
 	_, err := conn.UpdateConnectorWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("updating MSK Connect Connector (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "updating MSK Connect Connector (%s): %s", d.Id(), err)
 	}
 
 	_, err = waitConnectorUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
 
 	if err != nil {
-		return diag.Errorf("waiting for MSK Connect Connector (%s) update: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for MSK Connect Connector (%s) update: %s", d.Id(), err)
 	}
 
-	return resourceConnectorRead(ctx, d, meta)
+	return append(diags, resourceConnectorRead(ctx, d, meta)...)
 }
 
 func resourceConnectorDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).KafkaConnectConn(ctx)
 
 	log.Printf("[DEBUG] Deleting MSK Connect Connector: %s", d.Id())
@@ -536,20 +545,20 @@ func resourceConnectorDelete(ctx context.Context, d *schema.ResourceData, meta i
 	})
 
 	if tfawserr.ErrCodeEquals(err, kafkaconnect.ErrCodeNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting MSK Connect Connector (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting MSK Connect Connector (%s): %s", d.Id(), err)
 	}
 
 	_, err = waitConnectorDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete))
 
 	if err != nil {
-		return diag.Errorf("waiting for MSK Connect Connector (%s) delete: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for MSK Connect Connector (%s) delete: %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func expandCapacity(tfMap map[string]interface{}) *kafkaconnect.Capacity {

--- a/internal/service/kafkaconnect/connector_data_source.go
+++ b/internal/service/kafkaconnect/connector_data_source.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
@@ -41,6 +42,8 @@ func DataSourceConnector() *schema.Resource {
 }
 
 func dataSourceConnectorRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).KafkaConnectConn(ctx)
 
 	name := d.Get("name")
@@ -61,7 +64,7 @@ func dataSourceConnectorRead(ctx context.Context, d *schema.ResourceData, meta i
 	})
 
 	if err != nil {
-		return diag.Errorf("listing MSK Connect Connectors: %s", err)
+		return sdkdiag.AppendErrorf(diags, "listing MSK Connect Connectors: %s", err)
 	}
 
 	if len(output) == 0 || output[0] == nil {
@@ -71,7 +74,7 @@ func dataSourceConnectorRead(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	if err != nil {
-		return diag.FromErr(tfresource.SingularDataSourceFindError("MSK Connect Connector", err))
+		return sdkdiag.AppendFromErr(diags, tfresource.SingularDataSourceFindError("MSK Connect Connector", err))
 	}
 
 	connector := output[0]
@@ -83,5 +86,5 @@ func dataSourceConnectorRead(ctx context.Context, d *schema.ResourceData, meta i
 	d.Set("name", connector.ConnectorName)
 	d.Set("version", connector.CurrentVersion)
 
-	return nil
+	return diags
 }

--- a/internal/service/kafkaconnect/custom_plugin_data_source.go
+++ b/internal/service/kafkaconnect/custom_plugin_data_source.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
@@ -45,6 +46,8 @@ func DataSourceCustomPlugin() *schema.Resource {
 }
 
 func dataSourceCustomPluginRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).KafkaConnectConn(ctx)
 
 	name := d.Get("name")
@@ -65,7 +68,7 @@ func dataSourceCustomPluginRead(ctx context.Context, d *schema.ResourceData, met
 	})
 
 	if err != nil {
-		return diag.Errorf("listing MSK Connect Custom Plugins: %s", err)
+		return sdkdiag.AppendErrorf(diags, "listing MSK Connect Custom Plugins: %s", err)
 	}
 
 	if len(output) == 0 || output[0] == nil {
@@ -75,7 +78,7 @@ func dataSourceCustomPluginRead(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	if err != nil {
-		return diag.FromErr(tfresource.SingularDataSourceFindError("MSK Connect Custom Plugin", err))
+		return sdkdiag.AppendFromErr(diags, tfresource.SingularDataSourceFindError("MSK Connect Custom Plugin", err))
 	}
 
 	plugin := output[0]
@@ -93,5 +96,5 @@ func dataSourceCustomPluginRead(ctx context.Context, d *schema.ResourceData, met
 		d.Set("latest_revision", nil)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/kafkaconnect/worker_configuration_data_source.go
+++ b/internal/service/kafkaconnect/worker_configuration_data_source.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
@@ -45,6 +46,8 @@ func DataSourceWorkerConfiguration() *schema.Resource {
 }
 
 func dataSourceWorkerConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).KafkaConnectConn(ctx)
 
 	name := d.Get("name")
@@ -65,7 +68,7 @@ func dataSourceWorkerConfigurationRead(ctx context.Context, d *schema.ResourceDa
 	})
 
 	if err != nil {
-		return diag.Errorf("listing MSK Connect Worker Configurations: %s", err)
+		return sdkdiag.AppendErrorf(diags, "listing MSK Connect Worker Configurations: %s", err)
 	}
 
 	if len(output) == 0 || output[0] == nil {
@@ -75,14 +78,14 @@ func dataSourceWorkerConfigurationRead(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if err != nil {
-		return diag.FromErr(tfresource.SingularDataSourceFindError("MSK Connect Worker Configuration", err))
+		return sdkdiag.AppendFromErr(diags, tfresource.SingularDataSourceFindError("MSK Connect Worker Configuration", err))
 	}
 
 	arn := aws.StringValue(output[0].WorkerConfigurationArn)
 	config, err := FindWorkerConfigurationByARN(ctx, conn, arn)
 
 	if err != nil {
-		return diag.Errorf("reading MSK Connect Worker Configuration (%s): %s", arn, err)
+		return sdkdiag.AppendErrorf(diags, "reading MSK Connect Worker Configuration (%s): %s", arn, err)
 	}
 
 	d.SetId(aws.StringValue(config.Name))
@@ -99,5 +102,5 @@ func dataSourceWorkerConfigurationRead(ctx context.Context, d *schema.ResourceDa
 		d.Set("properties_file_content", nil)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/kendra/data_source.go
+++ b/internal/service/kendra/data_source.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -591,6 +592,8 @@ func documentAttributeValueSchema() *schema.Schema {
 }
 
 func resourceDataSourceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).KendraClient(ctx)
 
 	name := d.Get("name").(string)
@@ -642,11 +645,11 @@ func resourceDataSourceCreate(ctx context.Context, d *schema.ResourceData, meta 
 	)
 
 	if err != nil {
-		return diag.Errorf("creating Kendra Data Source (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "creating Kendra Data Source (%s): %s", name, err)
 	}
 
 	if outputRaw == nil {
-		return diag.Errorf("creating Kendra Data Source (%s): empty output", name)
+		return sdkdiag.AppendErrorf(diags, "creating Kendra Data Source (%s): empty output", name)
 	}
 
 	output := outputRaw.(*kendra.CreateDataSourceOutput)
@@ -657,18 +660,20 @@ func resourceDataSourceCreate(ctx context.Context, d *schema.ResourceData, meta 
 	d.SetId(fmt.Sprintf("%s/%s", id, indexId))
 
 	if _, err := waitDataSourceCreated(ctx, conn, id, indexId, d.Timeout(schema.TimeoutCreate)); err != nil {
-		return diag.Errorf("waiting for Data Source (%s) creation: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Data Source (%s) creation: %s", d.Id(), err)
 	}
 
-	return resourceDataSourceRead(ctx, d, meta)
+	return append(diags, resourceDataSourceRead(ctx, d, meta)...)
 }
 
 func resourceDataSourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).KendraClient(ctx)
 
 	id, indexId, err := DataSourceParseResourceID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	resp, err := FindDataSourceByID(ctx, conn, id, indexId)
@@ -676,11 +681,11 @@ func resourceDataSourceRead(ctx context.Context, d *schema.ResourceData, meta in
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Kendra Data Source (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("getting Kendra Data Source (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "getting Kendra Data Source (%s): %s", d.Id(), err)
 	}
 
 	arn := arn.ARN{
@@ -706,23 +711,25 @@ func resourceDataSourceRead(ctx context.Context, d *schema.ResourceData, meta in
 	d.Set("updated_at", aws.ToTime(resp.UpdatedAt).Format(time.RFC3339))
 
 	if err := d.Set("configuration", flattenDataSourceConfiguration(resp.Configuration)); err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	if err := d.Set("custom_document_enrichment_configuration", flattenCustomDocumentEnrichmentConfiguration(resp.CustomDocumentEnrichmentConfiguration)); err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceDataSourceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).KendraClient(ctx)
 
 	if d.HasChanges("configuration", "custom_document_enrichment_configuration", "description", "language_code", "name", "role_arn", "schedule") {
 		id, indexId, err := DataSourceParseResourceID(d.Id())
 		if err != nil {
-			return diag.FromErr(err)
+			return sdkdiag.AppendFromErr(diags, err)
 		}
 
 		input := &kendra.UpdateDataSourceInput{
@@ -776,25 +783,27 @@ func resourceDataSourceUpdate(ctx context.Context, d *schema.ResourceData, meta 
 		)
 
 		if err != nil {
-			return diag.Errorf("updating Kendra Data Source(%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating Kendra Data Source(%s): %s", d.Id(), err)
 		}
 
 		if _, err := waitDataSourceUpdated(ctx, conn, id, indexId, d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return diag.Errorf("waiting for Kendra Data Source (%s) update: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "waiting for Kendra Data Source (%s) update: %s", d.Id(), err)
 		}
 	}
 
-	return resourceDataSourceRead(ctx, d, meta)
+	return append(diags, resourceDataSourceRead(ctx, d, meta)...)
 }
 
 func resourceDataSourceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).KendraClient(ctx)
 
 	log.Printf("[INFO] Deleting Kendra Data Source %s", d.Id())
 
 	id, indexId, err := DataSourceParseResourceID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	_, err = conn.DeleteDataSource(ctx, &kendra.DeleteDataSourceInput{
@@ -804,18 +813,18 @@ func resourceDataSourceDelete(ctx context.Context, d *schema.ResourceData, meta 
 
 	var resourceNotFoundException *types.ResourceNotFoundException
 	if errors.As(err, &resourceNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting Kendra Data Source (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Kendra Data Source (%s): %s", d.Id(), err)
 	}
 
 	if _, err := waitDataSourceDeleted(ctx, conn, id, indexId, d.Timeout(schema.TimeoutDelete)); err != nil {
-		return diag.Errorf("waiting for Kendra Data Source (%s) delete: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Kendra Data Source (%s) delete: %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func waitDataSourceCreated(ctx context.Context, conn *kendra.Client, id, indexId string, timeout time.Duration) (*kendra.DescribeDataSourceOutput, error) {

--- a/internal/service/kendra/experience_data_source.go
+++ b/internal/service/kendra/experience_data_source.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 )
 
 // @SDKDataSource("aws_kendra_experience")
@@ -140,6 +141,8 @@ func DataSourceExperience() *schema.Resource {
 }
 
 func dataSourceExperienceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).KendraClient(ctx)
 
 	experienceID := d.Get("experience_id").(string)
@@ -148,7 +151,7 @@ func dataSourceExperienceRead(ctx context.Context, d *schema.ResourceData, meta 
 	resp, err := FindExperienceByID(ctx, conn, experienceID, indexID)
 
 	if err != nil {
-		return diag.Errorf("reading Kendra Experience (%s): %s", experienceID, err)
+		return sdkdiag.AppendErrorf(diags, "reading Kendra Experience (%s): %s", experienceID, err)
 	}
 
 	arn := arn.ARN{
@@ -170,14 +173,14 @@ func dataSourceExperienceRead(ctx context.Context, d *schema.ResourceData, meta 
 	d.Set("updated_at", aws.ToTime(resp.UpdatedAt).Format(time.RFC3339))
 
 	if err := d.Set("configuration", flattenConfiguration(resp.Configuration)); err != nil {
-		return diag.Errorf("setting configuration argument: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting configuration argument: %s", err)
 	}
 
 	if err := d.Set("endpoints", flattenEndpoints(resp.Endpoints)); err != nil {
-		return diag.Errorf("setting endpoints argument: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting endpoints argument: %s", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", experienceID, indexID))
 
-	return nil
+	return diags
 }

--- a/internal/service/kendra/query_suggestions_block_list_data_source.go
+++ b/internal/service/kendra/query_suggestions_block_list_data_source.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 )
 
@@ -101,6 +102,8 @@ func DataSourceQuerySuggestionsBlockList() *schema.Resource {
 }
 
 func dataSourceQuerySuggestionsBlockListRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).KendraClient(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
@@ -110,7 +113,7 @@ func dataSourceQuerySuggestionsBlockListRead(ctx context.Context, d *schema.Reso
 	resp, err := FindQuerySuggestionsBlockListByID(ctx, conn, querySuggestionsBlockListID, indexID)
 
 	if err != nil {
-		return diag.Errorf("reading Kendra QuerySuggestionsBlockList (%s): %s", querySuggestionsBlockListID, err)
+		return sdkdiag.AppendErrorf(diags, "reading Kendra QuerySuggestionsBlockList (%s): %s", querySuggestionsBlockListID, err)
 	}
 
 	arn := arn.ARN{
@@ -134,22 +137,22 @@ func dataSourceQuerySuggestionsBlockListRead(ctx context.Context, d *schema.Reso
 	d.Set("updated_at", aws.ToTime(resp.UpdatedAt).Format(time.RFC3339))
 
 	if err := d.Set("source_s3_path", flattenSourceS3Path(resp.SourceS3Path)); err != nil {
-		return diag.Errorf("setting source_s3_path: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting source_s3_path: %s", err)
 	}
 
 	tags, err := listTags(ctx, conn, arn)
 
 	if err != nil {
-		return diag.Errorf("listing tags for Kendra QuerySuggestionsBlockList (%s): %s", arn, err)
+		return sdkdiag.AppendErrorf(diags, "listing tags for Kendra QuerySuggestionsBlockList (%s): %s", arn, err)
 	}
 
 	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
 	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", querySuggestionsBlockListID, indexID))
 
-	return nil
+	return diags
 }

--- a/internal/service/kendra/thesaurus.go
+++ b/internal/service/kendra/thesaurus.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -103,6 +104,8 @@ func ResourceThesaurus() *schema.Resource {
 }
 
 func resourceThesaurusCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).KendraClient(ctx)
 
 	input := &kendra.CreateThesaurusInput{
@@ -134,11 +137,11 @@ func resourceThesaurusCreate(ctx context.Context, d *schema.ResourceData, meta i
 	)
 
 	if err != nil {
-		return diag.Errorf("creating Amazon Kendra Thesaurus (%s): %s", d.Get("name").(string), err)
+		return sdkdiag.AppendErrorf(diags, "creating Amazon Kendra Thesaurus (%s): %s", d.Get("name").(string), err)
 	}
 
 	if outputRaw == nil {
-		return diag.Errorf("creating Amazon Kendra Thesaurus (%s): empty output", d.Get("name").(string))
+		return sdkdiag.AppendErrorf(diags, "creating Amazon Kendra Thesaurus (%s): empty output", d.Get("name").(string))
 	}
 
 	output := outputRaw.(*kendra.CreateThesaurusOutput)
@@ -149,18 +152,20 @@ func resourceThesaurusCreate(ctx context.Context, d *schema.ResourceData, meta i
 	d.SetId(fmt.Sprintf("%s/%s", id, indexId))
 
 	if _, err := waitThesaurusCreated(ctx, conn, id, indexId, d.Timeout(schema.TimeoutCreate)); err != nil {
-		return diag.Errorf("waiting for Amazon Kendra Thesaurus (%s) create: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Amazon Kendra Thesaurus (%s) create: %s", d.Id(), err)
 	}
 
-	return resourceThesaurusRead(ctx, d, meta)
+	return append(diags, resourceThesaurusRead(ctx, d, meta)...)
 }
 
 func resourceThesaurusRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).KendraClient(ctx)
 
 	id, indexId, err := ThesaurusParseResourceID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	out, err := FindThesaurusByID(ctx, conn, id, indexId)
@@ -168,11 +173,11 @@ func resourceThesaurusRead(ctx context.Context, d *schema.ResourceData, meta int
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Kendra Thesaurus (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Kendra Thesaurus (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Kendra Thesaurus (%s): %s", d.Id(), err)
 	}
 
 	arn := arn.ARN{
@@ -192,19 +197,21 @@ func resourceThesaurusRead(ctx context.Context, d *schema.ResourceData, meta int
 	d.Set("thesaurus_id", out.Id)
 
 	if err := d.Set("source_s3_path", flattenSourceS3Path(out.SourceS3Path)); err != nil {
-		return diag.Errorf("setting complex argument: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting complex argument: %s", err)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceThesaurusUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).KendraClient(ctx)
 
 	if d.HasChangesExcept("tags", "tags_all") {
 		id, indexId, err := ThesaurusParseResourceID(d.Id())
 		if err != nil {
-			return diag.FromErr(err)
+			return sdkdiag.AppendFromErr(diags, err)
 		}
 
 		input := &kendra.UpdateThesaurusInput{
@@ -246,25 +253,27 @@ func resourceThesaurusUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		)
 
 		if err != nil {
-			return diag.Errorf("updating Kendra Thesaurus(%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating Kendra Thesaurus(%s): %s", d.Id(), err)
 		}
 
 		if _, err := waitThesaurusUpdated(ctx, conn, id, indexId, d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return diag.Errorf("waiting for Kendra Thesaurus (%s) update: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "waiting for Kendra Thesaurus (%s) update: %s", d.Id(), err)
 		}
 	}
 
-	return resourceThesaurusRead(ctx, d, meta)
+	return append(diags, resourceThesaurusRead(ctx, d, meta)...)
 }
 
 func resourceThesaurusDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).KendraClient(ctx)
 
 	log.Printf("[INFO] Deleting Kendra Thesaurus %s", d.Id())
 
 	id, indexId, err := ThesaurusParseResourceID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	_, err = conn.DeleteThesaurus(ctx, &kendra.DeleteThesaurusInput{
@@ -274,18 +283,18 @@ func resourceThesaurusDelete(ctx context.Context, d *schema.ResourceData, meta i
 
 	var resourceNotFoundException *types.ResourceNotFoundException
 	if errors.As(err, &resourceNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting Kendra Thesaurus (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Kendra Thesaurus (%s): %s", d.Id(), err)
 	}
 
 	if _, err := waitThesaurusDeleted(ctx, conn, id, indexId, d.Timeout(schema.TimeoutDelete)); err != nil {
-		return diag.Errorf("waiting for Kendra Thesaurus (%s) to be deleted: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Kendra Thesaurus (%s) to be deleted: %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func statusThesaurus(ctx context.Context, conn *kendra.Client, id, indexId string) retry.StateRefreshFunc {

--- a/internal/service/kendra/thesaurus_data_source.go
+++ b/internal/service/kendra/thesaurus_data_source.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 )
 
@@ -108,6 +109,8 @@ func DataSourceThesaurus() *schema.Resource {
 }
 
 func dataSourceThesaurusRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).KendraClient(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
@@ -117,7 +120,7 @@ func dataSourceThesaurusRead(ctx context.Context, d *schema.ResourceData, meta i
 	resp, err := FindThesaurusByID(ctx, conn, thesaurusID, indexID)
 
 	if err != nil {
-		return diag.Errorf("reading Kendra Thesaurus (%s): %s", thesaurusID, err)
+		return sdkdiag.AppendErrorf(diags, "reading Kendra Thesaurus (%s): %s", thesaurusID, err)
 	}
 
 	arn := arn.ARN{
@@ -142,22 +145,22 @@ func dataSourceThesaurusRead(ctx context.Context, d *schema.ResourceData, meta i
 	d.Set("updated_at", aws.ToTime(resp.UpdatedAt).Format(time.RFC3339))
 
 	if err := d.Set("source_s3_path", flattenSourceS3Path(resp.SourceS3Path)); err != nil {
-		return diag.Errorf("setting source_s3_path: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting source_s3_path: %s", err)
 	}
 
 	tags, err := listTags(ctx, conn, arn)
 
 	if err != nil {
-		return diag.Errorf("listing tags for Kendra Thesaurus (%s): %s", arn, err)
+		return sdkdiag.AppendErrorf(diags, "listing tags for Kendra Thesaurus (%s): %s", arn, err)
 	}
 
 	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
 	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", thesaurusID, indexID))
 
-	return nil
+	return diags
 }

--- a/internal/service/kms/custom_key_store_data_source.go
+++ b/internal/service/kms/custom_key_store_data_source.go
@@ -58,6 +58,8 @@ const (
 )
 
 func dataSourceCustomKeyStoreRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).KMSConn(ctx)
 
 	input := &kms.DescribeCustomKeyStoresInput{}
@@ -75,7 +77,7 @@ func dataSourceCustomKeyStoreRead(ctx context.Context, d *schema.ResourceData, m
 	keyStore, err := FindCustomKeyStoreByID(ctx, conn, input)
 
 	if err != nil {
-		return create.DiagError(names.KMS, create.ErrActionReading, DSNameCustomKeyStore, ksID, err)
+		return create.AppendDiagError(diags, names.KMS, create.ErrActionReading, DSNameCustomKeyStore, ksID, err)
 	}
 
 	d.SetId(aws.StringValue(keyStore.CustomKeyStoreId))
@@ -86,5 +88,5 @@ func dataSourceCustomKeyStoreRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set("creation_date", keyStore.CreationDate.Format(time.RFC3339))
 	d.Set("trust_anchor_certificate", keyStore.TrustAnchorCertificate)
 
-	return nil
+	return diags
 }

--- a/internal/service/kms/grant.go
+++ b/internal/service/kms/grant.go
@@ -206,11 +206,11 @@ func resourceGrantRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] KMS Grant (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading KMS Grant (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading KMS Grant (%s): %s", d.Id(), err)
 	}
 
 	if grant.Constraints != nil {

--- a/internal/service/kms/secret_data_source.go
+++ b/internal/service/kms/secret_data_source.go
@@ -16,7 +16,7 @@ const SecretRemovedMessage = "This data source has been replaced with the `aws_k
 func DataSourceSecret() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: func(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-			return diag.Errorf(SecretRemovedMessage)
+			return diag.Errorf(SecretRemovedMessage) // nosemgrep:ci.semgrep.pluginsdk.avoid-diag_Errorf
 		},
 
 		Schema: map[string]*schema.Schema{


### PR DESCRIPTION
### Description

Collects diagnostics in `diags` instead of returning error diagnostic directly. Ensures that warning diagnostics are not accidentally dropped.

Covers services starting with `e` (other than `ec2`), `f`, `g`, `i`, and `k`
