### PR TITLE
aws_batch_job_queue add `compute_environment_order` and deprecate `compute_environments`

### DIFF
--- a/.changelog/34750.txt
+++ b/.changelog/34750.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_batch_job_queue: added parameter `compute_environment_order` which conflicts with `compute_environments` but aligns with AWS API. `compute_environments` has been deprecated.
+```

--- a/internal/service/batch/job_queue.go
+++ b/internal/service/batch/job_queue.go
@@ -119,6 +119,7 @@ func (r *resourceJobQueue) Schema(ctx context.Context, request resource.SchemaRe
 			Delete: true,
 		}),
 		"compute_environment_order": schema.ListNestedBlock{
+			CustomType: fwtypes.NewListNestedObjectTypeOf[computeEnvironmentOrder](ctx),
 			NestedObject: schema.NestedBlockObject{
 				Attributes: map[string]schema.Attribute{
 					"order": schema.Int64Attribute{

--- a/internal/service/batch/job_queue.go
+++ b/internal/service/batch/job_queue.go
@@ -198,7 +198,7 @@ func (r *resourceJobQueue) Create(ctx context.Context, request resource.CreateRe
 	}
 
 	if !data.ComputeEnvironmentOrder.IsNull() {
-		state.ComputeEnvironmentOrder = flex.Flatten(ctx, out.ComputeEnvironmentOrder, data.ComputeEnvironmentOrder)
+		flex.Flatten(ctx, out.ComputeEnvironmentOrder, &data.ComputeEnvironmentOrder)
 	} else {
 		state.ComputeEnvironments = flex.FlattenFrameworkStringValueListLegacy(ctx, flattenComputeEnvironmentOrder(out.ComputeEnvironmentOrder))
 	}
@@ -232,6 +232,11 @@ func (r *resourceJobQueue) Read(ctx context.Context, request resource.ReadReques
 		return
 	}
 
+	if !data.ComputeEnvironmentOrder.IsNull() {
+		flex.Flatten(ctx, out.ComputeEnvironmentOrder, &data.ComputeEnvironmentOrder)
+	} else {
+		data.ComputeEnvironments = flex.FlattenFrameworkStringValueListLegacy(ctx, flattenComputeEnvironmentOrder(out.ComputeEnvironmentOrder))
+	}
 	response.Diagnostics.Append(data.refreshFromOutput(ctx, out)...)
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
@@ -408,8 +413,6 @@ func (r *resourceJobQueueData) refreshFromOutput(ctx context.Context, out *batch
 	r.Priority = flex.Int64ToFrameworkLegacy(ctx, out.Priority)
 	r.SchedulingPolicyARN = flex.StringToFrameworkARN(ctx, out.SchedulingPolicyArn)
 	r.State = flex.StringToFrameworkLegacy(ctx, out.State)
-
-	// r.ComputeEnvironments = flex.FlattenFrameworkStringValueListLegacy(ctx, flattenComputeEnvironmentOrder(out.ComputeEnvironmentOrder))
 
 	setTagsOut(ctx, out.Tags)
 

--- a/internal/service/batch/job_queue.go
+++ b/internal/service/batch/job_queue.go
@@ -247,17 +247,13 @@ func (r *resourceJobQueue) Update(ctx context.Context, request resource.UpdateRe
 		JobQueue: flex.StringFromFramework(ctx, plan.JobQueueName),
 	}
 
-	if !plan.ComputeEnvironmentOrder.IsNull() {
-		if !plan.ComputeEnvironmentOrder.Equal(state.ComputeEnvironmentOrder) {
-			flex.Expand(ctx, plan.ComputeEnvironmentOrder, &input.ComputeEnvironmentOrder)
-
-			update = true
-		}
+	if !plan.ComputeEnvironmentOrder.IsNull() && !plan.ComputeEnvironmentOrder.Equal(state.ComputeEnvironmentOrder) {
+		flex.Expand(ctx, plan.ComputeEnvironmentOrder, &input.ComputeEnvironmentOrder)
+		update = true
 	} else {
 		if !plan.ComputeEnvironments.Equal(state.ComputeEnvironments) {
 			ceo := flex.ExpandFrameworkStringValueList(ctx, plan.ComputeEnvironments)
 			input.ComputeEnvironmentOrder = expandComputeEnvironments(ceo)
-
 			update = true
 		}
 	}

--- a/internal/service/batch/job_queue.go
+++ b/internal/service/batch/job_queue.go
@@ -13,7 +13,6 @@ import (
 	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/batch"
-
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -127,8 +126,8 @@ func (r *resourceJobQueue) Schema(ctx context.Context, request resource.SchemaRe
 						Required: true,
 					},
 					"compute_environment": schema.StringAttribute{
-						// CustomType: fwtypes.ARNType,
-						Required: true,
+						CustomType: fwtypes.ARNType,
+						Required:   true,
 					},
 				},
 			},
@@ -405,8 +404,8 @@ type resourceJobQueueData struct {
 }
 
 type computeEnvironmentOrder struct {
-	ComputeEnvironment types.String `tfsdk:"compute_environment"`
-	Order              types.Int64  `tfsdk:"order"`
+	ComputeEnvironment fwtypes.ARN `tfsdk:"compute_environment"`
+	Order              types.Int64 `tfsdk:"order"`
 }
 
 func (r *resourceJobQueueData) refreshFromOutput(ctx context.Context, out *batch.JobQueueDetail) diag.Diagnostics { //nolint:unparam

--- a/internal/service/batch/job_queue.go
+++ b/internal/service/batch/job_queue.go
@@ -248,11 +248,19 @@ func (r *resourceJobQueue) Update(ctx context.Context, request resource.UpdateRe
 		JobQueue: flex.StringFromFramework(ctx, plan.JobQueueName),
 	}
 
-	if !plan.ComputeEnvironments.Equal(state.ComputeEnvironments) {
-		ceo := flex.ExpandFrameworkStringValueList(ctx, plan.ComputeEnvironments)
-		input.ComputeEnvironmentOrder = expandComputeEnvironments(ceo)
+	if !plan.ComputeEnvironmentOrder.IsNull() {
+		if !plan.ComputeEnvironmentOrder.Equal(state.ComputeEnvironmentOrder) {
+			flex.Expand(ctx, plan.ComputeEnvironmentOrder, &input.ComputeEnvironmentOrder)
 
-		update = true
+			update = true
+		}
+	} else {
+		if !plan.ComputeEnvironments.Equal(state.ComputeEnvironments) {
+			ceo := flex.ExpandFrameworkStringValueList(ctx, plan.ComputeEnvironments)
+			input.ComputeEnvironmentOrder = expandComputeEnvironments(ceo)
+
+			update = true
+		}
 	}
 
 	if !plan.Priority.Equal(state.Priority) {

--- a/internal/service/batch/job_queue.go
+++ b/internal/service/batch/job_queue.go
@@ -190,7 +190,7 @@ func (r *resourceJobQueue) Create(ctx context.Context, request resource.CreateRe
 	if !data.ComputeEnvironmentOrder.IsNull() {
 		flex.Flatten(ctx, out.ComputeEnvironmentOrder, &data.ComputeEnvironmentOrder)
 	} else {
-		state.ComputeEnvironments = flex.FlattenFrameworkStringValueListLegacy(ctx, flattenComputeEnvironmentOrder(out.ComputeEnvironmentOrder))
+		state.ComputeEnvironments = flex.FlattenFrameworkStringValueListLegacy(ctx, flattenComputeEnvironments(out.ComputeEnvironmentOrder))
 	}
 	response.Diagnostics.Append(state.refreshFromOutput(ctx, out)...)
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
@@ -225,7 +225,7 @@ func (r *resourceJobQueue) Read(ctx context.Context, request resource.ReadReques
 	if !data.ComputeEnvironmentOrder.IsNull() {
 		flex.Flatten(ctx, out.ComputeEnvironmentOrder, &data.ComputeEnvironmentOrder)
 	} else {
-		data.ComputeEnvironments = flex.FlattenFrameworkStringValueListLegacy(ctx, flattenComputeEnvironmentOrder(out.ComputeEnvironmentOrder))
+		data.ComputeEnvironments = flex.FlattenFrameworkStringValueListLegacy(ctx, flattenComputeEnvironments(out.ComputeEnvironmentOrder))
 	}
 	response.Diagnostics.Append(data.refreshFromOutput(ctx, out)...)
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
@@ -432,7 +432,7 @@ func expandComputeEnvironments(order []string) (envs []*batch.ComputeEnvironment
 	return
 }
 
-func flattenComputeEnvironmentOrder(apiObject []*batch.ComputeEnvironmentOrder) []string {
+func flattenComputeEnvironments(apiObject []*batch.ComputeEnvironmentOrder) []string {
 	sort.Slice(apiObject, func(i, j int) bool {
 		return aws.ToInt64(apiObject[i].Order) < aws.ToInt64(apiObject[j].Order)
 	})

--- a/internal/service/batch/job_queue.go
+++ b/internal/service/batch/job_queue.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/YakDriver/regexache"
@@ -331,7 +332,6 @@ func (r *resourceJobQueue) Delete(ctx context.Context, request resource.DeleteRe
 	found, err := disableJobQueue(ctx, conn, data.ID.ValueString(), deleteTimeout)
 
 	if !found {
-		response.State.RemoveResource(ctx)
 		return
 	}
 
@@ -469,8 +469,7 @@ func disableJobQueue(ctx context.Context, conn *batch.Batch, id string, timeout 
 	})
 
 	if err != nil {
-		notFound := regexache.MustCompile(queueNotFound)
-		if notFound.MatchString(err.Error()) {
+		if strings.Contains(err.Error(), queueNotFound) {
 			return false, nil
 		}
 		return true, err

--- a/internal/service/batch/job_queue_schema.go
+++ b/internal/service/batch/job_queue_schema.go
@@ -94,7 +94,7 @@ func upgradeJobQueueResourceStateV0toV1(ctx context.Context, req resource.Upgrad
 	jobQueueDataV2 := resourceJobQueueData{
 		ComputeEnvironments: jobQueueDataV0.ComputeEnvironments,
 		ID:                  jobQueueDataV0.ID,
-		Name:                jobQueueDataV0.Name,
+		JobQueueName:        jobQueueDataV0.Name,
 		Priority:            jobQueueDataV0.Priority,
 		State:               jobQueueDataV0.State,
 		Tags:                jobQueueDataV0.Tags,

--- a/internal/service/batch/job_queue_schema.go
+++ b/internal/service/batch/job_queue_schema.go
@@ -29,7 +29,7 @@ func jobQueueSchema0(ctx context.Context) schema.Schema {
 			"arn": framework.ARNAttributeComputedOnly(),
 			"compute_environments": schema.ListAttribute{
 				ElementType: types.StringType,
-				Required:    true,
+				// Required:    true,
 			},
 			"id": framework.IDAttribute(),
 			"name": schema.StringAttribute{
@@ -66,22 +66,37 @@ func jobQueueSchema0(ctx context.Context) schema.Schema {
 				Update: true,
 				Delete: true,
 			}),
+			"compute_environment_order": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[computeEnvironmentOrder](ctx),
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"order": schema.Int64Attribute{
+							Required: true,
+						},
+						"compute_environment": schema.StringAttribute{
+							// CustomType: fwtypes.ARNType,
+							Required: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
 
 func upgradeJobQueueResourceStateV0toV1(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
 	type resourceJobQueueDataV0 struct {
-		ARN                 types.String   `tfsdk:"arn"`
-		ComputeEnvironments types.List     `tfsdk:"compute_environments"`
-		ID                  types.String   `tfsdk:"id"`
-		Name                types.String   `tfsdk:"name"`
-		Priority            types.Int64    `tfsdk:"priority"`
-		SchedulingPolicyARN types.String   `tfsdk:"scheduling_policy_arn"`
-		State               types.String   `tfsdk:"state"`
-		Tags                types.Map      `tfsdk:"tags"`
-		TagsAll             types.Map      `tfsdk:"tags_all"`
-		Timeouts            timeouts.Value `tfsdk:"timeouts"`
+		ARN                     types.String                                             `tfsdk:"arn"`
+		ComputeEnvironments     types.List                                               `tfsdk:"compute_environments"`
+		ComputeEnvironmentOrder fwtypes.ListNestedObjectValueOf[computeEnvironmentOrder] `tfsdk:"compute_environment_order"`
+		ID                      types.String                                             `tfsdk:"id"`
+		Name                    types.String                                             `tfsdk:"name"`
+		Priority                types.Int64                                              `tfsdk:"priority"`
+		SchedulingPolicyARN     types.String                                             `tfsdk:"scheduling_policy_arn"`
+		State                   types.String                                             `tfsdk:"state"`
+		Tags                    types.Map                                                `tfsdk:"tags"`
+		TagsAll                 types.Map                                                `tfsdk:"tags_all"`
+		Timeouts                timeouts.Value                                           `tfsdk:"timeouts"`
 	}
 
 	var jobQueueDataV0 resourceJobQueueDataV0
@@ -91,15 +106,18 @@ func upgradeJobQueueResourceStateV0toV1(ctx context.Context, req resource.Upgrad
 		return
 	}
 
+	var ceo fwtypes.ListNestedObjectValueOf[computeEnvironmentOrder]
+
 	jobQueueDataV2 := resourceJobQueueData{
-		ComputeEnvironments: jobQueueDataV0.ComputeEnvironments,
-		ID:                  jobQueueDataV0.ID,
-		JobQueueName:        jobQueueDataV0.Name,
-		Priority:            jobQueueDataV0.Priority,
-		State:               jobQueueDataV0.State,
-		Tags:                jobQueueDataV0.Tags,
-		TagsAll:             jobQueueDataV0.TagsAll,
-		Timeouts:            jobQueueDataV0.Timeouts,
+		ComputeEnvironments:     jobQueueDataV0.ComputeEnvironments,
+		ComputeEnvironmentOrder: ceo,
+		ID:                      jobQueueDataV0.ID,
+		JobQueueName:            jobQueueDataV0.Name,
+		Priority:                jobQueueDataV0.Priority,
+		State:                   jobQueueDataV0.State,
+		Tags:                    jobQueueDataV0.Tags,
+		TagsAll:                 jobQueueDataV0.TagsAll,
+		Timeouts:                jobQueueDataV0.Timeouts,
 	}
 
 	if jobQueueDataV0.SchedulingPolicyARN.ValueString() == "" {

--- a/internal/service/batch/job_queue_schema.go
+++ b/internal/service/batch/job_queue_schema.go
@@ -29,7 +29,7 @@ func jobQueueSchema0(ctx context.Context) schema.Schema {
 			"arn": framework.ARNAttributeComputedOnly(),
 			"compute_environments": schema.ListAttribute{
 				ElementType: types.StringType,
-				// Required:    true,
+				Required:    true,
 			},
 			"id": framework.IDAttribute(),
 			"name": schema.StringAttribute{

--- a/internal/service/batch/job_queue_schema.go
+++ b/internal/service/batch/job_queue_schema.go
@@ -66,37 +66,22 @@ func jobQueueSchema0(ctx context.Context) schema.Schema {
 				Update: true,
 				Delete: true,
 			}),
-			"compute_environment_order": schema.ListNestedBlock{
-				CustomType: fwtypes.NewListNestedObjectTypeOf[computeEnvironmentOrder](ctx),
-				NestedObject: schema.NestedBlockObject{
-					Attributes: map[string]schema.Attribute{
-						"order": schema.Int64Attribute{
-							Required: true,
-						},
-						"compute_environment": schema.StringAttribute{
-							// CustomType: fwtypes.ARNType,
-							Required: true,
-						},
-					},
-				},
-			},
 		},
 	}
 }
 
 func upgradeJobQueueResourceStateV0toV1(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
 	type resourceJobQueueDataV0 struct {
-		ARN                     types.String                                             `tfsdk:"arn"`
-		ComputeEnvironments     types.List                                               `tfsdk:"compute_environments"`
-		ComputeEnvironmentOrder fwtypes.ListNestedObjectValueOf[computeEnvironmentOrder] `tfsdk:"compute_environment_order"`
-		ID                      types.String                                             `tfsdk:"id"`
-		Name                    types.String                                             `tfsdk:"name"`
-		Priority                types.Int64                                              `tfsdk:"priority"`
-		SchedulingPolicyARN     types.String                                             `tfsdk:"scheduling_policy_arn"`
-		State                   types.String                                             `tfsdk:"state"`
-		Tags                    types.Map                                                `tfsdk:"tags"`
-		TagsAll                 types.Map                                                `tfsdk:"tags_all"`
-		Timeouts                timeouts.Value                                           `tfsdk:"timeouts"`
+		ARN                 types.String   `tfsdk:"arn"`
+		ComputeEnvironments types.List     `tfsdk:"compute_environments"`
+		ID                  types.String   `tfsdk:"id"`
+		Name                types.String   `tfsdk:"name"`
+		Priority            types.Int64    `tfsdk:"priority"`
+		SchedulingPolicyARN types.String   `tfsdk:"scheduling_policy_arn"`
+		State               types.String   `tfsdk:"state"`
+		Tags                types.Map      `tfsdk:"tags"`
+		TagsAll             types.Map      `tfsdk:"tags_all"`
+		Timeouts            timeouts.Value `tfsdk:"timeouts"`
 	}
 
 	var jobQueueDataV0 resourceJobQueueDataV0
@@ -105,8 +90,7 @@ func upgradeJobQueueResourceStateV0toV1(ctx context.Context, req resource.Upgrad
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	var ceo fwtypes.ListNestedObjectValueOf[computeEnvironmentOrder]
+	ceo := fwtypes.NewListNestedObjectValueOfNull[computeEnvironmentOrder](ctx)
 
 	jobQueueDataV2 := resourceJobQueueData{
 		ComputeEnvironments:     jobQueueDataV0.ComputeEnvironments,

--- a/internal/service/batch/job_queue_test.go
+++ b/internal/service/batch/job_queue_test.go
@@ -64,17 +64,6 @@ func TestAccBatchJobQueue_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			// {
-			// 	// Validates the imported state matches `compute_environment_order`
-			// 	Config: testAccJobQueueConfig_stateCEO(rName, batch.JQStateEnabled),
-			// 	Check: resource.ComposeTestCheckFunc(
-			// 		testAccCheckJobQueueExists(ctx, resourceName, &jobQueue1),
-			// 		resource.TestCheckResourceAttr(resourceName, "compute_environment_order.#", "1"),
-			// 		resource.TestCheckResourceAttrPair(resourceName, "compute_environment_order.0.compute_environment", "aws_batch_compute_environment.test", "arn"),
-			// 		resource.TestCheckResourceAttr(resourceName, "compute_environments.#", "0"),
-			// 	),
-			// 	PlanOnly: true,
-			// },
 		},
 	})
 }
@@ -711,11 +700,11 @@ func testAccJobQueueConfig_state(rName string, state string) string {
 		testAccJobQueueConfigBase(rName),
 		fmt.Sprintf(`
 resource "aws_batch_job_queue" "test" {
-   compute_environments = [aws_batch_compute_environment.test.arn]
+  compute_environments = [aws_batch_compute_environment.test.arn]
 
-  name                 = %[1]q
-  priority             = 1
-  state                = %[2]q
+  name     = %[1]q
+  priority = 1
+  state    = %[2]q
 }
 `, rName, state))
 }
@@ -727,12 +716,12 @@ func testAccJobQueueConfig_stateCEO(rName string, state string) string {
 resource "aws_batch_job_queue" "test" {
   compute_environment_order {
     compute_environment = aws_batch_compute_environment.test.arn
-	order = 1
+    order               = 1
   }
 
-  name                 = %[1]q
-  priority             = 1
-  state                = %[2]q
+  name     = %[1]q
+  priority = 1
+  state    = %[2]q
 }
 `, rName, state))
 }
