### PR TITLE
New Data Source: `aws_dynamodb_table_query`

### DIFF
--- a/internal/service/dynamodb/service_package_gen.go
+++ b/internal/service/dynamodb/service_package_gen.go
@@ -33,6 +33,10 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 			Factory:  DataSourceTableItem,
 			TypeName: "aws_dynamodb_table_item",
 		},
+		{
+			Factory:  DataSourceTableQuery,
+			TypeName: "aws_dynamodb_table_query",
+		},
 	}
 }
 

--- a/internal/service/dynamodb/table_query_data_source.go
+++ b/internal/service/dynamodb/table_query_data_source.go
@@ -1,0 +1,325 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package dynamodb
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKDataSource("aws_dynamodb_table_query")
+func DataSourceTableQuery() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceTableQueryRead,
+
+		Schema: map[string]*schema.Schema{
+			"table_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"key_condition_expression": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"consistent_read": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"expression_attribute_names": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"expression_attribute_values": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"filter_expression": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"index_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"output_limit": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"projection_expression": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"scan_index_forward": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"select": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"ALL_ATTRIBUTES", "ALL_PROJECTED_ATTRIBUTES", "SPECIFIC_ATTRIBUTES", "COUNT"}, false),
+			},
+			"items": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"scanned_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"item_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"query_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+type AttributeValue struct {
+	B    []byte                     `json:"B,omitempty"`
+	BOOL *bool                      `json:"BOOL,omitempty"`
+	BS   [][]byte                   `json:"BS,omitempty"`
+	L    []*AttributeValue          `json:"L,omitempty"`
+	M    map[string]*AttributeValue `json:"M,omitempty"`
+	N    *string                    `json:"N,omitempty"`
+	NS   []*string                  `json:"NS,omitempty"`
+	NULL *bool                      `json:"NULL,omitempty"`
+	S    *string                    `json:"S,omitempty"`
+	SS   []*string                  `json:"SS,omitempty"`
+}
+
+func ConvertJSONToAttributeValue(jsonStr string) (*AttributeValue, error) {
+	data := AttributeValue{}
+
+	unescapedJSONStr, err := strconv.Unquote(jsonStr)
+	if err != nil {
+		// If unquoting fails, assume the string is unescaped and use it as-is
+		unescapedJSONStr = jsonStr
+	}
+
+	err = json.Unmarshal([]byte(unescapedJSONStr), &data)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling JSON: %v", err)
+	}
+
+	return &data, nil
+}
+
+func ConvertToDynamoAttributeValue(av *AttributeValue) (*dynamodb.AttributeValue, error) {
+	if av == nil {
+		return nil, nil
+	}
+	dynamoAV := &dynamodb.AttributeValue{}
+	if av.B != nil {
+		dynamoAV.B = av.B
+	}
+
+	if av.BOOL != nil {
+		dynamoAV.BOOL = av.BOOL
+	}
+
+	if av.BS != nil {
+		var bs [][]byte
+		for _, item := range av.BS {
+			bs = append(bs, item)
+		}
+		dynamoAV.BS = bs
+	}
+
+	if av.L != nil {
+		var l []*dynamodb.AttributeValue
+		for _, item := range av.L {
+			dynamoItem, err := ConvertToDynamoAttributeValue(item)
+			if err != nil {
+				return nil, err
+			}
+			l = append(l, dynamoItem)
+		}
+		dynamoAV.L = l
+	}
+
+	if av.M != nil {
+		m := make(map[string]*dynamodb.AttributeValue)
+		for k, v := range av.M {
+			dynamoItem, err := ConvertToDynamoAttributeValue(v)
+			if err != nil {
+				return nil, err
+			}
+			m[k] = dynamoItem
+		}
+		dynamoAV.M = m
+	}
+
+	if av.N != nil {
+		dynamoAV.N = av.N
+	}
+
+	if av.NS != nil {
+		var ns []*string
+		for _, item := range av.NS {
+			ns = append(ns, item)
+		}
+		dynamoAV.NS = ns
+	}
+
+	if av.NULL != nil {
+		dynamoAV.NULL = av.NULL
+	}
+
+	if av.S != nil {
+		dynamoAV.S = av.S
+	}
+
+	if av.SS != nil {
+		var ss []*string
+		for _, item := range av.SS {
+			ss = append(ss, item)
+		}
+		dynamoAV.SS = ss
+	}
+
+	return dynamoAV, nil
+}
+
+func dataSourceTableQueryRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).DynamoDBConn(ctx)
+
+	tableName := d.Get("table_name").(string)
+	keyConditionExpression := d.Get("key_condition_expression").(string)
+
+	in := &dynamodb.QueryInput{
+		TableName:              aws.String(tableName),
+		KeyConditionExpression: aws.String(keyConditionExpression),
+	}
+
+	if v, ok := d.GetOkExists("consistent_read"); ok {
+		in.ConsistentRead = aws.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOkExists("scan_index_forward"); ok {
+		in.ScanIndexForward = aws.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOk("filter_expression"); ok {
+		in.FilterExpression = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("index_name"); ok {
+		in.IndexName = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("projection_expression"); ok {
+		in.ProjectionExpression = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("select"); ok {
+		in.Select = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("expression_attribute_names"); ok && len(v.(map[string]interface{})) > 0 {
+		in.ExpressionAttributeNames = flex.ExpandStringMap(v.(map[string]interface{}))
+	}
+
+	if v, ok := d.GetOk("expression_attribute_values"); ok && len(v.(map[string]interface{})) > 0 {
+		expressionAttributeValues := flex.ExpandStringMap(v.(map[string]interface{}))
+		attributeValues := make(map[string]*dynamodb.AttributeValue)
+		for key, value := range expressionAttributeValues {
+			jsonData, err := json.Marshal(value)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			attributeValue, err := ConvertJSONToAttributeValue(string(jsonData))
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			dynamoAttributeValue, err := ConvertToDynamoAttributeValue(attributeValue)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			attributeValues[key] = dynamoAttributeValue
+		}
+		in.ExpressionAttributeValues = attributeValues
+	}
+
+	var outputLimit *int
+	if v, ok := d.GetOk("output_limit"); ok {
+		value := v.(int)
+		outputLimit = &value
+	}
+
+	id := buildTableQueryDataSourceID(tableName, keyConditionExpression)
+	d.SetId(id)
+
+	var flattenedItems []string
+	itemsProcessed := int64(0)
+	scannedCount := int64(0)
+	queryCount := int64(0)
+	itemCount := int64(0)
+
+	for {
+		out, err := conn.QueryWithContext(ctx, in)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		queryCount += 1
+		scannedCount += aws.Int64Value(out.ScannedCount)
+		itemCount += aws.Int64Value(out.Count)
+		for _, item := range out.Items {
+			flattened, err := flattenTableItemAttributes(item)
+			if err != nil {
+				return create.DiagError(names.DynamoDB, create.ErrActionReading, DSNameTableItem, id, err)
+			}
+			flattenedItems = append(flattenedItems, flattened)
+
+			itemsProcessed++
+			if (outputLimit != nil) && (itemsProcessed >= int64(*outputLimit)) {
+				itemCount = int64(*outputLimit)
+				goto ExitLoop
+			}
+		}
+		in.ExclusiveStartKey = out.LastEvaluatedKey
+
+		if out.LastEvaluatedKey == nil || len(out.LastEvaluatedKey) == 0 {
+			break
+		}
+	}
+ExitLoop:
+	d.Set("items", flattenedItems)
+	d.Set("item_count", itemCount)
+	d.Set("query_count", queryCount)
+	d.Set("scanned_count", scannedCount)
+	return nil
+}
+
+func buildTableQueryDataSourceID(tableName, keyConditionExpression string) string {
+	id := []string{tableName}
+	if keyConditionExpression != "" {
+		id = append(id, "KeyConditionExpression", keyConditionExpression)
+	}
+	id = append(id, fmt.Sprintf("%d", time.Now().UnixNano()))
+	return strings.Join(id, "|")
+}

--- a/internal/service/dynamodb/table_query_data_source_test.go
+++ b/internal/service/dynamodb/table_query_data_source_test.go
@@ -1,0 +1,980 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package dynamodb_test
+
+import (
+	"fmt"
+	"log"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfdynamo "github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb"
+)
+
+func TestAccDynamoDBTableQueryDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_dynamodb_table_query.test"
+	hashKey := "ID"
+	hashKeyValue := "0000A"
+	itemContent := `{
+		"ID": {"S": "0000A"},
+		"one": {"N": "11111"},
+		"two": {"N": "22222"}
+	}`
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, dynamodb.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, dynamodb.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableQueryDataSourceConfig_basic(rName, itemContent, hashKey, hashKeyValue),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "items.#", "1"),
+					acctest.CheckResourceAttrEquivalentJSON(dataSourceName, "items.0", itemContent),
+					resource.TestCheckResourceAttr(dataSourceName, "table_name", rName),
+					resource.TestCheckResourceAttr(dataSourceName, "scanned_count", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "item_count", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "query_count", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDynamoDBTableQueryDataSource_projectionExpression(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_dynamodb_table_query.test"
+	hashKey := "ID"
+	hashKeyValue := "0000A"
+	itemContent := `{
+		"ID": {"S": "0000A"},
+		"one": {"N": "11111"},
+		"two": {"N": "22222"},
+		"three": {"N": "33333"},
+		"four": {"N": "44444"}
+	}`
+
+	projectionExpression := "one,two"
+
+	expected := `{
+		"one": {"N": "11111"},
+		"two": {"N": "22222"}
+	}`
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, dynamodb.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, dynamodb.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableQueryDataSourceConfig_projectionExpression(rName, itemContent, projectionExpression, hashKey, hashKeyValue),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "items.#", "1"),
+					acctest.CheckResourceAttrEquivalentJSON(dataSourceName, "items.0", expected),
+					resource.TestCheckResourceAttr(dataSourceName, "table_name", rName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDynamoDBTableQueryDataSource_expressionAttributeNames(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_dynamodb_table_query.test"
+	hashKey := "ID"
+	hashKeyValue := "0000A"
+	itemContent := `{
+		"ID": {"S": "0000A"},
+		"one": {"N": "11111"},
+		"two": {"N": "22222"},
+		"Percentile": {"N": "33333"}
+	}`
+
+	projectionExpression := `#P`
+	expressionAttributeNames := `{
+    "#P" = "Percentile"
+  }`
+
+	expected := `{
+		"Percentile": {"N": "33333"}
+	}`
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, dynamodb.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, dynamodb.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableQueryDataSourceConfig_expressionAttributeNames(rName, itemContent, hashKey, hashKeyValue, expressionAttributeNames, projectionExpression),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "items.#", "1"),
+					acctest.CheckResourceAttrEquivalentJSON(dataSourceName, "items.0", expected),
+					resource.TestCheckResourceAttr(dataSourceName, "table_name", rName),
+					resource.TestCheckResourceAttr(dataSourceName, "projection_expression", "#P"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDynamoDBTableQueryDataSource_select(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_dynamodb_table_query.test"
+	hashKey := "ID"
+	hashKeyValue := "0000A"
+	itemContent := `{
+		"ID": {"S": "0000A"},
+		"one": {"N": "11111"},
+		"two": {"N": "22222"},
+		"three": {"N": "33333"},
+		"four": {"N": "44444"}
+	}`
+
+	selectValue := "COUNT"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, dynamodb.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, dynamodb.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableQueryDataSourceConfig_select(rName, itemContent, hashKey, hashKeyValue, selectValue),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "items.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "item_count", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "table_name", rName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDynamoDBTableQueryDataSource_filterExpression(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_dynamodb_table_query.test"
+	item1 := `{"ID": {"S": "0000A"}, "Category": {"S": "A"}}`
+	item2 := `{"ID": {"S": "0000B"}, "Category": {"S": "B"}}`
+	expressionAttributeValues := `{
+		":value" = jsonencode({"S": "0000A"})
+		":category" = jsonencode({"S": "A"})
+  }`
+
+	filterExpression := "Category = :category"
+
+	expected := `{
+  "ID": {"S": "0000A"},
+  "Category": {"S": "A"}
+}`
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, dynamodb.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableQueryDataSourceConfig_filterExpression(rName, item1, item2, expressionAttributeValues, filterExpression),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "items.#", "1"),
+					acctest.CheckResourceAttrEquivalentJSON(dataSourceName, "items.0", expected),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDynamoDBTableQueryDataSource_scanIndexForward(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_dynamodb_table_query.test"
+	sortKeyValue1 := "1"
+	sortKeyValue2 := "2"
+	sortKeyValue3 := "3"
+
+	scanIndexForward := "false"
+
+	expected := []string{
+		`{"ID":{"S":"0000A"},"sortKey":{"N":"3"}}`,
+		`{"ID":{"S":"0000A"},"sortKey":{"N":"2"}}`,
+		`{"ID":{"S":"0000A"},"sortKey":{"N":"1"}}`,
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, dynamodb.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, dynamodb.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableQueryDataSourceConfig_scanIndexForward(rName, sortKeyValue1, sortKeyValue2, sortKeyValue3, scanIndexForward),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "items.#", "3"),
+					resource.TestCheckResourceAttr(dataSourceName, "scan_index_forward", scanIndexForward),
+					acctest.CheckResourceAttrEquivalentJSON(dataSourceName, "items.0", expected[0]),
+					acctest.CheckResourceAttrEquivalentJSON(dataSourceName, "items.1", expected[1]),
+					acctest.CheckResourceAttrEquivalentJSON(dataSourceName, "items.2", expected[2]),
+					resource.TestCheckResourceAttr(dataSourceName, "table_name", rName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDynamoDBTableQueryDataSource_index(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_dynamodb_table_query.test"
+	itemContent := `{
+		"ID": {"S": "0000A"},
+		"value": {"N": "1111"},
+		"extraAttribute": {"S": "additionalValue"}
+	}`
+
+	projectionType := "INCLUDE"
+	indexName := "exampleIndex"
+
+	expected := []string{
+		`{"ID":{"S":"0000A"},"extraAttribute":{"S":"additionalValue"}}`,
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, dynamodb.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, dynamodb.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableQueryDataSourceConfig_index(rName, itemContent, projectionType, indexName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "items.#", "1"),
+					acctest.CheckResourceAttrEquivalentJSON(dataSourceName, "items.0", expected[0]),
+					resource.TestCheckResourceAttr(dataSourceName, "table_name", rName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDynamoDBTableQueryDataSource_handlesPagination(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_dynamodb_table_query.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, dynamodb.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, dynamodb.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableQueryDataSourceConfig_handlesPagination(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "items.#", "10"),
+					resource.TestCheckResourceAttr(dataSourceName, "table_name", rName),
+					resource.TestCheckResourceAttr(dataSourceName, "scanned_count", "10"),
+					resource.TestCheckResourceAttr(dataSourceName, "item_count", "10"),
+					resource.TestCheckResourceAttr(dataSourceName, "query_count", "3"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDynamoDBTableQueryDataSource_outputLimit(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_dynamodb_table_query.test"
+
+	outputLimit := 5
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, dynamodb.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, dynamodb.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableQueryDataSourceConfig_outputLimit(rName, outputLimit),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "items.#", "5"),
+					resource.TestCheckResourceAttr(dataSourceName, "output_limit", "5"),
+					resource.TestCheckResourceAttr(dataSourceName, "table_name", rName),
+					resource.TestCheckResourceAttr(dataSourceName, "item_count", "5"),
+					resource.TestCheckResourceAttr(dataSourceName, "query_count", "2"),
+					resource.TestCheckResourceAttr(dataSourceName, "scanned_count", "8"),
+				),
+			},
+		},
+	})
+}
+
+func testAccTableQueryDataSourceConfig_basic(tableName, item, hashKey, hashKeyValue string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  name           = %q
+  read_capacity  = 10
+  write_capacity = 10
+  hash_key       = %q
+
+  attribute {
+    name = %q
+    type = "S"
+  }
+}
+
+resource "aws_dynamodb_table_item" "test" {
+  table_name = aws_dynamodb_table.test.name
+  hash_key   = aws_dynamodb_table.test.hash_key
+  item = <<ITEM
+%s
+ITEM
+}
+
+data "aws_dynamodb_table_query" "test" {
+  table_name                  = aws_dynamodb_table.test.name
+	key_condition_expression    = "%s = :value"
+	expression_attribute_values = {
+		":value"= jsonencode({"S" = %q})
+	}
+  depends_on                  = [aws_dynamodb_table_item.test]
+}
+`, tableName, hashKey, hashKey, item, hashKey, hashKeyValue)
+}
+
+func testAccTableQueryDataSourceConfig_projectionExpression(tableName, item, projectionExpression, hashKey, hashKeyValue string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  name           = %q
+  read_capacity  = 10
+  write_capacity = 10
+  hash_key       = %q
+
+  attribute {
+    name = %q
+    type = "S"
+  }
+}
+
+resource "aws_dynamodb_table_item" "test" {
+  table_name = aws_dynamodb_table.test.name
+  hash_key   = aws_dynamodb_table.test.hash_key
+  item = <<ITEM
+%s
+ITEM
+}
+
+data "aws_dynamodb_table_query" "test" {
+  projection_expression = %q
+  table_name                  = aws_dynamodb_table.test.name
+	key_condition_expression    = "%s = :value"
+	expression_attribute_values = {
+		":value"= jsonencode({"S" = %q})
+	}
+  depends_on                  = [aws_dynamodb_table_item.test]
+}
+`, tableName, hashKey, hashKey, item, projectionExpression, hashKey, hashKeyValue)
+}
+
+func testAccTableQueryDataSourceConfig_expressionAttributeNames(tableName, item, hashKey, hashKeyValue, expressionAttributeNames, projectionExpression string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  name           = %q
+  read_capacity  = 10
+  write_capacity = 10
+  hash_key       = %q
+
+  attribute {
+    name = %q
+    type = "S"
+  }
+}
+
+resource "aws_dynamodb_table_item" "test" {
+  table_name = aws_dynamodb_table.test.name
+  hash_key   = aws_dynamodb_table.test.hash_key
+  item = <<ITEM
+%s
+ITEM
+}
+
+data "aws_dynamodb_table_query" "test" {
+	expression_attribute_names = %s
+  projection_expression = %q
+  table_name                  = aws_dynamodb_table.test.name
+	key_condition_expression    = "%s = :value"
+	expression_attribute_values = {
+		":value"= jsonencode({"S" = %q})
+	}
+  depends_on                  = [aws_dynamodb_table_item.test]
+}
+`, tableName, hashKey, hashKey, item, expressionAttributeNames, projectionExpression, hashKey, hashKeyValue)
+}
+
+func testAccTableQueryDataSourceConfig_select(tableName, item, hashKey, hashKeyValue, selectValue string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  name           = %q
+  read_capacity  = 10
+  write_capacity = 10
+  hash_key       = %q
+
+  attribute {
+    name = %q
+    type = "S"
+  }
+}
+
+resource "aws_dynamodb_table_item" "test" {
+  table_name = aws_dynamodb_table.test.name
+  hash_key   = aws_dynamodb_table.test.hash_key
+  item = <<ITEM
+%s
+ITEM
+}
+
+	data "aws_dynamodb_table_query" "test" {
+		select = %q
+	  table_name                  = aws_dynamodb_table.test.name
+		key_condition_expression    = "%s = :value"
+		expression_attribute_values = {
+			":value"= jsonencode({"S" = %q})
+		}
+	  depends_on                  = [aws_dynamodb_table_item.test]
+	}
+
+`, tableName, hashKey, hashKey, item, selectValue, hashKey, hashKeyValue)
+}
+
+func testAccTableQueryDataSourceConfig_filterExpression(tableName, item1, item2, expressionAttributeValues, filterExpression string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  name           = %q
+  read_capacity  = 10
+  write_capacity = 10
+  hash_key       = "ID"
+
+  attribute {
+    name = "ID"
+    type = "S"
+  }
+}
+
+resource "aws_dynamodb_table_item" "item1" {
+  table_name = aws_dynamodb_table.test.name
+  hash_key   = aws_dynamodb_table.test.hash_key
+  item       = %q
+}
+
+resource "aws_dynamodb_table_item" "item2" {
+  table_name = aws_dynamodb_table.test.name
+  hash_key   = aws_dynamodb_table.test.hash_key
+  item       = %q
+}
+
+data "aws_dynamodb_table_query" "test" {
+  table_name                  = aws_dynamodb_table.test.name
+	key_condition_expression    = "ID = :value"
+  expression_attribute_values = %s
+  filter_expression = %q
+  depends_on        = [aws_dynamodb_table_item.item1, aws_dynamodb_table_item.item2]
+}
+`, tableName, item1, item2, expressionAttributeValues, filterExpression)
+}
+
+func testAccTableQueryDataSourceConfig_scanIndexForward(tableName, sortKeyValue1, sortKeyValue2, sortKeyValue3, scanIndexForward string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  name           = %q
+  read_capacity  = 10
+  write_capacity = 10
+  hash_key       = "ID"
+  range_key      = "sortKey"
+
+  attribute {
+    name = "ID"
+    type = "S"
+  }
+
+  attribute {
+    name = "sortKey"
+    type = "N"
+  }
+}
+
+resource "aws_dynamodb_table_item" "item1" {
+  table_name = aws_dynamodb_table.test.name
+  hash_key   = aws_dynamodb_table.test.hash_key
+  range_key  = aws_dynamodb_table.test.range_key
+  item = <<ITEM
+{
+  "ID": {"S": "0000A"},
+  "sortKey": {"N": %q}
+}
+ITEM
+}
+
+resource "aws_dynamodb_table_item" "item2" {
+  table_name = aws_dynamodb_table.test.name
+  hash_key   = aws_dynamodb_table.test.hash_key
+  range_key  = aws_dynamodb_table.test.range_key
+  item = <<ITEM
+{
+  "ID": {"S": "0000A"},
+  "sortKey": {"N": %q}
+}
+ITEM
+}
+
+resource "aws_dynamodb_table_item" "item3" {
+  table_name = aws_dynamodb_table.test.name
+  hash_key   = aws_dynamodb_table.test.hash_key
+  range_key  = aws_dynamodb_table.test.range_key
+  item = <<ITEM
+{
+  "ID": {"S": "0000A"},
+  "sortKey": {"N": %q}
+}
+ITEM
+}
+
+data "aws_dynamodb_table_query" "test" {
+  table_name                = aws_dynamodb_table.test.name
+  key_condition_expression  = "ID = :value"
+  expression_attribute_values = {
+    ":value" = "{\"S\": \"0000A\"}"
+  }
+  scan_index_forward = %s
+	consistent_read = true
+  depends_on         = [aws_dynamodb_table_item.item1, aws_dynamodb_table_item.item2, aws_dynamodb_table_item.item3]
+}
+`, tableName, sortKeyValue1, sortKeyValue2, sortKeyValue3, scanIndexForward)
+}
+
+func testAccTableQueryDataSourceConfig_index(tableName, item, projectionType, GSIName string) string {
+	return fmt.Sprintf(`
+	resource "aws_dynamodb_table" "test" {
+		name           = %q
+		read_capacity  = 10
+		write_capacity = 10
+		hash_key       = "ID"
+	
+		attribute {
+			name = "ID"
+			type = "S"
+		}
+
+		global_secondary_index {
+			name            = %q
+			hash_key        = "ID"
+			read_capacity   = 5
+			write_capacity  = 5
+			projection_type = %q
+			non_key_attributes = ["extraAttribute"]
+		}
+	}
+	
+	resource "aws_dynamodb_table_item" "item" {
+		table_name = aws_dynamodb_table.test.name
+		hash_key   = aws_dynamodb_table.test.hash_key
+		item = <<ITEM
+%s
+	ITEM
+	}
+
+	data "aws_dynamodb_table_query" "test" {
+		table_name               = %q
+		key_condition_expression  = "ID = :value"
+		expression_attribute_values = {
+			":value" = "{\"S\": \"0000A\"}"
+		}
+		index_name              = %q
+		depends_on              = [aws_dynamodb_table_item.item]
+	}
+`, tableName, GSIName, projectionType, item, tableName, GSIName)
+}
+
+func generateRandomPayload(sizeKB int) string {
+	payload := make([]byte, sizeKB*1024)
+	for i := range payload {
+		payload[i] = byte('A' + i%26)
+	}
+	return string(payload)
+}
+
+func testAccTableQueryDataSourceConfig_handlesPagination(tableName string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  name           = %q
+  read_capacity  = 10
+  write_capacity = 10
+  hash_key       = "ID"
+	range_key      = "sortKey"
+
+  attribute {
+    name = "ID"
+    type = "S"
+  }
+	
+	attribute {
+    name = "sortKey"
+    type = "S"
+  }
+}
+
+resource "aws_dynamodb_table_item" "test" {
+	count = 10
+  table_name = aws_dynamodb_table.test.name
+  hash_key   = aws_dynamodb_table.test.hash_key
+	range_key  = aws_dynamodb_table.test.range_key
+  item = <<ITEM
+	{
+		"ID": {"S": "0000A"},
+		"sortKey": {"S": "sortValue${count.index + 1}"},
+		"payload": {"S": %q}
+	}
+ITEM
+}
+
+data "aws_dynamodb_table_query" "test" {
+  table_name                  = aws_dynamodb_table.test.name
+	key_condition_expression    = "ID = :value"
+	expression_attribute_values = {
+		":value"= jsonencode({"S" = "0000A"})
+	}
+  depends_on                  = [aws_dynamodb_table_item.test[0], aws_dynamodb_table_item.test[1], aws_dynamodb_table_item.test[2], aws_dynamodb_table_item.test[3], aws_dynamodb_table_item.test[4], aws_dynamodb_table_item.test[5], aws_dynamodb_table_item.test[6], aws_dynamodb_table_item.test[7], aws_dynamodb_table_item.test[8], aws_dynamodb_table_item.test[9]]
+}
+`, tableName, generateRandomPayload(300))
+}
+
+func testAccTableQueryDataSourceConfig_outputLimit(tableName string, outputLimit int) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  name           = %q
+  read_capacity  = 10
+  write_capacity = 10
+  hash_key       = "ID"
+	range_key      = "sortKey"
+
+  attribute {
+    name = "ID"
+    type = "S"
+  }
+	
+	attribute {
+    name = "sortKey"
+    type = "S"
+  }
+}
+
+resource "aws_dynamodb_table_item" "test" {
+	count = 10
+  table_name = aws_dynamodb_table.test.name
+  hash_key   = aws_dynamodb_table.test.hash_key
+	range_key  = aws_dynamodb_table.test.range_key
+  item = <<ITEM
+	{
+		"ID": {"S": "0000A"},
+		"sortKey": {"S": "sortValue${count.index + 1}"},
+		"payload": {"S": %q}
+	}
+ITEM
+}
+
+data "aws_dynamodb_table_query" "test" {
+	output_limit 							  = %d
+  table_name                  = aws_dynamodb_table.test.name
+	key_condition_expression    = "ID = :value"
+	expression_attribute_values = {
+		":value"= jsonencode({"S" = "0000A"})
+	}
+  depends_on                  = [aws_dynamodb_table_item.test[0], aws_dynamodb_table_item.test[1], aws_dynamodb_table_item.test[2], aws_dynamodb_table_item.test[3], aws_dynamodb_table_item.test[4], aws_dynamodb_table_item.test[5], aws_dynamodb_table_item.test[6], aws_dynamodb_table_item.test[7], aws_dynamodb_table_item.test[8], aws_dynamodb_table_item.test[9]]
+}
+`, tableName, generateRandomPayload(300), outputLimit)
+}
+
+func TestConvertJSONToAttributeValue(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		jsonStr     string
+		expectedAV  *tfdynamo.AttributeValue
+		expectedErr bool
+	}{
+		{
+			jsonStr: "{\"S\":\"example\"}",
+			expectedAV: &tfdynamo.AttributeValue{
+				S: strPtr("example"),
+			},
+			expectedErr: false,
+		},
+		{
+			jsonStr: `{"B":"YmFzZTY0IGVuY29kaW5nIGVuY3J5cHRpb24="}`,
+			expectedAV: &tfdynamo.AttributeValue{
+				B: []byte("base64 encoding encryption"),
+			},
+			expectedErr: false,
+		},
+		{
+			jsonStr: `{"BOOL":true}`,
+			expectedAV: &tfdynamo.AttributeValue{
+				BOOL: boolPtr(true),
+			},
+			expectedErr: false,
+		},
+		{
+			jsonStr: `{"BS":["YmFzZTY0","ZW5jb2Rpbmc="]}`,
+			expectedAV: &tfdynamo.AttributeValue{
+				BS: [][]byte{[]byte("base64"), []byte("encoding")},
+			},
+			expectedErr: false,
+		},
+		{
+			jsonStr: `{"L":[{"S":"value1"},{"S":"value2"}]}`,
+			expectedAV: &tfdynamo.AttributeValue{
+				L: []*tfdynamo.AttributeValue{
+					{S: strPtr("value1")},
+					{S: strPtr("value2")},
+				},
+			},
+			expectedErr: false,
+		},
+		{
+			jsonStr: `{"M":{"key1":{"S":"value1"},"key2":{"S":"value2"}}}`,
+			expectedAV: &tfdynamo.AttributeValue{
+				M: map[string]*tfdynamo.AttributeValue{
+					"key1": {S: strPtr("value1")},
+					"key2": {S: strPtr("value2")},
+				},
+			},
+			expectedErr: false,
+		},
+		{
+			jsonStr: `{"N":"12345"}`,
+			expectedAV: &tfdynamo.AttributeValue{
+				N: strPtr("12345"),
+			},
+			expectedErr: false,
+		},
+		{
+			jsonStr: `{"NS":["123","456"]}`,
+			expectedAV: &tfdynamo.AttributeValue{
+				NS: []*string{strPtr("123"), strPtr("456")},
+			},
+			expectedErr: false,
+		},
+		{
+			jsonStr: `{"NULL":true}`,
+			expectedAV: &tfdynamo.AttributeValue{
+				NULL: boolPtr(true),
+			},
+			expectedErr: false,
+		},
+		{
+			jsonStr: `{"SS":["value1","value2"]}`,
+			expectedAV: &tfdynamo.AttributeValue{
+				SS: []*string{strPtr("value1"), strPtr("value2")},
+			},
+			expectedErr: false,
+		},
+		{
+			jsonStr:     `invalidJSON`,
+			expectedAV:  nil,
+			expectedErr: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.jsonStr, func(t *testing.T) {
+			result, err := tfdynamo.ConvertJSONToAttributeValue(c.jsonStr)
+			log.Println("[ERROR] result: ", result)
+
+			if c.expectedErr && err == nil {
+				t.Errorf("Expected error, but got nil")
+			}
+
+			if !c.expectedErr && err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(result, c.expectedAV) {
+				t.Errorf("Unexpected result. Expected %+v, got %+v", c.expectedAV, result)
+			}
+		})
+	}
+}
+
+func TestConvertToDynamoAttributeValue(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		av          *tfdynamo.AttributeValue
+		expectedAV  *dynamodb.AttributeValue
+		expectedErr bool
+	}{
+		{
+			av: &tfdynamo.AttributeValue{
+				S: strPtr("example"),
+			},
+			expectedAV: &dynamodb.AttributeValue{
+				S: strPtr("example"),
+			},
+			expectedErr: false,
+		},
+		{
+			av: &tfdynamo.AttributeValue{
+				B: []byte("base64 encoding encryption"),
+			},
+			expectedAV: &dynamodb.AttributeValue{
+				B: []byte("base64 encoding encryption"),
+			},
+			expectedErr: false,
+		},
+		{
+			av: &tfdynamo.AttributeValue{
+				BOOL: boolPtr(true),
+			},
+			expectedAV: &dynamodb.AttributeValue{
+				BOOL: boolPtr(true),
+			},
+			expectedErr: false,
+		},
+		{
+			av: &tfdynamo.AttributeValue{
+				BS: [][]byte{[]byte("base64"), []byte("encoding")},
+			},
+			expectedAV: &dynamodb.AttributeValue{
+				BS: [][]byte{[]byte("base64"), []byte("encoding")},
+			},
+			expectedErr: false,
+		},
+		{
+			av: &tfdynamo.AttributeValue{
+				L: []*tfdynamo.AttributeValue{
+					{S: strPtr("value1")},
+					{S: strPtr("value2")},
+				},
+			},
+			expectedAV: &dynamodb.AttributeValue{
+				L: []*dynamodb.AttributeValue{
+					{S: strPtr("value1")},
+					{S: strPtr("value2")},
+				},
+			},
+			expectedErr: false,
+		},
+		{
+			av: &tfdynamo.AttributeValue{
+				M: map[string]*tfdynamo.AttributeValue{
+					"key1": {S: strPtr("value1")},
+					"key2": {S: strPtr("value2")},
+				},
+			},
+			expectedAV: &dynamodb.AttributeValue{
+				M: map[string]*dynamodb.AttributeValue{
+					"key1": {S: strPtr("value1")},
+					"key2": {S: strPtr("value2")},
+				},
+			},
+			expectedErr: false,
+		},
+		{
+			av: &tfdynamo.AttributeValue{
+				N: strPtr("12345"),
+			},
+			expectedAV: &dynamodb.AttributeValue{
+				N: strPtr("12345"),
+			},
+			expectedErr: false,
+		},
+		{
+			av: &tfdynamo.AttributeValue{
+				NS: []*string{strPtr("123"), strPtr("456")},
+			},
+			expectedAV: &dynamodb.AttributeValue{
+				NS: []*string{strPtr("123"), strPtr("456")},
+			},
+			expectedErr: false,
+		},
+		{
+			av: &tfdynamo.AttributeValue{
+				NULL: boolPtr(true),
+			},
+			expectedAV: &dynamodb.AttributeValue{
+				NULL: boolPtr(true),
+			},
+			expectedErr: false,
+		},
+		{
+			av: &tfdynamo.AttributeValue{
+				SS: []*string{strPtr("value1"), strPtr("value2")},
+			},
+			expectedAV: &dynamodb.AttributeValue{
+				SS: []*string{strPtr("value1"), strPtr("value2")},
+			},
+			expectedErr: false,
+		},
+		{
+			av:          nil,
+			expectedAV:  nil,
+			expectedErr: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run("", func(t *testing.T) {
+			result, err := tfdynamo.ConvertToDynamoAttributeValue(c.av)
+
+			if c.expectedErr && err == nil {
+				t.Errorf("Expected error, but got nil")
+			}
+
+			if !c.expectedErr && err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(result, c.expectedAV) {
+				t.Errorf("Unexpected result. Expected %+v, got %+v", c.expectedAV, result)
+			}
+		})
+	}
+}
+
+func strPtr(s string) *string {
+	return &s
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/website/docs/d/dynamodb_table_query.html.markdown
+++ b/website/docs/d/dynamodb_table_query.html.markdown
@@ -1,0 +1,55 @@
+---
+subcategory: "DynamoDB"
+layout: "aws"
+page_title: "AWS: aws_dynamodb_table_query"
+description: |-
+  Terraform data source for querying values from an AWS DynamoDB table.
+---
+
+# Data Source: aws_dynamodb_table_query
+
+Terraform data source for querying values from an AWS DynamoDB table.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_dynamodb_table_query" "test" {
+  table_name                  = aws_dynamodb_table.example.name
+	key_condition_expression    = "hashKey = :value"
+	expression_attribute_values = {
+		":value"= jsonencode({"S" = "something"})
+	}
+  depends_on                  = [aws_dynamodb_table_item.example]
+}
+```
+
+## Argument Reference (following [Query API documentation](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html))
+
+The following arguments are required:
+
+* `table_name` - (Required) The name of the table containing the requested item.
+* `key_condition_expression` - (Required) The condition that specifies the key values for items to be retrieved by the Query action.
+
+The following arguments are optional:
+
+* `expression_attribute_name` - (Optional) - One or more substitution tokens for attribute names in an expression. Use the `#` character in an expression to dereference an attribute name.
+* `expression_attribute_values` - (Optional) - One or more values that can be substituted in an expression. Use the `:` character in an expression to dereference an attribute value. The values must be valid JSON, for example: {":value" = "{\"S\": \"0000A\"}"} or {":value"= jsonencode({"S" = %q})}
+* `output_limit` - (Optional) - The total number of items to include in the result. This data source handles pagination internally (using the ExclusiveStartKey and LastEvaluatedKey parameters). It will stop performing additional queries once this `output_limit` is reached. When not specified, it will keep querying until the LastEvaluatedKey is null.
+* `projection_expression` - (Optional) A string that identifies one or more attributes to retrieve from the table. These attributes can include scalars, sets, or elements of a JSON document. The attributes in the expression must be separated by commas.
+If no attribute names are specified, then all attributes are returned. If any of the requested attributes are not found, they do not appear in the result.
+* `consistent_read` - (Optional) - If set to true, then the operation uses strongly consistent reads; otherwise, the operation uses eventually consistent reads.
+* `filter_expression` - (Optional) - A string that contains conditions that DynamoDB applies after the Query operation, but before the data is returned to you. Items that do not satisfy the FilterExpression criteria are not returned.
+* `index_name` - (Optional) - The name of an index to query. This index can be any local secondary index or global secondary index on the table.
+* `projection_expression` - (Optional) - A string that identifies one or more attributes to retrieve from the table. These attributes can include scalars, sets, or elements of a JSON document. The attributes in the expression must be separated by commas. If no attribute names are specified, then all attributes will be returned. If any of the requested attributes are not found, they will not appear in the result.
+* `scan_index_forward` - (Optional) - Specifies the order for index traversal: If true (default), the traversal is performed in ascending order; if false, the traversal is performed in descending order. If ScanIndexForward is true, DynamoDB returns the results in the order in which they are stored (by sort key value). This is the default behavior.
+* `select` - (Optional) - The attributes to be returned in the result. You can retrieve all item attributes, specific item attributes, the count of matching items, or in the case of an index, some or all of the attributes projected into the index with `ALL_ATTRIBUTES`, `ALL_PROJECTED_ATTRIBUTES`, `COUNT`, `SPECIFIC_ATTRIBUTES`.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+* `items` - List of JSON representations of maps of attribute names to [AttributeValue](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_AttributeValue.html) objects.
+* `item_count` - The number of items in the `items` list.
+* `scanned_count` - The number of items evaluated, before any QueryFilter is applied. A high ScannedCount value with few, or no, Count results indicates an inefficient Query operation.
+* `query_count` - The number of queries that were performed. As discussed earlier, the data source handles pagination internally, hence this number represents the number of query calls that were done against Dynamo until the output_limit (if specified) was reached.


