### PR TITLE
chore: add `region` argument to `target_table` in `aws_glue_catalog_table`

### DIFF
--- a/.changelog/34817.txt
+++ b/.changelog/34817.txt
@@ -1,0 +1,6 @@
+```release-note:enhancement
+resource/aws_glue_catalog_table: Add `region` attribute to `target_table` block.
+```
+```release-note:enhancement
+data-source//aws_glue_catalog_table: Add `region` attribute to `target_table` block.
+```

--- a/.changelog/34817.txt
+++ b/.changelog/34817.txt
@@ -2,5 +2,5 @@
 resource/aws_glue_catalog_table: Add `region` attribute to `target_table` block.
 ```
 ```release-note:enhancement
-data-source//aws_glue_catalog_table: Add `region` attribute to `target_table` block.
+data-source/aws_glue_catalog_table: Add `region` attribute to `target_table` block.
 ```

--- a/internal/service/glue/catalog_table.go
+++ b/internal/service/glue/catalog_table.go
@@ -345,6 +345,7 @@ func ResourceCatalogTable() *schema.Resource {
 						"region": {
 							Type:     schema.TypeString,
 							Optional: true,
+						},
 					},
 				},
 			},

--- a/internal/service/glue/catalog_table.go
+++ b/internal/service/glue/catalog_table.go
@@ -342,6 +342,9 @@ func ResourceCatalogTable() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 						},
+						"region": {
+							Type:     schema.TypeString,
+							Optional: true,
 					},
 				},
 			},
@@ -1119,6 +1122,10 @@ func expandTableTargetTable(tfMap map[string]interface{}) *glue.TableIdentifier 
 		apiObject.Name = aws.String(v)
 	}
 
+	if v, ok := tfMap["region"].(string); ok && v != "" {
+		apiObject.Region = aws.String(v)
+	}
+
 	return apiObject
 }
 
@@ -1139,6 +1146,10 @@ func flattenTableTargetTable(apiObject *glue.TableIdentifier) map[string]interfa
 
 	if v := apiObject.Name; v != nil {
 		tfMap["name"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.Region; v != nil {
+		tfMap["region"] = aws.StringValue(v)
 	}
 
 	return tfMap

--- a/internal/service/glue/catalog_table_data_source.go
+++ b/internal/service/glue/catalog_table_data_source.go
@@ -299,6 +299,10 @@ func DataSourceCatalogTable() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"region": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},

--- a/internal/service/glue/catalog_table_test.go
+++ b/internal/service/glue/catalog_table_test.go
@@ -1416,6 +1416,8 @@ resource "aws_glue_catalog_table" "test" {
 
 func testAccCatalogTableConfig_target(rName string) string {
 	return fmt.Sprintf(`
+data "aws_region" "current" {}
+
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
 }
@@ -1428,6 +1430,7 @@ resource "aws_glue_catalog_table" "test" {
     catalog_id    = aws_glue_catalog_table.test2.catalog_id
     database_name = aws_glue_catalog_table.test2.database_name
     name          = aws_glue_catalog_table.test2.name
+    region 		  = data.aws_region.current.name
   }
 }
 

--- a/internal/service/glue/catalog_table_test.go
+++ b/internal/service/glue/catalog_table_test.go
@@ -645,7 +645,6 @@ func TestAccGlueCatalogTable_targetTable(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "target_table.0.catalog_id", "aws_glue_catalog_table.test2", "catalog_id"),
 					resource.TestCheckResourceAttrPair(resourceName, "target_table.0.database_name", "aws_glue_catalog_table.test2", "database_name"),
 					resource.TestCheckResourceAttrPair(resourceName, "target_table.0.name", "aws_glue_catalog_table.test2", "name"),
-					resource.TestCheckResourceAttrPair(resourceName, "target_table.0.region", "aws_glue_catalog_table.test2", "region"),
 				),
 			},
 			{

--- a/internal/service/glue/catalog_table_test.go
+++ b/internal/service/glue/catalog_table_test.go
@@ -1429,7 +1429,7 @@ resource "aws_glue_catalog_table" "test" {
     catalog_id    = aws_glue_catalog_table.test2.catalog_id
     database_name = aws_glue_catalog_table.test2.database_name
     name          = aws_glue_catalog_table.test2.name
-    region 		  = data.aws_region.current.name
+    region        = data.aws_region.current.name
   }
 }
 

