### PR TITLE
d/aws_emr_supported_instance_types: add lifecycle precondition example

### DIFF
--- a/website/docs/d/emr_supported_instance_types.html.markdown
+++ b/website/docs/d/emr_supported_instance_types.html.markdown
@@ -20,6 +20,37 @@ data "aws_emr_supported_instance_types" "example" {
 }
 ```
 
+### With a Lifecycle Pre-Condition
+
+This data source can be used with a [lifecycle precondition](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#custom-condition-checks) to ensure a given instance type is supported by EMR.
+
+```terraform
+locals {
+  instance_type = "r7g.large"
+  release_label = "emr-6.15.0"
+}
+
+data "aws_emr_supported_instance_types" "test" {
+  release_label = local.release_label
+}
+
+resource "aws_emr_cluster" "test" {
+  ### additional configuration omitted for brevity ###
+
+  release_label = local.release_label
+  master_instance_group {
+    instance_type = local.instance_type
+  }
+
+  lifecycle {
+    precondition {
+      condition     = contains(data.aws_emr_supported_instance_types.test.supported_instance_types[*].type, local.instance_type)
+      error_message = "${local.instance_type} is not supported with this EMR release label!"
+    }
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are required:


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds an example describing how to pair this data source with a lifecycle precondition to create validation of the configured `instance_type` on resources such as `aws_emr_cluster`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #33998

### References
- https://github.com/hashicorp/terraform-provider-aws/issues/33998#issuecomment-1821203656

