### PR TITLE
skaff: datasource test template fixes

### DIFF
--- a/skaff/datasource/datasourcetest.tmpl
+++ b/skaff/datasource/datasourcetest.tmpl
@@ -178,7 +178,11 @@ func TestAcc{{ .Service }}{{ .DataSource }}DataSource_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
+			{{- if .AWSGoSDKV2 }}
+			acctest.PreCheckPartitionHasService(t, names.{{ .Service }}EndpointID)
+			{{- else }}
 			acctest.PreCheckPartitionHasService(t, {{ .ServicePackage }}.EndpointsID)
+			{{- end }}
 			testAccPreCheck(ctx, t)
 		},
 		{{- if .AWSGoSDKV2 }}

--- a/skaff/datasource/datasourcetest.tmpl
+++ b/skaff/datasource/datasourcetest.tmpl
@@ -44,7 +44,7 @@ import (
 	"testing"
 
 	"github.com/YakDriver/regexache"
-{{ if .AWSGoSDKV2 }}
+{{- if .AWSGoSDKV2 }}
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/{{ .ServicePackage }}"
 	"github.com/aws/aws-sdk-go-v2/service/{{ .ServicePackage }}/types"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Fixes import spacing and adds a conditional to the `PreCheckPartitionHasService` function to properly account for the use of AWS SDK for Go V2.

