### PR TITLE
r/aws_securitylake_data_lake: Fix panic on import

### DIFF
--- a/.changelog/34820.txt
+++ b/.changelog/34820.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_securitylake_data_lake: Fix `reflect.Set: value of type basetypes.StringValue is not assignable to type types.ARN` panic when importing resources with `nil` ARN fields
+```

--- a/internal/framework/flex/autoflex.go
+++ b/internal/framework/flex/autoflex.go
@@ -1047,7 +1047,7 @@ func (flattener autoFlattener) ptr(ctx context.Context, vFrom reflect.Value, tTo
 			//
 			// *struct -> types.List(OfObject).
 			//
-			diags.Append(flattener.ptrToStructNestedObject(ctx, vFrom, tTo, vTo)...)
+			diags.Append(flattener.ptrToStructNestedObject(ctx, vElem, isNilFrom, tTo, vTo)...)
 			return diags
 		}
 	}
@@ -1403,10 +1403,10 @@ func (flattener autoFlattener) structToNestedObject(ctx context.Context, vFrom r
 }
 
 // ptrToStructNestedObject copies an AWS API *struct value to a compatible Plugin Framework NestedObjectValue value.
-func (flattener autoFlattener) ptrToStructNestedObject(ctx context.Context, vFrom reflect.Value, tTo fwtypes.NestedObjectType, vTo reflect.Value) diag.Diagnostics {
+func (flattener autoFlattener) ptrToStructNestedObject(ctx context.Context, vFrom reflect.Value, isNullFrom bool, tTo fwtypes.NestedObjectType, vTo reflect.Value) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	if vFrom.IsNil() {
+	if isNullFrom {
 		val, d := tTo.NullValue(ctx)
 		diags.Append(d...)
 		if diags.HasError() {
@@ -1424,7 +1424,7 @@ func (flattener autoFlattener) ptrToStructNestedObject(ctx context.Context, vFro
 		return diags
 	}
 
-	diags.Append(autoFlexConvertStruct(ctx, vFrom.Elem().Interface(), to, flattener)...)
+	diags.Append(autoFlexConvertStruct(ctx, vFrom.Interface(), to, flattener)...)
 	if diags.HasError() {
 		return diags
 	}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

The underlying cause was the auto-flattening of a `nil` string pointer into the `ARN` custom type.
AutoFlEx was not correctly dealing with flattening `nil` pointers to any primitive type into a custom type -- it always assumed that the target was the "non-custom", base type.

I foresee problems with slices and maps of custom primitive types...

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/34802.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccSecurityLake_serial/DataLake' PKG=securitylake
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/securitylake/... -v -count 1 -parallel 20  -run=TestAccSecurityLake_serial/DataLake -timeout 360m
=== RUN   TestAccSecurityLake_serial
=== PAUSE TestAccSecurityLake_serial
=== CONT  TestAccSecurityLake_serial
=== RUN   TestAccSecurityLake_serial/DataLake
=== RUN   TestAccSecurityLake_serial/DataLake/lifecycle
=== RUN   TestAccSecurityLake_serial/DataLake/lifecycleUpdate
=== RUN   TestAccSecurityLake_serial/DataLake/replication
=== RUN   TestAccSecurityLake_serial/DataLake/basic
=== RUN   TestAccSecurityLake_serial/DataLake/disappears
=== RUN   TestAccSecurityLake_serial/DataLake/tags
--- PASS: TestAccSecurityLake_serial (414.81s)
    --- PASS: TestAccSecurityLake_serial/DataLake (414.81s)
        --- PASS: TestAccSecurityLake_serial/DataLake/lifecycle (61.88s)
        --- PASS: TestAccSecurityLake_serial/DataLake/lifecycleUpdate (81.90s)
        --- PASS: TestAccSecurityLake_serial/DataLake/replication (74.20s)
        --- PASS: TestAccSecurityLake_serial/DataLake/basic (82.44s)
        --- PASS: TestAccSecurityLake_serial/DataLake/disappears (48.61s)
        --- PASS: TestAccSecurityLake_serial/DataLake/tags (65.78s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/securitylake	420.475s
```

Another set of resources using AutoFlex to ensure no regression:

```console
% make testacc TESTARGS='-run=TestAccS3ControlAccessGrants_serial/Grant' PKG=s3control
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3control/... -v -count 1 -parallel 20  -run=TestAccS3ControlAccessGrants_serial/Grant -timeout 360m
=== RUN   TestAccS3ControlAccessGrants_serial
=== PAUSE TestAccS3ControlAccessGrants_serial
=== CONT  TestAccS3ControlAccessGrants_serial
=== RUN   TestAccS3ControlAccessGrants_serial/Grant
=== RUN   TestAccS3ControlAccessGrants_serial/Grant/basic
=== RUN   TestAccS3ControlAccessGrants_serial/Grant/disappears
=== RUN   TestAccS3ControlAccessGrants_serial/Grant/tags
=== RUN   TestAccS3ControlAccessGrants_serial/Grant/locationConfiguration
--- PASS: TestAccS3ControlAccessGrants_serial (227.76s)
    --- PASS: TestAccS3ControlAccessGrants_serial/Grant (227.76s)
        --- PASS: TestAccS3ControlAccessGrants_serial/Grant/basic (51.24s)
        --- PASS: TestAccS3ControlAccessGrants_serial/Grant/disappears (43.03s)
        --- PASS: TestAccS3ControlAccessGrants_serial/Grant/tags (84.71s)
        --- PASS: TestAccS3ControlAccessGrants_serial/Grant/locationConfiguration (48.79s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3control	233.249s
```
