### PR TITLE
tech debt: Collect diags instead of returning directly - `l`, `m`, and `n` services

### DIFF
--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,8 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/[l-z]*
+        - internal/service/l[e-o]*
+        - internal/service/[m-z]*
     pattern: return diag.FromErr($ERR)
     fix: return sdkdiag.AppendFromErr(diags, $ERR)
     severity: WARNING
@@ -14,7 +15,8 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/[l-z]*
+        - internal/service/l[e-o]*
+        - internal/service/[m-z]*
     pattern: append(diags, diag.FromErr($ERR)...)
     fix: sdkdiag.AppendFromErr(diags, $ERR)
     severity: WARNING
@@ -24,7 +26,8 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/[l-z]*
+        - internal/service/l[e-o]*
+        - internal/service/[m-z]*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
     severity: WARNING
@@ -34,7 +37,8 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/[l-z]*
+        - internal/service/l[e-o]*
+        - internal/service/[m-z]*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
     severity: WARNING
@@ -44,7 +48,8 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/[l-z]*
+        - internal/service/l[e-o]*
+        - internal/service/[m-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
     fix: create.AppendDiagError(diags, $...ARGS)
     severity: WARNING
@@ -54,7 +59,8 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/[l-z]*
+        - internal/service/l[e-o]*
+        - internal/service/[m-z]*
     pattern: create.DiagSettingError($...ARGS)
     fix: create.AppendDiagSettingError(diags, $...ARGS)
     severity: WARNING
@@ -64,7 +70,8 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/[l-z]*
+        - internal/service/l[e-o]*
+        - internal/service/[m-z]*
     patterns:
       - pattern: return $READFN($...ARGS)
       - metavariable-regex:
@@ -82,7 +89,8 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/[l-z]*
+        - internal/service/l[e-o]*
+        - internal/service/[m-z]*
     patterns:
       - pattern: return $UPDATEFN($...ARGS)
       - metavariable-regex:
@@ -98,7 +106,8 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/[l-z]*
+        - internal/service/l[e-o]*
+        - internal/service/[m-z]*
     patterns:
       - pattern: return nil
       - pattern-not-inside: |

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,8 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/[m-z]*
+        - internal/service/m[e-z]*
+        - internal/service/[n-z]*
     pattern: return diag.FromErr($ERR)
     fix: return sdkdiag.AppendFromErr(diags, $ERR)
     severity: WARNING
@@ -14,7 +15,8 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/[m-z]*
+        - internal/service/m[e-z]*
+        - internal/service/[n-z]*
     pattern: append(diags, diag.FromErr($ERR)...)
     fix: sdkdiag.AppendFromErr(diags, $ERR)
     severity: WARNING
@@ -24,7 +26,8 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/[m-z]*
+        - internal/service/m[e-z]*
+        - internal/service/[n-z]*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
     severity: WARNING
@@ -34,7 +37,8 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/[m-z]*
+        - internal/service/m[e-z]*
+        - internal/service/[n-z]*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
     severity: WARNING
@@ -44,7 +48,8 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/[m-z]*
+        - internal/service/m[e-z]*
+        - internal/service/[n-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
     fix: create.AppendDiagError(diags, $...ARGS)
     severity: WARNING
@@ -54,7 +59,8 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/[m-z]*
+        - internal/service/m[e-z]*
+        - internal/service/[n-z]*
     pattern: create.DiagSettingError($...ARGS)
     fix: create.AppendDiagSettingError(diags, $...ARGS)
     severity: WARNING
@@ -64,7 +70,8 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/[m-z]*
+        - internal/service/m[e-z]*
+        - internal/service/[n-z]*
     patterns:
       - pattern: return $READFN($...ARGS)
       - metavariable-regex:
@@ -82,7 +89,8 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/[m-z]*
+        - internal/service/m[e-z]*
+        - internal/service/[n-z]*
     patterns:
       - pattern: return $UPDATEFN($...ARGS)
       - metavariable-regex:
@@ -98,7 +106,8 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/[m-z]*
+        - internal/service/m[e-z]*
+        - internal/service/[n-z]*
     patterns:
       - pattern: return nil
       - pattern-not-inside: |

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,8 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/[n-z]*
+        - internal/service/net*
+        - internal/service/[o-z]*
     pattern: return diag.FromErr($ERR)
     fix: return sdkdiag.AppendFromErr(diags, $ERR)
     severity: WARNING
@@ -14,7 +15,8 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/[n-z]*
+        - internal/service/net*
+        - internal/service/[o-z]*
     pattern: append(diags, diag.FromErr($ERR)...)
     fix: sdkdiag.AppendFromErr(diags, $ERR)
     severity: WARNING
@@ -24,7 +26,8 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/[n-z]*
+        - internal/service/net*
+        - internal/service/[o-z]*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
     severity: WARNING
@@ -34,7 +37,8 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/[n-z]*
+        - internal/service/net*
+        - internal/service/[o-z]*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
     severity: WARNING
@@ -44,7 +48,8 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/[n-z]*
+        - internal/service/net*
+        - internal/service/[o-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
     fix: create.AppendDiagError(diags, $...ARGS)
     severity: WARNING
@@ -54,7 +59,8 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/[n-z]*
+        - internal/service/net*
+        - internal/service/[o-z]*
     pattern: create.DiagSettingError($...ARGS)
     fix: create.AppendDiagSettingError(diags, $...ARGS)
     severity: WARNING
@@ -64,7 +70,8 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/[n-z]*
+        - internal/service/net*
+        - internal/service/[o-z]*
     patterns:
       - pattern: return $READFN($...ARGS)
       - metavariable-regex:
@@ -82,7 +89,8 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/[n-z]*
+        - internal/service/net*
+        - internal/service/[o-z]*
     patterns:
       - pattern: return $UPDATEFN($...ARGS)
       - metavariable-regex:
@@ -98,7 +106,8 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/[n-z]*
+        - internal/service/net*
+        - internal/service/[o-z]*
     patterns:
       - pattern: return nil
       - pattern-not-inside: |

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,6 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/networkmanager
         - internal/service/[o-z]*
     pattern: return diag.FromErr($ERR)
     fix: return sdkdiag.AppendFromErr(diags, $ERR)
@@ -15,7 +14,6 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/networkmanager
         - internal/service/[o-z]*
     pattern: append(diags, diag.FromErr($ERR)...)
     fix: sdkdiag.AppendFromErr(diags, $ERR)
@@ -26,7 +24,6 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/networkmanager
         - internal/service/[o-z]*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
@@ -37,7 +34,6 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/networkmanager
         - internal/service/[o-z]*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
@@ -48,7 +44,6 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/networkmanager
         - internal/service/[o-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
     fix: create.AppendDiagError(diags, $...ARGS)
@@ -59,7 +54,6 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/networkmanager
         - internal/service/[o-z]*
     patterns:
       - pattern: return $READFN($...ARGS)
@@ -78,13 +72,17 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/networkmanager
         - internal/service/[o-z]*
     patterns:
       - pattern: return $UPDATEFN($...ARGS)
       - metavariable-regex:
           metavariable: "$UPDATEFN"
           regex: resource\w+Update
+      - pattern-not-inside: |
+          func $CREATEFN(...) {
+            d.SetId(...)
+            return $UPDATEFN($...ARGS)
+          }
     fix: return append(diags, $UPDATEFN($...ARGS)...)
     severity: WARNING
 
@@ -95,7 +93,6 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/networkmanager
         - internal/service/[o-z]*
     patterns:
       - pattern: return nil

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,8 +4,6 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/meta
-        - internal/service/mq
         - internal/service/mwaa
         - internal/service/[n-z]*
     pattern: return diag.FromErr($ERR)
@@ -17,8 +15,6 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/meta
-        - internal/service/mq
         - internal/service/mwaa
         - internal/service/[n-z]*
     pattern: append(diags, diag.FromErr($ERR)...)
@@ -30,8 +26,6 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/meta
-        - internal/service/mq
         - internal/service/mwaa
         - internal/service/[n-z]*
     pattern: diag.Errorf($...ARGS)
@@ -43,8 +37,6 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/meta
-        - internal/service/mq
         - internal/service/mwaa
         - internal/service/[n-z]*
     pattern: return create.DiagError($...ARGS)
@@ -56,8 +48,6 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/meta
-        - internal/service/mq
         - internal/service/mwaa
         - internal/service/[n-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
@@ -69,8 +59,6 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/meta
-        - internal/service/mq
         - internal/service/mwaa
         - internal/service/[n-z]*
     pattern: create.DiagSettingError($...ARGS)
@@ -82,8 +70,6 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/meta
-        - internal/service/mq
         - internal/service/mwaa
         - internal/service/[n-z]*
     patterns:
@@ -103,8 +89,6 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/meta
-        - internal/service/mq
         - internal/service/mwaa
         - internal/service/[n-z]*
     patterns:
@@ -122,8 +106,6 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/meta
-        - internal/service/mq
         - internal/service/mwaa
         - internal/service/[n-z]*
     patterns:

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,6 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/memorydb
         - internal/service/meta
         - internal/service/mq
         - internal/service/mwaa
@@ -18,7 +17,6 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/memorydb
         - internal/service/meta
         - internal/service/mq
         - internal/service/mwaa
@@ -32,7 +30,6 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/memorydb
         - internal/service/meta
         - internal/service/mq
         - internal/service/mwaa
@@ -46,7 +43,6 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/memorydb
         - internal/service/meta
         - internal/service/mq
         - internal/service/mwaa
@@ -60,7 +56,6 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/memorydb
         - internal/service/meta
         - internal/service/mq
         - internal/service/mwaa
@@ -74,7 +69,6 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/memorydb
         - internal/service/meta
         - internal/service/mq
         - internal/service/mwaa
@@ -88,7 +82,6 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/memorydb
         - internal/service/meta
         - internal/service/mq
         - internal/service/mwaa
@@ -110,7 +103,6 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/memorydb
         - internal/service/meta
         - internal/service/mq
         - internal/service/mwaa
@@ -130,7 +122,6 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/memorydb
         - internal/service/meta
         - internal/service/mq
         - internal/service/mwaa

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,7 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/net*
+        - internal/service/networkmanager
         - internal/service/[o-z]*
     pattern: return diag.FromErr($ERR)
     fix: return sdkdiag.AppendFromErr(diags, $ERR)
@@ -15,7 +15,7 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/net*
+        - internal/service/networkmanager
         - internal/service/[o-z]*
     pattern: append(diags, diag.FromErr($ERR)...)
     fix: sdkdiag.AppendFromErr(diags, $ERR)
@@ -26,7 +26,7 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/net*
+        - internal/service/networkmanager
         - internal/service/[o-z]*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
@@ -37,7 +37,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/net*
+        - internal/service/networkmanager
         - internal/service/[o-z]*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
@@ -48,7 +48,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/net*
+        - internal/service/networkmanager
         - internal/service/[o-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
     fix: create.AppendDiagError(diags, $...ARGS)
@@ -59,7 +59,7 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/net*
+        - internal/service/networkmanager
         - internal/service/[o-z]*
     pattern: create.DiagSettingError($...ARGS)
     fix: create.AppendDiagSettingError(diags, $...ARGS)
@@ -70,7 +70,7 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/net*
+        - internal/service/networkmanager
         - internal/service/[o-z]*
     patterns:
       - pattern: return $READFN($...ARGS)
@@ -89,7 +89,7 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/net*
+        - internal/service/networkmanager
         - internal/service/[o-z]*
     patterns:
       - pattern: return $UPDATEFN($...ARGS)
@@ -106,7 +106,7 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/net*
+        - internal/service/networkmanager
         - internal/service/[o-z]*
     patterns:
       - pattern: return nil

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,6 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/location
         - internal/service/logs
         - internal/service/[m-z]*
     pattern: return diag.FromErr($ERR)
@@ -16,7 +15,6 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/location
         - internal/service/logs
         - internal/service/[m-z]*
     pattern: append(diags, diag.FromErr($ERR)...)
@@ -28,7 +26,6 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/location
         - internal/service/logs
         - internal/service/[m-z]*
     pattern: diag.Errorf($...ARGS)
@@ -40,7 +37,6 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/location
         - internal/service/logs
         - internal/service/[m-z]*
     pattern: return create.DiagError($...ARGS)
@@ -52,7 +48,6 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/location
         - internal/service/logs
         - internal/service/[m-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
@@ -64,7 +59,6 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/location
         - internal/service/logs
         - internal/service/[m-z]*
     pattern: create.DiagSettingError($...ARGS)
@@ -76,7 +70,6 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/location
         - internal/service/logs
         - internal/service/[m-z]*
     patterns:
@@ -96,7 +89,6 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/location
         - internal/service/logs
         - internal/service/[m-z]*
     patterns:
@@ -114,7 +106,6 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/location
         - internal/service/logs
         - internal/service/[m-z]*
     patterns:

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,6 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/logs
         - internal/service/[m-z]*
     pattern: return diag.FromErr($ERR)
     fix: return sdkdiag.AppendFromErr(diags, $ERR)
@@ -15,7 +14,6 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/logs
         - internal/service/[m-z]*
     pattern: append(diags, diag.FromErr($ERR)...)
     fix: sdkdiag.AppendFromErr(diags, $ERR)
@@ -26,7 +24,6 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/logs
         - internal/service/[m-z]*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
@@ -37,7 +34,6 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/logs
         - internal/service/[m-z]*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
@@ -48,7 +44,6 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/logs
         - internal/service/[m-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
     fix: create.AppendDiagError(diags, $...ARGS)
@@ -59,7 +54,6 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/logs
         - internal/service/[m-z]*
     pattern: create.DiagSettingError($...ARGS)
     fix: create.AppendDiagSettingError(diags, $...ARGS)
@@ -70,7 +64,6 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/logs
         - internal/service/[m-z]*
     patterns:
       - pattern: return $READFN($...ARGS)
@@ -89,7 +82,6 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/logs
         - internal/service/[m-z]*
     patterns:
       - pattern: return $UPDATEFN($...ARGS)
@@ -106,7 +98,6 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/logs
         - internal/service/[m-z]*
     patterns:
       - pattern: return nil

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -54,17 +54,6 @@ rules:
     fix: create.AppendDiagError(diags, $...ARGS)
     severity: WARNING
 
-  - id: avoid-create_DiagSettingError
-    languages: [go]
-    message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
-    paths:
-      exclude:
-        - internal/service/networkmanager
-        - internal/service/[o-z]*
-    pattern: create.DiagSettingError($...ARGS)
-    fix: create.AppendDiagSettingError(diags, $...ARGS)
-    severity: WARNING
-
   - id: append-Read-to-diags
     languages: [go]
     message: Append results of $READFN to diags instead of returning directly

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,6 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/lightsail
         - internal/service/location
         - internal/service/logs
         - internal/service/[m-z]*
@@ -17,7 +16,6 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/lightsail
         - internal/service/location
         - internal/service/logs
         - internal/service/[m-z]*
@@ -30,7 +28,6 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/lightsail
         - internal/service/location
         - internal/service/logs
         - internal/service/[m-z]*
@@ -43,7 +40,6 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/lightsail
         - internal/service/location
         - internal/service/logs
         - internal/service/[m-z]*
@@ -56,7 +52,6 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/lightsail
         - internal/service/location
         - internal/service/logs
         - internal/service/[m-z]*
@@ -69,7 +64,6 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/lightsail
         - internal/service/location
         - internal/service/logs
         - internal/service/[m-z]*
@@ -82,7 +76,6 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/lightsail
         - internal/service/location
         - internal/service/logs
         - internal/service/[m-z]*
@@ -103,7 +96,6 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/lightsail
         - internal/service/location
         - internal/service/logs
         - internal/service/[m-z]*
@@ -122,7 +114,6 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/lightsail
         - internal/service/location
         - internal/service/logs
         - internal/service/[m-z]*

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,6 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/mwaa
         - internal/service/[n-z]*
     pattern: return diag.FromErr($ERR)
     fix: return sdkdiag.AppendFromErr(diags, $ERR)
@@ -15,7 +14,6 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/mwaa
         - internal/service/[n-z]*
     pattern: append(diags, diag.FromErr($ERR)...)
     fix: sdkdiag.AppendFromErr(diags, $ERR)
@@ -26,7 +24,6 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/mwaa
         - internal/service/[n-z]*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
@@ -37,7 +34,6 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/mwaa
         - internal/service/[n-z]*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
@@ -48,7 +44,6 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/mwaa
         - internal/service/[n-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
     fix: create.AppendDiagError(diags, $...ARGS)
@@ -59,7 +54,6 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/mwaa
         - internal/service/[n-z]*
     pattern: create.DiagSettingError($...ARGS)
     fix: create.AppendDiagSettingError(diags, $...ARGS)
@@ -70,7 +64,6 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/mwaa
         - internal/service/[n-z]*
     patterns:
       - pattern: return $READFN($...ARGS)
@@ -89,7 +82,6 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/mwaa
         - internal/service/[n-z]*
     patterns:
       - pattern: return $UPDATEFN($...ARGS)
@@ -106,7 +98,6 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/mwaa
         - internal/service/[n-z]*
     patterns:
       - pattern: return nil

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,9 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/l[e-o]*
+        - internal/service/lightsail
+        - internal/service/location
+        - internal/service/logs
         - internal/service/[m-z]*
     pattern: return diag.FromErr($ERR)
     fix: return sdkdiag.AppendFromErr(diags, $ERR)
@@ -15,7 +17,9 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/l[e-o]*
+        - internal/service/lightsail
+        - internal/service/location
+        - internal/service/logs
         - internal/service/[m-z]*
     pattern: append(diags, diag.FromErr($ERR)...)
     fix: sdkdiag.AppendFromErr(diags, $ERR)
@@ -26,7 +30,9 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/l[e-o]*
+        - internal/service/lightsail
+        - internal/service/location
+        - internal/service/logs
         - internal/service/[m-z]*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
@@ -37,7 +43,9 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/l[e-o]*
+        - internal/service/lightsail
+        - internal/service/location
+        - internal/service/logs
         - internal/service/[m-z]*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
@@ -48,7 +56,9 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/l[e-o]*
+        - internal/service/lightsail
+        - internal/service/location
+        - internal/service/logs
         - internal/service/[m-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
     fix: create.AppendDiagError(diags, $...ARGS)
@@ -59,7 +69,9 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/l[e-o]*
+        - internal/service/lightsail
+        - internal/service/location
+        - internal/service/logs
         - internal/service/[m-z]*
     pattern: create.DiagSettingError($...ARGS)
     fix: create.AppendDiagSettingError(diags, $...ARGS)
@@ -70,7 +82,9 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/l[e-o]*
+        - internal/service/lightsail
+        - internal/service/location
+        - internal/service/logs
         - internal/service/[m-z]*
     patterns:
       - pattern: return $READFN($...ARGS)
@@ -89,7 +103,9 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/l[e-o]*
+        - internal/service/lightsail
+        - internal/service/location
+        - internal/service/logs
         - internal/service/[m-z]*
     patterns:
       - pattern: return $UPDATEFN($...ARGS)
@@ -106,7 +122,9 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/l[e-o]*
+        - internal/service/lightsail
+        - internal/service/location
+        - internal/service/logs
         - internal/service/[m-z]*
     patterns:
       - pattern: return nil

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,10 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/m[e-z]*
+        - internal/service/memorydb
+        - internal/service/meta
+        - internal/service/mq
+        - internal/service/mwaa
         - internal/service/[n-z]*
     pattern: return diag.FromErr($ERR)
     fix: return sdkdiag.AppendFromErr(diags, $ERR)
@@ -15,7 +18,10 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/m[e-z]*
+        - internal/service/memorydb
+        - internal/service/meta
+        - internal/service/mq
+        - internal/service/mwaa
         - internal/service/[n-z]*
     pattern: append(diags, diag.FromErr($ERR)...)
     fix: sdkdiag.AppendFromErr(diags, $ERR)
@@ -26,7 +32,10 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/m[e-z]*
+        - internal/service/memorydb
+        - internal/service/meta
+        - internal/service/mq
+        - internal/service/mwaa
         - internal/service/[n-z]*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
@@ -37,7 +46,10 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/m[e-z]*
+        - internal/service/memorydb
+        - internal/service/meta
+        - internal/service/mq
+        - internal/service/mwaa
         - internal/service/[n-z]*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
@@ -48,7 +60,10 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/m[e-z]*
+        - internal/service/memorydb
+        - internal/service/meta
+        - internal/service/mq
+        - internal/service/mwaa
         - internal/service/[n-z]*
     pattern: append(diags, create.DiagError($...ARGS)...)
     fix: create.AppendDiagError(diags, $...ARGS)
@@ -59,7 +74,10 @@ rules:
     message: Prefer `create.AppendDiagSettingError` to `create.DiagSettingError`
     paths:
       exclude:
-        - internal/service/m[e-z]*
+        - internal/service/memorydb
+        - internal/service/meta
+        - internal/service/mq
+        - internal/service/mwaa
         - internal/service/[n-z]*
     pattern: create.DiagSettingError($...ARGS)
     fix: create.AppendDiagSettingError(diags, $...ARGS)
@@ -70,7 +88,10 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/m[e-z]*
+        - internal/service/memorydb
+        - internal/service/meta
+        - internal/service/mq
+        - internal/service/mwaa
         - internal/service/[n-z]*
     patterns:
       - pattern: return $READFN($...ARGS)
@@ -89,7 +110,10 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/m[e-z]*
+        - internal/service/memorydb
+        - internal/service/meta
+        - internal/service/mq
+        - internal/service/mwaa
         - internal/service/[n-z]*
     patterns:
       - pattern: return $UPDATEFN($...ARGS)
@@ -106,7 +130,10 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/m[e-z]*
+        - internal/service/memorydb
+        - internal/service/meta
+        - internal/service/mq
+        - internal/service/mwaa
         - internal/service/[n-z]*
     patterns:
       - pattern: return nil

--- a/internal/create/errors.go
+++ b/internal/create/errors.go
@@ -89,20 +89,8 @@ func AppendDiagErrorMessage(diags diag.Diagnostics, service, action, resource, i
 
 func AppendDiagSettingError(diags diag.Diagnostics, service, resource, id, argument string, gotError error) diag.Diagnostics {
 	return append(diags,
-		diagSettingError(service, resource, id, argument, gotError),
+		diagError(service, fmt.Sprintf("%s %s", ErrActionSetting, argument), resource, id, gotError),
 	)
-}
-
-// DiagSettingError returns a 1-length diag.Diagnostics with a diag.Error-level diag.Diagnostic
-// with a standardized error message when setting arguments and attributes values.
-func DiagSettingError(service, resource, id, argument string, gotError error) diag.Diagnostics {
-	return diag.Diagnostics{
-		diagSettingError(service, resource, id, argument, gotError),
-	}
-}
-
-func diagSettingError(service, resource, id, argument string, gotError error) diag.Diagnostic {
-	return diagError(service, fmt.Sprintf("%s %s", ErrActionSetting, argument), resource, id, gotError)
 }
 
 func AppendDiagWarningMessage(diags diag.Diagnostics, service, action, resource, id, message string) diag.Diagnostics {

--- a/internal/service/lambda/function_url.go
+++ b/internal/service/lambda/function_url.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
@@ -123,6 +124,8 @@ func ResourceFunctionURL() *schema.Resource {
 }
 
 func resourceFunctionURLCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LambdaConn(ctx)
 
 	name := d.Get("function_name").(string)
@@ -146,7 +149,7 @@ func resourceFunctionURLCreate(ctx context.Context, d *schema.ResourceData, meta
 	_, err := conn.CreateFunctionUrlConfigWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating Lambda Function URL (%s): %s", id, err)
+		return sdkdiag.AppendErrorf(diags, "creating Lambda Function URL (%s): %s", id, err)
 	}
 
 	d.SetId(id)
@@ -171,21 +174,23 @@ func resourceFunctionURLCreate(ctx context.Context, d *schema.ResourceData, meta
 			if tfawserr.ErrMessageContains(err, lambda.ErrCodeResourceConflictException, "The statement id (FunctionURLAllowPublicAccess) provided already exists") {
 				log.Printf("[DEBUG] function permission statement 'FunctionURLAllowPublicAccess' already exists.")
 			} else {
-				return diag.Errorf("adding Lambda Function URL (%s) permission %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "adding Lambda Function URL (%s) permission %s", d.Id(), err)
 			}
 		}
 	}
 
-	return resourceFunctionURLRead(ctx, d, meta)
+	return append(diags, resourceFunctionURLRead(ctx, d, meta)...)
 }
 
 func resourceFunctionURLRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LambdaConn(ctx)
 
 	name, qualifier, err := FunctionURLParseResourceID(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	output, err := FindFunctionURLByNameAndQualifier(ctx, conn, name, qualifier)
@@ -193,11 +198,11 @@ func resourceFunctionURLRead(ctx context.Context, d *schema.ResourceData, meta i
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Lambda Function URL %s not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Lambda Function URL (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Lambda Function URL (%s): %s", d.Id(), err)
 	}
 
 	functionURL := aws.StringValue(output.FunctionUrl)
@@ -205,7 +210,7 @@ func resourceFunctionURLRead(ctx context.Context, d *schema.ResourceData, meta i
 	d.Set("authorization_type", output.AuthType)
 	if output.Cors != nil {
 		if err := d.Set("cors", []interface{}{flattenCors(output.Cors)}); err != nil {
-			return diag.Errorf("setting cors: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting cors: %s", err)
 		}
 	} else {
 		d.Set("cors", nil)
@@ -219,23 +224,25 @@ func resourceFunctionURLRead(ctx context.Context, d *schema.ResourceData, meta i
 	// Function URL endpoints have the following format:
 	// https://<url-id>.lambda-url.<region>.on.aws
 	if v, err := url.Parse(functionURL); err != nil {
-		return diag.Errorf("parsing URL (%s): %s", functionURL, err)
+		return sdkdiag.AppendErrorf(diags, "parsing URL (%s): %s", functionURL, err)
 	} else if v := strings.Split(v.Host, "."); len(v) > 0 {
 		d.Set("url_id", v[0])
 	} else {
 		d.Set("url_id", nil)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceFunctionURLUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LambdaConn(ctx)
 
 	name, qualifier, err := FunctionURLParseResourceID(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	input := &lambda.UpdateFunctionUrlConfigInput{
@@ -266,19 +273,21 @@ func resourceFunctionURLUpdate(ctx context.Context, d *schema.ResourceData, meta
 	_, err = conn.UpdateFunctionUrlConfigWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("updating Lambda Function URL (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "updating Lambda Function URL (%s): %s", d.Id(), err)
 	}
 
-	return resourceFunctionURLRead(ctx, d, meta)
+	return append(diags, resourceFunctionURLRead(ctx, d, meta)...)
 }
 
 func resourceFunctionURLDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LambdaConn(ctx)
 
 	name, qualifier, err := FunctionURLParseResourceID(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	input := &lambda.DeleteFunctionUrlConfigInput{
@@ -293,14 +302,14 @@ func resourceFunctionURLDelete(ctx context.Context, d *schema.ResourceData, meta
 	_, err = conn.DeleteFunctionUrlConfigWithContext(ctx, input)
 
 	if tfawserr.ErrCodeEquals(err, lambda.ErrCodeResourceNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting Lambda Function URL (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Lambda Function URL (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func FindFunctionURLByNameAndQualifier(ctx context.Context, conn *lambda.Lambda, name, qualifier string) (*lambda.GetFunctionUrlConfigOutput, error) {

--- a/internal/service/lambda/function_url_data_source.go
+++ b/internal/service/lambda/function_url_data_source.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 )
 
 // @SDKDataSource("aws_lambda_function_url")
@@ -97,6 +98,8 @@ func DataSourceFunctionURL() *schema.Resource {
 }
 
 func dataSourceFunctionURLRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LambdaConn(ctx)
 
 	name := d.Get("function_name").(string)
@@ -105,7 +108,7 @@ func dataSourceFunctionURLRead(ctx context.Context, d *schema.ResourceData, meta
 	output, err := FindFunctionURLByNameAndQualifier(ctx, conn, name, qualifier)
 
 	if err != nil {
-		return diag.Errorf("reading Lambda Function URL (%s): %s", id, err)
+		return sdkdiag.AppendErrorf(diags, "reading Lambda Function URL (%s): %s", id, err)
 	}
 
 	functionURL := aws.StringValue(output.FunctionUrl)
@@ -114,7 +117,7 @@ func dataSourceFunctionURLRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set("authorization_type", output.AuthType)
 	if output.Cors != nil {
 		if err := d.Set("cors", []interface{}{flattenCors(output.Cors)}); err != nil {
-			return diag.Errorf("setting cors: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting cors: %s", err)
 		}
 	} else {
 		d.Set("cors", nil)
@@ -130,12 +133,12 @@ func dataSourceFunctionURLRead(ctx context.Context, d *schema.ResourceData, meta
 	// Function URL endpoints have the following format:
 	// https://<url-id>.lambda-url.<region>.on.aws
 	if v, err := url.Parse(functionURL); err != nil {
-		return diag.Errorf("parsing URL (%s): %s", functionURL, err)
+		return sdkdiag.AppendErrorf(diags, "parsing URL (%s): %s", functionURL, err)
 	} else if v := strings.Split(v.Host, "."); len(v) > 0 {
 		d.Set("url_id", v[0])
 	} else {
 		d.Set("url_id", nil)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/lambda/functions_data_source.go
+++ b/internal/service/lambda/functions_data_source.go
@@ -40,6 +40,8 @@ func DataSourceFunctions() *schema.Resource {
 }
 
 func dataSourceFunctionsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LambdaConn(ctx)
 
 	input := &lambda.ListFunctionsInput{}
@@ -65,12 +67,12 @@ func dataSourceFunctionsRead(ctx context.Context, d *schema.ResourceData, meta i
 	})
 
 	if err != nil {
-		return create.DiagError(names.Lambda, create.ErrActionReading, DSNameFunctions, "", err)
+		return create.AppendDiagError(diags, names.Lambda, create.ErrActionReading, DSNameFunctions, "", err)
 	}
 
 	d.SetId(meta.(*conns.AWSClient).Region)
 	d.Set("function_arns", functionARNs)
 	d.Set("function_names", functionNames)
 
-	return nil
+	return diags
 }

--- a/internal/service/lambda/layer_version.go
+++ b/internal/service/lambda/layer_version.go
@@ -221,11 +221,11 @@ func resourceLayerVersionRead(ctx context.Context, d *schema.ResourceData, meta 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Lambda Layer Version %s not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Lambda Layer Version (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Lambda Layer Version (%s): %s", d.Id(), err)
 	}
 
 	d.Set("arn", output.LayerVersionArn)

--- a/internal/service/licensemanager/association.go
+++ b/internal/service/licensemanager/association.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
@@ -48,6 +49,8 @@ func ResourceAssociation() *schema.Resource {
 }
 
 func resourceAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LicenseManagerConn(ctx)
 
 	licenseConfigurationARN := d.Get("license_configuration_arn").(string)
@@ -64,21 +67,23 @@ func resourceAssociationCreate(ctx context.Context, d *schema.ResourceData, meta
 	_, err := conn.UpdateLicenseSpecificationsForResourceWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating License Manager Association: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating License Manager Association: %s", err)
 	}
 
 	d.SetId(AssociationCreateResourceID(resourceARN, licenseConfigurationARN))
 
-	return resourceAssociationRead(ctx, d, meta)
+	return append(diags, resourceAssociationRead(ctx, d, meta)...)
 }
 
 func resourceAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LicenseManagerConn(ctx)
 
 	resourceARN, licenseConfigurationARN, err := AssociationParseResourceID(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	err = FindAssociation(ctx, conn, resourceARN, licenseConfigurationARN)
@@ -86,26 +91,28 @@ func resourceAssociationRead(ctx context.Context, d *schema.ResourceData, meta i
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] License Manager Association %s not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading License Manager Association (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading License Manager Association (%s): %s", d.Id(), err)
 	}
 
 	d.Set("license_configuration_arn", licenseConfigurationARN)
 	d.Set("resource_arn", resourceARN)
 
-	return nil
+	return diags
 }
 
 func resourceAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LicenseManagerConn(ctx)
 
 	resourceARN, licenseConfigurationARN, err := AssociationParseResourceID(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	input := &licensemanager.UpdateLicenseSpecificationsForResourceInput{
@@ -118,10 +125,10 @@ func resourceAssociationDelete(ctx context.Context, d *schema.ResourceData, meta
 	_, err = conn.UpdateLicenseSpecificationsForResourceWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("deleting License Manager Association (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting License Manager Association (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func FindAssociation(ctx context.Context, conn *licensemanager.LicenseManager, resourceARN, licenseConfigurationARN string) error {

--- a/internal/service/licensemanager/grant.go
+++ b/internal/service/licensemanager/grant.go
@@ -98,6 +98,8 @@ func ResourceGrant() *schema.Resource {
 }
 
 func resourceGrantCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LicenseManagerConn(ctx)
 
 	in := &licensemanager.CreateGrantInput{
@@ -112,15 +114,17 @@ func resourceGrantCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	out, err := conn.CreateGrantWithContext(ctx, in)
 
 	if err != nil {
-		return create.DiagError(names.LicenseManager, create.ErrActionCreating, ResGrant, d.Get("name").(string), err)
+		return create.AppendDiagError(diags, names.LicenseManager, create.ErrActionCreating, ResGrant, d.Get("name").(string), err)
 	}
 
 	d.SetId(aws.StringValue(out.GrantArn))
 
-	return resourceGrantRead(ctx, d, meta)
+	return append(diags, resourceGrantRead(ctx, d, meta)...)
 }
 
 func resourceGrantRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LicenseManagerConn(ctx)
 
 	out, err := FindGrantByARN(ctx, conn, d.Id())
@@ -128,11 +132,11 @@ func resourceGrantRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		create.LogNotFoundRemoveState(names.LicenseManager, create.ErrActionReading, ResGrant, d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.LicenseManager, create.ErrActionReading, ResGrant, d.Id(), err)
+		return create.AppendDiagError(diags, names.LicenseManager, create.ErrActionReading, ResGrant, d.Id(), err)
 	}
 
 	d.Set("allowed_operations", out.GrantedOperations)
@@ -145,10 +149,12 @@ func resourceGrantRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	d.Set("status", out.GrantStatus)
 	d.Set("version", out.Version)
 
-	return nil
+	return diags
 }
 
 func resourceGrantUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LicenseManagerConn(ctx)
 
 	in := &licensemanager.CreateGrantVersionInput{
@@ -167,24 +173,26 @@ func resourceGrantUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 	_, err := conn.CreateGrantVersionWithContext(ctx, in)
 
 	if err != nil {
-		return create.DiagError(names.LicenseManager, create.ErrActionUpdating, ResGrant, d.Id(), err)
+		return create.AppendDiagError(diags, names.LicenseManager, create.ErrActionUpdating, ResGrant, d.Id(), err)
 	}
 
-	return resourceGrantRead(ctx, d, meta)
+	return append(diags, resourceGrantRead(ctx, d, meta)...)
 }
 
 func resourceGrantDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LicenseManagerConn(ctx)
 
 	out, err := FindGrantByARN(ctx, conn, d.Id())
 
 	if tfresource.NotFound(err) {
 		create.LogNotFoundRemoveState(names.LicenseManager, create.ErrActionReading, ResGrant, d.Id())
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.LicenseManager, create.ErrActionReading, ResGrant, d.Id(), err)
+		return create.AppendDiagError(diags, names.LicenseManager, create.ErrActionReading, ResGrant, d.Id(), err)
 	}
 
 	in := &licensemanager.DeleteGrantInput{
@@ -195,10 +203,10 @@ func resourceGrantDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	_, err = conn.DeleteGrantWithContext(ctx, in)
 
 	if err != nil {
-		return create.DiagError(names.LicenseManager, create.ErrActionDeleting, ResGrant, d.Id(), err)
+		return create.AppendDiagError(diags, names.LicenseManager, create.ErrActionDeleting, ResGrant, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func FindGrantByARN(ctx context.Context, conn *licensemanager.LicenseManager, arn string) (*licensemanager.Grant, error) {

--- a/internal/service/licensemanager/license_configuration.go
+++ b/internal/service/licensemanager/license_configuration.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -86,6 +87,8 @@ func ResourceLicenseConfiguration() *schema.Resource {
 }
 
 func resourceLicenseConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LicenseManagerConn(ctx)
 
 	name := d.Get("name").(string)
@@ -114,15 +117,17 @@ func resourceLicenseConfigurationCreate(ctx context.Context, d *schema.ResourceD
 	output, err := conn.CreateLicenseConfigurationWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating License Manager License Configuration (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "creating License Manager License Configuration (%s): %s", name, err)
 	}
 
 	d.SetId(aws.StringValue(output.LicenseConfigurationArn))
 
-	return resourceLicenseConfigurationRead(ctx, d, meta)
+	return append(diags, resourceLicenseConfigurationRead(ctx, d, meta)...)
 }
 
 func resourceLicenseConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LicenseManagerConn(ctx)
 
 	output, err := FindLicenseConfigurationByARN(ctx, conn, d.Id())
@@ -130,11 +135,11 @@ func resourceLicenseConfigurationRead(ctx context.Context, d *schema.ResourceDat
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] License Manager License Configuration %s not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading License Manager License Configuration (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading License Manager License Configuration (%s): %s", d.Id(), err)
 	}
 
 	d.Set("arn", output.LicenseConfigurationArn)
@@ -148,10 +153,12 @@ func resourceLicenseConfigurationRead(ctx context.Context, d *schema.ResourceDat
 
 	setTagsOut(ctx, output.Tags)
 
-	return nil
+	return diags
 }
 
 func resourceLicenseConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LicenseManagerConn(ctx)
 
 	if d.HasChangesExcept("tags", "tags_all") {
@@ -169,14 +176,16 @@ func resourceLicenseConfigurationUpdate(ctx context.Context, d *schema.ResourceD
 		_, err := conn.UpdateLicenseConfigurationWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("updating License Manager License Configuration (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating License Manager License Configuration (%s): %s", d.Id(), err)
 		}
 	}
 
-	return resourceLicenseConfigurationRead(ctx, d, meta)
+	return append(diags, resourceLicenseConfigurationRead(ctx, d, meta)...)
 }
 
 func resourceLicenseConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LicenseManagerConn(ctx)
 
 	log.Printf("[DEBUG] Deleting License Manager License Configuration: %s", d.Id())
@@ -185,14 +194,14 @@ func resourceLicenseConfigurationDelete(ctx context.Context, d *schema.ResourceD
 	})
 
 	if tfawserr.ErrMessageContains(err, licensemanager.ErrCodeInvalidParameterValueException, "Invalid license configuration ARN") {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting License Manager License Configuration (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting License Manager License Configuration (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func FindLicenseConfigurationByARN(ctx context.Context, conn *licensemanager.LicenseManager, arn string) (*licensemanager.GetLicenseConfigurationOutput, error) {

--- a/internal/service/lightsail/bucket_access_key.go
+++ b/internal/service/lightsail/bucket_access_key.go
@@ -65,6 +65,8 @@ func ResourceBucketAccessKey() *schema.Resource {
 }
 
 func resourceBucketAccessKeyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 
 	in := lightsail.CreateBucketAccessKeyInput{
@@ -74,7 +76,7 @@ func resourceBucketAccessKeyCreate(ctx context.Context, d *schema.ResourceData, 
 	out, err := conn.CreateBucketAccessKey(ctx, &in)
 
 	if err != nil {
-		return create.DiagError(names.Lightsail, string(types.OperationTypeCreateBucketAccessKey), ResBucketAccessKey, d.Get("bucket_name").(string), err)
+		return create.AppendDiagError(diags, names.Lightsail, string(types.OperationTypeCreateBucketAccessKey), ResBucketAccessKey, d.Get("bucket_name").(string), err)
 	}
 
 	diag := expandOperations(ctx, conn, out.Operations, types.OperationTypeCreateBucketAccessKey, ResBucketAccessKey, d.Get("bucket_name").(string))
@@ -87,16 +89,18 @@ func resourceBucketAccessKeyCreate(ctx context.Context, d *schema.ResourceData, 
 	id, err := flex.FlattenResourceId(idParts, BucketAccessKeyIdPartsCount, false)
 
 	if err != nil {
-		return create.DiagError(names.Lightsail, create.ErrActionFlatteningResourceId, ResBucketAccessKey, d.Get("bucket_name").(string), err)
+		return create.AppendDiagError(diags, names.Lightsail, create.ErrActionFlatteningResourceId, ResBucketAccessKey, d.Get("bucket_name").(string), err)
 	}
 
 	d.SetId(id)
 	d.Set("secret_access_key", out.AccessKey.SecretAccessKey)
 
-	return resourceBucketAccessKeyRead(ctx, d, meta)
+	return append(diags, resourceBucketAccessKeyRead(ctx, d, meta)...)
 }
 
 func resourceBucketAccessKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 
 	out, err := FindBucketAccessKeyById(ctx, conn, d.Id())
@@ -104,11 +108,11 @@ func resourceBucketAccessKeyRead(ctx context.Context, d *schema.ResourceData, me
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		create.LogNotFoundRemoveState(names.Lightsail, create.ErrActionReading, ResBucketAccessKey, d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.Lightsail, create.ErrActionReading, ResBucketAccessKey, d.Id(), err)
+		return create.AppendDiagError(diags, names.Lightsail, create.ErrActionReading, ResBucketAccessKey, d.Id(), err)
 	}
 
 	d.Set("access_key_id", out.AccessKeyId)
@@ -116,15 +120,17 @@ func resourceBucketAccessKeyRead(ctx context.Context, d *schema.ResourceData, me
 	d.Set("created_at", out.CreatedAt.Format(time.RFC3339))
 	d.Set("status", out.Status)
 
-	return nil
+	return diags
 }
 
 func resourceBucketAccessKeyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 	parts, err := flex.ExpandResourceId(d.Id(), BucketAccessKeyIdPartsCount, false)
 
 	if err != nil {
-		return create.DiagError(names.Lightsail, create.ErrActionExpandingResourceId, ResBucketAccessKey, d.Id(), err)
+		return create.AppendDiagError(diags, names.Lightsail, create.ErrActionExpandingResourceId, ResBucketAccessKey, d.Id(), err)
 	}
 
 	out, err := conn.DeleteBucketAccessKey(ctx, &lightsail.DeleteBucketAccessKeyInput{
@@ -133,11 +139,11 @@ func resourceBucketAccessKeyDelete(ctx context.Context, d *schema.ResourceData, 
 	})
 
 	if err != nil && errs.IsA[*types.NotFoundException](err) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.Lightsail, create.ErrActionDeleting, ResBucketAccessKey, d.Id(), err)
+		return create.AppendDiagError(diags, names.Lightsail, create.ErrActionDeleting, ResBucketAccessKey, d.Id(), err)
 	}
 
 	diag := expandOperations(ctx, conn, out.Operations, types.OperationTypeDeleteBucketAccessKey, ResBucketAccessKey, d.Id())
@@ -146,7 +152,7 @@ func resourceBucketAccessKeyDelete(ctx context.Context, d *schema.ResourceData, 
 		return diag
 	}
 
-	return nil
+	return diags
 }
 
 func FindBucketAccessKeyById(ctx context.Context, conn *lightsail.Client, id string) (*types.AccessKey, error) {

--- a/internal/service/lightsail/bucket_resource_access.go
+++ b/internal/service/lightsail/bucket_resource_access.go
@@ -54,6 +54,8 @@ func ResourceBucketResourceAccess() *schema.Resource {
 }
 
 func resourceBucketResourceAccessCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 
 	in := lightsail.SetResourceAccessForBucketInput{
@@ -65,7 +67,7 @@ func resourceBucketResourceAccessCreate(ctx context.Context, d *schema.ResourceD
 	out, err := conn.SetResourceAccessForBucket(ctx, &in)
 
 	if err != nil {
-		return create.DiagError(names.Lightsail, string(types.OperationTypeSetResourceAccessForBucket), ResBucketResourceAccess, d.Get("bucket_name").(string), err)
+		return create.AppendDiagError(diags, names.Lightsail, string(types.OperationTypeSetResourceAccessForBucket), ResBucketResourceAccess, d.Get("bucket_name").(string), err)
 	}
 
 	diag := expandOperations(ctx, conn, out.Operations, types.OperationTypeSetResourceAccessForBucket, ResBucketResourceAccess, d.Get("bucket_name").(string))
@@ -78,15 +80,17 @@ func resourceBucketResourceAccessCreate(ctx context.Context, d *schema.ResourceD
 	id, err := flex.FlattenResourceId(idParts, BucketResourceAccessIdPartsCount, false)
 
 	if err != nil {
-		return create.DiagError(names.Lightsail, create.ErrActionFlatteningResourceId, ResBucketResourceAccess, d.Get("bucket_name").(string), err)
+		return create.AppendDiagError(diags, names.Lightsail, create.ErrActionFlatteningResourceId, ResBucketResourceAccess, d.Get("bucket_name").(string), err)
 	}
 
 	d.SetId(id)
 
-	return resourceBucketResourceAccessRead(ctx, d, meta)
+	return append(diags, resourceBucketResourceAccessRead(ctx, d, meta)...)
 }
 
 func resourceBucketResourceAccessRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 
 	out, err := FindBucketResourceAccessById(ctx, conn, d.Id())
@@ -94,31 +98,33 @@ func resourceBucketResourceAccessRead(ctx context.Context, d *schema.ResourceDat
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		create.LogNotFoundRemoveState(names.Lightsail, create.ErrActionReading, ResBucketResourceAccess, d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.Lightsail, create.ErrActionReading, ResBucketResourceAccess, d.Id(), err)
+		return create.AppendDiagError(diags, names.Lightsail, create.ErrActionReading, ResBucketResourceAccess, d.Id(), err)
 	}
 
 	parts, err := flex.ExpandResourceId(d.Id(), BucketResourceAccessIdPartsCount, false)
 
 	if err != nil {
-		return create.DiagError(names.Lightsail, create.ErrActionExpandingResourceId, ResBucketResourceAccess, d.Id(), err)
+		return create.AppendDiagError(diags, names.Lightsail, create.ErrActionExpandingResourceId, ResBucketResourceAccess, d.Id(), err)
 	}
 
 	d.Set("bucket_name", parts[0])
 	d.Set("resource_name", out.Name)
 
-	return nil
+	return diags
 }
 
 func resourceBucketResourceAccessDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 	parts, err := flex.ExpandResourceId(d.Id(), BucketResourceAccessIdPartsCount, false)
 
 	if err != nil {
-		return create.DiagError(names.Lightsail, create.ErrActionExpandingResourceId, ResBucketResourceAccess, d.Id(), err)
+		return create.AppendDiagError(diags, names.Lightsail, create.ErrActionExpandingResourceId, ResBucketResourceAccess, d.Id(), err)
 	}
 
 	out, err := conn.SetResourceAccessForBucket(ctx, &lightsail.SetResourceAccessForBucketInput{
@@ -128,11 +134,11 @@ func resourceBucketResourceAccessDelete(ctx context.Context, d *schema.ResourceD
 	})
 
 	if err != nil && errs.IsA[*types.NotFoundException](err) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.Lightsail, string(types.OperationTypeSetResourceAccessForBucket), ResBucketResourceAccess, d.Id(), err)
+		return create.AppendDiagError(diags, names.Lightsail, string(types.OperationTypeSetResourceAccessForBucket), ResBucketResourceAccess, d.Id(), err)
 	}
 
 	diag := expandOperations(ctx, conn, out.Operations, types.OperationTypeSetResourceAccessForBucket, ResBucketResourceAccess, d.Id())
@@ -141,7 +147,7 @@ func resourceBucketResourceAccessDelete(ctx context.Context, d *schema.ResourceD
 		return diag
 	}
 
-	return nil
+	return diags
 }
 
 func FindBucketResourceAccessById(ctx context.Context, conn *lightsail.Client, id string) (*types.ResourceReceivingAccess, error) {

--- a/internal/service/lightsail/certificate.go
+++ b/internal/service/lightsail/certificate.go
@@ -134,6 +134,8 @@ func ResourceCertificate() *schema.Resource {
 }
 
 func resourceCertificateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 
 	req := lightsail.CreateCertificateInput{
@@ -149,7 +151,7 @@ func resourceCertificateCreate(ctx context.Context, d *schema.ResourceData, meta
 	resp, err := conn.CreateCertificate(ctx, &req)
 
 	if err != nil {
-		return create.DiagError(names.Lightsail, string(types.OperationTypeCreateCertificate), ResCertificate, d.Get("name").(string), err)
+		return create.AppendDiagError(diags, names.Lightsail, string(types.OperationTypeCreateCertificate), ResCertificate, d.Get("name").(string), err)
 	}
 
 	id := d.Get("name").(string)
@@ -161,10 +163,12 @@ func resourceCertificateCreate(ctx context.Context, d *schema.ResourceData, meta
 
 	d.SetId(id)
 
-	return resourceCertificateRead(ctx, d, meta)
+	return append(diags, resourceCertificateRead(ctx, d, meta)...)
 }
 
 func resourceCertificateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 
 	certificate, err := FindCertificateById(ctx, conn, d.Id())
@@ -172,11 +176,11 @@ func resourceCertificateRead(ctx context.Context, d *schema.ResourceData, meta i
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		create.LogNotFoundRemoveState(names.Lightsail, create.ErrActionReading, ResCertificate, d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.Lightsail, create.ErrActionReading, ResCertificate, d.Id(), err)
+		return create.AppendDiagError(diags, names.Lightsail, create.ErrActionReading, ResCertificate, d.Id(), err)
 	}
 
 	d.Set("arn", certificate.Arn)
@@ -188,7 +192,7 @@ func resourceCertificateRead(ctx context.Context, d *schema.ResourceData, meta i
 
 	setTagsOut(ctx, certificate.Tags)
 
-	return nil
+	return diags
 }
 
 func resourceCertificateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -197,6 +201,8 @@ func resourceCertificateUpdate(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func resourceCertificateDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 
 	resp, err := conn.DeleteCertificate(ctx, &lightsail.DeleteCertificateInput{
@@ -204,11 +210,11 @@ func resourceCertificateDelete(ctx context.Context, d *schema.ResourceData, meta
 	})
 
 	if err != nil && errs.IsA[*types.NotFoundException](err) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.Lightsail, create.ErrActionDeleting, ResCertificate, d.Id(), err)
+		return create.AppendDiagError(diags, names.Lightsail, create.ErrActionDeleting, ResCertificate, d.Id(), err)
 	}
 
 	diag := expandOperations(ctx, conn, resp.Operations, types.OperationTypeDeleteCertificate, ResCertificate, d.Id())
@@ -217,7 +223,7 @@ func resourceCertificateDelete(ctx context.Context, d *schema.ResourceData, meta
 		return diag
 	}
 
-	return nil
+	return diags
 }
 
 func domainValidationOptionsHash(v interface{}) int {

--- a/internal/service/lightsail/container_service.go
+++ b/internal/service/lightsail/container_service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -169,6 +170,8 @@ func ResourceContainerService() *schema.Resource {
 }
 
 func resourceContainerServiceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 
 	serviceName := d.Get("name").(string)
@@ -189,13 +192,13 @@ func resourceContainerServiceCreate(ctx context.Context, d *schema.ResourceData,
 
 	_, err := conn.CreateContainerService(ctx, input)
 	if err != nil {
-		return diag.Errorf("creating Lightsail Container Service (%s): %s", serviceName, err)
+		return sdkdiag.AppendErrorf(diags, "creating Lightsail Container Service (%s): %s", serviceName, err)
 	}
 
 	d.SetId(serviceName)
 
 	if err := waitContainerServiceCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return diag.Errorf("waiting for Lightsail Container Service (%s) creation: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Lightsail Container Service (%s) creation: %s", d.Id(), err)
 	}
 
 	// once container service creation and/or deployment successful (now enabled by default), disable it if "is_disabled" is true
@@ -207,18 +210,20 @@ func resourceContainerServiceCreate(ctx context.Context, d *schema.ResourceData,
 
 		_, err := conn.UpdateContainerService(ctx, input)
 		if err != nil {
-			return diag.Errorf("disabling Lightsail Container Service (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "disabling Lightsail Container Service (%s): %s", d.Id(), err)
 		}
 
 		if err := waitContainerServiceDisabled(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-			return diag.Errorf("waiting for Lightsail Container Service (%s) to be disabled: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "waiting for Lightsail Container Service (%s) to be disabled: %s", d.Id(), err)
 		}
 	}
 
-	return resourceContainerServiceRead(ctx, d, meta)
+	return append(diags, resourceContainerServiceRead(ctx, d, meta)...)
 }
 
 func resourceContainerServiceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 
 	cs, err := FindContainerServiceByName(ctx, conn, d.Id())
@@ -226,11 +231,11 @@ func resourceContainerServiceRead(ctx context.Context, d *schema.ResourceData, m
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Lightsail Container Service (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Lightsail Container Service (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Lightsail Container Service (%s): %s", d.Id(), err)
 	}
 
 	d.Set("name", cs.ContainerServiceName)
@@ -239,10 +244,10 @@ func resourceContainerServiceRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set("is_disabled", cs.IsDisabled)
 
 	if err := d.Set("public_domain_names", flattenContainerServicePublicDomainNames(cs.PublicDomainNames)); err != nil {
-		return diag.Errorf("setting public_domain_names for Lightsail Container Service (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "setting public_domain_names for Lightsail Container Service (%s): %s", d.Id(), err)
 	}
 	if err := d.Set("private_registry_access", []interface{}{flattenPrivateRegistryAccess(cs.PrivateRegistryAccess)}); err != nil {
-		return diag.Errorf("setting private_registry_access for Lightsail Container Service (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "setting private_registry_access for Lightsail Container Service (%s): %s", d.Id(), err)
 	}
 	d.Set("arn", cs.Arn)
 	d.Set("availability_zone", cs.Location.AvailabilityZone)
@@ -256,10 +261,12 @@ func resourceContainerServiceRead(ctx context.Context, d *schema.ResourceData, m
 
 	setTagsOut(ctx, cs.Tags)
 
-	return nil
+	return diags
 }
 
 func resourceContainerServiceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 
 	if d.HasChangesExcept("tags", "tags_all") {
@@ -275,24 +282,26 @@ func resourceContainerServiceUpdate(ctx context.Context, d *schema.ResourceData,
 
 		_, err := conn.UpdateContainerService(ctx, input)
 		if err != nil {
-			return diag.Errorf("updating Lightsail Container Service (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating Lightsail Container Service (%s): %s", d.Id(), err)
 		}
 
 		if d.HasChange("is_disabled") && d.Get("is_disabled").(bool) {
 			if err := waitContainerServiceDisabled(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-				return diag.Errorf("waiting for Lightsail Container Service (%s) update: %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "waiting for Lightsail Container Service (%s) update: %s", d.Id(), err)
 			}
 		} else {
 			if err := waitContainerServiceUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-				return diag.Errorf("waiting for Lightsail Container Service (%s) update: %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "waiting for Lightsail Container Service (%s) update: %s", d.Id(), err)
 			}
 		}
 	}
 
-	return resourceContainerServiceRead(ctx, d, meta)
+	return append(diags, resourceContainerServiceRead(ctx, d, meta)...)
 }
 
 func resourceContainerServiceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 
 	input := &lightsail.DeleteContainerServiceInput{
@@ -302,18 +311,18 @@ func resourceContainerServiceDelete(ctx context.Context, d *schema.ResourceData,
 	_, err := conn.DeleteContainerService(ctx, input)
 
 	if IsANotFoundError(err) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting Lightsail Container Service (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Lightsail Container Service (%s): %s", d.Id(), err)
 	}
 
 	if err := waitContainerServiceDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return diag.Errorf("waiting for Lightsail Container Service (%s) deletion: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Lightsail Container Service (%s) deletion: %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func expandContainerServicePublicDomainNames(rawPublicDomainNames []interface{}) map[string][]string {

--- a/internal/service/lightsail/database.go
+++ b/internal/service/lightsail/database.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -189,6 +190,8 @@ func ResourceDatabase() *schema.Resource {
 }
 
 func resourceDatabaseCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 
 	relationalDatabaseName := d.Get("relational_database_name").(string)
@@ -224,7 +227,7 @@ func resourceDatabaseCreate(ctx context.Context, d *schema.ResourceData, meta in
 	output, err := conn.CreateRelationalDatabase(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating Lightsail Relational Database (%s): %s", relationalDatabaseName, err)
+		return sdkdiag.AppendErrorf(diags, "creating Lightsail Relational Database (%s): %s", relationalDatabaseName, err)
 	}
 
 	diagError := expandOperations(ctx, conn, output.Operations, types.OperationTypeCreateRelationalDatabase, ResNameDatabase, relationalDatabaseName)
@@ -247,7 +250,7 @@ func resourceDatabaseCreate(ctx context.Context, d *schema.ResourceData, meta in
 		output, err := conn.UpdateRelationalDatabase(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("updating Lightsail Relational Database (%s) backup retention: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating Lightsail Relational Database (%s) backup retention: %s", d.Id(), err)
 		}
 
 		diagError := expandOperations(ctx, conn, output.Operations, types.OperationTypeUpdateRelationalDatabase, ResNameDatabase, relationalDatabaseName)
@@ -257,19 +260,21 @@ func resourceDatabaseCreate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		if err := waitDatabaseBackupRetentionModified(ctx, conn, aws.String(d.Id()), false); err != nil {
-			return diag.Errorf("waiting for Lightsail Relational Database (%s) backup retention update: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "waiting for Lightsail Relational Database (%s) backup retention update: %s", d.Id(), err)
 		}
 	}
 
 	// Some Operations can complete before the Database enters the Available state. Added a waiter to make sure the Database is available before continuing.
 	if _, err = waitDatabaseModified(ctx, conn, aws.String(d.Id())); err != nil {
-		return diag.Errorf("waiting for Lightsail Relational Database (%s) to become available: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Lightsail Relational Database (%s) to become available: %s", d.Id(), err)
 	}
 
-	return resourceDatabaseRead(ctx, d, meta)
+	return append(diags, resourceDatabaseRead(ctx, d, meta)...)
 }
 
 func resourceDatabaseRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 
 	// Some Operations can complete before the Database enters the Available state. Added a waiter to make sure the Database is available before continuing.
@@ -279,11 +284,11 @@ func resourceDatabaseRead(ctx context.Context, d *schema.ResourceData, meta inte
 	if !d.IsNewResource() && IsANotFoundError(err) {
 		log.Printf("[WARN] Lightsail Relational Database (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Lightsail Relational Database (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Lightsail Relational Database (%s): %s", d.Id(), err)
 	}
 
 	rd := database.RelationalDatabase
@@ -313,10 +318,12 @@ func resourceDatabaseRead(ctx context.Context, d *schema.ResourceData, meta inte
 
 	setTagsOut(ctx, rd.Tags)
 
-	return nil
+	return diags
 }
 
 func resourceDatabaseUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 
 	if d.HasChangesExcept("apply_immediately", "final_snapshot_name", "skip_final_snapshot", "tags", "tags_all") {
@@ -356,7 +363,7 @@ func resourceDatabaseUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		output, err := conn.UpdateRelationalDatabase(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("updating Lightsail Relational Database (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating Lightsail Relational Database (%s): %s", d.Id(), err)
 		}
 
 		diagError := expandOperations(ctx, conn, output.Operations, types.OperationTypeUpdateRelationalDatabase, ResNameDatabase, d.Id())
@@ -367,31 +374,33 @@ func resourceDatabaseUpdate(ctx context.Context, d *schema.ResourceData, meta in
 
 		if d.HasChange("backup_retention_enabled") {
 			if err := waitDatabaseBackupRetentionModified(ctx, conn, aws.String(d.Id()), d.Get("backup_retention_enabled").(bool)); err != nil {
-				return diag.Errorf("waiting for Lightsail Relational Database (%s) backup retention update: %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "waiting for Lightsail Relational Database (%s) backup retention update: %s", d.Id(), err)
 			}
 		}
 
 		if d.HasChange("publicly_accessible") {
 			if err := waitDatabasePubliclyAccessibleModified(ctx, conn, aws.String(d.Id()), d.Get("publicly_accessible").(bool)); err != nil {
-				return diag.Errorf("waiting for Lightsail Relational Database (%s) publicly accessible update: %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "waiting for Lightsail Relational Database (%s) publicly accessible update: %s", d.Id(), err)
 			}
 		}
 
 		// Some Operations can complete before the Database enters the Available state. Added a waiter to make sure the Database is available before continuing.
 		if _, err = waitDatabaseModified(ctx, conn, aws.String(d.Id())); err != nil {
-			return diag.Errorf("waiting for Lightsail Relational Database (%s) to become available: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "waiting for Lightsail Relational Database (%s) to become available: %s", d.Id(), err)
 		}
 	}
 
-	return resourceDatabaseRead(ctx, d, meta)
+	return append(diags, resourceDatabaseRead(ctx, d, meta)...)
 }
 
 func resourceDatabaseDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 
 	// Some Operations can complete before the Database enters the Available state. Added a waiter to make sure the Database is available before continuing.
 	if _, err := waitDatabaseModified(ctx, conn, aws.String(d.Id())); err != nil {
-		return diag.Errorf("waiting for Lightsail Relational Database (%s) to become available: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Lightsail Relational Database (%s) to become available: %s", d.Id(), err)
 	}
 
 	skipFinalSnapshot := d.Get("skip_final_snapshot").(bool)
@@ -405,14 +414,14 @@ func resourceDatabaseDelete(ctx context.Context, d *schema.ResourceData, meta in
 		if name, present := d.GetOk("final_snapshot_name"); present {
 			input.FinalRelationalDatabaseSnapshotName = aws.String(name.(string))
 		} else {
-			return diag.Errorf("Lightsail Database FinalRelationalDatabaseSnapshotName is required when a final snapshot is required")
+			return sdkdiag.AppendErrorf(diags, "Lightsail Database FinalRelationalDatabaseSnapshotName is required when a final snapshot is required")
 		}
 	}
 
 	output, err := conn.DeleteRelationalDatabase(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("deleting Lightsail Relational Database (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Lightsail Relational Database (%s): %s", d.Id(), err)
 	}
 
 	diagError := expandOperations(ctx, conn, output.Operations, types.OperationTypeDeleteRelationalDatabase, ResNameDatabase, d.Id())
@@ -421,7 +430,7 @@ func resourceDatabaseDelete(ctx context.Context, d *schema.ResourceData, meta in
 		return diagError
 	}
 
-	return nil
+	return diags
 }
 
 func resourceDatabaseImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {

--- a/internal/service/lightsail/disk.go
+++ b/internal/service/lightsail/disk.go
@@ -77,6 +77,8 @@ func ResourceDisk() *schema.Resource {
 }
 
 func resourceDiskCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 
 	id := d.Get("name").(string)
@@ -90,7 +92,7 @@ func resourceDiskCreate(ctx context.Context, d *schema.ResourceData, meta interf
 	out, err := conn.CreateDisk(ctx, &in)
 
 	if err != nil {
-		return create.DiagError(names.Lightsail, string(types.OperationTypeCreateDisk), ResDisk, id, err)
+		return create.AppendDiagError(diags, names.Lightsail, string(types.OperationTypeCreateDisk), ResDisk, id, err)
 	}
 
 	diag := expandOperations(ctx, conn, out.Operations, types.OperationTypeCreateDisk, ResDisk, id)
@@ -101,10 +103,12 @@ func resourceDiskCreate(ctx context.Context, d *schema.ResourceData, meta interf
 
 	d.SetId(id)
 
-	return resourceDiskRead(ctx, d, meta)
+	return append(diags, resourceDiskRead(ctx, d, meta)...)
 }
 
 func resourceDiskRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 
 	out, err := FindDiskById(ctx, conn, d.Id())
@@ -112,11 +116,11 @@ func resourceDiskRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		create.LogNotFoundRemoveState(names.Lightsail, create.ErrActionReading, ResDisk, d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.Lightsail, create.ErrActionReading, ResDisk, d.Id(), err)
+		return create.AppendDiagError(diags, names.Lightsail, create.ErrActionReading, ResDisk, d.Id(), err)
 	}
 
 	d.Set("arn", out.Arn)
@@ -128,7 +132,7 @@ func resourceDiskRead(ctx context.Context, d *schema.ResourceData, meta interfac
 
 	setTagsOut(ctx, out.Tags)
 
-	return nil
+	return diags
 }
 
 func resourceDiskUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -137,6 +141,8 @@ func resourceDiskUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 }
 
 func resourceDiskDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 
 	out, err := conn.DeleteDisk(ctx, &lightsail.DeleteDiskInput{
@@ -144,11 +150,11 @@ func resourceDiskDelete(ctx context.Context, d *schema.ResourceData, meta interf
 	})
 
 	if IsANotFoundError(err) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.Lightsail, string(types.OperationTypeDeleteDisk), ResDisk, d.Get("name").(string), err)
+		return create.AppendDiagError(diags, names.Lightsail, string(types.OperationTypeDeleteDisk), ResDisk, d.Get("name").(string), err)
 	}
 
 	diag := expandOperations(ctx, conn, out.Operations, types.OperationTypeDeleteDisk, ResDisk, d.Id())
@@ -157,7 +163,7 @@ func resourceDiskDelete(ctx context.Context, d *schema.ResourceData, meta interf
 		return diag
 	}
 
-	return nil
+	return diags
 }
 
 func FindDiskById(ctx context.Context, conn *lightsail.Client, id string) (*types.Disk, error) {

--- a/internal/service/lightsail/distribution.go
+++ b/internal/service/lightsail/distribution.go
@@ -327,6 +327,8 @@ const (
 )
 
 func resourceDistributionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 
 	in := &lightsail.CreateDistributionInput{
@@ -352,11 +354,11 @@ func resourceDistributionCreate(ctx context.Context, d *schema.ResourceData, met
 	out, err := conn.CreateDistribution(ctx, in)
 
 	if err != nil {
-		return create.DiagError(names.Lightsail, create.ErrActionCreating, ResNameDistribution, d.Get("name").(string), err)
+		return create.AppendDiagError(diags, names.Lightsail, create.ErrActionCreating, ResNameDistribution, d.Get("name").(string), err)
 	}
 
 	if out == nil || out.Distribution == nil {
-		return create.DiagError(names.Lightsail, create.ErrActionCreating, ResNameDistribution, d.Get("name").(string), errors.New("empty output"))
+		return create.AppendDiagError(diags, names.Lightsail, create.ErrActionCreating, ResNameDistribution, d.Get("name").(string), errors.New("empty output"))
 	}
 
 	id := aws.ToString(out.Distribution.Name)
@@ -379,7 +381,7 @@ func resourceDistributionCreate(ctx context.Context, d *schema.ResourceData, met
 		updateOut, err := conn.UpdateDistribution(ctx, updateIn)
 
 		if err != nil {
-			return create.DiagError(names.Lightsail, create.ErrActionUpdating, ResNameDistribution, d.Id(), err)
+			return create.AppendDiagError(diags, names.Lightsail, create.ErrActionUpdating, ResNameDistribution, d.Id(), err)
 		}
 
 		diagUpdate := expandOperation(ctx, conn, *updateOut.Operation, types.OperationTypeUpdateDistribution, ResNameDistribution, d.Id())
@@ -389,10 +391,12 @@ func resourceDistributionCreate(ctx context.Context, d *schema.ResourceData, met
 		}
 	}
 
-	return resourceDistributionRead(ctx, d, meta)
+	return append(diags, resourceDistributionRead(ctx, d, meta)...)
 }
 
 func resourceDistributionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 
 	out, err := FindDistributionByID(ctx, conn, d.Id())
@@ -400,23 +404,23 @@ func resourceDistributionRead(ctx context.Context, d *schema.ResourceData, meta 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Lightsail Distribution (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.Lightsail, create.ErrActionReading, ResNameDistribution, d.Id(), err)
+		return create.AppendDiagError(diags, names.Lightsail, create.ErrActionReading, ResNameDistribution, d.Id(), err)
 	}
 
 	d.Set("alternative_domain_names", out.AlternativeDomainNames)
 	d.Set("arn", out.Arn)
 	d.Set("bundle_id", out.BundleId)
 	if err := d.Set("cache_behavior", flattenCacheBehaviorsPerPath(out.CacheBehaviors)); err != nil {
-		return create.DiagError(names.Lightsail, create.ErrActionSetting, ResNameDistribution, d.Id(), err)
+		return create.AppendDiagError(diags, names.Lightsail, create.ErrActionSetting, ResNameDistribution, d.Id(), err)
 	}
 
 	if out.CacheBehaviorSettings != nil {
 		if err := d.Set("cache_behavior_settings", []interface{}{flattenCacheSettings(out.CacheBehaviorSettings)}); err != nil {
-			return create.DiagError(names.Lightsail, create.ErrActionSetting, ResNameDistribution, d.Id(), err)
+			return create.AppendDiagError(diags, names.Lightsail, create.ErrActionSetting, ResNameDistribution, d.Id(), err)
 		}
 	} else {
 		d.Set("cache_behavior_settings", nil)
@@ -426,14 +430,14 @@ func resourceDistributionRead(ctx context.Context, d *schema.ResourceData, meta 
 	d.Set("created_at", out.CreatedAt.Format(time.RFC3339))
 
 	if err := d.Set("default_cache_behavior", []interface{}{flattenCacheBehavior(out.DefaultCacheBehavior)}); err != nil {
-		return create.DiagError(names.Lightsail, create.ErrActionSetting, ResNameDistribution, d.Id(), err)
+		return create.AppendDiagError(diags, names.Lightsail, create.ErrActionSetting, ResNameDistribution, d.Id(), err)
 	}
 	d.Set("domain_name", out.DomainName)
 	d.Set("is_enabled", out.IsEnabled)
 	d.Set("ip_address_type", out.IpAddressType)
 	d.Set("location", []interface{}{flattenResourceLocation(out.Location)})
 	if err := d.Set("origin", []interface{}{flattenOrigin(out.Origin)}); err != nil {
-		return create.DiagError(names.Lightsail, create.ErrActionSetting, ResNameDistribution, d.Id(), err)
+		return create.AppendDiagError(diags, names.Lightsail, create.ErrActionSetting, ResNameDistribution, d.Id(), err)
 	}
 	d.Set("name", out.Name)
 	d.Set("origin_public_dns", out.OriginPublicDNS)
@@ -443,10 +447,12 @@ func resourceDistributionRead(ctx context.Context, d *schema.ResourceData, meta 
 
 	setTagsOut(ctx, out.Tags)
 
-	return nil
+	return diags
 }
 
 func resourceDistributionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 
 	update := false
@@ -498,7 +504,7 @@ func resourceDistributionUpdate(ctx context.Context, d *schema.ResourceData, met
 		})
 
 		if err != nil {
-			return create.DiagError(names.Lightsail, string(types.OperationTypeSetIpAddressType), ResNameDistribution, d.Id(), err)
+			return create.AppendDiagError(diags, names.Lightsail, string(types.OperationTypeSetIpAddressType), ResNameDistribution, d.Id(), err)
 		}
 
 		diag := expandOperations(ctx, conn, out.Operations, types.OperationTypeSetIpAddressType, ResNameDistribution, d.Id())
@@ -512,7 +518,7 @@ func resourceDistributionUpdate(ctx context.Context, d *schema.ResourceData, met
 		log.Printf("[DEBUG] Updating Lightsail Distribution (%s): %#v", d.Id(), in)
 		out, err := conn.UpdateDistribution(ctx, in)
 		if err != nil {
-			return create.DiagError(names.Lightsail, create.ErrActionUpdating, ResNameDistribution, d.Id(), err)
+			return create.AppendDiagError(diags, names.Lightsail, create.ErrActionUpdating, ResNameDistribution, d.Id(), err)
 		}
 
 		diag := expandOperation(ctx, conn, *out.Operation, types.OperationTypeUpdateDistribution, ResNameDistribution, d.Id())
@@ -526,7 +532,7 @@ func resourceDistributionUpdate(ctx context.Context, d *schema.ResourceData, met
 		log.Printf("[DEBUG] Updating Lightsail Distribution Bundle (%s): %#v", d.Id(), in)
 		out, err := conn.UpdateDistributionBundle(ctx, bundleIn)
 		if err != nil {
-			return create.DiagError(names.Lightsail, create.ErrActionUpdating, ResNameDistribution, d.Id(), err)
+			return create.AppendDiagError(diags, names.Lightsail, create.ErrActionUpdating, ResNameDistribution, d.Id(), err)
 		}
 
 		diag := expandOperation(ctx, conn, *out.Operation, types.OperationTypeUpdateDistributionBundle, ResNameDistribution, d.Id())
@@ -536,10 +542,12 @@ func resourceDistributionUpdate(ctx context.Context, d *schema.ResourceData, met
 		}
 	}
 
-	return resourceDistributionRead(ctx, d, meta)
+	return append(diags, resourceDistributionRead(ctx, d, meta)...)
 }
 
 func resourceDistributionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 
 	log.Printf("[INFO] Deleting Lightsail Distribution %s", d.Id())
@@ -549,11 +557,11 @@ func resourceDistributionDelete(ctx context.Context, d *schema.ResourceData, met
 	})
 
 	if IsANotFoundError(err) || errs.IsA[*types.InvalidInputException](err) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.Lightsail, create.ErrActionDeleting, ResNameDistribution, d.Id(), err)
+		return create.AppendDiagError(diags, names.Lightsail, create.ErrActionDeleting, ResNameDistribution, d.Id(), err)
 	}
 
 	diag := expandOperation(ctx, conn, *out.Operation, types.OperationTypeDeleteDistribution, ResNameDistribution, d.Id())
@@ -562,7 +570,7 @@ func resourceDistributionDelete(ctx context.Context, d *schema.ResourceData, met
 		return diag
 	}
 
-	return nil
+	return diags
 }
 
 func FindDistributionByID(ctx context.Context, conn *lightsail.Client, id string) (*types.LightsailDistribution, error) {

--- a/internal/service/lightsail/domain.go
+++ b/internal/service/lightsail/domain.go
@@ -83,5 +83,5 @@ func resourceDomainDelete(ctx context.Context, d *schema.ResourceData, meta inte
 		return sdkdiag.AppendErrorf(diags, "deleting Lightsail Domain (%s):%s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/lightsail/domain_entry.go
+++ b/internal/service/lightsail/domain_entry.go
@@ -80,6 +80,8 @@ func ResourceDomainEntry() *schema.Resource {
 }
 
 func resourceDomainEntryCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 	name := d.Get("name").(string)
 	req := &lightsail.CreateDomainEntryInput{
@@ -96,7 +98,7 @@ func resourceDomainEntryCreate(ctx context.Context, d *schema.ResourceData, meta
 	resp, err := conn.CreateDomainEntry(ctx, req)
 
 	if err != nil {
-		return create.DiagError(names.Lightsail, string(types.OperationTypeCreateDomain), ResNameDomainEntry, name, err)
+		return create.AppendDiagError(diags, names.Lightsail, string(types.OperationTypeCreateDomain), ResNameDomainEntry, name, err)
 	}
 
 	diag := expandOperations(ctx, conn, []types.Operation{*resp.Operation}, types.OperationTypeCreateDomain, ResNameDomainEntry, name)
@@ -116,15 +118,17 @@ func resourceDomainEntryCreate(ctx context.Context, d *schema.ResourceData, meta
 	id, err := flex.FlattenResourceId(idParts, DomainEntryIdPartsCount, true)
 
 	if err != nil {
-		return create.DiagError(names.DynamoDB, create.ErrActionFlatteningResourceId, ResNameDomainEntry, d.Get("domain_name").(string), err)
+		return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionFlatteningResourceId, ResNameDomainEntry, d.Get("domain_name").(string), err)
 	}
 
 	d.SetId(id)
 
-	return resourceDomainEntryRead(ctx, d, meta)
+	return append(diags, resourceDomainEntryRead(ctx, d, meta)...)
 }
 
 func resourceDomainEntryRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 
 	entry, err := FindDomainEntryById(ctx, conn, d.Id())
@@ -132,17 +136,17 @@ func resourceDomainEntryRead(ctx context.Context, d *schema.ResourceData, meta i
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		create.LogNotFoundRemoveState(names.Lightsail, create.ErrActionReading, ResNameDomainEntry, d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.Lightsail, create.ErrActionReading, ResNameDomainEntry, d.Id(), err)
+		return create.AppendDiagError(diags, names.Lightsail, create.ErrActionReading, ResNameDomainEntry, d.Id(), err)
 	}
 
 	domainName, err := expandDomainNameFromId(d.Id())
 
 	if err != nil {
-		return create.DiagError(names.Lightsail, create.ErrActionExpandingResourceId, ResNameDomainEntry, d.Id(), err)
+		return create.AppendDiagError(diags, names.Lightsail, create.ErrActionExpandingResourceId, ResNameDomainEntry, d.Id(), err)
 	}
 
 	name := flattenDomainEntryName(aws.ToString(entry.Name), domainName)
@@ -161,7 +165,7 @@ func resourceDomainEntryRead(ctx context.Context, d *schema.ResourceData, meta i
 		id, err := flex.FlattenResourceId(idParts, DomainEntryIdPartsCount, true)
 
 		if err != nil {
-			return create.DiagError(names.DynamoDB, create.ErrActionFlatteningResourceId, ResNameDomainEntry, d.Get("domain_name").(string), err)
+			return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionFlatteningResourceId, ResNameDomainEntry, d.Get("domain_name").(string), err)
 		}
 
 		d.SetId(id)
@@ -172,22 +176,24 @@ func resourceDomainEntryRead(ctx context.Context, d *schema.ResourceData, meta i
 	d.Set("is_alias", entry.IsAlias)
 	d.Set("target", entry.Target)
 
-	return nil
+	return diags
 }
 
 func resourceDomainEntryDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 
 	domainName, err := expandDomainNameFromId(d.Id())
 
 	if err != nil {
-		return create.DiagError(names.Lightsail, create.ErrActionExpandingResourceId, ResNameDomainEntry, d.Id(), err)
+		return create.AppendDiagError(diags, names.Lightsail, create.ErrActionExpandingResourceId, ResNameDomainEntry, d.Id(), err)
 	}
 
 	domainEntry, err := expandDomainEntry(d.Id())
 
 	if err != nil {
-		return create.DiagError(names.Lightsail, create.ErrActionExpandingResourceId, ResNameDomainEntry, d.Id(), err)
+		return create.AppendDiagError(diags, names.Lightsail, create.ErrActionExpandingResourceId, ResNameDomainEntry, d.Id(), err)
 	}
 
 	resp, err := conn.DeleteDomainEntry(ctx, &lightsail.DeleteDomainEntryInput{
@@ -196,11 +202,11 @@ func resourceDomainEntryDelete(ctx context.Context, d *schema.ResourceData, meta
 	})
 
 	if err != nil && errs.IsA[*types.NotFoundException](err) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.Lightsail, create.ErrActionDeleting, ResNameDomainEntry, d.Id(), err)
+		return create.AppendDiagError(diags, names.Lightsail, create.ErrActionDeleting, ResNameDomainEntry, d.Id(), err)
 	}
 
 	diag := expandOperations(ctx, conn, []types.Operation{*resp.Operation}, types.OperationTypeDeleteDomain, ResNameDomainEntry, d.Id())
@@ -209,7 +215,7 @@ func resourceDomainEntryDelete(ctx context.Context, d *schema.ResourceData, meta
 		return diag
 	}
 
-	return nil
+	return diags
 }
 
 func expandDomainEntry(id string) (*types.DomainEntry, error) {

--- a/internal/service/lightsail/flex.go
+++ b/internal/service/lightsail/flex.go
@@ -16,30 +16,30 @@ import (
 )
 
 // expandOperations provides a uniform approach for handling lightsail operations and errors.
-func expandOperations(ctx context.Context, conn *lightsail.Client, operations []types.Operation, action types.OperationType, resource string, id string) diag.Diagnostics {
+func expandOperations(ctx context.Context, conn *lightsail.Client, operations []types.Operation, action types.OperationType, resource string, id string) (diags diag.Diagnostics) {
 	if len(operations) == 0 {
-		return create.DiagError(names.Lightsail, string(action), resource, id, errors.New("no operations found for request"))
+		return create.AppendDiagError(diags, names.Lightsail, string(action), resource, id, errors.New("no operations found for request"))
 	}
 
 	op := operations[0]
 
 	err := waitOperation(ctx, conn, op.Id)
 	if err != nil {
-		return create.DiagError(names.Lightsail, string(action), resource, id, errors.New("error waiting for request operation"))
+		return create.AppendDiagError(diags, names.Lightsail, string(action), resource, id, errors.New("error waiting for request operation"))
 	}
 
-	return nil
+	return diags
 }
 
 // expandOperation provides a uniform approach for handling a single lightsail operation and errors.
 func expandOperation(ctx context.Context, conn *lightsail.Client, operation types.Operation, action types.OperationType, resource string, id string) diag.Diagnostics {
-	diag := expandOperations(ctx, conn, []types.Operation{operation}, action, resource, id)
+	diags := expandOperations(ctx, conn, []types.Operation{operation}, action, resource, id)
 
-	if diag != nil {
-		return diag
+	if diags != nil {
+		return diags
 	}
 
-	return nil
+	return diags
 }
 
 func flattenResourceLocation(apiObject *types.ResourceLocation) map[string]interface{} {

--- a/internal/service/lightsail/instance.go
+++ b/internal/service/lightsail/instance.go
@@ -172,6 +172,8 @@ func ResourceInstance() *schema.Resource {
 }
 
 func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 
 	iName := d.Get("name").(string)
@@ -198,7 +200,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 
 	out, err := conn.CreateInstances(ctx, &in)
 	if err != nil {
-		return create.DiagError(names.Lightsail, string(types.OperationTypeCreateInstance), ResInstance, iName, err)
+		return create.AppendDiagError(diags, names.Lightsail, string(types.OperationTypeCreateInstance), ResInstance, iName, err)
 	}
 
 	diag := expandOperations(ctx, conn, out.Operations, types.OperationTypeCreateInstance, ResInstance, iName)
@@ -219,7 +221,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 		out, err := conn.EnableAddOn(ctx, &in)
 
 		if err != nil {
-			return create.DiagError(names.Lightsail, string(types.OperationTypeEnableAddOn), ResInstance, iName, err)
+			return create.AppendDiagError(diags, names.Lightsail, string(types.OperationTypeEnableAddOn), ResInstance, iName, err)
 		}
 
 		diag := expandOperations(ctx, conn, out.Operations, types.OperationTypeEnableAddOn, ResInstance, iName)
@@ -229,10 +231,12 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 	}
 
-	return resourceInstanceRead(ctx, d, meta)
+	return append(diags, resourceInstanceRead(ctx, d, meta)...)
 }
 
 func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 
 	out, err := FindInstanceById(ctx, conn, d.Id())
@@ -240,11 +244,11 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta inte
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		create.LogNotFoundRemoveState(names.Lightsail, create.ErrActionReading, ResInstance, d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.Lightsail, create.ErrActionReading, ResInstance, d.Id(), err)
+		return create.AppendDiagError(diags, names.Lightsail, create.ErrActionReading, ResInstance, d.Id(), err)
 	}
 
 	d.Set("add_on", flattenAddOns(out.AddOns))
@@ -269,10 +273,12 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta inte
 
 	setTagsOut(ctx, out.Tags)
 
-	return nil
+	return diags
 }
 
 func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 	out, err := conn.DeleteInstance(ctx, &lightsail.DeleteInstanceInput{
 		InstanceName:      aws.String(d.Id()),
@@ -280,11 +286,11 @@ func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta in
 	})
 
 	if err != nil && errs.IsA[*types.NotFoundException](err) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.Lightsail, create.ErrActionDeleting, ResInstance, d.Id(), err)
+		return create.AppendDiagError(diags, names.Lightsail, create.ErrActionDeleting, ResInstance, d.Id(), err)
 	}
 
 	diag := expandOperations(ctx, conn, out.Operations, types.OperationTypeDeleteInstance, ResInstance, d.Id())
@@ -293,10 +299,12 @@ func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta in
 		return diag
 	}
 
-	return nil
+	return diags
 }
 
 func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 
 	if d.HasChange("ip_address_type") {
@@ -307,7 +315,7 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		})
 
 		if err != nil {
-			return create.DiagError(names.Lightsail, string(types.OperationTypeSetIpAddressType), ResInstance, d.Id(), err)
+			return create.AppendDiagError(diags, names.Lightsail, string(types.OperationTypeSetIpAddressType), ResInstance, d.Id(), err)
 		}
 
 		diag := expandOperations(ctx, conn, out.Operations, types.OperationTypeSetIpAddressType, ResInstance, d.Id())
@@ -325,7 +333,7 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 	}
 
-	return resourceInstanceRead(ctx, d, meta)
+	return append(diags, resourceInstanceRead(ctx, d, meta)...)
 }
 
 func expandAddOnRequest(addOnListRaw []interface{}) *types.AddOnRequest {
@@ -376,6 +384,8 @@ func flattenAddOns(addOns []types.AddOn) []interface{} {
 }
 
 func updateAddOn(ctx context.Context, conn *lightsail.Client, name string, oldAddOnsRaw interface{}, newAddOnsRaw interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	oldAddOns := expandAddOnRequest(oldAddOnsRaw.([]interface{}))
 	newAddOns := expandAddOnRequest(newAddOnsRaw.([]interface{}))
 	oldAddOnStatus := expandAddOnEnabled(oldAddOnsRaw.([]interface{}))
@@ -390,7 +400,7 @@ func updateAddOn(ctx context.Context, conn *lightsail.Client, name string, oldAd
 		out, err := conn.DisableAddOn(ctx, &in)
 
 		if err != nil {
-			return create.DiagError(names.Lightsail, string(types.OperationTypeDisableAddOn), ResInstance, name, err)
+			return create.AppendDiagError(diags, names.Lightsail, string(types.OperationTypeDisableAddOn), ResInstance, name, err)
 		}
 
 		diag := expandOperations(ctx, conn, out.Operations, types.OperationTypeDisableAddOn, ResInstance, name)
@@ -409,7 +419,7 @@ func updateAddOn(ctx context.Context, conn *lightsail.Client, name string, oldAd
 		out, err := conn.EnableAddOn(ctx, &in)
 
 		if err != nil {
-			return create.DiagError(names.Lightsail, string(types.OperationTypeEnableAddOn), ResInstance, name, err)
+			return create.AppendDiagError(diags, names.Lightsail, string(types.OperationTypeEnableAddOn), ResInstance, name, err)
 		}
 
 		diag := expandOperations(ctx, conn, out.Operations, types.OperationTypeEnableAddOn, ResInstance, name)
@@ -419,7 +429,7 @@ func updateAddOn(ctx context.Context, conn *lightsail.Client, name string, oldAd
 		}
 	}
 
-	return nil
+	return diags
 }
 
 func flattenAddOnTypeValues(t []types.AddOnType) []string {

--- a/internal/service/lightsail/lb_https_redirection_policy.go
+++ b/internal/service/lightsail/lb_https_redirection_policy.go
@@ -53,6 +53,8 @@ func ResourceLoadBalancerHTTPSRedirectionPolicy() *schema.Resource {
 }
 
 func resourceLoadBalancerHTTPSRedirectionPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 	lbName := d.Get("lb_name").(string)
 	in := lightsail.UpdateLoadBalancerAttributeInput{
@@ -64,7 +66,7 @@ func resourceLoadBalancerHTTPSRedirectionPolicyCreate(ctx context.Context, d *sc
 	out, err := conn.UpdateLoadBalancerAttribute(ctx, &in)
 
 	if err != nil {
-		return create.DiagError(names.Lightsail, string(types.OperationTypeUpdateLoadBalancerAttribute), ResLoadBalancerHTTPSRedirectionPolicy, lbName, err)
+		return create.AppendDiagError(diags, names.Lightsail, string(types.OperationTypeUpdateLoadBalancerAttribute), ResLoadBalancerHTTPSRedirectionPolicy, lbName, err)
 	}
 
 	diag := expandOperations(ctx, conn, out.Operations, types.OperationTypeUpdateLoadBalancerAttribute, ResLoadBalancerHTTPSRedirectionPolicy, lbName)
@@ -75,10 +77,12 @@ func resourceLoadBalancerHTTPSRedirectionPolicyCreate(ctx context.Context, d *sc
 
 	d.SetId(lbName)
 
-	return resourceLoadBalancerHTTPSRedirectionPolicyRead(ctx, d, meta)
+	return append(diags, resourceLoadBalancerHTTPSRedirectionPolicyRead(ctx, d, meta)...)
 }
 
 func resourceLoadBalancerHTTPSRedirectionPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 
 	out, err := FindLoadBalancerHTTPSRedirectionPolicyById(ctx, conn, d.Id())
@@ -86,20 +90,22 @@ func resourceLoadBalancerHTTPSRedirectionPolicyRead(ctx context.Context, d *sche
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		create.LogNotFoundRemoveState(names.Lightsail, create.ErrActionReading, ResLoadBalancerHTTPSRedirectionPolicy, d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.Lightsail, create.ErrActionReading, ResLoadBalancerHTTPSRedirectionPolicy, d.Id(), err)
+		return create.AppendDiagError(diags, names.Lightsail, create.ErrActionReading, ResLoadBalancerHTTPSRedirectionPolicy, d.Id(), err)
 	}
 
 	d.Set("enabled", out)
 	d.Set("lb_name", d.Id())
 
-	return nil
+	return diags
 }
 
 func resourceLoadBalancerHTTPSRedirectionPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 	lbName := d.Get("lb_name").(string)
 	if d.HasChange("enabled") {
@@ -112,7 +118,7 @@ func resourceLoadBalancerHTTPSRedirectionPolicyUpdate(ctx context.Context, d *sc
 		out, err := conn.UpdateLoadBalancerAttribute(ctx, &in)
 
 		if err != nil {
-			return create.DiagError(names.Lightsail, string(types.OperationTypeUpdateLoadBalancerAttribute), ResLoadBalancerHTTPSRedirectionPolicy, lbName, err)
+			return create.AppendDiagError(diags, names.Lightsail, string(types.OperationTypeUpdateLoadBalancerAttribute), ResLoadBalancerHTTPSRedirectionPolicy, lbName, err)
 		}
 
 		diag := expandOperations(ctx, conn, out.Operations, types.OperationTypeUpdateLoadBalancerAttribute, ResLoadBalancerHTTPSRedirectionPolicy, lbName)
@@ -122,10 +128,12 @@ func resourceLoadBalancerHTTPSRedirectionPolicyUpdate(ctx context.Context, d *sc
 		}
 	}
 
-	return resourceLoadBalancerHTTPSRedirectionPolicyRead(ctx, d, meta)
+	return append(diags, resourceLoadBalancerHTTPSRedirectionPolicyRead(ctx, d, meta)...)
 }
 
 func resourceLoadBalancerHTTPSRedirectionPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 	lbName := d.Get("lb_name").(string)
 	in := lightsail.UpdateLoadBalancerAttributeInput{
@@ -137,7 +145,7 @@ func resourceLoadBalancerHTTPSRedirectionPolicyDelete(ctx context.Context, d *sc
 	out, err := conn.UpdateLoadBalancerAttribute(ctx, &in)
 
 	if err != nil {
-		return create.DiagError(names.Lightsail, string(types.OperationTypeUpdateLoadBalancerAttribute), ResLoadBalancerHTTPSRedirectionPolicy, lbName, err)
+		return create.AppendDiagError(diags, names.Lightsail, string(types.OperationTypeUpdateLoadBalancerAttribute), ResLoadBalancerHTTPSRedirectionPolicy, lbName, err)
 	}
 
 	diag := expandOperations(ctx, conn, out.Operations, types.OperationTypeUpdateLoadBalancerAttribute, ResLoadBalancerHTTPSRedirectionPolicy, lbName)
@@ -146,7 +154,7 @@ func resourceLoadBalancerHTTPSRedirectionPolicyDelete(ctx context.Context, d *sc
 		return diag
 	}
 
-	return nil
+	return diags
 }
 
 func FindLoadBalancerHTTPSRedirectionPolicyById(ctx context.Context, conn *lightsail.Client, id string) (*bool, error) {

--- a/internal/service/lightsail/lb_stickiness_policy.go
+++ b/internal/service/lightsail/lb_stickiness_policy.go
@@ -58,6 +58,8 @@ func ResourceLoadBalancerStickinessPolicy() *schema.Resource {
 }
 
 func resourceLoadBalancerStickinessPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 	lbName := d.Get("lb_name").(string)
 	for _, v := range []string{"enabled", "cookie_duration"} {
@@ -78,7 +80,7 @@ func resourceLoadBalancerStickinessPolicyCreate(ctx context.Context, d *schema.R
 		out, err := conn.UpdateLoadBalancerAttribute(ctx, &in)
 
 		if err != nil {
-			return create.DiagError(names.Lightsail, string(types.OperationTypeUpdateLoadBalancerAttribute), ResLoadBalancerStickinessPolicy, lbName, err)
+			return create.AppendDiagError(diags, names.Lightsail, string(types.OperationTypeUpdateLoadBalancerAttribute), ResLoadBalancerStickinessPolicy, lbName, err)
 		}
 
 		diag := expandOperations(ctx, conn, out.Operations, types.OperationTypeUpdateLoadBalancerAttribute, ResLoadBalancerStickinessPolicy, lbName)
@@ -90,10 +92,12 @@ func resourceLoadBalancerStickinessPolicyCreate(ctx context.Context, d *schema.R
 
 	d.SetId(lbName)
 
-	return resourceLoadBalancerStickinessPolicyRead(ctx, d, meta)
+	return append(diags, resourceLoadBalancerStickinessPolicyRead(ctx, d, meta)...)
 }
 
 func resourceLoadBalancerStickinessPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 
 	out, err := FindLoadBalancerStickinessPolicyById(ctx, conn, d.Id())
@@ -101,31 +105,33 @@ func resourceLoadBalancerStickinessPolicyRead(ctx context.Context, d *schema.Res
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		create.LogNotFoundRemoveState(names.Lightsail, create.ErrActionReading, ResLoadBalancerStickinessPolicy, d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.Lightsail, create.ErrActionReading, ResLoadBalancerStickinessPolicy, d.Id(), err)
+		return create.AppendDiagError(diags, names.Lightsail, create.ErrActionReading, ResLoadBalancerStickinessPolicy, d.Id(), err)
 	}
 
 	boolValue, err := strconv.ParseBool(out[string(types.LoadBalancerAttributeNameSessionStickinessEnabled)])
 	if err != nil {
-		return create.DiagError(names.Lightsail, create.ErrActionReading, ResLoadBalancerStickinessPolicy, d.Id(), err)
+		return create.AppendDiagError(diags, names.Lightsail, create.ErrActionReading, ResLoadBalancerStickinessPolicy, d.Id(), err)
 	}
 
 	intValue, err := strconv.Atoi(out[string(types.LoadBalancerAttributeNameSessionStickinessLbCookieDurationSeconds)])
 	if err != nil {
-		return create.DiagError(names.Lightsail, create.ErrActionReading, ResLoadBalancerStickinessPolicy, d.Id(), err)
+		return create.AppendDiagError(diags, names.Lightsail, create.ErrActionReading, ResLoadBalancerStickinessPolicy, d.Id(), err)
 	}
 
 	d.Set("cookie_duration", intValue)
 	d.Set("enabled", boolValue)
 	d.Set("lb_name", d.Id())
 
-	return nil
+	return diags
 }
 
 func resourceLoadBalancerStickinessPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 	lbName := d.Get("lb_name").(string)
 	if d.HasChange("enabled") {
@@ -138,7 +144,7 @@ func resourceLoadBalancerStickinessPolicyUpdate(ctx context.Context, d *schema.R
 		out, err := conn.UpdateLoadBalancerAttribute(ctx, &in)
 
 		if err != nil {
-			return create.DiagError(names.Lightsail, string(types.OperationTypeUpdateLoadBalancerAttribute), ResLoadBalancerStickinessPolicy, lbName, err)
+			return create.AppendDiagError(diags, names.Lightsail, string(types.OperationTypeUpdateLoadBalancerAttribute), ResLoadBalancerStickinessPolicy, lbName, err)
 		}
 
 		diag := expandOperations(ctx, conn, out.Operations, types.OperationTypeUpdateLoadBalancerAttribute, ResLoadBalancerStickinessPolicy, lbName)
@@ -158,7 +164,7 @@ func resourceLoadBalancerStickinessPolicyUpdate(ctx context.Context, d *schema.R
 		out, err := conn.UpdateLoadBalancerAttribute(ctx, &in)
 
 		if err != nil {
-			return create.DiagError(names.Lightsail, string(types.OperationTypeUpdateLoadBalancerAttribute), ResLoadBalancerStickinessPolicy, lbName, err)
+			return create.AppendDiagError(diags, names.Lightsail, string(types.OperationTypeUpdateLoadBalancerAttribute), ResLoadBalancerStickinessPolicy, lbName, err)
 		}
 
 		diag := expandOperations(ctx, conn, out.Operations, types.OperationTypeUpdateLoadBalancerAttribute, ResLoadBalancerStickinessPolicy, lbName)
@@ -168,10 +174,12 @@ func resourceLoadBalancerStickinessPolicyUpdate(ctx context.Context, d *schema.R
 		}
 	}
 
-	return resourceLoadBalancerStickinessPolicyRead(ctx, d, meta)
+	return append(diags, resourceLoadBalancerStickinessPolicyRead(ctx, d, meta)...)
 }
 
 func resourceLoadBalancerStickinessPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LightsailClient(ctx)
 	lbName := d.Get("lb_name").(string)
 	in := lightsail.UpdateLoadBalancerAttributeInput{
@@ -183,7 +191,7 @@ func resourceLoadBalancerStickinessPolicyDelete(ctx context.Context, d *schema.R
 	out, err := conn.UpdateLoadBalancerAttribute(ctx, &in)
 
 	if err != nil {
-		return create.DiagError(names.Lightsail, string(types.OperationTypeUpdateLoadBalancerAttribute), ResLoadBalancerStickinessPolicy, lbName, err)
+		return create.AppendDiagError(diags, names.Lightsail, string(types.OperationTypeUpdateLoadBalancerAttribute), ResLoadBalancerStickinessPolicy, lbName, err)
 	}
 
 	diag := expandOperations(ctx, conn, out.Operations, types.OperationTypeUpdateLoadBalancerAttribute, ResLoadBalancerStickinessPolicy, lbName)
@@ -192,7 +200,7 @@ func resourceLoadBalancerStickinessPolicyDelete(ctx context.Context, d *schema.R
 		return diag
 	}
 
-	return nil
+	return diags
 }
 
 func FindLoadBalancerStickinessPolicyById(ctx context.Context, conn *lightsail.Client, id string) (map[string]string, error) {

--- a/internal/service/location/geofence_collection.go
+++ b/internal/service/location/geofence_collection.go
@@ -86,6 +86,8 @@ const (
 )
 
 func resourceGeofenceCollectionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LocationConn(ctx)
 
 	in := &locationservice.CreateGeofenceCollectionInput{
@@ -103,19 +105,21 @@ func resourceGeofenceCollectionCreate(ctx context.Context, d *schema.ResourceDat
 
 	out, err := conn.CreateGeofenceCollectionWithContext(ctx, in)
 	if err != nil {
-		return create.DiagError(names.Location, create.ErrActionCreating, ResNameGeofenceCollection, d.Get("collection_name").(string), err)
+		return create.AppendDiagError(diags, names.Location, create.ErrActionCreating, ResNameGeofenceCollection, d.Get("collection_name").(string), err)
 	}
 
 	if out == nil {
-		return create.DiagError(names.Location, create.ErrActionCreating, ResNameGeofenceCollection, d.Get("collection_name").(string), errors.New("empty output"))
+		return create.AppendDiagError(diags, names.Location, create.ErrActionCreating, ResNameGeofenceCollection, d.Get("collection_name").(string), errors.New("empty output"))
 	}
 
 	d.SetId(aws.StringValue(out.CollectionName))
 
-	return resourceGeofenceCollectionRead(ctx, d, meta)
+	return append(diags, resourceGeofenceCollectionRead(ctx, d, meta)...)
 }
 
 func resourceGeofenceCollectionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LocationConn(ctx)
 
 	out, err := findGeofenceCollectionByName(ctx, conn, d.Id())
@@ -123,11 +127,11 @@ func resourceGeofenceCollectionRead(ctx context.Context, d *schema.ResourceData,
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Location GeofenceCollection (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.Location, create.ErrActionReading, ResNameGeofenceCollection, d.Id(), err)
+		return create.AppendDiagError(diags, names.Location, create.ErrActionReading, ResNameGeofenceCollection, d.Id(), err)
 	}
 
 	d.Set("collection_arn", out.CollectionArn)
@@ -137,10 +141,12 @@ func resourceGeofenceCollectionRead(ctx context.Context, d *schema.ResourceData,
 	d.Set("kms_key_id", out.KmsKeyId)
 	d.Set("update_time", aws.TimeValue(out.UpdateTime).Format(time.RFC3339))
 
-	return nil
+	return diags
 }
 
 func resourceGeofenceCollectionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LocationConn(ctx)
 
 	update := false
@@ -155,19 +161,21 @@ func resourceGeofenceCollectionUpdate(ctx context.Context, d *schema.ResourceDat
 	}
 
 	if !update {
-		return nil
+		return diags
 	}
 
 	log.Printf("[DEBUG] Updating Location GeofenceCollection (%s): %#v", d.Id(), in)
 	_, err := conn.UpdateGeofenceCollectionWithContext(ctx, in)
 	if err != nil {
-		return create.DiagError(names.Location, create.ErrActionUpdating, ResNameGeofenceCollection, d.Id(), err)
+		return create.AppendDiagError(diags, names.Location, create.ErrActionUpdating, ResNameGeofenceCollection, d.Id(), err)
 	}
 
-	return resourceGeofenceCollectionRead(ctx, d, meta)
+	return append(diags, resourceGeofenceCollectionRead(ctx, d, meta)...)
 }
 
 func resourceGeofenceCollectionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LocationConn(ctx)
 
 	log.Printf("[INFO] Deleting Location GeofenceCollection %s", d.Id())
@@ -177,14 +185,14 @@ func resourceGeofenceCollectionDelete(ctx context.Context, d *schema.ResourceDat
 	})
 
 	if tfawserr.ErrCodeEquals(err, locationservice.ErrCodeResourceNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.Location, create.ErrActionDeleting, ResNameGeofenceCollection, d.Id(), err)
+		return create.AppendDiagError(diags, names.Location, create.ErrActionDeleting, ResNameGeofenceCollection, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func findGeofenceCollectionByName(ctx context.Context, conn *locationservice.LocationService, name string) (*locationservice.DescribeGeofenceCollectionOutput, error) {

--- a/internal/service/location/geofence_collection_data_source.go
+++ b/internal/service/location/geofence_collection_data_source.go
@@ -59,13 +59,15 @@ const (
 )
 
 func dataSourceGeofenceCollectionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LocationConn(ctx)
 
 	name := d.Get("collection_name").(string)
 
 	out, err := findGeofenceCollectionByName(ctx, conn, name)
 	if err != nil {
-		return create.DiagError(names.Location, create.ErrActionReading, DSNameGeofenceCollection, name, err)
+		return create.AppendDiagError(diags, names.Location, create.ErrActionReading, DSNameGeofenceCollection, name, err)
 	}
 
 	d.SetId(aws.StringValue(out.CollectionName))
@@ -78,8 +80,8 @@ func dataSourceGeofenceCollectionRead(ctx context.Context, d *schema.ResourceDat
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	if err := d.Set("tags", KeyValueTags(ctx, out.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return create.DiagError(names.Location, create.ErrActionSetting, DSNameGeofenceCollection, d.Id(), err)
+		return create.AppendDiagError(diags, names.Location, create.ErrActionSetting, DSNameGeofenceCollection, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/location/route_calculator.go
+++ b/internal/service/location/route_calculator.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -79,6 +80,8 @@ func ResourceRouteCalculator() *schema.Resource {
 }
 
 func resourceRouteCalculatorCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LocationConn(ctx)
 
 	in := &locationservice.CreateRouteCalculatorInput{
@@ -93,19 +96,21 @@ func resourceRouteCalculatorCreate(ctx context.Context, d *schema.ResourceData, 
 
 	out, err := conn.CreateRouteCalculatorWithContext(ctx, in)
 	if err != nil {
-		return diag.Errorf("creating Location Service Route Calculator (%s): %s", d.Get("calculator_name").(string), err)
+		return sdkdiag.AppendErrorf(diags, "creating Location Service Route Calculator (%s): %s", d.Get("calculator_name").(string), err)
 	}
 
 	if out == nil {
-		return diag.Errorf("creating Location Service Route Calculator (%s): empty output", d.Get("calculator_name").(string))
+		return sdkdiag.AppendErrorf(diags, "creating Location Service Route Calculator (%s): empty output", d.Get("calculator_name").(string))
 	}
 
 	d.SetId(aws.StringValue(out.CalculatorName))
 
-	return resourceRouteCalculatorRead(ctx, d, meta)
+	return append(diags, resourceRouteCalculatorRead(ctx, d, meta)...)
 }
 
 func resourceRouteCalculatorRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LocationConn(ctx)
 
 	out, err := findRouteCalculatorByName(ctx, conn, d.Id())
@@ -113,11 +118,11 @@ func resourceRouteCalculatorRead(ctx context.Context, d *schema.ResourceData, me
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Location Service Route Calculator (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Location Service Route Calculator (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Location Service Route Calculator (%s): %s", d.Id(), err)
 	}
 
 	d.Set("calculator_arn", out.CalculatorArn)
@@ -127,10 +132,12 @@ func resourceRouteCalculatorRead(ctx context.Context, d *schema.ResourceData, me
 	d.Set("description", out.Description)
 	d.Set("update_time", aws.TimeValue(out.UpdateTime).Format(time.RFC3339))
 
-	return nil
+	return diags
 }
 
 func resourceRouteCalculatorUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LocationConn(ctx)
 
 	update := false
@@ -145,19 +152,21 @@ func resourceRouteCalculatorUpdate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if !update {
-		return nil
+		return diags
 	}
 
 	log.Printf("[DEBUG] Updating Location Service Route Calculator (%s): %#v", d.Id(), in)
 	_, err := conn.UpdateRouteCalculatorWithContext(ctx, in)
 	if err != nil {
-		return diag.Errorf("updating Location Service Route Calculator (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "updating Location Service Route Calculator (%s): %s", d.Id(), err)
 	}
 
-	return resourceRouteCalculatorRead(ctx, d, meta)
+	return append(diags, resourceRouteCalculatorRead(ctx, d, meta)...)
 }
 
 func resourceRouteCalculatorDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LocationConn(ctx)
 
 	log.Printf("[INFO] Deleting Location Service Route Calculator %s", d.Id())
@@ -167,14 +176,14 @@ func resourceRouteCalculatorDelete(ctx context.Context, d *schema.ResourceData, 
 	})
 
 	if tfawserr.ErrCodeEquals(err, locationservice.ErrCodeResourceNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting Location Service Route Calculator (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Location Service Route Calculator (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func findRouteCalculatorByName(ctx context.Context, conn *locationservice.LocationService, name string) (*locationservice.DescribeRouteCalculatorOutput, error) {

--- a/internal/service/location/route_calculator_data_source.go
+++ b/internal/service/location/route_calculator_data_source.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 )
 
@@ -52,15 +53,17 @@ func DataSourceRouteCalculator() *schema.Resource {
 }
 
 func dataSourceRouteCalculatorRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LocationConn(ctx)
 
 	out, err := findRouteCalculatorByName(ctx, conn, d.Get("calculator_name").(string))
 	if err != nil {
-		return diag.Errorf("reading Location Service Route Calculator (%s): %s", d.Get("calculator_name").(string), err)
+		return sdkdiag.AppendErrorf(diags, "reading Location Service Route Calculator (%s): %s", d.Get("calculator_name").(string), err)
 	}
 
 	if out == nil {
-		return diag.Errorf("reading Location Service Route Calculator (%s): empty response", d.Get("calculator_name").(string))
+		return sdkdiag.AppendErrorf(diags, "reading Location Service Route Calculator (%s): empty response", d.Get("calculator_name").(string))
 	}
 
 	d.SetId(aws.StringValue(out.CalculatorName))
@@ -74,8 +77,8 @@ func dataSourceRouteCalculatorRead(ctx context.Context, d *schema.ResourceData, 
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	if err := d.Set("tags", KeyValueTags(ctx, out.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("listing tags for Location Service Route Calculator (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "listing tags for Location Service Route Calculator (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/location/tracker_association.go
+++ b/internal/service/location/tracker_association.go
@@ -63,6 +63,8 @@ const (
 )
 
 func resourceTrackerAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LocationConn(ctx)
 
 	consumerArn := d.Get("consumer_arn").(string)
@@ -75,24 +77,26 @@ func resourceTrackerAssociationCreate(ctx context.Context, d *schema.ResourceDat
 
 	out, err := conn.AssociateTrackerConsumerWithContext(ctx, in)
 	if err != nil {
-		return create.DiagError(names.Location, create.ErrActionCreating, ResNameTrackerAssociation, d.Get("name").(string), err)
+		return create.AppendDiagError(diags, names.Location, create.ErrActionCreating, ResNameTrackerAssociation, d.Get("name").(string), err)
 	}
 
 	if out == nil {
-		return create.DiagError(names.Location, create.ErrActionCreating, ResNameTrackerAssociation, d.Get("name").(string), errors.New("empty output"))
+		return create.AppendDiagError(diags, names.Location, create.ErrActionCreating, ResNameTrackerAssociation, d.Get("name").(string), errors.New("empty output"))
 	}
 
 	d.SetId(fmt.Sprintf("%s|%s", trackerName, consumerArn))
 
-	return resourceTrackerAssociationRead(ctx, d, meta)
+	return append(diags, resourceTrackerAssociationRead(ctx, d, meta)...)
 }
 
 func resourceTrackerAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LocationConn(ctx)
 
 	trackerAssociationId, err := TrackerAssociationParseID(d.Id())
 	if err != nil {
-		return create.DiagError(names.Location, create.ErrActionReading, ResNameTrackerAssociation, d.Id(), err)
+		return create.AppendDiagError(diags, names.Location, create.ErrActionReading, ResNameTrackerAssociation, d.Id(), err)
 	}
 
 	err = FindTrackerAssociationByTrackerNameAndConsumerARN(ctx, conn, trackerAssociationId.TrackerName, trackerAssociationId.ConsumerARN)
@@ -100,27 +104,29 @@ func resourceTrackerAssociationRead(ctx context.Context, d *schema.ResourceData,
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Location TrackerAssociation (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.Location, create.ErrActionReading, ResNameTrackerAssociation, d.Id(), err)
+		return create.AppendDiagError(diags, names.Location, create.ErrActionReading, ResNameTrackerAssociation, d.Id(), err)
 	}
 
 	d.Set("consumer_arn", trackerAssociationId.ConsumerARN)
 	d.Set("tracker_name", trackerAssociationId.TrackerName)
 
-	return nil
+	return diags
 }
 
 func resourceTrackerAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LocationConn(ctx)
 
 	log.Printf("[INFO] Deleting Location TrackerAssociation %s", d.Id())
 
 	trackerAssociationId, err := TrackerAssociationParseID(d.Id())
 	if err != nil {
-		return create.DiagError(names.Location, create.ErrActionReading, ResNameTrackerAssociation, d.Id(), err)
+		return create.AppendDiagError(diags, names.Location, create.ErrActionReading, ResNameTrackerAssociation, d.Id(), err)
 	}
 
 	_, err = conn.DisassociateTrackerConsumerWithContext(ctx, &locationservice.DisassociateTrackerConsumerInput{
@@ -129,14 +135,14 @@ func resourceTrackerAssociationDelete(ctx context.Context, d *schema.ResourceDat
 	})
 
 	if tfawserr.ErrCodeEquals(err, locationservice.ErrCodeResourceNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.Location, create.ErrActionDeleting, ResNameTrackerAssociation, d.Id(), err)
+		return create.AppendDiagError(diags, names.Location, create.ErrActionDeleting, ResNameTrackerAssociation, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 // FindTrackerAssociationByTrackerNameAndConsumerARN returns an error if an association for specified tracker and consumer cannot be found

--- a/internal/service/location/tracker_association_data_source.go
+++ b/internal/service/location/tracker_association_data_source.go
@@ -41,6 +41,8 @@ const (
 )
 
 func dataSourceTrackerAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LocationConn(ctx)
 
 	consumerArn := d.Get("consumer_arn").(string)
@@ -49,10 +51,10 @@ func dataSourceTrackerAssociationRead(ctx context.Context, d *schema.ResourceDat
 
 	err := FindTrackerAssociationByTrackerNameAndConsumerARN(ctx, conn, trackerName, consumerArn)
 	if err != nil {
-		return create.DiagError(names.Location, create.ErrActionReading, DSNameTrackerAssociation, id, err)
+		return create.AppendDiagError(diags, names.Location, create.ErrActionReading, DSNameTrackerAssociation, id, err)
 	}
 
 	d.SetId(id)
 
-	return nil
+	return diags
 }

--- a/internal/service/location/tracker_associations_data_source.go
+++ b/internal/service/location/tracker_associations_data_source.go
@@ -41,6 +41,8 @@ const (
 )
 
 func dataSourceTrackerAssociationsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LocationConn(ctx)
 
 	name := d.Get("tracker_name").(string)
@@ -68,11 +70,11 @@ func dataSourceTrackerAssociationsRead(ctx context.Context, d *schema.ResourceDa
 	})
 
 	if err != nil {
-		return create.DiagError(names.Location, create.ErrActionReading, DSNameTrackerAssociations, name, err)
+		return create.AppendDiagError(diags, names.Location, create.ErrActionReading, DSNameTrackerAssociations, name, err)
 	}
 
 	d.SetId(meta.(*conns.AWSClient).Region)
 	d.Set("consumer_arns", arns)
 
-	return nil
+	return diags
 }

--- a/internal/service/logs/data_protection_policy_document_data_source.go
+++ b/internal/service/logs/data_protection_policy_document_data_source.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 )
 
@@ -156,6 +157,8 @@ const (
 )
 
 func dataSourceDataProtectionPolicyDocumentRead(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	document := DataProtectionPolicyDocument{
 		Description: d.Get("description").(string),
 		Name:        d.Get("name").(string),
@@ -251,17 +254,17 @@ func dataSourceDataProtectionPolicyDocumentRead(_ context.Context, d *schema.Res
 	// The schema requires exactly 2 elements, which is assumed here.
 
 	if op := document.Statements[0].Operation; op.Audit == nil || op.Deidentify != nil {
-		return diag.Errorf("the first policy statement must contain only the audit operation")
+		return sdkdiag.AppendErrorf(diags, "the first policy statement must contain only the audit operation")
 	}
 
 	if op := document.Statements[1].Operation; op.Audit != nil || op.Deidentify == nil {
-		return diag.Errorf("the second policy statement must contain only the deidentify operation")
+		return sdkdiag.AppendErrorf(diags, "the second policy statement must contain only the deidentify operation")
 	}
 
 	jsonBytes, err := json.MarshalIndent(document, "", "  ")
 
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	jsonString := string(jsonBytes)
@@ -269,7 +272,7 @@ func dataSourceDataProtectionPolicyDocumentRead(_ context.Context, d *schema.Res
 	d.Set("json", jsonString)
 	d.SetId(strconv.Itoa(create.StringHashcode(jsonString)))
 
-	return nil
+	return diags
 }
 
 type DataProtectionPolicyDocument struct {

--- a/internal/service/logs/destination_policy.go
+++ b/internal/service/logs/destination_policy.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
@@ -55,6 +56,8 @@ func resourceDestinationPolicy() *schema.Resource {
 }
 
 func resourceDestinationPolicyPut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LogsClient(ctx)
 
 	name := d.Get("destination_name").(string)
@@ -70,17 +73,19 @@ func resourceDestinationPolicyPut(ctx context.Context, d *schema.ResourceData, m
 	_, err := conn.PutDestinationPolicy(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("putting CloudWatch Logs Destination Policy (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "putting CloudWatch Logs Destination Policy (%s): %s", name, err)
 	}
 
 	if d.IsNewResource() {
 		d.SetId(name)
 	}
 
-	return resourceDestinationPolicyRead(ctx, d, meta)
+	return append(diags, resourceDestinationPolicyRead(ctx, d, meta)...)
 }
 
 func resourceDestinationPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LogsClient(ctx)
 
 	destination, err := findDestinationByName(ctx, conn, d.Id())
@@ -88,15 +93,15 @@ func resourceDestinationPolicyRead(ctx context.Context, d *schema.ResourceData, 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] CloudWatch Logs Destination Policy (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading CloudWatch Logs Destination Policy (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading CloudWatch Logs Destination Policy (%s): %s", d.Id(), err)
 	}
 
 	d.Set("access_policy", destination.AccessPolicy)
 	d.Set("destination_name", destination.DestinationName)
 
-	return nil
+	return diags
 }

--- a/internal/service/logs/group.go
+++ b/internal/service/logs/group.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -89,6 +90,8 @@ func resourceGroup() *schema.Resource {
 }
 
 func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LogsClient(ctx)
 
 	name := create.Name(d.Get("name").(string), d.Get("name_prefix").(string))
@@ -105,7 +108,7 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	_, err := conn.CreateLogGroup(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating CloudWatch Logs Log Group (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "creating CloudWatch Logs Log Group (%s): %s", name, err)
 	}
 
 	d.SetId(name)
@@ -121,14 +124,16 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta inter
 		}, "AccessDeniedException", "no identity-based policy allows the logs:PutRetentionPolicy action")
 
 		if err != nil {
-			return diag.Errorf("setting CloudWatch Logs Log Group (%s) retention policy: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "setting CloudWatch Logs Log Group (%s) retention policy: %s", d.Id(), err)
 		}
 	}
 
-	return resourceGroupRead(ctx, d, meta)
+	return append(diags, resourceGroupRead(ctx, d, meta)...)
 }
 
 func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LogsClient(ctx)
 
 	lg, err := findLogGroupByName(ctx, conn, d.Id())
@@ -136,11 +141,11 @@ func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] CloudWatch Logs Log Group (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading CloudWatch Logs Log Group (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading CloudWatch Logs Log Group (%s): %s", d.Id(), err)
 	}
 
 	d.Set("arn", TrimLogGroupARNWildcardSuffix(aws.ToString(lg.Arn)))
@@ -153,15 +158,17 @@ func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	tags, err := listLogGroupTags(ctx, conn, d.Id())
 
 	if err != nil {
-		return diag.Errorf("listing tags for CloudWatch Logs Log Group (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "listing tags for CloudWatch Logs Log Group (%s): %s", d.Id(), err)
 	}
 
 	setTagsOut(ctx, Tags(tags))
 
-	return nil
+	return diags
 }
 
 func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LogsClient(ctx)
 
 	if d.HasChange("retention_in_days") {
@@ -176,7 +183,7 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 			}, "AccessDeniedException", "no identity-based policy allows the logs:PutRetentionPolicy action")
 
 			if err != nil {
-				return diag.Errorf("setting CloudWatch Logs Log Group (%s) retention policy: %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "setting CloudWatch Logs Log Group (%s) retention policy: %s", d.Id(), err)
 			}
 		} else {
 			_, err := conn.DeleteRetentionPolicy(ctx, &cloudwatchlogs.DeleteRetentionPolicyInput{
@@ -184,7 +191,7 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 			})
 
 			if err != nil {
-				return diag.Errorf("deleting CloudWatch Logs Log Group (%s) retention policy: %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "deleting CloudWatch Logs Log Group (%s) retention policy: %s", d.Id(), err)
 			}
 		}
 	}
@@ -197,7 +204,7 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 			})
 
 			if err != nil {
-				return diag.Errorf("associating CloudWatch Logs Log Group (%s) KMS key: %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "associating CloudWatch Logs Log Group (%s) KMS key: %s", d.Id(), err)
 			}
 		} else {
 			_, err := conn.DisassociateKmsKey(ctx, &cloudwatchlogs.DisassociateKmsKeyInput{
@@ -205,7 +212,7 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 			})
 
 			if err != nil {
-				return diag.Errorf("disassociating CloudWatch Logs Log Group (%s) KMS key: %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "disassociating CloudWatch Logs Log Group (%s) KMS key: %s", d.Id(), err)
 			}
 		}
 	}
@@ -214,17 +221,19 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		o, n := d.GetChange("tags_all")
 
 		if err := updateLogGroupTags(ctx, conn, d.Id(), o, n); err != nil {
-			return diag.Errorf("updating CloudWatch Logs Log Group (%s) tags: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating CloudWatch Logs Log Group (%s) tags: %s", d.Id(), err)
 		}
 	}
 
-	return resourceGroupRead(ctx, d, meta)
+	return append(diags, resourceGroupRead(ctx, d, meta)...)
 }
 
 func resourceGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	if v, ok := d.GetOk("skip_destroy"); ok && v.(bool) {
 		log.Printf("[DEBUG] Retaining CloudWatch Logs Log Group: %s", d.Id())
-		return nil
+		return diags
 	}
 
 	conn := meta.(*conns.AWSClient).LogsClient(ctx)
@@ -237,14 +246,14 @@ func resourceGroupDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	}, "try again")
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting CloudWatch Logs Log Group (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting CloudWatch Logs Log Group (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func findLogGroupByName(ctx context.Context, conn *cloudwatchlogs.Client, name string) (*types.LogGroup, error) {

--- a/internal/service/logs/group_data_source.go
+++ b/internal/service/logs/group_data_source.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 )
 
@@ -49,6 +50,8 @@ func dataSourceGroup() *schema.Resource {
 }
 
 func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LogsClient(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
@@ -56,7 +59,7 @@ func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, meta inter
 	logGroup, err := findLogGroupByName(ctx, conn, name)
 
 	if err != nil {
-		return diag.Errorf("reading CloudWatch Logs Log Group (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "reading CloudWatch Logs Log Group (%s): %s", name, err)
 	}
 
 	d.SetId(name)
@@ -69,12 +72,12 @@ func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, meta inter
 	tags, err := listLogGroupTags(ctx, conn, name)
 
 	if err != nil {
-		return diag.Errorf("listing tags for CloudWatch Logs Log Group (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "listing tags for CloudWatch Logs Log Group (%s): %s", name, err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/logs/groups_data_source.go
+++ b/internal/service/logs/groups_data_source.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 )
 
 // @SDKDataSource("aws_cloudwatch_log_groups")
@@ -39,6 +40,8 @@ func dataSourceGroups() *schema.Resource {
 }
 
 func dataSourceGroupsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).LogsClient(ctx)
 
 	input := &cloudwatchlogs.DescribeLogGroupsInput{}
@@ -54,7 +57,7 @@ func dataSourceGroupsRead(ctx context.Context, d *schema.ResourceData, meta inte
 		page, err := pages.NextPage(ctx)
 
 		if err != nil {
-			return diag.Errorf("reading CloudWatch Log Groups: %s", err)
+			return sdkdiag.AppendErrorf(diags, "reading CloudWatch Log Groups: %s", err)
 		}
 
 		output = append(output, page.LogGroups...)
@@ -72,5 +75,5 @@ func dataSourceGroupsRead(ctx context.Context, d *schema.ResourceData, meta inte
 	d.Set("arns", arns)
 	d.Set("log_group_names", logGroupNames)
 
-	return nil
+	return diags
 }

--- a/internal/service/macie2/account.go
+++ b/internal/service/macie2/account.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
@@ -61,6 +62,8 @@ func ResourceAccount() *schema.Resource {
 }
 
 func resourceAccountCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).Macie2Conn(ctx)
 
 	input := &macie2.EnableMacieInput{
@@ -92,15 +95,17 @@ func resourceAccountCreate(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	if err != nil {
-		return diag.Errorf("enabling Macie Account: %s", err)
+		return sdkdiag.AppendErrorf(diags, "enabling Macie Account: %s", err)
 	}
 
 	d.SetId(meta.(*conns.AWSClient).AccountID)
 
-	return resourceAccountRead(ctx, d, meta)
+	return append(diags, resourceAccountRead(ctx, d, meta)...)
 }
 
 func resourceAccountRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).Macie2Conn(ctx)
 
 	input := &macie2.GetMacieSessionInput{}
@@ -111,11 +116,11 @@ func resourceAccountRead(ctx context.Context, d *schema.ResourceData, meta inter
 		tfawserr.ErrMessageContains(err, macie2.ErrCodeAccessDeniedException, "Macie is not enabled")) {
 		log.Printf("[WARN] Macie not enabled for AWS account (%s), removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Macie Account (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Macie Account (%s): %s", d.Id(), err)
 	}
 
 	d.Set("status", resp.Status)
@@ -124,10 +129,12 @@ func resourceAccountRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set("created_at", aws.TimeValue(resp.CreatedAt).Format(time.RFC3339))
 	d.Set("updated_at", aws.TimeValue(resp.UpdatedAt).Format(time.RFC3339))
 
-	return nil
+	return diags
 }
 
 func resourceAccountUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).Macie2Conn(ctx)
 
 	input := &macie2.UpdateMacieSessionInput{}
@@ -142,13 +149,15 @@ func resourceAccountUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 	_, err := conn.UpdateMacieSessionWithContext(ctx, input)
 	if err != nil {
-		return diag.Errorf("updating Macie Account (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "updating Macie Account (%s): %s", d.Id(), err)
 	}
 
-	return resourceAccountRead(ctx, d, meta)
+	return append(diags, resourceAccountRead(ctx, d, meta)...)
 }
 
 func resourceAccountDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).Macie2Conn(ctx)
 
 	input := &macie2.DisableMacieInput{}
@@ -178,10 +187,10 @@ func resourceAccountDelete(ctx context.Context, d *schema.ResourceData, meta int
 	if err != nil {
 		if tfawserr.ErrCodeEquals(err, macie2.ErrCodeResourceNotFoundException) ||
 			tfawserr.ErrMessageContains(err, macie2.ErrCodeAccessDeniedException, "Macie is not enabled") {
-			return nil
+			return diags
 		}
-		return diag.Errorf("disabling Macie Account (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "disabling Macie Account (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/macie2/classification_export_configuration.go
+++ b/internal/service/macie2/classification_export_configuration.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
@@ -56,16 +57,18 @@ func ResourceClassificationExportConfiguration() *schema.Resource {
 }
 
 func resourceClassificationExportConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).Macie2Conn(ctx)
 
 	if d.IsNewResource() {
 		output, err := conn.GetClassificationExportConfigurationWithContext(ctx, &macie2.GetClassificationExportConfigurationInput{})
 		if err != nil {
-			return diag.Errorf("reading Macie classification export configuration failed: %s", err)
+			return sdkdiag.AppendErrorf(diags, "reading Macie classification export configuration failed: %s", err)
 		}
 
 		if (macie2.ClassificationExportConfiguration{}) != *output.Configuration { // nosemgrep:ci.semgrep.aws.prefer-pointer-conversion-conditional
-			return diag.Errorf("creating Macie classification export configuration: a configuration already exists")
+			return sdkdiag.AppendErrorf(diags, "creating Macie classification export configuration: a configuration already exists")
 		}
 	}
 
@@ -82,13 +85,15 @@ func resourceClassificationExportConfigurationCreate(ctx context.Context, d *sch
 	_, err := conn.PutClassificationExportConfigurationWithContext(ctx, &input)
 
 	if err != nil {
-		return diag.Errorf("creating Macie classification export configuration failed: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating Macie classification export configuration failed: %s", err)
 	}
 
-	return resourceClassificationExportConfigurationRead(ctx, d, meta)
+	return append(diags, resourceClassificationExportConfigurationRead(ctx, d, meta)...)
 }
 
 func resourceClassificationExportConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).Macie2Conn(ctx)
 
 	input := macie2.PutClassificationExportConfigurationInput{
@@ -106,36 +111,40 @@ func resourceClassificationExportConfigurationUpdate(ctx context.Context, d *sch
 	_, err := conn.PutClassificationExportConfigurationWithContext(ctx, &input)
 
 	if err != nil {
-		return diag.Errorf("creating Macie classification export configuration failed: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating Macie classification export configuration failed: %s", err)
 	}
 
-	return resourceClassificationExportConfigurationRead(ctx, d, meta)
+	return append(diags, resourceClassificationExportConfigurationRead(ctx, d, meta)...)
 }
 
 func resourceClassificationExportConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).Macie2Conn(ctx)
 
 	input := macie2.GetClassificationExportConfigurationInput{} // api does not have a getById() like endpoint.
 	output, err := conn.GetClassificationExportConfigurationWithContext(ctx, &input)
 
 	if err != nil {
-		return diag.Errorf("reading Macie classification export configuration failed: %s", err)
+		return sdkdiag.AppendErrorf(diags, "reading Macie classification export configuration failed: %s", err)
 	}
 
 	if (macie2.ClassificationExportConfiguration{}) != *output.Configuration { // nosemgrep:ci.semgrep.aws.prefer-pointer-conversion-conditional
 		if (macie2.S3Destination{}) != *output.Configuration.S3Destination { // nosemgrep:ci.semgrep.aws.prefer-pointer-conversion-conditional
 			var flattenedS3Destination = flattenClassificationExportConfigurationS3DestinationResult(output.Configuration.S3Destination)
 			if err := d.Set("s3_destination", []interface{}{flattenedS3Destination}); err != nil {
-				return diag.Errorf("setting Macie classification export configuration s3_destination: %s", err)
+				return sdkdiag.AppendErrorf(diags, "setting Macie classification export configuration s3_destination: %s", err)
 			}
 		}
 		d.SetId(fmt.Sprintf("%s:%s:%s", "macie:classification_export_configuration", meta.(*conns.AWSClient).AccountID, meta.(*conns.AWSClient).Region))
 	}
 
-	return nil
+	return diags
 }
 
 func resourceClassificationExportConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).Macie2Conn(ctx)
 
 	input := macie2.PutClassificationExportConfigurationInput{
@@ -147,10 +156,10 @@ func resourceClassificationExportConfigurationDelete(ctx context.Context, d *sch
 	_, err := conn.PutClassificationExportConfigurationWithContext(ctx, &input)
 
 	if err != nil {
-		return diag.Errorf("deleting Macie classification export configuration failed: %s", err)
+		return sdkdiag.AppendErrorf(diags, "deleting Macie classification export configuration failed: %s", err)
 	}
 
-	return nil
+	return diags
 }
 
 func expandClassificationExportConfiguration(tfMap map[string]interface{}) *macie2.S3Destination {

--- a/internal/service/macie2/findings_filter.go
+++ b/internal/service/macie2/findings_filter.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -135,6 +136,8 @@ func ResourceFindingsFilter() *schema.Resource {
 }
 
 func resourceFindingsFilterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).Macie2Conn(ctx)
 
 	input := &macie2.CreateFindingsFilterInput{
@@ -147,7 +150,7 @@ func resourceFindingsFilterCreate(ctx context.Context, d *schema.ResourceData, m
 	var err error
 	input.FindingCriteria, err = expandFindingCriteriaFilter(d.Get("finding_criteria").([]interface{}))
 	if err != nil {
-		return diag.Errorf("creating Macie FindingsFilter: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating Macie FindingsFilter: %s", err)
 	}
 
 	if v, ok := d.GetOk("description"); ok {
@@ -177,15 +180,17 @@ func resourceFindingsFilterCreate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if err != nil {
-		return diag.Errorf("creating Macie FindingsFilter: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating Macie FindingsFilter: %s", err)
 	}
 
 	d.SetId(aws.StringValue(output.Id))
 
-	return resourceFindingsFilterRead(ctx, d, meta)
+	return append(diags, resourceFindingsFilterRead(ctx, d, meta)...)
 }
 
 func resourceFindingsFilterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).Macie2Conn(ctx)
 
 	input := &macie2.GetFindingsFilterInput{
@@ -198,15 +203,15 @@ func resourceFindingsFilterRead(ctx context.Context, d *schema.ResourceData, met
 		tfawserr.ErrMessageContains(err, macie2.ErrCodeAccessDeniedException, "Macie is not enabled")) {
 		log.Printf("[WARN] Macie FindingsFilter (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Macie FindingsFilter (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Macie FindingsFilter (%s): %s", d.Id(), err)
 	}
 
 	if err = d.Set("finding_criteria", flattenFindingCriteriaFindingsFilter(resp.FindingCriteria)); err != nil {
-		return diag.Errorf("setting `%s` for Macie FindingsFilter (%s): %s", "finding_criteria", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "setting `%s` for Macie FindingsFilter (%s): %s", "finding_criteria", d.Id(), err)
 	}
 	d.Set("name", resp.Name)
 	d.Set("name_prefix", create.NamePrefixFromName(aws.StringValue(resp.Name)))
@@ -218,10 +223,12 @@ func resourceFindingsFilterRead(ctx context.Context, d *schema.ResourceData, met
 
 	d.Set("arn", resp.Arn)
 
-	return nil
+	return diags
 }
 
 func resourceFindingsFilterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).Macie2Conn(ctx)
 
 	input := &macie2.UpdateFindingsFilterInput{
@@ -232,7 +239,7 @@ func resourceFindingsFilterUpdate(ctx context.Context, d *schema.ResourceData, m
 	if d.HasChange("finding_criteria") {
 		input.FindingCriteria, err = expandFindingCriteriaFilter(d.Get("finding_criteria").([]interface{}))
 		if err != nil {
-			return diag.Errorf("updating Macie FindingsFilter (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating Macie FindingsFilter (%s): %s", d.Id(), err)
 		}
 	}
 	if d.HasChange("name") {
@@ -253,13 +260,15 @@ func resourceFindingsFilterUpdate(ctx context.Context, d *schema.ResourceData, m
 
 	_, err = conn.UpdateFindingsFilterWithContext(ctx, input)
 	if err != nil {
-		return diag.Errorf("updating Macie FindingsFilter (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "updating Macie FindingsFilter (%s): %s", d.Id(), err)
 	}
 
-	return resourceFindingsFilterRead(ctx, d, meta)
+	return append(diags, resourceFindingsFilterRead(ctx, d, meta)...)
 }
 
 func resourceFindingsFilterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).Macie2Conn(ctx)
 
 	input := &macie2.DeleteFindingsFilterInput{
@@ -270,11 +279,11 @@ func resourceFindingsFilterDelete(ctx context.Context, d *schema.ResourceData, m
 	if err != nil {
 		if tfawserr.ErrCodeEquals(err, macie2.ErrCodeResourceNotFoundException) ||
 			tfawserr.ErrMessageContains(err, macie2.ErrCodeAccessDeniedException, "Macie is not enabled") {
-			return nil
+			return diags
 		}
-		return diag.Errorf("deleting Macie FindingsFilter (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Macie FindingsFilter (%s): %s", d.Id(), err)
 	}
-	return nil
+	return diags
 }
 
 func expandFindingCriteriaFilter(findingCriterias []interface{}) (*macie2.FindingCriteria, error) {

--- a/internal/service/macie2/member.go
+++ b/internal/service/macie2/member.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -97,6 +98,8 @@ func ResourceMember() *schema.Resource {
 }
 
 func resourceMemberCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).Macie2Conn(ctx)
 
 	accountId := d.Get("account_id").(string)
@@ -128,13 +131,13 @@ func resourceMemberCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if err != nil {
-		return diag.Errorf("creating Macie Member: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating Macie Member: %s", err)
 	}
 
 	d.SetId(accountId)
 
 	if !d.Get("invite").(bool) {
-		return resourceMemberRead(ctx, d, meta)
+		return append(diags, resourceMemberRead(ctx, d, meta)...)
 	}
 
 	// Invitation workflow
@@ -172,21 +175,23 @@ func resourceMemberCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if err != nil {
-		return diag.Errorf("inviting Macie Member: %s", err)
+		return sdkdiag.AppendErrorf(diags, "inviting Macie Member: %s", err)
 	}
 
 	if len(output.UnprocessedAccounts) != 0 {
-		return diag.Errorf("inviting Macie Member: %s: %s", aws.StringValue(output.UnprocessedAccounts[0].ErrorCode), aws.StringValue(output.UnprocessedAccounts[0].ErrorMessage))
+		return sdkdiag.AppendErrorf(diags, "inviting Macie Member: %s: %s", aws.StringValue(output.UnprocessedAccounts[0].ErrorCode), aws.StringValue(output.UnprocessedAccounts[0].ErrorMessage))
 	}
 
 	if _, err = waitMemberInvited(ctx, conn, d.Id()); err != nil {
-		return diag.Errorf("waiting for Macie Member (%s) invitation: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Macie Member (%s) invitation: %s", d.Id(), err)
 	}
 
-	return resourceMemberRead(ctx, d, meta)
+	return append(diags, resourceMemberRead(ctx, d, meta)...)
 }
 
 func resourceMemberRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).Macie2Conn(ctx)
 
 	input := &macie2.GetMemberInput{
@@ -201,11 +206,11 @@ func resourceMemberRead(ctx context.Context, d *schema.ResourceData, meta interf
 		tfawserr.ErrMessageContains(err, macie2.ErrCodeValidationException, "account is not associated with your account")) {
 		log.Printf("[WARN] Macie Member (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Macie Member (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Macie Member (%s): %s", d.Id(), err)
 	}
 
 	d.Set("account_id", resp.AccountId)
@@ -239,10 +244,12 @@ func resourceMemberRead(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 	d.Set("status", status)
 
-	return nil
+	return diags
 }
 
 func resourceMemberUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).Macie2Conn(ctx)
 
 	// Invitation workflow
@@ -282,15 +289,15 @@ func resourceMemberUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			}
 
 			if err != nil {
-				return diag.Errorf("inviting Macie Member: %s", err)
+				return sdkdiag.AppendErrorf(diags, "inviting Macie Member: %s", err)
 			}
 
 			if len(output.UnprocessedAccounts) != 0 {
-				return diag.Errorf("inviting Macie Member: %s: %s", aws.StringValue(output.UnprocessedAccounts[0].ErrorCode), aws.StringValue(output.UnprocessedAccounts[0].ErrorMessage))
+				return sdkdiag.AppendErrorf(diags, "inviting Macie Member: %s: %s", aws.StringValue(output.UnprocessedAccounts[0].ErrorCode), aws.StringValue(output.UnprocessedAccounts[0].ErrorMessage))
 			}
 
 			if _, err = waitMemberInvited(ctx, conn, d.Id()); err != nil {
-				return diag.Errorf("waiting for Macie Member (%s) invitation: %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "waiting for Macie Member (%s) invitation: %s", d.Id(), err)
 			}
 		} else {
 			input := &macie2.DisassociateMemberInput{
@@ -301,9 +308,9 @@ func resourceMemberUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			if err != nil {
 				if tfawserr.ErrCodeEquals(err, macie2.ErrCodeResourceNotFoundException) ||
 					tfawserr.ErrMessageContains(err, macie2.ErrCodeAccessDeniedException, "Macie is not enabled") {
-					return nil
+					return diags
 				}
-				return diag.Errorf("disassociating Macie Member invite (%s): %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "disassociating Macie Member invite (%s): %s", d.Id(), err)
 			}
 		}
 	}
@@ -318,14 +325,16 @@ func resourceMemberUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 
 		_, err := conn.UpdateMemberSessionWithContext(ctx, input)
 		if err != nil {
-			return diag.Errorf("updating Macie Member (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating Macie Member (%s): %s", d.Id(), err)
 		}
 	}
 
-	return resourceMemberRead(ctx, d, meta)
+	return append(diags, resourceMemberRead(ctx, d, meta)...)
 }
 
 func resourceMemberDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).Macie2Conn(ctx)
 
 	input := &macie2.DeleteMemberInput{
@@ -338,9 +347,9 @@ func resourceMemberDelete(ctx context.Context, d *schema.ResourceData, meta inte
 			tfawserr.ErrMessageContains(err, macie2.ErrCodeAccessDeniedException, "Macie is not enabled") ||
 			tfawserr.ErrMessageContains(err, macie2.ErrCodeConflictException, "member accounts are associated with your account") ||
 			tfawserr.ErrMessageContains(err, macie2.ErrCodeValidationException, "account is not associated with your account") {
-			return nil
+			return diags
 		}
-		return diag.Errorf("deleting Macie Member (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Macie Member (%s): %s", d.Id(), err)
 	}
-	return nil
+	return diags
 }

--- a/internal/service/macie2/organization_admin_account.go
+++ b/internal/service/macie2/organization_admin_account.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
@@ -39,6 +40,8 @@ func ResourceOrganizationAdminAccount() *schema.Resource {
 }
 
 func resourceOrganizationAdminAccountCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).Macie2Conn(ctx)
 	adminAccountID := d.Get("admin_account_id").(string)
 	input := &macie2.EnableOrganizationAdminAccountInput{
@@ -66,18 +69,18 @@ func resourceOrganizationAdminAccountCreate(ctx context.Context, d *schema.Resou
 	}
 
 	if err != nil {
-		return diag.Errorf("creating Macie OrganizationAdminAccount: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating Macie OrganizationAdminAccount: %s", err)
 	}
 
 	d.SetId(adminAccountID)
 
-	return resourceOrganizationAdminAccountRead(ctx, d, meta)
+	return append(diags, resourceOrganizationAdminAccountRead(ctx, d, meta)...)
 }
 
 func resourceOrganizationAdminAccountRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).Macie2Conn(ctx)
+	var diags diag.Diagnostics
 
-	var err error
+	conn := meta.(*conns.AWSClient).Macie2Conn(ctx)
 
 	res, err := GetOrganizationAdminAccount(ctx, conn, d.Id())
 
@@ -85,29 +88,31 @@ func resourceOrganizationAdminAccountRead(ctx context.Context, d *schema.Resourc
 		tfawserr.ErrMessageContains(err, macie2.ErrCodeAccessDeniedException, "Macie is not enabled")) {
 		log.Printf("[WARN] Macie OrganizationAdminAccount (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Macie OrganizationAdminAccount (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Macie OrganizationAdminAccount (%s): %s", d.Id(), err)
 	}
 
 	if res == nil {
 		if !d.IsNewResource() {
 			log.Printf("[WARN] Macie OrganizationAdminAccount (%s) not found, removing from state", d.Id())
 			d.SetId("")
-			return nil
+			return diags
 		}
 
-		return diag.FromErr(&retry.NotFoundError{})
+		return sdkdiag.AppendFromErr(diags, &retry.NotFoundError{})
 	}
 
 	d.Set("admin_account_id", res.AccountId)
 
-	return nil
+	return diags
 }
 
 func resourceOrganizationAdminAccountDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).Macie2Conn(ctx)
 
 	input := &macie2.DisableOrganizationAdminAccountInput{
@@ -118,11 +123,11 @@ func resourceOrganizationAdminAccountDelete(ctx context.Context, d *schema.Resou
 	if err != nil {
 		if tfawserr.ErrCodeEquals(err, macie2.ErrCodeResourceNotFoundException) ||
 			tfawserr.ErrMessageContains(err, macie2.ErrCodeAccessDeniedException, "Macie is not enabled") {
-			return nil
+			return diags
 		}
-		return diag.Errorf("deleting Macie OrganizationAdminAccount (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Macie OrganizationAdminAccount (%s): %s", d.Id(), err)
 	}
-	return nil
+	return diags
 }
 
 func GetOrganizationAdminAccount(ctx context.Context, conn *macie2.Macie2, adminAccountID string) (*macie2.AdminAccount, error) {

--- a/internal/service/medialive/channel.go
+++ b/internal/service/medialive/channel.go
@@ -738,6 +738,8 @@ const (
 )
 
 func resourceChannelCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MediaLiveClient(ctx)
 
 	in := &medialive.CreateChannelInput{
@@ -776,29 +778,31 @@ func resourceChannelCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 	out, err := conn.CreateChannel(ctx, in)
 	if err != nil {
-		return create.DiagError(names.MediaLive, create.ErrActionCreating, ResNameChannel, d.Get("name").(string), err)
+		return create.AppendDiagError(diags, names.MediaLive, create.ErrActionCreating, ResNameChannel, d.Get("name").(string), err)
 	}
 
 	if out == nil || out.Channel == nil {
-		return create.DiagError(names.MediaLive, create.ErrActionCreating, ResNameChannel, d.Get("name").(string), errors.New("empty output"))
+		return create.AppendDiagError(diags, names.MediaLive, create.ErrActionCreating, ResNameChannel, d.Get("name").(string), errors.New("empty output"))
 	}
 
 	d.SetId(aws.ToString(out.Channel.Id))
 
 	if _, err := waitChannelCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return create.DiagError(names.MediaLive, create.ErrActionWaitingForCreation, ResNameChannel, d.Id(), err)
+		return create.AppendDiagError(diags, names.MediaLive, create.ErrActionWaitingForCreation, ResNameChannel, d.Id(), err)
 	}
 
 	if d.Get("start_channel").(bool) {
 		if err := startChannel(ctx, conn, d.Timeout(schema.TimeoutCreate), d.Id()); err != nil {
-			return create.DiagError(names.MediaLive, create.ErrActionCreating, ResNameChannel, d.Get("name").(string), err)
+			return create.AppendDiagError(diags, names.MediaLive, create.ErrActionCreating, ResNameChannel, d.Get("name").(string), err)
 		}
 	}
 
-	return resourceChannelRead(ctx, d, meta)
+	return append(diags, resourceChannelRead(ctx, d, meta)...)
 }
 
 func resourceChannelRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MediaLiveClient(ctx)
 
 	out, err := FindChannelByID(ctx, conn, d.Id())
@@ -806,11 +810,11 @@ func resourceChannelRead(ctx context.Context, d *schema.ResourceData, meta inter
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] MediaLive Channel (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.MediaLive, create.ErrActionReading, ResNameChannel, d.Id(), err)
+		return create.AppendDiagError(diags, names.MediaLive, create.ErrActionReading, ResNameChannel, d.Id(), err)
 	}
 
 	d.Set("arn", out.Arn)
@@ -821,31 +825,33 @@ func resourceChannelRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set("role_arn", out.RoleArn)
 
 	if err := d.Set("cdi_input_specification", flattenChannelCdiInputSpecification(out.CdiInputSpecification)); err != nil {
-		return create.DiagError(names.MediaLive, create.ErrActionSetting, ResNameChannel, d.Id(), err)
+		return create.AppendDiagError(diags, names.MediaLive, create.ErrActionSetting, ResNameChannel, d.Id(), err)
 	}
 	if err := d.Set("input_attachments", flattenChannelInputAttachments(out.InputAttachments)); err != nil {
-		return create.DiagError(names.MediaLive, create.ErrActionSetting, ResNameChannel, d.Id(), err)
+		return create.AppendDiagError(diags, names.MediaLive, create.ErrActionSetting, ResNameChannel, d.Id(), err)
 	}
 	if err := d.Set("destinations", flattenChannelDestinations(out.Destinations)); err != nil {
-		return create.DiagError(names.MediaLive, create.ErrActionSetting, ResNameChannel, d.Id(), err)
+		return create.AppendDiagError(diags, names.MediaLive, create.ErrActionSetting, ResNameChannel, d.Id(), err)
 	}
 	if err := d.Set("encoder_settings", flattenChannelEncoderSettings(out.EncoderSettings)); err != nil {
-		return create.DiagError(names.MediaLive, create.ErrActionSetting, ResNameChannel, d.Id(), err)
+		return create.AppendDiagError(diags, names.MediaLive, create.ErrActionSetting, ResNameChannel, d.Id(), err)
 	}
 	if err := d.Set("input_specification", flattenChannelInputSpecification(out.InputSpecification)); err != nil {
-		return create.DiagError(names.MediaLive, create.ErrActionSetting, ResNameChannel, d.Id(), err)
+		return create.AppendDiagError(diags, names.MediaLive, create.ErrActionSetting, ResNameChannel, d.Id(), err)
 	}
 	if err := d.Set("maintenance", flattenChannelMaintenance(out.Maintenance)); err != nil {
-		return create.DiagError(names.MediaLive, create.ErrActionSetting, ResNameChannel, d.Id(), err)
+		return create.AppendDiagError(diags, names.MediaLive, create.ErrActionSetting, ResNameChannel, d.Id(), err)
 	}
 	if err := d.Set("vpc", flattenChannelVPC(out.Vpc)); err != nil {
-		return create.DiagError(names.MediaLive, create.ErrActionSetting, ResNameChannel, d.Id(), err)
+		return create.AppendDiagError(diags, names.MediaLive, create.ErrActionSetting, ResNameChannel, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceChannelUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MediaLiveClient(ctx)
 
 	if d.HasChangesExcept("tags", "tags_all", "start_channel") {
@@ -892,28 +898,28 @@ func resourceChannelUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		channel, err := FindChannelByID(ctx, conn, d.Id())
 
 		if err != nil {
-			return create.DiagError(names.MediaLive, create.ErrActionUpdating, ResNameChannel, d.Id(), err)
+			return create.AppendDiagError(diags, names.MediaLive, create.ErrActionUpdating, ResNameChannel, d.Id(), err)
 		}
 
 		if channel.State == types.ChannelStateRunning {
 			if err := stopChannel(ctx, conn, d.Timeout(schema.TimeoutUpdate), d.Id()); err != nil {
-				return create.DiagError(names.MediaLive, create.ErrActionUpdating, ResNameChannel, d.Id(), err)
+				return create.AppendDiagError(diags, names.MediaLive, create.ErrActionUpdating, ResNameChannel, d.Id(), err)
 			}
 		}
 
 		out, err := conn.UpdateChannel(ctx, in)
 		if err != nil {
-			return create.DiagError(names.MediaLive, create.ErrActionUpdating, ResNameChannel, d.Id(), err)
+			return create.AppendDiagError(diags, names.MediaLive, create.ErrActionUpdating, ResNameChannel, d.Id(), err)
 		}
 
 		if _, err := waitChannelUpdated(ctx, conn, aws.ToString(out.Channel.Id), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return create.DiagError(names.MediaLive, create.ErrActionWaitingForUpdate, ResNameChannel, d.Id(), err)
+			return create.AppendDiagError(diags, names.MediaLive, create.ErrActionWaitingForUpdate, ResNameChannel, d.Id(), err)
 		}
 	}
 
 	if d.Get("start_channel").(bool) {
 		if err := startChannel(ctx, conn, d.Timeout(schema.TimeoutUpdate), d.Id()); err != nil {
-			return create.DiagError(names.MediaLive, create.ErrActionUpdating, ResNameChannel, d.Get("name").(string), err)
+			return create.AppendDiagError(diags, names.MediaLive, create.ErrActionUpdating, ResNameChannel, d.Get("name").(string), err)
 		}
 	}
 
@@ -921,29 +927,31 @@ func resourceChannelUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		channel, err := FindChannelByID(ctx, conn, d.Id())
 
 		if err != nil {
-			return create.DiagError(names.MediaLive, create.ErrActionUpdating, ResNameChannel, d.Id(), err)
+			return create.AppendDiagError(diags, names.MediaLive, create.ErrActionUpdating, ResNameChannel, d.Id(), err)
 		}
 
 		switch d.Get("start_channel").(bool) {
 		case true:
 			if channel.State == types.ChannelStateIdle {
 				if err := startChannel(ctx, conn, d.Timeout(schema.TimeoutUpdate), d.Id()); err != nil {
-					return create.DiagError(names.MediaLive, create.ErrActionUpdating, ResNameChannel, d.Id(), err)
+					return create.AppendDiagError(diags, names.MediaLive, create.ErrActionUpdating, ResNameChannel, d.Id(), err)
 				}
 			}
 		default:
 			if channel.State == types.ChannelStateRunning {
 				if err := stopChannel(ctx, conn, d.Timeout(schema.TimeoutUpdate), d.Id()); err != nil {
-					return create.DiagError(names.MediaLive, create.ErrActionUpdating, ResNameChannel, d.Id(), err)
+					return create.AppendDiagError(diags, names.MediaLive, create.ErrActionUpdating, ResNameChannel, d.Id(), err)
 				}
 			}
 		}
 	}
 
-	return resourceChannelRead(ctx, d, meta)
+	return append(diags, resourceChannelRead(ctx, d, meta)...)
 }
 
 func resourceChannelDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MediaLiveClient(ctx)
 
 	log.Printf("[INFO] Deleting MediaLive Channel %s", d.Id())
@@ -951,12 +959,12 @@ func resourceChannelDelete(ctx context.Context, d *schema.ResourceData, meta int
 	channel, err := FindChannelByID(ctx, conn, d.Id())
 
 	if err != nil {
-		return create.DiagError(names.MediaLive, create.ErrActionDeleting, ResNameChannel, d.Id(), err)
+		return create.AppendDiagError(diags, names.MediaLive, create.ErrActionDeleting, ResNameChannel, d.Id(), err)
 	}
 
 	if channel.State == types.ChannelStateRunning {
 		if err := stopChannel(ctx, conn, d.Timeout(schema.TimeoutDelete), d.Id()); err != nil {
-			return create.DiagError(names.MediaLive, create.ErrActionDeleting, ResNameChannel, d.Id(), err)
+			return create.AppendDiagError(diags, names.MediaLive, create.ErrActionDeleting, ResNameChannel, d.Id(), err)
 		}
 	}
 
@@ -967,17 +975,17 @@ func resourceChannelDelete(ctx context.Context, d *schema.ResourceData, meta int
 	if err != nil {
 		var nfe *types.NotFoundException
 		if errors.As(err, &nfe) {
-			return nil
+			return diags
 		}
 
-		return create.DiagError(names.MediaLive, create.ErrActionDeleting, ResNameChannel, d.Id(), err)
+		return create.AppendDiagError(diags, names.MediaLive, create.ErrActionDeleting, ResNameChannel, d.Id(), err)
 	}
 
 	if _, err := waitChannelDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return create.DiagError(names.MediaLive, create.ErrActionWaitingForDeletion, ResNameChannel, d.Id(), err)
+		return create.AppendDiagError(diags, names.MediaLive, create.ErrActionWaitingForDeletion, ResNameChannel, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func startChannel(ctx context.Context, conn *medialive.Client, timeout time.Duration, id string) error {

--- a/internal/service/medialive/input_security_group.go
+++ b/internal/service/medialive/input_security_group.go
@@ -81,6 +81,8 @@ const (
 )
 
 func resourceInputSecurityGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MediaLiveClient(ctx)
 
 	in := &medialive.CreateInputSecurityGroupInput{
@@ -90,23 +92,25 @@ func resourceInputSecurityGroupCreate(ctx context.Context, d *schema.ResourceDat
 
 	out, err := conn.CreateInputSecurityGroup(ctx, in)
 	if err != nil {
-		return create.DiagError(names.MediaLive, create.ErrActionCreating, ResNameInputSecurityGroup, "", err)
+		return create.AppendDiagError(diags, names.MediaLive, create.ErrActionCreating, ResNameInputSecurityGroup, "", err)
 	}
 
 	if out == nil || out.SecurityGroup == nil {
-		return create.DiagError(names.MediaLive, create.ErrActionCreating, ResNameInputSecurityGroup, "", errors.New("empty output"))
+		return create.AppendDiagError(diags, names.MediaLive, create.ErrActionCreating, ResNameInputSecurityGroup, "", errors.New("empty output"))
 	}
 
 	d.SetId(aws.ToString(out.SecurityGroup.Id))
 
 	if _, err := waitInputSecurityGroupCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return create.DiagError(names.MediaLive, create.ErrActionWaitingForCreation, ResNameInputSecurityGroup, d.Id(), err)
+		return create.AppendDiagError(diags, names.MediaLive, create.ErrActionWaitingForCreation, ResNameInputSecurityGroup, d.Id(), err)
 	}
 
-	return resourceInputSecurityGroupRead(ctx, d, meta)
+	return append(diags, resourceInputSecurityGroupRead(ctx, d, meta)...)
 }
 
 func resourceInputSecurityGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MediaLiveClient(ctx)
 
 	out, err := FindInputSecurityGroupByID(ctx, conn, d.Id())
@@ -114,21 +118,23 @@ func resourceInputSecurityGroupRead(ctx context.Context, d *schema.ResourceData,
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] MediaLive InputSecurityGroup (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.MediaLive, create.ErrActionReading, ResNameInputSecurityGroup, d.Id(), err)
+		return create.AppendDiagError(diags, names.MediaLive, create.ErrActionReading, ResNameInputSecurityGroup, d.Id(), err)
 	}
 
 	d.Set("arn", out.Arn)
 	d.Set("inputs", out.Inputs)
 	d.Set("whitelist_rules", flattenInputWhitelistRules(out.WhitelistRules))
 
-	return nil
+	return diags
 }
 
 func resourceInputSecurityGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MediaLiveClient(ctx)
 
 	if d.HasChangesExcept("tags", "tags_all") {
@@ -143,18 +149,20 @@ func resourceInputSecurityGroupUpdate(ctx context.Context, d *schema.ResourceDat
 		log.Printf("[DEBUG] Updating MediaLive InputSecurityGroup (%s): %#v", d.Id(), in)
 		out, err := conn.UpdateInputSecurityGroup(ctx, in)
 		if err != nil {
-			return create.DiagError(names.MediaLive, create.ErrActionUpdating, ResNameInputSecurityGroup, d.Id(), err)
+			return create.AppendDiagError(diags, names.MediaLive, create.ErrActionUpdating, ResNameInputSecurityGroup, d.Id(), err)
 		}
 
 		if _, err := waitInputSecurityGroupUpdated(ctx, conn, aws.ToString(out.SecurityGroup.Id), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return create.DiagError(names.MediaLive, create.ErrActionWaitingForUpdate, ResNameInputSecurityGroup, d.Id(), err)
+			return create.AppendDiagError(diags, names.MediaLive, create.ErrActionWaitingForUpdate, ResNameInputSecurityGroup, d.Id(), err)
 		}
 	}
 
-	return resourceInputSecurityGroupRead(ctx, d, meta)
+	return append(diags, resourceInputSecurityGroupRead(ctx, d, meta)...)
 }
 
 func resourceInputSecurityGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MediaLiveClient(ctx)
 
 	log.Printf("[INFO] Deleting MediaLive InputSecurityGroup %s", d.Id())
@@ -166,17 +174,17 @@ func resourceInputSecurityGroupDelete(ctx context.Context, d *schema.ResourceDat
 	if err != nil {
 		var nfe *types.NotFoundException
 		if errors.As(err, &nfe) {
-			return nil
+			return diags
 		}
 
-		return create.DiagError(names.MediaLive, create.ErrActionDeleting, ResNameInputSecurityGroup, d.Id(), err)
+		return create.AppendDiagError(diags, names.MediaLive, create.ErrActionDeleting, ResNameInputSecurityGroup, d.Id(), err)
 	}
 
 	if _, err := waitInputSecurityGroupDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return create.DiagError(names.MediaLive, create.ErrActionWaitingForDeletion, ResNameInputSecurityGroup, d.Id(), err)
+		return create.AppendDiagError(diags, names.MediaLive, create.ErrActionWaitingForDeletion, ResNameInputSecurityGroup, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func waitInputSecurityGroupCreated(ctx context.Context, conn *medialive.Client, id string, timeout time.Duration) (*medialive.DescribeInputSecurityGroupOutput, error) {

--- a/internal/service/medialive/multiplex.go
+++ b/internal/service/medialive/multiplex.go
@@ -110,6 +110,8 @@ const (
 )
 
 func resourceMultiplexCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MediaLiveClient(ctx)
 
 	in := &medialive.CreateMultiplexInput{
@@ -125,29 +127,31 @@ func resourceMultiplexCreate(ctx context.Context, d *schema.ResourceData, meta i
 
 	out, err := conn.CreateMultiplex(ctx, in)
 	if err != nil {
-		return create.DiagError(names.MediaLive, create.ErrActionCreating, ResNameMultiplex, d.Get("name").(string), err)
+		return create.AppendDiagError(diags, names.MediaLive, create.ErrActionCreating, ResNameMultiplex, d.Get("name").(string), err)
 	}
 
 	if out == nil || out.Multiplex == nil {
-		return create.DiagError(names.MediaLive, create.ErrActionCreating, ResNameMultiplex, d.Get("name").(string), errors.New("empty output"))
+		return create.AppendDiagError(diags, names.MediaLive, create.ErrActionCreating, ResNameMultiplex, d.Get("name").(string), errors.New("empty output"))
 	}
 
 	d.SetId(aws.ToString(out.Multiplex.Id))
 
 	if _, err := waitMultiplexCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return create.DiagError(names.MediaLive, create.ErrActionWaitingForCreation, ResNameMultiplex, d.Id(), err)
+		return create.AppendDiagError(diags, names.MediaLive, create.ErrActionWaitingForCreation, ResNameMultiplex, d.Id(), err)
 	}
 
 	if d.Get("start_multiplex").(bool) {
 		if err := startMultiplex(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-			return create.DiagError(names.MediaLive, create.ErrActionCreating, ResNameMultiplex, d.Id(), err)
+			return create.AppendDiagError(diags, names.MediaLive, create.ErrActionCreating, ResNameMultiplex, d.Id(), err)
 		}
 	}
 
-	return resourceMultiplexRead(ctx, d, meta)
+	return append(diags, resourceMultiplexRead(ctx, d, meta)...)
 }
 
 func resourceMultiplexRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MediaLiveClient(ctx)
 
 	out, err := FindMultiplexByID(ctx, conn, d.Id())
@@ -155,11 +159,11 @@ func resourceMultiplexRead(ctx context.Context, d *schema.ResourceData, meta int
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] MediaLive Multiplex (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.MediaLive, create.ErrActionReading, ResNameMultiplex, d.Id(), err)
+		return create.AppendDiagError(diags, names.MediaLive, create.ErrActionReading, ResNameMultiplex, d.Id(), err)
 	}
 
 	d.Set("arn", out.Arn)
@@ -167,13 +171,15 @@ func resourceMultiplexRead(ctx context.Context, d *schema.ResourceData, meta int
 	d.Set("name", out.Name)
 
 	if err := d.Set("multiplex_settings", flattenMultiplexSettings(out.MultiplexSettings)); err != nil {
-		return create.DiagError(names.MediaLive, create.ErrActionSetting, ResNameMultiplex, d.Id(), err)
+		return create.AppendDiagError(diags, names.MediaLive, create.ErrActionSetting, ResNameMultiplex, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceMultiplexUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MediaLiveClient(ctx)
 
 	if d.HasChangesExcept("tags", "tags_all", "start_multiplex") {
@@ -191,38 +197,40 @@ func resourceMultiplexUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		log.Printf("[DEBUG] Updating MediaLive Multiplex (%s): %#v", d.Id(), in)
 		out, err := conn.UpdateMultiplex(ctx, in)
 		if err != nil {
-			return create.DiagError(names.MediaLive, create.ErrActionUpdating, ResNameMultiplex, d.Id(), err)
+			return create.AppendDiagError(diags, names.MediaLive, create.ErrActionUpdating, ResNameMultiplex, d.Id(), err)
 		}
 
 		if _, err := waitMultiplexUpdated(ctx, conn, aws.ToString(out.Multiplex.Id), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return create.DiagError(names.MediaLive, create.ErrActionWaitingForUpdate, ResNameMultiplex, d.Id(), err)
+			return create.AppendDiagError(diags, names.MediaLive, create.ErrActionWaitingForUpdate, ResNameMultiplex, d.Id(), err)
 		}
 	}
 
 	if d.HasChange("start_multiplex") {
 		out, err := FindMultiplexByID(ctx, conn, d.Id())
 		if err != nil {
-			return create.DiagError(names.MediaLive, create.ErrActionUpdating, ResNameMultiplex, d.Id(), err)
+			return create.AppendDiagError(diags, names.MediaLive, create.ErrActionUpdating, ResNameMultiplex, d.Id(), err)
 		}
 		if d.Get("start_multiplex").(bool) {
 			if out.State != types.MultiplexStateRunning {
 				if err := startMultiplex(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-					return create.DiagError(names.MediaLive, create.ErrActionUpdating, ResNameMultiplex, d.Id(), err)
+					return create.AppendDiagError(diags, names.MediaLive, create.ErrActionUpdating, ResNameMultiplex, d.Id(), err)
 				}
 			}
 		} else {
 			if out.State == types.MultiplexStateRunning {
 				if err := stopMultiplex(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-					return create.DiagError(names.MediaLive, create.ErrActionUpdating, ResNameMultiplex, d.Id(), err)
+					return create.AppendDiagError(diags, names.MediaLive, create.ErrActionUpdating, ResNameMultiplex, d.Id(), err)
 				}
 			}
 		}
 	}
 
-	return resourceMultiplexRead(ctx, d, meta)
+	return append(diags, resourceMultiplexRead(ctx, d, meta)...)
 }
 
 func resourceMultiplexDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MediaLiveClient(ctx)
 
 	log.Printf("[INFO] Deleting MediaLive Multiplex %s", d.Id())
@@ -230,7 +238,7 @@ func resourceMultiplexDelete(ctx context.Context, d *schema.ResourceData, meta i
 	out, err := FindMultiplexByID(ctx, conn, d.Id())
 
 	if tfresource.NotFound(err) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
@@ -239,7 +247,7 @@ func resourceMultiplexDelete(ctx context.Context, d *schema.ResourceData, meta i
 
 	if out.State == types.MultiplexStateRunning {
 		if err := stopMultiplex(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-			return create.DiagError(names.MediaLive, create.ErrActionDeleting, ResNameMultiplex, d.Id(), err)
+			return create.AppendDiagError(diags, names.MediaLive, create.ErrActionDeleting, ResNameMultiplex, d.Id(), err)
 		}
 	}
 
@@ -250,17 +258,17 @@ func resourceMultiplexDelete(ctx context.Context, d *schema.ResourceData, meta i
 	if err != nil {
 		var nfe *types.NotFoundException
 		if errors.As(err, &nfe) {
-			return nil
+			return diags
 		}
 
-		return create.DiagError(names.MediaLive, create.ErrActionDeleting, ResNameMultiplex, d.Id(), err)
+		return create.AppendDiagError(diags, names.MediaLive, create.ErrActionDeleting, ResNameMultiplex, d.Id(), err)
 	}
 
 	if _, err := waitMultiplexDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return create.DiagError(names.MediaLive, create.ErrActionWaitingForDeletion, ResNameMultiplex, d.Id(), err)
+		return create.AppendDiagError(diags, names.MediaLive, create.ErrActionWaitingForDeletion, ResNameMultiplex, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func waitMultiplexCreated(ctx context.Context, conn *medialive.Client, id string, timeout time.Duration) (*medialive.DescribeMultiplexOutput, error) {

--- a/internal/service/mediapackage/channel.go
+++ b/internal/service/mediapackage/channel.go
@@ -119,7 +119,7 @@ func resourceChannelRead(ctx context.Context, d *schema.ResourceData, meta inter
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] MediaPackage Channel (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {

--- a/internal/service/memorydb/acl.go
+++ b/internal/service/memorydb/acl.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -78,6 +79,8 @@ func ResourceACL() *schema.Resource {
 }
 
 func resourceACLCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MemoryDBConn(ctx)
 
 	name := create.Name(d.Get("name").(string), d.Get("name_prefix").(string))
@@ -94,19 +97,21 @@ func resourceACLCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 	_, err := conn.CreateACLWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating MemoryDB ACL (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "creating MemoryDB ACL (%s): %s", name, err)
 	}
 
 	if err := waitACLActive(ctx, conn, name); err != nil {
-		return diag.Errorf("waiting for MemoryDB ACL (%s) to be created: %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "waiting for MemoryDB ACL (%s) to be created: %s", name, err)
 	}
 
 	d.SetId(name)
 
-	return resourceACLRead(ctx, d, meta)
+	return append(diags, resourceACLRead(ctx, d, meta)...)
 }
 
 func resourceACLUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MemoryDBConn(ctx)
 
 	if d.HasChangesExcept("tags", "tags_all") {
@@ -130,7 +135,7 @@ func resourceACLUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 
 		initialState, err := FindACLByName(ctx, conn, d.Id())
 		if err != nil {
-			return diag.Errorf("getting MemoryDB ACL (%s) current state: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "getting MemoryDB ACL (%s) current state: %s", d.Id(), err)
 		}
 
 		initialUserNames := map[string]struct{}{}
@@ -152,19 +157,21 @@ func resourceACLUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 
 			_, err := conn.UpdateACLWithContext(ctx, input)
 			if err != nil {
-				return diag.Errorf("updating MemoryDB ACL (%s): %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "updating MemoryDB ACL (%s): %s", d.Id(), err)
 			}
 
 			if err := waitACLActive(ctx, conn, d.Id()); err != nil {
-				return diag.Errorf("waiting for MemoryDB ACL (%s) to be modified: %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "waiting for MemoryDB ACL (%s) to be modified: %s", d.Id(), err)
 			}
 		}
 	}
 
-	return resourceACLRead(ctx, d, meta)
+	return append(diags, resourceACLRead(ctx, d, meta)...)
 }
 
 func resourceACLRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MemoryDBConn(ctx)
 
 	acl, err := FindACLByName(ctx, conn, d.Id())
@@ -172,11 +179,11 @@ func resourceACLRead(ctx context.Context, d *schema.ResourceData, meta interface
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] MemoryDB ACL (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading MemoryDB ACL (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading MemoryDB ACL (%s): %s", d.Id(), err)
 	}
 
 	d.Set("arn", acl.ARN)
@@ -185,10 +192,12 @@ func resourceACLRead(ctx context.Context, d *schema.ResourceData, meta interface
 	d.Set("name_prefix", create.NamePrefixFromName(aws.StringValue(acl.Name)))
 	d.Set("user_names", flex.FlattenStringSet(acl.UserNames))
 
-	return nil
+	return diags
 }
 
 func resourceACLDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MemoryDBConn(ctx)
 
 	log.Printf("[DEBUG] Deleting MemoryDB ACL: (%s)", d.Id())
@@ -197,16 +206,16 @@ func resourceACLDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 	})
 
 	if tfawserr.ErrCodeEquals(err, memorydb.ErrCodeACLNotFoundFault) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting MemoryDB ACL (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting MemoryDB ACL (%s): %s", d.Id(), err)
 	}
 
 	if err := waitACLDeleted(ctx, conn, d.Id()); err != nil {
-		return diag.Errorf("waiting for MemoryDB ACL (%s) to be deleted: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for MemoryDB ACL (%s) to be deleted: %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/memorydb/acl_data_source.go
+++ b/internal/service/memorydb/acl_data_source.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -44,6 +45,8 @@ func DataSourceACL() *schema.Resource {
 }
 
 func dataSourceACLRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MemoryDBConn(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
@@ -52,7 +55,7 @@ func dataSourceACLRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	acl, err := FindACLByName(ctx, conn, name)
 
 	if err != nil {
-		return diag.FromErr(tfresource.SingularDataSourceFindError("MemoryDB ACL", err))
+		return sdkdiag.AppendFromErr(diags, tfresource.SingularDataSourceFindError("MemoryDB ACL", err))
 	}
 
 	d.SetId(aws.StringValue(acl.Name))
@@ -65,12 +68,12 @@ func dataSourceACLRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	tags, err := listTags(ctx, conn, d.Get("arn").(string))
 
 	if err != nil {
-		return diag.Errorf("listing tags for MemoryDB ACL (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "listing tags for MemoryDB ACL (%s): %s", d.Id(), err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/memorydb/cluster.go
+++ b/internal/service/memorydb/cluster.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -271,6 +272,8 @@ func endpointSchema() *schema.Schema {
 }
 
 func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MemoryDBConn(ctx)
 
 	name := create.Name(d.Get("name").(string), d.Get("name_prefix").(string))
@@ -348,19 +351,21 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 	_, err := conn.CreateClusterWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating MemoryDB Cluster (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "creating MemoryDB Cluster (%s): %s", name, err)
 	}
 
 	if err := waitClusterAvailable(ctx, conn, name, d.Timeout(schema.TimeoutCreate)); err != nil {
-		return diag.Errorf("waiting for MemoryDB Cluster (%s) to be created: %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "waiting for MemoryDB Cluster (%s) to be created: %s", name, err)
 	}
 
 	d.SetId(name)
 
-	return resourceClusterRead(ctx, d, meta)
+	return append(diags, resourceClusterRead(ctx, d, meta)...)
 }
 
 func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MemoryDBConn(ctx)
 
 	if d.HasChangesExcept("final_snapshot_name", "tags", "tags_all") {
@@ -416,7 +421,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 			v := d.Get("security_group_ids").(*schema.Set)
 
 			if v.Len() == 0 {
-				return diag.Errorf("unable to update MemoryDB Cluster (%s): removing all security groups is not possible", d.Id())
+				return sdkdiag.AppendErrorf(diags, "unable to update MemoryDB Cluster (%s): removing all security groups is not possible", d.Id())
 			}
 
 			input.SecurityGroupIds = flex.ExpandStringSet(v)
@@ -447,30 +452,32 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 		_, err := conn.UpdateClusterWithContext(ctx, input)
 		if err != nil {
-			return diag.Errorf("updating MemoryDB Cluster (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating MemoryDB Cluster (%s): %s", d.Id(), err)
 		}
 
 		if err := waitClusterAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return diag.Errorf("waiting for MemoryDB Cluster (%s) to be modified: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "waiting for MemoryDB Cluster (%s) to be modified: %s", d.Id(), err)
 		}
 
 		if waitParameterGroupInSync {
 			if err := waitClusterParameterGroupInSync(ctx, conn, d.Id()); err != nil {
-				return diag.Errorf("waiting for MemoryDB Cluster (%s) parameter group to be in sync: %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "waiting for MemoryDB Cluster (%s) parameter group to be in sync: %s", d.Id(), err)
 			}
 		}
 
 		if waitSecurityGroupsActive {
 			if err := waitClusterSecurityGroupsActive(ctx, conn, d.Id()); err != nil {
-				return diag.Errorf("waiting for MemoryDB Cluster (%s) security groups to be available: %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "waiting for MemoryDB Cluster (%s) security groups to be available: %s", d.Id(), err)
 			}
 		}
 	}
 
-	return resourceClusterRead(ctx, d, meta)
+	return append(diags, resourceClusterRead(ctx, d, meta)...)
 }
 
 func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MemoryDBConn(ctx)
 
 	cluster, err := FindClusterByName(ctx, conn, d.Id())
@@ -478,11 +485,11 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] MemoryDB Cluster (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading MemoryDB Cluster (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading MemoryDB Cluster (%s): %s", d.Id(), err)
 	}
 
 	d.Set("acl_name", cluster.ACLName)
@@ -497,7 +504,7 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
 	if v := aws.StringValue(cluster.DataTiering); v != "" {
 		b, err := strconv.ParseBool(v)
 		if err != nil {
-			return diag.Errorf("reading data_tiering for MemoryDB Cluster (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "reading data_tiering for MemoryDB Cluster (%s): %s", d.Id(), err)
 		}
 
 		d.Set("data_tiering", b)
@@ -514,7 +521,7 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
 
 	numReplicasPerShard, err := deriveClusterNumReplicasPerShard(cluster)
 	if err != nil {
-		return diag.Errorf("reading num_replicas_per_shard for MemoryDB Cluster (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading num_replicas_per_shard for MemoryDB Cluster (%s): %s", d.Id(), err)
 	}
 	d.Set("num_replicas_per_shard", numReplicasPerShard)
 
@@ -528,7 +535,7 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set("security_group_ids", flex.FlattenStringSet(securityGroupIds))
 
 	if err := d.Set("shards", flattenShards(cluster.Shards)); err != nil {
-		return diag.Errorf("failed to set shards for MemoryDB Cluster (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "failed to set shards for MemoryDB Cluster (%s): %s", d.Id(), err)
 	}
 
 	d.Set("snapshot_retention_limit", cluster.SnapshotRetentionLimit)
@@ -543,10 +550,12 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set("subnet_group_name", cluster.SubnetGroupName)
 	d.Set("tls_enabled", cluster.TLSEnabled)
 
-	return nil
+	return diags
 }
 
 func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MemoryDBConn(ctx)
 
 	input := &memorydb.DeleteClusterInput{
@@ -561,18 +570,18 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta int
 	_, err := conn.DeleteClusterWithContext(ctx, input)
 
 	if tfawserr.ErrCodeEquals(err, memorydb.ErrCodeClusterNotFoundFault) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting MemoryDB Cluster (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting MemoryDB Cluster (%s): %s", d.Id(), err)
 	}
 
 	if err := waitClusterDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return diag.Errorf("waiting for MemoryDB Cluster (%s) to be deleted: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for MemoryDB Cluster (%s) to be deleted: %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func shardHash(v interface{}) int {

--- a/internal/service/memorydb/cluster_data_source.go
+++ b/internal/service/memorydb/cluster_data_source.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -163,6 +164,8 @@ func DataSourceCluster() *schema.Resource {
 }
 
 func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MemoryDBConn(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
@@ -171,7 +174,7 @@ func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta int
 	cluster, err := FindClusterByName(ctx, conn, name)
 
 	if err != nil {
-		return diag.FromErr(tfresource.SingularDataSourceFindError("MemoryDB Cluster", err))
+		return sdkdiag.AppendFromErr(diags, tfresource.SingularDataSourceFindError("MemoryDB Cluster", err))
 	}
 
 	d.SetId(aws.StringValue(cluster.Name))
@@ -188,7 +191,7 @@ func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta int
 	if v := aws.StringValue(cluster.DataTiering); v != "" {
 		b, err := strconv.ParseBool(v)
 		if err != nil {
-			return diag.Errorf("reading data_tiering for MemoryDB Cluster (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "reading data_tiering for MemoryDB Cluster (%s): %s", d.Id(), err)
 		}
 
 		d.Set("data_tiering", b)
@@ -204,7 +207,7 @@ func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta int
 
 	numReplicasPerShard, err := deriveClusterNumReplicasPerShard(cluster)
 	if err != nil {
-		return diag.Errorf("reading num_replicas_per_shard for MemoryDB Cluster (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading num_replicas_per_shard for MemoryDB Cluster (%s): %s", d.Id(), err)
 	}
 	d.Set("num_replicas_per_shard", numReplicasPerShard)
 
@@ -218,7 +221,7 @@ func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta int
 	d.Set("security_group_ids", flex.FlattenStringSet(securityGroupIds))
 
 	if err := d.Set("shards", flattenShards(cluster.Shards)); err != nil {
-		return diag.Errorf("failed to set shards for MemoryDB Cluster (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "failed to set shards for MemoryDB Cluster (%s): %s", d.Id(), err)
 	}
 
 	d.Set("snapshot_retention_limit", cluster.SnapshotRetentionLimit)
@@ -236,12 +239,12 @@ func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta int
 	tags, err := listTags(ctx, conn, d.Get("arn").(string))
 
 	if err != nil {
-		return diag.Errorf("listing tags for MemoryDB Cluster (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "listing tags for MemoryDB Cluster (%s): %s", d.Id(), err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/memorydb/parameter_group.go
+++ b/internal/service/memorydb/parameter_group.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -97,6 +98,8 @@ func ResourceParameterGroup() *schema.Resource {
 }
 
 func resourceParameterGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MemoryDBConn(ctx)
 
 	name := create.Name(d.Get("name").(string), d.Get("name_prefix").(string))
@@ -111,7 +114,7 @@ func resourceParameterGroupCreate(ctx context.Context, d *schema.ResourceData, m
 	output, err := conn.CreateParameterGroupWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating MemoryDB Parameter Group (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "creating MemoryDB Parameter Group (%s): %s", name, err)
 	}
 
 	d.SetId(name)
@@ -120,10 +123,12 @@ func resourceParameterGroupCreate(ctx context.Context, d *schema.ResourceData, m
 	log.Printf("[INFO] MemoryDB Parameter Group ID: %s", d.Id())
 
 	// Update to apply parameter changes.
-	return resourceParameterGroupUpdate(ctx, d, meta)
+	return append(diags, resourceParameterGroupUpdate(ctx, d, meta)...)
 }
 
 func resourceParameterGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MemoryDBConn(ctx)
 
 	if d.HasChange("parameter") {
@@ -151,7 +156,7 @@ func resourceParameterGroupUpdate(ctx context.Context, d *schema.ResourceData, m
 			err := resetParameterGroupParameters(ctx, conn, d.Get("name").(string), paramsToReset)
 
 			if err != nil {
-				return diag.Errorf("resetting MemoryDB Parameter Group (%s) parameters to defaults: %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "resetting MemoryDB Parameter Group (%s) parameters to defaults: %s", d.Id(), err)
 			}
 		}
 
@@ -166,15 +171,17 @@ func resourceParameterGroupUpdate(ctx context.Context, d *schema.ResourceData, m
 			err := modifyParameterGroupParameters(ctx, conn, d.Get("name").(string), paramsToModify)
 
 			if err != nil {
-				return diag.Errorf("modifying MemoryDB Parameter Group (%s) parameters: %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "modifying MemoryDB Parameter Group (%s) parameters: %s", d.Id(), err)
 			}
 		}
 	}
 
-	return resourceParameterGroupRead(ctx, d, meta)
+	return append(diags, resourceParameterGroupRead(ctx, d, meta)...)
 }
 
 func resourceParameterGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MemoryDBConn(ctx)
 
 	group, err := FindParameterGroupByName(ctx, conn, d.Id())
@@ -182,11 +189,11 @@ func resourceParameterGroupRead(ctx context.Context, d *schema.ResourceData, met
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] MemoryDB Parameter Group (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading MemoryDB Parameter Group (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading MemoryDB Parameter Group (%s): %s", d.Id(), err)
 	}
 
 	d.Set("arn", group.ARN)
@@ -199,17 +206,19 @@ func resourceParameterGroupRead(ctx context.Context, d *schema.ResourceData, met
 
 	parameters, err := listParameterGroupParameters(ctx, conn, d.Get("family").(string), d.Id(), userDefinedParameters)
 	if err != nil {
-		return diag.Errorf("listing parameters for MemoryDB Parameter Group (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "listing parameters for MemoryDB Parameter Group (%s): %s", d.Id(), err)
 	}
 
 	if err := d.Set("parameter", flattenParameters(parameters)); err != nil {
-		return diag.Errorf("failed to set parameter: %s", err)
+		return sdkdiag.AppendErrorf(diags, "failed to set parameter: %s", err)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceParameterGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MemoryDBConn(ctx)
 
 	log.Printf("[DEBUG] Deleting MemoryDB Parameter Group: (%s)", d.Id())
@@ -218,14 +227,14 @@ func resourceParameterGroupDelete(ctx context.Context, d *schema.ResourceData, m
 	})
 
 	if tfawserr.ErrCodeEquals(err, memorydb.ErrCodeParameterGroupNotFoundFault) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting MemoryDB Parameter Group (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting MemoryDB Parameter Group (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 // resetParameterGroupParameters resets the given parameters to their default values.

--- a/internal/service/memorydb/parameter_group_data_source.go
+++ b/internal/service/memorydb/parameter_group_data_source.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
@@ -59,6 +60,8 @@ func DataSourceParameterGroup() *schema.Resource {
 }
 
 func dataSourceParameterGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MemoryDBConn(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
@@ -67,7 +70,7 @@ func dataSourceParameterGroupRead(ctx context.Context, d *schema.ResourceData, m
 	group, err := FindParameterGroupByName(ctx, conn, name)
 
 	if err != nil {
-		return diag.FromErr(tfresource.SingularDataSourceFindError("MemoryDB Parameter Group", err))
+		return sdkdiag.AppendFromErr(diags, tfresource.SingularDataSourceFindError("MemoryDB Parameter Group", err))
 	}
 
 	d.SetId(aws.StringValue(group.Name))
@@ -81,22 +84,22 @@ func dataSourceParameterGroupRead(ctx context.Context, d *schema.ResourceData, m
 
 	parameters, err := listParameterGroupParameters(ctx, conn, d.Get("family").(string), d.Id(), userDefinedParameters)
 	if err != nil {
-		return diag.Errorf("listing parameters for MemoryDB Parameter Group (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "listing parameters for MemoryDB Parameter Group (%s): %s", d.Id(), err)
 	}
 
 	if err := d.Set("parameter", flattenParameters(parameters)); err != nil {
-		return diag.Errorf("failed to set parameter: %s", err)
+		return sdkdiag.AppendErrorf(diags, "failed to set parameter: %s", err)
 	}
 
 	tags, err := listTags(ctx, conn, d.Get("arn").(string))
 
 	if err != nil {
-		return diag.Errorf("listing tags for MemoryDB Parameter Group (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "listing tags for MemoryDB Parameter Group (%s): %s", d.Id(), err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/memorydb/subnet_group.go
+++ b/internal/service/memorydb/subnet_group.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -80,6 +81,8 @@ func ResourceSubnetGroup() *schema.Resource {
 }
 
 func resourceSubnetGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MemoryDBConn(ctx)
 
 	name := create.Name(d.Get("name").(string), d.Get("name_prefix").(string))
@@ -94,15 +97,17 @@ func resourceSubnetGroupCreate(ctx context.Context, d *schema.ResourceData, meta
 	_, err := conn.CreateSubnetGroupWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating MemoryDB Subnet Group (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "creating MemoryDB Subnet Group (%s): %s", name, err)
 	}
 
 	d.SetId(name)
 
-	return resourceSubnetGroupRead(ctx, d, meta)
+	return append(diags, resourceSubnetGroupRead(ctx, d, meta)...)
 }
 
 func resourceSubnetGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MemoryDBConn(ctx)
 
 	if d.HasChangesExcept("tags", "tags_all") {
@@ -116,14 +121,16 @@ func resourceSubnetGroupUpdate(ctx context.Context, d *schema.ResourceData, meta
 		_, err := conn.UpdateSubnetGroupWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("updating MemoryDB Subnet Group (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating MemoryDB Subnet Group (%s): %s", d.Id(), err)
 		}
 	}
 
-	return resourceSubnetGroupRead(ctx, d, meta)
+	return append(diags, resourceSubnetGroupRead(ctx, d, meta)...)
 }
 
 func resourceSubnetGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MemoryDBConn(ctx)
 
 	group, err := FindSubnetGroupByName(ctx, conn, d.Id())
@@ -131,11 +138,11 @@ func resourceSubnetGroupRead(ctx context.Context, d *schema.ResourceData, meta i
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] MemoryDB Subnet Group (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading MemoryDB Subnet Group (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading MemoryDB Subnet Group (%s): %s", d.Id(), err)
 	}
 
 	var subnetIds []*string
@@ -150,10 +157,12 @@ func resourceSubnetGroupRead(ctx context.Context, d *schema.ResourceData, meta i
 	d.Set("name_prefix", create.NamePrefixFromName(aws.StringValue(group.Name)))
 	d.Set("vpc_id", group.VpcId)
 
-	return nil
+	return diags
 }
 
 func resourceSubnetGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MemoryDBConn(ctx)
 
 	log.Printf("[DEBUG] Deleting MemoryDB Subnet Group: (%s)", d.Id())
@@ -162,12 +171,12 @@ func resourceSubnetGroupDelete(ctx context.Context, d *schema.ResourceData, meta
 	})
 
 	if tfawserr.ErrCodeEquals(err, memorydb.ErrCodeSubnetGroupNotFoundFault) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting MemoryDB Subnet Group (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting MemoryDB Subnet Group (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/memorydb/subnet_group_data_source.go
+++ b/internal/service/memorydb/subnet_group_data_source.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -48,6 +49,8 @@ func DataSourceSubnetGroup() *schema.Resource {
 }
 
 func dataSourceSubnetGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MemoryDBConn(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
@@ -56,7 +59,7 @@ func dataSourceSubnetGroupRead(ctx context.Context, d *schema.ResourceData, meta
 	group, err := FindSubnetGroupByName(ctx, conn, name)
 
 	if err != nil {
-		return diag.FromErr(tfresource.SingularDataSourceFindError("MemoryDB Subnet Group", err))
+		return sdkdiag.AppendFromErr(diags, tfresource.SingularDataSourceFindError("MemoryDB Subnet Group", err))
 	}
 
 	d.SetId(aws.StringValue(group.Name))
@@ -75,12 +78,12 @@ func dataSourceSubnetGroupRead(ctx context.Context, d *schema.ResourceData, meta
 	tags, err := listTags(ctx, conn, d.Get("arn").(string))
 
 	if err != nil {
-		return diag.Errorf("listing tags for MemoryDB Subnet Group (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "listing tags for MemoryDB Subnet Group (%s): %s", d.Id(), err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/memorydb/user_data_source.go
+++ b/internal/service/memorydb/user_data_source.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
@@ -58,6 +59,8 @@ func DataSourceUser() *schema.Resource {
 }
 
 func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MemoryDBConn(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
@@ -66,7 +69,7 @@ func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, meta interf
 	user, err := FindUserByName(ctx, conn, userName)
 
 	if err != nil {
-		return diag.FromErr(tfresource.SingularDataSourceFindError("MemoryDB User", err))
+		return sdkdiag.AppendFromErr(diags, tfresource.SingularDataSourceFindError("MemoryDB User", err))
 	}
 
 	d.SetId(aws.StringValue(user.Name))
@@ -81,7 +84,7 @@ func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, meta interf
 		}
 
 		if err := d.Set("authentication_mode", []interface{}{authenticationMode}); err != nil {
-			return diag.Errorf("failed to set authentication_mode of MemoryDB User (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "failed to set authentication_mode of MemoryDB User (%s): %s", d.Id(), err)
 		}
 	}
 
@@ -91,12 +94,12 @@ func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, meta interf
 	tags, err := listTags(ctx, conn, d.Get("arn").(string))
 
 	if err != nil {
-		return diag.Errorf("listing tags for MemoryDB User (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "listing tags for MemoryDB User (%s): %s", d.Id(), err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/mq/broker_data_source.go
+++ b/internal/service/mq/broker_data_source.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/types/nullable"
 )
@@ -252,6 +253,8 @@ func DataSourceBroker() *schema.Resource {
 }
 
 func dataSourceBrokerRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MQConn(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
@@ -283,20 +286,20 @@ func dataSourceBrokerRead(ctx context.Context, d *schema.ResourceData, meta inte
 	})
 
 	if err != nil {
-		return diag.Errorf("reading MQ Brokers: %s", err)
+		return sdkdiag.AppendErrorf(diags, "reading MQ Brokers: %s", err)
 	}
 
 	if n := len(brokers); n == 0 {
-		return diag.Errorf("no MQ Brokers matched")
+		return sdkdiag.AppendErrorf(diags, "no MQ Brokers matched")
 	} else if n > 1 {
-		return diag.Errorf("%d MQ Brokers matched; use additional constraints to reduce matches to a single Broker", n)
+		return sdkdiag.AppendErrorf(diags, "%d MQ Brokers matched; use additional constraints to reduce matches to a single Broker", n)
 	}
 
 	brokerID := aws.StringValue(brokers[0].BrokerId)
 	output, err := FindBrokerByID(ctx, conn, brokerID)
 
 	if err != nil {
-		return diag.Errorf("reading MQ Broker (%s): %s", brokerID, err)
+		return sdkdiag.AppendErrorf(diags, "reading MQ Broker (%s): %s", brokerID, err)
 	}
 
 	d.SetId(brokerID)
@@ -316,11 +319,11 @@ func dataSourceBrokerRead(ctx context.Context, d *schema.ResourceData, meta inte
 	d.Set("subnet_ids", aws.StringValueSlice(output.SubnetIds))
 
 	if err := d.Set("configuration", flattenConfiguration(output.Configurations)); err != nil {
-		return diag.Errorf("setting configuration: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting configuration: %s", err)
 	}
 
 	if err := d.Set("encryption_options", flattenEncryptionOptions(output.EncryptionOptions)); err != nil {
-		return diag.Errorf("setting encryption_options: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting encryption_options: %s", err)
 	}
 
 	var password string
@@ -329,30 +332,30 @@ func dataSourceBrokerRead(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if err := d.Set("ldap_server_metadata", flattenLDAPServerMetadata(output.LdapServerMetadata, password)); err != nil {
-		return diag.Errorf("setting ldap_server_metadata: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting ldap_server_metadata: %s", err)
 	}
 
 	if err := d.Set("logs", flattenLogs(output.Logs)); err != nil {
-		return diag.Errorf("setting logs: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting logs: %s", err)
 	}
 
 	if err := d.Set("maintenance_window_start_time", flattenWeeklyStartTime(output.MaintenanceWindowStartTime)); err != nil {
-		return diag.Errorf("setting maintenance_window_start_time: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting maintenance_window_start_time: %s", err)
 	}
 
 	rawUsers, err := expandUsersForBroker(ctx, conn, brokerID, output.Users)
 
 	if err != nil {
-		return diag.Errorf("reading MQ Broker (%s) users: %s", brokerID, err)
+		return sdkdiag.AppendErrorf(diags, "reading MQ Broker (%s) users: %s", brokerID, err)
 	}
 
 	if err := d.Set("user", flattenUsers(rawUsers, d.Get("user").(*schema.Set).List())); err != nil {
-		return diag.Errorf("setting user: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting user: %s", err)
 	}
 
 	if err := d.Set("tags", KeyValueTags(ctx, output.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/mq/broker_instance_type_offerings_data_source.go
+++ b/internal/service/mq/broker_instance_type_offerings_data_source.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 )
 
@@ -82,6 +83,8 @@ func DataSourceBrokerInstanceTypeOfferings() *schema.Resource {
 }
 
 func dataSourceBrokerInstanceTypeOfferingsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MQConn(ctx)
 
 	input := &mq.DescribeBrokerInstanceOptionsInput{}
@@ -111,16 +114,16 @@ func dataSourceBrokerInstanceTypeOfferingsRead(ctx context.Context, d *schema.Re
 	})
 
 	if err != nil {
-		return diag.Errorf("reading MQ Broker Instance Options: %s", err)
+		return sdkdiag.AppendErrorf(diags, "reading MQ Broker Instance Options: %s", err)
 	}
 
 	d.SetId(meta.(*conns.AWSClient).Region)
 
 	if err := d.Set("broker_instance_options", flattenBrokerInstanceOptions(output)); err != nil {
-		return diag.Errorf("setting broker_instance_options: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting broker_instance_options: %s", err)
 	}
 
-	return nil
+	return diags
 }
 
 func flattenBrokerInstanceOptions(bios []*mq.BrokerInstanceOption) []interface{} {

--- a/internal/service/mq/configuration.go
+++ b/internal/service/mq/configuration.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -103,6 +104,8 @@ func ResourceConfiguration() *schema.Resource {
 }
 
 func resourceConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MQConn(ctx)
 
 	name := d.Get("name").(string)
@@ -120,7 +123,7 @@ func resourceConfigurationCreate(ctx context.Context, d *schema.ResourceData, me
 	output, err := conn.CreateConfigurationWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating MQ Configuration (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "creating MQ Configuration (%s): %s", name, err)
 	}
 
 	d.SetId(aws.StringValue(output.Id))
@@ -138,14 +141,16 @@ func resourceConfigurationCreate(ctx context.Context, d *schema.ResourceData, me
 		_, err := conn.UpdateConfigurationWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("updating MQ Configuration (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating MQ Configuration (%s): %s", d.Id(), err)
 		}
 	}
 
-	return resourceConfigurationRead(ctx, d, meta)
+	return append(diags, resourceConfigurationRead(ctx, d, meta)...)
 }
 
 func resourceConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MQConn(ctx)
 
 	configuration, err := FindConfigurationByID(ctx, conn, d.Id())
@@ -153,11 +158,11 @@ func resourceConfigurationRead(ctx context.Context, d *schema.ResourceData, meta
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] MQ Configuration (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading MQ Configuration (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading MQ Configuration (%s): %s", d.Id(), err)
 	}
 
 	d.Set("arn", configuration.Arn)
@@ -175,23 +180,25 @@ func resourceConfigurationRead(ctx context.Context, d *schema.ResourceData, meta
 	})
 
 	if err != nil {
-		return diag.Errorf("reading MQ Configuration (%s) revision (%s): %s", d.Id(), revision, err)
+		return sdkdiag.AppendErrorf(diags, "reading MQ Configuration (%s) revision (%s): %s", d.Id(), revision, err)
 	}
 
 	data, err := base64.StdEncoding.DecodeString(aws.StringValue(configurationRevision.Data))
 
 	if err != nil {
-		return diag.Errorf("base64 decoding: %s", err)
+		return sdkdiag.AppendErrorf(diags, "base64 decoding: %s", err)
 	}
 
 	d.Set("data", string(data))
 
 	setTagsOut(ctx, configuration.Tags)
 
-	return nil
+	return diags
 }
 
 func resourceConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).MQConn(ctx)
 
 	if d.HasChanges("data", "description") {
@@ -207,11 +214,11 @@ func resourceConfigurationUpdate(ctx context.Context, d *schema.ResourceData, me
 		_, err := conn.UpdateConfigurationWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("updating MQ Configuration (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating MQ Configuration (%s): %s", d.Id(), err)
 		}
 	}
 
-	return resourceConfigurationRead(ctx, d, meta)
+	return append(diags, resourceConfigurationRead(ctx, d, meta)...)
 }
 
 func FindConfigurationByID(ctx context.Context, conn *mq.MQ, id string) (*mq.DescribeConfigurationOutput, error) {

--- a/internal/service/neptune/cluster.go
+++ b/internal/service/neptune/cluster.go
@@ -682,7 +682,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		}
 
 		if err := removeClusterFromGlobalCluster(ctx, conn, d.Get("arn").(string), o, d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return append(diags, diag.FromErr(err)...)
+			return sdkdiag.AppendFromErr(diags, err)
 		}
 	}
 
@@ -740,7 +740,7 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta int
 
 	if v, ok := d.GetOk("global_cluster_identifier"); ok {
 		if err := removeClusterFromGlobalCluster(ctx, conn, d.Get("arn").(string), v.(string), d.Timeout(schema.TimeoutDelete)); err != nil {
-			return append(diags, diag.FromErr(err)...)
+			return sdkdiag.AppendFromErr(diags, err)
 		}
 	}
 
@@ -750,7 +750,7 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta int
 	}, neptune.ErrCodeInvalidDBClusterStateFault, "is not currently in the available state")
 
 	if tfawserr.ErrCodeEquals(err, neptune.ErrCodeDBClusterNotFoundFault) {
-		return nil
+		return diags
 	}
 
 	if err != nil {

--- a/internal/service/neptune/cluster_endpoint.go
+++ b/internal/service/neptune/cluster_endpoint.go
@@ -139,7 +139,7 @@ func resourceClusterEndpointRead(ctx context.Context, d *schema.ResourceData, me
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Neptune Cluster Endpoint (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {

--- a/internal/service/neptune/cluster_instance.go
+++ b/internal/service/neptune/cluster_instance.go
@@ -374,7 +374,7 @@ func resourceClusterInstanceDelete(ctx context.Context, d *schema.ResourceData, 
 		return sdkdiag.AppendErrorf(diags, "waiting for Neptune Cluster Instance (%s) delete: %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func FindDBInstanceByID(ctx context.Context, conn *neptune.Neptune, id string) (*neptune.DBInstance, error) {

--- a/internal/service/neptune/event_subscription.go
+++ b/internal/service/neptune/event_subscription.go
@@ -131,13 +131,13 @@ func resourceEventSubscriptionCreate(ctx context.Context, d *schema.ResourceData
 	output, err := conn.CreateEventSubscriptionWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating Neptune Event Subscription (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "creating Neptune Event Subscription (%s): %s", name, err)
 	}
 
 	d.SetId(aws.StringValue(output.EventSubscription.CustSubscriptionId))
 
 	if _, err := waitEventSubscriptionCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return diag.Errorf("waiting for Neptune Event Subscription (%s) create: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Neptune Event Subscription (%s) create: %s", d.Id(), err)
 	}
 
 	return append(diags, resourceEventSubscriptionRead(ctx, d, meta)...)
@@ -152,11 +152,11 @@ func resourceEventSubscriptionRead(ctx context.Context, d *schema.ResourceData, 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Neptune Event Subscription (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Neptune Event Subscription (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Neptune Event Subscription (%s): %s", d.Id(), err)
 	}
 
 	d.Set("arn", output.EventSubscriptionArn)
@@ -201,11 +201,11 @@ func resourceEventSubscriptionUpdate(ctx context.Context, d *schema.ResourceData
 		_, err := conn.ModifyEventSubscriptionWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("updating Neptune Event Subscription (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating Neptune Event Subscription (%s): %s", d.Id(), err)
 		}
 
 		if _, err := waitEventSubscriptionUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return diag.Errorf("waiting for Neptune Event Subscription (%s) update: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "waiting for Neptune Event Subscription (%s) update: %s", d.Id(), err)
 		}
 	}
 
@@ -231,7 +231,7 @@ func resourceEventSubscriptionUpdate(ctx context.Context, d *schema.ResourceData
 				})
 
 				if err != nil {
-					return diag.Errorf("removing Neptune Event Subscription (%s) source identifier: %s", d.Id(), err)
+					return sdkdiag.AppendErrorf(diags, "removing Neptune Event Subscription (%s) source identifier: %s", d.Id(), err)
 				}
 			}
 		}
@@ -244,7 +244,7 @@ func resourceEventSubscriptionUpdate(ctx context.Context, d *schema.ResourceData
 				})
 
 				if err != nil {
-					return diag.Errorf("adding Neptune Event Subscription (%s) source identifier: %s", d.Id(), err)
+					return sdkdiag.AppendErrorf(diags, "adding Neptune Event Subscription (%s) source identifier: %s", d.Id(), err)
 				}
 			}
 		}
@@ -271,7 +271,7 @@ func resourceEventSubscriptionDelete(ctx context.Context, d *schema.ResourceData
 	}
 
 	if _, err := waitEventSubscriptionDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return diag.Errorf("waiting for Neptune Event Subscription (%s) delete: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Neptune Event Subscription (%s) delete: %s", d.Id(), err)
 	}
 
 	return diags

--- a/internal/service/neptune/global_cluster.go
+++ b/internal/service/neptune/global_cluster.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"golang.org/x/exp/slices"
@@ -112,6 +113,8 @@ func ResourceGlobalCluster() *schema.Resource {
 }
 
 func resourceGlobalClusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NeptuneConn(ctx)
 
 	globalClusterID := d.Get("global_cluster_identifier").(string)
@@ -142,19 +145,21 @@ func resourceGlobalClusterCreate(ctx context.Context, d *schema.ResourceData, me
 	output, err := conn.CreateGlobalClusterWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating Neptune Global Cluster (%s): %s", globalClusterID, err)
+		return sdkdiag.AppendErrorf(diags, "creating Neptune Global Cluster (%s): %s", globalClusterID, err)
 	}
 
 	d.SetId(aws.StringValue(output.GlobalCluster.GlobalClusterIdentifier))
 
 	if _, err := waitGlobalClusterCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return diag.Errorf("waiting for Neptune Global Cluster (%s) create: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Neptune Global Cluster (%s) create: %s", d.Id(), err)
 	}
 
-	return resourceGlobalClusterRead(ctx, d, meta)
+	return append(diags, resourceGlobalClusterRead(ctx, d, meta)...)
 }
 
 func resourceGlobalClusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NeptuneConn(ctx)
 
 	globalCluster, err := FindGlobalClusterByID(ctx, conn, d.Id())
@@ -162,11 +167,11 @@ func resourceGlobalClusterRead(ctx context.Context, d *schema.ResourceData, meta
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Neptune Global Cluster (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Neptune Global Cluster (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Neptune Global Cluster (%s): %s", d.Id(), err)
 	}
 
 	d.Set("arn", globalCluster.GlobalClusterArn)
@@ -175,15 +180,17 @@ func resourceGlobalClusterRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set("engine_version", globalCluster.EngineVersion)
 	d.Set("global_cluster_identifier", globalCluster.GlobalClusterIdentifier)
 	if err := d.Set("global_cluster_members", flattenGlobalClusterMembers(globalCluster.GlobalClusterMembers)); err != nil {
-		return diag.Errorf("setting global_cluster_members: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting global_cluster_members: %s", err)
 	}
 	d.Set("global_cluster_resource_id", globalCluster.GlobalClusterResourceId)
 	d.Set("storage_encrypted", globalCluster.StorageEncrypted)
 
-	return nil
+	return diags
 }
 
 func resourceGlobalClusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NeptuneConn(ctx)
 
 	if d.HasChange("deletion_protection") {
@@ -195,15 +202,15 @@ func resourceGlobalClusterUpdate(ctx context.Context, d *schema.ResourceData, me
 		_, err := conn.ModifyGlobalClusterWithContext(ctx, input)
 
 		if tfawserr.ErrCodeEquals(err, neptune.ErrCodeGlobalClusterNotFoundFault) {
-			return nil
+			return diags
 		}
 
 		if err != nil {
-			return diag.Errorf("updating Neptune Global Cluster (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating Neptune Global Cluster (%s): %s", d.Id(), err)
 		}
 
 		if _, err := waitGlobalClusterUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return diag.Errorf("waiting for Neptune Global Cluster (%s) update: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "waiting for Neptune Global Cluster (%s) update: %s", d.Id(), err)
 		}
 	}
 
@@ -221,7 +228,7 @@ func resourceGlobalClusterUpdate(ctx context.Context, d *schema.ResourceData, me
 				cluster, err := findClusterByARN(ctx, conn, clusterARN)
 
 				if err != nil {
-					return diag.Errorf("reading Neptune Cluster (%s): %s", clusterARN, err)
+					return sdkdiag.AppendErrorf(diags, "reading Neptune Cluster (%s): %s", clusterARN, err)
 				}
 
 				clusterID := aws.StringValue(cluster.DBClusterIdentifier)
@@ -236,20 +243,22 @@ func resourceGlobalClusterUpdate(ctx context.Context, d *schema.ResourceData, me
 				}, "InvalidParameterValue", "IAM role ARN value is invalid or does not include the required permissions")
 
 				if err != nil {
-					return diag.Errorf("modifying Neptune Cluster (%s) engine version: %s", clusterID, err)
+					return sdkdiag.AppendErrorf(diags, "modifying Neptune Cluster (%s) engine version: %s", clusterID, err)
 				}
 
 				if _, err := waitDBClusterAvailable(ctx, conn, clusterID, d.Timeout(schema.TimeoutUpdate)); err != nil {
-					return diag.Errorf("waiting for Neptune Cluster (%s) update: %s", clusterID, err)
+					return sdkdiag.AppendErrorf(diags, "waiting for Neptune Cluster (%s) update: %s", clusterID, err)
 				}
 			}
 		}
 	}
 
-	return resourceGlobalClusterRead(ctx, d, meta)
+	return append(diags, resourceGlobalClusterRead(ctx, d, meta)...)
 }
 
 func resourceGlobalClusterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NeptuneConn(ctx)
 
 	// Remove any members from the global cluster.
@@ -262,7 +271,7 @@ func resourceGlobalClusterDelete(ctx context.Context, d *schema.ResourceData, me
 
 		if clusterARN, ok := tfMap["db_cluster_arn"].(string); ok && clusterARN != "" {
 			if err := removeClusterFromGlobalCluster(ctx, conn, clusterARN, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-				return diag.FromErr(err)
+				return sdkdiag.AppendFromErr(diags, err)
 			}
 		}
 	}
@@ -275,18 +284,18 @@ func resourceGlobalClusterDelete(ctx context.Context, d *schema.ResourceData, me
 	}, neptune.ErrCodeInvalidGlobalClusterStateFault, "is not empty")
 
 	if tfawserr.ErrCodeEquals(err, neptune.ErrCodeGlobalClusterNotFoundFault) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting Neptune Global Cluster (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Neptune Global Cluster (%s): %s", d.Id(), err)
 	}
 
 	if _, err := waitGlobalClusterDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return diag.Errorf("waiting for Neptune Global Cluster (%s) delete: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Neptune Global Cluster (%s) delete: %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func FindGlobalClusterByID(ctx context.Context, conn *neptune.Neptune, id string) (*neptune.GlobalCluster, error) {

--- a/internal/service/networkfirewall/firewall.go
+++ b/internal/service/networkfirewall/firewall.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -149,6 +150,8 @@ func ResourceFirewall() *schema.Resource {
 }
 
 func resourceFirewallCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkFirewallConn(ctx)
 
 	name := d.Get("name").(string)
@@ -183,19 +186,21 @@ func resourceFirewallCreate(ctx context.Context, d *schema.ResourceData, meta in
 	output, err := conn.CreateFirewallWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating NetworkFirewall Firewall (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "creating NetworkFirewall Firewall (%s): %s", name, err)
 	}
 
 	d.SetId(aws.StringValue(output.Firewall.FirewallArn))
 
 	if _, err := waitFirewallCreated(ctx, conn, d.Id()); err != nil {
-		return diag.Errorf("waiting for NetworkFirewall Firewall (%s) create: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for NetworkFirewall Firewall (%s) create: %s", d.Id(), err)
 	}
 
-	return resourceFirewallRead(ctx, d, meta)
+	return append(diags, resourceFirewallRead(ctx, d, meta)...)
 }
 
 func resourceFirewallRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkFirewallConn(ctx)
 
 	output, err := FindFirewallByARN(ctx, conn, d.Id())
@@ -203,11 +208,11 @@ func resourceFirewallRead(ctx context.Context, d *schema.ResourceData, meta inte
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] NetworkFirewall Firewall (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading NetworkFirewall Firewall (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading NetworkFirewall Firewall (%s): %s", d.Id(), err)
 	}
 
 	firewall := output.Firewall
@@ -215,27 +220,29 @@ func resourceFirewallRead(ctx context.Context, d *schema.ResourceData, meta inte
 	d.Set("delete_protection", firewall.DeleteProtection)
 	d.Set("description", firewall.Description)
 	if err := d.Set("encryption_configuration", flattenEncryptionConfiguration(firewall.EncryptionConfiguration)); err != nil {
-		return diag.Errorf("setting encryption_configuration: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting encryption_configuration: %s", err)
 	}
 	d.Set("firewall_policy_arn", firewall.FirewallPolicyArn)
 	d.Set("firewall_policy_change_protection", firewall.FirewallPolicyChangeProtection)
 	if err := d.Set("firewall_status", flattenFirewallStatus(output.FirewallStatus)); err != nil {
-		return diag.Errorf("setting firewall_status: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting firewall_status: %s", err)
 	}
 	d.Set("name", firewall.FirewallName)
 	d.Set("subnet_change_protection", firewall.SubnetChangeProtection)
 	if err := d.Set("subnet_mapping", flattenSubnetMappings(firewall.SubnetMappings)); err != nil {
-		return diag.Errorf("setting subnet_mapping: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting subnet_mapping: %s", err)
 	}
 	d.Set("update_token", output.UpdateToken)
 	d.Set("vpc_id", firewall.VpcId)
 
 	setTagsOut(ctx, firewall.Tags)
 
-	return nil
+	return diags
 }
 
 func resourceFirewallUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkFirewallConn(ctx)
 	updateToken := d.Get("update_token").(string)
 
@@ -249,7 +256,7 @@ func resourceFirewallUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		output, err := conn.UpdateFirewallDeleteProtectionWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("updating NetworkFirewall Firewall (%s) delete protection: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating NetworkFirewall Firewall (%s) delete protection: %s", d.Id(), err)
 		}
 
 		updateToken = aws.StringValue(output.UpdateToken)
@@ -265,7 +272,7 @@ func resourceFirewallUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		output, err := conn.UpdateFirewallDescriptionWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("updating NetworkFirewall Firewall (%s) description: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating NetworkFirewall Firewall (%s) description: %s", d.Id(), err)
 		}
 
 		updateToken = aws.StringValue(output.UpdateToken)
@@ -281,7 +288,7 @@ func resourceFirewallUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		output, err := conn.UpdateFirewallEncryptionConfigurationWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("updating NetworkFirewall Firewall (%s) encryption configuration: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating NetworkFirewall Firewall (%s) encryption configuration: %s", d.Id(), err)
 		}
 
 		updateToken = aws.StringValue(output.UpdateToken)
@@ -300,7 +307,7 @@ func resourceFirewallUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		output, err := conn.UpdateFirewallPolicyChangeProtectionWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("updating NetworkFirewall Firewall (%s) firewall policy change protection: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating NetworkFirewall Firewall (%s) firewall policy change protection: %s", d.Id(), err)
 		}
 
 		updateToken = aws.StringValue(output.UpdateToken)
@@ -316,7 +323,7 @@ func resourceFirewallUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		output, err := conn.AssociateFirewallPolicyWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("updating NetworkFirewall Firewall (%s) firewall policy ARN: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating NetworkFirewall Firewall (%s) firewall policy ARN: %s", d.Id(), err)
 		}
 
 		updateToken = aws.StringValue(output.UpdateToken)
@@ -332,7 +339,7 @@ func resourceFirewallUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		output, err := conn.UpdateSubnetChangeProtectionWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("updating NetworkFirewall Firewall (%s) subnet change protection: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating NetworkFirewall Firewall (%s) subnet change protection: %s", d.Id(), err)
 		}
 
 		updateToken = aws.StringValue(output.UpdateToken)
@@ -352,13 +359,13 @@ func resourceFirewallUpdate(ctx context.Context, d *schema.ResourceData, meta in
 			_, err := conn.AssociateSubnetsWithContext(ctx, input)
 
 			if err != nil {
-				return diag.Errorf("associating NetworkFirewall Firewall (%s) subnets: %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "associating NetworkFirewall Firewall (%s) subnets: %s", d.Id(), err)
 			}
 
 			updateToken, err = waitFirewallUpdated(ctx, conn, d.Id())
 
 			if err != nil {
-				return diag.Errorf("waiting for NetworkFirewall Firewall (%s) update: %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "waiting for NetworkFirewall Firewall (%s) update: %s", d.Id(), err)
 			}
 		}
 
@@ -375,18 +382,20 @@ func resourceFirewallUpdate(ctx context.Context, d *schema.ResourceData, meta in
 				/*updateToken*/ _, err = waitFirewallUpdated(ctx, conn, d.Id())
 
 				if err != nil {
-					return diag.Errorf("waiting for NetworkFirewall Firewall (%s) update: %s", d.Id(), err)
+					return sdkdiag.AppendErrorf(diags, "waiting for NetworkFirewall Firewall (%s) update: %s", d.Id(), err)
 				}
 			} else if !tfawserr.ErrMessageContains(err, networkfirewall.ErrCodeInvalidRequestException, "inaccessible") {
-				return diag.Errorf("disassociating NetworkFirewall Firewall (%s) subnets: %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "disassociating NetworkFirewall Firewall (%s) subnets: %s", d.Id(), err)
 			}
 		}
 	}
 
-	return resourceFirewallRead(ctx, d, meta)
+	return append(diags, resourceFirewallRead(ctx, d, meta)...)
 }
 
 func resourceFirewallDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkFirewallConn(ctx)
 
 	log.Printf("[DEBUG] Deleting NetworkFirewall Firewall: %s", d.Id())
@@ -395,18 +404,18 @@ func resourceFirewallDelete(ctx context.Context, d *schema.ResourceData, meta in
 	})
 
 	if tfawserr.ErrCodeEquals(err, networkfirewall.ErrCodeResourceNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting NetworkFirewall Firewall (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting NetworkFirewall Firewall (%s): %s", d.Id(), err)
 	}
 
 	if _, err := waitFirewallDeleted(ctx, conn, d.Id()); err != nil {
-		return diag.Errorf("waiting for NetworkFirewall Firewall (%s) delete: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for NetworkFirewall Firewall (%s) delete: %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func FindFirewallByARN(ctx context.Context, conn *networkfirewall.NetworkFirewall, arn string) (*networkfirewall.DescribeFirewallOutput, error) {

--- a/internal/service/networkfirewall/firewall_data_source.go
+++ b/internal/service/networkfirewall/firewall_data_source.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
@@ -184,6 +185,8 @@ func DataSourceFirewall() *schema.Resource {
 }
 
 func dataSourceFirewallResourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkFirewallConn(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
@@ -198,22 +201,22 @@ func dataSourceFirewallResourceRead(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if input.FirewallArn == nil && input.FirewallName == nil {
-		return diag.Errorf("must specify either arn, name, or both")
+		return sdkdiag.AppendErrorf(diags, "must specify either arn, name, or both")
 	}
 
 	output, err := conn.DescribeFirewallWithContext(ctx, input)
 	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, networkfirewall.ErrCodeResourceNotFoundException) {
 		log.Printf("[WARN] NetworkFirewall Firewall (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading NetworkFirewall Firewall (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading NetworkFirewall Firewall (%s): %s", d.Id(), err)
 	}
 
 	if output == nil || output.Firewall == nil {
-		return diag.Errorf("reading NetworkFirewall Firewall (%s): empty output", d.Id())
+		return sdkdiag.AppendErrorf(diags, "reading NetworkFirewall Firewall (%s): empty output", d.Id())
 	}
 
 	firewall := output.Firewall
@@ -231,16 +234,16 @@ func dataSourceFirewallResourceRead(ctx context.Context, d *schema.ResourceData,
 	d.Set("vpc_id", firewall.VpcId)
 
 	if err := d.Set("subnet_mapping", flattenDataSourceSubnetMappings(firewall.SubnetMappings)); err != nil {
-		return diag.Errorf("setting subnet_mappings: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting subnet_mappings: %s", err)
 	}
 
 	if err := d.Set("tags", KeyValueTags(ctx, firewall.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
 	}
 
 	d.SetId(aws.StringValue(firewall.FirewallArn))
 
-	return nil
+	return diags
 }
 
 func flattenDataSourceFirewallStatus(status *networkfirewall.FirewallStatus) []interface{} {

--- a/internal/service/networkfirewall/firewall_policy.go
+++ b/internal/service/networkfirewall/firewall_policy.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -207,6 +208,8 @@ func ResourceFirewallPolicy() *schema.Resource {
 }
 
 func resourceFirewallPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkFirewallConn(ctx)
 
 	name := d.Get("name").(string)
@@ -226,15 +229,17 @@ func resourceFirewallPolicyCreate(ctx context.Context, d *schema.ResourceData, m
 	output, err := conn.CreateFirewallPolicyWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating NetworkFirewall Firewall Policy (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "creating NetworkFirewall Firewall Policy (%s): %s", name, err)
 	}
 
 	d.SetId(aws.StringValue(output.FirewallPolicyResponse.FirewallPolicyArn))
 
-	return resourceFirewallPolicyRead(ctx, d, meta)
+	return append(diags, resourceFirewallPolicyRead(ctx, d, meta)...)
 }
 
 func resourceFirewallPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkFirewallConn(ctx)
 
 	output, err := FindFirewallPolicyByARN(ctx, conn, d.Id())
@@ -242,11 +247,11 @@ func resourceFirewallPolicyRead(ctx context.Context, d *schema.ResourceData, met
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] NetworkFirewall Firewall Policy (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading NetworkFirewall Firewall Policy (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading NetworkFirewall Firewall Policy (%s): %s", d.Id(), err)
 	}
 
 	response := output.FirewallPolicyResponse
@@ -254,17 +259,19 @@ func resourceFirewallPolicyRead(ctx context.Context, d *schema.ResourceData, met
 	d.Set("description", response.Description)
 	d.Set("encryption_configuration", flattenEncryptionConfiguration(response.EncryptionConfiguration))
 	if err := d.Set("firewall_policy", flattenFirewallPolicy(output.FirewallPolicy)); err != nil {
-		return diag.Errorf("setting firewall_policy: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting firewall_policy: %s", err)
 	}
 	d.Set("name", response.FirewallPolicyName)
 	d.Set("update_token", output.UpdateToken)
 
 	setTagsOut(ctx, response.Tags)
 
-	return nil
+	return diags
 }
 
 func resourceFirewallPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkFirewallConn(ctx)
 
 	if d.HasChanges("description", "encryption_configuration", "firewall_policy") {
@@ -283,14 +290,16 @@ func resourceFirewallPolicyUpdate(ctx context.Context, d *schema.ResourceData, m
 		_, err := conn.UpdateFirewallPolicyWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("updating NetworkFirewall Firewall Policy (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating NetworkFirewall Firewall Policy (%s): %s", d.Id(), err)
 		}
 	}
 
-	return resourceFirewallPolicyRead(ctx, d, meta)
+	return append(diags, resourceFirewallPolicyRead(ctx, d, meta)...)
 }
 
 func resourceFirewallPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	const (
 		timeout = 10 * time.Minute
 	)
@@ -304,18 +313,18 @@ func resourceFirewallPolicyDelete(ctx context.Context, d *schema.ResourceData, m
 	}, networkfirewall.ErrCodeInvalidOperationException, "Unable to delete the object because it is still in use")
 
 	if tfawserr.ErrCodeEquals(err, networkfirewall.ErrCodeResourceNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting NetworkFirewall Firewall Policy (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting NetworkFirewall Firewall Policy (%s): %s", d.Id(), err)
 	}
 
 	if _, err := waitFirewallPolicyDeleted(ctx, conn, d.Id(), timeout); err != nil {
-		return diag.Errorf("waiting for NetworkFirewall Firewall Policy (%s) delete: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for NetworkFirewall Firewall Policy (%s) delete: %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func FindFirewallPolicyByARN(ctx context.Context, conn *networkfirewall.NetworkFirewall, arn string) (*networkfirewall.DescribeFirewallPolicyOutput, error) {

--- a/internal/service/networkfirewall/firewall_policy_data_source.go
+++ b/internal/service/networkfirewall/firewall_policy_data_source.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
@@ -132,6 +133,8 @@ func DataSourceFirewallPolicy() *schema.Resource {
 }
 
 func dataSourceFirewallPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkFirewallConn(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
@@ -143,14 +146,14 @@ func dataSourceFirewallPolicyRead(ctx context.Context, d *schema.ResourceData, m
 	output, err := FindFirewallPolicyByNameAndARN(ctx, conn, arn, name)
 
 	if err != nil {
-		return diag.Errorf("reading NetworkFirewall Firewall Policy (%s, %s): %s", arn, name, err)
+		return sdkdiag.AppendErrorf(diags, "reading NetworkFirewall Firewall Policy (%s, %s): %s", arn, name, err)
 	}
 
 	if output == nil {
-		return diag.Errorf("reading NetworkFirewall Firewall Policy (%s, %s): empty output", arn, name)
+		return sdkdiag.AppendErrorf(diags, "reading NetworkFirewall Firewall Policy (%s, %s): empty output", arn, name)
 	}
 	if output.FirewallPolicyResponse == nil {
-		return diag.Errorf("reading NetworkFirewall Firewall Policy (%s, %s): empty output.FirewallPolicyResponse", arn, name)
+		return sdkdiag.AppendErrorf(diags, "reading NetworkFirewall Firewall Policy (%s, %s): empty output.FirewallPolicyResponse", arn, name)
 	}
 
 	resp := output.FirewallPolicyResponse
@@ -164,14 +167,14 @@ func dataSourceFirewallPolicyRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set("update_token", output.UpdateToken)
 
 	if err := d.Set("firewall_policy", flattenFirewallPolicy(policy)); err != nil {
-		return diag.Errorf("setting firewall_policy: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting firewall_policy: %s", err)
 	}
 
 	tags := KeyValueTags(ctx, resp.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
 	if err := d.Set("tags", tags.Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/networkfirewall/firewall_resource_policy_data_source.go
+++ b/internal/service/networkfirewall/firewall_resource_policy_data_source.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
@@ -33,22 +34,24 @@ func DataSourceFirewallResourcePolicy() *schema.Resource {
 }
 
 func dataSourceFirewallResourcePolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkFirewallConn(ctx)
 
 	resourceARN := d.Get("resource_arn").(string)
 	policy, err := FindResourcePolicy(ctx, conn, resourceARN)
 
 	if err != nil {
-		return diag.Errorf("reading NetworkFirewall Resource Policy (%s): %s", resourceARN, err)
+		return sdkdiag.AppendErrorf(diags, "reading NetworkFirewall Resource Policy (%s): %s", resourceARN, err)
 	}
 
 	if policy == nil {
-		return diag.Errorf("reading NetworkFirewall Resource Policy (%s): empty output", resourceARN)
+		return sdkdiag.AppendErrorf(diags, "reading NetworkFirewall Resource Policy (%s): empty output", resourceARN)
 	}
 
 	d.SetId(resourceARN)
 	d.Set("policy", policy)
 	d.Set("resource_arn", resourceARN)
 
-	return nil
+	return diags
 }

--- a/internal/service/networkfirewall/logging_configuration.go
+++ b/internal/service/networkfirewall/logging_configuration.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 )
 
 // @SDKResource("aws_networkfirewall_logging_configuration")
@@ -76,6 +77,8 @@ func ResourceLoggingConfiguration() *schema.Resource {
 }
 
 func resourceLoggingConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkFirewallConn(ctx)
 	firewallArn := d.Get("firewall_arn").(string)
 
@@ -85,15 +88,17 @@ func resourceLoggingConfigurationCreate(ctx context.Context, d *schema.ResourceD
 	// cumulatively add the configured "log_destination_config" in "logging_configuration"
 	err := putLoggingConfiguration(ctx, conn, firewallArn, loggingConfigs)
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	d.SetId(firewallArn)
 
-	return resourceLoggingConfigurationRead(ctx, d, meta)
+	return append(diags, resourceLoggingConfigurationRead(ctx, d, meta)...)
 }
 
 func resourceLoggingConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkFirewallConn(ctx)
 
 	log.Printf("[DEBUG] Reading Logging Configuration for NetworkFirewall Firewall: %s", d.Id())
@@ -102,27 +107,29 @@ func resourceLoggingConfigurationRead(ctx context.Context, d *schema.ResourceDat
 	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, networkfirewall.ErrCodeResourceNotFoundException) {
 		log.Printf("[WARN] Logging Configuration for NetworkFirewall Firewall (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Logging Configuration for NetworkFirewall Firewall: %s: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Logging Configuration for NetworkFirewall Firewall: %s: %s", d.Id(), err)
 	}
 
 	if output == nil {
-		return diag.Errorf("reading Logging Configuration for NetworkFirewall Firewall: %s: empty output", d.Id())
+		return sdkdiag.AppendErrorf(diags, "reading Logging Configuration for NetworkFirewall Firewall: %s: empty output", d.Id())
 	}
 
 	d.Set("firewall_arn", output.FirewallArn)
 
 	if err := d.Set("logging_configuration", flattenLoggingConfiguration(output.LoggingConfiguration)); err != nil {
-		return diag.Errorf("setting logging_configuration: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting logging_configuration: %s", err)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceLoggingConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkFirewallConn(ctx)
 
 	log.Printf("[DEBUG] Updating Logging Configuration for NetworkFirewall Firewall: %s", d.Id())
@@ -134,7 +141,7 @@ func resourceLoggingConfigurationUpdate(ctx context.Context, d *schema.ResourceD
 		if loggingConfig != nil {
 			err := removeLoggingConfiguration(ctx, conn, d.Id(), loggingConfig)
 			if err != nil {
-				return diag.FromErr(err)
+				return sdkdiag.AppendFromErr(diags, err)
 			}
 		}
 	}
@@ -144,34 +151,36 @@ func resourceLoggingConfigurationUpdate(ctx context.Context, d *schema.ResourceD
 		// cumulatively add the configured "log_destination_config" in "logging_configuration"
 		err := putLoggingConfiguration(ctx, conn, d.Id(), loggingConfigs)
 		if err != nil {
-			return diag.FromErr(err)
+			return sdkdiag.AppendFromErr(diags, err)
 		}
 	}
 
-	return resourceLoggingConfigurationRead(ctx, d, meta)
+	return append(diags, resourceLoggingConfigurationRead(ctx, d, meta)...)
 }
 
 func resourceLoggingConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkFirewallConn(ctx)
 
 	log.Printf("[DEBUG] Deleting Logging Configuration for NetworkFirewall Firewall: %s", d.Id())
 	output, err := FindLoggingConfiguration(ctx, conn, d.Id())
 	if tfawserr.ErrCodeEquals(err, networkfirewall.ErrCodeResourceNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting Logging Configuration for NetworkFirewall Firewall: %s: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Logging Configuration for NetworkFirewall Firewall: %s: %s", d.Id(), err)
 	}
 
 	if output != nil && output.LoggingConfiguration != nil {
 		err := removeLoggingConfiguration(ctx, conn, aws.StringValue(output.FirewallArn), output.LoggingConfiguration)
 		if err != nil {
-			return diag.FromErr(err)
+			return sdkdiag.AppendFromErr(diags, err)
 		}
 	}
 
-	return nil
+	return diags
 }
 
 func putLoggingConfiguration(ctx context.Context, conn *networkfirewall.NetworkFirewall, arn string, l []*networkfirewall.LoggingConfiguration) error {

--- a/internal/service/networkfirewall/resource_policy.go
+++ b/internal/service/networkfirewall/resource_policy.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
@@ -54,13 +55,15 @@ func ResourceResourcePolicy() *schema.Resource {
 }
 
 func resourceResourcePolicyPut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkFirewallConn(ctx)
 	resourceArn := d.Get("resource_arn").(string)
 
 	policy, err := structure.NormalizeJsonString(d.Get("policy").(string))
 
 	if err != nil {
-		return diag.Errorf("policy (%s) is invalid JSON: %s", policy, err)
+		return sdkdiag.AppendErrorf(diags, "policy (%s) is invalid JSON: %s", policy, err)
 	}
 
 	input := &networkfirewall.PutResourcePolicyInput{
@@ -72,15 +75,17 @@ func resourceResourcePolicyPut(ctx context.Context, d *schema.ResourceData, meta
 
 	_, err = conn.PutResourcePolicyWithContext(ctx, input)
 	if err != nil {
-		return diag.Errorf("putting NetworkFirewall Resource Policy (for resource: %s): %s", resourceArn, err)
+		return sdkdiag.AppendErrorf(diags, "putting NetworkFirewall Resource Policy (for resource: %s): %s", resourceArn, err)
 	}
 
 	d.SetId(resourceArn)
 
-	return resourceResourcePolicyRead(ctx, d, meta)
+	return append(diags, resourceResourcePolicyRead(ctx, d, meta)...)
 }
 
 func resourceResourcePolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkFirewallConn(ctx)
 	resourceArn := d.Id()
 
@@ -90,14 +95,14 @@ func resourceResourcePolicyRead(ctx context.Context, d *schema.ResourceData, met
 	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, networkfirewall.ErrCodeResourceNotFoundException) {
 		log.Printf("[WARN] NetworkFirewall Resource Policy (for resource: %s) not found, removing from state", resourceArn)
 		d.SetId("")
-		return nil
+		return diags
 	}
 	if err != nil {
-		return diag.Errorf("reading NetworkFirewall Resource Policy (for resource: %s): %s", resourceArn, err)
+		return sdkdiag.AppendErrorf(diags, "reading NetworkFirewall Resource Policy (for resource: %s): %s", resourceArn, err)
 	}
 
 	if policy == nil {
-		return diag.Errorf("reading NetworkFirewall Resource Policy (for resource: %s): empty output", resourceArn)
+		return sdkdiag.AppendErrorf(diags, "reading NetworkFirewall Resource Policy (for resource: %s): empty output", resourceArn)
 	}
 
 	d.Set("resource_arn", resourceArn)
@@ -105,15 +110,17 @@ func resourceResourcePolicyRead(ctx context.Context, d *schema.ResourceData, met
 	policyToSet, err := verify.PolicyToSet(d.Get("policy").(string), aws.StringValue(policy))
 
 	if err != nil {
-		return diag.Errorf("setting policy %s: %s", aws.StringValue(policy), err)
+		return sdkdiag.AppendErrorf(diags, "setting policy %s: %s", aws.StringValue(policy), err)
 	}
 
 	d.Set("policy", policyToSet)
 
-	return nil
+	return diags
 }
 
 func resourceResourcePolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	const (
 		timeout = 2 * time.Minute
 	)
@@ -127,12 +134,12 @@ func resourceResourcePolicyDelete(ctx context.Context, d *schema.ResourceData, m
 	}, networkfirewall.ErrCodeInvalidResourcePolicyException, "The supplied policy does not match RAM managed permissions")
 
 	if tfawserr.ErrCodeEquals(err, networkfirewall.ErrCodeResourceNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting NetworkFirewall Resource Policy (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting NetworkFirewall Resource Policy (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/networkfirewall/rule_group.go
+++ b/internal/service/networkfirewall/rule_group.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -459,6 +460,8 @@ func ResourceRuleGroup() *schema.Resource {
 }
 
 func resourceRuleGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkFirewallConn(ctx)
 
 	name := d.Get("name").(string)
@@ -488,15 +491,17 @@ func resourceRuleGroupCreate(ctx context.Context, d *schema.ResourceData, meta i
 	output, err := conn.CreateRuleGroupWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating NetworkFirewall Rule Group (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "creating NetworkFirewall Rule Group (%s): %s", name, err)
 	}
 
 	d.SetId(aws.StringValue(output.RuleGroupResponse.RuleGroupArn))
 
-	return resourceRuleGroupRead(ctx, d, meta)
+	return append(diags, resourceRuleGroupRead(ctx, d, meta)...)
 }
 
 func resourceRuleGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkFirewallConn(ctx)
 
 	output, err := FindRuleGroupByARN(ctx, conn, d.Id())
@@ -508,11 +513,11 @@ func resourceRuleGroupRead(ctx context.Context, d *schema.ResourceData, meta int
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] NetworkFirewall Rule Group (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading NetworkFirewall Rule Group (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading NetworkFirewall Rule Group (%s): %s", d.Id(), err)
 	}
 
 	response := output.RuleGroupResponse
@@ -522,17 +527,19 @@ func resourceRuleGroupRead(ctx context.Context, d *schema.ResourceData, meta int
 	d.Set("encryption_configuration", flattenEncryptionConfiguration(response.EncryptionConfiguration))
 	d.Set("name", response.RuleGroupName)
 	if err := d.Set("rule_group", flattenRuleGroup(output.RuleGroup)); err != nil {
-		return diag.Errorf("setting rule_group: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting rule_group: %s", err)
 	}
 	d.Set("type", response.Type)
 	d.Set("update_token", output.UpdateToken)
 
 	setTagsOut(ctx, response.Tags)
 
-	return nil
+	return diags
 }
 
 func resourceRuleGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkFirewallConn(ctx)
 
 	if d.HasChanges("description", "encryption_configuration", "rule_group", "rules", "type") {
@@ -573,14 +580,16 @@ func resourceRuleGroupUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		_, err := conn.UpdateRuleGroupWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("updating NetworkFirewall Rule Group (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating NetworkFirewall Rule Group (%s): %s", d.Id(), err)
 		}
 	}
 
-	return resourceRuleGroupRead(ctx, d, meta)
+	return append(diags, resourceRuleGroupRead(ctx, d, meta)...)
 }
 
 func resourceRuleGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	const (
 		timeout = 10 * time.Minute
 	)
@@ -594,18 +603,18 @@ func resourceRuleGroupDelete(ctx context.Context, d *schema.ResourceData, meta i
 	}, networkfirewall.ErrCodeInvalidOperationException, "Unable to delete the object because it is still in use")
 
 	if tfawserr.ErrCodeEquals(err, networkfirewall.ErrCodeResourceNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting NetworkFirewall Rule Group (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting NetworkFirewall Rule Group (%s): %s", d.Id(), err)
 	}
 
 	if _, err := waitRuleGroupDeleted(ctx, conn, d.Id(), timeout); err != nil {
-		return diag.Errorf("waiting for NetworkFirewall Rule Group (%s) delete : %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for NetworkFirewall Rule Group (%s) delete : %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func FindRuleGroupByARN(ctx context.Context, conn *networkfirewall.NetworkFirewall, arn string) (*networkfirewall.DescribeRuleGroupOutput, error) {

--- a/internal/service/networkmanager/attachment_accepter.go
+++ b/internal/service/networkmanager/attachment_accepter.go
@@ -97,7 +97,7 @@ func resourceAttachmentAccepterCreate(ctx context.Context, d *schema.ResourceDat
 		vpcAttachment, err := FindVPCAttachmentByID(ctx, conn, attachmentID)
 
 		if err != nil {
-			return diag.Errorf("reading Network Manager VPC Attachment (%s): %s", attachmentID, err)
+			return sdkdiag.AppendErrorf(diags, "reading Network Manager VPC Attachment (%s): %s", attachmentID, err)
 		}
 
 		state = aws.StringValue(vpcAttachment.Attachment.State)
@@ -108,7 +108,7 @@ func resourceAttachmentAccepterCreate(ctx context.Context, d *schema.ResourceDat
 		vpnAttachment, err := FindSiteToSiteVPNAttachmentByID(ctx, conn, attachmentID)
 
 		if err != nil {
-			return diag.Errorf("reading Network Manager Site To Site VPN Attachment (%s): %s", attachmentID, err)
+			return sdkdiag.AppendErrorf(diags, "reading Network Manager Site To Site VPN Attachment (%s): %s", attachmentID, err)
 		}
 
 		state = aws.StringValue(vpnAttachment.Attachment.State)
@@ -119,7 +119,7 @@ func resourceAttachmentAccepterCreate(ctx context.Context, d *schema.ResourceDat
 		connectAttachment, err := FindConnectAttachmentByID(ctx, conn, attachmentID)
 
 		if err != nil {
-			return diag.Errorf("reading Network Manager Connect Attachment (%s): %s", attachmentID, err)
+			return sdkdiag.AppendErrorf(diags, "reading Network Manager Connect Attachment (%s): %s", attachmentID, err)
 		}
 
 		state = aws.StringValue(connectAttachment.Attachment.State)
@@ -130,7 +130,7 @@ func resourceAttachmentAccepterCreate(ctx context.Context, d *schema.ResourceDat
 		tgwAttachment, err := FindTransitGatewayRouteTableAttachmentByID(ctx, conn, attachmentID)
 
 		if err != nil {
-			return diag.Errorf("reading Network Manager Transit Gateway Route Table Attachment (%s): %s", attachmentID, err)
+			return sdkdiag.AppendErrorf(diags, "reading Network Manager Transit Gateway Route Table Attachment (%s): %s", attachmentID, err)
 		}
 
 		state = aws.StringValue(tgwAttachment.Attachment.State)
@@ -138,7 +138,7 @@ func resourceAttachmentAccepterCreate(ctx context.Context, d *schema.ResourceDat
 		d.SetId(attachmentID)
 
 	default:
-		return diag.Errorf("unsupported Network Manager Attachment type: %s", attachmentType)
+		return sdkdiag.AppendErrorf(diags, "unsupported Network Manager Attachment type: %s", attachmentType)
 	}
 
 	if state == networkmanager.AttachmentStatePendingAttachmentAcceptance || state == networkmanager.AttachmentStatePendingTagAcceptance {
@@ -149,28 +149,28 @@ func resourceAttachmentAccepterCreate(ctx context.Context, d *schema.ResourceDat
 		_, err := conn.AcceptAttachmentWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("accepting Network Manager Attachment (%s): %s", attachmentID, err)
+			return sdkdiag.AppendErrorf(diags, "accepting Network Manager Attachment (%s): %s", attachmentID, err)
 		}
 
 		switch attachmentType {
 		case networkmanager.AttachmentTypeVpc:
 			if _, err := waitVPCAttachmentAvailable(ctx, conn, attachmentID, d.Timeout(schema.TimeoutCreate)); err != nil {
-				return diag.Errorf("waiting for Network Manager VPC Attachment (%s) to be attached: %s", attachmentID, err)
+				return sdkdiag.AppendErrorf(diags, "waiting for Network Manager VPC Attachment (%s) to be attached: %s", attachmentID, err)
 			}
 
 		case networkmanager.AttachmentTypeSiteToSiteVpn:
 			if _, err := waitSiteToSiteVPNAttachmentAvailable(ctx, conn, attachmentID, d.Timeout(schema.TimeoutCreate)); err != nil {
-				return diag.Errorf("waiting for Network Manager VPN Attachment (%s) create: %s", attachmentID, err)
+				return sdkdiag.AppendErrorf(diags, "waiting for Network Manager VPN Attachment (%s) create: %s", attachmentID, err)
 			}
 
 		case networkmanager.AttachmentTypeConnect:
 			if _, err := waitConnectAttachmentAvailable(ctx, conn, attachmentID, d.Timeout(schema.TimeoutCreate)); err != nil {
-				return diag.Errorf("waiting for Network Manager Connect Attachment (%s) create: %s", attachmentID, err)
+				return sdkdiag.AppendErrorf(diags, "waiting for Network Manager Connect Attachment (%s) create: %s", attachmentID, err)
 			}
 
 		case networkmanager.AttachmentTypeTransitGatewayRouteTable:
 			if _, err := waitTransitGatewayRouteTableAttachmentAvailable(ctx, conn, attachmentID, d.Timeout(schema.TimeoutCreate)); err != nil {
-				return diag.Errorf("waiting for Network Manager Transit Gateway Route Table Attachment (%s) create: %s", attachmentID, err)
+				return sdkdiag.AppendErrorf(diags, "waiting for Network Manager Transit Gateway Route Table Attachment (%s) create: %s", attachmentID, err)
 			}
 		}
 	}
@@ -196,7 +196,7 @@ func resourceAttachmentAccepterRead(ctx context.Context, d *schema.ResourceData,
 		}
 
 		if err != nil {
-			return diag.Errorf("reading Network Manager VPC Attachment (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "reading Network Manager VPC Attachment (%s): %s", d.Id(), err)
 		}
 
 		a = vpcAttachment.Attachment
@@ -211,7 +211,7 @@ func resourceAttachmentAccepterRead(ctx context.Context, d *schema.ResourceData,
 		}
 
 		if err != nil {
-			return diag.Errorf("reading Network Manager Site To Site VPN Attachment (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "reading Network Manager Site To Site VPN Attachment (%s): %s", d.Id(), err)
 		}
 
 		a = vpnAttachment.Attachment
@@ -226,7 +226,7 @@ func resourceAttachmentAccepterRead(ctx context.Context, d *schema.ResourceData,
 		}
 
 		if err != nil {
-			return diag.Errorf("reading Network Manager Connect Attachment (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "reading Network Manager Connect Attachment (%s): %s", d.Id(), err)
 		}
 
 		a = connectAttachment.Attachment
@@ -241,7 +241,7 @@ func resourceAttachmentAccepterRead(ctx context.Context, d *schema.ResourceData,
 		}
 
 		if err != nil {
-			return diag.Errorf("reading Network Manager Transit Gateway Route Table Attachment (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "reading Network Manager Transit Gateway Route Table Attachment (%s): %s", d.Id(), err)
 		}
 
 		a = tgwAttachment.Attachment

--- a/internal/service/networkmanager/connection.go
+++ b/internal/service/networkmanager/connection.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -104,6 +105,8 @@ func ResourceConnection() *schema.Resource {
 }
 
 func resourceConnectionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkManagerConn(ctx)
 
 	globalNetworkID := d.Get("global_network_id").(string)
@@ -130,19 +133,21 @@ func resourceConnectionCreate(ctx context.Context, d *schema.ResourceData, meta 
 	output, err := conn.CreateConnectionWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating Network Manager Connection: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating Network Manager Connection: %s", err)
 	}
 
 	d.SetId(aws.StringValue(output.Connection.ConnectionId))
 
 	if _, err := waitConnectionCreated(ctx, conn, globalNetworkID, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return diag.Errorf("waiting for Network Manager Connection (%s) create: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Network Manager Connection (%s) create: %s", d.Id(), err)
 	}
 
-	return resourceConnectionRead(ctx, d, meta)
+	return append(diags, resourceConnectionRead(ctx, d, meta)...)
 }
 
 func resourceConnectionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkManagerConn(ctx)
 
 	globalNetworkID := d.Get("global_network_id").(string)
@@ -151,11 +156,11 @@ func resourceConnectionRead(ctx context.Context, d *schema.ResourceData, meta in
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Network Manager Connection %s not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Network Manager Connection (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Network Manager Connection (%s): %s", d.Id(), err)
 	}
 
 	d.Set("arn", connection.ConnectionArn)
@@ -168,10 +173,12 @@ func resourceConnectionRead(ctx context.Context, d *schema.ResourceData, meta in
 
 	setTagsOut(ctx, connection.Tags)
 
-	return nil
+	return diags
 }
 
 func resourceConnectionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkManagerConn(ctx)
 
 	if d.HasChangesExcept("tags", "tags_all") {
@@ -188,18 +195,20 @@ func resourceConnectionUpdate(ctx context.Context, d *schema.ResourceData, meta 
 		_, err := conn.UpdateConnectionWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("updating Network Manager Connection (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating Network Manager Connection (%s): %s", d.Id(), err)
 		}
 
 		if _, err := waitConnectionUpdated(ctx, conn, globalNetworkID, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return diag.Errorf("waiting for Network Manager Connection (%s) update: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "waiting for Network Manager Connection (%s) update: %s", d.Id(), err)
 		}
 	}
 
-	return resourceConnectionRead(ctx, d, meta)
+	return append(diags, resourceConnectionRead(ctx, d, meta)...)
 }
 
 func resourceConnectionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkManagerConn(ctx)
 
 	globalNetworkID := d.Get("global_network_id").(string)
@@ -211,18 +220,18 @@ func resourceConnectionDelete(ctx context.Context, d *schema.ResourceData, meta 
 	})
 
 	if globalNetworkIDNotFoundError(err) || tfawserr.ErrCodeEquals(err, networkmanager.ErrCodeResourceNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting Network Manager Connection (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Network Manager Connection (%s): %s", d.Id(), err)
 	}
 
 	if _, err := waitConnectionDeleted(ctx, conn, globalNetworkID, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return diag.Errorf("waiting for Network Manager Connection (%s) delete: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Network Manager Connection (%s) delete: %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func FindConnection(ctx context.Context, conn *networkmanager.NetworkManager, input *networkmanager.GetConnectionsInput) (*networkmanager.Connection, error) {

--- a/internal/service/networkmanager/connection_data_source.go
+++ b/internal/service/networkmanager/connection_data_source.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 )
 
@@ -56,6 +57,8 @@ func DataSourceConnection() *schema.Resource {
 }
 
 func dataSourceConnectionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkManagerConn(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
@@ -64,7 +67,7 @@ func dataSourceConnectionRead(ctx context.Context, d *schema.ResourceData, meta 
 	connection, err := FindConnectionByTwoPartKey(ctx, conn, globalNetworkID, connectionID)
 
 	if err != nil {
-		return diag.Errorf("reading Network Manager Connection (%s): %s", connectionID, err)
+		return sdkdiag.AppendErrorf(diags, "reading Network Manager Connection (%s): %s", connectionID, err)
 	}
 
 	d.SetId(connectionID)
@@ -78,8 +81,8 @@ func dataSourceConnectionRead(ctx context.Context, d *schema.ResourceData, meta 
 	d.Set("link_id", connection.LinkId)
 
 	if err := d.Set("tags", KeyValueTags(ctx, connection.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/networkmanager/connections_data_source.go
+++ b/internal/service/networkmanager/connections_data_source.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 )
 
@@ -39,6 +40,8 @@ func DataSourceConnections() *schema.Resource {
 }
 
 func dataSourceConnectionsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkManagerConn(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 	tagsToMatch := tftags.New(ctx, d.Get("tags").(map[string]interface{})).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
@@ -54,7 +57,7 @@ func dataSourceConnectionsRead(ctx context.Context, d *schema.ResourceData, meta
 	output, err := FindConnections(ctx, conn, input)
 
 	if err != nil {
-		return diag.Errorf("listing Network Manager Connections: %s", err)
+		return sdkdiag.AppendErrorf(diags, "listing Network Manager Connections: %s", err)
 	}
 
 	var connectionIDs []string
@@ -72,5 +75,5 @@ func dataSourceConnectionsRead(ctx context.Context, d *schema.ResourceData, meta
 	d.SetId(meta.(*conns.AWSClient).Region)
 	d.Set("ids", connectionIDs)
 
-	return nil
+	return diags
 }

--- a/internal/service/networkmanager/core_network.go
+++ b/internal/service/networkmanager/core_network.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -170,6 +171,8 @@ func ResourceCoreNetwork() *schema.Resource {
 }
 
 func resourceCoreNetworkCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkManagerConn(ctx)
 
 	globalNetworkID := d.Get("global_network_id").(string)
@@ -202,7 +205,7 @@ func resourceCoreNetworkCreate(ctx context.Context, d *schema.ResourceData, meta
 
 			policyDocumentTarget, err := buildCoreNetworkBasePolicyDocument(regions)
 			if err != nil {
-				return diag.Errorf("Formatting Core Network Base Policy: %s", err)
+				return sdkdiag.AppendErrorf(diags, "Formatting Core Network Base Policy: %s", err)
 			}
 			input.PolicyDocument = aws.String(policyDocumentTarget)
 		}
@@ -211,19 +214,21 @@ func resourceCoreNetworkCreate(ctx context.Context, d *schema.ResourceData, meta
 	output, err := conn.CreateCoreNetworkWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating Core Network: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating Core Network: %s", err)
 	}
 
 	d.SetId(aws.StringValue(output.CoreNetwork.CoreNetworkId))
 
 	if _, err := waitCoreNetworkCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return diag.Errorf("waiting for Network Manager Core Network (%s) create: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Network Manager Core Network (%s) create: %s", d.Id(), err)
 	}
 
-	return resourceCoreNetworkRead(ctx, d, meta)
+	return append(diags, resourceCoreNetworkRead(ctx, d, meta)...)
 }
 
 func resourceCoreNetworkRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkManagerConn(ctx)
 
 	coreNetwork, err := FindCoreNetworkByID(ctx, conn, d.Id())
@@ -231,11 +236,11 @@ func resourceCoreNetworkRead(ctx context.Context, d *schema.ResourceData, meta i
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Network Manager Core Network %s not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Network Manager Core Network (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Network Manager Core Network (%s): %s", d.Id(), err)
 	}
 
 	d.Set("arn", coreNetwork.CoreNetworkArn)
@@ -246,20 +251,22 @@ func resourceCoreNetworkRead(ctx context.Context, d *schema.ResourceData, meta i
 	}
 	d.Set("description", coreNetwork.Description)
 	if err := d.Set("edges", flattenCoreNetworkEdges(coreNetwork.Edges)); err != nil {
-		return diag.Errorf("setting edges: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting edges: %s", err)
 	}
 	d.Set("global_network_id", coreNetwork.GlobalNetworkId)
 	if err := d.Set("segments", flattenCoreNetworkSegments(coreNetwork.Segments)); err != nil {
-		return diag.Errorf("setting segments: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting segments: %s", err)
 	}
 	d.Set("state", coreNetwork.State)
 
 	setTagsOut(ctx, coreNetwork.Tags)
 
-	return nil
+	return diags
 }
 
 func resourceCoreNetworkUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkManagerConn(ctx)
 
 	if d.HasChange("description") {
@@ -269,11 +276,11 @@ func resourceCoreNetworkUpdate(ctx context.Context, d *schema.ResourceData, meta
 		})
 
 		if err != nil {
-			return diag.Errorf("updating Network Manager Core Network (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating Network Manager Core Network (%s): %s", d.Id(), err)
 		}
 
 		if _, err := waitCoreNetworkUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return diag.Errorf("waiting for Network Manager Core Network (%s) update: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "waiting for Network Manager Core Network (%s) update: %s", d.Id(), err)
 		}
 	}
 
@@ -290,25 +297,27 @@ func resourceCoreNetworkUpdate(ctx context.Context, d *schema.ResourceData, meta
 			policyDocumentTarget, err := buildCoreNetworkBasePolicyDocument(regions)
 
 			if err != nil {
-				return diag.Errorf("Formatting Core Network Base Policy: %s", err)
+				return sdkdiag.AppendErrorf(diags, "Formatting Core Network Base Policy: %s", err)
 			}
 
 			err = PutAndExecuteCoreNetworkPolicy(ctx, conn, d.Id(), policyDocumentTarget)
 
 			if err != nil {
-				return diag.FromErr(err)
+				return sdkdiag.AppendFromErr(diags, err)
 			}
 
 			if _, err := waitCoreNetworkUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-				return diag.Errorf("waiting for Network Manager Core Network (%s) update: %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "waiting for Network Manager Core Network (%s) update: %s", d.Id(), err)
 			}
 		}
 	}
 
-	return resourceCoreNetworkRead(ctx, d, meta)
+	return append(diags, resourceCoreNetworkRead(ctx, d, meta)...)
 }
 
 func resourceCoreNetworkDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkManagerConn(ctx)
 
 	log.Printf("[DEBUG] Deleting Network Manager Core Network: %s", d.Id())
@@ -317,18 +326,18 @@ func resourceCoreNetworkDelete(ctx context.Context, d *schema.ResourceData, meta
 	})
 
 	if tfawserr.ErrCodeEquals(err, networkmanager.ErrCodeResourceNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting Network Manager Core Network (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Network Manager Core Network (%s): %s", d.Id(), err)
 	}
 
 	if _, err := waitCoreNetworkDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return diag.Errorf("waiting for Network Manager Core Network (%s) delete: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Network Manager Core Network (%s) delete: %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func FindCoreNetworkByID(ctx context.Context, conn *networkmanager.NetworkManager, id string) (*networkmanager.CoreNetwork, error) {

--- a/internal/service/networkmanager/core_network_policy_attachment.go
+++ b/internal/service/networkmanager/core_network_policy_attachment.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
@@ -73,6 +74,8 @@ func resourceCoreNetworkPolicyAttachmentCreate(ctx context.Context, d *schema.Re
 }
 
 func resourceCoreNetworkPolicyAttachmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkManagerConn(ctx)
 
 	coreNetwork, err := FindCoreNetworkByID(ctx, conn, d.Id())
@@ -80,11 +83,11 @@ func resourceCoreNetworkPolicyAttachmentRead(ctx context.Context, d *schema.Reso
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Network Manager Core Network %s not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Network Manager Core Network (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Network Manager Core Network (%s): %s", d.Id(), err)
 	}
 
 	d.Set("core_network_id", coreNetwork.CoreNetworkId)
@@ -97,33 +100,35 @@ func resourceCoreNetworkPolicyAttachmentRead(ctx context.Context, d *schema.Reso
 	if tfresource.NotFound(err) {
 		d.Set("policy_document", nil)
 	} else if err != nil {
-		return diag.Errorf("reading Network Manager Core Network (%s) policy: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Network Manager Core Network (%s) policy: %s", d.Id(), err)
 	} else {
 		encodedPolicyDocument, err := protocol.EncodeJSONValue(coreNetworkPolicy.PolicyDocument, protocol.NoEscape)
 
 		if err != nil {
-			return diag.Errorf("encoding Network Manager Core Network (%s) policy document: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "encoding Network Manager Core Network (%s) policy document: %s", d.Id(), err)
 		}
 
 		d.Set("policy_document", encodedPolicyDocument)
 	}
-	return nil
+	return diags
 }
 
 func resourceCoreNetworkPolicyAttachmentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkManagerConn(ctx)
 
 	if d.HasChange("policy_document") {
 		err := PutAndExecuteCoreNetworkPolicy(ctx, conn, d.Id(), d.Get("policy_document").(string))
 
 		if err != nil {
-			return diag.FromErr(err)
+			return sdkdiag.AppendFromErr(diags, err)
 		}
 
 		if _, err := waitCoreNetworkUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return diag.Errorf("waiting for Network Manager Core Network (%s) update: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "waiting for Network Manager Core Network (%s) update: %s", d.Id(), err)
 		}
 	}
 
-	return resourceCoreNetworkPolicyAttachmentRead(ctx, d, meta)
+	return append(diags, resourceCoreNetworkPolicyAttachmentRead(ctx, d, meta)...)
 }

--- a/internal/service/networkmanager/device_data_source.go
+++ b/internal/service/networkmanager/device_data_source.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 )
 
@@ -96,6 +97,8 @@ func DataSourceDevice() *schema.Resource {
 }
 
 func dataSourceDeviceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkManagerConn(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
@@ -104,14 +107,14 @@ func dataSourceDeviceRead(ctx context.Context, d *schema.ResourceData, meta inte
 	device, err := FindDeviceByTwoPartKey(ctx, conn, globalNetworkID, deviceID)
 
 	if err != nil {
-		return diag.Errorf("reading Network Manager Device (%s): %s", deviceID, err)
+		return sdkdiag.AppendErrorf(diags, "reading Network Manager Device (%s): %s", deviceID, err)
 	}
 
 	d.SetId(deviceID)
 	d.Set("arn", device.DeviceArn)
 	if device.AWSLocation != nil {
 		if err := d.Set("aws_location", []interface{}{flattenAWSLocation(device.AWSLocation)}); err != nil {
-			return diag.Errorf("setting aws_location: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting aws_location: %s", err)
 		}
 	} else {
 		d.Set("aws_location", nil)
@@ -120,7 +123,7 @@ func dataSourceDeviceRead(ctx context.Context, d *schema.ResourceData, meta inte
 	d.Set("device_id", device.DeviceId)
 	if device.Location != nil {
 		if err := d.Set("location", []interface{}{flattenLocation(device.Location)}); err != nil {
-			return diag.Errorf("setting location: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting location: %s", err)
 		}
 	} else {
 		d.Set("location", nil)
@@ -132,8 +135,8 @@ func dataSourceDeviceRead(ctx context.Context, d *schema.ResourceData, meta inte
 	d.Set("vendor", device.Vendor)
 
 	if err := d.Set("tags", KeyValueTags(ctx, device.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/networkmanager/devices_data_source.go
+++ b/internal/service/networkmanager/devices_data_source.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 )
 
@@ -39,6 +40,8 @@ func DataSourceDevices() *schema.Resource {
 }
 
 func dataSourceDevicesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkManagerConn(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 	tagsToMatch := tftags.New(ctx, d.Get("tags").(map[string]interface{})).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
@@ -54,7 +57,7 @@ func dataSourceDevicesRead(ctx context.Context, d *schema.ResourceData, meta int
 	output, err := FindDevices(ctx, conn, input)
 
 	if err != nil {
-		return diag.Errorf("listing Network Manager Devices: %s", err)
+		return sdkdiag.AppendErrorf(diags, "listing Network Manager Devices: %s", err)
 	}
 
 	var deviceIDs []string
@@ -72,5 +75,5 @@ func dataSourceDevicesRead(ctx context.Context, d *schema.ResourceData, meta int
 	d.SetId(meta.(*conns.AWSClient).Region)
 	d.Set("ids", deviceIDs)
 
-	return nil
+	return diags
 }

--- a/internal/service/networkmanager/global_network.go
+++ b/internal/service/networkmanager/global_network.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -60,6 +61,8 @@ func ResourceGlobalNetwork() *schema.Resource {
 }
 
 func resourceGlobalNetworkCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkManagerConn(ctx)
 
 	input := &networkmanager.CreateGlobalNetworkInput{
@@ -74,19 +77,21 @@ func resourceGlobalNetworkCreate(ctx context.Context, d *schema.ResourceData, me
 	output, err := conn.CreateGlobalNetworkWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating Network Manager Global Network: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating Network Manager Global Network: %s", err)
 	}
 
 	d.SetId(aws.StringValue(output.GlobalNetwork.GlobalNetworkId))
 
 	if _, err := waitGlobalNetworkCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return diag.Errorf("waiting for Network Manager Global Network (%s) create: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Network Manager Global Network (%s) create: %s", d.Id(), err)
 	}
 
-	return resourceGlobalNetworkRead(ctx, d, meta)
+	return append(diags, resourceGlobalNetworkRead(ctx, d, meta)...)
 }
 
 func resourceGlobalNetworkRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkManagerConn(ctx)
 
 	globalNetwork, err := FindGlobalNetworkByID(ctx, conn, d.Id())
@@ -94,11 +99,11 @@ func resourceGlobalNetworkRead(ctx context.Context, d *schema.ResourceData, meta
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Network Manager Global Network %s not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Network Manager Global Network (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Network Manager Global Network (%s): %s", d.Id(), err)
 	}
 
 	d.Set("arn", globalNetwork.GlobalNetworkArn)
@@ -106,10 +111,12 @@ func resourceGlobalNetworkRead(ctx context.Context, d *schema.ResourceData, meta
 
 	setTagsOut(ctx, globalNetwork.Tags)
 
-	return nil
+	return diags
 }
 
 func resourceGlobalNetworkUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkManagerConn(ctx)
 
 	if d.HasChangesExcept("tags", "tags_all") {
@@ -122,18 +129,20 @@ func resourceGlobalNetworkUpdate(ctx context.Context, d *schema.ResourceData, me
 		_, err := conn.UpdateGlobalNetworkWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("updating Network Manager Global Network (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating Network Manager Global Network (%s): %s", d.Id(), err)
 		}
 
 		if _, err := waitGlobalNetworkUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return diag.Errorf("waiting for Network Manager Global Network (%s) update: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "waiting for Network Manager Global Network (%s) update: %s", d.Id(), err)
 		}
 	}
 
-	return resourceGlobalNetworkRead(ctx, d, meta)
+	return append(diags, resourceGlobalNetworkRead(ctx, d, meta)...)
 }
 
 func resourceGlobalNetworkDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkManagerConn(ctx)
 
 	if diags := disassociateCustomerGateways(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); diags.HasError() {
@@ -165,21 +174,23 @@ func resourceGlobalNetworkDelete(ctx context.Context, d *schema.ResourceData, me
 	)
 
 	if tfawserr.ErrCodeEquals(err, networkmanager.ErrCodeResourceNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting Network Manager Global Network (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Network Manager Global Network (%s): %s", d.Id(), err)
 	}
 
 	if _, err := waitGlobalNetworkDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return diag.Errorf("waiting for Network Manager Global Network (%s) delete: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Network Manager Global Network (%s) delete: %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func deregisterTransitGateways(ctx context.Context, conn *networkmanager.NetworkManager, globalNetworkID string, timeout time.Duration) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	output, err := FindTransitGatewayRegistrations(ctx, conn, &networkmanager.GetTransitGatewayRegistrationsInput{
 		GlobalNetworkId: aws.String(globalNetworkID),
 	})
@@ -189,16 +200,14 @@ func deregisterTransitGateways(ctx context.Context, conn *networkmanager.Network
 	}
 
 	if err != nil {
-		return diag.Errorf("listing Network Manager Transit Gateway Registrations (%s): %s", globalNetworkID, err)
+		return sdkdiag.AppendErrorf(diags, "listing Network Manager Transit Gateway Registrations (%s): %s", globalNetworkID, err)
 	}
-
-	var diags diag.Diagnostics
 
 	for _, v := range output {
 		err := deregisterTransitGateway(ctx, conn, globalNetworkID, aws.StringValue(v.TransitGatewayArn), timeout)
 
 		if err != nil {
-			diags = append(diags, diag.FromErr(err)...)
+			diags = sdkdiag.AppendFromErr(diags, err)
 		}
 	}
 
@@ -206,10 +215,12 @@ func deregisterTransitGateways(ctx context.Context, conn *networkmanager.Network
 		return diags
 	}
 
-	return nil
+	return diags
 }
 
 func disassociateCustomerGateways(ctx context.Context, conn *networkmanager.NetworkManager, globalNetworkID string, timeout time.Duration) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	output, err := FindCustomerGatewayAssociations(ctx, conn, &networkmanager.GetCustomerGatewayAssociationsInput{
 		GlobalNetworkId: aws.String(globalNetworkID),
 	})
@@ -219,16 +230,14 @@ func disassociateCustomerGateways(ctx context.Context, conn *networkmanager.Netw
 	}
 
 	if err != nil {
-		return diag.Errorf("listing Network Manager Customer Gateway Associations (%s): %s", globalNetworkID, err)
+		return sdkdiag.AppendErrorf(diags, "listing Network Manager Customer Gateway Associations (%s): %s", globalNetworkID, err)
 	}
-
-	var diags diag.Diagnostics
 
 	for _, v := range output {
 		err := disassociateCustomerGateway(ctx, conn, globalNetworkID, aws.StringValue(v.CustomerGatewayArn), timeout)
 
 		if err != nil {
-			diags = append(diags, diag.FromErr(err)...)
+			diags = sdkdiag.AppendFromErr(diags, err)
 		}
 	}
 
@@ -236,10 +245,12 @@ func disassociateCustomerGateways(ctx context.Context, conn *networkmanager.Netw
 		return diags
 	}
 
-	return nil
+	return diags
 }
 
 func disassociateTransitGatewayConnectPeers(ctx context.Context, conn *networkmanager.NetworkManager, globalNetworkID string, timeout time.Duration) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	output, err := FindTransitGatewayConnectPeerAssociations(ctx, conn, &networkmanager.GetTransitGatewayConnectPeerAssociationsInput{
 		GlobalNetworkId: aws.String(globalNetworkID),
 	})
@@ -249,16 +260,14 @@ func disassociateTransitGatewayConnectPeers(ctx context.Context, conn *networkma
 	}
 
 	if err != nil {
-		return diag.Errorf("listing Network Manager Transit Gateway Connect Peer Associations (%s): %s", globalNetworkID, err)
+		return sdkdiag.AppendErrorf(diags, "listing Network Manager Transit Gateway Connect Peer Associations (%s): %s", globalNetworkID, err)
 	}
-
-	var diags diag.Diagnostics
 
 	for _, v := range output {
 		err := disassociateTransitGatewayConnectPeer(ctx, conn, globalNetworkID, aws.StringValue(v.TransitGatewayConnectPeerArn), timeout)
 
 		if err != nil {
-			diags = append(diags, diag.FromErr(err)...)
+			diags = sdkdiag.AppendFromErr(diags, err)
 		}
 	}
 
@@ -266,7 +275,7 @@ func disassociateTransitGatewayConnectPeers(ctx context.Context, conn *networkma
 		return diags
 	}
 
-	return nil
+	return diags
 }
 
 func globalNetworkIDNotFoundError(err error) bool {

--- a/internal/service/networkmanager/global_network_data_source.go
+++ b/internal/service/networkmanager/global_network_data_source.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 )
 
@@ -36,6 +37,8 @@ func DataSourceGlobalNetwork() *schema.Resource {
 }
 
 func dataSourceGlobalNetworkRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkManagerConn(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
@@ -43,7 +46,7 @@ func dataSourceGlobalNetworkRead(ctx context.Context, d *schema.ResourceData, me
 	globalNetwork, err := FindGlobalNetworkByID(ctx, conn, globalNetworkID)
 
 	if err != nil {
-		return diag.Errorf("reading Network Manager Global Network (%s): %s", globalNetworkID, err)
+		return sdkdiag.AppendErrorf(diags, "reading Network Manager Global Network (%s): %s", globalNetworkID, err)
 	}
 
 	d.SetId(globalNetworkID)
@@ -52,8 +55,8 @@ func dataSourceGlobalNetworkRead(ctx context.Context, d *schema.ResourceData, me
 	d.Set("global_network_id", globalNetwork.GlobalNetworkId)
 
 	if err := d.Set("tags", KeyValueTags(ctx, globalNetwork.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/networkmanager/global_networks_data_source.go
+++ b/internal/service/networkmanager/global_networks_data_source.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 )
 
@@ -31,6 +32,8 @@ func DataSourceGlobalNetworks() *schema.Resource {
 }
 
 func dataSourceGlobalNetworksRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkManagerConn(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 	tagsToMatch := tftags.New(ctx, d.Get("tags").(map[string]interface{})).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
@@ -38,7 +41,7 @@ func dataSourceGlobalNetworksRead(ctx context.Context, d *schema.ResourceData, m
 	output, err := FindGlobalNetworks(ctx, conn, &networkmanager.DescribeGlobalNetworksInput{})
 
 	if err != nil {
-		return diag.Errorf("listing Network Manager Global Networks: %s", err)
+		return sdkdiag.AppendErrorf(diags, "listing Network Manager Global Networks: %s", err)
 	}
 
 	var globalNetworkIDs []string
@@ -56,5 +59,5 @@ func dataSourceGlobalNetworksRead(ctx context.Context, d *schema.ResourceData, m
 	d.SetId(meta.(*conns.AWSClient).Region)
 	d.Set("ids", globalNetworkIDs)
 
-	return nil
+	return diags
 }

--- a/internal/service/networkmanager/link_data_source.go
+++ b/internal/service/networkmanager/link_data_source.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 )
 
@@ -68,6 +69,8 @@ func DataSourceLink() *schema.Resource {
 }
 
 func dataSourceLinkRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkManagerConn(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
@@ -76,14 +79,14 @@ func dataSourceLinkRead(ctx context.Context, d *schema.ResourceData, meta interf
 	link, err := FindLinkByTwoPartKey(ctx, conn, globalNetworkID, linkID)
 
 	if err != nil {
-		return diag.Errorf("reading Network Manager Link (%s): %s", linkID, err)
+		return sdkdiag.AppendErrorf(diags, "reading Network Manager Link (%s): %s", linkID, err)
 	}
 
 	d.SetId(linkID)
 	d.Set("arn", link.LinkArn)
 	if link.Bandwidth != nil {
 		if err := d.Set("bandwidth", []interface{}{flattenBandwidth(link.Bandwidth)}); err != nil {
-			return diag.Errorf("setting bandwidth: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting bandwidth: %s", err)
 		}
 	} else {
 		d.Set("bandwidth", nil)
@@ -96,8 +99,8 @@ func dataSourceLinkRead(ctx context.Context, d *schema.ResourceData, meta interf
 	d.Set("type", link.Type)
 
 	if err := d.Set("tags", KeyValueTags(ctx, link.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/networkmanager/links_data_source.go
+++ b/internal/service/networkmanager/links_data_source.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 )
 
@@ -47,6 +48,8 @@ func DataSourceLinks() *schema.Resource {
 }
 
 func dataSourceLinksRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkManagerConn(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 	tagsToMatch := tftags.New(ctx, d.Get("tags").(map[string]interface{})).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
@@ -70,7 +73,7 @@ func dataSourceLinksRead(ctx context.Context, d *schema.ResourceData, meta inter
 	output, err := FindLinks(ctx, conn, input)
 
 	if err != nil {
-		return diag.Errorf("listing Network Manager Links: %s", err)
+		return sdkdiag.AppendErrorf(diags, "listing Network Manager Links: %s", err)
 	}
 
 	var linkIDs []string
@@ -88,5 +91,5 @@ func dataSourceLinksRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.SetId(meta.(*conns.AWSClient).Region)
 	d.Set("ids", linkIDs)
 
-	return nil
+	return diags
 }

--- a/internal/service/networkmanager/site_data_source.go
+++ b/internal/service/networkmanager/site_data_source.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 )
 
@@ -60,6 +61,8 @@ func DataSourceSite() *schema.Resource {
 }
 
 func dataSourceSiteRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkManagerConn(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
@@ -68,7 +71,7 @@ func dataSourceSiteRead(ctx context.Context, d *schema.ResourceData, meta interf
 	site, err := FindSiteByTwoPartKey(ctx, conn, globalNetworkID, siteID)
 
 	if err != nil {
-		return diag.Errorf("reading Network Manager Site (%s): %s", siteID, err)
+		return sdkdiag.AppendErrorf(diags, "reading Network Manager Site (%s): %s", siteID, err)
 	}
 
 	d.SetId(siteID)
@@ -77,7 +80,7 @@ func dataSourceSiteRead(ctx context.Context, d *schema.ResourceData, meta interf
 	d.Set("global_network_id", site.GlobalNetworkId)
 	if site.Location != nil {
 		if err := d.Set("location", []interface{}{flattenLocation(site.Location)}); err != nil {
-			return diag.Errorf("setting location: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting location: %s", err)
 		}
 	} else {
 		d.Set("location", nil)
@@ -85,8 +88,8 @@ func dataSourceSiteRead(ctx context.Context, d *schema.ResourceData, meta interf
 	d.Set("site_id", site.SiteId)
 
 	if err := d.Set("tags", KeyValueTags(ctx, site.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/networkmanager/site_to_site_vpn_attachment.go
+++ b/internal/service/networkmanager/site_to_site_vpn_attachment.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -101,6 +102,8 @@ func ResourceSiteToSiteVPNAttachment() *schema.Resource {
 }
 
 func resourceSiteToSiteVPNAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkManagerConn(ctx)
 
 	coreNetworkID := d.Get("core_network_id").(string)
@@ -114,19 +117,21 @@ func resourceSiteToSiteVPNAttachmentCreate(ctx context.Context, d *schema.Resour
 	output, err := conn.CreateSiteToSiteVpnAttachmentWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating Network Manager Site To Site VPN (%s) Attachment (%s): %s", vpnConnectionARN, coreNetworkID, err)
+		return sdkdiag.AppendErrorf(diags, "creating Network Manager Site To Site VPN (%s) Attachment (%s): %s", vpnConnectionARN, coreNetworkID, err)
 	}
 
 	d.SetId(aws.StringValue(output.SiteToSiteVpnAttachment.Attachment.AttachmentId))
 
 	if _, err := waitSiteToSiteVPNAttachmentCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return diag.Errorf("waiting for Network Manager Site To Site VPN Attachment (%s) create: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Network Manager Site To Site VPN Attachment (%s) create: %s", d.Id(), err)
 	}
 
-	return resourceSiteToSiteVPNAttachmentRead(ctx, d, meta)
+	return append(diags, resourceSiteToSiteVPNAttachmentRead(ctx, d, meta)...)
 }
 
 func resourceSiteToSiteVPNAttachmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkManagerConn(ctx)
 
 	vpnAttachment, err := FindSiteToSiteVPNAttachmentByID(ctx, conn, d.Id())
@@ -134,11 +139,11 @@ func resourceSiteToSiteVPNAttachmentRead(ctx context.Context, d *schema.Resource
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Network Manager Site To Site VPN Attachment (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Network Manager Site To Site VPN Attachment (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Network Manager Site To Site VPN Attachment (%s): %s", d.Id(), err)
 	}
 
 	a := vpnAttachment.Attachment
@@ -162,7 +167,7 @@ func resourceSiteToSiteVPNAttachmentRead(ctx context.Context, d *schema.Resource
 
 	setTagsOut(ctx, a.Tags)
 
-	return nil
+	return diags
 }
 
 func resourceSiteToSiteVPNAttachmentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -171,6 +176,8 @@ func resourceSiteToSiteVPNAttachmentUpdate(ctx context.Context, d *schema.Resour
 }
 
 func resourceSiteToSiteVPNAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkManagerConn(ctx)
 
 	// If ResourceAttachmentAccepter is used, then VPN Attachment state
@@ -178,15 +185,15 @@ func resourceSiteToSiteVPNAttachmentDelete(ctx context.Context, d *schema.Resour
 	output, err := FindSiteToSiteVPNAttachmentByID(ctx, conn, d.Id())
 
 	if tfawserr.ErrCodeEquals(err, networkmanager.ErrCodeResourceNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Network Manager Site To Site VPN Attachment (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Network Manager Site To Site VPN Attachment (%s): %s", d.Id(), err)
 	}
 
 	if state := aws.StringValue(output.Attachment.State); state == networkmanager.AttachmentStatePendingAttachmentAcceptance || state == networkmanager.AttachmentStatePendingTagAcceptance {
-		return diag.Errorf("cannot delete Network Manager Site To Site VPN Attachment (%s) in state: %s", d.Id(), state)
+		return sdkdiag.AppendErrorf(diags, "cannot delete Network Manager Site To Site VPN Attachment (%s) in state: %s", d.Id(), state)
 	}
 
 	log.Printf("[DEBUG] Deleting Network Manager Site To Site VPN Attachment: %s", d.Id())
@@ -195,18 +202,18 @@ func resourceSiteToSiteVPNAttachmentDelete(ctx context.Context, d *schema.Resour
 	})
 
 	if tfawserr.ErrCodeEquals(err, networkmanager.ErrCodeResourceNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting Network Manager Site To Site VPN Attachment (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Network Manager Site To Site VPN Attachment (%s): %s", d.Id(), err)
 	}
 
 	if _, err := waitSiteToSiteVPNAttachmentDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return diag.Errorf("waiting for Network Manager Site To Site VPN Attachment (%s) delete: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Network Manager Site To Site VPN Attachment (%s) delete: %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func FindSiteToSiteVPNAttachmentByID(ctx context.Context, conn *networkmanager.NetworkManager, id string) (*networkmanager.SiteToSiteVpnAttachment, error) {

--- a/internal/service/networkmanager/sites_data_source.go
+++ b/internal/service/networkmanager/sites_data_source.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 )
 
@@ -35,6 +36,8 @@ func DataSourceSites() *schema.Resource {
 }
 
 func dataSourceSitesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkManagerConn(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 	tagsToMatch := tftags.New(ctx, d.Get("tags").(map[string]interface{})).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
@@ -44,7 +47,7 @@ func dataSourceSitesRead(ctx context.Context, d *schema.ResourceData, meta inter
 	})
 
 	if err != nil {
-		return diag.Errorf("listing Network Manager Sites: %s", err)
+		return sdkdiag.AppendErrorf(diags, "listing Network Manager Sites: %s", err)
 	}
 
 	var siteIDs []string
@@ -62,5 +65,5 @@ func dataSourceSitesRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.SetId(meta.(*conns.AWSClient).Region)
 	d.Set("ids", siteIDs)
 
-	return nil
+	return diags
 }

--- a/internal/service/networkmanager/transit_gateway_peering.go
+++ b/internal/service/networkmanager/transit_gateway_peering.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -90,6 +91,8 @@ func ResourceTransitGatewayPeering() *schema.Resource {
 }
 
 func resourceTransitGatewayPeeringCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkManagerConn(ctx)
 
 	coreNetworkID := d.Get("core_network_id").(string)
@@ -104,19 +107,21 @@ func resourceTransitGatewayPeeringCreate(ctx context.Context, d *schema.Resource
 	output, err := conn.CreateTransitGatewayPeeringWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating Network Manager Transit Gateway (%s) Peering (%s): %s", transitGatewayARN, coreNetworkID, err)
+		return sdkdiag.AppendErrorf(diags, "creating Network Manager Transit Gateway (%s) Peering (%s): %s", transitGatewayARN, coreNetworkID, err)
 	}
 
 	d.SetId(aws.StringValue(output.TransitGatewayPeering.Peering.PeeringId))
 
 	if _, err := waitTransitGatewayPeeringCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return diag.Errorf("waiting for Network Manager Transit Gateway Peering (%s) create: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Network Manager Transit Gateway Peering (%s) create: %s", d.Id(), err)
 	}
 
-	return resourceTransitGatewayPeeringRead(ctx, d, meta)
+	return append(diags, resourceTransitGatewayPeeringRead(ctx, d, meta)...)
 }
 
 func resourceTransitGatewayPeeringRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkManagerConn(ctx)
 
 	transitGatewayPeering, err := FindTransitGatewayPeeringByID(ctx, conn, d.Id())
@@ -124,11 +129,11 @@ func resourceTransitGatewayPeeringRead(ctx context.Context, d *schema.ResourceDa
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Network Manager Transit Gateway Peering %s not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Network Manager Transit Gateway Peering (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Network Manager Transit Gateway Peering (%s): %s", d.Id(), err)
 	}
 
 	p := transitGatewayPeering.Peering
@@ -150,7 +155,7 @@ func resourceTransitGatewayPeeringRead(ctx context.Context, d *schema.ResourceDa
 
 	setTagsOut(ctx, p.Tags)
 
-	return nil
+	return diags
 }
 
 func resourceTransitGatewayPeeringUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -159,6 +164,8 @@ func resourceTransitGatewayPeeringUpdate(ctx context.Context, d *schema.Resource
 }
 
 func resourceTransitGatewayPeeringDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkManagerConn(ctx)
 
 	log.Printf("[DEBUG] Deleting Network Manager Transit Gateway Peering: %s", d.Id())
@@ -167,18 +174,18 @@ func resourceTransitGatewayPeeringDelete(ctx context.Context, d *schema.Resource
 	})
 
 	if tfawserr.ErrCodeEquals(err, networkmanager.ErrCodeResourceNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting Network Manager Transit Gateway Peering (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Network Manager Transit Gateway Peering (%s): %s", d.Id(), err)
 	}
 
 	if _, err := waitTransitGatewayPeeringDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return diag.Errorf("waiting for Network Manager Transit Gateway Peering (%s) delete: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Network Manager Transit Gateway Peering (%s) delete: %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func FindTransitGatewayPeeringByID(ctx context.Context, conn *networkmanager.NetworkManager, id string) (*networkmanager.TransitGatewayPeering, error) {

--- a/internal/service/networkmanager/transit_gateway_route_table_attachment.go
+++ b/internal/service/networkmanager/transit_gateway_route_table_attachment.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -102,6 +103,8 @@ func ResourceTransitGatewayRouteTableAttachment() *schema.Resource {
 }
 
 func resourceTransitGatewayRouteTableAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkManagerConn(ctx)
 
 	peeringID := d.Get("peering_id").(string)
@@ -116,19 +119,21 @@ func resourceTransitGatewayRouteTableAttachmentCreate(ctx context.Context, d *sc
 	output, err := conn.CreateTransitGatewayRouteTableAttachmentWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating Network Manager Transit Gateway (%s) Route Table (%s) Attachment: %s", peeringID, transitGatewayRouteTableARN, err)
+		return sdkdiag.AppendErrorf(diags, "creating Network Manager Transit Gateway (%s) Route Table (%s) Attachment: %s", peeringID, transitGatewayRouteTableARN, err)
 	}
 
 	d.SetId(aws.StringValue(output.TransitGatewayRouteTableAttachment.Attachment.AttachmentId))
 
 	if _, err := waitTransitGatewayRouteTableAttachmentCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return diag.Errorf("waiting for Network Manager Transit Gateway Route Table Attachment (%s) create: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Network Manager Transit Gateway Route Table Attachment (%s) create: %s", d.Id(), err)
 	}
 
-	return resourceTransitGatewayRouteTableAttachmentRead(ctx, d, meta)
+	return append(diags, resourceTransitGatewayRouteTableAttachmentRead(ctx, d, meta)...)
 }
 
 func resourceTransitGatewayRouteTableAttachmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkManagerConn(ctx)
 
 	transitGatewayRouteTableAttachment, err := FindTransitGatewayRouteTableAttachmentByID(ctx, conn, d.Id())
@@ -136,11 +141,11 @@ func resourceTransitGatewayRouteTableAttachmentRead(ctx context.Context, d *sche
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Network Manager Transit Gateway Route Table Attachment %s not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Network Manager Transit Gateway Route Table Attachment (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Network Manager Transit Gateway Route Table Attachment (%s): %s", d.Id(), err)
 	}
 
 	a := transitGatewayRouteTableAttachment.Attachment
@@ -165,7 +170,7 @@ func resourceTransitGatewayRouteTableAttachmentRead(ctx context.Context, d *sche
 
 	setTagsOut(ctx, a.Tags)
 
-	return nil
+	return diags
 }
 
 func resourceTransitGatewayRouteTableAttachmentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -174,6 +179,8 @@ func resourceTransitGatewayRouteTableAttachmentUpdate(ctx context.Context, d *sc
 }
 
 func resourceTransitGatewayRouteTableAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	conn := meta.(*conns.AWSClient).NetworkManagerConn(ctx)
 
 	log.Printf("[DEBUG] Deleting Network Manager Transit Gateway Route Table Attachment: %s", d.Id())
@@ -182,18 +189,18 @@ func resourceTransitGatewayRouteTableAttachmentDelete(ctx context.Context, d *sc
 	})
 
 	if tfawserr.ErrCodeEquals(err, networkmanager.ErrCodeResourceNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting Network Manager Transit Gateway Route Table Attachment (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Network Manager Transit Gateway Route Table Attachment (%s): %s", d.Id(), err)
 	}
 
 	if _, err := waitTransitGatewayRouteTableAttachmentDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return diag.Errorf("waiting for Network Manager Transit Gateway Route Table Attachment (%s) delete: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Network Manager Transit Gateway Route Table Attachment (%s) delete: %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func FindTransitGatewayRouteTableAttachmentByID(ctx context.Context, conn *networkmanager.NetworkManager, id string) (*networkmanager.TransitGatewayRouteTableAttachment, error) {

--- a/internal/service/networkmanager/vpc_attachment.go
+++ b/internal/service/networkmanager/vpc_attachment.go
@@ -179,13 +179,13 @@ func resourceVPCAttachmentCreate(ctx context.Context, d *schema.ResourceData, me
 	output, err := conn.CreateVpcAttachmentWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating Network Manager VPC (%s) Attachment (%s): %s", vpcARN, coreNetworkID, err)
+		return sdkdiag.AppendErrorf(diags, "creating Network Manager VPC (%s) Attachment (%s): %s", vpcARN, coreNetworkID, err)
 	}
 
 	d.SetId(aws.StringValue(output.VpcAttachment.Attachment.AttachmentId))
 
 	if _, err := waitVPCAttachmentCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return diag.Errorf("waiting for Network Manager VPC Attachment (%s) create: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Network Manager VPC Attachment (%s) create: %s", d.Id(), err)
 	}
 
 	return append(diags, resourceVPCAttachmentRead(ctx, d, meta)...)
@@ -205,7 +205,7 @@ func resourceVPCAttachmentRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Network Manager VPC Attachment (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Network Manager VPC Attachment (%s): %s", d.Id(), err)
 	}
 
 	a := vpcAttachment.Attachment
@@ -223,7 +223,7 @@ func resourceVPCAttachmentRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set("edge_location", a.EdgeLocation)
 	if vpcAttachment.Options != nil {
 		if err := d.Set("options", []interface{}{flattenVpcOptions(vpcAttachment.Options)}); err != nil {
-			return diag.Errorf("setting options: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting options: %s", err)
 		}
 	} else {
 		d.Set("options", nil)
@@ -279,11 +279,11 @@ func resourceVPCAttachmentUpdate(ctx context.Context, d *schema.ResourceData, me
 		_, err := conn.UpdateVpcAttachmentWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("updating Network Manager VPC Attachment (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating Network Manager VPC Attachment (%s): %s", d.Id(), err)
 		}
 
 		if _, err := waitVPCAttachmentUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return diag.Errorf("waiting for Network Manager VPC Attachment (%s) update: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "waiting for Network Manager VPC Attachment (%s) update: %s", d.Id(), err)
 		}
 	}
 
@@ -304,7 +304,7 @@ func resourceVPCAttachmentDelete(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	if sErr != nil {
-		return diag.Errorf("reading Network Manager VPC Attachment (%s): %s", d.Id(), sErr)
+		return sdkdiag.AppendErrorf(diags, "reading Network Manager VPC Attachment (%s): %s", d.Id(), sErr)
 	}
 
 	d.Set("state", output.Attachment.State)


### PR DESCRIPTION
### Description

Collects diagnostics in `diags` instead of returning error diagnostic directly. Ensures that warning diagnostics are not accidentally dropped.

Covers services starting with `l`, `m`, and `n`
