### PR TITLE
Update documentation to add GP as a supported FinSpace Kx cluster type

### DIFF
--- a/website/docs/r/finspace_kx_cluster.html.markdown
+++ b/website/docs/r/finspace_kx_cluster.html.markdown
@@ -77,6 +77,7 @@ The following arguments are required:
     * HDB - Historical Database. The data is only accessible with read-only permissions from one of the FinSpace managed KX databases mounted to the cluster.
     * RDB - Realtime Database. This type of database captures all the data from a ticker plant and stores it in memory until the end of day, after which it writes all of its data to a disk and reloads the HDB. This cluster type requires local storage for temporary storage of data during the savedown process. If you specify this field in your request, you must provide the `savedownStorageConfiguration` parameter.
     * GATEWAY - A gateway cluster allows you to access data across processes in kdb systems. It allows you to create your own routing logic using the initialization scripts and custom code. This type of cluster does not require a  writable local storage.
+    * GP - A general purpose cluster allows you to quickly iterate on code during development by granting greater access to system commands and enabling a fast reload of custom code. This cluster type can optionally mount databases including cache and savedown storage. For this cluster type, the node count is fixed at 1. It does not support autoscaling and supports only `SINGLE` AZ mode.
 * `vpc_configuration` - (Required) Configuration details about the network where the Privatelink endpoint of the cluster resides. See [vpc_configuration](#vpc_configuration).
 
 The following arguments are optional:


### PR DESCRIPTION
Update documentation to add GP as a supported FinSpace Kx cluster type

### Description
This pull request updates the FinSpace Kx Cluster documentation to illustrate that General Purpose (GP) clusters can now be created via Terraform. The Go SDK v2 has already been updated with `GP` as an available cluster type and no resource handler changes are required on the provider side.

### References
AWS Go SDK v2 updated with `GP` as a `ClusterType`: https://github.com/aws/aws-sdk-go-v2/blob/main/service/finspace/types/enums.go#L265
Amazon FinSpace Reference outlining GP cluster capabilities: https://docs.aws.amazon.com/finspace/latest/userguide/kdb-cluster-types.html
