### PR TITLE
Fix IPAM allocation timeout

### DIFF
--- a/.changelog/34859.txt
+++ b/.changelog/34859.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_vpc: Increase IPAM pool allocation deletion timeout from 20 minutes to 35 minutes
+```

--- a/internal/service/ec2/vpc_.go
+++ b/internal/service/ec2/vpc_.go
@@ -482,7 +482,7 @@ func resourceVPCDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 	if ipamPoolID != "" && ipamPoolID != amazonIPv6PoolID {
 		const (
-			timeout = 20 * time.Minute // IPAM eventual consistency
+			timeout = 35 * time.Minute // IPAM eventual consistency. It can take ~30 min to release allocations.
 		)
 		_, err := tfresource.RetryUntilNotFound(ctx, timeout, func() (interface{}, error) {
 			return findIPAMPoolAllocationsForVPC(ctx, conn, ipamPoolID, d.Id())


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

IPAM can take ~30 minutes to release allocations, so the 20 minute time out is not long enough. This PR increases the timeout to 35 minutes.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/30165.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/34628.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30795.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/31211.


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
