### PR TITLE
f/aws_codepipeline add support for pipeline_type and variable

### DIFF
--- a/.changelog/34122.txt
+++ b/.changelog/34122.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_codepipeline: Add `pipeline_type`, `variable` attribute
+```

--- a/internal/service/codepipeline/codepipeline_test.go
+++ b/internal/service/codepipeline/codepipeline_test.go
@@ -613,6 +613,174 @@ func TestAccCodePipeline_ecr(t *testing.T) {
 	})
 }
 
+func TestAccCodePipeline_pipelinetype(t *testing.T) {
+	ctx := acctest.Context(t)
+	var p1, p2 codepipeline.PipelineDeclaration
+	name := sdkacctest.RandString(10)
+	resourceName := "aws_codepipeline.test"
+	codestarConnectionResourceName := "aws_codestarconnections_connection.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheckSupported(ctx, t)
+			acctest.PreCheckPartitionHasService(t, codestarconnections.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, codepipeline.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPipelineDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCodePipelineConfig_pipelinetype(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPipelineExists(ctx, resourceName, &p1),
+					resource.TestCheckResourceAttrPair(resourceName, "role_arn", "aws_iam_role.codepipeline_role", "arn"),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "codepipeline", regexache.MustCompile(fmt.Sprintf("test-pipeline-%s", name))),
+					resource.TestCheckResourceAttr(resourceName, "artifact_store.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "pipeline_type", codepipeline.PipelineTypeV1),
+
+					resource.TestCheckResourceAttr(resourceName, "stage.#", "2"),
+
+					resource.TestCheckResourceAttr(resourceName, "stage.0.name", "Source"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.name", "Source"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.category", "Source"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.owner", "AWS"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.provider", "CodeStarSourceConnection"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.version", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.input_artifacts.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.output_artifacts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.output_artifacts.0", "test"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.FullRepositoryId", "lifesum-terraform/test"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.BranchName", "main"),
+					resource.TestCheckResourceAttrPair(resourceName, "stage.0.action.0.configuration.ConnectionArn", codestarConnectionResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.role_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.run_order", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.region", ""),
+
+					resource.TestCheckResourceAttr(resourceName, "stage.1.name", "Build"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.name", "Build"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.category", "Build"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.owner", "AWS"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.provider", "CodeBuild"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.version", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.input_artifacts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.input_artifacts.0", "test"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.output_artifacts.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.configuration.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.configuration.ProjectName", "test"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.role_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.run_order", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.region", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccCodePipelineConfig_pipelinetypeUpdated(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPipelineExists(ctx, resourceName, &p2),
+					resource.TestCheckResourceAttr(resourceName, "pipeline_type", codepipeline.PipelineTypeV2),
+
+					resource.TestCheckResourceAttr(resourceName, "stage.#", "2"),
+
+					resource.TestCheckResourceAttr(resourceName, "stage.0.name", "Source"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.name", "Source"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.input_artifacts.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.output_artifacts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.output_artifacts.0", "artifacts"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.FullRepositoryId", "test-terraform/test-repo"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.BranchName", "stable"),
+					resource.TestCheckResourceAttrPair(resourceName, "stage.0.action.0.configuration.ConnectionArn", codestarConnectionResourceName, "arn"),
+
+					resource.TestCheckResourceAttr(resourceName, "stage.1.name", "Build"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.name", "Build"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.input_artifacts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.input_artifacts.0", "artifacts"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.configuration.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.configuration.ProjectName", "test"),
+
+					resource.TestCheckResourceAttr(resourceName, "variable.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "variable.0.name", "test_var1"),
+					resource.TestCheckResourceAttr(resourceName, "variable.0.description", "This is test pipeline variable 1."),
+					resource.TestCheckResourceAttr(resourceName, "variable.0.default_value", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "variable.1.name", "test_var2"),
+					resource.TestCheckResourceAttr(resourceName, "variable.1.description", "This is test pipeline variable 2."),
+					resource.TestCheckResourceAttr(resourceName, "variable.1.default_value", "value2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"stage.0.action.0.configuration.%",
+					"stage.0.action.0.configuration.OAuthToken",
+				},
+			},
+			{
+				Config: testAccCodePipelineConfig_pipelinetype(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPipelineExists(ctx, resourceName, &p1),
+					resource.TestCheckResourceAttrPair(resourceName, "role_arn", "aws_iam_role.codepipeline_role", "arn"),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "codepipeline", regexache.MustCompile(fmt.Sprintf("test-pipeline-%s", name))),
+					resource.TestCheckResourceAttr(resourceName, "artifact_store.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "pipeline_type", codepipeline.PipelineTypeV1),
+
+					resource.TestCheckResourceAttr(resourceName, "stage.#", "2"),
+
+					resource.TestCheckResourceAttr(resourceName, "stage.0.name", "Source"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.name", "Source"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.category", "Source"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.owner", "AWS"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.provider", "CodeStarSourceConnection"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.version", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.input_artifacts.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.output_artifacts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.output_artifacts.0", "test"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.FullRepositoryId", "lifesum-terraform/test"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.BranchName", "main"),
+					resource.TestCheckResourceAttrPair(resourceName, "stage.0.action.0.configuration.ConnectionArn", codestarConnectionResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.role_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.run_order", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.region", ""),
+
+					resource.TestCheckResourceAttr(resourceName, "stage.1.name", "Build"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.name", "Build"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.category", "Build"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.owner", "AWS"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.provider", "CodeBuild"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.version", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.input_artifacts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.input_artifacts.0", "test"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.output_artifacts.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.configuration.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.configuration.ProjectName", "test"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.role_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.run_order", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.region", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckPipelineExists(ctx context.Context, n string, v *codepipeline.PipelineDeclaration) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -927,6 +1095,149 @@ resource "aws_codepipeline" "test" {
       }
     }
   }
+}
+
+resource "aws_codestarconnections_connection" "test" {
+  name          = %[1]q
+  provider_type = "GitHub"
+}
+`, rName))
+}
+
+func testAccCodePipelineConfig_pipelinetype(rName string) string { // nosemgrep:ci.codepipeline-in-func-name
+	return acctest.ConfigCompose(
+		testAccS3DefaultBucket(rName),
+		testAccServiceIAMRole(rName),
+		fmt.Sprintf(`
+resource "aws_codepipeline" "test" {
+  name     = "test-pipeline-%[1]s"
+  role_arn = aws_iam_role.codepipeline_role.arn
+
+  artifact_store {
+    location = aws_s3_bucket.test.bucket
+    type     = "S3"
+
+    encryption_key {
+      id   = "1234"
+      type = "KMS"
+    }
+  }
+
+  stage {
+    name = "Source"
+
+    action {
+      name             = "Source"
+      category         = "Source"
+      owner            = "AWS"
+      provider         = "CodeStarSourceConnection"
+      version          = "1"
+      output_artifacts = ["test"]
+
+      configuration = {
+        ConnectionArn    = aws_codestarconnections_connection.test.arn
+        FullRepositoryId = "lifesum-terraform/test"
+        BranchName       = "main"
+      }
+    }
+  }
+
+  stage {
+    name = "Build"
+
+    action {
+      name            = "Build"
+      category        = "Build"
+      owner           = "AWS"
+      provider        = "CodeBuild"
+      input_artifacts = ["test"]
+      version         = "1"
+
+      configuration = {
+        ProjectName = "test"
+      }
+    }
+  }
+
+	pipeline_type = "V1"
+}
+
+resource "aws_codestarconnections_connection" "test" {
+  name          = %[1]q
+  provider_type = "GitHub"
+}
+`, rName))
+}
+
+func testAccCodePipelineConfig_pipelinetypeUpdated(rName string) string { // nosemgrep:ci.codepipeline-in-func-name
+	return acctest.ConfigCompose(
+		testAccS3DefaultBucket(rName),
+		testAccS3Bucket("updated", rName),
+		testAccServiceIAMRole(rName),
+		fmt.Sprintf(`
+resource "aws_codepipeline" "test" {
+  name     = "test-pipeline-%s"
+  role_arn = aws_iam_role.codepipeline_role.arn
+
+  artifact_store {
+    location = aws_s3_bucket.updated.bucket
+    type     = "S3"
+
+    encryption_key {
+      id   = "4567"
+      type = "KMS"
+    }
+  }
+
+  stage {
+    name = "Source"
+
+    action {
+      name             = "Source"
+      category         = "Source"
+      owner            = "AWS"
+      provider         = "CodeStarSourceConnection"
+      version          = "1"
+      output_artifacts = ["artifacts"]
+
+      configuration = {
+        ConnectionArn    = aws_codestarconnections_connection.test.arn
+        FullRepositoryId = "test-terraform/test-repo"
+        BranchName       = "stable"
+      }
+    }
+  }
+
+  stage {
+    name = "Build"
+
+    action {
+      name            = "Build"
+      category        = "Build"
+      owner           = "AWS"
+      provider        = "CodeBuild"
+      input_artifacts = ["artifacts"]
+      version         = "1"
+
+      configuration = {
+        ProjectName = "test"
+      }
+    }
+  }
+
+	pipeline_type = "V2"
+
+	variable {
+		name          = "test_var1"
+		description   = "This is test pipeline variable 1."
+		default_value = "value1"
+	}
+
+	variable {
+		name          = "test_var2"
+		description   = "This is test pipeline variable 2."
+		default_value = "value2"
+	}
 }
 
 resource "aws_codestarconnections_connection" "test" {

--- a/website/docs/r/codepipeline.html.markdown
+++ b/website/docs/r/codepipeline.html.markdown
@@ -170,10 +170,12 @@ data "aws_kms_alias" "s3kmskey" {
 This resource supports the following arguments:
 
 * `name` - (Required) The name of the pipeline.
+* `pipeline_type` - (Optional) Type of the pipeline. Possible values are: `V1` and `V2`. Default value is `V1`.
 * `role_arn` - (Required) A service role Amazon Resource Name (ARN) that grants AWS CodePipeline permission to make calls to AWS services on your behalf.
 * `artifact_store` (Required) One or more artifact_store blocks. Artifact stores are documented below.
 * `stage` (Minimum of at least two `stage` blocks is required) A stage block. Stages are documented below.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `variable` - (Optional) A pipeline-level variable block. Valid only when `pipeline_type` is `V2`. Variable are documented below.
 
 An `artifact_store` block supports the following arguments:
 
@@ -206,6 +208,12 @@ An `action` block supports the following arguments:
 * `run_order` - (Optional) The order in which actions are run.
 * `region` - (Optional) The region in which to run the action.
 * `namespace` - (Optional) The namespace all output variables will be accessed from.
+
+A `variable` block supports the following arguments:
+
+* `name` - (Required) The name of a pipeline-level variable.
+* `default_value` - (Optional) The default value of a pipeline-level variable.
+* `description` - (Optional) The description of a pipeline-level variable.
 
 ~> **Note:** The input artifact of an action must exactly match the output artifact declared in a preceding action, but the input artifact does not have to be the next action in strict sequence from the action that provided the output artifact. Actions in parallel can declare different output artifacts, which are in turn consumed by different following actions.
 


### PR DESCRIPTION
resource/aws_codepipeline: Add pipeline_type, variable attribute

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Add attributes: pipeline_type, variable
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

Closes: #34122 
--->

Closes #34122

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

- Docs: https://docs.aws.amazon.com/codepipeline/latest/userguide/pipeline-types.html
- API: https://docs.aws.amazon.com/codepipeline/latest/APIReference/API_CreatePipeline.html
- CLI: https://docs.aws.amazon.com/cli/latest/reference/codepipeline/create-pipeline.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

An error occurred at TestAccCodePipeline_MultiRegion_convertSingleRegion.
But this error was originally occurring.
New test name is TestAccCodePipeline_pipelinetype.

```console
% make testacc TESTS='TestAccCodePipeline_' PKG=codepipeline
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/codepipeline/... -v -count 1 -parallel 20 -run='TestAccCodePipeline_'  -timeout 360m
=== RUN   TestAccCodePipeline_basic
=== PAUSE TestAccCodePipeline_basic
=== RUN   TestAccCodePipeline_disappears
=== PAUSE TestAccCodePipeline_disappears
=== RUN   TestAccCodePipeline_emptyStageArtifacts
=== PAUSE TestAccCodePipeline_emptyStageArtifacts
=== RUN   TestAccCodePipeline_deployWithServiceRole
=== PAUSE TestAccCodePipeline_deployWithServiceRole
=== RUN   TestAccCodePipeline_tags
=== PAUSE TestAccCodePipeline_tags
=== RUN   TestAccCodePipeline_MultiRegion_basic
=== PAUSE TestAccCodePipeline_MultiRegion_basic
=== RUN   TestAccCodePipeline_MultiRegion_update
=== PAUSE TestAccCodePipeline_MultiRegion_update
=== RUN   TestAccCodePipeline_MultiRegion_convertSingleRegion
=== PAUSE TestAccCodePipeline_MultiRegion_convertSingleRegion
=== RUN   TestAccCodePipeline_withNamespace
=== PAUSE TestAccCodePipeline_withNamespace
=== RUN   TestAccCodePipeline_withGitHubV1SourceAction
    codepipeline_test.go:492: skipping test; environment variable GITHUB_TOKEN must be set. Usage: token with GitHub permissions to repository for CodePipeline source configuration
--- SKIP: TestAccCodePipeline_withGitHubV1SourceAction (0.00s)
=== RUN   TestAccCodePipeline_ecr
=== PAUSE TestAccCodePipeline_ecr
=== RUN   TestAccCodePipeline_pipelinetype
=== PAUSE TestAccCodePipeline_pipelinetype
=== CONT  TestAccCodePipeline_basic
=== CONT  TestAccCodePipeline_pipelinetype
=== CONT  TestAccCodePipeline_tags
=== CONT  TestAccCodePipeline_emptyStageArtifacts
=== CONT  TestAccCodePipeline_disappears
=== CONT  TestAccCodePipeline_MultiRegion_basic
=== CONT  TestAccCodePipeline_ecr
=== CONT  TestAccCodePipeline_withNamespace
=== CONT  TestAccCodePipeline_MultiRegion_convertSingleRegion
=== CONT  TestAccCodePipeline_MultiRegion_update
=== CONT  TestAccCodePipeline_deployWithServiceRole
--- PASS: TestAccCodePipeline_disappears (72.77s)
--- PASS: TestAccCodePipeline_withNamespace (73.97s)
--- PASS: TestAccCodePipeline_ecr (78.64s)
--- PASS: TestAccCodePipeline_deployWithServiceRole (83.56s)
--- PASS: TestAccCodePipeline_emptyStageArtifacts (94.11s)
--- PASS: TestAccCodePipeline_MultiRegion_basic (125.08s)
--- PASS: TestAccCodePipeline_basic (130.35s)
--- PASS: TestAccCodePipeline_tags (150.09s)
--- PASS: TestAccCodePipeline_pipelinetype (151.12s)
--- PASS: TestAccCodePipeline_MultiRegion_update (165.69s)
=== NAME  TestAccCodePipeline_MultiRegion_convertSingleRegion
    codepipeline_test.go:398: Step 3/4 error: Error running apply: exit status 1
        
        Error: region cannot be set for a single-region CodePipeline
        
          with aws_codepipeline.test,
          on terraform_plugin_test.tf line 75, in resource "aws_codepipeline" "test":
          75: resource "aws_codepipeline" "test" {
        
--- FAIL: TestAccCodePipeline_MultiRegion_convertSingleRegion (173.99s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/codepipeline       174.120s
FAIL
make: *** [GNUmakefile:346: testacc] Error 1
```
