### PR TITLE
update docs for sso to address provider issue

### DIFF
--- a/website/docs/r/ssoadmin_account_assignment.html.markdown
+++ b/website/docs/r/ssoadmin_account_assignment.html.markdown
@@ -10,10 +10,10 @@ description: |-
 
 Provides a Single Sign-On (SSO) Account Assignment resource
 
-**IMPORTANT:** Currently there is an issue where deletion of both an `aws_ssoadmin_managed_policy_attachment` and `aws_ssoadmin_account_assignment` can occur simultaneously. This causes a problem with the `Delete` operation of the policy attachment and can cause your `terraform destroy` to fail. To avoid this, add an explicit dependency between these resources with the `depends_on` meta argument.
+**IMPORTANT:** Currently there is an issue where deletion of both an `aws_ssoadmin_managed_policy_attachment` and `aws_ssoadmin_account_assignment` can occur simultaneously. This causes a problem with the `Delete` operation of the policy attachment and can cause your `terraform destroy` to fail. To avoid this, add an explicit dependency between these resources with the `depends_on` meta argument. See the `Account Assignmend with Managed Policy Attachment` example below.
 
 ## Example Usage
-
+### Basic Account Assignment
 ```terraform
 data "aws_ssoadmin_instances" "example" {}
 
@@ -40,10 +40,48 @@ resource "aws_ssoadmin_account_assignment" "example" {
   principal_id   = data.aws_identitystore_group.example.group_id
   principal_type = "GROUP"
 
-  target_id   = "012347678910"
+  target_id   = "123456789012"
   target_type = "AWS_ACCOUNT"
 }
 ```
+
+### Account Assignmend with Managed Policy Attachment
+```terraform
+data "aws_ssoadmin_instances" "example" {}
+
+resource "aws_ssoadmin_permission_set" "example" {
+  name         = "Example"
+  instance_arn = tolist(data.aws_ssoadmin_instances.example.arns)[0]
+}
+
+resource "aws_identitystore_group" "example" {
+
+  identity_store_id = tolist(data.aws_ssoadmin_instances.sso_instance.identity_store_ids)[0]
+  display_name      = "Admin"
+  description       = "Admin Group"
+}
+
+resource "aws_ssoadmin_account_assignment" "account_assignment" {
+  instance_arn       = tolist(data.aws_ssoadmin_instances.example.arns)[0]
+  permission_set_arn = aws_ssoadmin_permission_set.example.arn
+
+  principal_id   = aws_identitystore_group.example.group_id
+  principal_type = "GROUP"
+
+  target_id   = "123456789012"
+  target_type = "AWS_ACCOUNT"
+}
+
+resource "aws_ssoadmin_managed_policy_attachment" "example" {
+  instance_arn       = tolist(data.aws_ssoadmin_instances.example.arns)[0]
+  managed_policy_arn = "arn:aws:iam::aws:policy/job-function/ViewOnlyAccess"
+  permission_set_arn = aws_ssoadmin_permission_set.example.arn
+
+  # Adding an explicit dependency on the account assignment resource will
+  # allow the managed attachment to be safely destroyed prior to the removal
+  # of the account assignment.
+  depends_on = [aws_ssoadmin_account_assignment.example]
+}
 
 ## Argument Reference
 

--- a/website/docs/r/ssoadmin_account_assignment.html.markdown
+++ b/website/docs/r/ssoadmin_account_assignment.html.markdown
@@ -84,6 +84,7 @@ resource "aws_ssoadmin_managed_policy_attachment" "example" {
   managed_policy_arn = "arn:aws:iam::aws:policy/AlexaForBusinessDeviceSetup"
   permission_set_arn = aws_ssoadmin_permission_set.example.arn
 }
+```
 
 ## Argument Reference
 

--- a/website/docs/r/ssoadmin_account_assignment.html.markdown
+++ b/website/docs/r/ssoadmin_account_assignment.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides a Single Sign-On (SSO) Account Assignment resource
 
