### PR TITLE
r/aws_ssoadmin_application_assignment: new resource

### DIFF
--- a/.changelog/34741.txt
+++ b/.changelog/34741.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_ssoadmin_application_assignment
+```

--- a/internal/service/ssoadmin/application_assignment.go
+++ b/internal/service/ssoadmin/application_assignment.go
@@ -1,0 +1,217 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ssoadmin
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssoadmin"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/ssoadmin/types"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	intflex "github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource(name="Application Assignment")
+func newResourceApplicationAssignment(_ context.Context) (resource.ResourceWithConfigure, error) {
+	return &resourceApplicationAssignment{}, nil
+}
+
+const (
+	ResNameApplicationAssignment = "Application Assignment"
+
+	applicationAssignmentIDPartCount = 3
+)
+
+type resourceApplicationAssignment struct {
+	framework.ResourceWithConfigure
+}
+
+func (r *resourceApplicationAssignment) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "aws_ssoadmin_application_assignment"
+}
+
+func (r *resourceApplicationAssignment) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"application_arn": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"id": framework.IDAttribute(),
+			"principal_id": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"principal_type": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					enum.FrameworkValidate[awstypes.PrincipalType](),
+				},
+			},
+		},
+	}
+}
+
+func (r *resourceApplicationAssignment) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().SSOAdminClient(ctx)
+
+	var plan resourceApplicationAssignmentData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	applicationARN := plan.ApplicationARN.ValueString()
+	principalID := plan.PrincipalID.ValueString()
+	principalType := plan.PrincipalType.ValueString()
+
+	idParts := []string{
+		applicationARN,
+		principalID,
+		principalType,
+	}
+	id, _ := intflex.FlattenResourceId(idParts, applicationAssignmentIDPartCount, false)
+	plan.ID = types.StringValue(id)
+
+	in := &ssoadmin.CreateApplicationAssignmentInput{
+		ApplicationArn: aws.String(applicationARN),
+		PrincipalId:    aws.String(principalID),
+		PrincipalType:  awstypes.PrincipalType(principalType),
+	}
+
+	_, err := conn.CreateApplicationAssignment(ctx, in)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.SSOAdmin, create.ErrActionCreating, ResNameApplicationAssignment, plan.ApplicationARN.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *resourceApplicationAssignment) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().SSOAdminClient(ctx)
+
+	var state resourceApplicationAssignmentData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := findApplicationAssignmentByID(ctx, conn, state.ID.ValueString())
+	if tfresource.NotFound(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.SSOAdmin, create.ErrActionSetting, ResNameApplicationAssignment, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	state.ApplicationARN = flex.StringToFramework(ctx, out.ApplicationArn)
+	state.PrincipalID = flex.StringToFramework(ctx, out.PrincipalId)
+	state.PrincipalType = flex.StringValueToFramework(ctx, out.PrincipalType)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *resourceApplicationAssignment) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// Np-op update
+}
+
+func (r *resourceApplicationAssignment) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	conn := r.Meta().SSOAdminClient(ctx)
+
+	var state resourceApplicationAssignmentData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := &ssoadmin.DeleteApplicationAssignmentInput{
+		ApplicationArn: aws.String(state.ApplicationARN.ValueString()),
+		PrincipalId:    aws.String(state.PrincipalID.ValueString()),
+		PrincipalType:  awstypes.PrincipalType(state.PrincipalType.ValueString()),
+	}
+
+	_, err := conn.DeleteApplicationAssignment(ctx, in)
+	if err != nil {
+		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+			return
+		}
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.SSOAdmin, create.ErrActionDeleting, ResNameApplicationAssignment, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+}
+
+func (r *resourceApplicationAssignment) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func findApplicationAssignmentByID(ctx context.Context, conn *ssoadmin.Client, id string) (*ssoadmin.DescribeApplicationAssignmentOutput, error) {
+	parts, err := intflex.ExpandResourceId(id, applicationAssignmentIDPartCount, false)
+	if err != nil {
+		return nil, err
+	}
+
+	in := &ssoadmin.DescribeApplicationAssignmentInput{
+		ApplicationArn: aws.String(parts[0]),
+		PrincipalId:    aws.String(parts[1]),
+		PrincipalType:  awstypes.PrincipalType(parts[2]),
+	}
+
+	out, err := conn.DescribeApplicationAssignment(ctx, in)
+	if err != nil {
+		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+			return nil, &retry.NotFoundError{
+				LastError:   err,
+				LastRequest: in,
+			}
+		}
+
+		return nil, err
+	}
+
+	if out == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return out, nil
+}
+
+type resourceApplicationAssignmentData struct {
+	ApplicationARN types.String `tfsdk:"application_arn"`
+	ID             types.String `tfsdk:"id"`
+	PrincipalID    types.String `tfsdk:"principal_id"`
+	PrincipalType  types.String `tfsdk:"principal_type"`
+}

--- a/internal/service/ssoadmin/application_assignment_test.go
+++ b/internal/service/ssoadmin/application_assignment_test.go
@@ -1,0 +1,246 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ssoadmin_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/ssoadmin/types"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	tfssoadmin "github.com/hashicorp/terraform-provider-aws/internal/service/ssoadmin"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccSSOAdminApplicationAssignment_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_ssoadmin_application_assignment.test"
+	applicationResourceName := "aws_ssoadmin_application.test"
+	userResourceName := "aws_identitystore_user.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.SSOAdminEndpointID)
+			acctest.PreCheckSSOAdminInstances(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSOAdminEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckApplicationAssignmentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApplicationAssignmentConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApplicationAssignmentExists(ctx, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "application_arn", applicationResourceName, "application_arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "principal_id", userResourceName, "user_id"),
+					resource.TestCheckResourceAttr(resourceName, "principal_type", "USER"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSSOAdminApplicationAssignment_group(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_ssoadmin_application_assignment.test"
+	applicationResourceName := "aws_ssoadmin_application.test"
+	groupResourceName := "aws_identitystore_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.SSOAdminEndpointID)
+			acctest.PreCheckSSOAdminInstances(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSOAdminEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckApplicationAssignmentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApplicationAssignmentConfig_group(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApplicationAssignmentExists(ctx, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "application_arn", applicationResourceName, "application_arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "principal_id", groupResourceName, "group_id"),
+					resource.TestCheckResourceAttr(resourceName, "principal_type", "GROUP"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSSOAdminApplicationAssignment_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_ssoadmin_application_assignment.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.SSOAdminEndpointID)
+			acctest.PreCheckSSOAdminInstances(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSOAdminEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckApplicationAssignmentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApplicationAssignmentConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApplicationAssignmentExists(ctx, resourceName),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfssoadmin.ResourceApplicationAssignment, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccSSOAdminApplicationAssignment_disappears_Application(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_ssoadmin_application_assignment.test"
+	applicationResourceName := "aws_ssoadmin_application.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.SSOAdminEndpointID)
+			acctest.PreCheckSSOAdminInstances(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSOAdminEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckApplicationAssignmentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApplicationAssignmentConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApplicationAssignmentExists(ctx, resourceName),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfssoadmin.ResourceApplication, applicationResourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckApplicationAssignmentDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).SSOAdminClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_ssoadmin_application_assignment" {
+				continue
+			}
+
+			_, err := tfssoadmin.FindApplicationAssignmentByID(ctx, conn, rs.Primary.ID)
+			if errs.IsA[*types.ResourceNotFoundException](err) {
+				return nil
+			}
+			if err != nil {
+				return create.Error(names.SSOAdmin, create.ErrActionCheckingDestroyed, tfssoadmin.ResNameApplicationAssignment, rs.Primary.ID, err)
+			}
+
+			return create.Error(names.SSOAdmin, create.ErrActionCheckingDestroyed, tfssoadmin.ResNameApplicationAssignment, rs.Primary.ID, errors.New("not destroyed"))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckApplicationAssignmentExists(ctx context.Context, name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.SSOAdmin, create.ErrActionCheckingExistence, tfssoadmin.ResNameApplicationAssignment, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.SSOAdmin, create.ErrActionCheckingExistence, tfssoadmin.ResNameApplicationAssignment, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).SSOAdminClient(ctx)
+
+		_, err := tfssoadmin.FindApplicationAssignmentByID(ctx, conn, rs.Primary.ID)
+		if err != nil {
+			return create.Error(names.SSOAdmin, create.ErrActionCheckingExistence, tfssoadmin.ResNameApplicationAssignment, rs.Primary.ID, err)
+		}
+
+		return nil
+	}
+}
+
+func testAccApplicationAssignmentConfigBase(rName string) string {
+	return fmt.Sprintf(`
+data "aws_ssoadmin_instances" "test" {}
+
+resource "aws_ssoadmin_application" "test" {
+  name                     = %[1]q
+  application_provider_arn = %[2]q
+  instance_arn             = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+}
+`, rName, testAccApplicationProviderARN)
+}
+
+func testAccApplicationAssignmentConfig_basic(rName string) string {
+	return acctest.ConfigCompose(
+		testAccApplicationAssignmentConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_identitystore_user" "test" {
+  identity_store_id = tolist(data.aws_ssoadmin_instances.test.identity_store_ids)[0]
+
+  display_name = "Acceptance Test"
+  user_name    = %[1]q
+
+  name {
+    family_name = "Doe"
+    given_name  = "John"
+  }
+}
+
+resource "aws_ssoadmin_application_assignment" "test" {
+  application_arn = aws_ssoadmin_application.test.application_arn
+  principal_id    = aws_identitystore_user.test.user_id
+  principal_type  = "USER"
+}
+`, rName))
+}
+
+func testAccApplicationAssignmentConfig_group(rName string) string {
+	return acctest.ConfigCompose(
+		testAccApplicationAssignmentConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_identitystore_group" "test" {
+  identity_store_id = tolist(data.aws_ssoadmin_instances.test.identity_store_ids)[0]
+  display_name      = %[1]q
+}
+
+resource "aws_ssoadmin_application_assignment" "test" {
+  application_arn = aws_ssoadmin_application.test.application_arn
+  principal_id    = aws_identitystore_group.test.group_id
+  principal_type  = "GROUP"
+}
+`, rName))
+}

--- a/internal/service/ssoadmin/exports_test.go
+++ b/internal/service/ssoadmin/exports_test.go
@@ -5,7 +5,9 @@ package ssoadmin
 
 // Exports for use in tests only.
 var (
-	ResourceApplication = newResourceApplication
+	ResourceApplication           = newResourceApplication
+	ResourceApplicationAssignment = newResourceApplicationAssignment
 
-	FindApplicationByID = findApplicationByID
+	FindApplicationByID           = findApplicationByID
+	FindApplicationAssignmentByID = findApplicationAssignmentByID
 )

--- a/internal/service/ssoadmin/service_package_gen.go
+++ b/internal/service/ssoadmin/service_package_gen.go
@@ -28,6 +28,10 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 			Name:    "Application",
 			Tags:    &types.ServicePackageResourceTags{},
 		},
+		{
+			Factory: newResourceApplicationAssignment,
+			Name:    "Application Assignment",
+		},
 	}
 }
 

--- a/website/docs/r/ssoadmin_application_assignment.html.markdown
+++ b/website/docs/r/ssoadmin_application_assignment.html.markdown
@@ -1,0 +1,63 @@
+---
+subcategory: "SSO Admin"
+layout: "aws"
+page_title: "AWS: aws_ssoadmin_application_assignment"
+description: |-
+  Terraform resource for managing an AWS SSO Admin Application Assignment.
+---
+# Resource: aws_ssoadmin_application_assignment
+
+Terraform resource for managing an AWS SSO Admin Application Assignment.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_ssoadmin_application_assignment" "example" {
+  application_arn = aws_ssoadmin_application.example.application_arn
+  principal_id    = aws_identitystore_user.example.user_id
+  principal_type  = "USER"
+}
+```
+
+### Group Type
+
+```terraform
+resource "aws_ssoadmin_application_assignment" "example" {
+  application_arn = aws_ssoadmin_application.example.application_arn
+  principal_id    = aws_identitystore_group.example.group_id
+  principal_type  = "GROUP"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `application_arn` - (Required) ARN of the application provider.
+* `principal_id` - (Required) An identifier for an object in IAM Identity Center, such as a user or group.
+* `principal_type` - (Required) Entity type for which the assignment will be created. Valid values are `USER` or `GROUP`.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `id` - A comma-delimited string concatenating `application_arn`, `principal_id`, and `principal_type`.
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import SSO Admin Application Assignment using the `id`. For example:
+
+```terraform
+import {
+  to = aws_ssoadmin_application_assignment.example
+  id = "arn:aws:sso::012345678901:application/id-12345678,abcd1234,USER"
+}
+```
+
+Using `terraform import`, import SSO Admin Application Assignment using the `id`. For example:
+
+```console
+% terraform import aws_ssoadmin_application_assignment.example arn:aws:sso::012345678901:application/id-12345678,abcd1234,USER
+```


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This resource will allow practitioners to manage Identity Center application assignments with Terraform.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #28633

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/singlesignon/latest/APIReference/API_CreateApplicationAssignment.html
- https://docs.aws.amazon.com/singlesignon/latest/APIReference/API_DescribeApplicationAssignment.html
- https://docs.aws.amazon.com/singlesignon/latest/APIReference/API_DeleteApplicationAssignment.html


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=ssoadmin TESTS=TestAccSSOAdminApplicationAssignment_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ssoadmin/... -v -count 1 -parallel 20 -run='TestAccSSOAdminApplicationAssignment_'  -timeout 360m

--- PASS: TestAccSSOAdminApplicationAssignment_disappears (83.07s)
--- PASS: TestAccSSOAdminApplicationAssignment_disappears_Application (83.32s)
--- PASS: TestAccSSOAdminApplicationAssignment_basic (83.44s)
--- PASS: TestAccSSOAdminApplicationAssignment_group (83.65s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssoadmin   86.823s
```
