### PR TITLE
skaff: remove unintended newline in imports

### DIFF
--- a/skaff/resource/resourcetest.tmpl
+++ b/skaff/resource/resourcetest.tmpl
@@ -45,7 +45,7 @@ import (
 	"testing"
 
 	"github.com/YakDriver/regexache"
-{{ if .AWSGoSDKV2 }}
+{{- if .AWSGoSDKV2 }}
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/{{ .ServicePackage }}"
 	"github.com/aws/aws-sdk-go-v2/service/{{ .ServicePackage }}/types"


### PR DESCRIPTION
This newline was causing the import linter (impi) to fail when using skaff for resources with AWS SDK for Go V2.
