### PR TITLE
d/aws_ssoadmin_application: new data source

### DIFF
--- a/.changelog/34773.txt
+++ b/.changelog/34773.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_ssoadmin_application
+```

--- a/internal/service/ssoadmin/application_data_source.go
+++ b/internal/service/ssoadmin/application_data_source.go
@@ -1,0 +1,137 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ssoadmin
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource(name="Application")
+func newDataSourceApplication(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &dataSourceApplication{}, nil
+}
+
+const (
+	DSNameApplication = "Application Data Source"
+)
+
+type dataSourceApplication struct {
+	framework.DataSourceWithConfigure
+}
+
+func (d *dataSourceApplication) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) { // nosemgrep:ci.meta-in-func-name
+	resp.TypeName = "aws_ssoadmin_application"
+}
+
+func (d *dataSourceApplication) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"application_account": schema.StringAttribute{
+				Computed: true,
+			},
+			"application_arn": schema.StringAttribute{
+				CustomType: fwtypes.ARNType,
+				Required:   true,
+			},
+			"application_provider_arn": schema.StringAttribute{
+				CustomType: fwtypes.ARNType,
+				Computed:   true,
+			},
+			"description": schema.StringAttribute{
+				Computed: true,
+			},
+			"id": framework.IDAttribute(),
+			"instance_arn": schema.StringAttribute{
+				CustomType: fwtypes.ARNType,
+				Computed:   true,
+			},
+			"name": schema.StringAttribute{
+				Computed: true,
+			},
+			"status": schema.StringAttribute{
+				Computed: true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"portal_options": schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"visibility": schema.StringAttribute{
+							Computed: true,
+						},
+					},
+					Blocks: map[string]schema.Block{
+						"sign_in_options": schema.ListNestedBlock{
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"origin": schema.StringAttribute{
+										Computed: true,
+									},
+									"application_url": schema.StringAttribute{
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *dataSourceApplication) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	conn := d.Meta().SSOAdminClient(ctx)
+
+	var data dataSourceApplicationData
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := findApplicationByID(ctx, conn, data.ApplicationARN.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.SSOAdmin, create.ErrActionReading, DSNameApplication, data.Name.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	data.ApplicationAccount = flex.StringToFramework(ctx, out.ApplicationAccount)
+	data.ApplicationARN = flex.StringToFrameworkARN(ctx, out.ApplicationArn)
+	data.ApplicationProviderARN = flex.StringToFrameworkARN(ctx, out.ApplicationProviderArn)
+	data.Description = flex.StringToFramework(ctx, out.Description)
+	data.ID = flex.StringToFramework(ctx, out.ApplicationArn)
+	data.InstanceARN = flex.StringToFrameworkARN(ctx, out.InstanceArn)
+	data.Name = flex.StringToFramework(ctx, out.Name)
+	data.Status = flex.StringValueToFramework(ctx, out.Status)
+
+	portalOptions, diags := flattenPortalOptions(ctx, out.PortalOptions)
+	resp.Diagnostics.Append(diags...)
+	data.PortalOptions = portalOptions
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+type dataSourceApplicationData struct {
+	ApplicationAccount     types.String `tfsdk:"application_account"`
+	ApplicationARN         fwtypes.ARN  `tfsdk:"application_arn"`
+	ApplicationProviderARN fwtypes.ARN  `tfsdk:"application_provider_arn"`
+	Description            types.String `tfsdk:"description"`
+	ID                     types.String `tfsdk:"id"`
+	InstanceARN            fwtypes.ARN  `tfsdk:"instance_arn"`
+	Name                   types.String `tfsdk:"name"`
+	PortalOptions          types.List   `tfsdk:"portal_options"`
+	Status                 types.String `tfsdk:"status"`
+}

--- a/internal/service/ssoadmin/application_data_source_test.go
+++ b/internal/service/ssoadmin/application_data_source_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ssoadmin_test
+
+import (
+	"testing"
+
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccSSOAdminApplicationDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_ssoadmin_application.test"
+	applicationResourceName := "aws_ssoadmin_application.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.SSOAdminEndpointID)
+			acctest.PreCheckSSOAdminInstances(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSOAdminEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckApplicationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApplicationDataSourceConfig_basic(rName, testAccApplicationProviderARN),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "application_arn", applicationResourceName, "application_arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "application_provider_arn", applicationResourceName, "application_provider_arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "instance_arn", applicationResourceName, "instance_arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", applicationResourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "portal_options.#", applicationResourceName, "portal_options.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "status", applicationResourceName, "status"),
+				),
+			},
+		},
+	})
+}
+
+func testAccApplicationDataSourceConfig_basic(rName, applicationProviderARN string) string {
+	return acctest.ConfigCompose(
+		testAccApplicationConfig_basic(rName, applicationProviderARN),
+		`
+data "aws_ssoadmin_application" "test" {
+  application_arn = aws_ssoadmin_application.test.application_arn
+}
+`)
+}

--- a/internal/service/ssoadmin/service_package_gen.go
+++ b/internal/service/ssoadmin/service_package_gen.go
@@ -15,6 +15,10 @@ type servicePackage struct{}
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.ServicePackageFrameworkDataSource {
 	return []*types.ServicePackageFrameworkDataSource{
 		{
+			Factory: newDataSourceApplication,
+			Name:    "Application",
+		},
+		{
 			Factory: newDataSourceApplicationProviders,
 			Name:    "Application Providers",
 		},

--- a/website/docs/d/ssoadmin_application.html.markdown
+++ b/website/docs/d/ssoadmin_application.html.markdown
@@ -1,0 +1,40 @@
+---
+subcategory: "SSO Admin"
+layout: "aws"
+page_title: "AWS: aws_ssoadmin_application"
+description: |-
+  Terraform data source for managing an AWS SSO Admin Application.
+---
+
+# Data Source: aws_ssoadmin_application
+
+Terraform data source for managing an AWS SSO Admin Application.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_ssoadmin_application" "example" {
+  application_arn = "arn:aws:sso::012345678901:application/ssoins-1234/apl-5678"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `application_arn` - (Required) ARN of the application.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `application_account` - AWS account ID.
+* `application_provider_arn` - ARN of the application provider.
+* `description` - Description of the application.
+* `id` - ARN of the application.
+* `instance_arn` - ARN of the instance of IAM Identity Center.
+* `name` - Name of the application.
+* `portal_options` - Options for the portal associated with an application. See the `aws_ssoadmin_application` [resource documentation](../r/ssoadmin_application.html.markdown#portal_options-argument-reference). The attributes are the same.
+* `status` - Status of the application.


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This data source will allow practitioners to manage AWS Identity Center applications with Terraform.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #34723 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/singlesignon/latest/APIReference/API_DescribeApplication.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=ssoadmin TESTS=TestAccSSOAdminApplicationDataSource_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ssoadmin/... -v -count 1 -parallel 20 -run='TestAccSSOAdminApplicationDataSource_'  -timeout 360m
=== RUN   TestAccSSOAdminApplicationDataSource_basic
=== PAUSE TestAccSSOAdminApplicationDataSource_basic
=== CONT  TestAccSSOAdminApplicationDataSource_basic
--- PASS: TestAccSSOAdminApplicationDataSource_basic (43.73s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssoadmin   46.932s
```
