### PR TITLE
Make serverside encryption error check more compatible

### DIFF
--- a/.changelog/34890.txt
+++ b/.changelog/34890.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_s3_bucket: Modify server-side encryption configuration error handling, enabling support for NetApp StorageGRID
+```

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -31,6 +31,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -1116,7 +1117,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 		return diags
 	}
 
-	if err != nil && !tfawserr.ErrMessageContains(err, errCodeServerSideEncryptionConfigurationNotFound, "encryption configuration was not found") {
+	if err != nil && !tfawserr.ErrCodeEquals(err, errCodeServerSideEncryptionConfigurationNotFound) {
 		return sdkdiag.AppendErrorf(diags, "getting S3 Bucket encryption: %s", err)
 	}
 

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -31,7 +31,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"


### PR DESCRIPTION
Closes #34389.

The change acknowledges the variations in error message text across different S3 implementations while ensuring that the correct error code is the primary criterion for error detection.