### PR DESCRIPTION
### Description
Adds a new data source for supporting DynamoDB [Query](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html) API

### Relations
Closes #34648
Relates #9462

### References
An initial design for this data source was provided in this [comment](https://github.com/hashicorp/terraform-provider-aws/issues/9462#issuecomment-592034118).


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
» make testacc TESTARGS='-run=TestAccDynamoDBTableQueryDataSource_' PKG=dynamodb 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/dynamodb/... -v -count 1 -parallel 20  -run=TestAccDynamoDBTableQueryDataSource_ -timeout 360m
=== RUN   TestAccDynamoDBTableQueryDataSource_basic
=== PAUSE TestAccDynamoDBTableQueryDataSource_basic
=== RUN   TestAccDynamoDBTableQueryDataSource_projectionExpression
=== PAUSE TestAccDynamoDBTableQueryDataSource_projectionExpression
=== RUN   TestAccDynamoDBTableQueryDataSource_expressionAttributeNames
=== PAUSE TestAccDynamoDBTableQueryDataSource_expressionAttributeNames
=== RUN   TestAccDynamoDBTableQueryDataSource_select
=== PAUSE TestAccDynamoDBTableQueryDataSource_select
=== RUN   TestAccDynamoDBTableQueryDataSource_filterExpression
=== PAUSE TestAccDynamoDBTableQueryDataSource_filterExpression
=== RUN   TestAccDynamoDBTableQueryDataSource_scanIndexForward
=== PAUSE TestAccDynamoDBTableQueryDataSource_scanIndexForward
=== RUN   TestAccDynamoDBTableQueryDataSource_index
=== PAUSE TestAccDynamoDBTableQueryDataSource_index
=== RUN   TestAccDynamoDBTableQueryDataSource_handlesPagination
=== PAUSE TestAccDynamoDBTableQueryDataSource_handlesPagination
=== RUN   TestAccDynamoDBTableQueryDataSource_outputLimit
=== PAUSE TestAccDynamoDBTableQueryDataSource_outputLimit
=== CONT  TestAccDynamoDBTableQueryDataSource_basic
=== CONT  TestAccDynamoDBTableQueryDataSource_scanIndexForward
=== CONT  TestAccDynamoDBTableQueryDataSource_handlesPagination
=== CONT  TestAccDynamoDBTableQueryDataSource_outputLimit
=== CONT  TestAccDynamoDBTableQueryDataSource_index
=== CONT  TestAccDynamoDBTableQueryDataSource_select
=== CONT  TestAccDynamoDBTableQueryDataSource_filterExpression
=== CONT  TestAccDynamoDBTableQueryDataSource_expressionAttributeNames
=== CONT  TestAccDynamoDBTableQueryDataSource_projectionExpression
--- PASS: TestAccDynamoDBTableQueryDataSource_index (395.81s)
--- PASS: TestAccDynamoDBTableQueryDataSource_projectionExpression (412.80s)
--- PASS: TestAccDynamoDBTableQueryDataSource_select (414.20s)
--- PASS: TestAccDynamoDBTableQueryDataSource_expressionAttributeNames (414.53s)
--- PASS: TestAccDynamoDBTableQueryDataSource_basic (414.69s)
--- PASS: TestAccDynamoDBTableQueryDataSource_filterExpression (426.53s)
--- PASS: TestAccDynamoDBTableQueryDataSource_scanIndexForward (456.78s)
--- PASS: TestAccDynamoDBTableQueryDataSource_outputLimit (632.90s)
--- PASS: TestAccDynamoDBTableQueryDataSource_handlesPagination (645.14s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb   647.687s
```


Unit test output:
```console
» make test TESTS=TestConvertToDynamoAttributeValue PKG=dynamodb TF_LOG=ERROR 
==> Checking that code complies with gofmt requirements...
go test ./internal/service/dynamodb/...  -timeout=5m
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb   4.423s
```