### PR TITLE
Fixing empty `physical_connection_requirements` in `aws_glue_connection` resource

### DIFF
--- a/.changelog/34737.txt
+++ b/.changelog/34737.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_glue_connection: Fix Terraform crash while creating resource with empty `physical_connection_requirements` configuration block.
+```

--- a/.changelog/34737.txt
+++ b/.changelog/34737.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_glue_connection: Fix Terraform crash while creating resource with empty `physical_connection_requirements` configuration block.
+resource/aws_glue_connection: Fix crash while creating resource with empty `physical_connection_requirements` configuration block
 ```

--- a/internal/service/glue/connection.go
+++ b/internal/service/glue/connection.go
@@ -277,9 +277,8 @@ func expandConnectionInput(d *schema.ResourceData) *glue.ConnectionInput {
 		connectionInput.MatchCriteria = flex.ExpandStringList(v.([]interface{}))
 	}
 
-	if v, ok := d.GetOk("physical_connection_requirements"); ok {
-		physicalConnectionRequirementsList := v.([]interface{})
-		physicalConnectionRequirementsMap := physicalConnectionRequirementsList[0].(map[string]interface{})
+	if v, ok := d.GetOk("physical_connection_requirements"); ok && v.([]interface{})[0] != nil {
+		physicalConnectionRequirementsMap := v.([]interface{})[0].(map[string]interface{})
 		connectionInput.PhysicalConnectionRequirements = expandPhysicalConnectionRequirements(physicalConnectionRequirementsMap)
 	}
 


### PR DESCRIPTION
### Description

This PR fixes the [bug](https://github.com/hashicorp/terraform-provider-aws/issues/34735) in `aws_glue_connection` resource.


### Relations

Closes #34735

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
make testacc TESTS=TestAccGlueConnection_basic PKG=glue
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/glue/... -v -count 1 -parallel 20 -run='TestAccGlueConnection_basic'  -timeout 360m
=== RUN   TestAccGlueConnection_basic
=== PAUSE TestAccGlueConnection_basic
=== CONT  TestAccGlueConnection_basic
--- PASS: TestAccGlueConnection_basic (25.07s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/glue       30.483s
...
```
