### PR TITLE
Fix duplicate `service/meta` label issue

### DIFF
--- a/infrastructure/repository/labels-workflow.tf
+++ b/infrastructure/repository/labels-workflow.tf
@@ -133,10 +133,6 @@ variable "workflow_labels" {
       color       = "828a90", # color:stale grey
       description = "Repository modifications; GitHub Actions, developer docs, issue templates, codeowners, changelog."
     },
-    "service/meta" = {
-      color       = "7b42bc", # color:terraform (logomark)
-      description = "Issues and PRs that correspond to meta data sources."
-    },
     "size/XS" = {
       color       = "62d4dc", # color:lightest-darkest waypoint gradient
       description = "Managed by automation to categorize the size of a PR."


### PR DESCRIPTION
### Description

I've noticed for a while that the `service/meta` label was being recreated on every run in Terraform Cloud. Finally decided to chase it down, and it's due to us creating it in two places: where I've removed it in this PR, and in the `labels-service.tf` file. Since `labels-service.tf` is generated, it seemed more appropriate to remove the explicit definition here.

### References

`labels-service.tf` references:
- [in the list of services](https://github.com/hashicorp/terraform-provider-aws/blob/bca478224726ecd358774f2e333c95a4784bdc0b/infrastructure/repository/labels-service.tf#L210)
- ...which is used [in this `for_each`](https://github.com/hashicorp/terraform-provider-aws/blob/bca478224726ecd358774f2e333c95a4784bdc0b/infrastructure/repository/labels-service.tf#L342-L349)

### Output from Acceptance Testing

N/a, labels automation
