### PR TITLE
resource/aws_db_instance: Allow out-of-band Blue/Green update

### DIFF
--- a/.changelog/34728.txt
+++ b/.changelog/34728.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_db_instance: Fix error where Terraform loses track of resource if Blue/Green Deployment is applied outside of Terraform
+```

--- a/.ci/semgrep/pluginsdk/isnewresource.yml
+++ b/.ci/semgrep/pluginsdk/isnewresource.yml
@@ -23,4 +23,11 @@ rules:
           }
       - pattern-not-inside: |
           if <... !d.IsNewResource() ...> { ... }
+      - pattern-not-inside: |
+          if <... d.IsNewResource() ...> { ... } else {
+            ...
+            d.SetId("")
+            ...
+            return nil
+          }
     severity: WARNING

--- a/internal/service/rds/blue_green.go
+++ b/internal/service/rds/blue_green.go
@@ -46,7 +46,7 @@ func (o *blueGreenOrchestrator) cleanUp(ctx context.Context) { //nolint:unused /
 	}
 }
 
-func (o *blueGreenOrchestrator) createDeployment(ctx context.Context, input *rds_sdkv2.CreateBlueGreenDeploymentInput) (*types.BlueGreenDeployment, error) {
+func (o *blueGreenOrchestrator) CreateDeployment(ctx context.Context, input *rds_sdkv2.CreateBlueGreenDeploymentInput) (*types.BlueGreenDeployment, error) {
 	createOut, err := o.conn.CreateBlueGreenDeployment(ctx, input)
 	if err != nil {
 		return nil, fmt.Errorf("creating Blue/Green Deployment: %s", err)
@@ -63,7 +63,7 @@ func (o *blueGreenOrchestrator) waitForDeploymentAvailable(ctx context.Context, 
 	return dep, nil
 }
 
-func (o *blueGreenOrchestrator) switchover(ctx context.Context, identifier string, timeout time.Duration) (*types.BlueGreenDeployment, error) {
+func (o *blueGreenOrchestrator) Switchover(ctx context.Context, identifier string, timeout time.Duration) (*types.BlueGreenDeployment, error) {
 	input := &rds_sdkv2.SwitchoverBlueGreenDeploymentInput{
 		BlueGreenDeploymentIdentifier: aws.String(identifier),
 	}

--- a/internal/service/rds/blue_green.go
+++ b/internal/service/rds/blue_green.go
@@ -17,13 +17,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-type cleanupWaiterFunc func(context.Context, *rds_sdkv2.Client, ...tfresource.OptionsFunc) //nolint:unused // WIP
-
-type cleanupWaiterErrFunc func(context.Context, ...tfresource.OptionsFunc) error //nolint:unused // WIP
+type cleanupWaiterFunc func(context.Context, *rds_sdkv2.Client, ...tfresource.OptionsFunc)
 
 type blueGreenOrchestrator struct {
 	conn           *rds_sdkv2.Client
-	cleanupWaiters []cleanupWaiterFunc //nolint:unused // WIP
+	cleanupWaiters []cleanupWaiterFunc
 }
 
 func newBlueGreenOrchestrator(conn *rds_sdkv2.Client) *blueGreenOrchestrator {

--- a/internal/service/rds/exports_test.go
+++ b/internal/service/rds/exports_test.go
@@ -8,4 +8,19 @@ var (
 	FindDBInstanceByID = findDBInstanceByIDSDKv1
 
 	ListTags = listTags
+
+	NewBlueGreenOrchestrator = newBlueGreenOrchestrator
+
+	WaitBlueGreenDeploymentDeleted   = waitBlueGreenDeploymentDeleted
+	WaitBlueGreenDeploymentAvailable = waitBlueGreenDeploymentAvailable
+
+	ParseDBInstanceARN = parseDBInstanceARN
+
+	WaitDBInstanceAvailable = waitDBInstanceAvailableSDKv2
+	WaitDBInstanceDeleted   = waitDBInstanceDeleted
+)
+
+const (
+	ErrCodeInvalidParameterCombination = errCodeInvalidParameterCombination
+	ErrCodeInvalidParameterValue       = errCodeInvalidParameterValue
 )

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -2606,7 +2606,7 @@ func waitDBInstanceAvailableSDKv1(ctx context.Context, conn *rds.RDS, id string,
 	return nil, err
 }
 
-func waitDBInstanceAvailableSDKv2(ctx context.Context, conn *rds_sdkv2.Client, id string, timeout time.Duration, optFns ...tfresource.OptionsFunc) (*rds.DBInstance, error) { //nolint:unparam
+func waitDBInstanceAvailableSDKv2(ctx context.Context, conn *rds_sdkv2.Client, id string, timeout time.Duration, optFns ...tfresource.OptionsFunc) (*rds.DBInstance, error) {
 	options := tfresource.Options{
 		PollInterval:              10 * time.Second,
 		Delay:                     1 * time.Minute,
@@ -2649,7 +2649,7 @@ func waitDBInstanceAvailableSDKv2(ctx context.Context, conn *rds_sdkv2.Client, i
 	return nil, err
 }
 
-func waitDBInstanceDeleted(ctx context.Context, conn *rds.RDS, id string, timeout time.Duration, optFns ...tfresource.OptionsFunc) (*rds.DBInstance, error) { //nolint:unparam
+func waitDBInstanceDeleted(ctx context.Context, conn *rds.RDS, id string, timeout time.Duration, optFns ...tfresource.OptionsFunc) (*rds.DBInstance, error) {
 	options := tfresource.Options{
 		PollInterval:              10 * time.Second,
 		Delay:                     1 * time.Minute,

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -5423,7 +5423,6 @@ func TestAccRDSInstance_BlueGreenDeployment_outOfBand(t *testing.T) {
 			},
 		},
 	})
-
 }
 
 func TestAccRDSInstance_gp3MySQL(t *testing.T) {


### PR DESCRIPTION
### Description

If an `aws_db_instance` is updated manually using a Blue/Green Deployment, the provider would lose track of it. Allow the provider to keep it under management.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=rds TESTS=TestAccRDSInstance_BlueGreenDeployment_

--- PASS: TestAccRDSInstance_BlueGreenDeployment_deletionProtectionBypassesBlueGreen (978.93s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_tags (1082.57s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_passwordBypassesBlueGreen (1203.86s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateParameterGroup (2564.51s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateEngineVersion (2620.85s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateInstanceClass (2704.70s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateAndEnableBackups (2790.61s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_outOfBand (2810.39s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateWithDeletionProtection (2826.78s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateAndPromoteReplica (3434.78s)
```
