### PR TITLE
[Docs]: Fix errant import references to `example_id_arg`

### DIFF
--- a/website/docs/r/codecatalyst_project.html.markdown
+++ b/website/docs/r/codecatalyst_project.html.markdown
@@ -37,19 +37,20 @@ The following arguments are optional:
 
 This resource exports the following attributes in addition to the arguments above:
 
+* `id` - The name of the project in the space.
 * `name` - The name of the project in the space.
 
 ## Timeouts
 
 [Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
 
-* `create` - (Default `60m`)
-* `update` - (Default `180m`)
-* `delete` - (Default `90m`)
+* `create` - (Default `5m`)
+* `update` - (Default `5m`)
+* `delete` - (Default `5m`)
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import CodeCatalyst Project using the `example_id_arg`. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import CodeCatalyst Project using the `id`. For example:
 
 ```terraform
 import {
@@ -58,7 +59,7 @@ import {
 }
 ```
 
-Using `terraform import`, import CodeCatalyst Project using the `example_id_arg`. For example:
+Using `terraform import`, import CodeCatalyst Project using the `id`. For example:
 
 ```console
 % terraform import aws_codecatalyst_project.example project-id-12345678

--- a/website/docs/r/codecatalyst_source_repository.html.markdown
+++ b/website/docs/r/codecatalyst_source_repository.html.markdown
@@ -36,29 +36,31 @@ The following arguments are optional:
 
 ## Attribute Reference
 
-This resource exports no additional attributes.
+This resource exports the following attributes in addition to the arguments above:
+
+* `id` - The name of the source repository.
 
 ## Timeouts
 
 [Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
 
-* `create` - (Default `60m`)
-* `update` - (Default `180m`)
-* `delete` - (Default `90m`)
+* `create` - (Default `30m`)
+* `update` - (Default `30m`)
+* `delete` - (Default `30m`)
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import CodeCatalyst Source Repository using the `example_id_arg`. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import CodeCatalyst Source Repository using the `id`. For example:
 
 ```terraform
 import {
   to = aws_codecatalyst_source_repository.example
-  id = "source_repository-id-12345678"
+  id = "example-repo"
 }
 ```
 
-Using `terraform import`, import CodeCatalyst Source Repository using the `example_id_arg`. For example:
+Using `terraform import`, import CodeCatalyst Source Repository using the `id`. For example:
 
 ```console
-% terraform import aws_codecatalyst_source_repository.example source_repository-id-12345678
+% terraform import aws_codecatalyst_source_repository.example example-repo
 ```

--- a/website/docs/r/codeguruprofiler_profiling_group.html.markdown
+++ b/website/docs/r/codeguruprofiler_profiling_group.html.markdown
@@ -29,18 +29,19 @@ resource "aws_codeguruprofiler_profiling_group" "example" {
 The following arguments are required:
 
 * `agent_orchestration_config` - (Required) Specifies whether profiling is enabled or disabled for the created profiling. See [Agent Orchestration Config](#agent-orchestration-config) for more details.
-* `name` - (Required) The name of the profiling group.
+* `name` - (Required) Name of the profiling group.
 
 The following arguments are optional:
 
-* `compute_platform` - (Optional) The compute platform of the profiling group.
+* `compute_platform` - (Optional) Compute platform of the profiling group.
 * `tags` - (Optional) A map of tags assigned to the WorkSpaces Connection Alias. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `arn` - ARN of the Profiling Group.
+* `arn` - ARN of the profiling group.
+* `id` - Name of the profiling group.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ### Agent Orchestration Config
@@ -49,7 +50,7 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import CodeGuru Profiler Profiling Group using the `example_id_arg`. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import CodeGuru Profiler Profiling Group using the `id`. For example:
 
 ```terraform
 import {
@@ -58,7 +59,7 @@ import {
 }
 ```
 
-Using `terraform import`, import CodeGuru Profiler Profiling Group using the `name`. For example:
+Using `terraform import`, import CodeGuru Profiler Profiling Group using the `id`. For example:
 
 ```console
 % terraform import aws_codeguruprofiler_profiling_group.example profiling_group-name-12345678

--- a/website/docs/r/lexv2models_bot.html.markdown
+++ b/website/docs/r/lexv2models_bot.html.markdown
@@ -74,7 +74,7 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Lex V2 Models Bot using the `example_id_arg`. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Lex V2 Models Bot using the `id`. For example:
 
 ```terraform
 import {
@@ -83,7 +83,7 @@ import {
 }
 ```
 
-Using `terraform import`, import Lex V2 Models Bot using the `example_id_arg`. For example:
+Using `terraform import`, import Lex V2 Models Bot using the `id`. For example:
 
 ```console
 % terraform import aws_lexv2models_bot.example bot-id-12345678

--- a/website/docs/r/lexv2models_bot_locale.html.markdown
+++ b/website/docs/r/lexv2models_bot_locale.html.markdown
@@ -75,17 +75,17 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Lex V2 Models Bot Locale using the `example_id_arg`. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Lex V2 Models Bot Locale using the `id`. For example:
 
 ```terraform
 import {
   to = aws_lexv2models_bot_locale.example
-  id = "bot_locale-id-12345678"
+  id = "en_US,abcd-12345678,1"
 }
 ```
 
 Using `terraform import`, import Lex V2 Models Bot Locale using the `id`. For example:
 
 ```console
-% terraform import aws_lexv2models_bot_locale.example bot_locale-id-12345678
+% terraform import aws_lexv2models_bot_locale.example en_US,abcd-12345678,1
 ```

--- a/website/docs/r/lexv2models_bot_version.html.markdown
+++ b/website/docs/r/lexv2models_bot_version.html.markdown
@@ -17,8 +17,8 @@ Terraform resource for managing an AWS Lex V2 Models Bot Version.
 ```terraform
 resource "aws_lexv2models_bot_version" "test" {
   bot_id = aws_lexv2models.test.id
-  locale_details = {
-    test_key = {
+  locale_specification = {
+    "en_US" = {
       source_bot_version = "DRAFT"
     }
   }
@@ -30,7 +30,7 @@ resource "aws_lexv2models_bot_version" "test" {
 The following arguments are required:
 
 * `bot_id` - Idientifier of the bot to create the version for.
-* `version_locale_specification` - Specifies the locales that Amazon Lex adds to this version. You can choose the draft version or any other previously published version for each locale. When you specify a source version, the locale data is copied from the source version to the new version.
+* `locale_specification` - Specifies the locales that Amazon Lex adds to this version. You can choose the draft version or any other previously published version for each locale. When you specify a source version, the locale data is copied from the source version to the new version.
 
 The following arguments are optional:
 
@@ -40,12 +40,8 @@ The following arguments are optional:
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `members` - List of bot members in a network to be created.
-* `bot_type` - Type of a bot to create.
-* `name` - Name of the bot. The bot name must be unique in the account that creates the bot. Type String. Length Constraints: Minimum length of 1. Maximum length of 100.
-* `data_privacy` - Provides information on additional privacy protections Amazon Lex should use with the bot's data.
-* `idle_session_ttl_in_seconds` - Time, in seconds, that Amazon Lex should keep information about a user's conversation with the bot. You can specify between 60 (1 minute) and 86,400 (24 hours) seconds.
-* `role_arn` - ARN of an IAM role that has permission to access the bot.
+* `bot_version` - Version number assigned to the version.
+* `id` - A comma-delimited string concatinating `bot_id` and `bot_version`.
 
 ## Timeouts
 
@@ -56,17 +52,17 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Lex V2 Models Bot Version using the `example_id_arg`. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Lex V2 Models Bot Version using the `id`. For example:
 
 ```terraform
 import {
   to = aws_lexv2models_bot_version.example
-  id = "bot_version-id-12345678"
+  id = "id-12345678,1"
 }
 ```
 
-Using `terraform import`, import Lex V2 Models Bot Version using the `example_id_arg`. For example:
+Using `terraform import`, import Lex V2 Models Bot Version using the `id`. For example:
 
 ```console
-% terraform import aws_lexv2models_bot_version.example bot_version-id-12345678
+% terraform import aws_lexv2models_bot_version.example id-12345678,1
 ```

--- a/website/docs/r/servicequotas_template.html.markdown
+++ b/website/docs/r/servicequotas_template.html.markdown
@@ -45,7 +45,7 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Service Quotas Template using the `example_id_arg`. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Service Quotas Template using the `id`. For example:
 
 ```terraform
 import {

--- a/website/docs/r/servicequotas_template_association.html.markdown
+++ b/website/docs/r/servicequotas_template_association.html.markdown
@@ -34,7 +34,7 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Service Quotas Template Association using the `example_id_arg`. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Service Quotas Template Association using the `id`. For example:
 
 ```terraform
 import {

--- a/website/docs/r/sesv2_contact_list.html.markdown
+++ b/website/docs/r/sesv2_contact_list.html.markdown
@@ -40,11 +40,11 @@ resource "aws_sesv2_contact_list" "example" {
 
 The following arguments are required:
 
-* `contact_list_name` - (Required) The name of the contact list.
+* `contact_list_name` - (Required) Name of the contact list.
 
 The following arguments are optional:
 
-* `description` - (Optional) A description of what the contact list is about.
+* `description` - (Optional) Description of what the contact list is about.
 * `tags` - (Optional) Key-value map of resource tags for the contact list. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `topic` - (Optional) Configuration block(s) with topic for the contact list. Detailed below.
 
@@ -52,24 +52,25 @@ The following arguments are optional:
 
 The following arguments are required:
 
-* `default_subscription_status` - (Required) The default subscription status to be applied to a contact if the contact has not noted their preference for subscribing to a topic.
-* `display_name` - (Required) The name of the topic the contact will see.
-* `topic_name` - (Required) The name of the topic.
+* `default_subscription_status` - (Required) Default subscription status to be applied to a contact if the contact has not noted their preference for subscribing to a topic.
+* `display_name` - (Required) Name of the topic the contact will see.
+* `topic_name` - (Required) Name of the topic.
 
 The following arguments are optional:
 
-* `description` - (Optional) A description of what the topic is about, which the contact will see.
+* `description` - (Optional) Description of what the topic is about, which the contact will see.
 
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `created_timestamp` - A timestamp noting when the contact list was created in ISO 8601 format.
-* `last_updated_timestamp` - A timestamp noting the last time the contact list was updated in ISO 8601 format.
+* `created_timestamp` - Timestamp noting when the contact list was created in ISO 8601 format.
+* `id` - Name of the contact list.
+* `last_updated_timestamp` - Timestamp noting the last time the contact list was updated in ISO 8601 format.
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import SESv2 (Simple Email V2) Contact List using the `example_id_arg`. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import SESv2 (Simple Email V2) Contact List using the `id`. For example:
 
 ```terraform
 import {
@@ -78,7 +79,7 @@ import {
 }
 ```
 
-Using `terraform import`, import SESv2 (Simple Email V2) Contact List using the `example_id_arg`. For example:
+Using `terraform import`, import SESv2 (Simple Email V2) Contact List using the `id`. For example:
 
 ```console
 % terraform import aws_sesv2_contact_list.example example

--- a/website/docs/r/vpclattice_auth_policy.html.markdown
+++ b/website/docs/r/vpclattice_auth_policy.html.markdown
@@ -53,30 +53,31 @@ The following arguments are required:
 
 This resource exports the following attributes in addition to the arguments above:
 
+* `id` - The ID or Amazon Resource Name (ARN) of the service network or service for which the policy is created.
 * `policy` - The auth policy. The policy string in JSON must not contain newlines or blank lines.
-* `state` - The state of the auth policy. The auth policy is only active when the auth type is set to AWS_IAM. If you provide a policy, then authentication and authorization decisions are made based on this policy and the client's IAM policy. If the Auth type is NONE, then, any auth policy you provide will remain inactive.
+* `state` - The state of the auth policy. The auth policy is only active when the auth type is set to `AWS_IAM`. If you provide a policy, then authentication and authorization decisions are made based on this policy and the client's IAM policy. If the Auth type is `NONE`, then, any auth policy you provide will remain inactive.
 
 ## Timeouts
 
 [Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
 
-* `create` - (Default `60m`)
-* `update` - (Default `180m`)
-* `delete` - (Default `90m`)
+* `create` - (Default `30m`)
+* `update` - (Default `30m`)
+* `delete` - (Default `30m`)
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import VPC Lattice Auth Policy using the `example_id_arg`. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import VPC Lattice Auth Policy using the `id`. For example:
 
 ```terraform
 import {
   to = aws_vpclattice_auth_policy.example
-  id = "rft-8012925589"
+  id = "abcd-12345678"
 }
 ```
 
-Using `terraform import`, import VPC Lattice Auth Policy using the `example_id_arg`. For example:
+Using `terraform import`, import VPC Lattice Auth Policy using the `id`. For example:
 
 ```console
-% terraform import aws_vpclattice_auth_policy.example rft-8012925589
+% terraform import aws_vpclattice_auth_policy.example abcd-12345678
 ```

--- a/website/docs/r/vpclattice_listener_rule.html.markdown
+++ b/website/docs/r/vpclattice_listener_rule.html.markdown
@@ -147,6 +147,7 @@ path match match (`match`) supports the following:
 This resource exports the following attributes in addition to the arguments above:
 
 * `arn` - The ARN for the listener rule.
+* `id` - A forward slash-delimited string concatenating `service_identifier`, `listener_identifier`, and `rule_id`.
 * `rule_id` - Unique identifier for the listener rule.
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
 
@@ -160,17 +161,17 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import VPC Lattice Listener Rule using the `example_id_arg`. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import VPC Lattice Listener Rule using the `id`. For example:
 
 ```terraform
 import {
   to = aws_vpclattice_listener_rule.example
-  id = "rft-8012925589"
+  id = "service123/listener456/rule789"
 }
 ```
 
-Using `terraform import`, import VPC Lattice Listener Rule using the `example_id_arg`. For example:
+Using `terraform import`, import VPC Lattice Listener Rule using the `id`. For example:
 
 ```console
-% terraform import aws_vpclattice_listener_rule.example rft-8012925589
+% terraform import aws_vpclattice_listener_rule.example service123/listener456/rule789
 ```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Fixes the import section of various resources where the placeholder skaff argument `example_id_arg` was not replaced with the proper import key. Also fixes timeout argument values for a subset of the same resources.