@@ -779,18 +768,18 @@ func testAccJobQueueConfig_ComputeEnvironmentOrder_multiple(rName string, state 
 		fmt.Sprintf(`
 resource "aws_batch_job_queue" "test" {
   compute_environment_order {
-	order = %[3]d
-	compute_environment = aws_batch_compute_environment.test.arn
+    order               = %[3]d
+    compute_environment = aws_batch_compute_environment.test.arn
   }
 
   compute_environment_order {
-	order = %[4]d
-	compute_environment = aws_batch_compute_environment.more[0].arn
+    order               = %[4]d
+    compute_environment = aws_batch_compute_environment.more[0].arn
   }
 
   compute_environment_order {
-	order = %[5]d
-	compute_environment = aws_batch_compute_environment.more[1].arn
+    order               = %[5]d
+    compute_environment = aws_batch_compute_environment.more[1].arn
   }
 
   name     = %[1]q

--- a/internal/service/batch/job_queue_test.go
+++ b/internal/service/batch/job_queue_test.go
@@ -76,7 +76,7 @@ func TestAccBatchJobQueue_basicCEO(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckJobQueueDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -135,7 +135,7 @@ func TestAccBatchJobQueue_disappearsCEO(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckLaunchTemplateDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -192,7 +192,7 @@ func TestAccBatchJobQueue_ComputeEnvironments_multiple(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckJobQueueDestroy(ctx),
 		Steps: []resource.TestStep{

--- a/internal/service/batch/job_queue_test.go
+++ b/internal/service/batch/job_queue_test.go
@@ -56,6 +56,40 @@ func TestAccBatchJobQueue_basic(t *testing.T) {
 	})
 }
 
+func TestAccBatchJobQueue_basicCEO(t *testing.T) {
+	ctx := acctest.Context(t)
+	var jobQueue1 batch.JobQueueDetail
+	resourceName := "aws_batch_job_queue.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckJobQueueDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccJobQueueConfig_stateCEO(rName, batch.JQStateEnabled),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckJobQueueExists(ctx, resourceName, &jobQueue1),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "batch", fmt.Sprintf("job-queue/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "compute_environment_order.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "compute_environment_order.0.compute_environment", "aws_batch_compute_environment.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "priority", "1"),
+					resource.TestCheckResourceAttr(resourceName, "state", batch.JQStateEnabled),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccBatchJobQueue_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var jobQueue1 batch.JobQueueDetail
@@ -590,7 +624,20 @@ func testAccJobQueueConfig_state(rName string, state string) string {
 		testAccJobQueueConfigBase(rName),
 		fmt.Sprintf(`
 resource "aws_batch_job_queue" "test" {
-//   compute_environments = [aws_batch_compute_environment.test.arn]
+   compute_environments = [aws_batch_compute_environment.test.arn]
+
+  name                 = %[1]q
+  priority             = 1
+  state                = %[2]q
+}
+`, rName, state))
+}
+
+func testAccJobQueueConfig_stateCEO(rName string, state string) string {
+	return acctest.ConfigCompose(
+		testAccJobQueueConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_batch_job_queue" "test" {
   compute_environment_order {
     compute_environment = aws_batch_compute_environment.test.arn
 	order = 1

--- a/internal/service/batch/job_queue_test.go
+++ b/internal/service/batch/job_queue_test.go
@@ -590,7 +590,12 @@ func testAccJobQueueConfig_state(rName string, state string) string {
 		testAccJobQueueConfigBase(rName),
 		fmt.Sprintf(`
 resource "aws_batch_job_queue" "test" {
-  compute_environments = [aws_batch_compute_environment.test.arn]
+//   compute_environments = [aws_batch_compute_environment.test.arn]
+  compute_environment_order {
+    compute_environment = aws_batch_compute_environment.test.arn
+	order = 1
+  }
+
   name                 = %[1]q
   priority             = 1
   state                = %[2]q

--- a/website/docs/r/batch_job_queue.html.markdown
+++ b/website/docs/r/batch_job_queue.html.markdown
@@ -87,6 +87,8 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
+When importing a AWS Batch Job Queue, the parameter `compute_environment_order` will always be used over the deprecated `compute_environments`. Please adjust your HCL accordingly.
+
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Batch Job Queue using the `arn`. For example:
 
 ```terraform

--- a/website/docs/r/batch_job_queue.html.markdown
+++ b/website/docs/r/batch_job_queue.html.markdown
@@ -19,10 +19,16 @@ resource "aws_batch_job_queue" "test_queue" {
   name     = "tf-test-batch-job-queue"
   state    = "ENABLED"
   priority = 1
-  compute_environments = [
-    aws_batch_compute_environment.test_environment_1.arn,
-    aws_batch_compute_environment.test_environment_2.arn,
-  ]
+
+  compute_environment_order {
+    order               = 1
+    compute_environment = aws_batch_compute_environment.test_environment_1.arn
+  }
+
+  compute_environment_order {
+    order               = 2
+    compute_environment = aws_batch_compute_environment.test_environment_2.arn
+  }
 }
 ```
 
@@ -50,10 +56,15 @@ resource "aws_batch_job_queue" "example" {
   state                 = "ENABLED"
   priority              = 1
 
-  compute_environments = [
-    aws_batch_compute_environment.test_environment_1.arn,
-    aws_batch_compute_environment.test_environment_2.arn,
-  ]
+  compute_environment_order {
+    order               = 1
+    compute_environment = aws_batch_compute_environment.test_environment_1.arn
+  }
+
+  compute_environment_order {
+    order               = 2
+    compute_environment = aws_batch_compute_environment.test_environment_2.arn
+  }
 }
 ```
 
@@ -87,7 +98,7 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
-When importing a AWS Batch Job Queue, the parameter `compute_environment_order` will always be used over the deprecated `compute_environments`. Please adjust your HCL accordingly.
+When importing a AWS Batch Job Queue, the parameter `compute_environments` will always be used over `compute_environment_order`. Please adjust your HCL accordingly.
 
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Batch Job Queue using the `arn`. For example:
 

--- a/website/docs/r/batch_job_queue.html.markdown
+++ b/website/docs/r/batch_job_queue.html.markdown
@@ -73,13 +73,18 @@ resource "aws_batch_job_queue" "example" {
 This resource supports the following arguments:
 
 * `name` - (Required) Specifies the name of the job queue.
-* `compute_environments` - (Required) List of compute environment ARNs mapped to a job queue.
-  The position of the compute environments in the list will dictate the order.
+* `compute_environments` - (Deprecated) (Optional) List of compute environment ARNs mapped to a job queue. The position of the compute environments in the list will dictate the order. When importing a AWS Batch Job Queue, the parameter `compute_environments` will always be used over `compute_environment_order`. Please adjust your HCL accordingly.
+* `compute_environment_order` - (Optional) The set of compute environments mapped to a job queue and their order relative to each other. The job scheduler uses this parameter to determine which compute environment runs a specific job. Compute environments must be in the VALID state before you can associate them with a job queue. You can associate up to three compute environments with a job queue.  
 * `priority` - (Required) The priority of the job queue. Job queues with a higher priority
     are evaluated first when associated with the same compute environment.
 * `scheduling_policy_arn` - (Optional) The ARN of the fair share scheduling policy. If this parameter is specified, the job queue uses a fair share scheduling policy. If this parameter isn't specified, the job queue uses a first in, first out (FIFO) scheduling policy. After a job queue is created, you can replace but can't remove the fair share scheduling policy.
 * `state` - (Required) The state of the job queue. Must be one of: `ENABLED` or `DISABLED`
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### compute_environment_order
+
+* `compute_environment` - (Required) The Amazon Resource Name (ARN) of the compute environment.
+* `order` - (Required) The order of the compute environment. Compute environments are tried in ascending order. For example, if two compute environments are associated with a job queue, the compute environment with a lower order integer value is tried for job placement first.
 
 ## Attribute Reference
 
@@ -97,8 +102,6 @@ This resource exports the following attributes in addition to the arguments abov
 - `delete` - (Default `10m`)
 
 ## Import
-
-When importing a AWS Batch Job Queue, the parameter `compute_environments` will always be used over `compute_environment_order`. Please adjust your HCL accordingly.
 
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Batch Job Queue using the `arn`. For example:
 

--- a/website/docs/r/batch_job_queue.html.markdown
+++ b/website/docs/r/batch_job_queue.html.markdown
@@ -73,7 +73,7 @@ resource "aws_batch_job_queue" "example" {
 This resource supports the following arguments:
 
 * `name` - (Required) Specifies the name of the job queue.
-* `compute_environments` - (Deprecated) (Optional) List of compute environment ARNs mapped to a job queue. The position of the compute environments in the list will dictate the order. When importing a AWS Batch Job Queue, the parameter `compute_environments` will always be used over `compute_environment_order`. Please adjust your HCL accordingly.
+* `compute_environments` - (Deprecated) (Optional) This parameter is deprecated, please use `compute_environment_order` instead. List of compute environment ARNs mapped to a job queue. The position of the compute environments in the list will dictate the order. When importing a AWS Batch Job Queue, the parameter `compute_environments` will always be used over `compute_environment_order`. Please adjust your HCL accordingly.
 * `compute_environment_order` - (Optional) The set of compute environments mapped to a job queue and their order relative to each other. The job scheduler uses this parameter to determine which compute environment runs a specific job. Compute environments must be in the VALID state before you can associate them with a job queue. You can associate up to three compute environments with a job queue.  
 * `priority` - (Required) The priority of the job queue. Job queues with a higher priority
     are evaluated first when associated with the same compute environment.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

- `compute_environments` (CEs) and `compute_environment_order` (CEOs) are mutually exclusive
- In order to preserve schema migration, `compute_environments` must stay as the "default" or it will cause breaking changes when a users schema is migrated from CEs in state without requiring them to update their HCL to use CEOs.
- Because import requires `CEs` it is impossible to migrate to CEOs parameter :/  You must have done the initial `Create` with it


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #34760
Closes #19247
Closes #20764

**Does not close or resolve** #34794 however, migration does appear to work as expected

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccBatchJobQueue_ PKG=batch
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/batch/... -v -count 1 -parallel 20 -run='TestAccBatchJobQueue_'  -timeout 360m
=== RUN   TestAccBatchJobQueue_basic
=== PAUSE TestAccBatchJobQueue_basic
=== RUN   TestAccBatchJobQueue_basicCEO
=== PAUSE TestAccBatchJobQueue_basicCEO
=== RUN   TestAccBatchJobQueue_disappears
=== PAUSE TestAccBatchJobQueue_disappears
=== RUN   TestAccBatchJobQueue_disappearsCEO
=== PAUSE TestAccBatchJobQueue_disappearsCEO
=== RUN   TestAccBatchJobQueue_MigrateFromPluginSDK
=== PAUSE TestAccBatchJobQueue_MigrateFromPluginSDK
=== RUN   TestAccBatchJobQueue_ComputeEnvironments_multiple
=== PAUSE TestAccBatchJobQueue_ComputeEnvironments_multiple
=== RUN   TestAccBatchJobQueue_ComputeEnvironmentOrder_multiple
=== PAUSE TestAccBatchJobQueue_ComputeEnvironmentOrder_multiple
=== RUN   TestAccBatchJobQueue_ComputeEnvironments_externalOrderUpdate
=== PAUSE TestAccBatchJobQueue_ComputeEnvironments_externalOrderUpdate
=== RUN   TestAccBatchJobQueue_priority
=== PAUSE TestAccBatchJobQueue_priority
=== RUN   TestAccBatchJobQueue_schedulingPolicy
=== PAUSE TestAccBatchJobQueue_schedulingPolicy
=== RUN   TestAccBatchJobQueue_state
=== PAUSE TestAccBatchJobQueue_state
=== RUN   TestAccBatchJobQueue_tags
=== PAUSE TestAccBatchJobQueue_tags
=== CONT  TestAccBatchJobQueue_basic
=== CONT  TestAccBatchJobQueue_ComputeEnvironmentOrder_multiple
=== CONT  TestAccBatchJobQueue_disappearsCEO
=== CONT  TestAccBatchJobQueue_disappears
=== CONT  TestAccBatchJobQueue_tags
=== CONT  TestAccBatchJobQueue_priority
=== CONT  TestAccBatchJobQueue_MigrateFromPluginSDK
=== CONT  TestAccBatchJobQueue_schedulingPolicy
=== CONT  TestAccBatchJobQueue_ComputeEnvironments_multiple
=== CONT  TestAccBatchJobQueue_state
=== CONT  TestAccBatchJobQueue_ComputeEnvironments_externalOrderUpdate
=== CONT  TestAccBatchJobQueue_basicCEO
=== NAME  TestAccBatchJobQueue_MigrateFromPluginSDK
    testing_new.go:80: Error retrieving state, there may be dangling resources: exit status 1
        Failed to marshal state to json: schema version 0 for aws_batch_job_queue.test in state does not match version 1 from the provider
--- FAIL: TestAccBatchJobQueue_MigrateFromPluginSDK (225.20s)
--- PASS: TestAccBatchJobQueue_disappearsCEO (533.22s)
--- PASS: TestAccBatchJobQueue_disappears (533.37s)
--- PASS: TestAccBatchJobQueue_basic (542.01s)
--- PASS: TestAccBatchJobQueue_ComputeEnvironments_externalOrderUpdate (543.04s)
--- PASS: TestAccBatchJobQueue_basicCEO (547.48s)
--- PASS: TestAccBatchJobQueue_priority (705.88s)
--- PASS: TestAccBatchJobQueue_state (716.18s)
--- PASS: TestAccBatchJobQueue_ComputeEnvironmentOrder_multiple (767.04s)
--- PASS: TestAccBatchJobQueue_schedulingPolicy (770.29s)
--- PASS: TestAccBatchJobQueue_ComputeEnvironments_multiple (778.00s)
--- PASS: TestAccBatchJobQueue_tags (801.21s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/batch      803.366s
FAIL
make: *** [testacc] Error 1
```
