### PR TITLE
[New Resource]: Added ssoadmin `trusted_token_issuer` resource

### DIFF
--- a/.changelog/34839.txt
+++ b/.changelog/34839.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_ssoadmin_trusted_token_issuer
+```

--- a/internal/service/ssoadmin/exports_test.go
+++ b/internal/service/ssoadmin/exports_test.go
@@ -8,8 +8,10 @@ var (
 	ResourceApplication                        = newResourceApplication
 	ResourceApplicationAssignment              = newResourceApplicationAssignment
 	ResourceApplicationAssignmentConfiguration = newResourceApplicationAssignmentConfiguration
+	ResourceTrustedTokenIssuer                 = newResourceTrustedTokenIssuer
 
 	FindApplicationByID                        = findApplicationByID
 	FindApplicationAssignmentByID              = findApplicationAssignmentByID
 	FindApplicationAssignmentConfigurationByID = findApplicationAssignmentConfigurationByID
+	FindTrustedTokenIssuerByARN                = findTrustedTokenIssuerByARN
 )

--- a/internal/service/ssoadmin/service_package_gen.go
+++ b/internal/service/ssoadmin/service_package_gen.go
@@ -48,6 +48,11 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 			Factory: newResourceApplicationAssignmentConfiguration,
 			Name:    "Application Assignment Configuration",
 		},
+		{
+			Factory: newResourceTrustedTokenIssuer,
+			Name:    "Trusted Token Issuer",
+			Tags:    &types.ServicePackageResourceTags{},
+		},
 	}
 }
 
@@ -95,11 +100,6 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourcePermissionsBoundaryAttachment,
 			TypeName: "aws_ssoadmin_permissions_boundary_attachment",
-		},
-		{
-			Factory:  ResourceTrustedTokenIssuer,
-			TypeName: "aws_ssoadmin_trusted_token_issuer",
-			Tags:     &types.ServicePackageResourceTags{},
 		},
 	}
 }

--- a/internal/service/ssoadmin/service_package_gen.go
+++ b/internal/service/ssoadmin/service_package_gen.go
@@ -96,6 +96,11 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			Factory:  ResourcePermissionsBoundaryAttachment,
 			TypeName: "aws_ssoadmin_permissions_boundary_attachment",
 		},
+		{
+			Factory:  ResourceTrustedTokenIssuer,
+			TypeName: "aws_ssoadmin_trusted_token_issuer",
+			Tags:     &types.ServicePackageResourceTags{},
+		},
 	}
 }
 

--- a/internal/service/ssoadmin/trusted_token_issuer.go
+++ b/internal/service/ssoadmin/trusted_token_issuer.go
@@ -254,7 +254,7 @@ func FindTrustedTokenIssuerByARN(ctx context.Context, conn *ssoadmin.Client, tru
 }
 
 // Instance ID is not returned by DescribeTrustedTokenIssuer but is needed for schema consistency when importing and tagging.
-// Instance ID can be extracted from the Trusted Token Issuer ARN
+// Instance ID can be extracted from the Trusted Token Issuer ARN.
 func TrustedTokenIssuerParseInstanceID(conn *conns.AWSClient, id string) (string, error) {
 	parts := strings.Split(id, "/")
 

--- a/internal/service/ssoadmin/trusted_token_issuer.go
+++ b/internal/service/ssoadmin/trusted_token_issuer.go
@@ -249,7 +249,6 @@ func (r *resourceTrustedTokenIssuer) Update(ctx context.Context, req resource.Up
 	}
 
 	if !plan.Name.Equal(state.Name) || !plan.TrustedTokenIssuerConfiguration.Equal(state.TrustedTokenIssuerConfiguration) {
-
 		in := &ssoadmin.UpdateTrustedTokenIssuerInput{
 			TrustedTokenIssuerArn: aws.String(plan.ID.ValueString()),
 		}

--- a/internal/service/ssoadmin/trusted_token_issuer.go
+++ b/internal/service/ssoadmin/trusted_token_issuer.go
@@ -289,7 +289,7 @@ func (r *resourceTrustedTokenIssuer) Update(ctx context.Context, req resource.Up
 		}
 	}
 
-	// updateTags requires both application and instance ARN, so must be called
+	// updateTags requires both trusted token issuer and instance ARN, so must be called
 	// explicitly rather than with transparent tagging.
 	if oldTagsAll, newTagsAll := state.TagsAll, plan.TagsAll; !newTagsAll.Equal(oldTagsAll) {
 		if err := updateTags(ctx, conn, plan.ID.ValueString(), plan.InstanceARN.ValueString(), oldTagsAll, newTagsAll); err != nil {

--- a/internal/service/ssoadmin/trusted_token_issuer.go
+++ b/internal/service/ssoadmin/trusted_token_issuer.go
@@ -150,7 +150,7 @@ func resourceTrustedTokenIssuerRead(ctx context.Context, d *schema.ResourceData,
 		return sdkdiag.AppendErrorf(diags, "reading SSO Trusted Token Issuer (%s): %s", d.Id(), err)
 	}
 
-	instanceARN, _ := TrustedTokenIssuerParseInstanceID(meta.(*conns.AWSClient), d.Id())
+	instanceARN, _ := TrustedTokenIssuerParseInstanceARN(meta.(*conns.AWSClient), d.Id())
 
 	d.Set("name", output.Name)
 	d.Set("arn", output.TrustedTokenIssuerArn)
@@ -253,16 +253,16 @@ func FindTrustedTokenIssuerByARN(ctx context.Context, conn *ssoadmin.Client, tru
 	return output, nil
 }
 
-// Instance ID is not returned by DescribeTrustedTokenIssuer but is needed for schema consistency when importing and tagging.
-// Instance ID can be extracted from the Trusted Token Issuer ARN.
-func TrustedTokenIssuerParseInstanceID(conn *conns.AWSClient, id string) (string, error) {
+// Instance ARN is not returned by DescribeTrustedTokenIssuer but is needed for schema consistency when importing and tagging.
+// Instance ARN can be extracted from the Trusted Token Issuer ARN.
+func TrustedTokenIssuerParseInstanceARN(conn *conns.AWSClient, id string) (string, error) {
 	parts := strings.Split(id, "/")
 
 	if len(parts) == 3 && parts[0] != "" && parts[1] != "" && parts[2] != "" {
 		return fmt.Sprintf("arn:%s:sso:::instance/%s", conn.Partition, parts[1]), nil
 	}
 
-	return "", fmt.Errorf("unable to determine Instance ID from Trusted Token Issuer ARN: %s", id)
+	return "", fmt.Errorf("unable to construct Instance ARN from Trusted Token Issuer ARN: %s", id)
 }
 
 func expandTrustedTokenIssuerConfiguration(tfMap []interface{}) types.TrustedTokenIssuerConfiguration {

--- a/internal/service/ssoadmin/trusted_token_issuer.go
+++ b/internal/service/ssoadmin/trusted_token_issuer.go
@@ -194,7 +194,7 @@ func resourceTrustedTokenIssuerUpdate(ctx context.Context, d *schema.ResourceDat
 		}
 	}
 
-	// listTags requires both trusted token issuer and instance ARN, so must be called
+	// updateTags requires both trusted token issuer and instance ARN, so must be called
 	// explicitly rather than with transparent tagging.
 	if d.HasChange("tags_all") {
 		oldTagsAll, newTagsAll := d.GetChange("tags_all")

--- a/internal/service/ssoadmin/trusted_token_issuer.go
+++ b/internal/service/ssoadmin/trusted_token_issuer.go
@@ -1,0 +1,399 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ssoadmin
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssoadmin"
+	"github.com/aws/aws-sdk-go-v2/service/ssoadmin/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKResource("aws_ssoadmin_trusted_token_issuer")
+// @Tags
+func ResourceTrustedTokenIssuer() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceTrustedTokenIssuerCreate,
+		ReadWithoutTimeout:   resourceTrustedTokenIssuerRead,
+		UpdateWithoutTimeout: resourceTrustedTokenIssuerUpdate,
+		DeleteWithoutTimeout: resourceTrustedTokenIssuerDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"client_token": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+			},
+			"instance_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidARN,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"trusted_token_issuer_configuration": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"oidc_jwt_configuration": {
+							Type:     schema.TypeList,
+							Required: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"claim_attribute_path": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"identity_store_attribute_path": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"issuer_url": {
+										Type:     schema.TypeString,
+										Required: true,
+										ForceNew: true, // Not part of OidcJwtUpdateConfiguration struct, have to recreate at change
+									},
+									"jwks_retrieval_option": {
+										Type:             schema.TypeString,
+										Required:         true,
+										ValidateDiagFunc: enum.Validate[types.JwksRetrievalOption](),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"trusted_token_issuer_type": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: enum.Validate[types.TrustedTokenIssuerType](),
+			},
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+		},
+
+		CustomizeDiff: verify.SetTagsDiff,
+	}
+}
+
+func resourceTrustedTokenIssuerCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).SSOAdminClient(ctx)
+
+	input := &ssoadmin.CreateTrustedTokenIssuerInput{
+		InstanceArn:                     aws.String(d.Get("instance_arn").(string)),
+		Name:                            aws.String(d.Get("name").(string)),
+		TrustedTokenIssuerConfiguration: expandTrustedTokenIssuerConfiguration(d.Get("trusted_token_issuer_configuration").([]interface{})),
+		TrustedTokenIssuerType:          types.TrustedTokenIssuerType(d.Get("trusted_token_issuer_type").(string)),
+		Tags:                            getTagsIn(ctx),
+	}
+
+	if v, ok := d.GetOk("client_token"); ok {
+		input.ClientToken = aws.String(v.(string))
+	}
+
+	output, err := conn.CreateTrustedTokenIssuer(ctx, input)
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "creating SSO Trusted Token Issuer (%s): %s", d.Get("name").(string), err)
+	}
+
+	d.SetId(aws.ToString(output.TrustedTokenIssuerArn))
+
+	return append(diags, resourceTrustedTokenIssuerRead(ctx, d, meta)...)
+}
+
+func resourceTrustedTokenIssuerRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).SSOAdminClient(ctx)
+
+	output, err := FindTrustedTokenIssuerByARN(ctx, conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] SSO Trusted Token Issuer (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return diags
+	}
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading SSO Trusted Token Issuer (%s): %s", d.Id(), err)
+	}
+
+	instanceARN, _ := TrustedTokenIssuerParseInstanceID(d.Id())
+
+	d.Set("name", output.Name)
+	d.Set("arn", output.TrustedTokenIssuerArn)
+	d.Set("instance_arn", instanceARN)
+	d.Set("trusted_token_issuer_configuration", flattenTrustedTokenIssuerConfiguration(output.TrustedTokenIssuerConfiguration))
+	d.Set("trusted_token_issuer_type", output.TrustedTokenIssuerType)
+
+	// listTags requires both trusted token issuer and instance ARN, so must be called
+	// explicitly rather than with transparent tagging.
+	tags, err := listTags(ctx, conn, d.Id(), instanceARN)
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading SSO Trusted Token Issuer (%s): %s", d.Id(), err)
+	}
+
+	setTagsOut(ctx, Tags(tags))
+
+	return diags
+}
+
+func resourceTrustedTokenIssuerUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).SSOAdminClient(ctx)
+
+	if d.HasChangesExcept("tags", "tags_all") {
+		input := &ssoadmin.UpdateTrustedTokenIssuerInput{
+			TrustedTokenIssuerArn: aws.String(d.Id()),
+		}
+
+		if d.HasChange("name") {
+			input.Name = aws.String(d.Get("name").(string))
+		}
+
+		if d.HasChange("trusted_token_issuer_configuration") {
+			input.TrustedTokenIssuerConfiguration = expandTrustedTokenIssuerUpdateConfiguration(d.Get("trusted_token_issuer_configuration").([]interface{}))
+		}
+
+		_, err := conn.UpdateTrustedTokenIssuer(ctx, input)
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "updating SSO Trusted Token Issuer (%s): %s", d.Id(), err)
+		}
+	}
+
+	// listTags requires both trusted token issuer and instance ARN, so must be called
+	// explicitly rather than with transparent tagging.
+	if d.HasChange("tags_all") {
+		oldTagsAll, newTagsAll := d.GetChange("tags_all")
+		if err := updateTags(ctx, conn, d.Id(), d.Get("instance_arn").(string), oldTagsAll, newTagsAll); err != nil {
+			return sdkdiag.AppendErrorf(diags, "updating SSO Trusted Token Issuer (%s): %s", d.Id(), err)
+		}
+	}
+
+	return append(diags, resourceTrustedTokenIssuerRead(ctx, d, meta)...)
+}
+
+func resourceTrustedTokenIssuerDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).SSOAdminClient(ctx)
+
+	input := &ssoadmin.DeleteTrustedTokenIssuerInput{
+		TrustedTokenIssuerArn: aws.String(d.Id()),
+	}
+
+	log.Printf("[INFO] Deleting SSO Trusted Token Issuer: %s", d.Id())
+	_, err := conn.DeleteTrustedTokenIssuer(ctx, input)
+
+	if errs.IsA[*types.ResourceNotFoundException](err) {
+		return diags
+	}
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "deleting SSO Trusted Token Issuer (%s): %s", d.Id(), err)
+	}
+
+	return diags
+}
+
+func FindTrustedTokenIssuerByARN(ctx context.Context, conn *ssoadmin.Client, trustedTokenIssuerARN string) (*ssoadmin.DescribeTrustedTokenIssuerOutput, error) {
+	input := &ssoadmin.DescribeTrustedTokenIssuerInput{
+		TrustedTokenIssuerArn: aws.String(trustedTokenIssuerARN),
+	}
+
+	output, err := conn.DescribeTrustedTokenIssuer(ctx, input)
+
+	if errs.IsA[*types.ResourceNotFoundException](err) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output, nil
+}
+
+// Instance ID is not returned by DescribeTrustedTokenIssuer but is needed for schema consistency when importing and tagging.
+// Instance ID can be extracted from the Trusted Token Issuer ARN
+func TrustedTokenIssuerParseInstanceID(id string) (string, error) {
+	parts := strings.Split(id, "/")
+
+	if len(parts) == 3 && parts[0] != "" && parts[1] != "" && parts[2] != "" {
+		return fmt.Sprintf("arn:aws:sso:::instance/%s", parts[1]), nil
+	}
+
+	return "", fmt.Errorf("unable to determine Instance ID from Trusted Token Issuer ARN: %s", id)
+}
+
+func expandTrustedTokenIssuerConfiguration(tfMap []interface{}) types.TrustedTokenIssuerConfiguration {
+	if len(tfMap) == 0 {
+		return nil
+	}
+
+	tfList, ok := tfMap[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	if v, ok := tfList["oidc_jwt_configuration"]; ok {
+		return &types.TrustedTokenIssuerConfigurationMemberOidcJwtConfiguration{
+			Value: expandOidcJwtConfiguration(v.([]interface{})),
+		}
+	}
+
+	return nil
+}
+
+func expandOidcJwtConfiguration(tfMap []interface{}) types.OidcJwtConfiguration {
+	apiObject := types.OidcJwtConfiguration{}
+
+	if len(tfMap) == 0 {
+		return apiObject
+	}
+
+	tfList, ok := tfMap[0].(map[string]interface{})
+	if !ok {
+		return apiObject
+	}
+
+	if v, ok := tfList["claim_attribute_path"]; ok {
+		apiObject.ClaimAttributePath = aws.String(v.(string))
+	}
+
+	if v, ok := tfList["identity_store_attribute_path"]; ok {
+		apiObject.IdentityStoreAttributePath = aws.String(v.(string))
+	}
+
+	if v, ok := tfList["issuer_url"]; ok {
+		apiObject.IssuerUrl = aws.String(v.(string))
+	}
+
+	if v, ok := tfList["jwks_retrieval_option"]; ok {
+		apiObject.JwksRetrievalOption = types.JwksRetrievalOption(v.(string))
+	}
+
+	return apiObject
+}
+
+func expandTrustedTokenIssuerUpdateConfiguration(tfMap []interface{}) types.TrustedTokenIssuerUpdateConfiguration {
+	if len(tfMap) == 0 {
+		return nil
+	}
+
+	tfList, ok := tfMap[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	if v, ok := tfList["oidc_jwt_configuration"]; ok {
+		return &types.TrustedTokenIssuerUpdateConfigurationMemberOidcJwtConfiguration{
+			Value: expandOidcJwtUpdateConfiguration(v.([]interface{})),
+		}
+	}
+
+	return nil
+}
+
+func expandOidcJwtUpdateConfiguration(tfMap []interface{}) types.OidcJwtUpdateConfiguration {
+	apiObject := types.OidcJwtUpdateConfiguration{}
+
+	if len(tfMap) == 0 {
+		return apiObject
+	}
+
+	tfList, ok := tfMap[0].(map[string]interface{})
+	if !ok {
+		return apiObject
+	}
+
+	if v, ok := tfList["claim_attribute_path"]; ok {
+		apiObject.ClaimAttributePath = aws.String(v.(string))
+	}
+
+	if v, ok := tfList["identity_store_attribute_path"]; ok {
+		apiObject.IdentityStoreAttributePath = aws.String(v.(string))
+	}
+
+	if v, ok := tfList["jwks_retrieval_option"]; ok {
+		apiObject.JwksRetrievalOption = types.JwksRetrievalOption(v.(string))
+	}
+
+	return apiObject
+}
+
+func flattenTrustedTokenIssuerConfiguration(apiObject types.TrustedTokenIssuerConfiguration) []interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	switch v := apiObject.(type) {
+	case *types.TrustedTokenIssuerConfigurationMemberOidcJwtConfiguration:
+		tfMap["oidc_jwt_configuration"] = flattenOidcJwtConfiguration(v.Value)
+	default:
+		log.Println("union is nil or unknown type")
+	}
+
+	return []interface{}{tfMap}
+}
+
+func flattenOidcJwtConfiguration(apiObject types.OidcJwtConfiguration) []interface{} {
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.ClaimAttributePath; v != nil {
+		tfMap["claim_attribute_path"] = aws.ToString(v)
+	}
+
+	if v := apiObject.IdentityStoreAttributePath; v != nil {
+		tfMap["identity_store_attribute_path"] = aws.ToString(v)
+	}
+
+	if v := apiObject.IssuerUrl; v != nil {
+		tfMap["issuer_url"] = aws.ToString(v)
+	}
+
+	tfMap["jwks_retrieval_option"] = string(apiObject.JwksRetrievalOption)
+
+	return []interface{}{tfMap}
+}

--- a/internal/service/ssoadmin/trusted_token_issuer.go
+++ b/internal/service/ssoadmin/trusted_token_issuer.go
@@ -150,7 +150,7 @@ func resourceTrustedTokenIssuerRead(ctx context.Context, d *schema.ResourceData,
 		return sdkdiag.AppendErrorf(diags, "reading SSO Trusted Token Issuer (%s): %s", d.Id(), err)
 	}
 
-	instanceARN, _ := TrustedTokenIssuerParseInstanceID(d.Id())
+	instanceARN, _ := TrustedTokenIssuerParseInstanceID(meta.(*conns.AWSClient), d.Id())
 
 	d.Set("name", output.Name)
 	d.Set("arn", output.TrustedTokenIssuerArn)
@@ -255,11 +255,11 @@ func FindTrustedTokenIssuerByARN(ctx context.Context, conn *ssoadmin.Client, tru
 
 // Instance ID is not returned by DescribeTrustedTokenIssuer but is needed for schema consistency when importing and tagging.
 // Instance ID can be extracted from the Trusted Token Issuer ARN
-func TrustedTokenIssuerParseInstanceID(id string) (string, error) {
+func TrustedTokenIssuerParseInstanceID(conn *conns.AWSClient, id string) (string, error) {
 	parts := strings.Split(id, "/")
 
 	if len(parts) == 3 && parts[0] != "" && parts[1] != "" && parts[2] != "" {
-		return fmt.Sprintf("arn:aws:sso:::instance/%s", parts[1]), nil
+		return fmt.Sprintf("arn:%s:sso:::instance/%s", conn.Partition, parts[1]), nil
 	}
 
 	return "", fmt.Errorf("unable to determine Instance ID from Trusted Token Issuer ARN: %s", id)

--- a/internal/service/ssoadmin/trusted_token_issuer.go
+++ b/internal/service/ssoadmin/trusted_token_issuer.go
@@ -277,14 +277,14 @@ func expandTrustedTokenIssuerConfiguration(tfMap []interface{}) types.TrustedTok
 
 	if v, ok := tfList["oidc_jwt_configuration"]; ok {
 		return &types.TrustedTokenIssuerConfigurationMemberOidcJwtConfiguration{
-			Value: expandOidcJwtConfiguration(v.([]interface{})),
+			Value: expandOIDCJWTConfiguration(v.([]interface{})),
 		}
 	}
 
 	return nil
 }
 
-func expandOidcJwtConfiguration(tfMap []interface{}) types.OidcJwtConfiguration {
+func expandOIDCJWTConfiguration(tfMap []interface{}) types.OidcJwtConfiguration {
 	apiObject := types.OidcJwtConfiguration{}
 
 	if len(tfMap) == 0 {
@@ -327,14 +327,14 @@ func expandTrustedTokenIssuerUpdateConfiguration(tfMap []interface{}) types.Trus
 
 	if v, ok := tfList["oidc_jwt_configuration"]; ok {
 		return &types.TrustedTokenIssuerUpdateConfigurationMemberOidcJwtConfiguration{
-			Value: expandOidcJwtUpdateConfiguration(v.([]interface{})),
+			Value: expandOIDCJWTUpdateConfiguration(v.([]interface{})),
 		}
 	}
 
 	return nil
 }
 
-func expandOidcJwtUpdateConfiguration(tfMap []interface{}) types.OidcJwtUpdateConfiguration {
+func expandOIDCJWTUpdateConfiguration(tfMap []interface{}) types.OidcJwtUpdateConfiguration {
 	apiObject := types.OidcJwtUpdateConfiguration{}
 
 	if len(tfMap) == 0 {
@@ -370,7 +370,7 @@ func flattenTrustedTokenIssuerConfiguration(apiObject types.TrustedTokenIssuerCo
 
 	switch v := apiObject.(type) {
 	case *types.TrustedTokenIssuerConfigurationMemberOidcJwtConfiguration:
-		tfMap["oidc_jwt_configuration"] = flattenOidcJwtConfiguration(v.Value)
+		tfMap["oidc_jwt_configuration"] = flattenOIDCJWTConfiguration(v.Value)
 	default:
 		log.Println("union is nil or unknown type")
 	}
@@ -378,7 +378,7 @@ func flattenTrustedTokenIssuerConfiguration(apiObject types.TrustedTokenIssuerCo
 	return []interface{}{tfMap}
 }
 
-func flattenOidcJwtConfiguration(apiObject types.OidcJwtConfiguration) []interface{} {
+func flattenOIDCJWTConfiguration(apiObject types.OidcJwtConfiguration) []interface{} {
 	tfMap := map[string]interface{}{}
 
 	if v := apiObject.ClaimAttributePath; v != nil {

--- a/internal/service/ssoadmin/trusted_token_issuer_test.go
+++ b/internal/service/ssoadmin/trusted_token_issuer_test.go
@@ -1,0 +1,293 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ssoadmin_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/ssoadmin/types"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/service/ssoadmin"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccSSOAdminTrustedTokenIssuer_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_ssoadmin_trusted_token_issuer.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckSSOAdminInstances(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSOAdminEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTrustedTokenIssuerDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTrustedTokenIssuerConfigBase_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTrustedTokenIssuerExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "trusted_token_issuer_type", string(types.TrustedTokenIssuerTypeOidcJwt)),
+					resource.TestCheckResourceAttr(resourceName, "trusted_token_issuer_configuration.0.oidc_jwt_configuration.0.claim_attribute_path", "email"),
+					resource.TestCheckResourceAttr(resourceName, "trusted_token_issuer_configuration.0.oidc_jwt_configuration.0.identity_store_attribute_path", "emails.value"),
+					resource.TestCheckResourceAttr(resourceName, "trusted_token_issuer_configuration.0.oidc_jwt_configuration.0.issuer_url", "https://example.com"),
+					resource.TestCheckResourceAttr(resourceName, "trusted_token_issuer_configuration.0.oidc_jwt_configuration.0.jwks_retrieval_option", string(types.JwksRetrievalOptionOpenIdDiscovery)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSSOAdminTrustedTokenIssuer_update(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNameUpdated := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_ssoadmin_trusted_token_issuer.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckSSOAdminInstances(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSOAdminEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTrustedTokenIssuerDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTrustedTokenIssuerConfigBase_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTrustedTokenIssuerExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "trusted_token_issuer_configuration.0.oidc_jwt_configuration.0.claim_attribute_path", "email"),
+					resource.TestCheckResourceAttr(resourceName, "trusted_token_issuer_configuration.0.oidc_jwt_configuration.0.identity_store_attribute_path", "emails.value"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccTrustedTokenIssuerConfigBase_basicUpdated(rNameUpdated, "name", "userName"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTrustedTokenIssuerExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					resource.TestCheckResourceAttr(resourceName, "trusted_token_issuer_configuration.0.oidc_jwt_configuration.0.claim_attribute_path", "name"),
+					resource.TestCheckResourceAttr(resourceName, "trusted_token_issuer_configuration.0.oidc_jwt_configuration.0.identity_store_attribute_path", "userName"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSSOAdminTrustedTokenIssuer_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_ssoadmin_trusted_token_issuer.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckSSOAdminInstances(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSOAdminEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTrustedTokenIssuerDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTrustedTokenIssuerConfigBase_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTrustedTokenIssuerExists(ctx, resourceName),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, ssoadmin.ResourceTrustedTokenIssuer(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccSSOAdminTrustedTokenIssuer_tags(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_ssoadmin_trusted_token_issuer.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckSSOAdminInstances(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSOAdminEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTrustedTokenIssuerDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTrustedTokenIssuerConfigBase_tags(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTrustedTokenIssuerExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccTrustedTokenIssuerConfigBase_tags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTrustedTokenIssuerExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccTrustedTokenIssuerConfigBase_tags(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTrustedTokenIssuerExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckTrustedTokenIssuerExists(ctx context.Context, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).SSOAdminClient(ctx)
+
+		_, err := ssoadmin.FindTrustedTokenIssuerByARN(ctx, conn, rs.Primary.ID)
+
+		return err
+	}
+}
+
+func testAccCheckTrustedTokenIssuerDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).SSOAdminClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_ssoadmin_trusted_token_issuer" {
+				continue
+			}
+
+			_, err := ssoadmin.FindTrustedTokenIssuerByARN(ctx, conn, rs.Primary.ID)
+
+			if tfresource.NotFound(err) {
+				continue
+			}
+
+			if err != nil {
+				return err
+			}
+
+			return fmt.Errorf("SSO Admin Trusted Token Issuer %s still exists", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccTrustedTokenIssuerConfigBase_basic(rName string) string {
+	return fmt.Sprintf(`
+data "aws_ssoadmin_instances" "test" {}
+
+resource "aws_ssoadmin_trusted_token_issuer" "test" {
+  name                      = %[1]q
+  instance_arn              = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+  trusted_token_issuer_type = "OIDC_JWT"
+
+  trusted_token_issuer_configuration {
+    oidc_jwt_configuration {
+      claim_attribute_path          = "email"
+      identity_store_attribute_path = "emails.value"
+      issuer_url                    = "https://example.com"
+      jwks_retrieval_option         = "OPEN_ID_DISCOVERY"
+    }
+  }
+}
+`, rName)
+}
+
+func testAccTrustedTokenIssuerConfigBase_basicUpdated(rNameUpdated, claimAttributePath, identityStoreAttributePath string) string {
+	return fmt.Sprintf(`
+data "aws_ssoadmin_instances" "test" {}
+
+resource "aws_ssoadmin_trusted_token_issuer" "test" {
+  name                      = %[1]q
+  instance_arn              = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+  trusted_token_issuer_type = "OIDC_JWT"
+
+  trusted_token_issuer_configuration {
+    oidc_jwt_configuration {
+      claim_attribute_path          = %[2]q
+      identity_store_attribute_path = %[3]q
+      issuer_url                    = "https://example.com"
+      jwks_retrieval_option         = "OPEN_ID_DISCOVERY"
+    }
+  }
+}
+`, rNameUpdated, claimAttributePath, identityStoreAttributePath)
+}
+
+func testAccTrustedTokenIssuerConfigBase_tags(rName, tagKey, tagValue string) string {
+	return fmt.Sprintf(`
+data "aws_ssoadmin_instances" "test" {}
+
+resource "aws_ssoadmin_trusted_token_issuer" "test" {
+  name                      = %[1]q
+  instance_arn              = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+  trusted_token_issuer_type = "OIDC_JWT"
+
+  trusted_token_issuer_configuration {
+    oidc_jwt_configuration {
+      claim_attribute_path          = "email"
+      identity_store_attribute_path = "emails.value"
+      issuer_url                    = "https://example.com"
+      jwks_retrieval_option         = "OPEN_ID_DISCOVERY"
+    }
+  }
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey, tagValue)
+}
+
+func testAccTrustedTokenIssuerConfigBase_tags2(rName, tagKey, tagValue, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+data "aws_ssoadmin_instances" "test" {}
+
+resource "aws_ssoadmin_trusted_token_issuer" "test" {
+  name                      = %[1]q
+  instance_arn              = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+  trusted_token_issuer_type = "OIDC_JWT"
+
+  trusted_token_issuer_configuration {
+    oidc_jwt_configuration {
+      claim_attribute_path          = "email"
+      identity_store_attribute_path = "emails.value"
+      issuer_url                    = "https://example.com"
+      jwks_retrieval_option         = "OPEN_ID_DISCOVERY"
+    }
+  }
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey, tagValue, tagKey2, tagValue2)
+}