--- a/internal/service/glue/catalog_table_test.go
+++ b/internal/service/glue/catalog_table_test.go
@@ -645,6 +645,7 @@ func TestAccGlueCatalogTable_targetTable(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "target_table.0.catalog_id", "aws_glue_catalog_table.test2", "catalog_id"),
 					resource.TestCheckResourceAttrPair(resourceName, "target_table.0.database_name", "aws_glue_catalog_table.test2", "database_name"),
 					resource.TestCheckResourceAttrPair(resourceName, "target_table.0.name", "aws_glue_catalog_table.test2", "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "target_table.0.region", "aws_glue_catalog_table.test2", "region"),
 				),
 			},
 			{

--- a/website/docs/d/glue_catalog_table.html.markdown
+++ b/website/docs/d/glue_catalog_table.html.markdown
@@ -115,3 +115,4 @@ This data source exports the following attributes in addition to the arguments a
 * `catalog_id` - ID of the Data Catalog in which the table resides.
 * `database_name` - Name of the catalog database that contains the target table.
 * `name` - Name of the target table.
+* `region` - Region of the target table.

--- a/website/docs/r/glue_catalog_table.html.markdown
+++ b/website/docs/r/glue_catalog_table.html.markdown
@@ -190,6 +190,7 @@ To add an index to an existing table, see the [`glue_partition_index` resource](
 * `catalog_id` - (Required) ID of the Data Catalog in which the table resides.
 * `database_name` - (Required) Name of the catalog database that contains the target table.
 * `name` - (Required) Name of the target table.
+* `region` - (Optional) Region of the target table.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds the `region` to the `target_table` block for both the resource and data source: `aws_glue_catalog_table`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #34806

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Resource `aws_glue_catalog_table `:
```console
make testacc TESTS=TestAccGlueCatalogTable_ PKG=glue                                                                                                             rbenv:3.1.0
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/glue/... -v -count 1 -parallel 20 -run='TestAccGlueCatalogTable_'  -timeout 360m
=== RUN   TestAccGlueCatalogTable_basic
=== PAUSE TestAccGlueCatalogTable_basic
=== RUN   TestAccGlueCatalogTable_columnParameters
=== PAUSE TestAccGlueCatalogTable_columnParameters
=== RUN   TestAccGlueCatalogTable_full
=== PAUSE TestAccGlueCatalogTable_full
=== RUN   TestAccGlueCatalogTable_Update_addValues
=== PAUSE TestAccGlueCatalogTable_Update_addValues
=== RUN   TestAccGlueCatalogTable_Update_replaceValues
=== PAUSE TestAccGlueCatalogTable_Update_replaceValues
=== RUN   TestAccGlueCatalogTable_StorageDescriptor_emptyBlock
=== PAUSE TestAccGlueCatalogTable_StorageDescriptor_emptyBlock
=== RUN   TestAccGlueCatalogTable_StorageDescriptorSerDeInfo_emptyBlock
=== PAUSE TestAccGlueCatalogTable_StorageDescriptorSerDeInfo_emptyBlock
=== RUN   TestAccGlueCatalogTable_StorageDescriptorSerDeInfo_updateValues
=== PAUSE TestAccGlueCatalogTable_StorageDescriptorSerDeInfo_updateValues
=== RUN   TestAccGlueCatalogTable_StorageDescriptorSkewedInfo_emptyBlock
=== PAUSE TestAccGlueCatalogTable_StorageDescriptorSkewedInfo_emptyBlock
=== RUN   TestAccGlueCatalogTable_StorageDescriptor_schemaReference
=== PAUSE TestAccGlueCatalogTable_StorageDescriptor_schemaReference
=== RUN   TestAccGlueCatalogTable_StorageDescriptor_schemaReferenceARN
=== PAUSE TestAccGlueCatalogTable_StorageDescriptor_schemaReferenceARN
=== RUN   TestAccGlueCatalogTable_partitionIndexesSingle
=== PAUSE TestAccGlueCatalogTable_partitionIndexesSingle
=== RUN   TestAccGlueCatalogTable_partitionIndexesMultiple
=== PAUSE TestAccGlueCatalogTable_partitionIndexesMultiple
=== RUN   TestAccGlueCatalogTable_Disappears_database
=== PAUSE TestAccGlueCatalogTable_Disappears_database
=== RUN   TestAccGlueCatalogTable_targetTable
=== PAUSE TestAccGlueCatalogTable_targetTable
=== RUN   TestAccGlueCatalogTable_disappears
=== PAUSE TestAccGlueCatalogTable_disappears
=== RUN   TestAccGlueCatalogTable_openTableFormat
=== PAUSE TestAccGlueCatalogTable_openTableFormat
=== CONT  TestAccGlueCatalogTable_basic
=== CONT  TestAccGlueCatalogTable_StorageDescriptor_schemaReference
=== CONT  TestAccGlueCatalogTable_openTableFormat
=== CONT  TestAccGlueCatalogTable_StorageDescriptor_emptyBlock
=== CONT  TestAccGlueCatalogTable_disappears
=== CONT  TestAccGlueCatalogTable_targetTable
=== CONT  TestAccGlueCatalogTable_Disappears_database
=== CONT  TestAccGlueCatalogTable_partitionIndexesMultiple
=== CONT  TestAccGlueCatalogTable_partitionIndexesSingle
=== CONT  TestAccGlueCatalogTable_StorageDescriptor_schemaReferenceARN
=== CONT  TestAccGlueCatalogTable_Update_addValues
=== CONT  TestAccGlueCatalogTable_Update_replaceValues
=== CONT  TestAccGlueCatalogTable_StorageDescriptorSerDeInfo_updateValues
=== CONT  TestAccGlueCatalogTable_StorageDescriptorSkewedInfo_emptyBlock
=== CONT  TestAccGlueCatalogTable_full
=== CONT  TestAccGlueCatalogTable_columnParameters
=== CONT  TestAccGlueCatalogTable_StorageDescriptorSerDeInfo_emptyBlock
--- PASS: TestAccGlueCatalogTable_StorageDescriptor_emptyBlock (45.47s)
=== NAME  TestAccGlueCatalogTable_Disappears_database
    testing_new.go:91: Error running post-test destroy, there may be dangling resources: exit status 1

        Error: deleting Glue Catalog Database (396541922245:tf-acc-test-5285385946469498629): EntityNotFoundException: Database tf-acc-test-5285385946469498629 not found.
        {
          RespMetadata: {
            StatusCode: 400,
            RequestID: "ba4a7048-fb26-4b0d-be6f-06f85385f394"
          },
          Message_: "Database tf-acc-test-5285385946469498629 not found."
        }

--- FAIL: TestAccGlueCatalogTable_Disappears_database (48.95s)
--- PASS: TestAccGlueCatalogTable_disappears (49.32s)
--- PASS: TestAccGlueCatalogTable_StorageDescriptorSerDeInfo_emptyBlock (50.34s)
--- PASS: TestAccGlueCatalogTable_StorageDescriptorSkewedInfo_emptyBlock (50.44s)
--- PASS: TestAccGlueCatalogTable_partitionIndexesMultiple (51.65s)
--- PASS: TestAccGlueCatalogTable_columnParameters (52.97s)
--- PASS: TestAccGlueCatalogTable_partitionIndexesSingle (53.55s)
--- PASS: TestAccGlueCatalogTable_full (53.61s)
--- PASS: TestAccGlueCatalogTable_basic (55.06s)
--- PASS: TestAccGlueCatalogTable_targetTable (55.43s)
--- PASS: TestAccGlueCatalogTable_StorageDescriptor_schemaReferenceARN (56.21s)
--- PASS: TestAccGlueCatalogTable_Update_replaceValues (70.80s)
--- PASS: TestAccGlueCatalogTable_StorageDescriptorSerDeInfo_updateValues (70.82s)
--- PASS: TestAccGlueCatalogTable_Update_addValues (70.82s)
--- PASS: TestAccGlueCatalogTable_StorageDescriptor_schemaReference (73.26s)
--- PASS: TestAccGlueCatalogTable_openTableFormat (77.54s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/glue	79.884s
FAIL
make: *** [testacc] Error 1
```

Data source `aws_glue_catalog_table `:
```console
make testacc TESTS=TestAccGlueCatalogTableDataSource_ PKG=glue                                                                                                    rbenv:3.1.0
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/glue/... -v -count 1 -parallel 20 -run='TestAccGlueCatalogTableDataSource_'  -timeout 360m
=== RUN   TestAccGlueCatalogTableDataSource_basic
=== PAUSE TestAccGlueCatalogTableDataSource_basic
=== CONT  TestAccGlueCatalogTableDataSource_basic
--- PASS: TestAccGlueCatalogTableDataSource_basic (20.43s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/glue	22.724s
```