+**IMPORTANT:** Currently there is an issue where deletion of both an `aws_ssoadmin_managed_policy_attachment` and `aws_ssoadmin_account_assignment` can occur simultaneously. This causes a problem with the `Delete` operation of the policy attachment and can cause your `terraform destroy` to fail. To avoid this, add an explicit dependency between these resources with the `depends_on` meta argument.
+
 ## Example Usage
 
 ```terraform

--- a/website/docs/r/ssoadmin_managed_policy_attachment.html.markdown
+++ b/website/docs/r/ssoadmin_managed_policy_attachment.html.markdown
@@ -26,7 +26,7 @@ resource "aws_ssoadmin_permission_set" "example" {
 
 resource "aws_ssoadmin_managed_policy_attachment" "example" {
   instance_arn       = tolist(data.aws_ssoadmin_instances.example.arns)[0]
-  managed_policy_arn = "arn:aws:iam::aws:policy/job-function/ViewOnlyAccess"
+  managed_policy_arn = "arn:aws:iam::aws:policy/AlexaForBusinessDeviceSetup"
   permission_set_arn = aws_ssoadmin_permission_set.example.arn
 }
 ```

--- a/website/docs/r/ssoadmin_managed_policy_attachment.html.markdown
+++ b/website/docs/r/ssoadmin_managed_policy_attachment.html.markdown
@@ -10,9 +10,6 @@ description: |-
 
 Provides an IAM managed policy for a Single Sign-On (SSO) Permission Set resource
 