--- a/website/docs/r/ssoadmin_trusted_token_issuer.html.markdown
+++ b/website/docs/r/ssoadmin_trusted_token_issuer.html.markdown
@@ -1,0 +1,84 @@
+---
+subcategory: "SSO Admin"
+layout: "aws"
+page_title: "AWS: aws_ssoadmin_trusted_token_issuer"
+description: |-
+  Terraform resource for managing an AWS SSO Admin Trusted Token Issuer.
+---
+# Resource: aws_ssoadmin_trusted_token_issuer
+
+Terraform resource for managing an AWS SSO Admin Trusted Token Issuer.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_ssoadmin_instances" "example" {}
+
+resource "aws_ssoadmin_trusted_token_issuer" "example" {
+  name                      = "example"
+  instance_arn              = tolist(data.aws_ssoadmin_instances.example.arns)[0]
+  trusted_token_issuer_type = "OIDC_JWT"
+
+  trusted_token_issuer_configuration {
+    oidc_jwt_configuration {
+      claim_attribute_path          = "email"
+      identity_store_attribute_path = "emails.value"
+      issuer_url                    = "https://example.com"
+      jwks_retrieval_option         = "OPEN_ID_DISCOVERY"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `instance_arn` - (Required) ARN of the instance of IAM Identity Center.
+* `name` - (Required) Name of the trusted token issuer.
+* `trusted_token_issuer_configuration` - (Required) A block that specifies settings that apply to the trusted token issuer, these change depending on the type you specify in `trusted_token_issuer_type`. [Documented below](#trusted_token_issuer_configuration-argument-reference).
+* `trusted_token_issuer_type` - (Required) Specifies the type of the trusted token issuer. Valid values are `OIDC_JWT`
+
+The following arguments are optional:
+
+* `client_token` - (Optional) A unique, case-sensitive ID that you provide to ensure the idempotency of the request. AWS generates a random value when not provided.
+* `tags` - (Optional) Key-value mapping of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### `trusted_token_issuer_configuration` Argument Reference
+
+* `oidc_jwt_configuration` - (Optional) A block that describes the settings for a trusted token issuer that works with OpenID Connect (OIDC) by using JSON Web Tokens (JWT). See [Documented below](#oidc_jwt_configuration-argument-reference) below.
+
+
+### `oidc_jwt_configuration` Argument Reference
+
+* `claim_attribute_path` - (Required) Specifies the path of the source attribute in the JWT from the trusted token issuer.
+* `identity_store_attribute_path` - (Required) Specifies path of the destination attribute in a JWT from IAM Identity Center. The attribute mapped by this JMESPath expression is compared against the attribute mapped by `claim_attribute_path` when a trusted token issuer token is exchanged for an IAM Identity Center token. 
+* `issuer_url` - (Required) Specifies the URL that IAM Identity Center uses for OpenID Discovery. OpenID Discovery is used to obtain the information required to verify the tokens that the trusted token issuer generates.
+* `jwks_retrieval_option` - (Required) The method that the trusted token issuer can use to retrieve the JSON Web Key Set used to verify a JWT. Valid values are `OPEN_ID_DISCOVERY`
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `arn` - ARN of the trusted token issuer.
+* `id` - ARN of the trusted token issuer.
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import SSO Admin Trusted Token Issuer using the `id`. For example:
+
+```terraform
+import {
+  to = aws_ssoadmin_trusted_token_issuer.example
+  id = "arn:aws:sso::012345678901:trustedTokenIssuer/ssoins-lu1ye3gew4mbc7ju/tti-2657c556-9707-11ee-b9d1-0242ac120002"
+}
+```
+
+Using `terraform import`, import SSO Admin Trusted Token Issuer using the `id`. For example:
+
+```console
+% terraform import aws_ssoadmin_trusted_token_issuer.example arn:aws:sso::012345678901:trustedTokenIssuer/ssoins-lu1ye3gew4mbc7ju/tti-2657c556-9707-11ee-b9d1-0242ac120002
+```

--- a/website/docs/r/ssoadmin_trusted_token_issuer.html.markdown
+++ b/website/docs/r/ssoadmin_trusted_token_issuer.html.markdown
@@ -50,11 +50,10 @@ The following arguments are optional:
 
 * `oidc_jwt_configuration` - (Optional) A block that describes the settings for a trusted token issuer that works with OpenID Connect (OIDC) by using JSON Web Tokens (JWT). See [Documented below](#oidc_jwt_configuration-argument-reference) below.
 
-
 ### `oidc_jwt_configuration` Argument Reference
 
 * `claim_attribute_path` - (Required) Specifies the path of the source attribute in the JWT from the trusted token issuer.
-* `identity_store_attribute_path` - (Required) Specifies path of the destination attribute in a JWT from IAM Identity Center. The attribute mapped by this JMESPath expression is compared against the attribute mapped by `claim_attribute_path` when a trusted token issuer token is exchanged for an IAM Identity Center token. 
+* `identity_store_attribute_path` - (Required) Specifies path of the destination attribute in a JWT from IAM Identity Center. The attribute mapped by this JMESPath expression is compared against the attribute mapped by `claim_attribute_path` when a trusted token issuer token is exchanged for an IAM Identity Center token.
 * `issuer_url` - (Required) Specifies the URL that IAM Identity Center uses for OpenID Discovery. OpenID Discovery is used to obtain the information required to verify the tokens that the trusted token issuer generates.
 * `jwks_retrieval_option` - (Required) The method that the trusted token issuer can use to retrieve the JSON Web Key Set used to verify a JWT. Valid values are `OPEN_ID_DISCOVERY`
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR adds the ability to manage AWS Identity Center trusted token issuers with Terraform by introducing the `aws_ssoadmin_trusted_token_issuer` resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/34766

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
make testacc TESTS=TestAccSSOAdminTrustedTokenIssuer_ PKG=ssoadmin
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ssoadmin/... -v -count 1 -parallel 20 -run='TestAccSSOAdminTrustedTokenIssuer_'  -timeout 360m
=== RUN   TestAccSSOAdminTrustedTokenIssuer_basic
=== PAUSE TestAccSSOAdminTrustedTokenIssuer_basic
=== RUN   TestAccSSOAdminTrustedTokenIssuer_update
=== PAUSE TestAccSSOAdminTrustedTokenIssuer_update
=== RUN   TestAccSSOAdminTrustedTokenIssuer_disappears
=== PAUSE TestAccSSOAdminTrustedTokenIssuer_disappears
=== RUN   TestAccSSOAdminTrustedTokenIssuer_tags
=== PAUSE TestAccSSOAdminTrustedTokenIssuer_tags
=== CONT  TestAccSSOAdminTrustedTokenIssuer_basic
=== CONT  TestAccSSOAdminTrustedTokenIssuer_disappears
=== CONT  TestAccSSOAdminTrustedTokenIssuer_tags
=== CONT  TestAccSSOAdminTrustedTokenIssuer_update
--- PASS: TestAccSSOAdminTrustedTokenIssuer_disappears (51.85s)
--- PASS: TestAccSSOAdminTrustedTokenIssuer_basic (54.77s)
--- PASS: TestAccSSOAdminTrustedTokenIssuer_update (85.45s)
--- PASS: TestAccSSOAdminTrustedTokenIssuer_tags (114.15s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssoadmin   116.371s
```
