### PR TITLE
fix: Wait until RAM resource share available after accepting the invitation

### DIFF
--- a/.changelog/34753.txt
+++ b/.changelog/34753.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/resource_share_acceptor: Wait until RAM resource share available after accepting the invitation
+```

--- a/internal/service/ram/resource_share_accepter.go
+++ b/internal/service/ram/resource_share_accepter.go
@@ -118,6 +118,14 @@ func resourceResourceShareAccepterCreate(ctx context.Context, d *schema.Resource
 	)
 
 	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "waiting for RAM resource share invitation accepted (%s) state: %s", d.Id(), err)
+	}
+
+	_, err = tfresource.RetryWhenNotFound(ctx, FindResourceShareTimeout, func() (interface{}, error) {
+		return findResourceShareOwnerOtherAccountsByARN(ctx, conn, d.Id())
+	})
+
+	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for RAM resource share (%s) state: %s", d.Id(), err)
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
When a RAM resource share invitation from another account is accepted, there will be a slight delay until the resource share can be found. This PR adds wait for the delay.

### Relations

Closes #33701

### Output from Acceptance Testing

With AWS_PROFILE env variable:
```console
% make testacc TESTS=TestAccRAMResourceShareAccepter PKG=ram
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ram/... -v -count 1 -parallel 20 -run='TestAccRAMResourceShareAccepter'  -timeout 360m
=== RUN   TestAccRAMResourceShareAccepter_basic
=== PAUSE TestAccRAMResourceShareAccepter_basic
=== RUN   TestAccRAMResourceShareAccepter_disappears
=== PAUSE TestAccRAMResourceShareAccepter_disappears
=== RUN   TestAccRAMResourceShareAccepter_resourceAssociation
=== PAUSE TestAccRAMResourceShareAccepter_resourceAssociation
=== CONT  TestAccRAMResourceShareAccepter_basic
=== CONT  TestAccRAMResourceShareAccepter_resourceAssociation
=== CONT  TestAccRAMResourceShareAccepter_disappears
=== NAME  TestAccRAMResourceShareAccepter_basic
    acctest.go:848: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
=== NAME  TestAccRAMResourceShareAccepter_resourceAssociation
    acctest.go:848: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccRAMResourceShareAccepter_basic (0.47s)
--- SKIP: TestAccRAMResourceShareAccepter_resourceAssociation (0.47s)
=== NAME  TestAccRAMResourceShareAccepter_disappears
    acctest.go:848: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccRAMResourceShareAccepter_disappears (0.47s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ram        6.114s
```

As the warning says, I've also tried setting AWS_ALTERNATE_PROFILE env variable on the latest main branch, but it seems very flaky. Note that the error message of the first failed test is the same as the original issue.

<details>

```
make testacc TESTS=TestAccRAMResourceShareAccepter PKG=ram
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ram/... -v -count 1 -parallel 20 -run='TestAccRAMResourceShareAccepter'  -timeout 360m
=== RUN   TestAccRAMResourceShareAccepter_basic
=== PAUSE TestAccRAMResourceShareAccepter_basic
=== RUN   TestAccRAMResourceShareAccepter_disappears
=== PAUSE TestAccRAMResourceShareAccepter_disappears
=== RUN   TestAccRAMResourceShareAccepter_resourceAssociation
=== PAUSE TestAccRAMResourceShareAccepter_resourceAssociation
=== CONT  TestAccRAMResourceShareAccepter_basic
=== CONT  TestAccRAMResourceShareAccepter_resourceAssociation
=== CONT  TestAccRAMResourceShareAccepter_disappears
    resource_share_accepter_test.go:78: Step 1/1 error: Error running apply: exit status 1
        
        Error: reading RAM Resource Share (arn:aws:ram:us-west-2:433616233360:resource-share/51bcfb61-e944-42da-b306-7fdac02c6d66): couldn't find resource
        
          with aws_ram_resource_share_accepter.test,
          on terraform_plugin_test.tf line 21, in resource "aws_ram_resource_share_accepter" "test":
          21: resource "aws_ram_resource_share_accepter" "test" {
        
--- FAIL: TestAccRAMResourceShareAccepter_disappears (32.52s)
=== NAME  TestAccRAMResourceShareAccepter_resourceAssociation
    resource_share_accepter_test.go:105: Step 2/2 error running import: ImportStateVerify attributes not equivalent. Difference is shown below. The - symbol indicates attributes missing after import.
        
          map[string]string{
        +       "resources.#": "1",
        +       "resources.0": "arn:aws:codebuild:us-west-2:433616233360:project/tf-acc-test-8943434103236148295",
          }
--- PASS: TestAccRAMResourceShareAccepter_basic (65.69s)
--- FAIL: TestAccRAMResourceShareAccepter_resourceAssociation (76.61s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/ram        82.620s
FAIL
make: *** [testacc] Error 1
```
</details>

After adding my change, the first failed test case become to PASS.

<details>

```
 make testacc TESTS=TestAccRAMResourceShareAccepter PKG=ram
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ram/... -v -count 1 -parallel 20 -run='TestAccRAMResourceShareAccepter'  -timeout 360m
=== RUN   TestAccRAMResourceShareAccepter_basic
=== PAUSE TestAccRAMResourceShareAccepter_basic
=== RUN   TestAccRAMResourceShareAccepter_disappears
=== PAUSE TestAccRAMResourceShareAccepter_disappears
=== RUN   TestAccRAMResourceShareAccepter_resourceAssociation
=== PAUSE TestAccRAMResourceShareAccepter_resourceAssociation
=== CONT  TestAccRAMResourceShareAccepter_basic
=== CONT  TestAccRAMResourceShareAccepter_resourceAssociation
=== CONT  TestAccRAMResourceShareAccepter_disappears
=== NAME  TestAccRAMResourceShareAccepter_resourceAssociation
    resource_share_accepter_test.go:105: Step 2/2 error running import: ImportStateVerify attributes not equivalent. Difference is shown below. The - symbol indicates attributes missing after import.
        
          map[string]string{
        +       "resources.#": "1",
        +       "resources.0": "arn:aws:codebuild:us-west-2:433616233360:project/tf-acc-test-7733603511406526370",
          }
--- PASS: TestAccRAMResourceShareAccepter_basic (64.24s)
--- FAIL: TestAccRAMResourceShareAccepter_resourceAssociation (73.23s)
=== NAME  TestAccRAMResourceShareAccepter_disappears
    testing_new.go:91: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: leaving RAM resource share: UnknownResourceException: ResourceShare arn:aws:ram:us-west-2:433616233360:resource-share/ed27dfdb-6e5b-408a-be0d-7b13f36123ce could not be found.
        
--- FAIL: TestAccRAMResourceShareAccepter_disappears (171.52s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/ram        176.353s
FAIL
make: *** [testacc] Error 1
```
</details>