-~> **IMPORTANT:** Currently there is an issue where deletion of both an `aws_ssoadmin_managed_policy_attachment` and `aws_ssoadmin_account_assignment` can occur simultaneously. This causes a problem with the `Delete` operation of the policy attachment and can cause your `terraform destroy` to fail. To avoid this, add an explicit dependency between these resources with the `depends_on` meta argument. See the `Managed Policy Attachment with Account Assignment (Identity Store Group)` example below.
-
-
 ~> **NOTE:** Creating this resource will automatically [Provision the Permission Set](https://docs.aws.amazon.com/singlesignon/latest/APIReference/API_ProvisionPermissionSet.html) to apply the corresponding updates to all assigned accounts.
 
 ## Example Usage

--- a/website/docs/r/ssoadmin_managed_policy_attachment.html.markdown
+++ b/website/docs/r/ssoadmin_managed_policy_attachment.html.markdown
@@ -10,6 +10,9 @@ description: |-
 
 Provides an IAM managed policy for a Single Sign-On (SSO) Permission Set resource
 
+~> **IMPORTANT:** Currently there is an issue where deletion of both an `aws_ssoadmin_managed_policy_attachment` and `aws_ssoadmin_account_assignment` can occur simultaneously. This causes a problem with the `Delete` operation of the policy attachment and can cause your `terraform destroy` to fail. To avoid this, add an explicit dependency between these resources with the `depends_on` meta argument.
+
+
 ~> **NOTE:** Creating this resource will automatically [Provision the Permission Set](https://docs.aws.amazon.com/singlesignon/latest/APIReference/API_ProvisionPermissionSet.html) to apply the corresponding updates to all assigned accounts.
 
 ## Example Usage

--- a/website/docs/r/ssoadmin_managed_policy_attachment.html.markdown
+++ b/website/docs/r/ssoadmin_managed_policy_attachment.html.markdown
@@ -73,6 +73,7 @@ resource "aws_ssoadmin_managed_policy_attachment" "example" {
   managed_policy_arn = "arn:aws:iam::aws:policy/AlexaForBusinessDeviceSetup"
   permission_set_arn = aws_ssoadmin_permission_set.example.arn
 }
+```
 
 ## Argument Reference
 

--- a/website/docs/r/ssoadmin_managed_policy_attachment.html.markdown
+++ b/website/docs/r/ssoadmin_managed_policy_attachment.html.markdown
@@ -10,13 +10,13 @@ description: |-
 
 Provides an IAM managed policy for a Single Sign-On (SSO) Permission Set resource
 
-~> **IMPORTANT:** Currently there is an issue where deletion of both an `aws_ssoadmin_managed_policy_attachment` and `aws_ssoadmin_account_assignment` can occur simultaneously. This causes a problem with the `Delete` operation of the policy attachment and can cause your `terraform destroy` to fail. To avoid this, add an explicit dependency between these resources with the `depends_on` meta argument.
+~> **IMPORTANT:** Currently there is an issue where deletion of both an `aws_ssoadmin_managed_policy_attachment` and `aws_ssoadmin_account_assignment` can occur simultaneously. This causes a problem with the `Delete` operation of the policy attachment and can cause your `terraform destroy` to fail. To avoid this, add an explicit dependency between these resources with the `depends_on` meta argument. See the `Managed Policy Attachment with Account Assignment (Identity Store Group)` example below.
 
 
 ~> **NOTE:** Creating this resource will automatically [Provision the Permission Set](https://docs.aws.amazon.com/singlesignon/latest/APIReference/API_ProvisionPermissionSet.html) to apply the corresponding updates to all assigned accounts.
 
 ## Example Usage
-
+### Basic Managed Policy Attachment
 ```terraform
 data "aws_ssoadmin_instances" "example" {}
 
@@ -27,10 +27,48 @@ resource "aws_ssoadmin_permission_set" "example" {
 
 resource "aws_ssoadmin_managed_policy_attachment" "example" {
   instance_arn       = tolist(data.aws_ssoadmin_instances.example.arns)[0]
-  managed_policy_arn = "arn:aws:iam::aws:policy/AlexaForBusinessDeviceSetup"
+  managed_policy_arn = "arn:aws:iam::aws:policy/job-function/ViewOnlyAccess"
   permission_set_arn = aws_ssoadmin_permission_set.example.arn
 }
 ```
+
+### Managed Policy Attachment with Account Assignment (Identity Store Group)
+```terraform
+data "aws_ssoadmin_instances" "example" {}
+
+resource "aws_ssoadmin_permission_set" "example" {
+  name         = "Example"
+  instance_arn = tolist(data.aws_ssoadmin_instances.example.arns)[0]
+}
+
+resource "aws_identitystore_group" "example" {
+
+  identity_store_id = tolist(data.aws_ssoadmin_instances.sso_instance.identity_store_ids)[0]
+  display_name      = "Admin"
+  description       = "Admin Group"
+}
+
+resource "aws_ssoadmin_account_assignment" "account_assignment" {
+  instance_arn       = tolist(data.aws_ssoadmin_instances.example.arns)[0]
+  permission_set_arn = aws_ssoadmin_permission_set.example.arn
+
+  principal_id   = aws_identitystore_group.example.group_id
+  principal_type = "GROUP"
+
+  target_id   = "123456789012"
+  target_type = "AWS_ACCOUNT"
+}
+
+resource "aws_ssoadmin_managed_policy_attachment" "example" {
+  instance_arn       = tolist(data.aws_ssoadmin_instances.example.arns)[0]
+  managed_policy_arn = "arn:aws:iam::aws:policy/AlexaForBusinessDeviceSetup"
+  permission_set_arn = aws_ssoadmin_permission_set.example.arn
+
+  # Adding an explicit dependency on the account assignment resource will
+  # allow the managed attachment to be safely destroyed prior to the removal
+  # of the account assignment.
+  depends_on = [aws_ssoadmin_account_assignment.example]
+}
 
 ## Argument Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
This PR addresses the bug with `aws_ssoadmin_account_assignment` and `aws_ssoadmin_managed_policy_attachment` listed in this [GitHub Issue - #33337](https://github.com/hashicorp/terraform-provider-aws/issues/33337). Per @jar-b's further investigation, adding an explicit dependency between these two resources resolves a provider issue where both resources are attempted to be destroyed at the same time, causing `terraform destroy` to fail until the command is run a second time.

This PR adds clear documentation of this error and the resolution to resource documentation pages for the above affected resources.

### Relations

Closes [#33337](https://github.com/hashicorp/terraform-provider-aws/issues/33337)
Closes[#33384](https://github.com/hashicorp/terraform-provider-aws/pull/33384)


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
