### PR TITLE
Generate `aws-sdk-go-v2` per-operation options for tagging

### DIFF
--- a/internal/generate/tags/templates/v2/get_tag_body.tmpl
+++ b/internal/generate/tags/templates/v2/get_tag_body.tmpl
@@ -4,9 +4,9 @@
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 {{- if or ( .TagTypeIDElem ) ( .TagTypeAddBoolElem ) }}
-func {{ .GetTagFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier{{ if .TagResTypeElem }}, resourceType{{ end }}, key string) (*tftags.TagData, error) {
+func {{ .GetTagFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier{{ if .TagResTypeElem }}, resourceType{{ end }}, key string, optFns ...func(*{{ .AWSService }}.Options)) (*tftags.TagData, error) {
 {{- else }}
-func {{ .GetTagFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier{{ if .TagResTypeElem }}, resourceType{{ end }}, key string) (*string, error) {
+func {{ .GetTagFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier{{ if .TagResTypeElem }}, resourceType{{ end }}, key string, optFns ...func(*{{ .AWSService }}.Options)) (*string, error) {
 {{- end }}
 	{{- if .ListTagsInFiltIDName }}
 	input := &{{ .AWSService  }}.{{ .ListTagsOp }}Input{
@@ -22,7 +22,7 @@ func {{ .GetTagFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier{{
 		},
 	}
 
-	output, err := conn.{{ .ListTagsOp }}(ctx, input)
+	output, err := conn.{{ .ListTagsOp }}(ctx, input, optFns...)
 
 	if err != nil {
 		return nil, err
@@ -30,7 +30,7 @@ func {{ .GetTagFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier{{
 
 	listTags := {{ .KeyValueTagsFunc }}(ctx, output.{{ .ListTagsOutTagsElem }}{{ if .TagTypeIDElem }}, identifier{{ if .TagResTypeElem }}, resourceType{{ end }}{{ end }})
 	{{- else }}
-	listTags, err := {{ .ListTagsFunc }}(ctx, conn, identifier{{ if .TagResTypeElem }}, resourceType{{ end }})
+	listTags, err := {{ .ListTagsFunc }}(ctx, conn, identifier{{ if .TagResTypeElem }}, resourceType{{ end }}, optFns...)
 
 	if err != nil {
 		return nil, err

--- a/internal/generate/tags/templates/v2/list_tags_body.tmpl
+++ b/internal/generate/tags/templates/v2/list_tags_body.tmpl
@@ -1,7 +1,7 @@
 // {{ .ListTagsFunc }} lists {{ .ServicePackage }} service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func {{ .ListTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier{{ if .TagResTypeElem }}, resourceType{{ end }} string) (tftags.KeyValueTags, error) {
+func {{ .ListTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier{{ if .TagResTypeElem }}, resourceType{{ end }} string, optFns ...func(*{{ .AWSService }}.Options)) (tftags.KeyValueTags, error) {
 	input := &{{ .TagPackage  }}.{{ .ListTagsOp }}Input{
 		{{- if .ListTagsInFiltIDName }}
 		Filters: []*{{ .AWSService  }}.Filter{
@@ -22,7 +22,7 @@ func {{ .ListTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier
 		{{- end }}
 	}
 
-	output, err := conn.{{ .ListTagsOp }}(ctx, input)
+	output, err := conn.{{ .ListTagsOp }}(ctx, input, optFns...)
 
 	{{ if and ( .ParentNotFoundErrCode ) ( .ParentNotFoundErrMsg ) }}
 			if tfawserr.ErrMessageContains(err, "{{ .ParentNotFoundErrCode }}", "{{ .ParentNotFoundErrMsg }}") {

--- a/internal/generate/tags/templates/v2/update_tags_body.tmpl
+++ b/internal/generate/tags/templates/v2/update_tags_body.tmpl
@@ -2,11 +2,11 @@
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 {{if  .TagTypeAddBoolElem -}}
-func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier{{ if .TagResTypeElem }}, resourceType{{ end }} string, oldTagsSet, newTagsSet any) error {
+func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier{{ if .TagResTypeElem }}, resourceType{{ end }} string, oldTagsSet, newTagsSet any, optFns ...func(*{{ .AWSService }}.Options)) error {
 	oldTags := {{ .KeyValueTagsFunc }}(ctx, oldTagsSet, identifier{{ if .TagResTypeElem }}, resourceType{{ end }})
 	newTags := {{ .KeyValueTagsFunc }}(ctx, newTagsSet, identifier{{ if .TagResTypeElem }}, resourceType{{ end }})
 {{- else -}}
-func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier{{ if .TagResTypeElem }}, resourceType{{ end }} string, oldTagsMap, newTagsMap any) error {
+func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier{{ if .TagResTypeElem }}, resourceType{{ end }} string, oldTagsMap, newTagsMap any, optFns ...func(*{{ .AWSService }}.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 {{- end }}
@@ -60,7 +60,7 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 		{{- end }}
 	}
 
-	_, err := conn.{{ .TagOp }}(ctx, input)
+	_, err := conn.{{ .TagOp }}(ctx, input, optFns...)
 
 	if err != nil {
 		return fmt.Errorf("tagging resource (%s): %w", identifier, err)
@@ -100,7 +100,7 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 			{{- end }}
 		}
 
-		_, err := conn.{{ .UntagOp }}(ctx, input)
+		_, err := conn.{{ .UntagOp }}(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -138,7 +138,7 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 			{{- end }}
 		}
 
-		_, err := conn.{{ .TagOp }}(ctx, input)
+		_, err := conn.{{ .TagOp }}(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/generate/tags/templates/v2/update_tags_body.tmpl
+++ b/internal/generate/tags/templates/v2/update_tags_body.tmpl
@@ -152,7 +152,7 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 
 	{{ if .WaitForPropagation }}
 	if len(removedTags) > 0 || len(updatedTags) > 0 {
-		if err := {{ .WaitTagsPropagatedFunc }}(ctx, conn, identifier, newTags); err != nil {
+		if err := {{ .WaitTagsPropagatedFunc }}(ctx, conn, identifier, newTags, optFns...); err != nil {
 			return fmt.Errorf("waiting for resource (%s) tag propagation: %w", identifier, err)
 		}
 	}

--- a/internal/generate/tags/templates/v2/wait_tags_propagated_body.tmpl
+++ b/internal/generate/tags/templates/v2/wait_tags_propagated_body.tmpl
@@ -1,13 +1,13 @@
 // {{ .WaitTagsPropagatedFunc }} waits for {{ .ServicePackage }} service tags to be propagated.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func {{ .WaitTagsPropagatedFunc }}(ctx context.Context, conn {{ .ClientType }}, id string, tags tftags.KeyValueTags) error {
+func {{ .WaitTagsPropagatedFunc }}(ctx context.Context, conn {{ .ClientType }}, id string, tags tftags.KeyValueTags, optFns ...func(*{{ .AWSService }}.Options)) error {
 	tflog.Debug(ctx, "Waiting for tag propagation", map[string]any{
 		"tags": tags,
 	})
 
 	checkFunc := func() (bool, error) {
-		output, err := {{ .ListTagsFunc }}(ctx, conn, id)
+		output, err := {{ .ListTagsFunc }}(ctx, conn, id, optFns...)
 
 		if tfresource.NotFound(err) {
 			return false, nil

--- a/internal/service/accessanalyzer/tags_gen.go
+++ b/internal/service/accessanalyzer/tags_gen.go
@@ -18,12 +18,12 @@ import (
 // listTags lists accessanalyzer service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *accessanalyzer.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *accessanalyzer.Client, identifier string, optFns ...func(*accessanalyzer.Options)) (tftags.KeyValueTags, error) {
 	input := &accessanalyzer.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -82,7 +82,7 @@ func setTagsOut(ctx context.Context, tags map[string]string) {
 // updateTags updates accessanalyzer service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *accessanalyzer.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *accessanalyzer.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*accessanalyzer.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -96,7 +96,7 @@ func updateTags(ctx context.Context, conn *accessanalyzer.Client, identifier str
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -111,7 +111,7 @@ func updateTags(ctx context.Context, conn *accessanalyzer.Client, identifier str
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/acm/tags_gen.go
+++ b/internal/service/acm/tags_gen.go
@@ -19,12 +19,12 @@ import (
 // listTags lists acm service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *acm.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *acm.Client, identifier string, optFns ...func(*acm.Options)) (tftags.KeyValueTags, error) {
 	input := &acm.ListTagsForCertificateInput{
 		CertificateArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForCertificate(ctx, input)
+	output, err := conn.ListTagsForCertificate(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -100,7 +100,7 @@ func setTagsOut(ctx context.Context, tags []awstypes.Tag) {
 // updateTags updates acm service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *acm.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *acm.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*acm.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -114,7 +114,7 @@ func updateTags(ctx context.Context, conn *acm.Client, identifier string, oldTag
 			Tags:           Tags(removedTags),
 		}
 
-		_, err := conn.RemoveTagsFromCertificate(ctx, input)
+		_, err := conn.RemoveTagsFromCertificate(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -129,7 +129,7 @@ func updateTags(ctx context.Context, conn *acm.Client, identifier string, oldTag
 			Tags:           Tags(updatedTags),
 		}
 
-		_, err := conn.AddTagsToCertificate(ctx, input)
+		_, err := conn.AddTagsToCertificate(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/appflow/tags_gen.go
+++ b/internal/service/appflow/tags_gen.go
@@ -18,12 +18,12 @@ import (
 // listTags lists appflow service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *appflow.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *appflow.Client, identifier string, optFns ...func(*appflow.Options)) (tftags.KeyValueTags, error) {
 	input := &appflow.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -82,7 +82,7 @@ func setTagsOut(ctx context.Context, tags map[string]string) {
 // updateTags updates appflow service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *appflow.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *appflow.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*appflow.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -96,7 +96,7 @@ func updateTags(ctx context.Context, conn *appflow.Client, identifier string, ol
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -111,7 +111,7 @@ func updateTags(ctx context.Context, conn *appflow.Client, identifier string, ol
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/apprunner/tags_gen.go
+++ b/internal/service/apprunner/tags_gen.go
@@ -19,12 +19,12 @@ import (
 // listTags lists apprunner service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *apprunner.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *apprunner.Client, identifier string, optFns ...func(*apprunner.Options)) (tftags.KeyValueTags, error) {
 	input := &apprunner.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -100,7 +100,7 @@ func setTagsOut(ctx context.Context, tags []awstypes.Tag) {
 // updateTags updates apprunner service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *apprunner.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *apprunner.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*apprunner.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -114,7 +114,7 @@ func updateTags(ctx context.Context, conn *apprunner.Client, identifier string, 
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -129,7 +129,7 @@ func updateTags(ctx context.Context, conn *apprunner.Client, identifier string, 
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/athena/tags_gen.go
+++ b/internal/service/athena/tags_gen.go
@@ -19,12 +19,12 @@ import (
 // listTags lists athena service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *athena.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *athena.Client, identifier string, optFns ...func(*athena.Options)) (tftags.KeyValueTags, error) {
 	input := &athena.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -100,7 +100,7 @@ func setTagsOut(ctx context.Context, tags []awstypes.Tag) {
 // updateTags updates athena service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *athena.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *athena.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*athena.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -114,7 +114,7 @@ func updateTags(ctx context.Context, conn *athena.Client, identifier string, old
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -129,7 +129,7 @@ func updateTags(ctx context.Context, conn *athena.Client, identifier string, old
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/auditmanager/tags_gen.go
+++ b/internal/service/auditmanager/tags_gen.go
@@ -18,12 +18,12 @@ import (
 // listTags lists auditmanager service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *auditmanager.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *auditmanager.Client, identifier string, optFns ...func(*auditmanager.Options)) (tftags.KeyValueTags, error) {
 	input := &auditmanager.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -82,7 +82,7 @@ func setTagsOut(ctx context.Context, tags map[string]string) {
 // updateTags updates auditmanager service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *auditmanager.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *auditmanager.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*auditmanager.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -96,7 +96,7 @@ func updateTags(ctx context.Context, conn *auditmanager.Client, identifier strin
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -111,7 +111,7 @@ func updateTags(ctx context.Context, conn *auditmanager.Client, identifier strin
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/chime/tags_gen.go
+++ b/internal/service/chime/tags_gen.go
@@ -19,12 +19,12 @@ import (
 // listTags lists chime service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *chimesdkvoice.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *chimesdkvoice.Client, identifier string, optFns ...func(*chimesdkvoice.Options)) (tftags.KeyValueTags, error) {
 	input := &chimesdkvoice.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -100,7 +100,7 @@ func setTagsOut(ctx context.Context, tags []awstypes.Tag) {
 // updateTags updates chime service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *chimesdkvoice.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *chimesdkvoice.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*chimesdkvoice.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -114,7 +114,7 @@ func updateTags(ctx context.Context, conn *chimesdkvoice.Client, identifier stri
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -129,7 +129,7 @@ func updateTags(ctx context.Context, conn *chimesdkvoice.Client, identifier stri
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/chimesdkmediapipelines/tags_gen.go
+++ b/internal/service/chimesdkmediapipelines/tags_gen.go
@@ -19,12 +19,12 @@ import (
 // listTags lists chimesdkmediapipelines service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *chimesdkmediapipelines.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *chimesdkmediapipelines.Client, identifier string, optFns ...func(*chimesdkmediapipelines.Options)) (tftags.KeyValueTags, error) {
 	input := &chimesdkmediapipelines.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -100,7 +100,7 @@ func setTagsOut(ctx context.Context, tags []awstypes.Tag) {
 // updateTags updates chimesdkmediapipelines service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *chimesdkmediapipelines.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *chimesdkmediapipelines.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*chimesdkmediapipelines.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -114,7 +114,7 @@ func updateTags(ctx context.Context, conn *chimesdkmediapipelines.Client, identi
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -129,7 +129,7 @@ func updateTags(ctx context.Context, conn *chimesdkmediapipelines.Client, identi
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/chimesdkvoice/tags_gen.go
+++ b/internal/service/chimesdkvoice/tags_gen.go
@@ -19,12 +19,12 @@ import (
 // listTags lists chimesdkvoice service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *chimesdkvoice.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *chimesdkvoice.Client, identifier string, optFns ...func(*chimesdkvoice.Options)) (tftags.KeyValueTags, error) {
 	input := &chimesdkvoice.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -100,7 +100,7 @@ func setTagsOut(ctx context.Context, tags []awstypes.Tag) {
 // updateTags updates chimesdkvoice service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *chimesdkvoice.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *chimesdkvoice.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*chimesdkvoice.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -114,7 +114,7 @@ func updateTags(ctx context.Context, conn *chimesdkvoice.Client, identifier stri
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -129,7 +129,7 @@ func updateTags(ctx context.Context, conn *chimesdkvoice.Client, identifier stri
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/cleanrooms/tags_gen.go
+++ b/internal/service/cleanrooms/tags_gen.go
@@ -18,12 +18,12 @@ import (
 // listTags lists cleanrooms service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *cleanrooms.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *cleanrooms.Client, identifier string, optFns ...func(*cleanrooms.Options)) (tftags.KeyValueTags, error) {
 	input := &cleanrooms.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -82,7 +82,7 @@ func setTagsOut(ctx context.Context, tags map[string]string) {
 // updateTags updates cleanrooms service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *cleanrooms.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *cleanrooms.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*cleanrooms.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -96,7 +96,7 @@ func updateTags(ctx context.Context, conn *cleanrooms.Client, identifier string,
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -111,7 +111,7 @@ func updateTags(ctx context.Context, conn *cleanrooms.Client, identifier string,
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/codeguruprofiler/tags_gen.go
+++ b/internal/service/codeguruprofiler/tags_gen.go
@@ -18,12 +18,12 @@ import (
 // listTags lists codeguruprofiler service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *codeguruprofiler.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *codeguruprofiler.Client, identifier string, optFns ...func(*codeguruprofiler.Options)) (tftags.KeyValueTags, error) {
 	input := &codeguruprofiler.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -82,7 +82,7 @@ func setTagsOut(ctx context.Context, tags map[string]string) {
 // updateTags updates codeguruprofiler service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *codeguruprofiler.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *codeguruprofiler.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*codeguruprofiler.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -96,7 +96,7 @@ func updateTags(ctx context.Context, conn *codeguruprofiler.Client, identifier s
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -111,7 +111,7 @@ func updateTags(ctx context.Context, conn *codeguruprofiler.Client, identifier s
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/codestarconnections/tags_gen.go
+++ b/internal/service/codestarconnections/tags_gen.go
@@ -19,12 +19,12 @@ import (
 // listTags lists codestarconnections service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *codestarconnections.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *codestarconnections.Client, identifier string, optFns ...func(*codestarconnections.Options)) (tftags.KeyValueTags, error) {
 	input := &codestarconnections.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -100,7 +100,7 @@ func setTagsOut(ctx context.Context, tags []awstypes.Tag) {
 // updateTags updates codestarconnections service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *codestarconnections.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *codestarconnections.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*codestarconnections.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -114,7 +114,7 @@ func updateTags(ctx context.Context, conn *codestarconnections.Client, identifie
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -129,7 +129,7 @@ func updateTags(ctx context.Context, conn *codestarconnections.Client, identifie
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/codestarnotifications/tags_gen.go
+++ b/internal/service/codestarnotifications/tags_gen.go
@@ -18,12 +18,12 @@ import (
 // listTags lists codestarnotifications service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *codestarnotifications.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *codestarnotifications.Client, identifier string, optFns ...func(*codestarnotifications.Options)) (tftags.KeyValueTags, error) {
 	input := &codestarnotifications.ListTagsForResourceInput{
 		Arn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -82,7 +82,7 @@ func setTagsOut(ctx context.Context, tags map[string]string) {
 // updateTags updates codestarnotifications service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *codestarnotifications.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *codestarnotifications.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*codestarnotifications.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -96,7 +96,7 @@ func updateTags(ctx context.Context, conn *codestarnotifications.Client, identif
 			TagKeys: removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -111,7 +111,7 @@ func updateTags(ctx context.Context, conn *codestarnotifications.Client, identif
 			Tags: Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/comprehend/tags_gen.go
+++ b/internal/service/comprehend/tags_gen.go
@@ -19,12 +19,12 @@ import (
 // listTags lists comprehend service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *comprehend.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *comprehend.Client, identifier string, optFns ...func(*comprehend.Options)) (tftags.KeyValueTags, error) {
 	input := &comprehend.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -100,7 +100,7 @@ func setTagsOut(ctx context.Context, tags []awstypes.Tag) {
 // updateTags updates comprehend service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *comprehend.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *comprehend.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*comprehend.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -114,7 +114,7 @@ func updateTags(ctx context.Context, conn *comprehend.Client, identifier string,
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -129,7 +129,7 @@ func updateTags(ctx context.Context, conn *comprehend.Client, identifier string,
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/deploy/tags_gen.go
+++ b/internal/service/deploy/tags_gen.go
@@ -19,12 +19,12 @@ import (
 // listTags lists deploy service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *codedeploy.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *codedeploy.Client, identifier string, optFns ...func(*codedeploy.Options)) (tftags.KeyValueTags, error) {
 	input := &codedeploy.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -100,7 +100,7 @@ func setTagsOut(ctx context.Context, tags []awstypes.Tag) {
 // updateTags updates deploy service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *codedeploy.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *codedeploy.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*codedeploy.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -114,7 +114,7 @@ func updateTags(ctx context.Context, conn *codedeploy.Client, identifier string,
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -129,7 +129,7 @@ func updateTags(ctx context.Context, conn *codedeploy.Client, identifier string,
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/docdbelastic/tags_gen.go
+++ b/internal/service/docdbelastic/tags_gen.go
@@ -18,12 +18,12 @@ import (
 // listTags lists docdbelastic service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *docdbelastic.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *docdbelastic.Client, identifier string, optFns ...func(*docdbelastic.Options)) (tftags.KeyValueTags, error) {
 	input := &docdbelastic.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -82,7 +82,7 @@ func setTagsOut(ctx context.Context, tags map[string]string) {
 // updateTags updates docdbelastic service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *docdbelastic.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *docdbelastic.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*docdbelastic.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -96,7 +96,7 @@ func updateTags(ctx context.Context, conn *docdbelastic.Client, identifier strin
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -111,7 +111,7 @@ func updateTags(ctx context.Context, conn *docdbelastic.Client, identifier strin
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/ec2/tagsv2_gen.go
+++ b/internal/service/ec2/tagsv2_gen.go
@@ -66,7 +66,7 @@ func setTagsOutV2(ctx context.Context, tags []awstypes.Tag) {
 // updateTagsV2 updates ec2 service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTagsV2(ctx context.Context, conn *ec2.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTagsV2(ctx context.Context, conn *ec2.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*ec2.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -80,7 +80,7 @@ func updateTagsV2(ctx context.Context, conn *ec2.Client, identifier string, oldT
 			Tags:      TagsV2(removedTags),
 		}
 
-		_, err := conn.DeleteTags(ctx, input)
+		_, err := conn.DeleteTags(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -95,7 +95,7 @@ func updateTagsV2(ctx context.Context, conn *ec2.Client, identifier string, oldT
 			Tags:      TagsV2(updatedTags),
 		}
 
-		_, err := conn.CreateTags(ctx, input)
+		_, err := conn.CreateTags(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/eks/tags_gen.go
+++ b/internal/service/eks/tags_gen.go
@@ -18,12 +18,12 @@ import (
 // listTags lists eks service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *eks.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *eks.Client, identifier string, optFns ...func(*eks.Options)) (tftags.KeyValueTags, error) {
 	input := &eks.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -82,7 +82,7 @@ func setTagsOut(ctx context.Context, tags map[string]string) {
 // updateTags updates eks service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *eks.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *eks.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*eks.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -96,7 +96,7 @@ func updateTags(ctx context.Context, conn *eks.Client, identifier string, oldTag
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -111,7 +111,7 @@ func updateTags(ctx context.Context, conn *eks.Client, identifier string, oldTag
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/emrserverless/tags_gen.go
+++ b/internal/service/emrserverless/tags_gen.go
@@ -18,12 +18,12 @@ import (
 // listTags lists emrserverless service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *emrserverless.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *emrserverless.Client, identifier string, optFns ...func(*emrserverless.Options)) (tftags.KeyValueTags, error) {
 	input := &emrserverless.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -82,7 +82,7 @@ func setTagsOut(ctx context.Context, tags map[string]string) {
 // updateTags updates emrserverless service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *emrserverless.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *emrserverless.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*emrserverless.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -96,7 +96,7 @@ func updateTags(ctx context.Context, conn *emrserverless.Client, identifier stri
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -111,7 +111,7 @@ func updateTags(ctx context.Context, conn *emrserverless.Client, identifier stri
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/evidently/tags_gen.go
+++ b/internal/service/evidently/tags_gen.go
@@ -49,7 +49,7 @@ func setTagsOut(ctx context.Context, tags map[string]string) {
 // updateTags updates evidently service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *evidently.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *evidently.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*evidently.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -63,7 +63,7 @@ func updateTags(ctx context.Context, conn *evidently.Client, identifier string, 
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -78,7 +78,7 @@ func updateTags(ctx context.Context, conn *evidently.Client, identifier string, 
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/finspace/tags_gen.go
+++ b/internal/service/finspace/tags_gen.go
@@ -18,12 +18,12 @@ import (
 // listTags lists finspace service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *finspace.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *finspace.Client, identifier string, optFns ...func(*finspace.Options)) (tftags.KeyValueTags, error) {
 	input := &finspace.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,7 +91,7 @@ func createTags(ctx context.Context, conn *finspace.Client, identifier string, t
 // updateTags updates finspace service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *finspace.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *finspace.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*finspace.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -105,7 +105,7 @@ func updateTags(ctx context.Context, conn *finspace.Client, identifier string, o
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -120,7 +120,7 @@ func updateTags(ctx context.Context, conn *finspace.Client, identifier string, o
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/fis/tags_gen.go
+++ b/internal/service/fis/tags_gen.go
@@ -18,12 +18,12 @@ import (
 // listTags lists fis service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *fis.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *fis.Client, identifier string, optFns ...func(*fis.Options)) (tftags.KeyValueTags, error) {
 	input := &fis.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -82,7 +82,7 @@ func setTagsOut(ctx context.Context, tags map[string]string) {
 // updateTags updates fis service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *fis.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *fis.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*fis.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -96,7 +96,7 @@ func updateTags(ctx context.Context, conn *fis.Client, identifier string, oldTag
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -111,7 +111,7 @@ func updateTags(ctx context.Context, conn *fis.Client, identifier string, oldTag
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/glacier/tags_gen.go
+++ b/internal/service/glacier/tags_gen.go
@@ -18,12 +18,12 @@ import (
 // listTags lists glacier service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *glacier.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *glacier.Client, identifier string, optFns ...func(*glacier.Options)) (tftags.KeyValueTags, error) {
 	input := &glacier.ListTagsForVaultInput{
 		VaultName: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForVault(ctx, input)
+	output, err := conn.ListTagsForVault(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,7 +91,7 @@ func createTags(ctx context.Context, conn *glacier.Client, identifier string, ta
 // updateTags updates glacier service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *glacier.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *glacier.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*glacier.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -105,7 +105,7 @@ func updateTags(ctx context.Context, conn *glacier.Client, identifier string, ol
 			TagKeys:   removedTags.Keys(),
 		}
 
-		_, err := conn.RemoveTagsFromVault(ctx, input)
+		_, err := conn.RemoveTagsFromVault(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -120,7 +120,7 @@ func updateTags(ctx context.Context, conn *glacier.Client, identifier string, ol
 			Tags:      Tags(updatedTags),
 		}
 
-		_, err := conn.AddTagsToVault(ctx, input)
+		_, err := conn.AddTagsToVault(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/healthlake/tags_gen.go
+++ b/internal/service/healthlake/tags_gen.go
@@ -19,12 +19,12 @@ import (
 // listTags lists healthlake service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *healthlake.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *healthlake.Client, identifier string, optFns ...func(*healthlake.Options)) (tftags.KeyValueTags, error) {
 	input := &healthlake.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -100,7 +100,7 @@ func setTagsOut(ctx context.Context, tags []awstypes.Tag) {
 // updateTags updates healthlake service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *healthlake.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *healthlake.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*healthlake.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -114,7 +114,7 @@ func updateTags(ctx context.Context, conn *healthlake.Client, identifier string,
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -129,7 +129,7 @@ func updateTags(ctx context.Context, conn *healthlake.Client, identifier string,
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/internetmonitor/tags_gen.go
+++ b/internal/service/internetmonitor/tags_gen.go
@@ -18,12 +18,12 @@ import (
 // listTags lists internetmonitor service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *internetmonitor.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *internetmonitor.Client, identifier string, optFns ...func(*internetmonitor.Options)) (tftags.KeyValueTags, error) {
 	input := &internetmonitor.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -82,7 +82,7 @@ func setTagsOut(ctx context.Context, tags map[string]string) {
 // updateTags updates internetmonitor service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *internetmonitor.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *internetmonitor.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*internetmonitor.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -96,7 +96,7 @@ func updateTags(ctx context.Context, conn *internetmonitor.Client, identifier st
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -111,7 +111,7 @@ func updateTags(ctx context.Context, conn *internetmonitor.Client, identifier st
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/ivschat/tags_gen.go
+++ b/internal/service/ivschat/tags_gen.go
@@ -18,12 +18,12 @@ import (
 // listTags lists ivschat service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *ivschat.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *ivschat.Client, identifier string, optFns ...func(*ivschat.Options)) (tftags.KeyValueTags, error) {
 	input := &ivschat.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -82,7 +82,7 @@ func setTagsOut(ctx context.Context, tags map[string]string) {
 // updateTags updates ivschat service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *ivschat.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *ivschat.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*ivschat.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -96,7 +96,7 @@ func updateTags(ctx context.Context, conn *ivschat.Client, identifier string, ol
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -111,7 +111,7 @@ func updateTags(ctx context.Context, conn *ivschat.Client, identifier string, ol
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/kendra/tags_gen.go
+++ b/internal/service/kendra/tags_gen.go
@@ -19,12 +19,12 @@ import (
 // listTags lists kendra service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *kendra.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *kendra.Client, identifier string, optFns ...func(*kendra.Options)) (tftags.KeyValueTags, error) {
 	input := &kendra.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -100,7 +100,7 @@ func setTagsOut(ctx context.Context, tags []awstypes.Tag) {
 // updateTags updates kendra service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *kendra.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *kendra.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*kendra.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -114,7 +114,7 @@ func updateTags(ctx context.Context, conn *kendra.Client, identifier string, old
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -129,7 +129,7 @@ func updateTags(ctx context.Context, conn *kendra.Client, identifier string, old
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/keyspaces/tags_gen.go
+++ b/internal/service/keyspaces/tags_gen.go
@@ -19,12 +19,12 @@ import (
 // listTags lists keyspaces service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *keyspaces.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *keyspaces.Client, identifier string, optFns ...func(*keyspaces.Options)) (tftags.KeyValueTags, error) {
 	input := &keyspaces.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -100,7 +100,7 @@ func setTagsOut(ctx context.Context, tags []awstypes.Tag) {
 // updateTags updates keyspaces service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *keyspaces.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *keyspaces.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*keyspaces.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -114,7 +114,7 @@ func updateTags(ctx context.Context, conn *keyspaces.Client, identifier string, 
 			Tags:        Tags(removedTags),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -129,7 +129,7 @@ func updateTags(ctx context.Context, conn *keyspaces.Client, identifier string, 
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/lambda/tags_gen.go
+++ b/internal/service/lambda/tags_gen.go
@@ -18,12 +18,12 @@ import (
 // listTags lists lambda service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *lambda.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *lambda.Client, identifier string, optFns ...func(*lambda.Options)) (tftags.KeyValueTags, error) {
 	input := &lambda.ListTagsInput{
 		Resource: aws.String(identifier),
 	}
 
-	output, err := conn.ListTags(ctx, input)
+	output, err := conn.ListTags(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -82,7 +82,7 @@ func setTagsOut(ctx context.Context, tags map[string]string) {
 // updateTags updates lambda service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *lambda.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *lambda.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*lambda.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -96,7 +96,7 @@ func updateTags(ctx context.Context, conn *lambda.Client, identifier string, old
 			TagKeys:  removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -111,7 +111,7 @@ func updateTags(ctx context.Context, conn *lambda.Client, identifier string, old
 			Tags:     Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/lexv2models/tags_gen.go
+++ b/internal/service/lexv2models/tags_gen.go
@@ -18,12 +18,12 @@ import (
 // listTags lists lexv2models service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *lexmodelsv2.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *lexmodelsv2.Client, identifier string, optFns ...func(*lexmodelsv2.Options)) (tftags.KeyValueTags, error) {
 	input := &lexmodelsv2.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -82,7 +82,7 @@ func setTagsOut(ctx context.Context, tags map[string]string) {
 // updateTags updates lexv2models service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *lexmodelsv2.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *lexmodelsv2.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*lexmodelsv2.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -96,7 +96,7 @@ func updateTags(ctx context.Context, conn *lexmodelsv2.Client, identifier string
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -111,7 +111,7 @@ func updateTags(ctx context.Context, conn *lexmodelsv2.Client, identifier string
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/lightsail/tags_gen.go
+++ b/internal/service/lightsail/tags_gen.go
@@ -76,7 +76,7 @@ func createTags(ctx context.Context, conn *lightsail.Client, identifier string, 
 // updateTags updates lightsail service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *lightsail.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *lightsail.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*lightsail.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -90,7 +90,7 @@ func updateTags(ctx context.Context, conn *lightsail.Client, identifier string, 
 			TagKeys:      removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -105,7 +105,7 @@ func updateTags(ctx context.Context, conn *lightsail.Client, identifier string, 
 			Tags:         Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/logs/log_group_tags_gen.go
+++ b/internal/service/logs/log_group_tags_gen.go
@@ -16,12 +16,12 @@ import (
 // listLogGroupTags lists logs service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listLogGroupTags(ctx context.Context, conn *cloudwatchlogs.Client, identifier string) (tftags.KeyValueTags, error) {
+func listLogGroupTags(ctx context.Context, conn *cloudwatchlogs.Client, identifier string, optFns ...func(*cloudwatchlogs.Options)) (tftags.KeyValueTags, error) {
 	input := &cloudwatchlogs.ListTagsLogGroupInput{
 		LogGroupName: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsLogGroup(ctx, input)
+	output, err := conn.ListTagsLogGroup(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -33,7 +33,7 @@ func listLogGroupTags(ctx context.Context, conn *cloudwatchlogs.Client, identifi
 // updateLogGroupTags updates logs service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateLogGroupTags(ctx context.Context, conn *cloudwatchlogs.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateLogGroupTags(ctx context.Context, conn *cloudwatchlogs.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*cloudwatchlogs.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -47,7 +47,7 @@ func updateLogGroupTags(ctx context.Context, conn *cloudwatchlogs.Client, identi
 			Tags:         removedTags.Keys(),
 		}
 
-		_, err := conn.UntagLogGroup(ctx, input)
+		_, err := conn.UntagLogGroup(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -62,7 +62,7 @@ func updateLogGroupTags(ctx context.Context, conn *cloudwatchlogs.Client, identi
 			Tags:         Tags(updatedTags),
 		}
 
-		_, err := conn.TagLogGroup(ctx, input)
+		_, err := conn.TagLogGroup(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/logs/tags_gen.go
+++ b/internal/service/logs/tags_gen.go
@@ -18,12 +18,12 @@ import (
 // listTags lists logs service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *cloudwatchlogs.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *cloudwatchlogs.Client, identifier string, optFns ...func(*cloudwatchlogs.Options)) (tftags.KeyValueTags, error) {
 	input := &cloudwatchlogs.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,7 +91,7 @@ func createTags(ctx context.Context, conn *cloudwatchlogs.Client, identifier str
 // updateTags updates logs service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *cloudwatchlogs.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *cloudwatchlogs.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*cloudwatchlogs.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -105,7 +105,7 @@ func updateTags(ctx context.Context, conn *cloudwatchlogs.Client, identifier str
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -120,7 +120,7 @@ func updateTags(ctx context.Context, conn *cloudwatchlogs.Client, identifier str
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/mediaconnect/tags_gen.go
+++ b/internal/service/mediaconnect/tags_gen.go
@@ -18,12 +18,12 @@ import (
 // listTags lists mediaconnect service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *mediaconnect.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *mediaconnect.Client, identifier string, optFns ...func(*mediaconnect.Options)) (tftags.KeyValueTags, error) {
 	input := &mediaconnect.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -82,7 +82,7 @@ func setTagsOut(ctx context.Context, tags map[string]string) {
 // updateTags updates mediaconnect service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *mediaconnect.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *mediaconnect.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*mediaconnect.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -96,7 +96,7 @@ func updateTags(ctx context.Context, conn *mediaconnect.Client, identifier strin
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -111,7 +111,7 @@ func updateTags(ctx context.Context, conn *mediaconnect.Client, identifier strin
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/medialive/tags_gen.go
+++ b/internal/service/medialive/tags_gen.go
@@ -18,12 +18,12 @@ import (
 // listTags lists medialive service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *medialive.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *medialive.Client, identifier string, optFns ...func(*medialive.Options)) (tftags.KeyValueTags, error) {
 	input := &medialive.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -82,7 +82,7 @@ func setTagsOut(ctx context.Context, tags map[string]string) {
 // updateTags updates medialive service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *medialive.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *medialive.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*medialive.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -96,7 +96,7 @@ func updateTags(ctx context.Context, conn *medialive.Client, identifier string, 
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.DeleteTags(ctx, input)
+		_, err := conn.DeleteTags(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -111,7 +111,7 @@ func updateTags(ctx context.Context, conn *medialive.Client, identifier string, 
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.CreateTags(ctx, input)
+		_, err := conn.CreateTags(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/mediapackage/tags_gen.go
+++ b/internal/service/mediapackage/tags_gen.go
@@ -18,12 +18,12 @@ import (
 // listTags lists mediapackage service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *mediapackage.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *mediapackage.Client, identifier string, optFns ...func(*mediapackage.Options)) (tftags.KeyValueTags, error) {
 	input := &mediapackage.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -82,7 +82,7 @@ func setTagsOut(ctx context.Context, tags map[string]string) {
 // updateTags updates mediapackage service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *mediapackage.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *mediapackage.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*mediapackage.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -96,7 +96,7 @@ func updateTags(ctx context.Context, conn *mediapackage.Client, identifier strin
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -111,7 +111,7 @@ func updateTags(ctx context.Context, conn *mediapackage.Client, identifier strin
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/oam/tags_gen.go
+++ b/internal/service/oam/tags_gen.go
@@ -18,12 +18,12 @@ import (
 // listTags lists oam service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *oam.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *oam.Client, identifier string, optFns ...func(*oam.Options)) (tftags.KeyValueTags, error) {
 	input := &oam.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -82,7 +82,7 @@ func setTagsOut(ctx context.Context, tags map[string]string) {
 // updateTags updates oam service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *oam.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *oam.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*oam.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -96,7 +96,7 @@ func updateTags(ctx context.Context, conn *oam.Client, identifier string, oldTag
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -111,7 +111,7 @@ func updateTags(ctx context.Context, conn *oam.Client, identifier string, oldTag
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/opensearchserverless/tags_gen.go
+++ b/internal/service/opensearchserverless/tags_gen.go
@@ -19,12 +19,12 @@ import (
 // listTags lists opensearchserverless service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *opensearchserverless.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *opensearchserverless.Client, identifier string, optFns ...func(*opensearchserverless.Options)) (tftags.KeyValueTags, error) {
 	input := &opensearchserverless.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -100,7 +100,7 @@ func setTagsOut(ctx context.Context, tags []awstypes.Tag) {
 // updateTags updates opensearchserverless service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *opensearchserverless.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *opensearchserverless.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*opensearchserverless.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -114,7 +114,7 @@ func updateTags(ctx context.Context, conn *opensearchserverless.Client, identifi
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -129,7 +129,7 @@ func updateTags(ctx context.Context, conn *opensearchserverless.Client, identifi
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/pipes/tags_gen.go
+++ b/internal/service/pipes/tags_gen.go
@@ -18,12 +18,12 @@ import (
 // listTags lists pipes service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *pipes.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *pipes.Client, identifier string, optFns ...func(*pipes.Options)) (tftags.KeyValueTags, error) {
 	input := &pipes.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -82,7 +82,7 @@ func setTagsOut(ctx context.Context, tags map[string]string) {
 // updateTags updates pipes service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *pipes.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *pipes.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*pipes.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -96,7 +96,7 @@ func updateTags(ctx context.Context, conn *pipes.Client, identifier string, oldT
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -111,7 +111,7 @@ func updateTags(ctx context.Context, conn *pipes.Client, identifier string, oldT
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/qldb/tags_gen.go
+++ b/internal/service/qldb/tags_gen.go
@@ -18,12 +18,12 @@ import (
 // listTags lists qldb service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *qldb.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *qldb.Client, identifier string, optFns ...func(*qldb.Options)) (tftags.KeyValueTags, error) {
 	input := &qldb.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -82,7 +82,7 @@ func setTagsOut(ctx context.Context, tags map[string]*string) {
 // updateTags updates qldb service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *qldb.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *qldb.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*qldb.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -96,7 +96,7 @@ func updateTags(ctx context.Context, conn *qldb.Client, identifier string, oldTa
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -111,7 +111,7 @@ func updateTags(ctx context.Context, conn *qldb.Client, identifier string, oldTa
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/rbin/tags_gen.go
+++ b/internal/service/rbin/tags_gen.go
@@ -19,12 +19,12 @@ import (
 // listTags lists rbin service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *rbin.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *rbin.Client, identifier string, optFns ...func(*rbin.Options)) (tftags.KeyValueTags, error) {
 	input := &rbin.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -100,7 +100,7 @@ func setTagsOut(ctx context.Context, tags []awstypes.Tag) {
 // updateTags updates rbin service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *rbin.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *rbin.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*rbin.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -114,7 +114,7 @@ func updateTags(ctx context.Context, conn *rbin.Client, identifier string, oldTa
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -129,7 +129,7 @@ func updateTags(ctx context.Context, conn *rbin.Client, identifier string, oldTa
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/resourceexplorer2/tags_gen.go
+++ b/internal/service/resourceexplorer2/tags_gen.go
@@ -18,12 +18,12 @@ import (
 // listTags lists resourceexplorer2 service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *resourceexplorer2.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *resourceexplorer2.Client, identifier string, optFns ...func(*resourceexplorer2.Options)) (tftags.KeyValueTags, error) {
 	input := &resourceexplorer2.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -82,7 +82,7 @@ func setTagsOut(ctx context.Context, tags map[string]string) {
 // updateTags updates resourceexplorer2 service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *resourceexplorer2.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *resourceexplorer2.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*resourceexplorer2.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -96,7 +96,7 @@ func updateTags(ctx context.Context, conn *resourceexplorer2.Client, identifier 
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -111,7 +111,7 @@ func updateTags(ctx context.Context, conn *resourceexplorer2.Client, identifier 
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/resourcegroups/tags_gen.go
+++ b/internal/service/resourcegroups/tags_gen.go
@@ -18,12 +18,12 @@ import (
 // listTags lists resourcegroups service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *resourcegroups.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *resourcegroups.Client, identifier string, optFns ...func(*resourcegroups.Options)) (tftags.KeyValueTags, error) {
 	input := &resourcegroups.GetTagsInput{
 		Arn: aws.String(identifier),
 	}
 
-	output, err := conn.GetTags(ctx, input)
+	output, err := conn.GetTags(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -82,7 +82,7 @@ func setTagsOut(ctx context.Context, tags map[string]string) {
 // updateTags updates resourcegroups service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *resourcegroups.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *resourcegroups.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*resourcegroups.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -96,7 +96,7 @@ func updateTags(ctx context.Context, conn *resourcegroups.Client, identifier str
 			Keys: removedTags.Keys(),
 		}
 
-		_, err := conn.Untag(ctx, input)
+		_, err := conn.Untag(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -111,7 +111,7 @@ func updateTags(ctx context.Context, conn *resourcegroups.Client, identifier str
 			Tags: Tags(updatedTags),
 		}
 
-		_, err := conn.Tag(ctx, input)
+		_, err := conn.Tag(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/rolesanywhere/tags_gen.go
+++ b/internal/service/rolesanywhere/tags_gen.go
@@ -19,12 +19,12 @@ import (
 // listTags lists rolesanywhere service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *rolesanywhere.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *rolesanywhere.Client, identifier string, optFns ...func(*rolesanywhere.Options)) (tftags.KeyValueTags, error) {
 	input := &rolesanywhere.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -100,7 +100,7 @@ func setTagsOut(ctx context.Context, tags []awstypes.Tag) {
 // updateTags updates rolesanywhere service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *rolesanywhere.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *rolesanywhere.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*rolesanywhere.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -114,7 +114,7 @@ func updateTags(ctx context.Context, conn *rolesanywhere.Client, identifier stri
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -129,7 +129,7 @@ func updateTags(ctx context.Context, conn *rolesanywhere.Client, identifier stri
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/route53domains/tags_gen.go
+++ b/internal/service/route53domains/tags_gen.go
@@ -22,8 +22,8 @@ import (
 // This function will optimise the handling over listTags, if possible.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func GetTag(ctx context.Context, conn *route53domains.Client, identifier, key string) (*string, error) {
-	listTags, err := listTags(ctx, conn, identifier)
+func GetTag(ctx context.Context, conn *route53domains.Client, identifier, key string, optFns ...func(*route53domains.Options)) (*string, error) {
+	listTags, err := listTags(ctx, conn, identifier, optFns...)
 
 	if err != nil {
 		return nil, err
@@ -39,12 +39,12 @@ func GetTag(ctx context.Context, conn *route53domains.Client, identifier, key st
 // listTags lists route53domains service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *route53domains.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *route53domains.Client, identifier string, optFns ...func(*route53domains.Options)) (tftags.KeyValueTags, error) {
 	input := &route53domains.ListTagsForDomainInput{
 		DomainName: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForDomain(ctx, input)
+	output, err := conn.ListTagsForDomain(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -120,7 +120,7 @@ func setTagsOut(ctx context.Context, tags []awstypes.Tag) {
 // updateTags updates route53domains service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *route53domains.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *route53domains.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*route53domains.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -134,7 +134,7 @@ func updateTags(ctx context.Context, conn *route53domains.Client, identifier str
 			TagsToDelete: removedTags.Keys(),
 		}
 
-		_, err := conn.DeleteTagsForDomain(ctx, input)
+		_, err := conn.DeleteTagsForDomain(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -149,7 +149,7 @@ func updateTags(ctx context.Context, conn *route53domains.Client, identifier str
 			TagsToUpdate: Tags(updatedTags),
 		}
 
-		_, err := conn.UpdateTagsForDomain(ctx, input)
+		_, err := conn.UpdateTagsForDomain(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/s3control/tags_gen.go
+++ b/internal/service/s3control/tags_gen.go
@@ -19,13 +19,13 @@ import (
 // listTags lists s3control service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *s3control.Client, identifier, resourceType string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *s3control.Client, identifier, resourceType string, optFns ...func(*s3control.Options)) (tftags.KeyValueTags, error) {
 	input := &s3control.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 		AccountId:   aws.String(resourceType),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -101,7 +101,7 @@ func setTagsOut(ctx context.Context, tags []awstypes.Tag) {
 // updateTags updates s3control service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *s3control.Client, identifier, resourceType string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *s3control.Client, identifier, resourceType string, oldTagsMap, newTagsMap any, optFns ...func(*s3control.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -116,7 +116,7 @@ func updateTags(ctx context.Context, conn *s3control.Client, identifier, resourc
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -132,7 +132,7 @@ func updateTags(ctx context.Context, conn *s3control.Client, identifier, resourc
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/scheduler/tags_gen.go
+++ b/internal/service/scheduler/tags_gen.go
@@ -19,12 +19,12 @@ import (
 // listTags lists scheduler service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *scheduler.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *scheduler.Client, identifier string, optFns ...func(*scheduler.Options)) (tftags.KeyValueTags, error) {
 	input := &scheduler.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -100,7 +100,7 @@ func setTagsOut(ctx context.Context, tags []awstypes.Tag) {
 // updateTags updates scheduler service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *scheduler.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *scheduler.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*scheduler.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -114,7 +114,7 @@ func updateTags(ctx context.Context, conn *scheduler.Client, identifier string, 
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -129,7 +129,7 @@ func updateTags(ctx context.Context, conn *scheduler.Client, identifier string, 
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/securityhub/tags_gen.go
+++ b/internal/service/securityhub/tags_gen.go
@@ -18,12 +18,12 @@ import (
 // listTags lists securityhub service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *securityhub.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *securityhub.Client, identifier string, optFns ...func(*securityhub.Options)) (tftags.KeyValueTags, error) {
 	input := &securityhub.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -82,7 +82,7 @@ func setTagsOut(ctx context.Context, tags map[string]string) {
 // updateTags updates securityhub service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *securityhub.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *securityhub.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*securityhub.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -96,7 +96,7 @@ func updateTags(ctx context.Context, conn *securityhub.Client, identifier string
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -111,7 +111,7 @@ func updateTags(ctx context.Context, conn *securityhub.Client, identifier string
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/sesv2/tags_gen.go
+++ b/internal/service/sesv2/tags_gen.go
@@ -19,12 +19,12 @@ import (
 // listTags lists sesv2 service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *sesv2.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *sesv2.Client, identifier string, optFns ...func(*sesv2.Options)) (tftags.KeyValueTags, error) {
 	input := &sesv2.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -100,7 +100,7 @@ func setTagsOut(ctx context.Context, tags []awstypes.Tag) {
 // updateTags updates sesv2 service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *sesv2.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *sesv2.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*sesv2.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -114,7 +114,7 @@ func updateTags(ctx context.Context, conn *sesv2.Client, identifier string, oldT
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -129,7 +129,7 @@ func updateTags(ctx context.Context, conn *sesv2.Client, identifier string, oldT
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/signer/tags_gen.go
+++ b/internal/service/signer/tags_gen.go
@@ -18,12 +18,12 @@ import (
 // listTags lists signer service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *signer.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *signer.Client, identifier string, optFns ...func(*signer.Options)) (tftags.KeyValueTags, error) {
 	input := &signer.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -82,7 +82,7 @@ func setTagsOut(ctx context.Context, tags map[string]string) {
 // updateTags updates signer service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *signer.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *signer.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*signer.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -96,7 +96,7 @@ func updateTags(ctx context.Context, conn *signer.Client, identifier string, old
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -111,7 +111,7 @@ func updateTags(ctx context.Context, conn *signer.Client, identifier string, old
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/sns/tags_gen.go
+++ b/internal/service/sns/tags_gen.go
@@ -19,12 +19,12 @@ import (
 // listTags lists sns service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *sns.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *sns.Client, identifier string, optFns ...func(*sns.Options)) (tftags.KeyValueTags, error) {
 	input := &sns.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,7 +109,7 @@ func createTags(ctx context.Context, conn *sns.Client, identifier string, tags [
 // updateTags updates sns service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *sns.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *sns.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*sns.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -123,7 +123,7 @@ func updateTags(ctx context.Context, conn *sns.Client, identifier string, oldTag
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -138,7 +138,7 @@ func updateTags(ctx context.Context, conn *sns.Client, identifier string, oldTag
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/sqs/tags_gen.go
+++ b/internal/service/sqs/tags_gen.go
@@ -18,12 +18,12 @@ import (
 // listTags lists sqs service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *sqs.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *sqs.Client, identifier string, optFns ...func(*sqs.Options)) (tftags.KeyValueTags, error) {
 	input := &sqs.ListQueueTagsInput{
 		QueueUrl: aws.String(identifier),
 	}
 
-	output, err := conn.ListQueueTags(ctx, input)
+	output, err := conn.ListQueueTags(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,7 +91,7 @@ func createTags(ctx context.Context, conn *sqs.Client, identifier string, tags m
 // updateTags updates sqs service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *sqs.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *sqs.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*sqs.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -105,7 +105,7 @@ func updateTags(ctx context.Context, conn *sqs.Client, identifier string, oldTag
 			TagKeys:  removedTags.Keys(),
 		}
 
-		_, err := conn.UntagQueue(ctx, input)
+		_, err := conn.UntagQueue(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -120,7 +120,7 @@ func updateTags(ctx context.Context, conn *sqs.Client, identifier string, oldTag
 			Tags:     Tags(updatedTags),
 		}
 
-		_, err := conn.TagQueue(ctx, input)
+		_, err := conn.TagQueue(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/ssmcontacts/tags_gen.go
+++ b/internal/service/ssmcontacts/tags_gen.go
@@ -19,12 +19,12 @@ import (
 // listTags lists ssmcontacts service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *ssmcontacts.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *ssmcontacts.Client, identifier string, optFns ...func(*ssmcontacts.Options)) (tftags.KeyValueTags, error) {
 	input := &ssmcontacts.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -100,7 +100,7 @@ func setTagsOut(ctx context.Context, tags []awstypes.Tag) {
 // updateTags updates ssmcontacts service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *ssmcontacts.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *ssmcontacts.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*ssmcontacts.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -114,7 +114,7 @@ func updateTags(ctx context.Context, conn *ssmcontacts.Client, identifier string
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -129,7 +129,7 @@ func updateTags(ctx context.Context, conn *ssmcontacts.Client, identifier string
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/ssmincidents/tags_gen.go
+++ b/internal/service/ssmincidents/tags_gen.go
@@ -18,12 +18,12 @@ import (
 // listTags lists ssmincidents service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *ssmincidents.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *ssmincidents.Client, identifier string, optFns ...func(*ssmincidents.Options)) (tftags.KeyValueTags, error) {
 	input := &ssmincidents.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -82,7 +82,7 @@ func setTagsOut(ctx context.Context, tags map[string]string) {
 // updateTags updates ssmincidents service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *ssmincidents.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *ssmincidents.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*ssmincidents.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -96,7 +96,7 @@ func updateTags(ctx context.Context, conn *ssmincidents.Client, identifier strin
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -111,7 +111,7 @@ func updateTags(ctx context.Context, conn *ssmincidents.Client, identifier strin
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/ssoadmin/tags_gen.go
+++ b/internal/service/ssoadmin/tags_gen.go
@@ -19,13 +19,13 @@ import (
 // listTags lists ssoadmin service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *ssoadmin.Client, identifier, resourceType string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *ssoadmin.Client, identifier, resourceType string, optFns ...func(*ssoadmin.Options)) (tftags.KeyValueTags, error) {
 	input := &ssoadmin.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 		InstanceArn: aws.String(resourceType),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -101,7 +101,7 @@ func setTagsOut(ctx context.Context, tags []awstypes.Tag) {
 // updateTags updates ssoadmin service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *ssoadmin.Client, identifier, resourceType string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *ssoadmin.Client, identifier, resourceType string, oldTagsMap, newTagsMap any, optFns ...func(*ssoadmin.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -116,7 +116,7 @@ func updateTags(ctx context.Context, conn *ssoadmin.Client, identifier, resource
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -132,7 +132,7 @@ func updateTags(ctx context.Context, conn *ssoadmin.Client, identifier, resource
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/swf/tags_gen.go
+++ b/internal/service/swf/tags_gen.go
@@ -19,12 +19,12 @@ import (
 // listTags lists swf service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *swf.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *swf.Client, identifier string, optFns ...func(*swf.Options)) (tftags.KeyValueTags, error) {
 	input := &swf.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -100,7 +100,7 @@ func setTagsOut(ctx context.Context, tags []awstypes.ResourceTag) {
 // updateTags updates swf service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *swf.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *swf.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*swf.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -114,7 +114,7 @@ func updateTags(ctx context.Context, conn *swf.Client, identifier string, oldTag
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -129,7 +129,7 @@ func updateTags(ctx context.Context, conn *swf.Client, identifier string, oldTag
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/timestreamwrite/tags_gen.go
+++ b/internal/service/timestreamwrite/tags_gen.go
@@ -19,12 +19,12 @@ import (
 // listTags lists timestreamwrite service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *timestreamwrite.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *timestreamwrite.Client, identifier string, optFns ...func(*timestreamwrite.Options)) (tftags.KeyValueTags, error) {
 	input := &timestreamwrite.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -100,7 +100,7 @@ func setTagsOut(ctx context.Context, tags []awstypes.Tag) {
 // updateTags updates timestreamwrite service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *timestreamwrite.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *timestreamwrite.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*timestreamwrite.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -114,7 +114,7 @@ func updateTags(ctx context.Context, conn *timestreamwrite.Client, identifier st
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -129,7 +129,7 @@ func updateTags(ctx context.Context, conn *timestreamwrite.Client, identifier st
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/transcribe/tags_gen.go
+++ b/internal/service/transcribe/tags_gen.go
@@ -19,12 +19,12 @@ import (
 // listTags lists transcribe service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *transcribe.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *transcribe.Client, identifier string, optFns ...func(*transcribe.Options)) (tftags.KeyValueTags, error) {
 	input := &transcribe.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -100,7 +100,7 @@ func setTagsOut(ctx context.Context, tags []awstypes.Tag) {
 // updateTags updates transcribe service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *transcribe.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *transcribe.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*transcribe.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -114,7 +114,7 @@ func updateTags(ctx context.Context, conn *transcribe.Client, identifier string,
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -129,7 +129,7 @@ func updateTags(ctx context.Context, conn *transcribe.Client, identifier string,
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/vpclattice/tags_gen.go
+++ b/internal/service/vpclattice/tags_gen.go
@@ -18,12 +18,12 @@ import (
 // listTags lists vpclattice service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *vpclattice.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *vpclattice.Client, identifier string, optFns ...func(*vpclattice.Options)) (tftags.KeyValueTags, error) {
 	input := &vpclattice.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -82,7 +82,7 @@ func setTagsOut(ctx context.Context, tags map[string]string) {
 // updateTags updates vpclattice service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *vpclattice.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *vpclattice.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*vpclattice.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -96,7 +96,7 @@ func updateTags(ctx context.Context, conn *vpclattice.Client, identifier string,
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -111,7 +111,7 @@ func updateTags(ctx context.Context, conn *vpclattice.Client, identifier string,
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/workspaces/tags_gen.go
+++ b/internal/service/workspaces/tags_gen.go
@@ -19,12 +19,12 @@ import (
 // listTags lists workspaces service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *workspaces.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *workspaces.Client, identifier string, optFns ...func(*workspaces.Options)) (tftags.KeyValueTags, error) {
 	input := &workspaces.DescribeTagsInput{
 		ResourceId: aws.String(identifier),
 	}
 
-	output, err := conn.DescribeTags(ctx, input)
+	output, err := conn.DescribeTags(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -100,7 +100,7 @@ func setTagsOut(ctx context.Context, tags []awstypes.Tag) {
 // updateTags updates workspaces service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *workspaces.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *workspaces.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*workspaces.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -114,7 +114,7 @@ func updateTags(ctx context.Context, conn *workspaces.Client, identifier string,
 			TagKeys:    removedTags.Keys(),
 		}
 
-		_, err := conn.DeleteTags(ctx, input)
+		_, err := conn.DeleteTags(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -129,7 +129,7 @@ func updateTags(ctx context.Context, conn *workspaces.Client, identifier string,
 			Tags:       Tags(updatedTags),
 		}
 
-		_, err := conn.CreateTags(ctx, input)
+		_, err := conn.CreateTags(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/xray/tags_gen.go
+++ b/internal/service/xray/tags_gen.go
@@ -19,12 +19,12 @@ import (
 // listTags lists xray service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn *xray.Client, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *xray.Client, identifier string, optFns ...func(*xray.Options)) (tftags.KeyValueTags, error) {
 	input := &xray.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -100,7 +100,7 @@ func setTagsOut(ctx context.Context, tags []awstypes.Tag) {
 // updateTags updates xray service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *xray.Client, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *xray.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*xray.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -114,7 +114,7 @@ func updateTags(ctx context.Context, conn *xray.Client, identifier string, oldTa
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -129,7 +129,7 @@ func updateTags(ctx context.Context, conn *xray.Client, identifier string, oldTa
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Generates `aws-sdk-go-v2` per-operation options for tagging.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/34771.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
