### PR TITLE
lexv2models/intent: New resource

### DIFF
--- a/.changelog/34891.txt
+++ b/.changelog/34891.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_lexv2models_intent
+```

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -93,6 +93,7 @@ cleango: ## Clean up Go cache
 	go clean -modcache -testcache -cache ; \
 
 clean: cleango build tools ## Clean up Go cache and re-install tools
+	go mod tidy
 
 copyright: ## Run copywrite (generate source code headers)
 	@copywrite headers

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -90,10 +90,10 @@ cleango: ## Clean up Go cache
 		echo "Killing gopls process $$proc" ; \
 		kill -9 $$proc ; \
 	done ; \
-	go clean -modcache -testcache -cache ; \
+	$(GO_VER) clean -modcache -testcache -cache ; \
 
 clean: cleango build tools ## Clean up Go cache and re-install tools
-	go mod tidy
+	$(GO_VER) mod tidy
 
 copyright: ## Run copywrite (generate source code headers)
 	@copywrite headers

--- a/internal/framework/flex/auto_expand_test.go
+++ b/internal/framework/flex/auto_expand_test.go
@@ -464,7 +464,7 @@ func TestExpandGeneric(t *testing.T) {
 		{
 			TestName: "map string",
 			Source: &TestFlexTF11{
-				FieldInner: fwtypes.NewMapValueOf(ctx, map[string]basetypes.StringValue{
+				FieldInner: fwtypes.NewMapValueOfMust[types.String](ctx, map[string]attr.Value{
 					"x": types.StringValue("y"),
 				}),
 			},
@@ -537,7 +537,7 @@ func TestExpandGeneric(t *testing.T) {
 			TestName: "nested string map",
 			Source: &TestFlexTF14{
 				FieldOuter: fwtypes.NewListNestedObjectValueOfPtr(ctx, &TestFlexTF11{
-					FieldInner: fwtypes.NewMapValueOf(ctx, map[string]basetypes.StringValue{
+					FieldInner: fwtypes.NewMapValueOfMust[basetypes.StringValue](ctx, map[string]attr.Value{
 						"x": types.StringValue("y"),
 					}),
 				}),
@@ -744,7 +744,7 @@ func TestExpandGeneric(t *testing.T) {
 						},
 					}),
 				}),
-				SessionAttributes: fwtypes.NewMapValueOf(ctx, map[string]basetypes.StringValue{
+				SessionAttributes: fwtypes.NewMapValueOfMust[basetypes.StringValue](ctx, map[string]attr.Value{
 					"x": basetypes.NewStringValue("y"),
 				}),
 			},

--- a/internal/framework/flex/auto_flatten_test.go
+++ b/internal/framework/flex/auto_flatten_test.go
@@ -259,11 +259,11 @@ func TestFlatten(t *testing.T) {
 					types.StringValue("a"),
 					types.StringValue("b"),
 				}),
-				Field5: fwtypes.NewMapValueOf[types.String](ctx, map[string]basetypes.StringValue{
+				Field5: fwtypes.NewMapValueOfMust[types.String](ctx, map[string]attr.Value{
 					"A": types.StringValue("a"),
 					"B": types.StringValue("b"),
 				}),
-				Field6: fwtypes.NewMapValueOf[types.String](ctx, map[string]basetypes.StringValue{
+				Field6: fwtypes.NewMapValueOfMust[types.String](ctx, map[string]attr.Value{
 					"A": types.StringValue("a"),
 					"B": types.StringValue("b"),
 				}),
@@ -624,7 +624,7 @@ func TestFlattenGeneric(t *testing.T) {
 			},
 			Target: &TestFlexTF11{},
 			WantTarget: &TestFlexTF11{
-				FieldInner: fwtypes.NewMapValueOf(ctx, map[string]basetypes.StringValue{
+				FieldInner: fwtypes.NewMapValueOfMust[basetypes.StringValue](ctx, map[string]attr.Value{
 					"x": types.StringValue("y"),
 				}),
 			},
@@ -719,7 +719,7 @@ func TestFlattenGeneric(t *testing.T) {
 			Target: &TestFlexTF14{},
 			WantTarget: &TestFlexTF14{
 				FieldOuter: fwtypes.NewListNestedObjectValueOfPtr(ctx, &TestFlexTF11{
-					FieldInner: fwtypes.NewMapValueOf(ctx, map[string]basetypes.StringValue{
+					FieldInner: fwtypes.NewMapValueOfMust[basetypes.StringValue](ctx, map[string]attr.Value{
 						"x": types.StringValue("y"),
 					}),
 				}),
@@ -895,7 +895,7 @@ func TestFlattenGeneric(t *testing.T) {
 						},
 					}),
 				}),
-				SessionAttributes: fwtypes.NewMapValueOf(ctx, map[string]basetypes.StringValue{
+				SessionAttributes: fwtypes.NewMapValueOfMust[basetypes.StringValue](ctx, map[string]attr.Value{
 					"x": basetypes.NewStringValue("y"),
 				}),
 			},

--- a/internal/service/lexv2models/bot_locale.go
+++ b/internal/service/lexv2models/bot_locale.go
@@ -374,6 +374,7 @@ func waitBotLocaleCreated(ctx context.Context, conn *lexmodelsv2.Client, id stri
 		Target:                    enum.Slice(awstypes.BotLocaleStatusBuilt, awstypes.BotLocaleStatusNotBuilt),
 		Refresh:                   statusBotLocale(ctx, conn, id),
 		Timeout:                   timeout,
+		MinTimeout:                5 * time.Second,
 		NotFoundChecks:            20,
 		ContinuousTargetOccurence: 2,
 	}

--- a/internal/service/lexv2models/exports_test.go
+++ b/internal/service/lexv2models/exports_test.go
@@ -8,4 +8,5 @@ var (
 	ResourceBot        = newResourceBot
 	ResourceBotLocale  = newResourceBotLocale
 	ResourceBotVersion = newResourceBotVersion
+	ResourceIntent     = newResourceIntent
 )

--- a/internal/service/lexv2models/intent.go
+++ b/internal/service/lexv2models/intent.go
@@ -1193,14 +1193,15 @@ type IntentConfirmationSetting struct {
 }
 
 type PromptSpecification struct {
-	MaxRetries                  types.Int64                                           `tfsdk:"max_retries"`
-	MessageGroup                fwtypes.ListNestedObjectValueOf[MessageGroup]         `tfsdk:"message_groups"`
-	AllowInterrupt              types.Bool                                            `tfsdk:"allow_interrupt"`
-	MessageSelectionStrategy    fwtypes.StringEnum[awstypes.MessageSelectionStrategy] `tfsdk:"message_selection_strategy"`
-	PromptAttemptsSpecification fwtypes.ObjectMapValueOf[PromptAttemptSpecification]  `tfsdk:"prompt_attempts_specification"`
+	MaxRetries                  types.Int64                                                 `tfsdk:"max_retries"`
+	MessageGroup                fwtypes.ListNestedObjectValueOf[MessageGroup]               `tfsdk:"message_groups"`
+	AllowInterrupt              types.Bool                                                  `tfsdk:"allow_interrupt"`
+	MessageSelectionStrategy    fwtypes.StringEnum[awstypes.MessageSelectionStrategy]       `tfsdk:"message_selection_strategy"`
+	PromptAttemptsSpecification fwtypes.ListNestedObjectValueOf[PromptAttemptSpecification] `tfsdk:"prompt_attempts_specification"`
 }
 
 type PromptAttemptSpecification struct {
+	Key                            string                                                          `tfsdk:"-"`
 	AllowedInputTypes              fwtypes.ListNestedObjectValueOf[AllowedInputTypes]              `tfsdk:"allowed_input_types"`
 	AllowInterrupt                 types.Bool                                                      `tfsdk:"allow_interrupt"`
 	AudioAndDTMFInputSpecification fwtypes.ListNestedObjectValueOf[AudioAndDTMFInputSpecification] `tfsdk:"audio_and_dtmf_input_specification"`

--- a/internal/service/lexv2models/intent.go
+++ b/internal/service/lexv2models/intent.go
@@ -1047,9 +1047,9 @@ type Condition struct {
 }
 
 type DialogState struct {
-	DialogAction fwtypes.ListNestedObjectValueOf[DialogAction]   `tfsdk:"dialog_action"`
-	Intent       fwtypes.ListNestedObjectValueOf[IntentOverride] `tfsdk:"intent"`
-	//SessionAttributes types.Map                                       `tfsdk:"session_attributes"`
+	DialogAction      fwtypes.ListNestedObjectValueOf[DialogAction]   `tfsdk:"dialog_action"`
+	Intent            fwtypes.ListNestedObjectValueOf[IntentOverride] `tfsdk:"intent"`
+	SessionAttributes types.Map                                       `tfsdk:"session_attributes"`
 }
 
 type DialogAction struct {

--- a/internal/service/lexv2models/intent.go
+++ b/internal/service/lexv2models/intent.go
@@ -1,0 +1,1223 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package lexv2models
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lexmodelsv2"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/lexmodelsv2/types"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource(name="Intent")
+func newResourceIntent(_ context.Context) (resource.ResourceWithConfigure, error) {
+	r := &resourceIntent{}
+
+	r.SetDefaultCreateTimeout(30 * time.Minute)
+	r.SetDefaultUpdateTimeout(30 * time.Minute)
+	r.SetDefaultDeleteTimeout(30 * time.Minute)
+
+	return r, nil
+}
+
+const (
+	ResNameIntent = "Intent"
+)
+
+type resourceIntent struct {
+	framework.ResourceWithConfigure
+	framework.WithTimeouts
+}
+
+func (r *resourceIntent) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "aws_lexv2models_intent"
+}
+
+func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	messageNBO := schema.NestedBlockObject{
+		Blocks: map[string]schema.Block{
+			"custom_playload": schema.ListNestedBlock{
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"value": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
+			"image_response_card": schema.ListNestedBlock{
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"image_url": schema.StringAttribute{
+							Optional: true,
+						},
+						"subtitle": schema.StringAttribute{
+							Optional: true,
+						},
+						"title": schema.StringAttribute{
+							Required: true,
+						},
+					},
+					Blocks: map[string]schema.Block{
+						"button": schema.ListNestedBlock{
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"text": schema.StringAttribute{
+										Required: true,
+									},
+									"value": schema.StringAttribute{
+										Required: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"plain_text_message": schema.ListNestedBlock{
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"value": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
+			"ssml_message": schema.ListNestedBlock{
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"value": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
+		},
+	}
+	messageGroupLNB := schema.ListNestedBlock{
+		Validators: []validator.List{
+			listvalidator.SizeAtLeast(1),
+		},
+		NestedObject: schema.NestedBlockObject{
+			Blocks: map[string]schema.Block{
+				"message": schema.ListNestedBlock{
+					Validators: []validator.List{
+						listvalidator.SizeBetween(1, 1),
+					},
+					NestedObject: messageNBO,
+				},
+				"variations": schema.ListNestedBlock{
+					NestedObject: messageNBO,
+				},
+			},
+		},
+	}
+	// O for "Object"
+	slotValueOverrideO := types.ObjectType{
+		AttrTypes: map[string]attr.Type{
+			"shape": types.StringType,
+			"value": types.ObjectType{
+				AttrTypes: map[string]attr.Type{
+					"interpreted_value": types.StringType,
+				},
+			},
+		},
+	}
+	slotValueOverrideO.AttrTypes["values"] = slotValueOverrideO // recursive type
+	dialogStateNBO := schema.NestedBlockObject{
+		Attributes: map[string]schema.Attribute{
+			"session_attributes": schema.MapAttribute{
+				ElementType: types.StringType,
+				Optional:    true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"dialog_action": schema.ListNestedBlock{
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"type": schema.StringAttribute{
+							Required: true,
+						},
+						"slot_to_elicit": schema.StringAttribute{
+							Optional: true,
+						},
+						"suppress_next_message": schema.StringAttribute{
+							Optional: true,
+						},
+					},
+				},
+			},
+			"intent": schema.ListNestedBlock{
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							Optional: true,
+						},
+						"slots": schema.MapAttribute{
+							Optional:    true,
+							ElementType: slotValueOverrideO,
+						},
+					},
+				},
+			},
+		},
+	}
+	responseSpecificationLNB := schema.ListNestedBlock{
+		Validators: []validator.List{
+			listvalidator.SizeAtMost(1),
+		},
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"allow_interrupt": schema.BoolAttribute{
+					Optional: true,
+				},
+			},
+			Blocks: map[string]schema.Block{
+				"message_group": messageGroupLNB,
+			},
+		},
+	}
+	conditionalSpecificationLNB := schema.ListNestedBlock{
+		Validators: []validator.List{
+			listvalidator.SizeAtMost(1),
+		},
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"active": schema.BoolAttribute{
+					Required: true,
+				},
+			},
+			Blocks: map[string]schema.Block{
+				"conditional_branch": schema.ListNestedBlock{
+					Validators: []validator.List{
+						listvalidator.SizeAtLeast(1),
+					},
+					NestedObject: schema.NestedBlockObject{
+						Attributes: map[string]schema.Attribute{
+							"name": schema.StringAttribute{
+								Required: true,
+							},
+						},
+						Blocks: map[string]schema.Block{
+							"condition": schema.ListNestedBlock{
+								Validators: []validator.List{
+									listvalidator.SizeBetween(1, 1),
+								},
+								NestedObject: schema.NestedBlockObject{
+									Attributes: map[string]schema.Attribute{
+										"expression_string": schema.StringAttribute{
+											Required: true,
+										},
+									},
+								},
+							},
+							"next_step": schema.ListNestedBlock{
+								Validators: []validator.List{
+									listvalidator.SizeBetween(1, 1),
+								},
+								NestedObject: dialogStateNBO,
+							},
+							"response": responseSpecificationLNB,
+						},
+					},
+				},
+				"default_branch": schema.ListNestedBlock{
+					Validators: []validator.List{
+						listvalidator.SizeBetween(1, 1),
+					},
+					NestedObject: schema.NestedBlockObject{
+						Blocks: map[string]schema.Block{
+							"next_step": schema.ListNestedBlock{
+								Validators: []validator.List{
+									listvalidator.SizeAtMost(1),
+								},
+								NestedObject: dialogStateNBO,
+							},
+							"response": responseSpecificationLNB,
+						},
+					},
+				},
+			},
+		},
+	}
+	failureSuccessTimeoutNBO := schema.NestedBlockObject{
+		Blocks: map[string]schema.Block{
+			"failure_conditional": conditionalSpecificationLNB,
+			"failure_next_step": schema.ListNestedBlock{
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: dialogStateNBO,
+			},
+			"failure_response":    responseSpecificationLNB,
+			"success_conditional": conditionalSpecificationLNB,
+			"success_next_step": schema.ListNestedBlock{
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: dialogStateNBO,
+			},
+			"success_response":    responseSpecificationLNB,
+			"timeout_conditional": conditionalSpecificationLNB,
+			"timeout_next_step": schema.ListNestedBlock{
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: dialogStateNBO,
+			},
+			"timeout_response": responseSpecificationLNB,
+		},
+	}
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"bot_id": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"bot_version": schema.StringAttribute{
+				Required: true,
+			},
+			"description": schema.StringAttribute{
+				Optional: true,
+			},
+			"id": framework.IDAttribute(),
+			"locale_id": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Required: true,
+			},
+			"parent_intent_signature": schema.StringAttribute{
+				Optional: true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"dialog_code_hook": schema.ListNestedBlock{
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"enabled": schema.BoolAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
+			"fulfillment_code_hook": schema.ListNestedBlock{
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"enabled": schema.BoolAttribute{
+							Required: true,
+						},
+						"active": schema.BoolAttribute{
+							Computed: true,
+						},
+					},
+					Blocks: map[string]schema.Block{
+						"fulfillment_updates_specification": schema.ListNestedBlock{
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"active": schema.BoolAttribute{
+										Required: true,
+									},
+									"timeout_in_seconds": schema.Int64Attribute{
+										Optional: true,
+									},
+								},
+								Blocks: map[string]schema.Block{
+									"start_response": schema.ListNestedBlock{
+										Validators: []validator.List{
+											listvalidator.SizeAtMost(1),
+										},
+										NestedObject: schema.NestedBlockObject{
+											Attributes: map[string]schema.Attribute{
+												"allow_interrupt": schema.BoolAttribute{
+													Optional: true,
+												},
+												"delay_in_seconds": schema.Int64Attribute{
+													Optional: true,
+												},
+											},
+											Blocks: map[string]schema.Block{
+												"message_group": schema.ListNestedBlock{
+													Validators: []validator.List{
+														listvalidator.SizeBetween(1, 5),
+													},
+													NestedObject: schema.NestedBlockObject{
+														Blocks: map[string]schema.Block{
+															"message": schema.ListNestedBlock{
+																Validators: []validator.List{
+																	listvalidator.SizeBetween(1, 1),
+																},
+																NestedObject: messageNBO,
+															},
+															"variations": schema.ListNestedBlock{
+																NestedObject: messageNBO,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+									"update_response": schema.ListNestedBlock{
+										Validators: []validator.List{
+											listvalidator.SizeAtMost(1),
+										},
+										NestedObject: schema.NestedBlockObject{
+											Attributes: map[string]schema.Attribute{
+												"allow_interrupt": schema.BoolAttribute{
+													Optional: true,
+												},
+												"frequency_in_seconds": schema.Int64Attribute{
+													Required: true,
+												},
+											},
+											Blocks: map[string]schema.Block{
+												"message_group": messageGroupLNB,
+											},
+										},
+									},
+								},
+							},
+						},
+						"post_fulfillment_status_specification": schema.ListNestedBlock{
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							NestedObject: failureSuccessTimeoutNBO,
+						},
+					},
+				},
+			},
+			"initial_response_setting": schema.ListNestedBlock{
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Blocks: map[string]schema.Block{
+						"code_hook": schema.ListNestedBlock{
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"active": schema.BoolAttribute{
+										Required: true,
+									},
+									"enable_code_hook_invocation": schema.BoolAttribute{
+										Required: true,
+									},
+									"invocation_label": schema.StringAttribute{
+										Optional: true,
+									},
+								},
+								Blocks: map[string]schema.Block{
+									"post_code_hook_specification": schema.ListNestedBlock{
+										Validators: []validator.List{
+											listvalidator.SizeBetween(1, 1),
+										},
+										NestedObject: failureSuccessTimeoutNBO,
+									},
+								},
+							},
+						},
+						"conditional":      conditionalSpecificationLNB,
+						"initial_response": responseSpecificationLNB,
+						"next_step": schema.ListNestedBlock{
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							NestedObject: dialogStateNBO,
+						},
+					},
+				},
+			},
+			"input_context": schema.ListNestedBlock{
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(5),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
+			"closing_setting": schema.ListNestedBlock{
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"active": schema.BoolAttribute{
+							Optional: true,
+						},
+					},
+					Blocks: map[string]schema.Block{
+						"closing_response": responseSpecificationLNB,
+						"conditional":      conditionalSpecificationLNB,
+						"next_step": schema.ListNestedBlock{
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							NestedObject: dialogStateNBO,
+						},
+					},
+				},
+			},
+			"confirmation_setting": schema.ListNestedBlock{
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"active": schema.BoolAttribute{
+							Optional: true,
+						},
+					},
+					Blocks: map[string]schema.Block{
+						"prompt_specification": schema.ListNestedBlock{
+							Validators: []validator.List{
+								listvalidator.SizeBetween(1, 1),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"allow_interrupt": schema.BoolAttribute{
+										Optional: true,
+									},
+									"max_retries": schema.Int64Attribute{
+										Required: true,
+									},
+									"message_selection_strategy": schema.StringAttribute{
+										Optional: true,
+									},
+									"prompt_attempts_specification": schema.MapAttribute{
+										Optional: true,
+										ElementType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"allowed_input_types": types.ObjectType{
+													AttrTypes: map[string]attr.Type{
+														"allow_audio_input": types.BoolType,
+														"allow_dtmf_input":  types.BoolType,
+													},
+												},
+												"allow_interrupt": types.BoolType,
+												"audio_and_dtmf_input_specification": types.ObjectType{
+													AttrTypes: map[string]attr.Type{
+														"start_timeout_ms": types.Int64Type,
+														"audio_specification": types.ObjectType{
+															AttrTypes: map[string]attr.Type{
+																"end_timeout_ms": types.Int64Type,
+																"max_length_ms":  types.Int64Type,
+															},
+														},
+														"dtmf_specification": types.ObjectType{
+															AttrTypes: map[string]attr.Type{
+																"deletion_character": types.StringType,
+																"end_character":      types.StringType,
+																"end_timeout_ms":     types.Int64Type,
+																"max_length":         types.Int64Type,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								Blocks: map[string]schema.Block{
+									"message_group": messageGroupLNB,
+								},
+							},
+						},
+						"conditional": conditionalSpecificationLNB,
+						"next_step": schema.ListNestedBlock{
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							NestedObject: dialogStateNBO,
+						},
+					},
+				},
+			},
+			"kendra_configuration": schema.ListNestedBlock{
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"index": schema.StringAttribute{
+							Required: true,
+						},
+						"query_filter_string": schema.StringAttribute{
+							Optional: true,
+						},
+						"query_filter_string_enabled": schema.BoolAttribute{
+							Optional: true,
+						},
+					},
+				},
+			},
+			"output_context": schema.ListNestedBlock{
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(10),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							Required: true,
+						},
+						"time_to_live_in_seconds": schema.Int64Attribute{
+							Required: true,
+						},
+						"turns_to_live": schema.Int64Attribute{
+							Required: true,
+						},
+					},
+				},
+			},
+			"sample_utterance": schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"utterance": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
+			"slot_priority": schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"priority": schema.Int64Attribute{
+							Required: true,
+						},
+						"slot_id": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
+			"timeouts": timeouts.Block(ctx, timeouts.Opts{
+				Create: true,
+				Update: true,
+				Delete: true,
+			}),
+		},
+	}
+}
+
+func (r *resourceIntent) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().LexV2ModelsClient(ctx)
+
+	var plan ResourceIntentData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := &lexmodelsv2.CreateIntentInput{}
+
+	resp.Diagnostics.Append(flex.Expand(ctx, &plan, in)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := conn.CreateIntent(ctx, in)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.LexV2Models, create.ErrActionCreating, ResNameIntent, plan.Name.String(), err),
+			err.Error(),
+		)
+		return
+	}
+	if out == nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.LexV2Models, create.ErrActionCreating, ResNameIntent, plan.Name.String(), nil),
+			errors.New("empty output").Error(),
+		)
+		return
+	}
+
+	plan.ID = flex.StringToFramework(ctx, out.IntentId)
+
+	createTimeout := r.CreateTimeout(ctx, plan.Timeouts)
+	_, err = waitIntentNormal(ctx, conn, plan.ID.ValueString(), plan.BotID.ValueString(), plan.BotVersion.ValueString(), plan.LocaleID.ValueString(), createTimeout)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.LexV2Models, create.ErrActionWaitingForCreation, ResNameIntent, plan.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	//if len(plan.SlotPriority) > 0 {
+	// update because SlotPriority can't be set on create
+	//}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *resourceIntent) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().LexV2ModelsClient(ctx)
+
+	var state ResourceIntentData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := findIntentByIDs(ctx, conn, state.ID.ValueString(), state.BotID.ValueString(), state.BotVersion.ValueString(), state.LocaleID.ValueString())
+	if tfresource.NotFound(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.LexV2Models, create.ErrActionSetting, ResNameIntent, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(flex.Flatten(ctx, out, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *resourceIntent) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	conn := r.Meta().LexV2ModelsClient(ctx)
+
+	var plan, state ResourceIntentData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := &lexmodelsv2.UpdateIntentInput{
+		BotId:      plan.BotID.ValueStringPointer(),
+		BotVersion: plan.BotVersion.ValueStringPointer(),
+		IntentId:   plan.ID.ValueStringPointer(),
+		IntentName: plan.Name.ValueStringPointer(),
+		LocaleId:   plan.LocaleID.ValueStringPointer(),
+	}
+
+	resp.Diagnostics.Append(flex.Expand(ctx, &plan, in)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := conn.UpdateIntent(ctx, in)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.LexV2Models, create.ErrActionUpdating, ResNameIntent, plan.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+	if out == nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.LexV2Models, create.ErrActionUpdating, ResNameIntent, plan.ID.String(), nil),
+			errors.New("empty output").Error(),
+		)
+		return
+	}
+
+	plan.ID = flex.StringToFramework(ctx, out.IntentId)
+
+	updateTimeout := r.UpdateTimeout(ctx, plan.Timeouts)
+	_, err = waitIntentNormal(ctx, conn, plan.ID.ValueString(), plan.BotID.ValueString(), plan.BotVersion.ValueString(), plan.LocaleID.ValueString(), updateTimeout)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.LexV2Models, create.ErrActionWaitingForUpdate, ResNameIntent, plan.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *resourceIntent) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	conn := r.Meta().LexV2ModelsClient(ctx)
+
+	var state ResourceIntentData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := &lexmodelsv2.DeleteIntentInput{
+		IntentId: aws.String(state.ID.ValueString()),
+	}
+
+	_, err := conn.DeleteIntent(ctx, in)
+	if err != nil {
+		var nfe *awstypes.ResourceNotFoundException
+		if errors.As(err, &nfe) {
+			return
+		}
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.LexV2Models, create.ErrActionDeleting, ResNameIntent, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	deleteTimeout := r.DeleteTimeout(ctx, state.Timeouts)
+	_, err = waitIntentDeleted(ctx, conn, state.ID.ValueString(), state.BotID.ValueString(), state.BotVersion.ValueString(), state.LocaleID.ValueString(), deleteTimeout)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.LexV2Models, create.ErrActionWaitingForDeletion, ResNameIntent, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+}
+
+func (r *resourceIntent) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
+	parts := strings.Split(request.ID, ":")
+	if len(parts) != 4 {
+		response.Diagnostics.AddError("Invalid Resource Import Key", fmt.Sprintf(`Unexpected format for import key (%s), use: "ID:BotID:BotVersion:LocaleID"`, request.ID))
+		return
+	}
+
+	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("id"), parts[0])...)
+	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("bot_id"), parts[1])...)
+	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("bot_version"), parts[2])...)
+	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("locale_id"), parts[3])...)
+}
+
+// TIP: ==== STATUS CONSTANTS ====
+// Create constants for states and statuses if the service does not
+// already have suitable constants. We prefer that you use the constants
+// provided in the service if available (e.g., amp.WorkspaceStatusCodeActive).
+const (
+	statusNormal = "Normal"
+)
+
+// TIP: ==== WAITERS ====
+// Some resources of some services have waiters provided by the AWS API.
+// Unless they do not work properly, use them rather than defining new ones
+// here.
+//
+// Sometimes we define the wait, status, and find functions in separate
+// files, wait.go, status.go, and find.go. Follow the pattern set out in the
+// service and define these where it makes the most sense.
+//
+// If these functions are used in the _test.go file, they will need to be
+// exported (i.e., capitalized).
+//
+// You will need to adjust the parameters and names to fit the service.
+
+// TIP: It is easier to determine whether a resource is updated for some
+// resources than others. The best case is a status flag that tells you when
+// the update has been fully realized. Other times, you can check to see if a
+// key resource argument is updated to a new value or not.
+func waitIntentNormal(ctx context.Context, conn *lexmodelsv2.Client, id, botID, botVersion, localeID string, timeout time.Duration) (*lexmodelsv2.DescribeIntentOutput, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending:                   []string{},
+		Target:                    []string{statusNormal},
+		Refresh:                   statusIntent(ctx, conn, id, botID, botVersion, localeID),
+		Timeout:                   timeout,
+		NotFoundChecks:            20,
+		ContinuousTargetOccurence: 2,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if out, ok := outputRaw.(*lexmodelsv2.DescribeIntentOutput); ok {
+		return out, err
+	}
+
+	return nil, err
+}
+
+// TIP: A deleted waiter is almost like a backwards created waiter. There may
+// be additional pending states, however.
+func waitIntentDeleted(ctx context.Context, conn *lexmodelsv2.Client, id, botID, botVersion, localeID string, timeout time.Duration) (*lexmodelsv2.DescribeIntentOutput, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{statusNormal},
+		Target:  []string{},
+		Refresh: statusIntent(ctx, conn, id, botID, botVersion, localeID),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if out, ok := outputRaw.(*lexmodelsv2.DescribeIntentOutput); ok {
+		return out, err
+	}
+
+	return nil, err
+}
+
+// TIP: ==== STATUS ====
+// The status function can return an actual status when that field is
+// available from the API (e.g., out.Status). Otherwise, you can use custom
+// statuses to communicate the states of the resource.
+//
+// Waiters consume the values returned by status functions. Design status so
+// that it can be reused by a create, update, and delete waiter, if possible.
+func statusIntent(ctx context.Context, conn *lexmodelsv2.Client, id, botID, botVersion, localeID string) retry.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		out, err := findIntentByIDs(ctx, conn, id, botID, botVersion, localeID)
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return out, statusNormal, nil
+	}
+}
+
+func findIntentByIDs(ctx context.Context, conn *lexmodelsv2.Client, id, botID, botVersion, localeID string) (*lexmodelsv2.DescribeIntentOutput, error) {
+	in := &lexmodelsv2.DescribeIntentInput{
+		BotId:      aws.String(botID),
+		BotVersion: aws.String(botVersion),
+		IntentId:   aws.String(id),
+		LocaleId:   aws.String(localeID),
+	}
+
+	out, err := conn.DescribeIntent(ctx, in)
+	if err != nil {
+		var nfe *awstypes.ResourceNotFoundException
+		if errors.As(err, &nfe) {
+			return nil, &retry.NotFoundError{
+				LastError:   err,
+				LastRequest: in,
+			}
+		}
+
+		return nil, err
+	}
+
+	if out == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return out, nil
+}
+
+type ResourceIntentData struct {
+	BotID                  types.String                                                 `tfsdk:"bot_id"`
+	BotVersion             types.String                                                 `tfsdk:"bot_version"`
+	ClosingSetting         fwtypes.ListNestedObjectValueOf[IntentClosingSetting]        `tfsdk:"closing_setting"`
+	ConfirmationSetting    fwtypes.ListNestedObjectValueOf[IntentConfirmationSetting]   `tfsdk:"confirmation_setting"`
+	CreationDateTime       fwtypes.TimestampType                                        `tfsdk:"creation_date_time"`
+	Description            types.String                                                 `tfsdk:"description"`
+	DialogCodeHook         fwtypes.ListNestedObjectValueOf[DialogCodeHookSettings]      `tfsdk:"dialog_code_hook"`
+	FulfillmentCodeHook    fwtypes.ListNestedObjectValueOf[FulfillmentCodeHookSettings] `tfsdk:"fulfillment_code_hook"`
+	ID                     types.String                                                 `tfsdk:"id"`
+	InitialResponseSetting fwtypes.ListNestedObjectValueOf[InitialResponseSetting]      `tfsdk:"initial_response_setting"`
+	InputContext           fwtypes.ListNestedObjectValueOf[InputContext]                `tfsdk:"input_context"`
+	KendraConfiguration    fwtypes.ListNestedObjectValueOf[KendraConfiguration]         `tfsdk:"kendra_configuration"`
+	LastUpdatedDateTime    fwtypes.TimestampType                                        `tfsdk:"last_updated_date_time"`
+	LocaleID               types.String                                                 `tfsdk:"locale_id"`
+	Name                   types.String                                                 `tfsdk:"name"`
+	OutputContext          fwtypes.ListNestedObjectValueOf[OutputContext]               `tfsdk:"output_context"`
+	ParentIntentSignature  types.String                                                 `tfsdk:"parent_intent_signature"`
+	SampleUtterance        fwtypes.ListNestedObjectValueOf[SampleUtterance]             `tfsdk:"sample_utterance"`
+	SlotPriority           fwtypes.ListNestedObjectValueOf[SlotPriority]                `tfsdk:"slot_priority"`
+	Timeouts               timeouts.Value                                               `tfsdk:"timeouts"`
+}
+
+type IntentClosingSetting struct {
+	Active          types.Bool                                                `tfsdk:"active"`
+	ClosingResponse fwtypes.ListNestedObjectValueOf[ResponseSpecification]    `tfsdk:"closing_response"`
+	Conditional     fwtypes.ListNestedObjectValueOf[ConditionalSpecification] `tfsdk:"conditional"`
+	NextStep        fwtypes.ListNestedObjectValueOf[DialogState]              `tfsdk:"next_step"`
+}
+
+type ResponseSpecification struct {
+	MessageGroup   fwtypes.ListNestedObjectValueOf[MessageGroup] `tfsdk:"message_group"`
+	AllowInterrupt types.Bool                                    `tfsdk:"allow_interrupt"`
+}
+
+type MessageGroup struct {
+	Message    fwtypes.ListNestedObjectValueOf[Message] `tfsdk:"message"`
+	Variations fwtypes.ListNestedObjectValueOf[Message] `tfsdk:"variations"`
+}
+
+type Message struct {
+	CustomPayload     fwtypes.ListNestedObjectValueOf[CustomPayload]     `tfsdk:"custom_payload"`
+	ImageResponseCard fwtypes.ListNestedObjectValueOf[ImageResponseCard] `tfsdk:"image_response_card"`
+	PlainTextMessage  fwtypes.ListNestedObjectValueOf[PlainTextMessage]  `tfsdk:"plain_text_message"`
+	SSMLMessage       fwtypes.ListNestedObjectValueOf[SSMLMessage]       `tfsdk:"ssml_message"`
+}
+
+type CustomPayload struct {
+	Value types.String `tfsdk:"value"`
+}
+
+type ImageResponseCard struct {
+	Title    types.String                            `tfsdk:"title"`
+	Button   fwtypes.ListNestedObjectValueOf[Button] `tfsdk:"buttons"`
+	ImageURL types.String                            `tfsdk:"image_url"`
+	Subtitle types.String                            `tfsdk:"subtitle"`
+}
+
+type Button struct {
+	Text  types.String `tfsdk:"text"`
+	Value types.String `tfsdk:"value"`
+}
+
+type PlainTextMessage struct {
+	Value types.String `tfsdk:"value"`
+}
+
+type SSMLMessage struct {
+	Value types.String `tfsdk:"value"`
+}
+
+type ConditionalSpecification struct {
+	Active            types.Bool                                                `tfsdk:"active"`
+	ConditionalBranch fwtypes.ListNestedObjectValueOf[ConditionalBranch]        `tfsdk:"conditional_branch"`
+	DefaultBranch     fwtypes.ListNestedObjectValueOf[DefaultConditionalBranch] `tfsdk:"default_branch"`
+}
+
+type ConditionalBranch struct {
+	Condition fwtypes.ListNestedObjectValueOf[Condition]             `tfsdk:"condition"`
+	Name      types.String                                           `tfsdk:"name"`
+	NextStep  fwtypes.ListNestedObjectValueOf[DialogState]           `tfsdk:"next_step"`
+	Response  fwtypes.ListNestedObjectValueOf[ResponseSpecification] `tfsdk:"response"`
+}
+
+type Condition struct {
+	ExpressionString types.String `tfsdk:"expression_string"`
+}
+
+type DialogState struct {
+	DialogAction fwtypes.ListNestedObjectValueOf[DialogAction]   `tfsdk:"dialog_action"`
+	Intent       fwtypes.ListNestedObjectValueOf[IntentOverride] `tfsdk:"intent"`
+	//SessionAttributes types.Map                                       `tfsdk:"session_attributes"`
+}
+
+type DialogAction struct {
+	Type                types.String `tfsdk:"type"`
+	SlotToElicit        types.String `tfsdk:"slot_to_elicit"`
+	SuppressNextMessage types.Bool   `tfsdk:"suppress_next_message"`
+}
+
+type IntentOverride struct {
+	Name types.String `tfsdk:"name"`
+	//Slots fwtypes.MapValueOf[SlotValueOverride] `tfsdk:"slots"`
+}
+
+type SlotValueOverride struct {
+	Shape  types.String                                       `tfsdk:"shape"`
+	Value  fwtypes.ListNestedObjectValueOf[SlotValue]         `tfsdk:"value"`
+	Values fwtypes.ListNestedObjectValueOf[SlotValueOverride] `tfsdk:"values"`
+}
+
+type SlotValue struct {
+	InterpretedValue types.String `tfsdk:"interpreted_value"`
+}
+
+type DefaultConditionalBranch struct {
+	NextStep fwtypes.ListNestedObjectValueOf[DialogState]           `tfsdk:"next_step"`
+	Response fwtypes.ListNestedObjectValueOf[ResponseSpecification] `tfsdk:"response"`
+}
+
+type IntentConfirmationSetting struct {
+	PromptSpecification     fwtypes.ListNestedObjectValueOf[PromptSpecification]                  `tfsdk:"prompt_specification"`
+	Active                  types.Bool                                                            `tfsdk:"active"`
+	CodeHook                fwtypes.ListNestedObjectValueOf[DialogCodeHookInvocationSetting]      `tfsdk:"code_hook"`
+	ConfirmationConditional fwtypes.ListNestedObjectValueOf[ConditionalSpecification]             `tfsdk:"confirmation_conditional"`
+	ConfirmationNextStep    fwtypes.ListNestedObjectValueOf[DialogState]                          `tfsdk:"confirmation_next_step"`
+	ConfirmationResponse    fwtypes.ListNestedObjectValueOf[ResponseSpecification]                `tfsdk:"confirmation_response"`
+	DeclinationConditional  fwtypes.ListNestedObjectValueOf[ConditionalSpecification]             `tfsdk:"declination_conditional"`
+	DeclinationNextStep     fwtypes.ListNestedObjectValueOf[DialogState]                          `tfsdk:"declination_next_step"`
+	DeclinationResponse     fwtypes.ListNestedObjectValueOf[ResponseSpecification]                `tfsdk:"declination_response"`
+	ElicitationCodeHook     fwtypes.ListNestedObjectValueOf[ElicitationCodeHookInvocationSetting] `tfsdk:"elicitation_code_hook"`
+	FailureConditional      fwtypes.ListNestedObjectValueOf[ConditionalSpecification]             `tfsdk:"failure_conditional"`
+	FailureNextStep         fwtypes.ListNestedObjectValueOf[DialogState]                          `tfsdk:"failure_next_step"`
+	FailureResponse         fwtypes.ListNestedObjectValueOf[ResponseSpecification]                `tfsdk:"failure_response"`
+}
+
+type PromptSpecification struct {
+	MaxRetries               types.Int64                                   `tfsdk:"max_retries"`
+	MessageGroup             fwtypes.ListNestedObjectValueOf[MessageGroup] `tfsdk:"message_groups"`
+	AllowInterrupt           types.Bool                                    `tfsdk:"allow_interrupt"`
+	MessageSelectionStrategy types.String                                  `tfsdk:"message_selection_strategy"`
+	//PromptAttemptsSpecification map[string]PromptAttemptSpecification         `tfsdk:"prompt_attempts_specification"`
+}
+
+type PromptAttemptSpecification struct {
+	AllowedInputTypes              fwtypes.ListNestedObjectValueOf[AllowedInputTypes]              `tfsdk:"allowed_input_types"`
+	AllowInterrupt                 types.Bool                                                      `tfsdk:"allow_interrupt"`
+	AudioAndDTMFInputSpecification fwtypes.ListNestedObjectValueOf[AudioAndDTMFInputSpecification] `tfsdk:"audio_and_dtmf_input_specification"`
+	TextInputSpecification         fwtypes.ListNestedObjectValueOf[TextInputSpecification]         `tfsdk:"text_input_specification"`
+}
+
+type AllowedInputTypes struct {
+	AllowAudioInput types.Bool `tfsdk:"allow_audio_input"`
+	AllowDTMFInput  types.Bool `tfsdk:"allow_dtmf_input"`
+}
+
+type AudioAndDTMFInputSpecification struct {
+	StartTimeoutMs     types.Int64                                         `tfsdk:"start_timeout_ms"`
+	AudioSpecification fwtypes.ListNestedObjectValueOf[AudioSpecification] `tfsdk:"audio_specification"`
+	DTMFSpecification  fwtypes.ListNestedObjectValueOf[DTMFSpecification]  `tfsdk:"dtmf_specification"`
+}
+
+type AudioSpecification struct {
+	EndTimeoutMs types.Int64 `tfsdk:"end_timeout_ms"`
+	MaxLengthMs  types.Int64 `tfsdk:"max_length_ms"`
+}
+
+type DTMFSpecification struct {
+	DeletionCharacter types.String `tfsdk:"deletion_character"`
+	EndCharacter      types.String `tfsdk:"end_character"`
+	EndTimeoutMs      types.Int64  `tfsdk:"end_timeout_ms"`
+	MaxLength         types.Int64  `tfsdk:"max_length"`
+}
+
+type TextInputSpecification struct {
+	StartTimeoutMs types.Int64 `tfsdk:"start_timeout_ms"`
+}
+
+type DialogCodeHookInvocationSetting struct {
+	Active                    types.Bool                                             `tfsdk:"active"`
+	EnableCodeHookInvocation  types.Bool                                             `tfsdk:"enable_code_hook_invocation"`
+	PostCodeHookSpecification fwtypes.ListNestedObjectValueOf[FailureSuccessTimeout] `tfsdk:"post_code_hook_specification"`
+	InvocationLabel           types.String                                           `tfsdk:"invocation_label"`
+}
+
+type FailureSuccessTimeout struct {
+	FailureConditional fwtypes.ListNestedObjectValueOf[ConditionalSpecification] `tfsdk:"failure_conditional"`
+	FailureNextStep    fwtypes.ListNestedObjectValueOf[DialogState]              `tfsdk:"failure_next_step"`
+	FailureResponse    fwtypes.ListNestedObjectValueOf[ResponseSpecification]    `tfsdk:"failure_response"`
+	SuccessConditional fwtypes.ListNestedObjectValueOf[ConditionalSpecification] `tfsdk:"success_conditional"`
+	SuccessNextStep    fwtypes.ListNestedObjectValueOf[DialogState]              `tfsdk:"success_next_step"`
+	SuccessResponse    fwtypes.ListNestedObjectValueOf[ResponseSpecification]    `tfsdk:"success_response"`
+	TimeoutConditional fwtypes.ListNestedObjectValueOf[ConditionalSpecification] `tfsdk:"timeout_conditional"`
+	TimeoutNextStep    fwtypes.ListNestedObjectValueOf[DialogState]              `tfsdk:"timeout_next_step"`
+	TimeoutResponse    fwtypes.ListNestedObjectValueOf[ResponseSpecification]    `tfsdk:"timeout_response"`
+}
+
+type ElicitationCodeHookInvocationSetting struct {
+	EnableCodeHookInvocation types.Bool   `tfsdk:"enable_code_hook_invocation"`
+	InvocationLabel          types.String `tfsdk:"invocation_label"`
+}
+
+type DialogCodeHookSettings struct {
+	Enabled types.Bool `tfsdk:"enabled"`
+}
+
+type FulfillmentCodeHookSettings struct {
+	Enabled                            types.Bool                                                       `tfsdk:"enabled"`
+	Active                             types.Bool                                                       `tfsdk:"active"`
+	FulfillmentUpdatesSpecification    fwtypes.ListNestedObjectValueOf[FulfillmentUpdatesSpecification] `tfsdk:"fulfillment_updates_specification"`
+	PostFulfillmentStatusSpecification fwtypes.ListNestedObjectValueOf[FailureSuccessTimeout]           `tfsdk:"post_fulfillment_status_specification"`
+}
+
+type FulfillmentUpdatesSpecification struct {
+	Active           types.Bool                                                              `tfsdk:"active"`
+	StartResponse    fwtypes.ListNestedObjectValueOf[FulfillmentStartResponseSpecification]  `tfsdk:"start_response"`
+	TimeoutInSeconds types.Int64                                                             `tfsdk:"timeout_in_seconds"`
+	UpdateResponse   fwtypes.ListNestedObjectValueOf[FulfillmentUpdateResponseSpecification] `tfsdk:"update_response"`
+}
+
+type FulfillmentStartResponseSpecification struct {
+	DelayInSeconds types.Int64                                   `tfsdk:"delay_in_seconds"`
+	MessageGroup   fwtypes.ListNestedObjectValueOf[MessageGroup] `tfsdk:"message_group"`
+	AllowInterrupt types.Bool                                    `tfsdk:"allow_interrupt"`
+}
+
+type FulfillmentUpdateResponseSpecification struct {
+	FrequencyInSeconds types.Int64                                   `tfsdk:"frequency_in_seconds"`
+	MessageGroup       fwtypes.ListNestedObjectValueOf[MessageGroup] `tfsdk:"message_group"`
+	AllowInterrupt     types.Bool                                    `tfsdk:"allow_interrupt"`
+}
+
+type InitialResponseSetting struct {
+	CodeHook        fwtypes.ListNestedObjectValueOf[DialogCodeHookInvocationSetting] `tfsdk:"code_hook"`
+	Conditional     fwtypes.ListNestedObjectValueOf[ConditionalSpecification]        `tfsdk:"conditional"`
+	InitialResponse fwtypes.ListNestedObjectValueOf[ResponseSpecification]           `tfsdk:"initial_response"`
+	NextStep        fwtypes.ListNestedObjectValueOf[DialogState]                     `tfsdk:"next_step"`
+}
+
+type InputContext struct {
+	Name types.String `tfsdk:"name"`
+}
+
+type KendraConfiguration struct {
+	KendraIndex              types.String `tfsdk:"kendra_index"`
+	QueryFilterString        types.String `tfsdk:"query_filter_string"`
+	QueryFilterStringEnabled types.Bool   `tfsdk:"query_filter_string_enabled"`
+}
+
+type OutputContext struct {
+	Name                types.String `tfsdk:"name"`
+	TimeToLiveInSeconds types.Int64  `tfsdk:"time_to_live_in_seconds"`
+	TurnsToLive         types.Int64  `tfsdk:"turns_to_live"`
+}
+
+type SampleUtterance struct {
+	Utterance types.String `tfsdk:"utterance"`
+}
+
+type SlotPriority struct {
+	Priority types.Int64  `tfsdk:"priority"`
+	SlotID   types.String `tfsdk:"slot_id"`
+}

--- a/internal/service/lexv2models/intent.go
+++ b/internal/service/lexv2models/intent.go
@@ -607,8 +607,23 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 										Optional:   true,
 										CustomType: fwtypes.StringEnumType[awstypes.MessageSelectionStrategy](),
 									},
-									"prompt_attempts_specification": schema.MapAttribute{
-										Optional: true,
+									// New autoflex:
+									//  - MapNestedAttributeOf
+									//  - ObjectAttributeOf
+									// but, v5 v v6 and attributes not supported
+									//  - could model maps as blocks and frankenstein some autoflex
+									"prompt_attempts_specification1": schema.MapNestedAttribute{
+										Optional:   true,
+										CustomType: fwtypes.NewObjectMapTypeOf[PromptAttemptSpecification](ctx),
+										NestedObject: schema.NestedAttributeObject{
+											Attributes: map[string]schema.Attribute{
+												"allowed_input_types": schema.ObjectAttribute{
+													Optional: true,
+												},
+											},
+										},
+									},
+									"prompt_attempts_specification2": schema.MapAttribute{
 										ElementType: types.ObjectType{
 											AttrTypes: map[string]attr.Type{
 												"allowed_input_types": types.ObjectType{

--- a/internal/service/lexv2models/intent.go
+++ b/internal/service/lexv2models/intent.go
@@ -64,6 +64,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 				Validators: []validator.List{
 					listvalidator.SizeAtMost(1),
 				},
+				CustomType: fwtypes.NewListNestedObjectTypeOf[CustomPayload](ctx),
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"value": schema.StringAttribute{
@@ -76,6 +77,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 				Validators: []validator.List{
 					listvalidator.SizeAtMost(1),
 				},
+				CustomType: fwtypes.NewListNestedObjectTypeOf[ImageResponseCard](ctx),
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"image_url": schema.StringAttribute{
@@ -90,6 +92,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 					},
 					Blocks: map[string]schema.Block{
 						"button": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[Button](ctx),
 							NestedObject: schema.NestedBlockObject{
 								Attributes: map[string]schema.Attribute{
 									"text": schema.StringAttribute{
@@ -108,6 +111,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 				Validators: []validator.List{
 					listvalidator.SizeAtMost(1),
 				},
+				CustomType: fwtypes.NewListNestedObjectTypeOf[PlainTextMessage](ctx),
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"value": schema.StringAttribute{
@@ -120,6 +124,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 				Validators: []validator.List{
 					listvalidator.SizeAtMost(1),
 				},
+				CustomType: fwtypes.NewListNestedObjectTypeOf[SSMLMessage](ctx),
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"value": schema.StringAttribute{
@@ -134,15 +139,18 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 		Validators: []validator.List{
 			listvalidator.SizeAtLeast(1),
 		},
+		CustomType: fwtypes.NewListNestedObjectTypeOf[MessageGroup](ctx),
 		NestedObject: schema.NestedBlockObject{
 			Blocks: map[string]schema.Block{
 				"message": schema.ListNestedBlock{
 					Validators: []validator.List{
 						listvalidator.SizeBetween(1, 1),
 					},
+					CustomType:   fwtypes.NewListNestedObjectTypeOf[Message](ctx),
 					NestedObject: messageNBO,
 				},
 				"variations": schema.ListNestedBlock{
+					CustomType:   fwtypes.NewListNestedObjectTypeOf[Message](ctx),
 					NestedObject: messageNBO,
 				},
 			},
@@ -178,6 +186,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 				Validators: []validator.List{
 					listvalidator.SizeAtMost(1),
 				},
+				CustomType: fwtypes.NewListNestedObjectTypeOf[DialogAction](ctx),
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"type": schema.StringAttribute{
@@ -196,6 +205,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 				Validators: []validator.List{
 					listvalidator.SizeAtMost(1),
 				},
+				CustomType: fwtypes.NewListNestedObjectTypeOf[IntentOverride](ctx),
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"name": schema.StringAttribute{
@@ -214,6 +224,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 		Validators: []validator.List{
 			listvalidator.SizeAtMost(1),
 		},
+		CustomType: fwtypes.NewListNestedObjectTypeOf[ResponseSpecification](ctx),
 		NestedObject: schema.NestedBlockObject{
 			Attributes: map[string]schema.Attribute{
 				"allow_interrupt": schema.BoolAttribute{
@@ -229,6 +240,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 		Validators: []validator.List{
 			listvalidator.SizeAtMost(1),
 		},
+		CustomType: fwtypes.NewListNestedObjectTypeOf[ConditionalSpecification](ctx),
 		NestedObject: schema.NestedBlockObject{
 			Attributes: map[string]schema.Attribute{
 				"active": schema.BoolAttribute{
@@ -240,6 +252,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 					Validators: []validator.List{
 						listvalidator.SizeAtLeast(1),
 					},
+					CustomType: fwtypes.NewListNestedObjectTypeOf[ConditionalBranch](ctx),
 					NestedObject: schema.NestedBlockObject{
 						Attributes: map[string]schema.Attribute{
 							"name": schema.StringAttribute{
@@ -251,6 +264,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 								Validators: []validator.List{
 									listvalidator.SizeBetween(1, 1),
 								},
+								CustomType: fwtypes.NewListNestedObjectTypeOf[Condition](ctx),
 								NestedObject: schema.NestedBlockObject{
 									Attributes: map[string]schema.Attribute{
 										"expression_string": schema.StringAttribute{
@@ -263,6 +277,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 								Validators: []validator.List{
 									listvalidator.SizeBetween(1, 1),
 								},
+								CustomType:   fwtypes.NewListNestedObjectTypeOf[DialogState](ctx),
 								NestedObject: dialogStateNBO,
 							},
 							"response": responseSpecificationLNB,
@@ -273,12 +288,14 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 					Validators: []validator.List{
 						listvalidator.SizeBetween(1, 1),
 					},
+					CustomType: fwtypes.NewListNestedObjectTypeOf[DefaultConditionalBranch](ctx),
 					NestedObject: schema.NestedBlockObject{
 						Blocks: map[string]schema.Block{
 							"next_step": schema.ListNestedBlock{
 								Validators: []validator.List{
 									listvalidator.SizeAtMost(1),
 								},
+								CustomType:   fwtypes.NewListNestedObjectTypeOf[DialogState](ctx),
 								NestedObject: dialogStateNBO,
 							},
 							"response": responseSpecificationLNB,
@@ -295,6 +312,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 				Validators: []validator.List{
 					listvalidator.SizeAtMost(1),
 				},
+				CustomType:   fwtypes.NewListNestedObjectTypeOf[DialogState](ctx),
 				NestedObject: dialogStateNBO,
 			},
 			"failure_response":    responseSpecificationLNB,
@@ -303,6 +321,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 				Validators: []validator.List{
 					listvalidator.SizeAtMost(1),
 				},
+				CustomType:   fwtypes.NewListNestedObjectTypeOf[DialogState](ctx),
 				NestedObject: dialogStateNBO,
 			},
 			"success_response":    responseSpecificationLNB,
@@ -311,6 +330,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 				Validators: []validator.List{
 					listvalidator.SizeAtMost(1),
 				},
+				CustomType:   fwtypes.NewListNestedObjectTypeOf[DialogState](ctx),
 				NestedObject: dialogStateNBO,
 			},
 			"timeout_response": responseSpecificationLNB,
@@ -327,10 +347,18 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 			"bot_version": schema.StringAttribute{
 				Required: true,
 			},
+			"creation_date_time": schema.StringAttribute{
+				Computed:   true,
+				CustomType: fwtypes.TimestampType,
+			},
 			"description": schema.StringAttribute{
 				Optional: true,
 			},
 			"id": framework.IDAttribute(),
+			"last_updated_date_time": schema.StringAttribute{
+				Computed:   true,
+				CustomType: fwtypes.TimestampType,
+			},
 			"locale_id": schema.StringAttribute{
 				Required: true,
 				PlanModifiers: []planmodifier.String{
@@ -349,6 +377,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 				Validators: []validator.List{
 					listvalidator.SizeAtMost(1),
 				},
+				CustomType: fwtypes.NewListNestedObjectTypeOf[DialogCodeHookSettings](ctx),
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"enabled": schema.BoolAttribute{
@@ -361,6 +390,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 				Validators: []validator.List{
 					listvalidator.SizeAtMost(1),
 				},
+				CustomType: fwtypes.NewListNestedObjectTypeOf[FulfillmentCodeHookSettings](ctx),
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"enabled": schema.BoolAttribute{
@@ -375,6 +405,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 							Validators: []validator.List{
 								listvalidator.SizeAtMost(1),
 							},
+							CustomType: fwtypes.NewListNestedObjectTypeOf[FulfillmentUpdatesSpecification](ctx),
 							NestedObject: schema.NestedBlockObject{
 								Attributes: map[string]schema.Attribute{
 									"active": schema.BoolAttribute{
@@ -389,6 +420,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 										Validators: []validator.List{
 											listvalidator.SizeAtMost(1),
 										},
+										CustomType: fwtypes.NewListNestedObjectTypeOf[FulfillmentStartResponseSpecification](ctx),
 										NestedObject: schema.NestedBlockObject{
 											Attributes: map[string]schema.Attribute{
 												"allow_interrupt": schema.BoolAttribute{
@@ -403,15 +435,18 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 													Validators: []validator.List{
 														listvalidator.SizeBetween(1, 5),
 													},
+													CustomType: fwtypes.NewListNestedObjectTypeOf[MessageGroup](ctx),
 													NestedObject: schema.NestedBlockObject{
 														Blocks: map[string]schema.Block{
 															"message": schema.ListNestedBlock{
 																Validators: []validator.List{
 																	listvalidator.SizeBetween(1, 1),
 																},
+																CustomType:   fwtypes.NewListNestedObjectTypeOf[Message](ctx),
 																NestedObject: messageNBO,
 															},
 															"variations": schema.ListNestedBlock{
+																CustomType:   fwtypes.NewListNestedObjectTypeOf[Message](ctx),
 																NestedObject: messageNBO,
 															},
 														},
@@ -424,6 +459,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 										Validators: []validator.List{
 											listvalidator.SizeAtMost(1),
 										},
+										CustomType: fwtypes.NewListNestedObjectTypeOf[FulfillmentUpdateResponseSpecification](ctx),
 										NestedObject: schema.NestedBlockObject{
 											Attributes: map[string]schema.Attribute{
 												"allow_interrupt": schema.BoolAttribute{
@@ -445,6 +481,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 							Validators: []validator.List{
 								listvalidator.SizeAtMost(1),
 							},
+							CustomType:   fwtypes.NewListNestedObjectTypeOf[FailureSuccessTimeout](ctx),
 							NestedObject: failureSuccessTimeoutNBO,
 						},
 					},
@@ -454,12 +491,14 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 				Validators: []validator.List{
 					listvalidator.SizeAtMost(1),
 				},
+				CustomType: fwtypes.NewListNestedObjectTypeOf[InitialResponseSetting](ctx),
 				NestedObject: schema.NestedBlockObject{
 					Blocks: map[string]schema.Block{
 						"code_hook": schema.ListNestedBlock{
 							Validators: []validator.List{
 								listvalidator.SizeAtMost(1),
 							},
+							CustomType: fwtypes.NewListNestedObjectTypeOf[DialogCodeHookInvocationSetting](ctx),
 							NestedObject: schema.NestedBlockObject{
 								Attributes: map[string]schema.Attribute{
 									"active": schema.BoolAttribute{
@@ -477,6 +516,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 										Validators: []validator.List{
 											listvalidator.SizeBetween(1, 1),
 										},
+										CustomType:   fwtypes.NewListNestedObjectTypeOf[FailureSuccessTimeout](ctx),
 										NestedObject: failureSuccessTimeoutNBO,
 									},
 								},
@@ -488,6 +528,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 							Validators: []validator.List{
 								listvalidator.SizeAtMost(1),
 							},
+							CustomType:   fwtypes.NewListNestedObjectTypeOf[DialogState](ctx),
 							NestedObject: dialogStateNBO,
 						},
 					},
@@ -497,6 +538,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 				Validators: []validator.List{
 					listvalidator.SizeAtMost(5),
 				},
+				CustomType: fwtypes.NewListNestedObjectTypeOf[InputContext](ctx),
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"name": schema.StringAttribute{
@@ -509,6 +551,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 				Validators: []validator.List{
 					listvalidator.SizeAtMost(1),
 				},
+				CustomType: fwtypes.NewListNestedObjectTypeOf[IntentClosingSetting](ctx),
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"active": schema.BoolAttribute{
@@ -522,6 +565,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 							Validators: []validator.List{
 								listvalidator.SizeAtMost(1),
 							},
+							CustomType:   fwtypes.NewListNestedObjectTypeOf[DialogState](ctx),
 							NestedObject: dialogStateNBO,
 						},
 					},
@@ -531,6 +575,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 				Validators: []validator.List{
 					listvalidator.SizeAtMost(1),
 				},
+				CustomType: fwtypes.NewListNestedObjectTypeOf[IntentConfirmationSetting](ctx),
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"active": schema.BoolAttribute{
@@ -542,6 +587,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 							Validators: []validator.List{
 								listvalidator.SizeBetween(1, 1),
 							},
+							CustomType: fwtypes.NewListNestedObjectTypeOf[PromptSpecification](ctx),
 							NestedObject: schema.NestedBlockObject{
 								Attributes: map[string]schema.Attribute{
 									"allow_interrupt": schema.BoolAttribute{
@@ -597,6 +643,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 							Validators: []validator.List{
 								listvalidator.SizeAtMost(1),
 							},
+							CustomType:   fwtypes.NewListNestedObjectTypeOf[DialogState](ctx),
 							NestedObject: dialogStateNBO,
 						},
 					},
@@ -606,6 +653,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 				Validators: []validator.List{
 					listvalidator.SizeAtMost(1),
 				},
+				CustomType: fwtypes.NewListNestedObjectTypeOf[KendraConfiguration](ctx),
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"index": schema.StringAttribute{
@@ -624,6 +672,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 				Validators: []validator.List{
 					listvalidator.SizeAtMost(10),
 				},
+				CustomType: fwtypes.NewListNestedObjectTypeOf[OutputContext](ctx),
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"name": schema.StringAttribute{
@@ -639,6 +688,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 				},
 			},
 			"sample_utterance": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[SampleUtterance](ctx),
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"utterance": schema.StringAttribute{
@@ -648,6 +698,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 				},
 			},
 			"slot_priority": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[SlotPriority](ctx),
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"priority": schema.Int64Attribute{
@@ -679,10 +730,14 @@ func (r *resourceIntent) Create(ctx context.Context, req resource.CreateRequest,
 
 	in := &lexmodelsv2.CreateIntentInput{}
 
+	fmt.Printf("plan: %+v\n", plan)
+
 	resp.Diagnostics.Append(flex.Expand(ctx, &plan, in)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	fmt.Printf("in: %+v\n", in)
 
 	out, err := conn.CreateIntent(ctx, in)
 	if err != nil {

--- a/internal/service/lexv2models/intent.go
+++ b/internal/service/lexv2models/intent.go
@@ -1096,11 +1096,11 @@ type IntentConfirmationSetting struct {
 }
 
 type PromptSpecification struct {
-	MaxRetries               types.Int64                                   `tfsdk:"max_retries"`
-	MessageGroup             fwtypes.ListNestedObjectValueOf[MessageGroup] `tfsdk:"message_groups"`
-	AllowInterrupt           types.Bool                                    `tfsdk:"allow_interrupt"`
-	MessageSelectionStrategy types.String                                  `tfsdk:"message_selection_strategy"`
-	//PromptAttemptsSpecification map[string]PromptAttemptSpecification         `tfsdk:"prompt_attempts_specification"`
+	MaxRetries                  types.Int64                                           `tfsdk:"max_retries"`
+	MessageGroup                fwtypes.ListNestedObjectValueOf[MessageGroup]         `tfsdk:"message_groups"`
+	AllowInterrupt              types.Bool                                            `tfsdk:"allow_interrupt"`
+	MessageSelectionStrategy    fwtypes.StringEnum[awstypes.MessageSelectionStrategy] `tfsdk:"message_selection_strategy"`
+	PromptAttemptsSpecification fwtypes.ObjectMapValueOf[PromptAttemptSpecification]  `tfsdk:"prompt_attempts_specification"`
 }
 
 type PromptAttemptSpecification struct {

--- a/internal/service/lexv2models/intent.go
+++ b/internal/service/lexv2models/intent.go
@@ -159,7 +159,13 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 			},
 		},
 	}
-	slotValueOverrideO.AttrTypes["values"] = slotValueOverrideO // recursive type
+
+	// This recursive type blows up autoflex and potentially schema.
+	// In order to continue work, we are intentionally leaving this out for now
+	// and will need to return to it when needed.
+
+	//slotValueOverrideO.AttrTypes["values"] = slotValueOverrideO
+
 	dialogStateNBO := schema.NestedBlockObject{
 		Attributes: map[string]schema.Attribute{
 			"session_attributes": schema.MapAttribute{
@@ -1054,9 +1060,9 @@ type DialogState struct {
 }
 
 type DialogAction struct {
-	Type                types.String `tfsdk:"type"`
-	SlotToElicit        types.String `tfsdk:"slot_to_elicit"`
-	SuppressNextMessage types.Bool   `tfsdk:"suppress_next_message"`
+	Type                fwtypes.StringEnum[awstypes.DialogActionType] `tfsdk:"type"`
+	SlotToElicit        types.String                                  `tfsdk:"slot_to_elicit"`
+	SuppressNextMessage types.Bool                                    `tfsdk:"suppress_next_message"`
 }
 
 type IntentOverride struct {

--- a/internal/service/lexv2models/intent.go
+++ b/internal/service/lexv2models/intent.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
@@ -963,7 +964,7 @@ type ResourceIntentData struct {
 	BotVersion             types.String                                                 `tfsdk:"bot_version"`
 	ClosingSetting         fwtypes.ListNestedObjectValueOf[IntentClosingSetting]        `tfsdk:"closing_setting"`
 	ConfirmationSetting    fwtypes.ListNestedObjectValueOf[IntentConfirmationSetting]   `tfsdk:"confirmation_setting"`
-	CreationDateTime       fwtypes.TimestampType                                        `tfsdk:"creation_date_time"`
+	CreationDateTime       fwtypes.Timestamp                                            `tfsdk:"creation_date_time"`
 	Description            types.String                                                 `tfsdk:"description"`
 	DialogCodeHook         fwtypes.ListNestedObjectValueOf[DialogCodeHookSettings]      `tfsdk:"dialog_code_hook"`
 	FulfillmentCodeHook    fwtypes.ListNestedObjectValueOf[FulfillmentCodeHookSettings] `tfsdk:"fulfillment_code_hook"`
@@ -971,7 +972,7 @@ type ResourceIntentData struct {
 	InitialResponseSetting fwtypes.ListNestedObjectValueOf[InitialResponseSetting]      `tfsdk:"initial_response_setting"`
 	InputContext           fwtypes.ListNestedObjectValueOf[InputContext]                `tfsdk:"input_context"`
 	KendraConfiguration    fwtypes.ListNestedObjectValueOf[KendraConfiguration]         `tfsdk:"kendra_configuration"`
-	LastUpdatedDateTime    fwtypes.TimestampType                                        `tfsdk:"last_updated_date_time"`
+	LastUpdatedDateTime    fwtypes.Timestamp                                            `tfsdk:"last_updated_date_time"`
 	LocaleID               types.String                                                 `tfsdk:"locale_id"`
 	Name                   types.String                                                 `tfsdk:"name"`
 	OutputContext          fwtypes.ListNestedObjectValueOf[OutputContext]               `tfsdk:"output_context"`
@@ -1049,7 +1050,7 @@ type Condition struct {
 type DialogState struct {
 	DialogAction      fwtypes.ListNestedObjectValueOf[DialogAction]   `tfsdk:"dialog_action"`
 	Intent            fwtypes.ListNestedObjectValueOf[IntentOverride] `tfsdk:"intent"`
-	SessionAttributes types.Map                                       `tfsdk:"session_attributes"`
+	SessionAttributes fwtypes.MapValueOf[basetypes.StringValue]       `tfsdk:"session_attributes"`
 }
 
 type DialogAction struct {
@@ -1059,14 +1060,14 @@ type DialogAction struct {
 }
 
 type IntentOverride struct {
-	Name types.String `tfsdk:"name"`
-	//Slots fwtypes.MapValueOf[SlotValueOverride] `tfsdk:"slots"`
+	Name  types.String                                `tfsdk:"name"`
+	Slots fwtypes.ObjectMapValueOf[SlotValueOverride] `tfsdk:"slots"`
 }
 
 type SlotValueOverride struct {
-	Shape  types.String                                       `tfsdk:"shape"`
-	Value  fwtypes.ListNestedObjectValueOf[SlotValue]         `tfsdk:"value"`
-	Values fwtypes.ListNestedObjectValueOf[SlotValueOverride] `tfsdk:"values"`
+	Shape fwtypes.StringEnum[awstypes.SlotShape]     `tfsdk:"shape"`
+	Value fwtypes.ListNestedObjectValueOf[SlotValue] `tfsdk:"value"`
+	//Values fwtypes.ListNestedObjectValueOf[SlotValueOverride] `tfsdk:"values"`
 }
 
 type SlotValue struct {

--- a/internal/service/lexv2models/intent.go
+++ b/internal/service/lexv2models/intent.go
@@ -400,6 +400,14 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 		},
 	}
 
+	nextStepLNB := schema.ListNestedBlock{
+		Validators: []validator.List{
+			listvalidator.SizeAtMost(1),
+		},
+		CustomType:   fwtypes.NewListNestedObjectTypeOf[DialogState](ctx),
+		NestedObject: dialogStateNBO,
+	}
+
 	defaultBranchLNB := schema.ListNestedBlock{
 		Validators: []validator.List{
 			listvalidator.SizeBetween(1, 1),
@@ -407,14 +415,8 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 		CustomType: fwtypes.NewListNestedObjectTypeOf[DefaultConditionalBranch](ctx),
 		NestedObject: schema.NestedBlockObject{
 			Blocks: map[string]schema.Block{
-				"next_step": schema.ListNestedBlock{
-					Validators: []validator.List{
-						listvalidator.SizeAtMost(1),
-					},
-					CustomType:   fwtypes.NewListNestedObjectTypeOf[DialogState](ctx),
-					NestedObject: dialogStateNBO,
-				},
-				"response": responseSpecificationLNB,
+				"next_step": nextStepLNB,
+				"response":  responseSpecificationLNB,
 			},
 		},
 	}
@@ -435,14 +437,6 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 				"default_branch":     defaultBranchLNB,
 			},
 		},
-	}
-
-	nextStepLNB := schema.ListNestedBlock{
-		Validators: []validator.List{
-			listvalidator.SizeAtMost(1),
-		},
-		CustomType:   fwtypes.NewListNestedObjectTypeOf[DialogState](ctx),
-		NestedObject: dialogStateNBO,
 	}
 
 	closingSettingLNB := schema.ListNestedBlock{

--- a/internal/service/lexv2models/intent.go
+++ b/internal/service/lexv2models/intent.go
@@ -35,25 +35,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// todo:
-//  x invalid result object
-//  x get basic test working
-//  x disappears
-//  x import/ID
-//  x update autoflex for StringEnum map keys
-//  - test all (reasonable number) attributes
-//  x tags (no tags on intents)
-//  - slot_priority on create
-//  x prompt_attempts_specification schema
-//  x prompt_attempts_specification model
-//  x prompt_attempts_specification test
-//  x intent-slots-slot-value-override schema
-//  x intent-slots-slot-value-override model
-//  x intent-slots-slot-value-override test
-//  x timeouts
-//  - get config with confirmation_setting.prompt_specification.prompt_attempts_specification working
-//  - updates
-
 // @FrameworkResource(name="Intent")
 func newResourceIntent(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &resourceIntent{}

--- a/internal/service/lexv2models/intent.go
+++ b/internal/service/lexv2models/intent.go
@@ -861,14 +861,21 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 				Required: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"bot_version": schema.StringAttribute{
 				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"creation_date_time": schema.StringAttribute{
 				Computed:   true,
 				CustomType: fwtypes.TimestampType,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"description": schema.StringAttribute{
 				Optional: true,
@@ -876,15 +883,22 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 			"id": framework.IDAttribute(),
 			"intent_id": schema.StringAttribute{
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"last_updated_date_time": schema.StringAttribute{
 				Computed:   true,
 				CustomType: fwtypes.TimestampType,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"locale_id": schema.StringAttribute{
 				Required: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"name": schema.StringAttribute{

--- a/internal/service/lexv2models/intent.go
+++ b/internal/service/lexv2models/intent.go
@@ -982,10 +982,6 @@ func (r *resourceIntent) Create(ctx context.Context, req resource.CreateRequest,
 	data.CreationDateTime = dataAfter.CreationDateTime
 	data.LastUpdatedDateTime = dataAfter.LastUpdatedDateTime
 
-	//if len(data.SlotPriority) > 0 {
-	// update because SlotPriority can't be set on create
-	//}
-
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 

--- a/internal/service/lexv2models/intent.go
+++ b/internal/service/lexv2models/intent.go
@@ -34,8 +34,10 @@ import (
 // todo:
 //  x invalid result object
 //  x get basic test working
+//  x disappears
 //  x import/ID
-//  - test all attributes
+//  x update autoflex for StringEnum map keys
+//  - test all (reasonable number) attributes
 //  x tags (no tags on intents)
 //  - slot_priority on create
 //  x prompt_attempts_specification schema
@@ -43,10 +45,10 @@ import (
 //  x prompt_attempts_specification test
 //  x intent-slots-slot-value-override schema
 //  x intent-slots-slot-value-override model
-//  - intent-slots-slot-value-override test
+//  x intent-slots-slot-value-override test
 //  x timeouts
+//  - get config with confirmation_setting.prompt_specification.prompt_attempts_specification working
 //  - updates
-//  x disappears
 
 // @FrameworkResource(name="Intent")
 func newResourceIntent(_ context.Context) (resource.ResourceWithConfigure, error) {
@@ -178,7 +180,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 		CustomType: fwtypes.NewListNestedObjectTypeOf[SlotValueOverride](ctx),
 		NestedObject: schema.NestedBlockObject{
 			Attributes: map[string]schema.Attribute{
-				flex.MapBlockKey: schema.StringAttribute{
+				"map_block_key": schema.StringAttribute{
 					Required: true,
 					// pattern: ^([0-9a-zA-Z][_-]?){1,100}$
 				},
@@ -378,7 +380,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 		CustomType: fwtypes.NewListNestedObjectTypeOf[PromptAttemptsSpecification](ctx),
 		NestedObject: schema.NestedBlockObject{
 			Attributes: map[string]schema.Attribute{
-				flex.MapBlockKey: schema.StringAttribute{
+				"map_block_key": schema.StringAttribute{
 					Required:   true,
 					CustomType: fwtypes.StringEnumType[PromptAttemptsType](),
 				},

--- a/internal/service/lexv2models/intent.go
+++ b/internal/service/lexv2models/intent.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -14,7 +15,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/lexmodelsv2"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/lexmodelsv2/types"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -182,7 +185,12 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 			Attributes: map[string]schema.Attribute{
 				"map_block_key": schema.StringAttribute{
 					Required: true,
-					// pattern: ^([0-9a-zA-Z][_-]?){1,100}$
+					Validators: []validator.String{
+						stringvalidator.RegexMatches(
+							regexp.MustCompile(` ^([0-9a-zA-Z][_-]?){1,100}$`),
+							"alphanumeric characters and hyphens (-) and underscores (_) at the end and must be between 1 and 100 characters in length",
+						),
+					},
 				},
 				"shape": schema.StringAttribute{
 					Optional:   true,
@@ -199,7 +207,9 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 						Attributes: map[string]schema.Attribute{
 							"interpreted_value": schema.StringAttribute{
 								Optional: true,
-								// min length: 1
+								Validators: []validator.String{
+									stringvalidator.LengthAtLeast(1),
+								},
 							},
 						},
 					},
@@ -413,9 +423,9 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 					NestedObject: schema.NestedBlockObject{
 						Attributes: map[string]schema.Attribute{
 							"start_timeout_ms": schema.Int64Attribute{
-								Required:   true,
+								Required: true,
 								Validators: []validator.Int64{
-									// at least 1
+									int64validator.AtLeast(1),
 								},
 							},
 						},
@@ -428,15 +438,15 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 								NestedObject: schema.NestedBlockObject{
 									Attributes: map[string]schema.Attribute{
 										"end_timeout_ms": schema.Int64Attribute{
-											Required:   true,
+											Required: true,
 											Validators: []validator.Int64{
-												// at least 1
+												int64validator.AtLeast(1),
 											},
 										},
 										"max_length_ms": schema.Int64Attribute{
-											Required:   true,
+											Required: true,
 											Validators: []validator.Int64{
-												// at least 1
+												int64validator.AtLeast(1),
 											},
 										},
 									},
@@ -451,22 +461,32 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 									Attributes: map[string]schema.Attribute{
 										"deletion_character": schema.StringAttribute{
 											Required: true,
-											// pattern: ^[A-D0-9#*]{1}$
+											Validators: []validator.String{
+												stringvalidator.RegexMatches(
+													regexp.MustCompile(`^[A-D0-9#*]{1}$`),
+													"alphanumeric characters",
+												),
+											},
 										},
 										"end_character": schema.StringAttribute{
 											Required: true,
-											// pattern: ^[A-D0-9#*]{1}$
+											Validators: []validator.String{
+												stringvalidator.RegexMatches(
+													regexp.MustCompile(`^[A-D0-9#*]{1}$`),
+													"alphanumeric characters",
+												),
+											},
 										},
 										"end_timeout_ms": schema.Int64Attribute{
-											Required:   true,
+											Required: true,
 											Validators: []validator.Int64{
-												// at least 1
+												int64validator.AtLeast(1),
 											},
 										},
 										"max_length": schema.Int64Attribute{
-											Required:   true,
+											Required: true,
 											Validators: []validator.Int64{
-												//validators.Int64Between(1, 1024),
+												int64validator.Between(1, 1024),
 											},
 										},
 									},

--- a/internal/service/lexv2models/intent.go
+++ b/internal/service/lexv2models/intent.go
@@ -79,84 +79,159 @@ func (r *resourceIntent) Metadata(_ context.Context, req resource.MetadataReques
 }
 
 func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
-	// building blocks for the schema
-	messageNBO := schema.NestedBlockObject{
-		Blocks: map[string]schema.Block{
-			"custom_playload": schema.ListNestedBlock{
-				Validators: []validator.List{
-					listvalidator.SizeAtMost(1),
+	slotPriorityLNB := schema.ListNestedBlock{
+		CustomType: fwtypes.NewListNestedObjectTypeOf[SlotPriority](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"priority": schema.Int64Attribute{
+					Required: true,
 				},
-				CustomType: fwtypes.NewListNestedObjectTypeOf[CustomPayload](ctx),
-				NestedObject: schema.NestedBlockObject{
-					Attributes: map[string]schema.Attribute{
-						"value": schema.StringAttribute{
-							Required: true,
-						},
-					},
-				},
-			},
-			"image_response_card": schema.ListNestedBlock{
-				Validators: []validator.List{
-					listvalidator.SizeAtMost(1),
-				},
-				CustomType: fwtypes.NewListNestedObjectTypeOf[ImageResponseCard](ctx),
-				NestedObject: schema.NestedBlockObject{
-					Attributes: map[string]schema.Attribute{
-						"image_url": schema.StringAttribute{
-							Optional: true,
-						},
-						"subtitle": schema.StringAttribute{
-							Optional: true,
-						},
-						"title": schema.StringAttribute{
-							Required: true,
-						},
-					},
-					Blocks: map[string]schema.Block{
-						"button": schema.ListNestedBlock{
-							CustomType: fwtypes.NewListNestedObjectTypeOf[Button](ctx),
-							NestedObject: schema.NestedBlockObject{
-								Attributes: map[string]schema.Attribute{
-									"text": schema.StringAttribute{
-										Required: true,
-									},
-									"value": schema.StringAttribute{
-										Required: true,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			"plain_text_message": schema.ListNestedBlock{
-				Validators: []validator.List{
-					listvalidator.SizeAtMost(1),
-				},
-				CustomType: fwtypes.NewListNestedObjectTypeOf[PlainTextMessage](ctx),
-				NestedObject: schema.NestedBlockObject{
-					Attributes: map[string]schema.Attribute{
-						"value": schema.StringAttribute{
-							Required: true,
-						},
-					},
-				},
-			},
-			"ssml_message": schema.ListNestedBlock{
-				Validators: []validator.List{
-					listvalidator.SizeAtMost(1),
-				},
-				CustomType: fwtypes.NewListNestedObjectTypeOf[SSMLMessage](ctx),
-				NestedObject: schema.NestedBlockObject{
-					Attributes: map[string]schema.Attribute{
-						"value": schema.StringAttribute{
-							Required: true,
-						},
-					},
+				"slot_id": schema.StringAttribute{
+					Required: true,
 				},
 			},
 		},
 	}
+
+	sampleUtteranceLNB := schema.ListNestedBlock{
+		CustomType: fwtypes.NewListNestedObjectTypeOf[SampleUtterance](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"utterance": schema.StringAttribute{
+					Required: true,
+				},
+			},
+		},
+	}
+
+	outputContextLNB := schema.ListNestedBlock{
+		Validators: []validator.List{
+			listvalidator.SizeAtMost(10),
+		},
+		CustomType: fwtypes.NewListNestedObjectTypeOf[OutputContext](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"name": schema.StringAttribute{
+					Required: true,
+				},
+				"time_to_live_in_seconds": schema.Int64Attribute{
+					Required: true,
+				},
+				"turns_to_live": schema.Int64Attribute{
+					Required: true,
+				},
+			},
+		},
+	}
+
+	kendraConfigurationLNB := schema.ListNestedBlock{
+		Validators: []validator.List{
+			listvalidator.SizeAtMost(1),
+		},
+		CustomType: fwtypes.NewListNestedObjectTypeOf[KendraConfiguration](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"kendra_index": schema.StringAttribute{
+					Required: true,
+				},
+				"query_filter_string": schema.StringAttribute{
+					Optional: true,
+				},
+				"query_filter_string_enabled": schema.BoolAttribute{
+					Optional: true,
+				},
+			},
+		},
+	}
+
+	customPayloadLNB := schema.ListNestedBlock{
+		Validators: []validator.List{
+			listvalidator.SizeAtMost(1),
+		},
+		CustomType: fwtypes.NewListNestedObjectTypeOf[CustomPayload](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"value": schema.StringAttribute{
+					Required: true,
+				},
+			},
+		},
+	}
+
+	buttonLNB := schema.ListNestedBlock{
+		CustomType: fwtypes.NewListNestedObjectTypeOf[Button](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"text": schema.StringAttribute{
+					Required: true,
+				},
+				"value": schema.StringAttribute{
+					Required: true,
+				},
+			},
+		},
+	}
+
+	imageResponseCardLNB := schema.ListNestedBlock{
+		Validators: []validator.List{
+			listvalidator.SizeAtMost(1),
+		},
+		CustomType: fwtypes.NewListNestedObjectTypeOf[ImageResponseCard](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"image_url": schema.StringAttribute{
+					Optional: true,
+				},
+				"subtitle": schema.StringAttribute{
+					Optional: true,
+				},
+				"title": schema.StringAttribute{
+					Required: true,
+				},
+			},
+			Blocks: map[string]schema.Block{
+				"button": buttonLNB,
+			},
+		},
+	}
+
+	plainTextMessageLNB := schema.ListNestedBlock{
+		Validators: []validator.List{
+			listvalidator.SizeAtMost(1),
+		},
+		CustomType: fwtypes.NewListNestedObjectTypeOf[PlainTextMessage](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"value": schema.StringAttribute{
+					Required: true,
+				},
+			},
+		},
+	}
+
+	ssmlMessageLNB := schema.ListNestedBlock{
+		Validators: []validator.List{
+			listvalidator.SizeAtMost(1),
+		},
+		CustomType: fwtypes.NewListNestedObjectTypeOf[SSMLMessage](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"value": schema.StringAttribute{
+					Required: true,
+				},
+			},
+		},
+	}
+
+	messageNBO := schema.NestedBlockObject{
+		Blocks: map[string]schema.Block{
+			"custom_playload":     customPayloadLNB,
+			"image_response_card": imageResponseCardLNB,
+			"plain_text_message":  plainTextMessageLNB,
+			"ssml_message":        ssmlMessageLNB,
+		},
+	}
+
 	messageGroupLNB := schema.ListNestedBlock{
 		Validators: []validator.List{
 			listvalidator.SizeAtLeast(1),
@@ -171,9 +246,26 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 					CustomType:   fwtypes.NewListNestedObjectTypeOf[Message](ctx),
 					NestedObject: messageNBO,
 				},
-				"variations": schema.ListNestedBlock{
+				"variation": schema.ListNestedBlock{
 					CustomType:   fwtypes.NewListNestedObjectTypeOf[Message](ctx),
 					NestedObject: messageNBO,
+				},
+			},
+		},
+	}
+
+	slotValueLNB := schema.ListNestedBlock{
+		Validators: []validator.List{
+			listvalidator.SizeAtMost(1),
+		},
+		CustomType: fwtypes.NewListNestedObjectTypeOf[SlotValue](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"interpreted_value": schema.StringAttribute{
+					Optional: true,
+					Validators: []validator.String{
+						stringvalidator.LengthAtLeast(1),
+					},
 				},
 			},
 		},
@@ -198,27 +290,50 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 				},
 			},
 			Blocks: map[string]schema.Block{
-				"value": schema.ListNestedBlock{
-					Validators: []validator.List{
-						listvalidator.SizeAtMost(1),
-					},
-					CustomType: fwtypes.NewListNestedObjectTypeOf[SlotValue](ctx),
-					NestedObject: schema.NestedBlockObject{
-						Attributes: map[string]schema.Attribute{
-							"interpreted_value": schema.StringAttribute{
-								Optional: true,
-								Validators: []validator.String{
-									stringvalidator.LengthAtLeast(1),
-								},
-							},
-						},
-					},
-				},
+				"value": slotValueLNB,
 			},
 		},
 	}
 
 	// slotValueOverrideLNB.NestedObject.Blocks["values"] = slotValueOverrideLNB // recursive type, purposely left out, future feature
+
+	dialogActionLNB := schema.ListNestedBlock{
+		Validators: []validator.List{
+			listvalidator.SizeAtMost(1),
+		},
+		CustomType: fwtypes.NewListNestedObjectTypeOf[DialogAction](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"type": schema.StringAttribute{
+					Required:   true,
+					CustomType: fwtypes.StringEnumType[awstypes.DialogActionType](),
+				},
+				"slot_to_elicit": schema.StringAttribute{
+					Optional: true,
+				},
+				"suppress_next_message": schema.BoolAttribute{
+					Optional: true,
+				},
+			},
+		},
+	}
+
+	intentOverrideLNB := schema.ListNestedBlock{
+		Validators: []validator.List{
+			listvalidator.SizeAtMost(1),
+		},
+		CustomType: fwtypes.NewListNestedObjectTypeOf[IntentOverride](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"name": schema.StringAttribute{
+					Optional: true,
+				},
+			},
+			Blocks: map[string]schema.Block{
+				"slot": slotValueOverrideLNB,
+			},
+		},
+	}
 
 	dialogStateNBO := schema.NestedBlockObject{
 		Attributes: map[string]schema.Attribute{
@@ -228,44 +343,11 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 			},
 		},
 		Blocks: map[string]schema.Block{
-			"dialog_action": schema.ListNestedBlock{
-				Validators: []validator.List{
-					listvalidator.SizeAtMost(1),
-				},
-				CustomType: fwtypes.NewListNestedObjectTypeOf[DialogAction](ctx),
-				NestedObject: schema.NestedBlockObject{
-					Attributes: map[string]schema.Attribute{
-						"type": schema.StringAttribute{
-							Required:   true,
-							CustomType: fwtypes.StringEnumType[awstypes.DialogActionType](),
-						},
-						"slot_to_elicit": schema.StringAttribute{
-							Optional: true,
-						},
-						"suppress_next_message": schema.StringAttribute{
-							Optional: true,
-						},
-					},
-				},
-			},
-			"intent": schema.ListNestedBlock{
-				Validators: []validator.List{
-					listvalidator.SizeAtMost(1),
-				},
-				CustomType: fwtypes.NewListNestedObjectTypeOf[IntentOverride](ctx),
-				NestedObject: schema.NestedBlockObject{
-					Attributes: map[string]schema.Attribute{
-						"name": schema.StringAttribute{
-							Optional: true,
-						},
-					},
-					Blocks: map[string]schema.Block{
-						"slot": slotValueOverrideLNB,
-					},
-				},
-			},
+			"dialog_action": dialogActionLNB,
+			"intent":        intentOverrideLNB,
 		},
 	}
+
 	responseSpecificationLNB := schema.ListNestedBlock{
 		Validators: []validator.List{
 			listvalidator.SizeAtMost(1),
@@ -282,6 +364,65 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 			},
 		},
 	}
+
+	conditionLNB := schema.ListNestedBlock{
+		Validators: []validator.List{
+			listvalidator.SizeBetween(1, 1),
+		},
+		CustomType: fwtypes.NewListNestedObjectTypeOf[Condition](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"expression_string": schema.StringAttribute{
+					Required: true,
+				},
+			},
+		},
+	}
+
+	conditionalBranchLNB := schema.ListNestedBlock{
+		Validators: []validator.List{
+			listvalidator.SizeAtLeast(1),
+		},
+		CustomType: fwtypes.NewListNestedObjectTypeOf[ConditionalBranch](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"name": schema.StringAttribute{
+					Required: true,
+				},
+			},
+			Blocks: map[string]schema.Block{
+				"condition": conditionLNB,
+				"next_step": schema.ListNestedBlock{
+					Validators: []validator.List{
+						listvalidator.SizeBetween(1, 1),
+					},
+					CustomType:   fwtypes.NewListNestedObjectTypeOf[DialogState](ctx),
+					NestedObject: dialogStateNBO,
+				},
+				"response": responseSpecificationLNB,
+			},
+		},
+	}
+
+	defaultBranchLNB := schema.ListNestedBlock{
+		Validators: []validator.List{
+			listvalidator.SizeBetween(1, 1),
+		},
+		CustomType: fwtypes.NewListNestedObjectTypeOf[DefaultConditionalBranch](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Blocks: map[string]schema.Block{
+				"next_step": schema.ListNestedBlock{
+					Validators: []validator.List{
+						listvalidator.SizeAtMost(1),
+					},
+					CustomType:   fwtypes.NewListNestedObjectTypeOf[DialogState](ctx),
+					NestedObject: dialogStateNBO,
+				},
+				"response": responseSpecificationLNB,
+			},
+		},
+	}
+
 	conditionalSpecificationLNB := schema.ListNestedBlock{
 		Validators: []validator.List{
 			listvalidator.SizeAtMost(1),
@@ -294,92 +435,167 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 				},
 			},
 			Blocks: map[string]schema.Block{
-				"conditional_branch": schema.ListNestedBlock{
-					Validators: []validator.List{
-						listvalidator.SizeAtLeast(1),
-					},
-					CustomType: fwtypes.NewListNestedObjectTypeOf[ConditionalBranch](ctx),
-					NestedObject: schema.NestedBlockObject{
-						Attributes: map[string]schema.Attribute{
-							"name": schema.StringAttribute{
-								Required: true,
-							},
-						},
-						Blocks: map[string]schema.Block{
-							"condition": schema.ListNestedBlock{
-								Validators: []validator.List{
-									listvalidator.SizeBetween(1, 1),
-								},
-								CustomType: fwtypes.NewListNestedObjectTypeOf[Condition](ctx),
-								NestedObject: schema.NestedBlockObject{
-									Attributes: map[string]schema.Attribute{
-										"expression_string": schema.StringAttribute{
-											Required: true,
-										},
-									},
-								},
-							},
-							"next_step": schema.ListNestedBlock{
-								Validators: []validator.List{
-									listvalidator.SizeBetween(1, 1),
-								},
-								CustomType:   fwtypes.NewListNestedObjectTypeOf[DialogState](ctx),
-								NestedObject: dialogStateNBO,
-							},
-							"response": responseSpecificationLNB,
-						},
+				"conditional_branch": conditionalBranchLNB,
+				"default_branch":     defaultBranchLNB,
+			},
+		},
+	}
+
+	nextStepLNB := schema.ListNestedBlock{
+		Validators: []validator.List{
+			listvalidator.SizeAtMost(1),
+		},
+		CustomType:   fwtypes.NewListNestedObjectTypeOf[DialogState](ctx),
+		NestedObject: dialogStateNBO,
+	}
+
+	closingSettingLNB := schema.ListNestedBlock{
+		Validators: []validator.List{
+			listvalidator.SizeAtMost(1),
+		},
+		CustomType: fwtypes.NewListNestedObjectTypeOf[IntentClosingSetting](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"active": schema.BoolAttribute{
+					Optional: true,
+				},
+			},
+			Blocks: map[string]schema.Block{
+				"closing_response": responseSpecificationLNB,
+				"conditional":      conditionalSpecificationLNB,
+				"next_step":        nextStepLNB,
+			},
+		},
+	}
+
+	inputContextLNB := schema.ListNestedBlock{
+		Validators: []validator.List{
+			listvalidator.SizeAtMost(5),
+		},
+		CustomType: fwtypes.NewListNestedObjectTypeOf[InputContext](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"name": schema.StringAttribute{
+					Required: true,
+				},
+			},
+		},
+	}
+
+	allowedInputTypesLNB := schema.ListNestedBlock{
+		Validators: []validator.List{
+			listvalidator.SizeBetween(1, 1),
+		},
+		CustomType: fwtypes.NewListNestedObjectTypeOf[AllowedInputTypes](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"allow_audio_input": schema.BoolAttribute{
+					Required: true,
+				},
+				"allow_dtmf_input": schema.BoolAttribute{
+					Required: true,
+				},
+			},
+		},
+	}
+
+	audioSpecificationLNB := schema.ListNestedBlock{
+		Validators: []validator.List{
+			listvalidator.SizeAtMost(1),
+		},
+		CustomType: fwtypes.NewListNestedObjectTypeOf[AudioSpecification](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"end_timeout_ms": schema.Int64Attribute{
+					Required: true,
+					Validators: []validator.Int64{
+						int64validator.AtLeast(1),
 					},
 				},
-				"default_branch": schema.ListNestedBlock{
-					Validators: []validator.List{
-						listvalidator.SizeBetween(1, 1),
-					},
-					CustomType: fwtypes.NewListNestedObjectTypeOf[DefaultConditionalBranch](ctx),
-					NestedObject: schema.NestedBlockObject{
-						Blocks: map[string]schema.Block{
-							"next_step": schema.ListNestedBlock{
-								Validators: []validator.List{
-									listvalidator.SizeAtMost(1),
-								},
-								CustomType:   fwtypes.NewListNestedObjectTypeOf[DialogState](ctx),
-								NestedObject: dialogStateNBO,
-							},
-							"response": responseSpecificationLNB,
-						},
+				"max_length_ms": schema.Int64Attribute{
+					Required: true,
+					Validators: []validator.Int64{
+						int64validator.AtLeast(1),
 					},
 				},
 			},
 		},
 	}
-	failureSuccessTimeoutNBO := schema.NestedBlockObject{
-		Blocks: map[string]schema.Block{
-			"failure_conditional": conditionalSpecificationLNB,
-			"failure_next_step": schema.ListNestedBlock{
-				Validators: []validator.List{
-					listvalidator.SizeAtMost(1),
+
+	dtmfSpecificationLNB := schema.ListNestedBlock{
+		Validators: []validator.List{
+			listvalidator.SizeAtMost(1),
+		},
+		CustomType: fwtypes.NewListNestedObjectTypeOf[DTMFSpecification](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"deletion_character": schema.StringAttribute{
+					Required: true,
+					Validators: []validator.String{
+						stringvalidator.RegexMatches(
+							regexp.MustCompile(`^[A-D0-9#*]{1}$`),
+							"alphanumeric characters",
+						),
+					},
 				},
-				CustomType:   fwtypes.NewListNestedObjectTypeOf[DialogState](ctx),
-				NestedObject: dialogStateNBO,
-			},
-			"failure_response":    responseSpecificationLNB,
-			"success_conditional": conditionalSpecificationLNB,
-			"success_next_step": schema.ListNestedBlock{
-				Validators: []validator.List{
-					listvalidator.SizeAtMost(1),
+				"end_character": schema.StringAttribute{
+					Required: true,
+					Validators: []validator.String{
+						stringvalidator.RegexMatches(
+							regexp.MustCompile(`^[A-D0-9#*]{1}$`),
+							"alphanumeric characters",
+						),
+					},
 				},
-				CustomType:   fwtypes.NewListNestedObjectTypeOf[DialogState](ctx),
-				NestedObject: dialogStateNBO,
-			},
-			"success_response":    responseSpecificationLNB,
-			"timeout_conditional": conditionalSpecificationLNB,
-			"timeout_next_step": schema.ListNestedBlock{
-				Validators: []validator.List{
-					listvalidator.SizeAtMost(1),
+				"end_timeout_ms": schema.Int64Attribute{
+					Required: true,
+					Validators: []validator.Int64{
+						int64validator.AtLeast(1),
+					},
 				},
-				CustomType:   fwtypes.NewListNestedObjectTypeOf[DialogState](ctx),
-				NestedObject: dialogStateNBO,
+				"max_length": schema.Int64Attribute{
+					Required: true,
+					Validators: []validator.Int64{
+						int64validator.Between(1, 1024),
+					},
+				},
 			},
-			"timeout_response": responseSpecificationLNB,
+		},
+	}
+
+	audioAndDTMFInputSpecificationLNB := schema.ListNestedBlock{
+		Validators: []validator.List{
+			listvalidator.SizeAtMost(1),
+		},
+		CustomType: fwtypes.NewListNestedObjectTypeOf[AudioAndDTMFInputSpecification](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"start_timeout_ms": schema.Int64Attribute{
+					Required: true,
+					Validators: []validator.Int64{
+						int64validator.AtLeast(1),
+					},
+				},
+			},
+			Blocks: map[string]schema.Block{
+				"audio_specification": audioSpecificationLNB,
+				"dtmf_specification":  dtmfSpecificationLNB,
+			},
+		},
+	}
+
+	textInputSpecificationLNB := schema.ListNestedBlock{
+		Validators: []validator.List{
+			listvalidator.SizeAtMost(1),
+		},
+		CustomType: fwtypes.NewListNestedObjectTypeOf[TextInputSpecification](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"start_timeout_ms": schema.Int64Attribute{
+					Required: true,
+					//Min:       1,
+				},
+			},
 		},
 	}
 
@@ -399,121 +615,245 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 				},
 			},
 			Blocks: map[string]schema.Block{
-				"allowed_input_types": schema.ListNestedBlock{
-					Validators: []validator.List{
-						listvalidator.SizeBetween(1, 1),
-					},
-					CustomType: fwtypes.NewListNestedObjectTypeOf[AllowedInputTypes](ctx),
-					NestedObject: schema.NestedBlockObject{
-						Attributes: map[string]schema.Attribute{
-							"allow_audio_input": schema.BoolAttribute{
-								Required: true,
-							},
-							"allow_dtmf_input": schema.BoolAttribute{
-								Required: true,
-							},
-						},
-					},
+				"allowed_input_types":                allowedInputTypesLNB,
+				"audio_and_dtmf_input_specification": audioAndDTMFInputSpecificationLNB,
+				"text_input_specification":           textInputSpecificationLNB,
+			},
+		},
+	}
+
+	promptSpecificationLNB := schema.ListNestedBlock{
+		Validators: []validator.List{
+			listvalidator.SizeBetween(1, 1),
+		},
+		CustomType: fwtypes.NewListNestedObjectTypeOf[PromptSpecification](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"allow_interrupt": schema.BoolAttribute{
+					Optional: true,
 				},
-				"audio_and_dtmf_input_specification": schema.ListNestedBlock{
-					Validators: []validator.List{
-						listvalidator.SizeAtMost(1),
-					},
-					CustomType: fwtypes.NewListNestedObjectTypeOf[AudioAndDTMFInputSpecification](ctx),
-					NestedObject: schema.NestedBlockObject{
-						Attributes: map[string]schema.Attribute{
-							"start_timeout_ms": schema.Int64Attribute{
-								Required: true,
-								Validators: []validator.Int64{
-									int64validator.AtLeast(1),
-								},
-							},
-						},
-						Blocks: map[string]schema.Block{
-							"audio_specification": schema.ListNestedBlock{
-								Validators: []validator.List{
-									listvalidator.SizeAtMost(1),
-								},
-								CustomType: fwtypes.NewListNestedObjectTypeOf[AudioSpecification](ctx),
-								NestedObject: schema.NestedBlockObject{
-									Attributes: map[string]schema.Attribute{
-										"end_timeout_ms": schema.Int64Attribute{
-											Required: true,
-											Validators: []validator.Int64{
-												int64validator.AtLeast(1),
-											},
-										},
-										"max_length_ms": schema.Int64Attribute{
-											Required: true,
-											Validators: []validator.Int64{
-												int64validator.AtLeast(1),
-											},
-										},
-									},
-								},
-							},
-							"dtmf_specification": schema.ListNestedBlock{
-								Validators: []validator.List{
-									listvalidator.SizeAtMost(1),
-								},
-								CustomType: fwtypes.NewListNestedObjectTypeOf[DTMFSpecification](ctx),
-								NestedObject: schema.NestedBlockObject{
-									Attributes: map[string]schema.Attribute{
-										"deletion_character": schema.StringAttribute{
-											Required: true,
-											Validators: []validator.String{
-												stringvalidator.RegexMatches(
-													regexp.MustCompile(`^[A-D0-9#*]{1}$`),
-													"alphanumeric characters",
-												),
-											},
-										},
-										"end_character": schema.StringAttribute{
-											Required: true,
-											Validators: []validator.String{
-												stringvalidator.RegexMatches(
-													regexp.MustCompile(`^[A-D0-9#*]{1}$`),
-													"alphanumeric characters",
-												),
-											},
-										},
-										"end_timeout_ms": schema.Int64Attribute{
-											Required: true,
-											Validators: []validator.Int64{
-												int64validator.AtLeast(1),
-											},
-										},
-										"max_length": schema.Int64Attribute{
-											Required: true,
-											Validators: []validator.Int64{
-												int64validator.Between(1, 1024),
-											},
-										},
-									},
-								},
-							},
-						},
-					},
+				"max_retries": schema.Int64Attribute{
+					Required: true,
 				},
-				"text_input_specification": schema.ListNestedBlock{
-					Validators: []validator.List{
-						listvalidator.SizeAtMost(1),
-					},
-					CustomType: fwtypes.NewListNestedObjectTypeOf[TextInputSpecification](ctx),
-					NestedObject: schema.NestedBlockObject{
-						Attributes: map[string]schema.Attribute{
-							"start_timeout_ms": schema.Int64Attribute{
-								Required: true,
-								//Min:       1,
-							},
-						},
-					},
+				"message_selection_strategy": schema.StringAttribute{
+					Optional:   true,
+					CustomType: fwtypes.StringEnumType[awstypes.MessageSelectionStrategy](),
+				},
+			},
+			Blocks: map[string]schema.Block{
+				"message_group":                 messageGroupLNB,
+				"prompt_attempts_specification": promptAttemptsSpecificationLNB,
+			},
+		},
+	}
+
+	failureSuccessTimeoutNBO := schema.NestedBlockObject{
+		Blocks: map[string]schema.Block{
+			"failure_conditional": conditionalSpecificationLNB,
+			"failure_next_step":   nextStepLNB,
+			"failure_response":    responseSpecificationLNB,
+			"success_conditional": conditionalSpecificationLNB,
+			"success_next_step":   nextStepLNB,
+			"success_response":    responseSpecificationLNB,
+			"timeout_conditional": conditionalSpecificationLNB,
+			"timeout_next_step":   nextStepLNB,
+			"timeout_response":    responseSpecificationLNB,
+		},
+	}
+
+	postCodeHookSpecificationLNB := schema.ListNestedBlock{
+		Validators: []validator.List{
+			listvalidator.SizeBetween(1, 1),
+		},
+		CustomType:   fwtypes.NewListNestedObjectTypeOf[FailureSuccessTimeout](ctx),
+		NestedObject: failureSuccessTimeoutNBO,
+	}
+
+	codeHookLNB := schema.ListNestedBlock{
+		Validators: []validator.List{
+			listvalidator.SizeAtMost(1),
+		},
+		CustomType: fwtypes.NewListNestedObjectTypeOf[DialogCodeHookInvocationSetting](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"active": schema.BoolAttribute{
+					Required: true,
+				},
+				"enable_code_hook_invocation": schema.BoolAttribute{
+					Required: true,
+				},
+				"invocation_label": schema.StringAttribute{
+					Optional: true,
+				},
+			},
+			Blocks: map[string]schema.Block{
+				"post_code_hook_specification": postCodeHookSpecificationLNB,
+			},
+		},
+	}
+
+	elicitationCodeHookInvocationSettingLNB := schema.ListNestedBlock{
+		Validators: []validator.List{
+			listvalidator.SizeAtMost(1),
+		},
+		CustomType: fwtypes.NewListNestedObjectTypeOf[FulfillmentStartResponseSpecification](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"enable_code_hook_invocation": schema.BoolAttribute{
+					Optional: true,
+				},
+				"invocation_label": schema.StringAttribute{
+					Optional: true,
 				},
 			},
 		},
 	}
 
-	// start of schema proper
+	confirmationSettingLNB := schema.ListNestedBlock{
+		Validators: []validator.List{
+			listvalidator.SizeAtMost(1),
+		},
+		CustomType: fwtypes.NewListNestedObjectTypeOf[IntentConfirmationSetting](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"active": schema.BoolAttribute{
+					Optional: true,
+				},
+			},
+			Blocks: map[string]schema.Block{
+				"code_hook":                codeHookLNB,
+				"confirmation_conditional": conditionalSpecificationLNB,
+				"confirmation_next_step":   nextStepLNB,
+				"confirmation_response":    responseSpecificationLNB,
+				"declination_conditional":  conditionalSpecificationLNB,
+				"declination_next_step":    nextStepLNB,
+				"declination_response":     responseSpecificationLNB,
+				"elicitation_code_hook":    elicitationCodeHookInvocationSettingLNB,
+				"failure_conditional":      conditionalSpecificationLNB,
+				"failure_next_step":        nextStepLNB,
+				"failure_response":         responseSpecificationLNB,
+				"prompt_specification":     promptSpecificationLNB,
+			},
+		},
+	}
+
+	initialResponseSettingLNB := schema.ListNestedBlock{
+		Validators: []validator.List{
+			listvalidator.SizeAtMost(1),
+		},
+		CustomType: fwtypes.NewListNestedObjectTypeOf[InitialResponseSetting](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Blocks: map[string]schema.Block{
+				"code_hook":        codeHookLNB,
+				"conditional":      conditionalSpecificationLNB,
+				"initial_response": responseSpecificationLNB,
+				"next_step":        nextStepLNB,
+			},
+		},
+	}
+
+	updateResponseLNB := schema.ListNestedBlock{
+		Validators: []validator.List{
+			listvalidator.SizeAtMost(1),
+		},
+		CustomType: fwtypes.NewListNestedObjectTypeOf[FulfillmentUpdateResponseSpecification](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"allow_interrupt": schema.BoolAttribute{
+					Optional: true,
+				},
+				"frequency_in_seconds": schema.Int64Attribute{
+					Required: true,
+				},
+			},
+			Blocks: map[string]schema.Block{
+				"message_group": messageGroupLNB,
+			},
+		},
+	}
+
+	startResponseLNB := schema.ListNestedBlock{
+		Validators: []validator.List{
+			listvalidator.SizeAtMost(1),
+		},
+		CustomType: fwtypes.NewListNestedObjectTypeOf[FulfillmentStartResponseSpecification](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"allow_interrupt": schema.BoolAttribute{
+					Optional: true,
+				},
+				"delay_in_seconds": schema.Int64Attribute{
+					Optional: true,
+				},
+			},
+			Blocks: map[string]schema.Block{
+				"message_group": messageGroupLNB,
+			},
+		},
+	}
+
+	fulfillmentUpdatesSpecificationLNB := schema.ListNestedBlock{
+		Validators: []validator.List{
+			listvalidator.SizeAtMost(1),
+		},
+		CustomType: fwtypes.NewListNestedObjectTypeOf[FulfillmentUpdatesSpecification](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"active": schema.BoolAttribute{
+					Required: true,
+				},
+				"timeout_in_seconds": schema.Int64Attribute{
+					Optional: true,
+				},
+			},
+			Blocks: map[string]schema.Block{
+				"start_response":  startResponseLNB,
+				"update_response": updateResponseLNB,
+			},
+		},
+	}
+
+	fulfillmentCodeHookLNB := schema.ListNestedBlock{
+		Validators: []validator.List{
+			listvalidator.SizeAtMost(1),
+		},
+		CustomType: fwtypes.NewListNestedObjectTypeOf[FulfillmentCodeHookSettings](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"active": schema.BoolAttribute{
+					Computed: true,
+				},
+				"enabled": schema.BoolAttribute{
+					Required: true,
+				},
+			},
+			Blocks: map[string]schema.Block{
+				"fulfillment_updates_specification": fulfillmentUpdatesSpecificationLNB,
+				"post_fulfillment_status_specification": schema.ListNestedBlock{
+					Validators: []validator.List{
+						listvalidator.SizeAtMost(1),
+					},
+					CustomType:   fwtypes.NewListNestedObjectTypeOf[FailureSuccessTimeout](ctx),
+					NestedObject: failureSuccessTimeoutNBO,
+				},
+			},
+		},
+	}
+
+	dialogCodeHookLNB := schema.ListNestedBlock{
+		Validators: []validator.List{
+			listvalidator.SizeAtMost(1),
+		},
+		CustomType: fwtypes.NewListNestedObjectTypeOf[DialogCodeHookSettings](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"enabled": schema.BoolAttribute{
+					Required: true,
+				},
+			},
+		},
+	}
+
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"bot_id": schema.StringAttribute{
@@ -554,312 +894,16 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 			},
 		},
 		Blocks: map[string]schema.Block{
-			"dialog_code_hook": schema.ListNestedBlock{
-				Validators: []validator.List{
-					listvalidator.SizeAtMost(1),
-				},
-				CustomType: fwtypes.NewListNestedObjectTypeOf[DialogCodeHookSettings](ctx),
-				NestedObject: schema.NestedBlockObject{
-					Attributes: map[string]schema.Attribute{
-						"enabled": schema.BoolAttribute{
-							Required: true,
-						},
-					},
-				},
-			},
-			"fulfillment_code_hook": schema.ListNestedBlock{
-				Validators: []validator.List{
-					listvalidator.SizeAtMost(1),
-				},
-				CustomType: fwtypes.NewListNestedObjectTypeOf[FulfillmentCodeHookSettings](ctx),
-				NestedObject: schema.NestedBlockObject{
-					Attributes: map[string]schema.Attribute{
-						"enabled": schema.BoolAttribute{
-							Required: true,
-						},
-						"active": schema.BoolAttribute{
-							Computed: true,
-						},
-					},
-					Blocks: map[string]schema.Block{
-						"fulfillment_updates_specification": schema.ListNestedBlock{
-							Validators: []validator.List{
-								listvalidator.SizeAtMost(1),
-							},
-							CustomType: fwtypes.NewListNestedObjectTypeOf[FulfillmentUpdatesSpecification](ctx),
-							NestedObject: schema.NestedBlockObject{
-								Attributes: map[string]schema.Attribute{
-									"active": schema.BoolAttribute{
-										Required: true,
-									},
-									"timeout_in_seconds": schema.Int64Attribute{
-										Optional: true,
-									},
-								},
-								Blocks: map[string]schema.Block{
-									"start_response": schema.ListNestedBlock{
-										Validators: []validator.List{
-											listvalidator.SizeAtMost(1),
-										},
-										CustomType: fwtypes.NewListNestedObjectTypeOf[FulfillmentStartResponseSpecification](ctx),
-										NestedObject: schema.NestedBlockObject{
-											Attributes: map[string]schema.Attribute{
-												"allow_interrupt": schema.BoolAttribute{
-													Optional: true,
-												},
-												"delay_in_seconds": schema.Int64Attribute{
-													Optional: true,
-												},
-											},
-											Blocks: map[string]schema.Block{
-												"message_group": schema.ListNestedBlock{
-													Validators: []validator.List{
-														listvalidator.SizeBetween(1, 5),
-													},
-													CustomType: fwtypes.NewListNestedObjectTypeOf[MessageGroup](ctx),
-													NestedObject: schema.NestedBlockObject{
-														Blocks: map[string]schema.Block{
-															"message": schema.ListNestedBlock{
-																Validators: []validator.List{
-																	listvalidator.SizeBetween(1, 1),
-																},
-																CustomType:   fwtypes.NewListNestedObjectTypeOf[Message](ctx),
-																NestedObject: messageNBO,
-															},
-															"variations": schema.ListNestedBlock{
-																CustomType:   fwtypes.NewListNestedObjectTypeOf[Message](ctx),
-																NestedObject: messageNBO,
-															},
-														},
-													},
-												},
-											},
-										},
-									},
-									"update_response": schema.ListNestedBlock{
-										Validators: []validator.List{
-											listvalidator.SizeAtMost(1),
-										},
-										CustomType: fwtypes.NewListNestedObjectTypeOf[FulfillmentUpdateResponseSpecification](ctx),
-										NestedObject: schema.NestedBlockObject{
-											Attributes: map[string]schema.Attribute{
-												"allow_interrupt": schema.BoolAttribute{
-													Optional: true,
-												},
-												"frequency_in_seconds": schema.Int64Attribute{
-													Required: true,
-												},
-											},
-											Blocks: map[string]schema.Block{
-												"message_group": messageGroupLNB,
-											},
-										},
-									},
-								},
-							},
-						},
-						"post_fulfillment_status_specification": schema.ListNestedBlock{
-							Validators: []validator.List{
-								listvalidator.SizeAtMost(1),
-							},
-							CustomType:   fwtypes.NewListNestedObjectTypeOf[FailureSuccessTimeout](ctx),
-							NestedObject: failureSuccessTimeoutNBO,
-						},
-					},
-				},
-			},
-			"initial_response_setting": schema.ListNestedBlock{
-				Validators: []validator.List{
-					listvalidator.SizeAtMost(1),
-				},
-				CustomType: fwtypes.NewListNestedObjectTypeOf[InitialResponseSetting](ctx),
-				NestedObject: schema.NestedBlockObject{
-					Blocks: map[string]schema.Block{
-						"code_hook": schema.ListNestedBlock{
-							Validators: []validator.List{
-								listvalidator.SizeAtMost(1),
-							},
-							CustomType: fwtypes.NewListNestedObjectTypeOf[DialogCodeHookInvocationSetting](ctx),
-							NestedObject: schema.NestedBlockObject{
-								Attributes: map[string]schema.Attribute{
-									"active": schema.BoolAttribute{
-										Required: true,
-									},
-									"enable_code_hook_invocation": schema.BoolAttribute{
-										Required: true,
-									},
-									"invocation_label": schema.StringAttribute{
-										Optional: true,
-									},
-								},
-								Blocks: map[string]schema.Block{
-									"post_code_hook_specification": schema.ListNestedBlock{
-										Validators: []validator.List{
-											listvalidator.SizeBetween(1, 1),
-										},
-										CustomType:   fwtypes.NewListNestedObjectTypeOf[FailureSuccessTimeout](ctx),
-										NestedObject: failureSuccessTimeoutNBO,
-									},
-								},
-							},
-						},
-						"conditional":      conditionalSpecificationLNB,
-						"initial_response": responseSpecificationLNB,
-						"next_step": schema.ListNestedBlock{
-							Validators: []validator.List{
-								listvalidator.SizeAtMost(1),
-							},
-							CustomType:   fwtypes.NewListNestedObjectTypeOf[DialogState](ctx),
-							NestedObject: dialogStateNBO,
-						},
-					},
-				},
-			},
-			"input_context": schema.ListNestedBlock{
-				Validators: []validator.List{
-					listvalidator.SizeAtMost(5),
-				},
-				CustomType: fwtypes.NewListNestedObjectTypeOf[InputContext](ctx),
-				NestedObject: schema.NestedBlockObject{
-					Attributes: map[string]schema.Attribute{
-						"name": schema.StringAttribute{
-							Required: true,
-						},
-					},
-				},
-			},
-			"closing_setting": schema.ListNestedBlock{
-				Validators: []validator.List{
-					listvalidator.SizeAtMost(1),
-				},
-				CustomType: fwtypes.NewListNestedObjectTypeOf[IntentClosingSetting](ctx),
-				NestedObject: schema.NestedBlockObject{
-					Attributes: map[string]schema.Attribute{
-						"active": schema.BoolAttribute{
-							Optional: true,
-						},
-					},
-					Blocks: map[string]schema.Block{
-						"closing_response": responseSpecificationLNB,
-						"conditional":      conditionalSpecificationLNB,
-						"next_step": schema.ListNestedBlock{
-							Validators: []validator.List{
-								listvalidator.SizeAtMost(1),
-							},
-							CustomType:   fwtypes.NewListNestedObjectTypeOf[DialogState](ctx),
-							NestedObject: dialogStateNBO,
-						},
-					},
-				},
-			},
-			"confirmation_setting": schema.ListNestedBlock{
-				Validators: []validator.List{
-					listvalidator.SizeAtMost(1),
-				},
-				CustomType: fwtypes.NewListNestedObjectTypeOf[IntentConfirmationSetting](ctx),
-				NestedObject: schema.NestedBlockObject{
-					Attributes: map[string]schema.Attribute{
-						"active": schema.BoolAttribute{
-							Optional: true,
-						},
-					},
-					Blocks: map[string]schema.Block{
-						"prompt_specification": schema.ListNestedBlock{
-							Validators: []validator.List{
-								listvalidator.SizeBetween(1, 1),
-							},
-							CustomType: fwtypes.NewListNestedObjectTypeOf[PromptSpecification](ctx),
-							NestedObject: schema.NestedBlockObject{
-								Attributes: map[string]schema.Attribute{
-									"allow_interrupt": schema.BoolAttribute{
-										Optional: true,
-									},
-									"max_retries": schema.Int64Attribute{
-										Required: true,
-									},
-									"message_selection_strategy": schema.StringAttribute{
-										Optional:   true,
-										CustomType: fwtypes.StringEnumType[awstypes.MessageSelectionStrategy](),
-									},
-								},
-								Blocks: map[string]schema.Block{
-									"message_group":                 messageGroupLNB,
-									"prompt_attempts_specification": promptAttemptsSpecificationLNB,
-								},
-							},
-						},
-						"conditional": conditionalSpecificationLNB,
-						"next_step": schema.ListNestedBlock{
-							Validators: []validator.List{
-								listvalidator.SizeAtMost(1),
-							},
-							CustomType:   fwtypes.NewListNestedObjectTypeOf[DialogState](ctx),
-							NestedObject: dialogStateNBO,
-						},
-					},
-				},
-			},
-			"kendra_configuration": schema.ListNestedBlock{
-				Validators: []validator.List{
-					listvalidator.SizeAtMost(1),
-				},
-				CustomType: fwtypes.NewListNestedObjectTypeOf[KendraConfiguration](ctx),
-				NestedObject: schema.NestedBlockObject{
-					Attributes: map[string]schema.Attribute{
-						"index": schema.StringAttribute{
-							Required: true,
-						},
-						"query_filter_string": schema.StringAttribute{
-							Optional: true,
-						},
-						"query_filter_string_enabled": schema.BoolAttribute{
-							Optional: true,
-						},
-					},
-				},
-			},
-			"output_context": schema.ListNestedBlock{
-				Validators: []validator.List{
-					listvalidator.SizeAtMost(10),
-				},
-				CustomType: fwtypes.NewListNestedObjectTypeOf[OutputContext](ctx),
-				NestedObject: schema.NestedBlockObject{
-					Attributes: map[string]schema.Attribute{
-						"name": schema.StringAttribute{
-							Required: true,
-						},
-						"time_to_live_in_seconds": schema.Int64Attribute{
-							Required: true,
-						},
-						"turns_to_live": schema.Int64Attribute{
-							Required: true,
-						},
-					},
-				},
-			},
-			"sample_utterance": schema.ListNestedBlock{
-				CustomType: fwtypes.NewListNestedObjectTypeOf[SampleUtterance](ctx),
-				NestedObject: schema.NestedBlockObject{
-					Attributes: map[string]schema.Attribute{
-						"utterance": schema.StringAttribute{
-							Required: true,
-						},
-					},
-				},
-			},
-			"slot_priority": schema.ListNestedBlock{
-				CustomType: fwtypes.NewListNestedObjectTypeOf[SlotPriority](ctx),
-				NestedObject: schema.NestedBlockObject{
-					Attributes: map[string]schema.Attribute{
-						"priority": schema.Int64Attribute{
-							Required: true,
-						},
-						"slot_id": schema.StringAttribute{
-							Required: true,
-						},
-					},
-				},
-			},
+			"dialog_code_hook":         dialogCodeHookLNB,
+			"fulfillment_code_hook":    fulfillmentCodeHookLNB,
+			"initial_response_setting": initialResponseSettingLNB,
+			"input_context":            inputContextLNB,
+			"closing_setting":          closingSettingLNB,
+			"confirmation_setting":     confirmationSettingLNB,
+			"kendra_configuration":     kendraConfigurationLNB,
+			"output_context":           outputContextLNB,
+			"sample_utterance":         sampleUtteranceLNB,
+			"slot_priority":            slotPriorityLNB,
 			"timeouts": timeouts.Block(ctx, timeouts.Opts{
 				Create: true,
 				Update: true,
@@ -1194,6 +1238,249 @@ func (PromptAttemptsType) Values() []PromptAttemptsType {
 	}
 }
 
+type SlotPriority struct {
+	Priority types.Int64  `tfsdk:"priority"`
+	SlotID   types.String `tfsdk:"slot_id"`
+}
+
+type SampleUtterance struct {
+	Utterance types.String `tfsdk:"utterance"`
+}
+
+type OutputContext struct {
+	Name                types.String `tfsdk:"name"`
+	TimeToLiveInSeconds types.Int64  `tfsdk:"time_to_live_in_seconds"`
+	TurnsToLive         types.Int64  `tfsdk:"turns_to_live"`
+}
+
+type KendraConfiguration struct {
+	KendraIndex              types.String `tfsdk:"kendra_index"`
+	QueryFilterString        types.String `tfsdk:"query_filter_string"`
+	QueryFilterStringEnabled types.Bool   `tfsdk:"query_filter_string_enabled"`
+}
+
+type CustomPayload struct {
+	Value types.String `tfsdk:"value"`
+}
+
+type Button struct {
+	Text  types.String `tfsdk:"text"`
+	Value types.String `tfsdk:"value"`
+}
+
+type ImageResponseCard struct {
+	Button   fwtypes.ListNestedObjectValueOf[Button] `tfsdk:"button"`
+	ImageURL types.String                            `tfsdk:"image_url"`
+	Subtitle types.String                            `tfsdk:"subtitle"`
+	Title    types.String                            `tfsdk:"title"`
+}
+
+type PlainTextMessage struct {
+	Value types.String `tfsdk:"value"`
+}
+
+type SSMLMessage struct {
+	Value types.String `tfsdk:"value"`
+}
+
+type Message struct {
+	CustomPayload     fwtypes.ListNestedObjectValueOf[CustomPayload]     `tfsdk:"custom_payload"`
+	ImageResponseCard fwtypes.ListNestedObjectValueOf[ImageResponseCard] `tfsdk:"image_response_card"`
+	PlainTextMessage  fwtypes.ListNestedObjectValueOf[PlainTextMessage]  `tfsdk:"plain_text_message"`
+	SSMLMessage       fwtypes.ListNestedObjectValueOf[SSMLMessage]       `tfsdk:"ssml_message"`
+}
+
+type MessageGroup struct {
+	Message   fwtypes.ListNestedObjectValueOf[Message] `tfsdk:"message"`
+	Variation fwtypes.ListNestedObjectValueOf[Message] `tfsdk:"variation"`
+}
+
+type SlotValue struct {
+	InterpretedValue types.String `tfsdk:"interpreted_value"`
+}
+
+type SlotValueOverride struct {
+	MapBlockKey types.String                               `tfsdk:"map_block_key"`
+	Shape       fwtypes.StringEnum[awstypes.SlotShape]     `tfsdk:"shape"`
+	Value       fwtypes.ListNestedObjectValueOf[SlotValue] `tfsdk:"value"`
+	//Values fwtypes.ListNestedObjectValueOf[SlotValueOverride] `tfsdk:"values"` // recursive type, future support, needs additional development
+}
+
+type DialogAction struct {
+	Type                fwtypes.StringEnum[awstypes.DialogActionType] `tfsdk:"type"`
+	SlotToElicit        types.String                                  `tfsdk:"slot_to_elicit"`
+	SuppressNextMessage types.Bool                                    `tfsdk:"suppress_next_message"`
+}
+
+type IntentOverride struct {
+	Name types.String                                       `tfsdk:"name"`
+	Slot fwtypes.ListNestedObjectValueOf[SlotValueOverride] `tfsdk:"slot"`
+}
+
+type DialogState struct {
+	DialogAction      fwtypes.ListNestedObjectValueOf[DialogAction]   `tfsdk:"dialog_action"`
+	Intent            fwtypes.ListNestedObjectValueOf[IntentOverride] `tfsdk:"intent"`
+	SessionAttributes fwtypes.MapValueOf[basetypes.StringValue]       `tfsdk:"session_attributes"`
+}
+
+type ResponseSpecification struct {
+	AllowInterrupt types.Bool                                    `tfsdk:"allow_interrupt"`
+	MessageGroup   fwtypes.ListNestedObjectValueOf[MessageGroup] `tfsdk:"message_group"`
+}
+
+type Condition struct {
+	ExpressionString types.String `tfsdk:"expression_string"`
+}
+
+type ConditionalBranch struct {
+	Condition fwtypes.ListNestedObjectValueOf[Condition]             `tfsdk:"condition"`
+	Name      types.String                                           `tfsdk:"name"`
+	NextStep  fwtypes.ListNestedObjectValueOf[DialogState]           `tfsdk:"next_step"`
+	Response  fwtypes.ListNestedObjectValueOf[ResponseSpecification] `tfsdk:"response"`
+}
+
+type DefaultConditionalBranch struct {
+	NextStep fwtypes.ListNestedObjectValueOf[DialogState]           `tfsdk:"next_step"`
+	Response fwtypes.ListNestedObjectValueOf[ResponseSpecification] `tfsdk:"response"`
+}
+
+type ConditionalSpecification struct {
+	Active            types.Bool                                                `tfsdk:"active"`
+	ConditionalBranch fwtypes.ListNestedObjectValueOf[ConditionalBranch]        `tfsdk:"conditional_branch"`
+	DefaultBranch     fwtypes.ListNestedObjectValueOf[DefaultConditionalBranch] `tfsdk:"default_branch"`
+}
+
+type IntentClosingSetting struct {
+	Active          types.Bool                                                `tfsdk:"active"`
+	ClosingResponse fwtypes.ListNestedObjectValueOf[ResponseSpecification]    `tfsdk:"closing_response"`
+	Conditional     fwtypes.ListNestedObjectValueOf[ConditionalSpecification] `tfsdk:"conditional"`
+	NextStep        fwtypes.ListNestedObjectValueOf[DialogState]              `tfsdk:"next_step"`
+}
+
+type InputContext struct {
+	Name types.String `tfsdk:"name"`
+}
+
+type AllowedInputTypes struct {
+	AllowAudioInput types.Bool `tfsdk:"allow_audio_input"`
+	AllowDTMFInput  types.Bool `tfsdk:"allow_dtmf_input"`
+}
+
+type AudioSpecification struct {
+	EndTimeoutMs types.Int64 `tfsdk:"end_timeout_ms"`
+	MaxLengthMs  types.Int64 `tfsdk:"max_length_ms"`
+}
+
+type DTMFSpecification struct {
+	DeletionCharacter types.String `tfsdk:"deletion_character"`
+	EndCharacter      types.String `tfsdk:"end_character"`
+	EndTimeoutMs      types.Int64  `tfsdk:"end_timeout_ms"`
+	MaxLength         types.Int64  `tfsdk:"max_length"`
+}
+
+type AudioAndDTMFInputSpecification struct {
+	StartTimeoutMs     types.Int64                                         `tfsdk:"start_timeout_ms"`
+	AudioSpecification fwtypes.ListNestedObjectValueOf[AudioSpecification] `tfsdk:"audio_specification"`
+	DTMFSpecification  fwtypes.ListNestedObjectValueOf[DTMFSpecification]  `tfsdk:"dtmf_specification"`
+}
+
+type TextInputSpecification struct {
+	StartTimeoutMs types.Int64 `tfsdk:"start_timeout_ms"`
+}
+
+type PromptAttemptsSpecification struct {
+	AllowedInputTypes              fwtypes.ListNestedObjectValueOf[AllowedInputTypes]              `tfsdk:"allowed_input_types"`
+	AllowInterrupt                 types.Bool                                                      `tfsdk:"allow_interrupt"`
+	AudioAndDTMFInputSpecification fwtypes.ListNestedObjectValueOf[AudioAndDTMFInputSpecification] `tfsdk:"audio_and_dtmf_input_specification"`
+	MapBlockKey                    fwtypes.StringEnum[PromptAttemptsType]                          `tfsdk:"map_block_key"`
+	TextInputSpecification         fwtypes.ListNestedObjectValueOf[TextInputSpecification]         `tfsdk:"text_input_specification"`
+}
+
+type PromptSpecification struct {
+	AllowInterrupt              types.Bool                                                   `tfsdk:"allow_interrupt"`
+	MaxRetries                  types.Int64                                                  `tfsdk:"max_retries"`
+	MessageGroup                fwtypes.ListNestedObjectValueOf[MessageGroup]                `tfsdk:"message_groups"`
+	MessageSelectionStrategy    fwtypes.StringEnum[awstypes.MessageSelectionStrategy]        `tfsdk:"message_selection_strategy"`
+	PromptAttemptsSpecification fwtypes.ListNestedObjectValueOf[PromptAttemptsSpecification] `tfsdk:"prompt_attempts_specification"`
+}
+
+type FailureSuccessTimeout struct {
+	FailureConditional fwtypes.ListNestedObjectValueOf[ConditionalSpecification] `tfsdk:"failure_conditional"`
+	FailureNextStep    fwtypes.ListNestedObjectValueOf[DialogState]              `tfsdk:"failure_next_step"`
+	FailureResponse    fwtypes.ListNestedObjectValueOf[ResponseSpecification]    `tfsdk:"failure_response"`
+	SuccessConditional fwtypes.ListNestedObjectValueOf[ConditionalSpecification] `tfsdk:"success_conditional"`
+	SuccessNextStep    fwtypes.ListNestedObjectValueOf[DialogState]              `tfsdk:"success_next_step"`
+	SuccessResponse    fwtypes.ListNestedObjectValueOf[ResponseSpecification]    `tfsdk:"success_response"`
+	TimeoutConditional fwtypes.ListNestedObjectValueOf[ConditionalSpecification] `tfsdk:"timeout_conditional"`
+	TimeoutNextStep    fwtypes.ListNestedObjectValueOf[DialogState]              `tfsdk:"timeout_next_step"`
+	TimeoutResponse    fwtypes.ListNestedObjectValueOf[ResponseSpecification]    `tfsdk:"timeout_response"`
+}
+
+type DialogCodeHookInvocationSetting struct {
+	Active                    types.Bool                                             `tfsdk:"active"`
+	EnableCodeHookInvocation  types.Bool                                             `tfsdk:"enable_code_hook_invocation"`
+	InvocationLabel           types.String                                           `tfsdk:"invocation_label"`
+	PostCodeHookSpecification fwtypes.ListNestedObjectValueOf[FailureSuccessTimeout] `tfsdk:"post_code_hook_specification"`
+}
+
+type ElicitationCodeHookInvocationSetting struct {
+	EnableCodeHookInvocation types.Bool   `tfsdk:"enable_code_hook_invocation"`
+	InvocationLabel          types.String `tfsdk:"invocation_label"`
+}
+
+type IntentConfirmationSetting struct {
+	Active                  types.Bool                                                            `tfsdk:"active"`
+	CodeHook                fwtypes.ListNestedObjectValueOf[DialogCodeHookInvocationSetting]      `tfsdk:"code_hook"`
+	ConfirmationConditional fwtypes.ListNestedObjectValueOf[ConditionalSpecification]             `tfsdk:"confirmation_conditional"`
+	ConfirmationNextStep    fwtypes.ListNestedObjectValueOf[DialogState]                          `tfsdk:"confirmation_next_step"`
+	ConfirmationResponse    fwtypes.ListNestedObjectValueOf[ResponseSpecification]                `tfsdk:"confirmation_response"`
+	DeclinationConditional  fwtypes.ListNestedObjectValueOf[ConditionalSpecification]             `tfsdk:"declination_conditional"`
+	DeclinationNextStep     fwtypes.ListNestedObjectValueOf[DialogState]                          `tfsdk:"declination_next_step"`
+	DeclinationResponse     fwtypes.ListNestedObjectValueOf[ResponseSpecification]                `tfsdk:"declination_response"`
+	ElicitationCodeHook     fwtypes.ListNestedObjectValueOf[ElicitationCodeHookInvocationSetting] `tfsdk:"elicitation_code_hook"`
+	FailureConditional      fwtypes.ListNestedObjectValueOf[ConditionalSpecification]             `tfsdk:"failure_conditional"`
+	FailureNextStep         fwtypes.ListNestedObjectValueOf[DialogState]                          `tfsdk:"failure_next_step"`
+	FailureResponse         fwtypes.ListNestedObjectValueOf[ResponseSpecification]                `tfsdk:"failure_response"`
+	PromptSpecification     fwtypes.ListNestedObjectValueOf[PromptSpecification]                  `tfsdk:"prompt_specification"`
+}
+
+type InitialResponseSetting struct {
+	CodeHook        fwtypes.ListNestedObjectValueOf[DialogCodeHookInvocationSetting] `tfsdk:"code_hook"`
+	Conditional     fwtypes.ListNestedObjectValueOf[ConditionalSpecification]        `tfsdk:"conditional"`
+	InitialResponse fwtypes.ListNestedObjectValueOf[ResponseSpecification]           `tfsdk:"initial_response"`
+	NextStep        fwtypes.ListNestedObjectValueOf[DialogState]                     `tfsdk:"next_step"`
+}
+
+type FulfillmentUpdateResponseSpecification struct {
+	AllowInterrupt     types.Bool                                    `tfsdk:"allow_interrupt"`
+	FrequencyInSeconds types.Int64                                   `tfsdk:"frequency_in_seconds"`
+	MessageGroup       fwtypes.ListNestedObjectValueOf[MessageGroup] `tfsdk:"message_group"`
+}
+
+type FulfillmentStartResponseSpecification struct {
+	AllowInterrupt types.Bool                                    `tfsdk:"allow_interrupt"`
+	DelayInSeconds types.Int64                                   `tfsdk:"delay_in_seconds"`
+	MessageGroup   fwtypes.ListNestedObjectValueOf[MessageGroup] `tfsdk:"message_group"`
+}
+
+type FulfillmentUpdatesSpecification struct {
+	Active           types.Bool                                                              `tfsdk:"active"`
+	StartResponse    fwtypes.ListNestedObjectValueOf[FulfillmentStartResponseSpecification]  `tfsdk:"start_response"`
+	TimeoutInSeconds types.Int64                                                             `tfsdk:"timeout_in_seconds"`
+	UpdateResponse   fwtypes.ListNestedObjectValueOf[FulfillmentUpdateResponseSpecification] `tfsdk:"update_response"`
+}
+
+type FulfillmentCodeHookSettings struct {
+	Active                             types.Bool                                                       `tfsdk:"active"`
+	Enabled                            types.Bool                                                       `tfsdk:"enabled"`
+	FulfillmentUpdatesSpecification    fwtypes.ListNestedObjectValueOf[FulfillmentUpdatesSpecification] `tfsdk:"fulfillment_updates_specification"`
+	PostFulfillmentStatusSpecification fwtypes.ListNestedObjectValueOf[FailureSuccessTimeout]           `tfsdk:"post_fulfillment_status_specification"`
+}
+
+type DialogCodeHookSettings struct {
+	Enabled types.Bool `tfsdk:"enabled"`
+}
+
 type ResourceIntentData struct {
 	BotID                  types.String                                                 `tfsdk:"bot_id"`
 	BotVersion             types.String                                                 `tfsdk:"bot_version"`
@@ -1216,247 +1503,4 @@ type ResourceIntentData struct {
 	SampleUtterance        fwtypes.ListNestedObjectValueOf[SampleUtterance]             `tfsdk:"sample_utterance"`
 	SlotPriority           fwtypes.ListNestedObjectValueOf[SlotPriority]                `tfsdk:"slot_priority"`
 	Timeouts               timeouts.Value                                               `tfsdk:"timeouts"`
-}
-
-type IntentClosingSetting struct {
-	Active          types.Bool                                                `tfsdk:"active"`
-	ClosingResponse fwtypes.ListNestedObjectValueOf[ResponseSpecification]    `tfsdk:"closing_response"`
-	Conditional     fwtypes.ListNestedObjectValueOf[ConditionalSpecification] `tfsdk:"conditional"`
-	NextStep        fwtypes.ListNestedObjectValueOf[DialogState]              `tfsdk:"next_step"`
-}
-
-type ResponseSpecification struct {
-	MessageGroup   fwtypes.ListNestedObjectValueOf[MessageGroup] `tfsdk:"message_group"`
-	AllowInterrupt types.Bool                                    `tfsdk:"allow_interrupt"`
-}
-
-type MessageGroup struct {
-	Message    fwtypes.ListNestedObjectValueOf[Message] `tfsdk:"message"`
-	Variations fwtypes.ListNestedObjectValueOf[Message] `tfsdk:"variations"`
-}
-
-type Message struct {
-	CustomPayload     fwtypes.ListNestedObjectValueOf[CustomPayload]     `tfsdk:"custom_payload"`
-	ImageResponseCard fwtypes.ListNestedObjectValueOf[ImageResponseCard] `tfsdk:"image_response_card"`
-	PlainTextMessage  fwtypes.ListNestedObjectValueOf[PlainTextMessage]  `tfsdk:"plain_text_message"`
-	SSMLMessage       fwtypes.ListNestedObjectValueOf[SSMLMessage]       `tfsdk:"ssml_message"`
-}
-
-type CustomPayload struct {
-	Value types.String `tfsdk:"value"`
-}
-
-type ImageResponseCard struct {
-	Title    types.String                            `tfsdk:"title"`
-	Button   fwtypes.ListNestedObjectValueOf[Button] `tfsdk:"buttons"`
-	ImageURL types.String                            `tfsdk:"image_url"`
-	Subtitle types.String                            `tfsdk:"subtitle"`
-}
-
-type Button struct {
-	Text  types.String `tfsdk:"text"`
-	Value types.String `tfsdk:"value"`
-}
-
-type PlainTextMessage struct {
-	Value types.String `tfsdk:"value"`
-}
-
-type SSMLMessage struct {
-	Value types.String `tfsdk:"value"`
-}
-
-type ConditionalSpecification struct {
-	Active            types.Bool                                                `tfsdk:"active"`
-	ConditionalBranch fwtypes.ListNestedObjectValueOf[ConditionalBranch]        `tfsdk:"conditional_branch"`
-	DefaultBranch     fwtypes.ListNestedObjectValueOf[DefaultConditionalBranch] `tfsdk:"default_branch"`
-}
-
-type ConditionalBranch struct {
-	Condition fwtypes.ListNestedObjectValueOf[Condition]             `tfsdk:"condition"`
-	Name      types.String                                           `tfsdk:"name"`
-	NextStep  fwtypes.ListNestedObjectValueOf[DialogState]           `tfsdk:"next_step"`
-	Response  fwtypes.ListNestedObjectValueOf[ResponseSpecification] `tfsdk:"response"`
-}
-
-type Condition struct {
-	ExpressionString types.String `tfsdk:"expression_string"`
-}
-
-type DialogState struct {
-	DialogAction      fwtypes.ListNestedObjectValueOf[DialogAction]   `tfsdk:"dialog_action"`
-	Intent            fwtypes.ListNestedObjectValueOf[IntentOverride] `tfsdk:"intent"`
-	SessionAttributes fwtypes.MapValueOf[basetypes.StringValue]       `tfsdk:"session_attributes"`
-}
-
-type DialogAction struct {
-	Type                fwtypes.StringEnum[awstypes.DialogActionType] `tfsdk:"type"`
-	SlotToElicit        types.String                                  `tfsdk:"slot_to_elicit"`
-	SuppressNextMessage types.Bool                                    `tfsdk:"suppress_next_message"`
-}
-
-type IntentOverride struct {
-	Name types.String                                       `tfsdk:"name"`
-	Slot fwtypes.ListNestedObjectValueOf[SlotValueOverride] `tfsdk:"slot"`
-}
-
-type SlotValueOverride struct {
-	MapBlockKey types.String                               `tfsdk:"map_block_key"`
-	Shape       fwtypes.StringEnum[awstypes.SlotShape]     `tfsdk:"shape"`
-	Value       fwtypes.ListNestedObjectValueOf[SlotValue] `tfsdk:"value"`
-	//Values fwtypes.ListNestedObjectValueOf[SlotValueOverride] `tfsdk:"values"` // recursive type, future support, needs additional development
-}
-
-type SlotValue struct {
-	InterpretedValue types.String `tfsdk:"interpreted_value"`
-}
-
-type DefaultConditionalBranch struct {
-	NextStep fwtypes.ListNestedObjectValueOf[DialogState]           `tfsdk:"next_step"`
-	Response fwtypes.ListNestedObjectValueOf[ResponseSpecification] `tfsdk:"response"`
-}
-
-type IntentConfirmationSetting struct {
-	PromptSpecification     fwtypes.ListNestedObjectValueOf[PromptSpecification]                  `tfsdk:"prompt_specification"`
-	Active                  types.Bool                                                            `tfsdk:"active"`
-	CodeHook                fwtypes.ListNestedObjectValueOf[DialogCodeHookInvocationSetting]      `tfsdk:"code_hook"`
-	ConfirmationConditional fwtypes.ListNestedObjectValueOf[ConditionalSpecification]             `tfsdk:"confirmation_conditional"`
-	ConfirmationNextStep    fwtypes.ListNestedObjectValueOf[DialogState]                          `tfsdk:"confirmation_next_step"`
-	ConfirmationResponse    fwtypes.ListNestedObjectValueOf[ResponseSpecification]                `tfsdk:"confirmation_response"`
-	DeclinationConditional  fwtypes.ListNestedObjectValueOf[ConditionalSpecification]             `tfsdk:"declination_conditional"`
-	DeclinationNextStep     fwtypes.ListNestedObjectValueOf[DialogState]                          `tfsdk:"declination_next_step"`
-	DeclinationResponse     fwtypes.ListNestedObjectValueOf[ResponseSpecification]                `tfsdk:"declination_response"`
-	ElicitationCodeHook     fwtypes.ListNestedObjectValueOf[ElicitationCodeHookInvocationSetting] `tfsdk:"elicitation_code_hook"`
-	FailureConditional      fwtypes.ListNestedObjectValueOf[ConditionalSpecification]             `tfsdk:"failure_conditional"`
-	FailureNextStep         fwtypes.ListNestedObjectValueOf[DialogState]                          `tfsdk:"failure_next_step"`
-	FailureResponse         fwtypes.ListNestedObjectValueOf[ResponseSpecification]                `tfsdk:"failure_response"`
-}
-
-type PromptSpecification struct {
-	MaxRetries                  types.Int64                                                  `tfsdk:"max_retries"`
-	MessageGroup                fwtypes.ListNestedObjectValueOf[MessageGroup]                `tfsdk:"message_groups"`
-	AllowInterrupt              types.Bool                                                   `tfsdk:"allow_interrupt"`
-	MessageSelectionStrategy    fwtypes.StringEnum[awstypes.MessageSelectionStrategy]        `tfsdk:"message_selection_strategy"`
-	PromptAttemptsSpecification fwtypes.ListNestedObjectValueOf[PromptAttemptsSpecification] `tfsdk:"prompt_attempts_specification"`
-}
-
-type PromptAttemptsSpecification struct {
-	MapBlockKey                    fwtypes.StringEnum[PromptAttemptsType]                          `tfsdk:"map_block_key"`
-	AllowedInputTypes              fwtypes.ListNestedObjectValueOf[AllowedInputTypes]              `tfsdk:"allowed_input_types"`
-	AllowInterrupt                 types.Bool                                                      `tfsdk:"allow_interrupt"`
-	AudioAndDTMFInputSpecification fwtypes.ListNestedObjectValueOf[AudioAndDTMFInputSpecification] `tfsdk:"audio_and_dtmf_input_specification"`
-	TextInputSpecification         fwtypes.ListNestedObjectValueOf[TextInputSpecification]         `tfsdk:"text_input_specification"`
-}
-
-type AllowedInputTypes struct {
-	AllowAudioInput types.Bool `tfsdk:"allow_audio_input"`
-	AllowDTMFInput  types.Bool `tfsdk:"allow_dtmf_input"`
-}
-
-type AudioAndDTMFInputSpecification struct {
-	StartTimeoutMs     types.Int64                                         `tfsdk:"start_timeout_ms"`
-	AudioSpecification fwtypes.ListNestedObjectValueOf[AudioSpecification] `tfsdk:"audio_specification"`
-	DTMFSpecification  fwtypes.ListNestedObjectValueOf[DTMFSpecification]  `tfsdk:"dtmf_specification"`
-}
-
-type AudioSpecification struct {
-	EndTimeoutMs types.Int64 `tfsdk:"end_timeout_ms"`
-	MaxLengthMs  types.Int64 `tfsdk:"max_length_ms"`
-}
-
-type DTMFSpecification struct {
-	DeletionCharacter types.String `tfsdk:"deletion_character"`
-	EndCharacter      types.String `tfsdk:"end_character"`
-	EndTimeoutMs      types.Int64  `tfsdk:"end_timeout_ms"`
-	MaxLength         types.Int64  `tfsdk:"max_length"`
-}
-
-type TextInputSpecification struct {
-	StartTimeoutMs types.Int64 `tfsdk:"start_timeout_ms"`
-}
-
-type DialogCodeHookInvocationSetting struct {
-	Active                    types.Bool                                             `tfsdk:"active"`
-	EnableCodeHookInvocation  types.Bool                                             `tfsdk:"enable_code_hook_invocation"`
-	PostCodeHookSpecification fwtypes.ListNestedObjectValueOf[FailureSuccessTimeout] `tfsdk:"post_code_hook_specification"`
-	InvocationLabel           types.String                                           `tfsdk:"invocation_label"`
-}
-
-type FailureSuccessTimeout struct {
-	FailureConditional fwtypes.ListNestedObjectValueOf[ConditionalSpecification] `tfsdk:"failure_conditional"`
-	FailureNextStep    fwtypes.ListNestedObjectValueOf[DialogState]              `tfsdk:"failure_next_step"`
-	FailureResponse    fwtypes.ListNestedObjectValueOf[ResponseSpecification]    `tfsdk:"failure_response"`
-	SuccessConditional fwtypes.ListNestedObjectValueOf[ConditionalSpecification] `tfsdk:"success_conditional"`
-	SuccessNextStep    fwtypes.ListNestedObjectValueOf[DialogState]              `tfsdk:"success_next_step"`
-	SuccessResponse    fwtypes.ListNestedObjectValueOf[ResponseSpecification]    `tfsdk:"success_response"`
-	TimeoutConditional fwtypes.ListNestedObjectValueOf[ConditionalSpecification] `tfsdk:"timeout_conditional"`
-	TimeoutNextStep    fwtypes.ListNestedObjectValueOf[DialogState]              `tfsdk:"timeout_next_step"`
-	TimeoutResponse    fwtypes.ListNestedObjectValueOf[ResponseSpecification]    `tfsdk:"timeout_response"`
-}
-
-type ElicitationCodeHookInvocationSetting struct {
-	EnableCodeHookInvocation types.Bool   `tfsdk:"enable_code_hook_invocation"`
-	InvocationLabel          types.String `tfsdk:"invocation_label"`
-}
-
-type DialogCodeHookSettings struct {
-	Enabled types.Bool `tfsdk:"enabled"`
-}
-
-type FulfillmentCodeHookSettings struct {
-	Enabled                            types.Bool                                                       `tfsdk:"enabled"`
-	Active                             types.Bool                                                       `tfsdk:"active"`
-	FulfillmentUpdatesSpecification    fwtypes.ListNestedObjectValueOf[FulfillmentUpdatesSpecification] `tfsdk:"fulfillment_updates_specification"`
-	PostFulfillmentStatusSpecification fwtypes.ListNestedObjectValueOf[FailureSuccessTimeout]           `tfsdk:"post_fulfillment_status_specification"`
-}
-
-type FulfillmentUpdatesSpecification struct {
-	Active           types.Bool                                                              `tfsdk:"active"`
-	StartResponse    fwtypes.ListNestedObjectValueOf[FulfillmentStartResponseSpecification]  `tfsdk:"start_response"`
-	TimeoutInSeconds types.Int64                                                             `tfsdk:"timeout_in_seconds"`
-	UpdateResponse   fwtypes.ListNestedObjectValueOf[FulfillmentUpdateResponseSpecification] `tfsdk:"update_response"`
-}
-
-type FulfillmentStartResponseSpecification struct {
-	DelayInSeconds types.Int64                                   `tfsdk:"delay_in_seconds"`
-	MessageGroup   fwtypes.ListNestedObjectValueOf[MessageGroup] `tfsdk:"message_group"`
-	AllowInterrupt types.Bool                                    `tfsdk:"allow_interrupt"`
-}
-
-type FulfillmentUpdateResponseSpecification struct {
-	FrequencyInSeconds types.Int64                                   `tfsdk:"frequency_in_seconds"`
-	MessageGroup       fwtypes.ListNestedObjectValueOf[MessageGroup] `tfsdk:"message_group"`
-	AllowInterrupt     types.Bool                                    `tfsdk:"allow_interrupt"`
-}
-
-type InitialResponseSetting struct {
-	CodeHook        fwtypes.ListNestedObjectValueOf[DialogCodeHookInvocationSetting] `tfsdk:"code_hook"`
-	Conditional     fwtypes.ListNestedObjectValueOf[ConditionalSpecification]        `tfsdk:"conditional"`
-	InitialResponse fwtypes.ListNestedObjectValueOf[ResponseSpecification]           `tfsdk:"initial_response"`
-	NextStep        fwtypes.ListNestedObjectValueOf[DialogState]                     `tfsdk:"next_step"`
-}
-
-type InputContext struct {
-	Name types.String `tfsdk:"name"`
-}
-
-type KendraConfiguration struct {
-	KendraIndex              types.String `tfsdk:"kendra_index"`
-	QueryFilterString        types.String `tfsdk:"query_filter_string"`
-	QueryFilterStringEnabled types.Bool   `tfsdk:"query_filter_string_enabled"`
-}
-
-type OutputContext struct {
-	Name                types.String `tfsdk:"name"`
-	TimeToLiveInSeconds types.Int64  `tfsdk:"time_to_live_in_seconds"`
-	TurnsToLive         types.Int64  `tfsdk:"turns_to_live"`
-}
-
-type SampleUtterance struct {
-	Utterance types.String `tfsdk:"utterance"`
-}
-
-type SlotPriority struct {
-	Priority types.Int64  `tfsdk:"priority"`
-	SlotID   types.String `tfsdk:"slot_id"`
 }

--- a/internal/service/lexv2models/intent.go
+++ b/internal/service/lexv2models/intent.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -225,7 +226,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 
 	messageNBO := schema.NestedBlockObject{
 		Blocks: map[string]schema.Block{
-			"custom_playload":     customPayloadLNB,
+			"custom_payload":      customPayloadLNB,
 			"image_response_card": imageResponseCardLNB,
 			"plain_text_message":  plainTextMessageLNB,
 			"ssml_message":        ssmlMessageLNB,
@@ -599,11 +600,11 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 		},
 	}
 
-	promptAttemptsSpecificationLNB := schema.ListNestedBlock{
-		Validators: []validator.List{
-			listvalidator.SizeAtMost(1),
+	promptAttemptsSpecificationLNB := schema.SetNestedBlock{
+		Validators: []validator.Set{
+			setvalidator.SizeAtMost(6),
 		},
-		CustomType: fwtypes.NewListNestedObjectTypeOf[PromptAttemptsSpecification](ctx),
+		CustomType: fwtypes.NewSetNestedObjectTypeOf[PromptAttemptsSpecification](ctx),
 		NestedObject: schema.NestedBlockObject{
 			Attributes: map[string]schema.Attribute{
 				"map_block_key": schema.StringAttribute{
@@ -696,7 +697,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 		Validators: []validator.List{
 			listvalidator.SizeAtMost(1),
 		},
-		CustomType: fwtypes.NewListNestedObjectTypeOf[FulfillmentStartResponseSpecification](ctx),
+		CustomType: fwtypes.NewListNestedObjectTypeOf[ElicitationCodeHookInvocationSetting](ctx),
 		NestedObject: schema.NestedBlockObject{
 			Attributes: map[string]schema.Attribute{
 				"enable_code_hook_invocation": schema.BoolAttribute{
@@ -1397,11 +1398,11 @@ type PromptAttemptsSpecification struct {
 }
 
 type PromptSpecification struct {
-	AllowInterrupt              types.Bool                                                   `tfsdk:"allow_interrupt"`
-	MaxRetries                  types.Int64                                                  `tfsdk:"max_retries"`
-	MessageGroup                fwtypes.ListNestedObjectValueOf[MessageGroup]                `tfsdk:"message_groups"`
-	MessageSelectionStrategy    fwtypes.StringEnum[awstypes.MessageSelectionStrategy]        `tfsdk:"message_selection_strategy"`
-	PromptAttemptsSpecification fwtypes.ListNestedObjectValueOf[PromptAttemptsSpecification] `tfsdk:"prompt_attempts_specification"`
+	AllowInterrupt              types.Bool                                                  `tfsdk:"allow_interrupt"`
+	MaxRetries                  types.Int64                                                 `tfsdk:"max_retries"`
+	MessageGroup                fwtypes.ListNestedObjectValueOf[MessageGroup]               `tfsdk:"message_group"`
+	MessageSelectionStrategy    fwtypes.StringEnum[awstypes.MessageSelectionStrategy]       `tfsdk:"message_selection_strategy"`
+	PromptAttemptsSpecification fwtypes.SetNestedObjectValueOf[PromptAttemptsSpecification] `tfsdk:"prompt_attempts_specification"`
 }
 
 type FailureSuccessTimeout struct {

--- a/internal/service/lexv2models/intent.go
+++ b/internal/service/lexv2models/intent.go
@@ -7,10 +7,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"regexp"
 	"strings"
 	"time"
 
+	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/lexmodelsv2"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/lexmodelsv2/types"
@@ -529,7 +529,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 					Required: true,
 					Validators: []validator.String{
 						stringvalidator.RegexMatches(
-							regexp.MustCompile(`^[A-D0-9#*]{1}$`),
+							regexache.MustCompile(`^[A-D0-9#*]{1}$`),
 							"alphanumeric characters",
 						),
 					},
@@ -538,7 +538,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 					Required: true,
 					Validators: []validator.String{
 						stringvalidator.RegexMatches(
-							regexp.MustCompile(`^[A-D0-9#*]{1}$`),
+							regexache.MustCompile(`^[A-D0-9#*]{1}$`),
 							"alphanumeric characters",
 						),
 					},

--- a/internal/service/lexv2models/intent.go
+++ b/internal/service/lexv2models/intent.go
@@ -272,8 +272,8 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 		},
 	}
 
-	slotValueOverrideLNB := schema.ListNestedBlock{
-		CustomType: fwtypes.NewListNestedObjectTypeOf[SlotValueOverride](ctx),
+	slotValueOverrideLNB := schema.SetNestedBlock{
+		CustomType: fwtypes.NewSetNestedObjectTypeOf[SlotValueOverride](ctx),
 		NestedObject: schema.NestedBlockObject{
 			Attributes: map[string]schema.Attribute{
 				"map_block_key": schema.StringAttribute{
@@ -1314,8 +1314,8 @@ type DialogAction struct {
 }
 
 type IntentOverride struct {
-	Name types.String                                       `tfsdk:"name"`
-	Slot fwtypes.ListNestedObjectValueOf[SlotValueOverride] `tfsdk:"slot"`
+	Name types.String                                      `tfsdk:"name"`
+	Slot fwtypes.SetNestedObjectValueOf[SlotValueOverride] `tfsdk:"slot"`
 }
 
 type DialogState struct {

--- a/internal/service/lexv2models/intent.go
+++ b/internal/service/lexv2models/intent.go
@@ -340,6 +340,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 		Attributes: map[string]schema.Attribute{
 			"session_attributes": schema.MapAttribute{
 				ElementType: types.StringType,
+				CustomType:  fwtypes.NewMapTypeOf[types.String](ctx),
 				Optional:    true,
 			},
 		},

--- a/internal/service/lexv2models/intent.go
+++ b/internal/service/lexv2models/intent.go
@@ -278,12 +278,6 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 			Attributes: map[string]schema.Attribute{
 				"map_block_key": schema.StringAttribute{
 					Required: true,
-					Validators: []validator.String{
-						stringvalidator.RegexMatches(
-							regexp.MustCompile(` ^([0-9a-zA-Z][_-]?){1,100}$`),
-							"alphanumeric characters and hyphens (-) and underscores (_) at the end and must be between 1 and 100 characters in length",
-						),
-					},
 				},
 				"shape": schema.StringAttribute{
 					Optional:   true,
@@ -823,7 +817,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 		NestedObject: schema.NestedBlockObject{
 			Attributes: map[string]schema.Attribute{
 				"active": schema.BoolAttribute{
-					Computed: true,
+					Optional: true,
 				},
 				"enabled": schema.BoolAttribute{
 					Required: true,

--- a/internal/service/lexv2models/intent_test.go
+++ b/internal/service/lexv2models/intent_test.go
@@ -324,19 +324,20 @@ func TestIntentAutoFlex(t *testing.T) {
 		TextInputSpecification:         &textInputSpecificationAWS,
 	}
 
-	promptAttemptSpecificationMapTF := map[string]tflexv2models.PromptAttemptSpecification{
-		testString: promptAttemptSpecificationTF,
-	}
+	//promptAttemptSpecificationMapTF := map[string]tflexv2models.PromptAttemptSpecification{
+	//	testString: promptAttemptSpecificationTF,
+	//}
 	promptAttemptSpecificationMapAWS := map[string]lextypes.PromptAttemptSpecification{
 		testString: promptAttemptSpecificationAWS,
 	}
 
 	promptSpecificationTF := tflexv2models.PromptSpecification{
-		MaxRetries:                  types.Int64Value(1),
-		MessageGroup:                fwtypes.NewListNestedObjectValueOfPtr(ctx, &messageGroupTF),
-		AllowInterrupt:              types.BoolValue(true),
-		MessageSelectionStrategy:    fwtypes.StringEnumValue(lextypes.MessageSelectionStrategyOrdered),
-		PromptAttemptsSpecification: fwtypes.NewObjectMapValueMapOf[tflexv2models.PromptAttemptSpecification](ctx, promptAttemptSpecificationMapTF),
+		MaxRetries:               types.Int64Value(1),
+		MessageGroup:             fwtypes.NewListNestedObjectValueOfPtr(ctx, &messageGroupTF),
+		AllowInterrupt:           types.BoolValue(true),
+		MessageSelectionStrategy: fwtypes.StringEnumValue(lextypes.MessageSelectionStrategyOrdered),
+		//PromptAttemptsSpecification: fwtypes.NewObjectMapValueMapOf[tflexv2models.PromptAttemptSpecification](ctx, promptAttemptSpecificationMapTF),
+		PromptAttemptsSpecification: fwtypes.NewListNestedObjectValueOfPtr(ctx, &promptAttemptSpecificationTF),
 	}
 	promptSpecificationAWS := lextypes.PromptSpecification{
 		MaxRetries:                  aws.Int32(1),
@@ -713,6 +714,13 @@ func TestIntentAutoFlex(t *testing.T) {
 			TF:         &responseSpecificationTF,
 			AWS:        &lextypes.ResponseSpecification{},
 			WantTarget: &responseSpecificationAWS,
+		},
+		{
+			TestName:   "promptSpecification",
+			Expand:     true,
+			TF:         &promptSpecificationTF,
+			AWS:        &lextypes.PromptSpecification{},
+			WantTarget: &promptSpecificationAWS,
 		},
 		{
 			TestName:   "dialogState",

--- a/internal/service/lexv2models/intent_test.go
+++ b/internal/service/lexv2models/intent_test.go
@@ -154,8 +154,9 @@ func TestIntentAutoFlex(t *testing.T) {
 	}
 
 	slotValueOverrideTF := tflexv2models.SlotValueOverride{
-		Shape: fwtypes.StringEnumValue(lextypes.SlotShapeList),
-		Value: fwtypes.NewListNestedObjectValueOfPtr(ctx, &slotValueTF),
+		MapBlockKey: types.StringValue(testString),
+		Shape:       fwtypes.StringEnumValue(lextypes.SlotShapeList),
+		Value:       fwtypes.NewListNestedObjectValueOfPtr(ctx, &slotValueTF),
 		//Values: fwtypes.NewListNestedObjectValueOfValueSlice(ctx, []tflexv2models.SlotValueOverride{ // recursive so must be defined in line instead of in variable
 		//	{
 		//		Shape: types.StringValue(testString),
@@ -176,9 +177,7 @@ func TestIntentAutoFlex(t *testing.T) {
 
 	intentOverrideTF := tflexv2models.IntentOverride{
 		Name: types.StringValue(testString),
-		Slots: fwtypes.NewObjectMapValueMapOf[tflexv2models.SlotValueOverride](ctx, map[string]tflexv2models.SlotValueOverride{
-			testString: slotValueOverrideTF,
-		}),
+		Slot: fwtypes.NewListNestedObjectValueOfPtr(ctx, &slotValueOverrideTF),
 	}
 	intentOverrideAWS := lextypes.IntentOverride{
 		Name: aws.String(testString),
@@ -311,7 +310,8 @@ func TestIntentAutoFlex(t *testing.T) {
 		StartTimeoutMs: aws.Int32(1),
 	}
 
-	promptAttemptSpecificationTF := tflexv2models.PromptAttemptSpecification{
+	promptAttemptSpecificationTF := tflexv2models.PromptAttemptsSpecification{
+		MapBlockKey:                    fwtypes.StringEnumValue(tflexv2models.PromptAttemptsTypeInitial),
 		AllowedInputTypes:              fwtypes.NewListNestedObjectValueOfPtr(ctx, &allowedInputTypesTF),
 		AllowInterrupt:                 types.BoolValue(true),
 		AudioAndDTMFInputSpecification: fwtypes.NewListNestedObjectValueOfPtr(ctx, &audioAndDTMFInputSpecificationTF),
@@ -324,27 +324,21 @@ func TestIntentAutoFlex(t *testing.T) {
 		TextInputSpecification:         &textInputSpecificationAWS,
 	}
 
-	//promptAttemptSpecificationMapTF := map[string]tflexv2models.PromptAttemptSpecification{
-	//	testString: promptAttemptSpecificationTF,
-	//}
-	promptAttemptSpecificationMapAWS := map[string]lextypes.PromptAttemptSpecification{
-		testString: promptAttemptSpecificationAWS,
-	}
-
 	promptSpecificationTF := tflexv2models.PromptSpecification{
-		MaxRetries:               types.Int64Value(1),
-		MessageGroup:             fwtypes.NewListNestedObjectValueOfPtr(ctx, &messageGroupTF),
-		AllowInterrupt:           types.BoolValue(true),
-		MessageSelectionStrategy: fwtypes.StringEnumValue(lextypes.MessageSelectionStrategyOrdered),
-		//PromptAttemptsSpecification: fwtypes.NewObjectMapValueMapOf[tflexv2models.PromptAttemptSpecification](ctx, promptAttemptSpecificationMapTF),
+		MaxRetries:                  types.Int64Value(1),
+		MessageGroup:                fwtypes.NewListNestedObjectValueOfPtr(ctx, &messageGroupTF),
+		AllowInterrupt:              types.BoolValue(true),
+		MessageSelectionStrategy:    fwtypes.StringEnumValue(lextypes.MessageSelectionStrategyOrdered),
 		PromptAttemptsSpecification: fwtypes.NewListNestedObjectValueOfPtr(ctx, &promptAttemptSpecificationTF),
 	}
 	promptSpecificationAWS := lextypes.PromptSpecification{
-		MaxRetries:                  aws.Int32(1),
-		MessageGroups:               messageGroupAWS,
-		AllowInterrupt:              aws.Bool(true),
-		MessageSelectionStrategy:    lextypes.MessageSelectionStrategyOrdered,
-		PromptAttemptsSpecification: promptAttemptSpecificationMapAWS,
+		MaxRetries:               aws.Int32(1),
+		MessageGroups:            messageGroupAWS,
+		AllowInterrupt:           aws.Bool(true),
+		MessageSelectionStrategy: lextypes.MessageSelectionStrategyOrdered,
+		PromptAttemptsSpecification: map[string]lextypes.PromptAttemptSpecification{
+			string(tflexv2models.PromptAttemptsTypeInitial): promptAttemptSpecificationAWS,
+		},
 	}
 
 	failureSuccessTimeoutTF := tflexv2models.FailureSuccessTimeout{
@@ -358,6 +352,7 @@ func TestIntentAutoFlex(t *testing.T) {
 		TimeoutNextStep:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogStateTF),
 		TimeoutResponse:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecificationTF),
 	}
+
 	postCodeHookSpecificationAWS := lextypes.PostDialogCodeHookInvocationSpecification{
 		FailureConditional: &conditionalSpecificationAWS,
 		FailureNextStep:    &dialogStateAWS,

--- a/internal/service/lexv2models/intent_test.go
+++ b/internal/service/lexv2models/intent_test.go
@@ -10,12 +10,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/lexmodelsv2"
 	lextypes "github.com/aws/aws-sdk-go-v2/service/lexmodelsv2/types"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"

--- a/internal/service/lexv2models/intent_test.go
+++ b/internal/service/lexv2models/intent_test.go
@@ -5,13 +5,13 @@ package lexv2models_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lexmodelsv2"
 	lextypes "github.com/aws/aws-sdk-go-v2/service/lexmodelsv2/types"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -30,25 +30,53 @@ func TestIntentAutoExpand(t *testing.T) {
 	ssmlMessageTF := tflexv2models.SSMLMessage{
 		Value: types.StringValue(testString),
 	}
+	ssmlMessageAWS := lextypes.SSMLMessage{
+		Value: aws.String(testString),
+	}
+
 	plainTextMessageTF := tflexv2models.PlainTextMessage{
 		Value: types.StringValue(testString),
 	}
+	plainTextMessageAWS := lextypes.PlainTextMessage{
+		Value: aws.String(testString),
+	}
+
 	buttonTF := tflexv2models.Button{
 		Text:  types.StringValue(testString),
 		Value: types.StringValue(testString),
 	}
+	buttonAWS := lextypes.Button{
+		Text:  aws.String(testString),
+		Value: aws.String(testString),
+	}
+
 	buttonsTF := []tflexv2models.Button{
 		buttonTF,
 	}
+	buttonsAWS := []lextypes.Button{
+		buttonAWS,
+	}
+
 	imageResponseCardTF := tflexv2models.ImageResponseCard{
 		Title:    types.StringValue(testString),
 		Button:   fwtypes.NewListNestedObjectValueOfValueSlice[tflexv2models.Button](ctx, buttonsTF),
 		ImageURL: types.StringValue(testString),
 		Subtitle: types.StringValue(testString),
 	}
+	imageResponseCardAWS := lextypes.ImageResponseCard{
+		Title:    aws.String(testString),
+		Buttons:  buttonsAWS,
+		ImageUrl: aws.String(testString),
+		Subtitle: aws.String(testString),
+	}
+
 	customPayloadTF := tflexv2models.CustomPayload{
 		Value: types.StringValue(testString),
 	}
+	customPayloadAWS := lextypes.CustomPayload{
+		Value: aws.String(testString),
+	}
+
 	messageTF := tflexv2models.Message{
 		CustomPayload:     fwtypes.NewListNestedObjectValueOfPtr(ctx, &customPayloadTF),
 		ImageResponseCard: fwtypes.NewListNestedObjectValueOfPtr(ctx, &imageResponseCardTF),
@@ -56,32 +84,30 @@ func TestIntentAutoExpand(t *testing.T) {
 		SSMLMessage:       fwtypes.NewListNestedObjectValueOfPtr(ctx, &ssmlMessageTF),
 	}
 	messageAWS := lextypes.Message{
-		CustomPayload: &lextypes.CustomPayload{
-			Value: aws.String(testString),
-		},
-		ImageResponseCard: &lextypes.ImageResponseCard{
-			Title: aws.String(testString),
-			Buttons: []lextypes.Button{{
-				Text:  aws.String(testString),
-				Value: aws.String(testString),
-			}},
-			ImageUrl: aws.String(testString),
-			Subtitle: aws.String(testString),
-		},
-		PlainTextMessage: &lextypes.PlainTextMessage{
-			Value: aws.String(testString),
-		},
-		SsmlMessage: &lextypes.SSMLMessage{
-			Value: aws.String(testString),
-		},
+		CustomPayload:     &customPayloadAWS,
+		ImageResponseCard: &imageResponseCardAWS,
+		PlainTextMessage:  &plainTextMessageAWS,
+		SsmlMessage:       &ssmlMessageAWS,
 	}
+
 	messagesTF := []tflexv2models.Message{
 		messageTF,
 	}
+	messagesAWS := []lextypes.Message{
+		messageAWS,
+	}
+
 	messageGroupTF := tflexv2models.MessageGroup{
 		Message:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &messageTF),
 		Variations: fwtypes.NewListNestedObjectValueOfValueSlice[tflexv2models.Message](ctx, messagesTF),
 	}
+	messageGroupAWS := []lextypes.MessageGroup{
+		{
+			Message:    &messageAWS,
+			Variations: messagesAWS,
+		},
+	}
+
 	responseSpecificationTF := tflexv2models.ResponseSpecification{
 		MessageGroup:   fwtypes.NewListNestedObjectValueOfPtr[tflexv2models.MessageGroup](ctx, &messageGroupTF),
 		AllowInterrupt: types.BoolValue(true),
@@ -97,6 +123,7 @@ func TestIntentAutoExpand(t *testing.T) {
 		},
 		AllowInterrupt: aws.Bool(true),
 	}
+
 	slotValue := tflexv2models.SlotValue{
 		InterpretedValue: types.StringValue(testString),
 	}
@@ -121,6 +148,7 @@ func TestIntentAutoExpand(t *testing.T) {
 		SlotToElicit:        types.StringValue(testString),
 		SuppressNextMessage: types.BoolValue(true),
 	}
+
 	dialogStateTF := tflexv2models.DialogState{
 		DialogAction: fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogActionTF),
 		Intent:       fwtypes.NewListNestedObjectValueOfPtr(ctx, &intentOverrideTF),
@@ -205,177 +233,347 @@ func TestIntentAutoExpand(t *testing.T) {
 		NextStep:        &dialogStateAWS,
 	}
 
-	/*
-			allowedInputTypes := tflexv2models.AllowedInputTypes{
-				AllowAudioInput: types.BoolValue(true),
-				AllowDTMFInput:  types.BoolValue(true),
-			}
-			audioSpecification := tflexv2models.AudioSpecification{
-				EndTimeoutMs: types.Int64Value(1),
-				MaxLengthMs:  types.Int64Value(1),
-			}
-			dtmfSpecification := tflexv2models.DTMFSpecification{
-				DeletionCharacter: types.StringValue(testString),
-				EndCharacter:      types.StringValue(testString),
-				EndTimeoutMs:      types.Int64Value(1),
-				MaxLength:         types.Int64Value(1),
-			}
-			audioAndDTMFInputSpecification := tflexv2models.AudioAndDTMFInputSpecification{
-				StartTimeoutMs:     types.Int64Value(1),
-				AudioSpecification: fwtypes.NewListNestedObjectValueOfPtr(ctx, &audioSpecification),
-				DTMFSpecification:  fwtypes.NewListNestedObjectValueOfPtr(ctx, &dtmfSpecification),
-			}
+	allowedInputTypesTF := tflexv2models.AllowedInputTypes{
+		AllowAudioInput: types.BoolValue(true),
+		AllowDTMFInput:  types.BoolValue(true),
+	}
+	allowedInputTypesAWS := lextypes.AllowedInputTypes{
+		AllowAudioInput: aws.Bool(true),
+		AllowDTMFInput:  aws.Bool(true),
+	}
 
-			textInputSpecification := tflexv2models.TextInputSpecification{
-				StartTimeoutMs: types.Int64Value(1),
-			}
-			promptAttemptSpecification := tflexv2models.PromptAttemptSpecification{
-				AllowedInputTypes:              fwtypes.NewListNestedObjectValueOfPtr(ctx, &allowedInputTypes),
-				AllowInterrupt:                 types.BoolValue(true),
-				AudioAndDTMFInputSpecification: fwtypes.NewListNestedObjectValueOfPtr(ctx, &audioAndDTMFInputSpecification),
-				TextInputSpecification:         fwtypes.NewListNestedObjectValueOfPtr(ctx, &textInputSpecification),
-			}
-			promptAttemptSpecificationMap := map[string]tflexv2models.PromptAttemptSpecification{
-				testString: promptAttemptSpecification,
-			}
-		promptSpecificationTF := tflexv2models.PromptSpecification{
-			MaxRetries:               types.Int64Value(1),
-			MessageGroup:             fwtypes.NewListNestedObjectValueOfPtr(ctx, &messageGroupTF),
-			AllowInterrupt:           types.BoolValue(true),
-			MessageSelectionStrategy: types.StringValue(testString),
-			//PromptAttemptsSpecification: promptAttemptSpecificationMap,
-		}
-	*/
-	/*
-		failureSuccessTimeoutTF := tflexv2models.FailureSuccessTimeout{
-			FailureConditional: fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecificationTF),
-			FailureNextStep:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogStateTF),
-			FailureResponse:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecificationTF),
-			SuccessConditional: fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecificationTF),
-			SuccessNextStep:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogStateTF),
-			SuccessResponse:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecificationTF),
-			TimeoutConditional: fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecificationTF),
-			TimeoutNextStep:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogStateTF),
-			TimeoutResponse:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecificationTF),
-		}
+	audioSpecificationTF := tflexv2models.AudioSpecification{
+		EndTimeoutMs: types.Int64Value(1),
+		MaxLengthMs:  types.Int64Value(1),
+	}
+	audioSpecificationAWS := lextypes.AudioSpecification{
+		EndTimeoutMs: aws.Int32(1),
+		MaxLengthMs:  aws.Int32(1),
+	}
 
-		dialogCodeHookInvocationSettingTF := tflexv2models.DialogCodeHookInvocationSetting{
-			Active:                    types.BoolValue(true),
-			EnableCodeHookInvocation:  types.BoolValue(true),
-			InvocationLabel:           types.StringValue(testString),
-			PostCodeHookSpecification: fwtypes.NewListNestedObjectValueOfPtr(ctx, &failureSuccessTimeoutTF),
-		}
-	*/
-	/*
-		elicitationCodeHookTF := tflexv2models.ElicitationCodeHookInvocationSetting{
-			EnableCodeHookInvocation: types.BoolValue(true),
-			InvocationLabel:          types.StringValue(testString),
-		}
-		/*
-		intentConfirmationSettingTF := tflexv2models.IntentConfirmationSetting{
-			PromptSpecification:     fwtypes.NewListNestedObjectValueOfPtr(ctx, &promptSpecificationTF),
-			Active:                  types.BoolValue(true),
-			CodeHook:                fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogCodeHookInvocationSettingTF),
-			ConfirmationConditional: fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecificationTF),
-			ConfirmationNextStep:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogStateTF),
-			ConfirmationResponse:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecificationTF),
-			DeclinationConditional:  fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecificationTF),
-			DeclinationNextStep:     fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogStateTF),
-			DeclinationResponse:     fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecificationTF),
-			ElicitationCodeHook:     fwtypes.NewListNestedObjectValueOfPtr(ctx, &elicitationCodeHookTF),
-			FailureConditional:      fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecificationTF),
-			FailureNextStep:         fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogStateTF),
-			FailureResponse:         fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecificationTF),
-		}
-	*/
+	dtmfSpecificationTF := tflexv2models.DTMFSpecification{
+		DeletionCharacter: types.StringValue(testString),
+		EndCharacter:      types.StringValue(testString),
+		EndTimeoutMs:      types.Int64Value(1),
+		MaxLength:         types.Int64Value(1),
+	}
+	dtmfSpecificationAWS := lextypes.DTMFSpecification{
+		DeletionCharacter: aws.String(testString),
+		EndCharacter:      aws.String(testString),
+		EndTimeoutMs:      aws.Int32(1),
+		MaxLength:         aws.Int32(1),
+	}
+
+	audioAndDTMFInputSpecificationTF := tflexv2models.AudioAndDTMFInputSpecification{
+		StartTimeoutMs:     types.Int64Value(1),
+		AudioSpecification: fwtypes.NewListNestedObjectValueOfPtr(ctx, &audioSpecificationTF),
+		DTMFSpecification:  fwtypes.NewListNestedObjectValueOfPtr(ctx, &dtmfSpecificationTF),
+	}
+	audioAndDTMFInputSpecificationAWS := lextypes.AudioAndDTMFInputSpecification{
+		StartTimeoutMs:     aws.Int32(1),
+		AudioSpecification: &audioSpecificationAWS,
+		DtmfSpecification:  &dtmfSpecificationAWS,
+	}
+
+	textInputSpecificationTF := tflexv2models.TextInputSpecification{
+		StartTimeoutMs: types.Int64Value(1),
+	}
+	textInputSpecificationAWS := lextypes.TextInputSpecification{
+		StartTimeoutMs: aws.Int32(1),
+	}
+
+	promptAttemptSpecificationTF := tflexv2models.PromptAttemptSpecification{
+		AllowedInputTypes:              fwtypes.NewListNestedObjectValueOfPtr(ctx, &allowedInputTypesTF),
+		AllowInterrupt:                 types.BoolValue(true),
+		AudioAndDTMFInputSpecification: fwtypes.NewListNestedObjectValueOfPtr(ctx, &audioAndDTMFInputSpecificationTF),
+		TextInputSpecification:         fwtypes.NewListNestedObjectValueOfPtr(ctx, &textInputSpecificationTF),
+	}
+	promptAttemptSpecificationAWS := lextypes.PromptAttemptSpecification{
+		AllowedInputTypes:              &allowedInputTypesAWS,
+		AllowInterrupt:                 aws.Bool(true),
+		AudioAndDTMFInputSpecification: &audioAndDTMFInputSpecificationAWS,
+		TextInputSpecification:         &textInputSpecificationAWS,
+	}
+
+	promptAttemptSpecificationMapTF := map[string]tflexv2models.PromptAttemptSpecification{
+		testString: promptAttemptSpecificationTF,
+	}
+	promptAttemptSpecificationMapAWS := map[string]lextypes.PromptAttemptSpecification{
+		testString: promptAttemptSpecificationAWS,
+	}
+
+	promptSpecificationTF := tflexv2models.PromptSpecification{
+		MaxRetries:                  types.Int64Value(1),
+		MessageGroup:                fwtypes.NewListNestedObjectValueOfPtr(ctx, &messageGroupTF),
+		AllowInterrupt:              types.BoolValue(true),
+		MessageSelectionStrategy:    fwtypes.StringEnumValue(lextypes.MessageSelectionStrategyOrdered),
+		PromptAttemptsSpecification: fwtypes.NewObjectMapValueMapOf[tflexv2models.PromptAttemptSpecification](ctx, promptAttemptSpecificationMapTF),
+	}
+	promptSpecificationAWS := lextypes.PromptSpecification{
+		MaxRetries:                  aws.Int32(1),
+		MessageGroups:               messageGroupAWS,
+		AllowInterrupt:              aws.Bool(true),
+		MessageSelectionStrategy:    lextypes.MessageSelectionStrategyOrdered,
+		PromptAttemptsSpecification: promptAttemptSpecificationMapAWS,
+	}
+
+	failureSuccessTimeoutTF := tflexv2models.FailureSuccessTimeout{
+		FailureConditional: fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecificationTF),
+		FailureNextStep:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogStateTF),
+		FailureResponse:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecificationTF),
+		SuccessConditional: fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecificationTF),
+		SuccessNextStep:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogStateTF),
+		SuccessResponse:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecificationTF),
+		TimeoutConditional: fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecificationTF),
+		TimeoutNextStep:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogStateTF),
+		TimeoutResponse:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecificationTF),
+	}
+	postCodeHookSpecificationAWS := lextypes.PostDialogCodeHookInvocationSpecification{
+		FailureConditional: &conditionalSpecificationAWS,
+		FailureNextStep:    &dialogStateAWS,
+		FailureResponse:    &responseSpecificationAWS,
+		SuccessConditional: &conditionalSpecificationAWS,
+		SuccessNextStep:    &dialogStateAWS,
+		SuccessResponse:    &responseSpecificationAWS,
+		TimeoutConditional: &conditionalSpecificationAWS,
+		TimeoutNextStep:    &dialogStateAWS,
+		TimeoutResponse:    &responseSpecificationAWS,
+	}
+	postFulfillmentStatusSpecificationAWS := lextypes.PostFulfillmentStatusSpecification{
+		FailureConditional: &conditionalSpecificationAWS,
+		FailureNextStep:    &dialogStateAWS,
+		FailureResponse:    &responseSpecificationAWS,
+		SuccessConditional: &conditionalSpecificationAWS,
+		SuccessNextStep:    &dialogStateAWS,
+		SuccessResponse:    &responseSpecificationAWS,
+		TimeoutConditional: &conditionalSpecificationAWS,
+		TimeoutNextStep:    &dialogStateAWS,
+		TimeoutResponse:    &responseSpecificationAWS,
+	}
+
+	dialogCodeHookInvocationSettingTF := tflexv2models.DialogCodeHookInvocationSetting{
+		Active:                    types.BoolValue(true),
+		EnableCodeHookInvocation:  types.BoolValue(true),
+		InvocationLabel:           types.StringValue(testString),
+		PostCodeHookSpecification: fwtypes.NewListNestedObjectValueOfPtr(ctx, &failureSuccessTimeoutTF),
+	}
+	dialogCodeHookInvocationSettingAWS := lextypes.DialogCodeHookInvocationSetting{
+		Active:                    aws.Bool(true),
+		EnableCodeHookInvocation:  aws.Bool(true),
+		InvocationLabel:           aws.String(testString),
+		PostCodeHookSpecification: &postCodeHookSpecificationAWS,
+	}
+
+	elicitationCodeHookTF := tflexv2models.ElicitationCodeHookInvocationSetting{
+		EnableCodeHookInvocation: types.BoolValue(true),
+		InvocationLabel:          types.StringValue(testString),
+	}
+	elicitationCodeHookAWS := lextypes.ElicitationCodeHookInvocationSetting{
+		EnableCodeHookInvocation: aws.Bool(true),
+		InvocationLabel:          aws.String(testString),
+	}
+
+	intentConfirmationSettingTF := tflexv2models.IntentConfirmationSetting{
+		PromptSpecification:     fwtypes.NewListNestedObjectValueOfPtr(ctx, &promptSpecificationTF),
+		Active:                  types.BoolValue(true),
+		CodeHook:                fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogCodeHookInvocationSettingTF),
+		ConfirmationConditional: fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecificationTF),
+		ConfirmationNextStep:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogStateTF),
+		ConfirmationResponse:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecificationTF),
+		DeclinationConditional:  fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecificationTF),
+		DeclinationNextStep:     fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogStateTF),
+		DeclinationResponse:     fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecificationTF),
+		ElicitationCodeHook:     fwtypes.NewListNestedObjectValueOfPtr(ctx, &elicitationCodeHookTF),
+		FailureConditional:      fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecificationTF),
+		FailureNextStep:         fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogStateTF),
+		FailureResponse:         fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecificationTF),
+	}
+	intentConfirmationSettingAWS := lextypes.IntentConfirmationSetting{
+		PromptSpecification:     &promptSpecificationAWS,
+		Active:                  aws.Bool(true),
+		CodeHook:                &dialogCodeHookInvocationSettingAWS,
+		ConfirmationConditional: &conditionalSpecificationAWS,
+		ConfirmationNextStep:    &dialogStateAWS,
+		ConfirmationResponse:    &responseSpecificationAWS,
+		DeclinationConditional:  &conditionalSpecificationAWS,
+		DeclinationNextStep:     &dialogStateAWS,
+		DeclinationResponse:     &responseSpecificationAWS,
+		ElicitationCodeHook:     &elicitationCodeHookAWS,
+		FailureConditional:      &conditionalSpecificationAWS,
+		FailureNextStep:         &dialogStateAWS,
+		FailureResponse:         &responseSpecificationAWS,
+	}
+
 	dialogCodeHookSettingsTF := tflexv2models.DialogCodeHookSettings{
 		Enabled: types.BoolValue(true),
 	}
-	/*
-		fulfillmentStartResponseSpecificationTF := tflexv2models.FulfillmentStartResponseSpecification{
-			DelayInSeconds: types.Int64Value(1),
-			MessageGroup:   fwtypes.NewListNestedObjectValueOfPtr(ctx, &messageGroupTF),
-			AllowInterrupt: types.BoolValue(true),
-		}
-		fulfillmentUpdateResponseSpecificationTF := tflexv2models.FulfillmentUpdateResponseSpecification{
-			FrequencyInSeconds: types.Int64Value(1),
-			MessageGroup:       fwtypes.NewListNestedObjectValueOfPtr(ctx, &messageGroupTF),
-			AllowInterrupt:     types.BoolValue(true),
-		}
-		fulfillmentUpdatesSpecificationTF := tflexv2models.FulfillmentUpdatesSpecification{
-			Active:           types.BoolValue(true),
-			StartResponse:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &fulfillmentStartResponseSpecificationTF),
-			TimeoutInSeconds: types.Int64Value(1),
-			UpdateResponse:   fwtypes.NewListNestedObjectValueOfPtr(ctx, &fulfillmentUpdateResponseSpecificationTF),
-		}
+	dialogCodeHookSettingsAWS := lextypes.DialogCodeHookSettings{
+		Enabled: true,
+	}
 
-		fulfillmentCodeHookSettingsTF := tflexv2models.FulfillmentCodeHookSettings{
-			Enabled:                            types.BoolValue(true),
-			Active:                             types.BoolValue(true),
-			FulfillmentUpdatesSpecification:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &fulfillmentUpdatesSpecificationTF),
-			PostFulfillmentStatusSpecification: fwtypes.NewListNestedObjectValueOfPtr(ctx, &failureSuccessTimeoutTF),
-		}
-		initialResponseSettingTF := tflexv2models.InitialResponseSetting{
-			CodeHook:        fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogCodeHookInvocationSettingTF),
-			Conditional:     fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecificationTF),
-			InitialResponse: fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecificationTF),
-			NextStep:        fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogStateTF),
-		}
-	*/
+	fulfillmentStartResponseSpecificationTF := tflexv2models.FulfillmentStartResponseSpecification{
+		DelayInSeconds: types.Int64Value(1),
+		MessageGroup:   fwtypes.NewListNestedObjectValueOfPtr(ctx, &messageGroupTF),
+		AllowInterrupt: types.BoolValue(true),
+	}
+	fulfillmentStartResponseSpecificationAWS := lextypes.FulfillmentStartResponseSpecification{
+		DelayInSeconds: aws.Int32(1),
+		MessageGroups:  messageGroupAWS,
+		AllowInterrupt: aws.Bool(true),
+	}
+
+	fulfillmentUpdateResponseSpecificationTF := tflexv2models.FulfillmentUpdateResponseSpecification{
+		FrequencyInSeconds: types.Int64Value(1),
+		MessageGroup:       fwtypes.NewListNestedObjectValueOfPtr(ctx, &messageGroupTF),
+		AllowInterrupt:     types.BoolValue(true),
+	}
+	fulfillmentUpdateResponseSpecificationAWS := lextypes.FulfillmentUpdateResponseSpecification{
+		FrequencyInSeconds: aws.Int32(1),
+		MessageGroups:      messageGroupAWS,
+		AllowInterrupt:     aws.Bool(true),
+	}
+
+	fulfillmentUpdatesSpecificationTF := tflexv2models.FulfillmentUpdatesSpecification{
+		Active:           types.BoolValue(true),
+		StartResponse:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &fulfillmentStartResponseSpecificationTF),
+		TimeoutInSeconds: types.Int64Value(1),
+		UpdateResponse:   fwtypes.NewListNestedObjectValueOfPtr(ctx, &fulfillmentUpdateResponseSpecificationTF),
+	}
+	fulfillmentUpdatesSpecificationAWS := lextypes.FulfillmentUpdatesSpecification{
+		Active:           aws.Bool(true),
+		StartResponse:    &fulfillmentStartResponseSpecificationAWS,
+		TimeoutInSeconds: aws.Int32(1),
+		UpdateResponse:   &fulfillmentUpdateResponseSpecificationAWS,
+	}
+
+	fulfillmentCodeHookSettingsTF := tflexv2models.FulfillmentCodeHookSettings{
+		Enabled:                            types.BoolValue(true),
+		Active:                             types.BoolValue(true),
+		FulfillmentUpdatesSpecification:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &fulfillmentUpdatesSpecificationTF),
+		PostFulfillmentStatusSpecification: fwtypes.NewListNestedObjectValueOfPtr(ctx, &failureSuccessTimeoutTF),
+	}
+	fulfillmentCodeHookSettingsAWS := lextypes.FulfillmentCodeHookSettings{
+		Enabled:                            true,
+		Active:                             aws.Bool(true),
+		FulfillmentUpdatesSpecification:    &fulfillmentUpdatesSpecificationAWS,
+		PostFulfillmentStatusSpecification: &postFulfillmentStatusSpecificationAWS,
+	}
+
+	initialResponseSettingTF := tflexv2models.InitialResponseSetting{
+		CodeHook:        fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogCodeHookInvocationSettingTF),
+		Conditional:     fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecificationTF),
+		InitialResponse: fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecificationTF),
+		NextStep:        fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogStateTF),
+	}
+	initialResponseSettingAWS := lextypes.InitialResponseSetting{
+		CodeHook:        &dialogCodeHookInvocationSettingAWS,
+		Conditional:     &conditionalSpecificationAWS,
+		InitialResponse: &responseSpecificationAWS,
+		NextStep:        &dialogStateAWS,
+	}
+
 	inputContextTF := tflexv2models.InputContext{
 		Name: types.StringValue(testString),
 	}
+	inputContextAWS := lextypes.InputContext{
+		Name: aws.String(testString),
+	}
+
 	inputContextsTF := []tflexv2models.InputContext{
 		inputContextTF,
 	}
+	inputContextsAWS := []lextypes.InputContext{
+		inputContextAWS,
+	}
+
 	kendraConfigurationTF := tflexv2models.KendraConfiguration{
 		KendraIndex:              types.StringValue(testString),
 		QueryFilterString:        types.StringValue(testString),
 		QueryFilterStringEnabled: types.BoolValue(true),
 	}
+	kendraConfigurationAWS := lextypes.KendraConfiguration{
+		KendraIndex:              aws.String(testString),
+		QueryFilterString:        aws.String(testString),
+		QueryFilterStringEnabled: true,
+	}
+
 	outputContextTF := tflexv2models.OutputContext{
 		Name:                types.StringValue(testString),
 		TimeToLiveInSeconds: types.Int64Value(1),
 		TurnsToLive:         types.Int64Value(1),
 	}
+	outputContextAWS := lextypes.OutputContext{
+		Name:                aws.String(testString),
+		TimeToLiveInSeconds: aws.Int32(1),
+		TurnsToLive:         aws.Int32(1),
+	}
+
 	outputContextsTF := []tflexv2models.OutputContext{
 		outputContextTF,
 	}
+	outputContextsAWS := []lextypes.OutputContext{
+		outputContextAWS,
+	}
+
 	sampleUtteranceTF := tflexv2models.SampleUtterance{
 		Utterance: types.StringValue(testString),
 	}
+	sampleUtteranceAWS := lextypes.SampleUtterance{
+		Utterance: aws.String(testString),
+	}
+
 	sampleUtterancesTF := []tflexv2models.SampleUtterance{
 		sampleUtteranceTF,
 	}
-	slotPriorityTF := tflexv2models.SlotPriority{
-		Priority: types.Int64Value(1),
-		SlotID:   types.StringValue(testString),
+	sampleUtterancesAWS := []lextypes.SampleUtterance{
+		sampleUtteranceAWS,
 	}
-	slotPrioritiesTF := []tflexv2models.SlotPriority{
-		slotPriorityTF,
+
+	/*
+		slotPriorityTF := tflexv2models.SlotPriority{
+			Priority: types.Int64Value(1),
+			SlotID:   types.StringValue(testString),
+		}
+		slotPrioritiesTF := []tflexv2models.SlotPriority{
+			slotPriorityTF,
+		}
+	*/
+
+	createIntentTF := tflexv2models.ResourceIntentData{
+		BotID:                  types.StringValue(testString),
+		BotVersion:             types.StringValue(testString),
+		Name:                   types.StringValue(testString),
+		LocaleID:               types.StringValue(testString),
+		Description:            types.StringValue(testString),
+		DialogCodeHook:         fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogCodeHookSettingsTF),
+		FulfillmentCodeHook:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &fulfillmentCodeHookSettingsTF),
+		InitialResponseSetting: fwtypes.NewListNestedObjectValueOfPtr(ctx, &initialResponseSettingTF),
+		InputContext:           fwtypes.NewListNestedObjectValueOfValueSlice[tflexv2models.InputContext](ctx, inputContextsTF),
+		ClosingSetting:         fwtypes.NewListNestedObjectValueOfPtr(ctx, &intentClosingSettingTF),
+		ConfirmationSetting:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &intentConfirmationSettingTF),
+		KendraConfiguration:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &kendraConfigurationTF),
+		OutputContext:          fwtypes.NewListNestedObjectValueOfValueSlice[tflexv2models.OutputContext](ctx, outputContextsTF),
+		ParentIntentSignature:  types.StringValue(testString),
+		SampleUtterance:        fwtypes.NewListNestedObjectValueOfValueSlice[tflexv2models.SampleUtterance](ctx, sampleUtterancesTF),
 	}
-	intentResourceTF := tflexv2models.ResourceIntentData{
-		BotID:      types.StringValue(testString),
-		BotVersion: types.StringValue(testString),
-		//ClosingSetting:         fwtypes.NewListNestedObjectValueOfPtr(ctx, &intentClosingSettingTF),
-		//ConfirmationSetting:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &intentConfirmationSettingTF),
-		CreationDateTime: fwtypes.Timestamp{},
-		Description:      types.StringValue(testString),
-		DialogCodeHook:   fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogCodeHookSettingsTF),
-		//FulfillmentCodeHook:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &fulfillmentCodeHookSettingsTF),
-		ID: types.StringValue(testString),
-		//InitialResponseSetting: fwtypes.NewListNestedObjectValueOfPtr(ctx, &initialResponseSettingTF),
-		InputContext:          fwtypes.NewListNestedObjectValueOfValueSlice[tflexv2models.InputContext](ctx, inputContextsTF),
-		KendraConfiguration:   fwtypes.NewListNestedObjectValueOfPtr(ctx, &kendraConfigurationTF),
-		LastUpdatedDateTime:   fwtypes.Timestamp{},
-		LocaleID:              types.StringValue(testString),
-		Name:                  types.StringValue(testString),
-		OutputContext:         fwtypes.NewListNestedObjectValueOfValueSlice[tflexv2models.OutputContext](ctx, outputContextsTF),
-		ParentIntentSignature: types.StringValue(testString),
-		SampleUtterance:       fwtypes.NewListNestedObjectValueOfValueSlice[tflexv2models.SampleUtterance](ctx, sampleUtterancesTF),
-		SlotPriority:          fwtypes.NewListNestedObjectValueOfValueSlice[tflexv2models.SlotPriority](ctx, slotPrioritiesTF),
+	createIntentAWS := lexmodelsv2.CreateIntentInput{
+		BotId:                     aws.String(testString),
+		BotVersion:                aws.String(testString),
+		IntentName:                aws.String(testString),
+		LocaleId:                  aws.String(testString),
+		Description:               aws.String(testString),
+		DialogCodeHook:            &dialogCodeHookSettingsAWS,
+		FulfillmentCodeHook:       &fulfillmentCodeHookSettingsAWS,
+		InitialResponseSetting:    &initialResponseSettingAWS,
+		InputContexts:             inputContextsAWS,
+		IntentClosingSetting:      &intentClosingSettingAWS,
+		IntentConfirmationSetting: &intentConfirmationSettingAWS,
+		KendraConfiguration:       &kendraConfigurationAWS,
+		OutputContexts:            outputContextsAWS,
+		ParentIntentSignature:     aws.String(testString),
+		SampleUtterances:          sampleUtterancesAWS,
 	}
-	fmt.Printf("intentResourceTF %s\n", intentResourceTF)
+	//fmt.Printf("intentResourceTF %s\n", createIntentTF)
 
 	testCases := []struct {
 		TestName   string
@@ -414,9 +612,25 @@ func TestIntentAutoExpand(t *testing.T) {
 			Target:     &lextypes.IntentClosingSetting{},
 			WantTarget: &intentClosingSettingAWS,
 		},
+		{
+			TestName:   "intentConfirmationSetting",
+			Source:     &intentConfirmationSettingTF,
+			Target:     &lextypes.IntentConfirmationSetting{},
+			WantTarget: &intentConfirmationSettingAWS,
+		},
+		{
+			TestName:   "create intent",
+			Source:     &createIntentTF,
+			Target:     &lexmodelsv2.CreateIntentInput{},
+			WantTarget: &createIntentAWS,
+		},
 	}
 
 	opts := cmpopts.IgnoreUnexported(
+		lexmodelsv2.CreateIntentInput{},
+		lextypes.AllowedInputTypes{},
+		lextypes.AudioAndDTMFInputSpecification{},
+		lextypes.AudioSpecification{},
 		lextypes.Button{},
 		lextypes.Condition{},
 		lextypes.ConditionalBranch{},
@@ -424,17 +638,36 @@ func TestIntentAutoExpand(t *testing.T) {
 		lextypes.CustomPayload{},
 		lextypes.DefaultConditionalBranch{},
 		lextypes.DialogAction{},
+		lextypes.DialogCodeHookInvocationSetting{},
+		lextypes.DialogCodeHookSettings{},
 		lextypes.DialogState{},
+		lextypes.DTMFSpecification{},
+		lextypes.ElicitationCodeHookInvocationSetting{},
+		lextypes.FulfillmentCodeHookSettings{},
+		lextypes.FulfillmentStartResponseSpecification{},
+		lextypes.FulfillmentUpdateResponseSpecification{},
+		lextypes.FulfillmentUpdatesSpecification{},
 		lextypes.ImageResponseCard{},
+		lextypes.InitialResponseSetting{},
+		lextypes.InputContext{},
 		lextypes.IntentClosingSetting{},
+		lextypes.IntentConfirmationSetting{},
 		lextypes.IntentOverride{},
+		lextypes.KendraConfiguration{},
 		lextypes.Message{},
 		lextypes.MessageGroup{},
+		lextypes.OutputContext{},
 		lextypes.PlainTextMessage{},
+		lextypes.PostDialogCodeHookInvocationSpecification{},
+		lextypes.PostFulfillmentStatusSpecification{},
+		lextypes.PromptAttemptSpecification{},
+		lextypes.PromptSpecification{},
 		lextypes.ResponseSpecification{},
+		lextypes.SampleUtterance{},
 		lextypes.SlotValue{},
 		lextypes.SlotValueOverride{},
 		lextypes.SSMLMessage{},
+		lextypes.TextInputSpecification{},
 	)
 
 	for _, testCase := range testCases {
@@ -442,7 +675,7 @@ func TestIntentAutoExpand(t *testing.T) {
 		t.Run(testCase.TestName, func(t *testing.T) {
 			t.Parallel()
 
-			err := flex.Expand(ctx, testCase.Source, testCase.Target)
+			err := flex.Expand(context.WithValue(ctx, flex.ResourcePrefix, "Intent"), testCase.Source, testCase.Target)
 			gotErr := err != nil
 
 			if gotErr != testCase.WantErr {

--- a/internal/service/lexv2models/intent_test.go
+++ b/internal/service/lexv2models/intent_test.go
@@ -1,0 +1,632 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package lexv2models_test
+
+// **PLEASE DELETE THIS AND ALL TIP COMMENTS BEFORE SUBMITTING A PR FOR REVIEW!**
+//
+// TIP: ==== INTRODUCTION ====
+// Thank you for trying the skaff tool!
+//
+// You have opted to include these helpful comments. They all include "TIP:"
+// to help you find and remove them when you're done with them.
+//
+// While some aspects of this file are customized to your input, the
+// scaffold tool does *not* look at the AWS API and ensure it has correct
+// function, structure, and variable names. It makes guesses based on
+// commonalities. You will need to make significant adjustments.
+//
+// In other words, as generated, this is a rough outline of the work you will
+// need to do. If something doesn't make sense for your situation, get rid of
+// it.
+
+import (
+	// TIP: ==== IMPORTS ====
+	// This is a common set of imports but not customized to your code since
+	// your code hasn't been written yet. Make sure you, your IDE, or
+	// goimports -w <file> fixes these imports.
+	//
+	// The provider linter wants your imports to be in two groups: first,
+	// standard library (i.e., "fmt" or "strings"), second, everything else.
+	//
+	// Also, AWS Go SDK v2 may handle nested structures differently than v1,
+	// using the services/lexv2models/types package. If so, you'll
+	// need to import types and reference the nested types, e.g., as
+	// types.<Type Name>.
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	lextypes "github.com/aws/aws-sdk-go-v2/service/lexmodelsv2/types"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+
+	// TIP: You will often need to import the package that this test file lives
+	// in. Since it is in the "test" context, it must import the package to use
+	// any normal context constants, variables, or functions.
+	tflexv2models "github.com/hashicorp/terraform-provider-aws/internal/service/lexv2models"
+)
+
+// TIP: File Structure. The basic outline for all test files should be as
+// follows. Improve this resource's maintainability by following this
+// outline.
+//
+// 1. Package declaration (add "_test" since this is a test file)
+// 2. Imports
+// 3. Unit tests
+// 4. Basic test
+// 5. Disappears test
+// 6. All the other tests
+// 7. Helper functions (exists, destroy, check, etc.)
+// 8. Functions that return Terraform configurations
+
+// TIP: ==== UNIT TESTS ====
+// This is an example of a unit test. Its name is not prefixed with
+// "TestAcc" like an acceptance test.
+//
+// Unlike acceptance tests, unit tests do not access AWS and are focused on a
+// function (or method). Because of this, they are quick and cheap to run.
+//
+// In designing a resource's implementation, isolate complex bits from AWS bits
+// so that they can be tested through a unit test. We encourage more unit tests
+// in the provider.
+//
+// Cut and dry functions using well-used patterns, like typical flatteners and
+// expanders, don't need unit testing. However, if they are complex or
+// intricate, they should be unit tested.
+
+// TestIntentAutoExpand tests autoflex expand for the specific intent data
+// structures. As such, this is not meant to be a comprehensive test of autoflex
+// generally, but a test to make sure the complex intent data structures work
+// with autoflex now and in the future.
+func TestIntentAutoExpand(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	testString := "b72d06fd-2b78-5fe2-a6a3-e06e5efde347"
+	//testString2 := "a47c2004-f58b-5982-880a-f68c80f6307c"
+
+	ssmlMessage := tflexv2models.SSMLMessage{
+		Value: types.StringValue(testString),
+	}
+	plainTextMessage := tflexv2models.PlainTextMessage{
+		Value: types.StringValue(testString),
+	}
+	button := tflexv2models.Button{
+		Text:  types.StringValue(testString),
+		Value: types.StringValue(testString),
+	}
+	buttons := []tflexv2models.Button{
+		button,
+	}
+	imageResponseCard := tflexv2models.ImageResponseCard{
+		Title:    types.StringValue(testString),
+		Button:   fwtypes.NewListNestedObjectValueOfValueSlice[tflexv2models.Button](ctx, buttons),
+		ImageURL: types.StringValue(testString),
+		Subtitle: types.StringValue(testString),
+	}
+	customPayload := tflexv2models.CustomPayload{
+		Value: types.StringValue(testString),
+	}
+	message := tflexv2models.Message{
+		CustomPayload:     fwtypes.NewListNestedObjectValueOfPtr(ctx, &customPayload),
+		ImageResponseCard: fwtypes.NewListNestedObjectValueOfPtr(ctx, &imageResponseCard),
+		PlainTextMessage:  fwtypes.NewListNestedObjectValueOfPtr(ctx, &plainTextMessage),
+		SSMLMessage:       fwtypes.NewListNestedObjectValueOfPtr(ctx, &ssmlMessage),
+	}
+	messages := []tflexv2models.Message{
+		message,
+	}
+	messageGroup := tflexv2models.MessageGroup{
+		Message:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &message),
+		Variations: fwtypes.NewListNestedObjectValueOfValueSlice[tflexv2models.Message](ctx, messages),
+	}
+	responseSpecification := tflexv2models.ResponseSpecification{
+		MessageGroup:   fwtypes.NewListNestedObjectValueOfPtr[tflexv2models.MessageGroup](ctx, &messageGroup),
+		AllowInterrupt: types.BoolValue(true),
+	}
+	/*
+		slotValue := tflexv2models.SlotValue{
+			InterpretedValue: types.StringValue(testString),
+		}
+	*/
+	/*
+		slotValueOverride := tflexv2models.SlotValueOverride{
+			Shape: types.StringValue(testString),
+			Value: fwtypes.NewListNestedObjectValueOfPtr(ctx, &slotValue),
+			Values: fwtypes.NewListNestedObjectValueOfValueSlice(ctx, []tflexv2models.SlotValueOverride{ // recursive so must be defined in line instead of in variable
+				{
+					Shape: types.StringValue(testString),
+					Value: fwtypes.NewListNestedObjectValueOfPtr(ctx, &slotValue),
+				},
+			}),
+		}
+	*/
+	intentOverride := tflexv2models.IntentOverride{
+		Name: types.StringValue(testString),
+		//Slots: fwtypes.NewMapValueOf[tflexv2models.SlotValueOverride](ctx, &slotValueOverride),
+	}
+	dialogAction := tflexv2models.DialogAction{
+		Type:                types.StringValue(testString),
+		SlotToElicit:        types.StringValue(testString),
+		SuppressNextMessage: types.BoolValue(true),
+	}
+	dialogState := tflexv2models.DialogState{
+		DialogAction: fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogAction),
+		Intent:       fwtypes.NewListNestedObjectValueOfPtr(ctx, &intentOverride),
+		/*SessionAttributes: types.MapValueMust(types.StringType, map[string]attr.Value{
+			testString: types.StringValue(testString2),
+		}),*/
+	}
+	condition := tflexv2models.Condition{
+		ExpressionString: types.StringValue(testString),
+	}
+	defaultConditionalBranch := tflexv2models.DefaultConditionalBranch{
+		NextStep: fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogState),
+		Response: fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecification),
+	}
+	conditionalBranch := tflexv2models.ConditionalBranch{
+		Condition: fwtypes.NewListNestedObjectValueOfPtr(ctx, &condition),
+		Name:      types.StringValue(testString),
+		NextStep:  fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogState),
+		Response:  fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecification),
+	}
+	conditionalBranches := []tflexv2models.ConditionalBranch{
+		conditionalBranch,
+	}
+	conditionalSpecification := tflexv2models.ConditionalSpecification{
+		Active:            types.BoolValue(true),
+		ConditionalBranch: fwtypes.NewListNestedObjectValueOfValueSlice(ctx, conditionalBranches),
+		DefaultBranch:     fwtypes.NewListNestedObjectValueOfPtr(ctx, &defaultConditionalBranch),
+	}
+	intentClosingSetting := tflexv2models.IntentClosingSetting{
+		Active:          types.BoolValue(true),
+		ClosingResponse: fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecification),
+		Conditional:     fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecification),
+		NextStep:        fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogState),
+	}
+	/*
+		allowedInputTypes := tflexv2models.AllowedInputTypes{
+			AllowAudioInput: types.BoolValue(true),
+			AllowDTMFInput:  types.BoolValue(true),
+		}
+		audioSpecification := tflexv2models.AudioSpecification{
+			EndTimeoutMs: types.Int64Value(1),
+			MaxLengthMs:  types.Int64Value(1),
+		}
+		dtmfSpecification := tflexv2models.DTMFSpecification{
+			DeletionCharacter: types.StringValue(testString),
+			EndCharacter:      types.StringValue(testString),
+			EndTimeoutMs:      types.Int64Value(1),
+			MaxLength:         types.Int64Value(1),
+		}
+		audioAndDTMFInputSpecification := tflexv2models.AudioAndDTMFInputSpecification{
+			StartTimeoutMs:     types.Int64Value(1),
+			AudioSpecification: fwtypes.NewListNestedObjectValueOfPtr(ctx, &audioSpecification),
+			DTMFSpecification:  fwtypes.NewListNestedObjectValueOfPtr(ctx, &dtmfSpecification),
+		}
+
+		textInputSpecification := tflexv2models.TextInputSpecification{
+			StartTimeoutMs: types.Int64Value(1),
+		}
+		promptAttemptSpecification := tflexv2models.PromptAttemptSpecification{
+			AllowedInputTypes:              fwtypes.NewListNestedObjectValueOfPtr(ctx, &allowedInputTypes),
+			AllowInterrupt:                 types.BoolValue(true),
+			AudioAndDTMFInputSpecification: fwtypes.NewListNestedObjectValueOfPtr(ctx, &audioAndDTMFInputSpecification),
+			TextInputSpecification:         fwtypes.NewListNestedObjectValueOfPtr(ctx, &textInputSpecification),
+		}
+		promptAttemptSpecificationMap := map[string]tflexv2models.PromptAttemptSpecification{
+			testString: promptAttemptSpecification,
+		}*/
+	promptSpecification := tflexv2models.PromptSpecification{
+		MaxRetries:               types.Int64Value(1),
+		MessageGroup:             fwtypes.NewListNestedObjectValueOfPtr(ctx, &messageGroup),
+		AllowInterrupt:           types.BoolValue(true),
+		MessageSelectionStrategy: types.StringValue(testString),
+		//PromptAttemptsSpecification: promptAttemptSpecificationMap,
+	}
+	failureSuccessTimeout := tflexv2models.FailureSuccessTimeout{
+		FailureConditional: fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecification),
+		FailureNextStep:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogState),
+		FailureResponse:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecification),
+		SuccessConditional: fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecification),
+		SuccessNextStep:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogState),
+		SuccessResponse:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecification),
+		TimeoutConditional: fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecification),
+		TimeoutNextStep:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogState),
+		TimeoutResponse:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecification),
+	}
+	dialogCodeHookInvocationSetting := tflexv2models.DialogCodeHookInvocationSetting{
+		Active:                    types.BoolValue(true),
+		EnableCodeHookInvocation:  types.BoolValue(true),
+		InvocationLabel:           types.StringValue(testString),
+		PostCodeHookSpecification: fwtypes.NewListNestedObjectValueOfPtr(ctx, &failureSuccessTimeout),
+	}
+	elicitationCodeHook := tflexv2models.ElicitationCodeHookInvocationSetting{
+		EnableCodeHookInvocation: types.BoolValue(true),
+		InvocationLabel:          types.StringValue(testString),
+	}
+	intentConfirmationSetting := tflexv2models.IntentConfirmationSetting{
+		PromptSpecification:     fwtypes.NewListNestedObjectValueOfPtr(ctx, &promptSpecification),
+		Active:                  types.BoolValue(true),
+		CodeHook:                fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogCodeHookInvocationSetting),
+		ConfirmationConditional: fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecification),
+		ConfirmationNextStep:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogState),
+		ConfirmationResponse:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecification),
+		DeclinationConditional:  fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecification),
+		DeclinationNextStep:     fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogState),
+		DeclinationResponse:     fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecification),
+		ElicitationCodeHook:     fwtypes.NewListNestedObjectValueOfPtr(ctx, &elicitationCodeHook),
+		FailureConditional:      fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecification),
+		FailureNextStep:         fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogState),
+		FailureResponse:         fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecification),
+	}
+	dialogCodeHookSettings := tflexv2models.DialogCodeHookSettings{
+		Enabled: types.BoolValue(true),
+	}
+	fulfillmentStartResponseSpecification := tflexv2models.FulfillmentStartResponseSpecification{
+		DelayInSeconds: types.Int64Value(1),
+		MessageGroup:   fwtypes.NewListNestedObjectValueOfPtr(ctx, &messageGroup),
+		AllowInterrupt: types.BoolValue(true),
+	}
+	fulfillmentUpdateResponseSpecification := tflexv2models.FulfillmentUpdateResponseSpecification{
+		FrequencyInSeconds: types.Int64Value(1),
+		MessageGroup:       fwtypes.NewListNestedObjectValueOfPtr(ctx, &messageGroup),
+		AllowInterrupt:     types.BoolValue(true),
+	}
+	fulfillmentUpdatesSpecification := tflexv2models.FulfillmentUpdatesSpecification{
+		Active:           types.BoolValue(true),
+		StartResponse:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &fulfillmentStartResponseSpecification),
+		TimeoutInSeconds: types.Int64Value(1),
+		UpdateResponse:   fwtypes.NewListNestedObjectValueOfPtr(ctx, &fulfillmentUpdateResponseSpecification),
+	}
+	fulfillmentCodeHookSettings := tflexv2models.FulfillmentCodeHookSettings{
+		Enabled:                            types.BoolValue(true),
+		Active:                             types.BoolValue(true),
+		FulfillmentUpdatesSpecification:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &fulfillmentUpdatesSpecification),
+		PostFulfillmentStatusSpecification: fwtypes.NewListNestedObjectValueOfPtr(ctx, &failureSuccessTimeout),
+	}
+	initialResponseSetting := tflexv2models.InitialResponseSetting{
+		CodeHook:        fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogCodeHookInvocationSetting),
+		Conditional:     fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecification),
+		InitialResponse: fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecification),
+		NextStep:        fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogState),
+	}
+	inputContext := tflexv2models.InputContext{
+		Name: types.StringValue(testString),
+	}
+	inputContexts := []tflexv2models.InputContext{
+		inputContext,
+	}
+	kendraConfiguration := tflexv2models.KendraConfiguration{
+		KendraIndex:              types.StringValue(testString),
+		QueryFilterString:        types.StringValue(testString),
+		QueryFilterStringEnabled: types.BoolValue(true),
+	}
+	outputContext := tflexv2models.OutputContext{
+		Name:                types.StringValue(testString),
+		TimeToLiveInSeconds: types.Int64Value(1),
+		TurnsToLive:         types.Int64Value(1),
+	}
+	outputContexts := []tflexv2models.OutputContext{
+		outputContext,
+	}
+	sampleUtterance := tflexv2models.SampleUtterance{
+		Utterance: types.StringValue(testString),
+	}
+	sampleUtterances := []tflexv2models.SampleUtterance{
+		sampleUtterance,
+	}
+	slotPriority := tflexv2models.SlotPriority{
+		Priority: types.Int64Value(1),
+		SlotID:   types.StringValue(testString),
+	}
+	slotPriorities := []tflexv2models.SlotPriority{
+		slotPriority,
+	}
+	intentResource := tflexv2models.ResourceIntentData{
+		BotID:                  types.StringValue(testString),
+		BotVersion:             types.StringValue(testString),
+		ClosingSetting:         fwtypes.NewListNestedObjectValueOfPtr(ctx, &intentClosingSetting),
+		ConfirmationSetting:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &intentConfirmationSetting),
+		CreationDateTime:       fwtypes.TimestampType{},
+		Description:            types.StringValue(testString),
+		DialogCodeHook:         fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogCodeHookSettings),
+		FulfillmentCodeHook:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &fulfillmentCodeHookSettings),
+		ID:                     types.StringValue(testString),
+		InitialResponseSetting: fwtypes.NewListNestedObjectValueOfPtr(ctx, &initialResponseSetting),
+		InputContext:           fwtypes.NewListNestedObjectValueOfValueSlice[tflexv2models.InputContext](ctx, inputContexts),
+		KendraConfiguration:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &kendraConfiguration),
+		LastUpdatedDateTime:    fwtypes.TimestampType{},
+		LocaleID:               types.StringValue(testString),
+		Name:                   types.StringValue(testString),
+		OutputContext:          fwtypes.NewListNestedObjectValueOfValueSlice[tflexv2models.OutputContext](ctx, outputContexts),
+		ParentIntentSignature:  types.StringValue(testString),
+		SampleUtterance:        fwtypes.NewListNestedObjectValueOfValueSlice[tflexv2models.SampleUtterance](ctx, sampleUtterances),
+		SlotPriority:           fwtypes.NewListNestedObjectValueOfValueSlice[tflexv2models.SlotPriority](ctx, slotPriorities),
+	}
+	fmt.Printf("intentResource %s\n", intentResource)
+
+	testCases := []struct {
+		TestName   string
+		Source     any
+		Target     any
+		WantErr    bool
+		WantTarget any
+	}{
+		{
+			TestName: "message",
+			Source:   &message,
+			Target:   &lextypes.Message{},
+			WantTarget: &lextypes.Message{
+				CustomPayload: &lextypes.CustomPayload{
+					Value: aws.String(testString),
+				},
+				ImageResponseCard: &lextypes.ImageResponseCard{
+					Title: aws.String(testString),
+					Buttons: []lextypes.Button{{
+						Text:  aws.String(testString),
+						Value: aws.String(testString),
+					}},
+					ImageUrl: aws.String(testString),
+					Subtitle: aws.String(testString),
+				},
+				PlainTextMessage: &lextypes.PlainTextMessage{
+					Value: aws.String(testString),
+				},
+				SsmlMessage: &lextypes.SSMLMessage{
+					Value: aws.String(testString),
+				},
+			},
+		},
+		{
+			TestName: "plainTextMessage",
+			Source:   &plainTextMessage,
+			Target:   &lextypes.PlainTextMessage{},
+			WantTarget: &lextypes.PlainTextMessage{
+				Value: aws.String(testString),
+			},
+		},
+		{
+			TestName: "button",
+			Source:   &button,
+			Target:   &lextypes.Button{},
+			WantTarget: &lextypes.Button{
+				Text:  aws.String(testString),
+				Value: aws.String(testString),
+			},
+		},
+		/*
+			{
+				TestName: "complex Source and complex Target",
+				Source:   &intentResource,
+				Target:   &lexmodelsv2.CreateIntentInput{},
+				WantTarget: &lexmodelsv2.CreateIntentInput{
+					BotId: aws.String(testString),
+				},
+			},
+		*/
+	}
+
+	opts := cmpopts.IgnoreUnexported(
+		lextypes.SSMLMessage{},
+		lextypes.PlainTextMessage{},
+		lextypes.Button{},
+		lextypes.CustomPayload{},
+		lextypes.ImageResponseCard{},
+		lextypes.Message{},
+	)
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.TestName, func(t *testing.T) {
+			t.Parallel()
+
+			err := flex.Expand(ctx, testCase.Source, testCase.Target)
+			gotErr := err != nil
+
+			if gotErr != testCase.WantErr {
+				t.Errorf("gotErr = %v, wantErr = %v", gotErr, testCase.WantErr)
+			}
+
+			if gotErr {
+				if !testCase.WantErr {
+					t.Errorf("err = %q", err)
+				}
+			} else if diff := cmp.Diff(testCase.Target, testCase.WantTarget, opts); diff != "" {
+				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}
+
+/*
+// TIP: ==== ACCEPTANCE TESTS ====
+// This is an example of a basic acceptance test. This should test as much of
+// standard functionality of the resource as possible, and test importing, if
+// applicable. We prefix its name with "TestAcc", the service, and the
+// resource name.
+//
+// Acceptance test access AWS and cost money to run.
+func TestAccLexV2ModelsIntent_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	// TIP: This is a long-running test guard for tests that run longer than
+	// 300s (5 min) generally.
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var intent lexv2models.DescribeIntentResponse
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lexv2models_intent.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.LexV2ModelsEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.LexV2ModelsEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckIntentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIntentConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIntentExists(ctx, resourceName, &intent),
+					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "maintenance_window_start_time.0.day_of_week"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
+						"console_access": "false",
+						"groups.#":       "0",
+						"username":       "Test",
+						"password":       "TestTest1234",
+					}),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "lexv2models", regexache.MustCompile(`intent:+.`)),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately", "user"},
+			},
+		},
+	})
+}
+
+func TestAccLexV2ModelsIntent_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var intent lexv2models.DescribeIntentResponse
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lexv2models_intent.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.LexV2ModelsEndpointID)
+			testAccPreCheck(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.LexV2ModelsEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckIntentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIntentConfig_basic(rName, testAccIntentVersionNewer),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIntentExists(ctx, resourceName, &intent),
+					// TIP: The Plugin-Framework disappears helper is similar to the Plugin-SDK version,
+					// but expects a new resource factory function as the third argument. To expose this
+					// private function to the testing package, you may need to add a line like the following
+					// to exports_test.go:
+					//
+					//   var ResourceIntent = newResourceIntent
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tflexv2models.ResourceIntent, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckIntentDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).LexV2ModelsClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_lexv2models_intent" {
+				continue
+			}
+
+			input := &lexv2models.DescribeIntentInput{
+				IntentId: aws.String(rs.Primary.ID),
+			}
+			_, err := conn.DescribeIntent(ctx, &lexv2models.DescribeIntentInput{
+				IntentId: aws.String(rs.Primary.ID),
+			})
+			if errs.IsA[*types.ResourceNotFoundException](err) {
+				return nil
+			}
+			if err != nil {
+				return create.Error(names.LexV2Models, create.ErrActionCheckingDestroyed, tflexv2models.ResNameIntent, rs.Primary.ID, err)
+			}
+
+			return create.Error(names.LexV2Models, create.ErrActionCheckingDestroyed, tflexv2models.ResNameIntent, rs.Primary.ID, errors.New("not destroyed"))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckIntentExists(ctx context.Context, name string, intent *lexv2models.DescribeIntentResponse) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.LexV2Models, create.ErrActionCheckingExistence, tflexv2models.ResNameIntent, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.LexV2Models, create.ErrActionCheckingExistence, tflexv2models.ResNameIntent, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).LexV2ModelsClient(ctx)
+		resp, err := conn.DescribeIntent(ctx, &lexv2models.DescribeIntentInput{
+			IntentId: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return create.Error(names.LexV2Models, create.ErrActionCheckingExistence, tflexv2models.ResNameIntent, rs.Primary.ID, err)
+		}
+
+		*intent = *resp
+
+		return nil
+	}
+}
+
+func testAccCheckIntentNotRecreated(before, after *lexv2models.DescribeIntentResponse) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if before, after := aws.ToString(before.IntentId), aws.ToString(after.IntentId); before != after {
+			return create.Error(names.LexV2Models, create.ErrActionCheckingNotRecreated, tflexv2models.ResNameIntent, aws.ToString(before.IntentId), errors.New("recreated"))
+		}
+
+		return nil
+	}
+}
+
+func testAccIntentConfig_basic(rName, version string) string {
+	return fmt.Sprintf(`
+resource "aws_security_group" "test" {
+  name = %[1]q
+}
+
+resource "aws_lexv2models_intent" "test" {
+  intent_name             = %[1]q
+  engine_type             = "ActiveLexV2Models"
+  engine_version          = %[2]q
+  host_instance_type      = "lexv2models.t2.micro"
+  security_groups         = [aws_security_group.test.id]
+  authentication_strategy = "simple"
+  storage_type            = "efs"
+
+  logs {
+    general = true
+  }
+
+  user {
+    username = "Test"
+    password = "TestTest1234"
+  }
+}
+`, rName, version)
+}
+*/

--- a/internal/service/lexv2models/intent_test.go
+++ b/internal/service/lexv2models/intent_test.go
@@ -3,36 +3,7 @@
 
 package lexv2models_test
 
-// **PLEASE DELETE THIS AND ALL TIP COMMENTS BEFORE SUBMITTING A PR FOR REVIEW!**
-//
-// TIP: ==== INTRODUCTION ====
-// Thank you for trying the skaff tool!
-//
-// You have opted to include these helpful comments. They all include "TIP:"
-// to help you find and remove them when you're done with them.
-//
-// While some aspects of this file are customized to your input, the
-// scaffold tool does *not* look at the AWS API and ensure it has correct
-// function, structure, and variable names. It makes guesses based on
-// commonalities. You will need to make significant adjustments.
-//
-// In other words, as generated, this is a rough outline of the work you will
-// need to do. If something doesn't make sense for your situation, get rid of
-// it.
-
 import (
-	// TIP: ==== IMPORTS ====
-	// This is a common set of imports but not customized to your code since
-	// your code hasn't been written yet. Make sure you, your IDE, or
-	// goimports -w <file> fixes these imports.
-	//
-	// The provider linter wants your imports to be in two groups: first,
-	// standard library (i.e., "fmt" or "strings"), second, everything else.
-	//
-	// Also, AWS Go SDK v2 may handle nested structures differently than v1,
-	// using the services/lexv2models/types package. If so, you'll
-	// need to import types and reference the nested types, e.g., as
-	// types.<Type Name>.
 	"context"
 	"fmt"
 	"testing"
@@ -42,93 +13,89 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	lextypes "github.com/aws/aws-sdk-go-v2/service/lexmodelsv2/types"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
-
-	// TIP: You will often need to import the package that this test file lives
-	// in. Since it is in the "test" context, it must import the package to use
-	// any normal context constants, variables, or functions.
 	tflexv2models "github.com/hashicorp/terraform-provider-aws/internal/service/lexv2models"
 )
 
-// TIP: File Structure. The basic outline for all test files should be as
-// follows. Improve this resource's maintainability by following this
-// outline.
-//
-// 1. Package declaration (add "_test" since this is a test file)
-// 2. Imports
-// 3. Unit tests
-// 4. Basic test
-// 5. Disappears test
-// 6. All the other tests
-// 7. Helper functions (exists, destroy, check, etc.)
-// 8. Functions that return Terraform configurations
-
-// TIP: ==== UNIT TESTS ====
-// This is an example of a unit test. Its name is not prefixed with
-// "TestAcc" like an acceptance test.
-//
-// Unlike acceptance tests, unit tests do not access AWS and are focused on a
-// function (or method). Because of this, they are quick and cheap to run.
-//
-// In designing a resource's implementation, isolate complex bits from AWS bits
-// so that they can be tested through a unit test. We encourage more unit tests
-// in the provider.
-//
-// Cut and dry functions using well-used patterns, like typical flatteners and
-// expanders, don't need unit testing. However, if they are complex or
-// intricate, they should be unit tested.
-
-// TestIntentAutoExpand tests autoflex expand for the specific intent data
-// structures. As such, this is not meant to be a comprehensive test of autoflex
-// generally, but a test to make sure the complex intent data structures work
-// with autoflex now and in the future.
 func TestIntentAutoExpand(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
 	testString := "b72d06fd-2b78-5fe2-a6a3-e06e5efde347"
-	//testString2 := "a47c2004-f58b-5982-880a-f68c80f6307c"
+	testString2 := "a47c2004-f58b-5982-880a-f68c80f6307c"
 
-	ssmlMessage := tflexv2models.SSMLMessage{
+	ssmlMessageTF := tflexv2models.SSMLMessage{
 		Value: types.StringValue(testString),
 	}
-	plainTextMessage := tflexv2models.PlainTextMessage{
+	plainTextMessageTF := tflexv2models.PlainTextMessage{
 		Value: types.StringValue(testString),
 	}
-	button := tflexv2models.Button{
+	buttonTF := tflexv2models.Button{
 		Text:  types.StringValue(testString),
 		Value: types.StringValue(testString),
 	}
-	buttons := []tflexv2models.Button{
-		button,
+	buttonsTF := []tflexv2models.Button{
+		buttonTF,
 	}
-	imageResponseCard := tflexv2models.ImageResponseCard{
+	imageResponseCardTF := tflexv2models.ImageResponseCard{
 		Title:    types.StringValue(testString),
-		Button:   fwtypes.NewListNestedObjectValueOfValueSlice[tflexv2models.Button](ctx, buttons),
+		Button:   fwtypes.NewListNestedObjectValueOfValueSlice[tflexv2models.Button](ctx, buttonsTF),
 		ImageURL: types.StringValue(testString),
 		Subtitle: types.StringValue(testString),
 	}
-	customPayload := tflexv2models.CustomPayload{
+	customPayloadTF := tflexv2models.CustomPayload{
 		Value: types.StringValue(testString),
 	}
-	message := tflexv2models.Message{
-		CustomPayload:     fwtypes.NewListNestedObjectValueOfPtr(ctx, &customPayload),
-		ImageResponseCard: fwtypes.NewListNestedObjectValueOfPtr(ctx, &imageResponseCard),
-		PlainTextMessage:  fwtypes.NewListNestedObjectValueOfPtr(ctx, &plainTextMessage),
-		SSMLMessage:       fwtypes.NewListNestedObjectValueOfPtr(ctx, &ssmlMessage),
+	messageTF := tflexv2models.Message{
+		CustomPayload:     fwtypes.NewListNestedObjectValueOfPtr(ctx, &customPayloadTF),
+		ImageResponseCard: fwtypes.NewListNestedObjectValueOfPtr(ctx, &imageResponseCardTF),
+		PlainTextMessage:  fwtypes.NewListNestedObjectValueOfPtr(ctx, &plainTextMessageTF),
+		SSMLMessage:       fwtypes.NewListNestedObjectValueOfPtr(ctx, &ssmlMessageTF),
 	}
-	messages := []tflexv2models.Message{
-		message,
+	messageAWS := lextypes.Message{
+		CustomPayload: &lextypes.CustomPayload{
+			Value: aws.String(testString),
+		},
+		ImageResponseCard: &lextypes.ImageResponseCard{
+			Title: aws.String(testString),
+			Buttons: []lextypes.Button{{
+				Text:  aws.String(testString),
+				Value: aws.String(testString),
+			}},
+			ImageUrl: aws.String(testString),
+			Subtitle: aws.String(testString),
+		},
+		PlainTextMessage: &lextypes.PlainTextMessage{
+			Value: aws.String(testString),
+		},
+		SsmlMessage: &lextypes.SSMLMessage{
+			Value: aws.String(testString),
+		},
 	}
-	messageGroup := tflexv2models.MessageGroup{
-		Message:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &message),
-		Variations: fwtypes.NewListNestedObjectValueOfValueSlice[tflexv2models.Message](ctx, messages),
+	messagesTF := []tflexv2models.Message{
+		messageTF,
 	}
-	responseSpecification := tflexv2models.ResponseSpecification{
-		MessageGroup:   fwtypes.NewListNestedObjectValueOfPtr[tflexv2models.MessageGroup](ctx, &messageGroup),
+	messageGroupTF := tflexv2models.MessageGroup{
+		Message:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &messageTF),
+		Variations: fwtypes.NewListNestedObjectValueOfValueSlice[tflexv2models.Message](ctx, messagesTF),
+	}
+	responseSpecificationTF := tflexv2models.ResponseSpecification{
+		MessageGroup:   fwtypes.NewListNestedObjectValueOfPtr[tflexv2models.MessageGroup](ctx, &messageGroupTF),
 		AllowInterrupt: types.BoolValue(true),
+	}
+	responseSpecificationAWS := lextypes.ResponseSpecification{
+		MessageGroups: []lextypes.MessageGroup{
+			{
+				Message: &messageAWS,
+				Variations: []lextypes.Message{
+					messageAWS,
+				},
+			},
+		},
+		AllowInterrupt: aws.Bool(true),
 	}
 	/*
 		slotValue := tflexv2models.SlotValue{
@@ -147,210 +114,272 @@ func TestIntentAutoExpand(t *testing.T) {
 			}),
 		}
 	*/
-	intentOverride := tflexv2models.IntentOverride{
+	intentOverrideTF := tflexv2models.IntentOverride{
 		Name: types.StringValue(testString),
 		//Slots: fwtypes.NewMapValueOf[tflexv2models.SlotValueOverride](ctx, &slotValueOverride),
 	}
-	dialogAction := tflexv2models.DialogAction{
-		Type:                types.StringValue(testString),
+	dialogActionTF := tflexv2models.DialogAction{
+		Type:                types.StringValue(string(lextypes.DialogActionTypeCloseIntent)),
 		SlotToElicit:        types.StringValue(testString),
 		SuppressNextMessage: types.BoolValue(true),
 	}
-	dialogState := tflexv2models.DialogState{
-		DialogAction: fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogAction),
-		Intent:       fwtypes.NewListNestedObjectValueOfPtr(ctx, &intentOverride),
-		/*SessionAttributes: types.MapValueMust(types.StringType, map[string]attr.Value{
+	dialogStateTF := tflexv2models.DialogState{
+		DialogAction: fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogActionTF),
+		Intent:       fwtypes.NewListNestedObjectValueOfPtr(ctx, &intentOverrideTF),
+		SessionAttributes: types.MapValueMust(types.StringType, map[string]attr.Value{
 			testString: types.StringValue(testString2),
-		}),*/
+		}),
 	}
-	condition := tflexv2models.Condition{
-		ExpressionString: types.StringValue(testString),
+	dialogStateAWS := lextypes.DialogState{
+		DialogAction: &lextypes.DialogAction{
+			Type:                lextypes.DialogActionTypeCloseIntent,
+			SlotToElicit:        aws.String(testString),
+			SuppressNextMessage: aws.Bool(true),
+		},
+		Intent: &lextypes.IntentOverride{
+			Name: aws.String(testString),
+		},
+		SessionAttributes: map[string]string{
+			testString: testString2,
+		},
 	}
-	defaultConditionalBranch := tflexv2models.DefaultConditionalBranch{
-		NextStep: fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogState),
-		Response: fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecification),
+
+	//conditionTF := tflexv2models.Condition{
+	//	ExpressionString: types.StringValue(testString),
+	//}
+
+	defaultConditionalBranchTF := tflexv2models.DefaultConditionalBranch{
+		NextStep: fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogStateTF),
+		Response: fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecificationTF),
 	}
-	conditionalBranch := tflexv2models.ConditionalBranch{
-		Condition: fwtypes.NewListNestedObjectValueOfPtr(ctx, &condition),
-		Name:      types.StringValue(testString),
-		NextStep:  fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogState),
-		Response:  fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecification),
+
+	/*
+		conditionalBranchTF := tflexv2models.ConditionalBranch{
+			Condition: fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionTF),
+			Name:      types.StringValue(testString),
+			//NextStep:  fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogStateTF),
+			Response: fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecificationTF),
+		}
+	*/
+
+	//conditionalBranchesTF := []tflexv2models.ConditionalBranch{
+	//	conditionalBranchTF,
+	//}
+	conditionalSpecificationTF := tflexv2models.ConditionalSpecification{
+		Active: types.BoolValue(true),
+		/*
+			ConditionalBranch: fwtypes.NewListNestedObjectValueOfValueSlice(ctx, []tflexv2models.ConditionalBranch{
+				{
+					Condition: fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionTF),
+					Name: types.StringValue(testString),
+					NextStep:  fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogStateTF),
+					Response: fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecificationTF),
+				},
+			}),
+		*/
+		DefaultBranch: fwtypes.NewListNestedObjectValueOfPtr(ctx, &defaultConditionalBranchTF),
 	}
-	conditionalBranches := []tflexv2models.ConditionalBranch{
-		conditionalBranch,
-	}
-	conditionalSpecification := tflexv2models.ConditionalSpecification{
-		Active:            types.BoolValue(true),
-		ConditionalBranch: fwtypes.NewListNestedObjectValueOfValueSlice(ctx, conditionalBranches),
-		DefaultBranch:     fwtypes.NewListNestedObjectValueOfPtr(ctx, &defaultConditionalBranch),
-	}
-	intentClosingSetting := tflexv2models.IntentClosingSetting{
-		Active:          types.BoolValue(true),
-		ClosingResponse: fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecification),
-		Conditional:     fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecification),
-		NextStep:        fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogState),
+	conditionalSpecificationAWS := lextypes.ConditionalSpecification{
+		Active: aws.Bool(true),
+		ConditionalBranches: []lextypes.ConditionalBranch{
+			{
+				Condition: &lextypes.Condition{
+					ExpressionString: aws.String(testString),
+				},
+				Name: aws.String(testString),
+				//NextStep: &dialogStateAWS,
+				Response: &responseSpecificationAWS,
+			},
+		},
+		DefaultBranch: &lextypes.DefaultConditionalBranch{
+			//NextStep: &dialogStateAWS,
+			Response: &responseSpecificationAWS,
+		},
 	}
 	/*
-		allowedInputTypes := tflexv2models.AllowedInputTypes{
-			AllowAudioInput: types.BoolValue(true),
-			AllowDTMFInput:  types.BoolValue(true),
+		intentClosingSettingTF := tflexv2models.IntentClosingSetting{
+			Active:          types.BoolValue(true),
+			ClosingResponse: fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecificationTF),
+			Conditional:     fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecificationTF),
+			NextStep:        fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogStateTF),
 		}
-		audioSpecification := tflexv2models.AudioSpecification{
-			EndTimeoutMs: types.Int64Value(1),
-			MaxLengthMs:  types.Int64Value(1),
-		}
-		dtmfSpecification := tflexv2models.DTMFSpecification{
-			DeletionCharacter: types.StringValue(testString),
-			EndCharacter:      types.StringValue(testString),
-			EndTimeoutMs:      types.Int64Value(1),
-			MaxLength:         types.Int64Value(1),
-		}
-		audioAndDTMFInputSpecification := tflexv2models.AudioAndDTMFInputSpecification{
-			StartTimeoutMs:     types.Int64Value(1),
-			AudioSpecification: fwtypes.NewListNestedObjectValueOfPtr(ctx, &audioSpecification),
-			DTMFSpecification:  fwtypes.NewListNestedObjectValueOfPtr(ctx, &dtmfSpecification),
+		intentClosingSettingAWS := lextypes.IntentClosingSetting{
+			Active:          aws.Bool(true),
+			ClosingResponse: &responseSpecificationAWS,
+			Conditional:     &conditionalSpecificationAWS,
 		}
 
-		textInputSpecification := tflexv2models.TextInputSpecification{
-			StartTimeoutMs: types.Int64Value(1),
+		/*
+				allowedInputTypes := tflexv2models.AllowedInputTypes{
+					AllowAudioInput: types.BoolValue(true),
+					AllowDTMFInput:  types.BoolValue(true),
+				}
+				audioSpecification := tflexv2models.AudioSpecification{
+					EndTimeoutMs: types.Int64Value(1),
+					MaxLengthMs:  types.Int64Value(1),
+				}
+				dtmfSpecification := tflexv2models.DTMFSpecification{
+					DeletionCharacter: types.StringValue(testString),
+					EndCharacter:      types.StringValue(testString),
+					EndTimeoutMs:      types.Int64Value(1),
+					MaxLength:         types.Int64Value(1),
+				}
+				audioAndDTMFInputSpecification := tflexv2models.AudioAndDTMFInputSpecification{
+					StartTimeoutMs:     types.Int64Value(1),
+					AudioSpecification: fwtypes.NewListNestedObjectValueOfPtr(ctx, &audioSpecification),
+					DTMFSpecification:  fwtypes.NewListNestedObjectValueOfPtr(ctx, &dtmfSpecification),
+				}
+
+				textInputSpecification := tflexv2models.TextInputSpecification{
+					StartTimeoutMs: types.Int64Value(1),
+				}
+				promptAttemptSpecification := tflexv2models.PromptAttemptSpecification{
+					AllowedInputTypes:              fwtypes.NewListNestedObjectValueOfPtr(ctx, &allowedInputTypes),
+					AllowInterrupt:                 types.BoolValue(true),
+					AudioAndDTMFInputSpecification: fwtypes.NewListNestedObjectValueOfPtr(ctx, &audioAndDTMFInputSpecification),
+					TextInputSpecification:         fwtypes.NewListNestedObjectValueOfPtr(ctx, &textInputSpecification),
+				}
+				promptAttemptSpecificationMap := map[string]tflexv2models.PromptAttemptSpecification{
+					testString: promptAttemptSpecification,
+				}
+			promptSpecificationTF := tflexv2models.PromptSpecification{
+				MaxRetries:               types.Int64Value(1),
+				MessageGroup:             fwtypes.NewListNestedObjectValueOfPtr(ctx, &messageGroupTF),
+				AllowInterrupt:           types.BoolValue(true),
+				MessageSelectionStrategy: types.StringValue(testString),
+				//PromptAttemptsSpecification: promptAttemptSpecificationMap,
+			}
+	*/
+	/*
+		failureSuccessTimeoutTF := tflexv2models.FailureSuccessTimeout{
+			FailureConditional: fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecificationTF),
+			FailureNextStep:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogStateTF),
+			FailureResponse:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecificationTF),
+			SuccessConditional: fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecificationTF),
+			SuccessNextStep:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogStateTF),
+			SuccessResponse:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecificationTF),
+			TimeoutConditional: fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecificationTF),
+			TimeoutNextStep:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogStateTF),
+			TimeoutResponse:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecificationTF),
 		}
-		promptAttemptSpecification := tflexv2models.PromptAttemptSpecification{
-			AllowedInputTypes:              fwtypes.NewListNestedObjectValueOfPtr(ctx, &allowedInputTypes),
-			AllowInterrupt:                 types.BoolValue(true),
-			AudioAndDTMFInputSpecification: fwtypes.NewListNestedObjectValueOfPtr(ctx, &audioAndDTMFInputSpecification),
-			TextInputSpecification:         fwtypes.NewListNestedObjectValueOfPtr(ctx, &textInputSpecification),
+
+		dialogCodeHookInvocationSettingTF := tflexv2models.DialogCodeHookInvocationSetting{
+			Active:                    types.BoolValue(true),
+			EnableCodeHookInvocation:  types.BoolValue(true),
+			InvocationLabel:           types.StringValue(testString),
+			PostCodeHookSpecification: fwtypes.NewListNestedObjectValueOfPtr(ctx, &failureSuccessTimeoutTF),
 		}
-		promptAttemptSpecificationMap := map[string]tflexv2models.PromptAttemptSpecification{
-			testString: promptAttemptSpecification,
-		}*/
-	promptSpecification := tflexv2models.PromptSpecification{
-		MaxRetries:               types.Int64Value(1),
-		MessageGroup:             fwtypes.NewListNestedObjectValueOfPtr(ctx, &messageGroup),
-		AllowInterrupt:           types.BoolValue(true),
-		MessageSelectionStrategy: types.StringValue(testString),
-		//PromptAttemptsSpecification: promptAttemptSpecificationMap,
-	}
-	failureSuccessTimeout := tflexv2models.FailureSuccessTimeout{
-		FailureConditional: fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecification),
-		FailureNextStep:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogState),
-		FailureResponse:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecification),
-		SuccessConditional: fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecification),
-		SuccessNextStep:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogState),
-		SuccessResponse:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecification),
-		TimeoutConditional: fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecification),
-		TimeoutNextStep:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogState),
-		TimeoutResponse:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecification),
-	}
-	dialogCodeHookInvocationSetting := tflexv2models.DialogCodeHookInvocationSetting{
-		Active:                    types.BoolValue(true),
-		EnableCodeHookInvocation:  types.BoolValue(true),
-		InvocationLabel:           types.StringValue(testString),
-		PostCodeHookSpecification: fwtypes.NewListNestedObjectValueOfPtr(ctx, &failureSuccessTimeout),
-	}
-	elicitationCodeHook := tflexv2models.ElicitationCodeHookInvocationSetting{
-		EnableCodeHookInvocation: types.BoolValue(true),
-		InvocationLabel:          types.StringValue(testString),
-	}
-	intentConfirmationSetting := tflexv2models.IntentConfirmationSetting{
-		PromptSpecification:     fwtypes.NewListNestedObjectValueOfPtr(ctx, &promptSpecification),
-		Active:                  types.BoolValue(true),
-		CodeHook:                fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogCodeHookInvocationSetting),
-		ConfirmationConditional: fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecification),
-		ConfirmationNextStep:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogState),
-		ConfirmationResponse:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecification),
-		DeclinationConditional:  fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecification),
-		DeclinationNextStep:     fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogState),
-		DeclinationResponse:     fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecification),
-		ElicitationCodeHook:     fwtypes.NewListNestedObjectValueOfPtr(ctx, &elicitationCodeHook),
-		FailureConditional:      fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecification),
-		FailureNextStep:         fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogState),
-		FailureResponse:         fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecification),
-	}
-	dialogCodeHookSettings := tflexv2models.DialogCodeHookSettings{
+	*/
+	/*
+		elicitationCodeHookTF := tflexv2models.ElicitationCodeHookInvocationSetting{
+			EnableCodeHookInvocation: types.BoolValue(true),
+			InvocationLabel:          types.StringValue(testString),
+		}
+		/*
+		intentConfirmationSettingTF := tflexv2models.IntentConfirmationSetting{
+			PromptSpecification:     fwtypes.NewListNestedObjectValueOfPtr(ctx, &promptSpecificationTF),
+			Active:                  types.BoolValue(true),
+			CodeHook:                fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogCodeHookInvocationSettingTF),
+			ConfirmationConditional: fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecificationTF),
+			ConfirmationNextStep:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogStateTF),
+			ConfirmationResponse:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecificationTF),
+			DeclinationConditional:  fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecificationTF),
+			DeclinationNextStep:     fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogStateTF),
+			DeclinationResponse:     fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecificationTF),
+			ElicitationCodeHook:     fwtypes.NewListNestedObjectValueOfPtr(ctx, &elicitationCodeHookTF),
+			FailureConditional:      fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecificationTF),
+			FailureNextStep:         fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogStateTF),
+			FailureResponse:         fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecificationTF),
+		}
+	*/
+	dialogCodeHookSettingsTF := tflexv2models.DialogCodeHookSettings{
 		Enabled: types.BoolValue(true),
 	}
-	fulfillmentStartResponseSpecification := tflexv2models.FulfillmentStartResponseSpecification{
-		DelayInSeconds: types.Int64Value(1),
-		MessageGroup:   fwtypes.NewListNestedObjectValueOfPtr(ctx, &messageGroup),
-		AllowInterrupt: types.BoolValue(true),
-	}
-	fulfillmentUpdateResponseSpecification := tflexv2models.FulfillmentUpdateResponseSpecification{
-		FrequencyInSeconds: types.Int64Value(1),
-		MessageGroup:       fwtypes.NewListNestedObjectValueOfPtr(ctx, &messageGroup),
-		AllowInterrupt:     types.BoolValue(true),
-	}
-	fulfillmentUpdatesSpecification := tflexv2models.FulfillmentUpdatesSpecification{
-		Active:           types.BoolValue(true),
-		StartResponse:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &fulfillmentStartResponseSpecification),
-		TimeoutInSeconds: types.Int64Value(1),
-		UpdateResponse:   fwtypes.NewListNestedObjectValueOfPtr(ctx, &fulfillmentUpdateResponseSpecification),
-	}
-	fulfillmentCodeHookSettings := tflexv2models.FulfillmentCodeHookSettings{
-		Enabled:                            types.BoolValue(true),
-		Active:                             types.BoolValue(true),
-		FulfillmentUpdatesSpecification:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &fulfillmentUpdatesSpecification),
-		PostFulfillmentStatusSpecification: fwtypes.NewListNestedObjectValueOfPtr(ctx, &failureSuccessTimeout),
-	}
-	initialResponseSetting := tflexv2models.InitialResponseSetting{
-		CodeHook:        fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogCodeHookInvocationSetting),
-		Conditional:     fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecification),
-		InitialResponse: fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecification),
-		NextStep:        fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogState),
-	}
-	inputContext := tflexv2models.InputContext{
+	/*
+		fulfillmentStartResponseSpecificationTF := tflexv2models.FulfillmentStartResponseSpecification{
+			DelayInSeconds: types.Int64Value(1),
+			MessageGroup:   fwtypes.NewListNestedObjectValueOfPtr(ctx, &messageGroupTF),
+			AllowInterrupt: types.BoolValue(true),
+		}
+		fulfillmentUpdateResponseSpecificationTF := tflexv2models.FulfillmentUpdateResponseSpecification{
+			FrequencyInSeconds: types.Int64Value(1),
+			MessageGroup:       fwtypes.NewListNestedObjectValueOfPtr(ctx, &messageGroupTF),
+			AllowInterrupt:     types.BoolValue(true),
+		}
+		fulfillmentUpdatesSpecificationTF := tflexv2models.FulfillmentUpdatesSpecification{
+			Active:           types.BoolValue(true),
+			StartResponse:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &fulfillmentStartResponseSpecificationTF),
+			TimeoutInSeconds: types.Int64Value(1),
+			UpdateResponse:   fwtypes.NewListNestedObjectValueOfPtr(ctx, &fulfillmentUpdateResponseSpecificationTF),
+		}
+
+		fulfillmentCodeHookSettingsTF := tflexv2models.FulfillmentCodeHookSettings{
+			Enabled:                            types.BoolValue(true),
+			Active:                             types.BoolValue(true),
+			FulfillmentUpdatesSpecification:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &fulfillmentUpdatesSpecificationTF),
+			PostFulfillmentStatusSpecification: fwtypes.NewListNestedObjectValueOfPtr(ctx, &failureSuccessTimeoutTF),
+		}
+		initialResponseSettingTF := tflexv2models.InitialResponseSetting{
+			CodeHook:        fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogCodeHookInvocationSettingTF),
+			Conditional:     fwtypes.NewListNestedObjectValueOfPtr(ctx, &conditionalSpecificationTF),
+			InitialResponse: fwtypes.NewListNestedObjectValueOfPtr(ctx, &responseSpecificationTF),
+			NextStep:        fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogStateTF),
+		}
+	*/
+	inputContextTF := tflexv2models.InputContext{
 		Name: types.StringValue(testString),
 	}
-	inputContexts := []tflexv2models.InputContext{
-		inputContext,
+	inputContextsTF := []tflexv2models.InputContext{
+		inputContextTF,
 	}
-	kendraConfiguration := tflexv2models.KendraConfiguration{
+	kendraConfigurationTF := tflexv2models.KendraConfiguration{
 		KendraIndex:              types.StringValue(testString),
 		QueryFilterString:        types.StringValue(testString),
 		QueryFilterStringEnabled: types.BoolValue(true),
 	}
-	outputContext := tflexv2models.OutputContext{
+	outputContextTF := tflexv2models.OutputContext{
 		Name:                types.StringValue(testString),
 		TimeToLiveInSeconds: types.Int64Value(1),
 		TurnsToLive:         types.Int64Value(1),
 	}
-	outputContexts := []tflexv2models.OutputContext{
-		outputContext,
+	outputContextsTF := []tflexv2models.OutputContext{
+		outputContextTF,
 	}
-	sampleUtterance := tflexv2models.SampleUtterance{
+	sampleUtteranceTF := tflexv2models.SampleUtterance{
 		Utterance: types.StringValue(testString),
 	}
-	sampleUtterances := []tflexv2models.SampleUtterance{
-		sampleUtterance,
+	sampleUtterancesTF := []tflexv2models.SampleUtterance{
+		sampleUtteranceTF,
 	}
-	slotPriority := tflexv2models.SlotPriority{
+	slotPriorityTF := tflexv2models.SlotPriority{
 		Priority: types.Int64Value(1),
 		SlotID:   types.StringValue(testString),
 	}
-	slotPriorities := []tflexv2models.SlotPriority{
-		slotPriority,
+	slotPrioritiesTF := []tflexv2models.SlotPriority{
+		slotPriorityTF,
 	}
-	intentResource := tflexv2models.ResourceIntentData{
-		BotID:                  types.StringValue(testString),
-		BotVersion:             types.StringValue(testString),
-		ClosingSetting:         fwtypes.NewListNestedObjectValueOfPtr(ctx, &intentClosingSetting),
-		ConfirmationSetting:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &intentConfirmationSetting),
-		CreationDateTime:       fwtypes.TimestampType{},
-		Description:            types.StringValue(testString),
-		DialogCodeHook:         fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogCodeHookSettings),
-		FulfillmentCodeHook:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &fulfillmentCodeHookSettings),
-		ID:                     types.StringValue(testString),
-		InitialResponseSetting: fwtypes.NewListNestedObjectValueOfPtr(ctx, &initialResponseSetting),
-		InputContext:           fwtypes.NewListNestedObjectValueOfValueSlice[tflexv2models.InputContext](ctx, inputContexts),
-		KendraConfiguration:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &kendraConfiguration),
-		LastUpdatedDateTime:    fwtypes.TimestampType{},
-		LocaleID:               types.StringValue(testString),
-		Name:                   types.StringValue(testString),
-		OutputContext:          fwtypes.NewListNestedObjectValueOfValueSlice[tflexv2models.OutputContext](ctx, outputContexts),
-		ParentIntentSignature:  types.StringValue(testString),
-		SampleUtterance:        fwtypes.NewListNestedObjectValueOfValueSlice[tflexv2models.SampleUtterance](ctx, sampleUtterances),
-		SlotPriority:           fwtypes.NewListNestedObjectValueOfValueSlice[tflexv2models.SlotPriority](ctx, slotPriorities),
+	intentResourceTF := tflexv2models.ResourceIntentData{
+		BotID:      types.StringValue(testString),
+		BotVersion: types.StringValue(testString),
+		//ClosingSetting:         fwtypes.NewListNestedObjectValueOfPtr(ctx, &intentClosingSettingTF),
+		//ConfirmationSetting:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &intentConfirmationSettingTF),
+		CreationDateTime: fwtypes.TimestampType{},
+		Description:      types.StringValue(testString),
+		DialogCodeHook:   fwtypes.NewListNestedObjectValueOfPtr(ctx, &dialogCodeHookSettingsTF),
+		//FulfillmentCodeHook:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &fulfillmentCodeHookSettingsTF),
+		ID: types.StringValue(testString),
+		//InitialResponseSetting: fwtypes.NewListNestedObjectValueOfPtr(ctx, &initialResponseSettingTF),
+		InputContext:          fwtypes.NewListNestedObjectValueOfValueSlice[tflexv2models.InputContext](ctx, inputContextsTF),
+		KendraConfiguration:   fwtypes.NewListNestedObjectValueOfPtr(ctx, &kendraConfigurationTF),
+		LastUpdatedDateTime:   fwtypes.TimestampType{},
+		LocaleID:              types.StringValue(testString),
+		Name:                  types.StringValue(testString),
+		OutputContext:         fwtypes.NewListNestedObjectValueOfValueSlice[tflexv2models.OutputContext](ctx, outputContextsTF),
+		ParentIntentSignature: types.StringValue(testString),
+		SampleUtterance:       fwtypes.NewListNestedObjectValueOfValueSlice[tflexv2models.SampleUtterance](ctx, sampleUtterancesTF),
+		SlotPriority:          fwtypes.NewListNestedObjectValueOfValueSlice[tflexv2models.SlotPriority](ctx, slotPrioritiesTF),
 	}
-	fmt.Printf("intentResource %s\n", intentResource)
+	fmt.Printf("intentResourceTF %s\n", intentResourceTF)
 
 	testCases := []struct {
 		TestName   string
@@ -360,51 +389,34 @@ func TestIntentAutoExpand(t *testing.T) {
 		WantTarget any
 	}{
 		{
-			TestName: "message",
-			Source:   &message,
-			Target:   &lextypes.Message{},
-			WantTarget: &lextypes.Message{
-				CustomPayload: &lextypes.CustomPayload{
-					Value: aws.String(testString),
-				},
-				ImageResponseCard: &lextypes.ImageResponseCard{
-					Title: aws.String(testString),
-					Buttons: []lextypes.Button{{
-						Text:  aws.String(testString),
-						Value: aws.String(testString),
-					}},
-					ImageUrl: aws.String(testString),
-					Subtitle: aws.String(testString),
-				},
-				PlainTextMessage: &lextypes.PlainTextMessage{
-					Value: aws.String(testString),
-				},
-				SsmlMessage: &lextypes.SSMLMessage{
-					Value: aws.String(testString),
-				},
-			},
+			TestName:   "message",
+			Source:     &messageTF,
+			Target:     &lextypes.Message{},
+			WantTarget: &messageAWS,
 		},
 		{
-			TestName: "plainTextMessage",
-			Source:   &plainTextMessage,
-			Target:   &lextypes.PlainTextMessage{},
-			WantTarget: &lextypes.PlainTextMessage{
-				Value: aws.String(testString),
-			},
+			TestName:   "responseSpecification",
+			Source:     &responseSpecificationTF,
+			Target:     &lextypes.ResponseSpecification{},
+			WantTarget: &responseSpecificationAWS,
 		},
 		{
-			TestName: "button",
-			Source:   &button,
-			Target:   &lextypes.Button{},
-			WantTarget: &lextypes.Button{
-				Text:  aws.String(testString),
-				Value: aws.String(testString),
-			},
+			TestName:   "dialogState",
+			Source:     &dialogStateTF,
+			Target:     &lextypes.DialogState{},
+			WantTarget: &dialogStateAWS,
 		},
+		{
+			TestName:   "conditionalSpecification",
+			Source:     &conditionalSpecificationTF,
+			Target:     &lextypes.ConditionalSpecification{},
+			WantTarget: &conditionalSpecificationAWS,
+		},
+
 		/*
 			{
 				TestName: "complex Source and complex Target",
-				Source:   &intentResource,
+				Source:   &intentResourceTF,
 				Target:   &lexmodelsv2.CreateIntentInput{},
 				WantTarget: &lexmodelsv2.CreateIntentInput{
 					BotId: aws.String(testString),
@@ -420,6 +432,13 @@ func TestIntentAutoExpand(t *testing.T) {
 		lextypes.CustomPayload{},
 		lextypes.ImageResponseCard{},
 		lextypes.Message{},
+		lextypes.ResponseSpecification{},
+		lextypes.MessageGroup{},
+		lextypes.DialogAction{},
+		lextypes.DialogState{},
+		lextypes.IntentOverride{},
+		lextypes.ConditionalSpecification{},
+		lextypes.ConditionalBranch{},
 	)
 
 	for _, testCase := range testCases {

--- a/internal/service/lexv2models/intent_test.go
+++ b/internal/service/lexv2models/intent_test.go
@@ -2073,7 +2073,7 @@ resource "aws_lexv2models_intent" "test" {
 
         next_step {
           dialog_action {
-            type = "CloseIntent"
+            type           = "CloseIntent"
             slot_to_elicit = "slot1"
           }
 
@@ -2098,7 +2098,7 @@ resource "aws_lexv2models_intent" "test" {
       default_branch {
         next_step {
           dialog_action {
-            type = "CloseIntent"
+            type           = "CloseIntent"
             slot_to_elicit = "slot1"
           }
 
@@ -2179,7 +2179,7 @@ resource "aws_lexv2models_intent" "test" {
 
             next_step {
               dialog_action {
-                type = "CloseIntent"
+                type           = "CloseIntent"
                 slot_to_elicit = "slot1"
               }
 
@@ -2204,7 +2204,7 @@ resource "aws_lexv2models_intent" "test" {
           default_branch {
             next_step {
               dialog_action {
-                type = "CloseIntent"
+                type           = "CloseIntent"
                 slot_to_elicit = "slot1"
               }
 
@@ -2342,7 +2342,7 @@ resource "aws_lexv2models_intent" "test" {
         default_branch {
           next_step {
             dialog_action {
-              type = "CloseIntent"
+              type           = "CloseIntent"
               slot_to_elicit = "slot1"
             }
 

--- a/internal/service/lexv2models/intent_test.go
+++ b/internal/service/lexv2models/intent_test.go
@@ -1138,34 +1138,35 @@ resource "aws_lexv2models_intent" "test" {
       message_selection_strategy = "Ordered"
 
       prompt_attempts_specification {
-        Attempt1 {
-          allowed_input_types {
-            allow_audio_input = true
-            allow_dtmf_input  = true
+        map_block_key = "Initial"
+        
+        allowed_input_types {
+          allow_audio_input = true
+          allow_dtmf_input  = true
+        }
+
+        allow_interrupt = true
+
+        audio_and_dtmf_input_specification {
+          start_timeout_ms = 1
+
+          audio_specification {
+            end_timeout_ms = 1
+            max_length_ms = 1
           }
 
-          allow_interrupt = true
-
-          audio_and_dtmf_input_specification {
-            start_timeout_ms = 1
-
-            audio_specification {
-              end_timeout_ms = 1
-              max_length_ms = 1
-            }
-
-            dtmf_specification {
-              deletion_character = "#"
-              end_character      = "#"
-              end_timeout_ms     = 1
-              max_length         = 1
-            }
-          }
-
-          text_input_specification {
-            start_timeout_ms = 1
+          dtmf_specification {
+            deletion_character = "#"
+            end_character      = "#"
+            end_timeout_ms     = 1
+            max_length         = 1
           }
         }
+
+        text_input_specification {
+          start_timeout_ms = 1
+        }
+      
       }
     }
   }

--- a/internal/service/lexv2models/intent_test.go
+++ b/internal/service/lexv2models/intent_test.go
@@ -331,7 +331,7 @@ func TestIntentAutoFlex(t *testing.T) {
 		MessageGroup:                fwtypes.NewListNestedObjectValueOfPtr(ctx, &messageGroupTF),
 		AllowInterrupt:              types.BoolValue(true),
 		MessageSelectionStrategy:    fwtypes.StringEnumValue(lextypes.MessageSelectionStrategyOrdered),
-		PromptAttemptsSpecification: fwtypes.NewListNestedObjectValueOfPtr(ctx, &promptAttemptSpecificationTF),
+		PromptAttemptsSpecification: fwtypes.NewSetNestedObjectValueOfPtr(ctx, &promptAttemptSpecificationTF),
 	}
 	promptSpecificationAWS := lextypes.PromptSpecification{
 		MaxRetries:               aws.Int32(1),
@@ -1132,43 +1132,79 @@ resource "aws_lexv2models_intent" "test" {
   confirmation_setting {
     active = true
 
-    #prompt_specification {
-      #allow_interrupt = true
-      #max_retries     = 1
-      #message_selection_strategy = "Ordered"
+    prompt_specification {
+      allow_interrupt = true
+      max_retries     = 1
+      message_selection_strategy = "Ordered"
 
-      #prompt_attempts_specification {
-        #map_block_key = "Initial"
+      message_group {
+        message {
+          plain_text_message {
+            value = "test"
+          }
+        }
+      }
 
-        #allowed_input_types {
-          #allow_audio_input = true
-          #allow_dtmf_input  = true
-        #}
+      prompt_attempts_specification {
+        allow_interrupt = true
+        map_block_key   = "Initial"
 
-        #allow_interrupt = true
+        allowed_input_types {
+          allow_audio_input = true
+          allow_dtmf_input  = true
+        }
 
-        #audio_and_dtmf_input_specification {
-          #start_timeout_ms = 1
+        audio_and_dtmf_input_specification {
+          start_timeout_ms = 4000
 
-          #audio_specification {
-            #end_timeout_ms = 1
-            #max_length_ms = 1
-          #}
+          audio_specification {
+            end_timeout_ms = 640
+            max_length_ms  = 15000
+          }
 
-          #dtmf_specification {
-            #deletion_character = "#"
-            #end_character      = "#"
-            #end_timeout_ms     = 1
-            #max_length         = 1
-          #}
-        #}
+          dtmf_specification {
+            deletion_character = "*"
+            end_character      = "#"
+            end_timeout_ms     = 5000
+            max_length         = 513
+          }
+        }
 
-        #text_input_specification {
-          #start_timeout_ms = 1
-        #}
+        text_input_specification {
+          start_timeout_ms = 30000
+        }
+      }
 
-      #}
-    #}
+      prompt_attempts_specification {
+        allow_interrupt = true
+        map_block_key   = "Retry1"
+
+        allowed_input_types {
+          allow_audio_input = true
+          allow_dtmf_input  = true
+        }
+
+        audio_and_dtmf_input_specification {
+          start_timeout_ms = 4000
+
+          audio_specification {
+            end_timeout_ms = 640
+            max_length_ms  = 15000
+          }
+
+          dtmf_specification {
+            deletion_character = "*"
+            end_character      = "#"
+            end_timeout_ms     = 5000
+            max_length         = 513
+          }
+        }
+
+        text_input_specification {
+          start_timeout_ms = 30000
+        }
+      }
+    }
   }
 }
 `, rName))

--- a/internal/service/lexv2models/intent_test.go
+++ b/internal/service/lexv2models/intent_test.go
@@ -1047,7 +1047,7 @@ func TestAccLexV2ModelsIntent_updateClosingSetting(t *testing.T) {
 		CheckDestroy:             testAccCheckIntentDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIntentConfig_updateClosingSetting(rName, "test", "test"),
+				Config: testAccIntentConfig_updateClosingSetting(rName, "test1", "test2", "test3"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIntentExists(ctx, resourceName, &intent),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -1057,12 +1057,763 @@ func TestAccLexV2ModelsIntent_updateClosingSetting(t *testing.T) {
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "closing_setting.*", map[string]string{
 						"active": "true",
 					}),
-					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "closing_setting.*.closing_response.*.message_group.*.message.*.plain_text_message.*", map[string]string{
-						"value": "test",
-					}),
-					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "closing_setting.*.closing_response.*.conditional.*.conditional_branch.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "closing_setting.*.conditional.*.conditional_branch.*", map[string]string{
 						"name": rName,
 					}),
+					resource.TestCheckResourceAttr(resourceName, "closing_setting.0.conditional.0.conditional_branch.0.next_step.0.session_attributes.slot1", "roligt"),
+					resource.TestCheckResourceAttr(resourceName, "closing_setting.0.conditional.0.default_branch.0.next_step.0.session_attributes.slot1", "hallon"),
+					resource.TestCheckResourceAttr(resourceName, "closing_setting.0.closing_response.0.message_group.0.message.0.plain_text_message.0.value", "test1"),
+					resource.TestCheckResourceAttr(resourceName, "closing_setting.0.conditional.0.conditional_branch.0.response.0.message_group.0.message.0.plain_text_message.0.value", "test2"),
+					resource.TestCheckResourceAttr(resourceName, "closing_setting.0.conditional.0.default_branch.0.response.0.message_group.0.message.0.plain_text_message.0.value", "test3"),
+				),
+			},
+			{
+				Config: testAccIntentConfig_updateClosingSetting(rName, "Hvad", "er", "hygge"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIntentExists(ctx, resourceName, &intent),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrPair(resourceName, "bot_id", botLocaleName, "bot_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "bot_version", botLocaleName, "bot_version"),
+					resource.TestCheckResourceAttrPair(resourceName, "locale_id", botLocaleName, "locale_id"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "closing_setting.*", map[string]string{
+						"active": "true",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "closing_setting.*.conditional.*.conditional_branch.*", map[string]string{
+						"name": rName,
+					}),
+					resource.TestCheckResourceAttr(resourceName, "closing_setting.0.conditional.0.conditional_branch.0.next_step.0.session_attributes.slot1", "roligt"),
+					resource.TestCheckResourceAttr(resourceName, "closing_setting.0.conditional.0.default_branch.0.next_step.0.session_attributes.slot1", "hallon"),
+					resource.TestCheckResourceAttr(resourceName, "closing_setting.0.closing_response.0.message_group.0.message.0.plain_text_message.0.value", "Hvad"),
+					resource.TestCheckResourceAttr(resourceName, "closing_setting.0.conditional.0.conditional_branch.0.response.0.message_group.0.message.0.plain_text_message.0.value", "er"),
+					resource.TestCheckResourceAttr(resourceName, "closing_setting.0.conditional.0.default_branch.0.response.0.message_group.0.message.0.plain_text_message.0.value", "hygge"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccLexV2ModelsIntent_updateInputContext(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var intent lexmodelsv2.DescribeIntentOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lexv2models_intent.test"
+	botLocaleName := "aws_lexv2models_bot_locale.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.LexV2ModelsEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.LexV2ModelsEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckIntentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIntentConfig_updateInputContext(rName, "sammanhang1", "sammanhang2", "sammanhang3"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIntentExists(ctx, resourceName, &intent),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrPair(resourceName, "bot_id", botLocaleName, "bot_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "bot_version", botLocaleName, "bot_version"),
+					resource.TestCheckResourceAttrPair(resourceName, "locale_id", botLocaleName, "locale_id"),
+					resource.TestCheckResourceAttr(resourceName, "input_context.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "input_context.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "input_context.0.name", "sammanhang1"),
+					resource.TestCheckResourceAttr(resourceName, "input_context.1.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "input_context.1.name", "sammanhang2"),
+					resource.TestCheckResourceAttr(resourceName, "input_context.2.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "input_context.2.name", "sammanhang3"),
+				),
+			},
+			{
+				Config: testAccIntentConfig_updateInputContext(rName, "kropp", "utan", "blod"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIntentExists(ctx, resourceName, &intent),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrPair(resourceName, "bot_id", botLocaleName, "bot_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "bot_version", botLocaleName, "bot_version"),
+					resource.TestCheckResourceAttrPair(resourceName, "locale_id", botLocaleName, "locale_id"),
+					resource.TestCheckResourceAttr(resourceName, "input_context.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "input_context.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "input_context.0.name", "kropp"),
+					resource.TestCheckResourceAttr(resourceName, "input_context.1.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "input_context.1.name", "utan"),
+					resource.TestCheckResourceAttr(resourceName, "input_context.2.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "input_context.2.name", "blod"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccLexV2ModelsIntent_updateInitialResponseSetting(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var intent lexmodelsv2.DescribeIntentOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lexv2models_intent.test"
+	botLocaleName := "aws_lexv2models_bot_locale.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.LexV2ModelsEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.LexV2ModelsEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckIntentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIntentConfig_updateInitialResponseSetting(rName, "branch1", "tre", "slumpmässiga", "ord"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIntentExists(ctx, resourceName, &intent),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrPair(resourceName, "bot_id", botLocaleName, "bot_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "bot_version", botLocaleName, "bot_version"),
+					resource.TestCheckResourceAttrPair(resourceName, "locale_id", botLocaleName, "locale_id"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.active", "true"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.enable_code_hook_invocation", "true"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.invocation_label", "test"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.%", "9"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.active", "true"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.condition.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.condition.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.condition.0.expression_string", "slot1 = \"test\""),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.name", "branch1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.next_step.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.dialog_action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.dialog_action.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.dialog_action.0.slot_to_elicit", "slot1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.dialog_action.0.type", "CloseIntent"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.intent.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.session_attributes.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.session_attributes.slot1", "roligt"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.response.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.response.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.response.0.allow_interrupt", "true"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.message.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.message.0.custom_payload.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.message.0.image_response_card.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.message.0.plain_text_message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.message.0.plain_text_message.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.message.0.plain_text_message.0.value", "tre"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.message.0.ssml_message.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.variation.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.next_step.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.next_step.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.next_step.0.dialog_action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.next_step.0.dialog_action.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.next_step.0.dialog_action.0.slot_to_elicit", "slot1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.next_step.0.dialog_action.0.type", "CloseIntent"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.next_step.0.intent.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.next_step.0.session_attributes.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.next_step.0.session_attributes.slot1", "hallon"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.response.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.response.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.response.0.allow_interrupt", "true"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.message.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.message.0.custom_payload.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.message.0.image_response_card.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.message.0.plain_text_message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.message.0.plain_text_message.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.message.0.plain_text_message.0.value", "slumpmässiga"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.message.0.ssml_message.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.variation.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_next_step.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_response.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.success_conditional.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.success_next_step.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.success_response.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.timeout_conditional.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.timeout_next_step.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.timeout_response.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.conditional.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.initial_response.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.initial_response.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.initial_response.0.allow_interrupt", "true"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.initial_response.0.message_group.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.initial_response.0.message_group.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.initial_response.0.message_group.0.message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.initial_response.0.message_group.0.message.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.initial_response.0.message_group.0.message.0.custom_payload.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.initial_response.0.message_group.0.message.0.image_response_card.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.initial_response.0.message_group.0.message.0.plain_text_message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.initial_response.0.message_group.0.message.0.plain_text_message.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.initial_response.0.message_group.0.message.0.plain_text_message.0.value", "ord"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.initial_response.0.message_group.0.message.0.ssml_message.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.initial_response.0.message_group.0.variation.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.next_step.#", "0"),
+				),
+			},
+			{
+				Config: testAccIntentConfig_updateInitialResponseSetting(rName, "gren1", "några", "olika", "bokstäver"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIntentExists(ctx, resourceName, &intent),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrPair(resourceName, "bot_id", botLocaleName, "bot_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "bot_version", botLocaleName, "bot_version"),
+					resource.TestCheckResourceAttrPair(resourceName, "locale_id", botLocaleName, "locale_id"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.active", "true"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.enable_code_hook_invocation", "true"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.invocation_label", "test"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.%", "9"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.active", "true"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.condition.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.condition.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.condition.0.expression_string", "slot1 = \"test\""),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.name", "gren1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.next_step.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.dialog_action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.dialog_action.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.dialog_action.0.slot_to_elicit", "slot1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.dialog_action.0.type", "CloseIntent"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.intent.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.session_attributes.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.session_attributes.slot1", "roligt"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.response.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.response.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.response.0.allow_interrupt", "true"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.message.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.message.0.custom_payload.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.message.0.image_response_card.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.message.0.plain_text_message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.message.0.plain_text_message.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.message.0.plain_text_message.0.value", "några"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.message.0.ssml_message.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.variation.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.next_step.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.next_step.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.next_step.0.dialog_action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.next_step.0.dialog_action.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.next_step.0.dialog_action.0.slot_to_elicit", "slot1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.next_step.0.dialog_action.0.type", "CloseIntent"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.next_step.0.intent.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.next_step.0.session_attributes.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.next_step.0.session_attributes.slot1", "hallon"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.response.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.response.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.response.0.allow_interrupt", "true"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.message.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.message.0.custom_payload.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.message.0.image_response_card.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.message.0.plain_text_message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.message.0.plain_text_message.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.message.0.plain_text_message.0.value", "olika"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.message.0.ssml_message.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.variation.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_next_step.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.failure_response.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.success_conditional.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.success_next_step.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.success_response.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.timeout_conditional.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.timeout_next_step.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.code_hook.0.post_code_hook_specification.0.timeout_response.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.conditional.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.initial_response.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.initial_response.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.initial_response.0.allow_interrupt", "true"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.initial_response.0.message_group.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.initial_response.0.message_group.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.initial_response.0.message_group.0.message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.initial_response.0.message_group.0.message.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.initial_response.0.message_group.0.message.0.custom_payload.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.initial_response.0.message_group.0.message.0.image_response_card.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.initial_response.0.message_group.0.message.0.plain_text_message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.initial_response.0.message_group.0.message.0.plain_text_message.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.initial_response.0.message_group.0.message.0.plain_text_message.0.value", "bokstäver"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.initial_response.0.message_group.0.message.0.ssml_message.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.initial_response.0.message_group.0.variation.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "initial_response_setting.0.next_step.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccLexV2ModelsIntent_updateFulfillmentCodeHook(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var intent lexmodelsv2.DescribeIntentOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lexv2models_intent.test"
+	botLocaleName := "aws_lexv2models_bot_locale.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.LexV2ModelsEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.LexV2ModelsEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckIntentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIntentConfig_updateFulfillmentCodeHook(rName, "meddelande", 10, "slumpmässiga", "gren1", "alfanumerisk", "olika"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIntentExists(ctx, resourceName, &intent),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrPair(resourceName, "bot_id", botLocaleName, "bot_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "bot_version", botLocaleName, "bot_version"),
+					resource.TestCheckResourceAttrPair(resourceName, "locale_id", botLocaleName, "locale_id"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.active", "true"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.active", "true"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.start_response.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.start_response.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.start_response.0.allow_interrupt", "true"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.start_response.0.delay_in_seconds", "5"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.start_response.0.message_group.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.start_response.0.message_group.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.start_response.0.message_group.0.message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.start_response.0.message_group.0.message.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.start_response.0.message_group.0.message.0.custom_payload.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.start_response.0.message_group.0.message.0.image_response_card.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.start_response.0.message_group.0.message.0.plain_text_message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.start_response.0.message_group.0.message.0.plain_text_message.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.start_response.0.message_group.0.message.0.plain_text_message.0.value", "meddelande"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.start_response.0.message_group.0.message.0.ssml_message.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.start_response.0.message_group.0.variation.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.timeout_in_seconds", "10"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.update_response.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.update_response.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.update_response.0.allow_interrupt", "true"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.update_response.0.frequency_in_seconds", "10"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.update_response.0.message_group.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.update_response.0.message_group.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.update_response.0.message_group.0.message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.update_response.0.message_group.0.message.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.update_response.0.message_group.0.message.0.custom_payload.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.update_response.0.message_group.0.message.0.image_response_card.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.update_response.0.message_group.0.message.0.plain_text_message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.update_response.0.message_group.0.message.0.plain_text_message.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.update_response.0.message_group.0.message.0.plain_text_message.0.value", "slumpmässiga"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.update_response.0.message_group.0.message.0.ssml_message.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.update_response.0.message_group.0.variation.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.%", "9"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.active", "true"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.condition.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.condition.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.condition.0.expression_string", "slot1 = \"test\""),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.name", "gren1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.dialog_action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.dialog_action.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.dialog_action.0.slot_to_elicit", "slot1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.dialog_action.0.suppress_next_message", "true"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.dialog_action.0.type", "CloseIntent"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.intent.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.intent.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.intent.0.name", "test"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.intent.0.slot.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.intent.0.slot.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.intent.0.slot.0.map_block_key", "test"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.intent.0.slot.0.shape", "Scalar"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.intent.0.slot.0.value.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.intent.0.slot.0.value.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.intent.0.slot.0.value.0.interpreted_value", "alfanumerisk"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.session_attributes.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.session_attributes.slot1", "roligt"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.session_attributes.slot2", "roligt2"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.response.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.response.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.response.0.allow_interrupt", "true"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.message.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.message.0.custom_payload.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.message.0.image_response_card.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.message.0.plain_text_message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.message.0.plain_text_message.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.message.0.plain_text_message.0.value", "olika"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.message.0.ssml_message.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.variation.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.next_step.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.next_step.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.next_step.0.dialog_action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.next_step.0.dialog_action.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.next_step.0.dialog_action.0.slot_to_elicit", "slot1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.next_step.0.dialog_action.0.type", "CloseIntent"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.next_step.0.intent.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.next_step.0.session_attributes.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.next_step.0.session_attributes.slot1", "hallon"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.response.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.response.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.response.0.allow_interrupt", "true"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.message.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.message.0.custom_payload.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.message.0.image_response_card.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.message.0.plain_text_message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.message.0.plain_text_message.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.message.0.plain_text_message.0.value", "safriduo"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.message.0.ssml_message.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.variation.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_next_step.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_response.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.success_conditional.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.success_next_step.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.success_response.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.timeout_conditional.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.timeout_next_step.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.timeout_response.#", "0"),
+				),
+			},
+			{
+				Config: testAccIntentConfig_updateFulfillmentCodeHook(rName, "dagdröm", 10, "dansa", "dumbom", "gås", "mat"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIntentExists(ctx, resourceName, &intent),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrPair(resourceName, "bot_id", botLocaleName, "bot_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "bot_version", botLocaleName, "bot_version"),
+					resource.TestCheckResourceAttrPair(resourceName, "locale_id", botLocaleName, "locale_id"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.active", "true"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.active", "true"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.start_response.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.start_response.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.start_response.0.allow_interrupt", "true"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.start_response.0.delay_in_seconds", "5"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.start_response.0.message_group.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.start_response.0.message_group.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.start_response.0.message_group.0.message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.start_response.0.message_group.0.message.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.start_response.0.message_group.0.message.0.custom_payload.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.start_response.0.message_group.0.message.0.image_response_card.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.start_response.0.message_group.0.message.0.plain_text_message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.start_response.0.message_group.0.message.0.plain_text_message.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.start_response.0.message_group.0.message.0.plain_text_message.0.value", "dagdröm"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.start_response.0.message_group.0.message.0.ssml_message.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.start_response.0.message_group.0.variation.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.timeout_in_seconds", "10"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.update_response.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.update_response.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.update_response.0.allow_interrupt", "true"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.update_response.0.frequency_in_seconds", "10"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.update_response.0.message_group.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.update_response.0.message_group.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.update_response.0.message_group.0.message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.update_response.0.message_group.0.message.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.update_response.0.message_group.0.message.0.custom_payload.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.update_response.0.message_group.0.message.0.image_response_card.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.update_response.0.message_group.0.message.0.plain_text_message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.update_response.0.message_group.0.message.0.plain_text_message.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.update_response.0.message_group.0.message.0.plain_text_message.0.value", "dansa"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.update_response.0.message_group.0.message.0.ssml_message.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.fulfillment_updates_specification.0.update_response.0.message_group.0.variation.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.%", "9"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.active", "true"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.condition.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.condition.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.condition.0.expression_string", "slot1 = \"test\""),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.name", "dumbom"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.dialog_action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.dialog_action.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.dialog_action.0.slot_to_elicit", "slot1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.dialog_action.0.suppress_next_message", "true"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.dialog_action.0.type", "CloseIntent"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.intent.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.intent.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.intent.0.name", "test"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.intent.0.slot.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.intent.0.slot.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.intent.0.slot.0.map_block_key", "test"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.intent.0.slot.0.shape", "Scalar"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.intent.0.slot.0.value.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.intent.0.slot.0.value.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.intent.0.slot.0.value.0.interpreted_value", "gås"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.session_attributes.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.session_attributes.slot1", "roligt"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.next_step.0.session_attributes.slot2", "roligt2"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.response.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.response.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.response.0.allow_interrupt", "true"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.message.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.message.0.custom_payload.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.message.0.image_response_card.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.message.0.plain_text_message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.message.0.plain_text_message.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.message.0.plain_text_message.0.value", "mat"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.message.0.ssml_message.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.conditional_branch.0.response.0.message_group.0.variation.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.next_step.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.next_step.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.next_step.0.dialog_action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.next_step.0.dialog_action.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.next_step.0.dialog_action.0.slot_to_elicit", "slot1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.next_step.0.dialog_action.0.type", "CloseIntent"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.next_step.0.intent.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.next_step.0.session_attributes.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.next_step.0.session_attributes.slot1", "hallon"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.response.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.response.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.response.0.allow_interrupt", "true"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.message.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.message.0.custom_payload.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.message.0.image_response_card.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.message.0.plain_text_message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.message.0.plain_text_message.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.message.0.plain_text_message.0.value", "safriduo"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.message.0.ssml_message.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_conditional.0.default_branch.0.response.0.message_group.0.variation.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_next_step.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.failure_response.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.success_conditional.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.success_next_step.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.success_response.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.timeout_conditional.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.timeout_next_step.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_code_hook.0.post_fulfillment_status_specification.0.timeout_response.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccLexV2ModelsIntent_updateDialogCodeHook(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var intent lexmodelsv2.DescribeIntentOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lexv2models_intent.test"
+	botLocaleName := "aws_lexv2models_bot_locale.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.LexV2ModelsEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.LexV2ModelsEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckIntentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIntentConfig_updateDialogCodeHook(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIntentExists(ctx, resourceName, &intent),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrPair(resourceName, "bot_id", botLocaleName, "bot_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "bot_version", botLocaleName, "bot_version"),
+					resource.TestCheckResourceAttrPair(resourceName, "locale_id", botLocaleName, "locale_id"),
+					resource.TestCheckResourceAttr(resourceName, "dialog_code_hook.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "dialog_code_hook.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "dialog_code_hook.0.enabled", "true"),
+				),
+			},
+			{
+				Config: testAccIntentConfig_updateDialogCodeHook(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIntentExists(ctx, resourceName, &intent),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrPair(resourceName, "bot_id", botLocaleName, "bot_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "bot_version", botLocaleName, "bot_version"),
+					resource.TestCheckResourceAttrPair(resourceName, "locale_id", botLocaleName, "locale_id"),
+					resource.TestCheckResourceAttr(resourceName, "dialog_code_hook.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "dialog_code_hook.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "dialog_code_hook.0.enabled", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccLexV2ModelsIntent_updateOutputContext(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var intent lexmodelsv2.DescribeIntentOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lexv2models_intent.test"
+	botLocaleName := "aws_lexv2models_bot_locale.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.LexV2ModelsEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.LexV2ModelsEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckIntentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIntentConfig_updateOutputContext(rName, "name1", "name2", "name3"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIntentExists(ctx, resourceName, &intent),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrPair(resourceName, "bot_id", botLocaleName, "bot_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "bot_version", botLocaleName, "bot_version"),
+					resource.TestCheckResourceAttrPair(resourceName, "locale_id", botLocaleName, "locale_id"),
+					resource.TestCheckResourceAttr(resourceName, "output_context.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "output_context.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "output_context.0.name", "name1"),
+					resource.TestCheckResourceAttr(resourceName, "output_context.0.time_to_live_in_seconds", "300"),
+					resource.TestCheckResourceAttr(resourceName, "output_context.0.turns_to_live", "5"),
+					resource.TestCheckResourceAttr(resourceName, "output_context.1.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "output_context.1.name", "name2"),
+					resource.TestCheckResourceAttr(resourceName, "output_context.1.time_to_live_in_seconds", "300"),
+					resource.TestCheckResourceAttr(resourceName, "output_context.1.turns_to_live", "5"),
+					resource.TestCheckResourceAttr(resourceName, "output_context.2.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "output_context.2.name", "name3"),
+					resource.TestCheckResourceAttr(resourceName, "output_context.2.time_to_live_in_seconds", "300"),
+					resource.TestCheckResourceAttr(resourceName, "output_context.2.turns_to_live", "5"),
+				),
+			},
+			{
+				Config: testAccIntentConfig_updateOutputContext(rName, "name2", "name3", "name4"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIntentExists(ctx, resourceName, &intent),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrPair(resourceName, "bot_id", botLocaleName, "bot_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "bot_version", botLocaleName, "bot_version"),
+					resource.TestCheckResourceAttrPair(resourceName, "locale_id", botLocaleName, "locale_id"),
+					resource.TestCheckResourceAttr(resourceName, "output_context.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "output_context.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "output_context.0.name", "name2"),
+					resource.TestCheckResourceAttr(resourceName, "output_context.0.time_to_live_in_seconds", "300"),
+					resource.TestCheckResourceAttr(resourceName, "output_context.0.turns_to_live", "5"),
+					resource.TestCheckResourceAttr(resourceName, "output_context.1.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "output_context.1.name", "name3"),
+					resource.TestCheckResourceAttr(resourceName, "output_context.1.time_to_live_in_seconds", "300"),
+					resource.TestCheckResourceAttr(resourceName, "output_context.1.turns_to_live", "5"),
+					resource.TestCheckResourceAttr(resourceName, "output_context.2.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "output_context.2.name", "name4"),
+					resource.TestCheckResourceAttr(resourceName, "output_context.2.time_to_live_in_seconds", "300"),
+					resource.TestCheckResourceAttr(resourceName, "output_context.2.turns_to_live", "5"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccLexV2ModelsIntent_updateSampleUtterance(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var intent lexmodelsv2.DescribeIntentOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lexv2models_intent.test"
+	botLocaleName := "aws_lexv2models_bot_locale.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.LexV2ModelsEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.LexV2ModelsEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckIntentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIntentConfig_updateSampleUtterance(rName, "yttrande", "twocolors", "danny", "dansa"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIntentExists(ctx, resourceName, &intent),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrPair(resourceName, "bot_id", botLocaleName, "bot_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "bot_version", botLocaleName, "bot_version"),
+					resource.TestCheckResourceAttrPair(resourceName, "locale_id", botLocaleName, "locale_id"),
+					resource.TestCheckResourceAttr(resourceName, "sample_utterance.#", "4"),
+					resource.TestCheckResourceAttr(resourceName, "sample_utterance.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "sample_utterance.0.utterance", "yttrande"),
+					resource.TestCheckResourceAttr(resourceName, "sample_utterance.1.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "sample_utterance.1.utterance", "twocolors"),
+					resource.TestCheckResourceAttr(resourceName, "sample_utterance.2.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "sample_utterance.2.utterance", "danny"),
+					resource.TestCheckResourceAttr(resourceName, "sample_utterance.3.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "sample_utterance.3.utterance", "dansa"),
+				),
+			},
+			{
+				Config: testAccIntentConfig_updateSampleUtterance(rName, "rustedroot", "sendme", "onmy", "way"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIntentExists(ctx, resourceName, &intent),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrPair(resourceName, "bot_id", botLocaleName, "bot_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "bot_version", botLocaleName, "bot_version"),
+					resource.TestCheckResourceAttrPair(resourceName, "locale_id", botLocaleName, "locale_id"),
+					resource.TestCheckResourceAttr(resourceName, "sample_utterance.#", "4"),
+					resource.TestCheckResourceAttr(resourceName, "sample_utterance.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "sample_utterance.0.utterance", "rustedroot"),
+					resource.TestCheckResourceAttr(resourceName, "sample_utterance.1.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "sample_utterance.1.utterance", "sendme"),
+					resource.TestCheckResourceAttr(resourceName, "sample_utterance.2.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "sample_utterance.2.utterance", "onmy"),
+					resource.TestCheckResourceAttr(resourceName, "sample_utterance.3.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "sample_utterance.3.utterance", "way"),
 				),
 			},
 		},
@@ -1285,7 +2036,7 @@ resource "aws_lexv2models_intent" "test" {
 `, rName, retries, textMsg, endTOMs1, endTOMs2))
 }
 
-func testAccIntentConfig_updateClosingSetting(rName string, textMsg1, testMsg2 string) string {
+func testAccIntentConfig_updateClosingSetting(rName string, textMsg1, textMsg2, textMsg3 string) string {
 	return acctest.ConfigCompose(
 		testAccIntentConfig_base(rName, 60, true),
 		fmt.Sprintf(`
@@ -1325,6 +2076,10 @@ resource "aws_lexv2models_intent" "test" {
             type = "CloseIntent"
             slot_to_elicit = "slot1"
           }
+
+          session_attributes = {
+            slot1 = "roligt"
+          }
         }
 
         response {
@@ -1339,8 +2094,355 @@ resource "aws_lexv2models_intent" "test" {
           }
         }
       }
+
+      default_branch {
+        next_step {
+          dialog_action {
+            type = "CloseIntent"
+            slot_to_elicit = "slot1"
+          }
+
+          session_attributes = {
+            slot1 = "hallon"
+          }
+        }
+
+        response {
+          allow_interrupt = true
+
+          message_group {
+            message {
+              plain_text_message {
+                value = %[4]q
+              }
+            }
+          }
+        }
+      }
     }
   }
 }
-`, rName, textMsg1, testMsg2))
+`, rName, textMsg1, textMsg2, textMsg3))
+}
+
+func testAccIntentConfig_updateInputContext(rName, inputContext1, inputContext2, inputContext3 string) string {
+	return acctest.ConfigCompose(
+		testAccIntentConfig_base(rName, 60, true),
+		fmt.Sprintf(`
+resource "aws_lexv2models_intent" "test" {
+  bot_id      = aws_lexv2models_bot.test.id
+  bot_version = aws_lexv2models_bot_locale.test.bot_version
+  name        = %[1]q
+  locale_id   = aws_lexv2models_bot_locale.test.locale_id
+
+  input_context {
+    name = %[2]q
+  }
+
+  input_context {
+    name = %[3]q
+  }
+
+  input_context {
+    name = %[4]q
+  }
+}
+`, rName, inputContext1, inputContext2, inputContext3))
+}
+
+func testAccIntentConfig_updateInitialResponseSetting(rName, branchName, msg1, msg2, msg3 string) string {
+	return acctest.ConfigCompose(
+		testAccIntentConfig_base(rName, 60, true),
+		fmt.Sprintf(`
+resource "aws_lexv2models_intent" "test" {
+  bot_id      = aws_lexv2models_bot.test.id
+  bot_version = aws_lexv2models_bot_locale.test.bot_version
+  name        = %[1]q
+  locale_id   = aws_lexv2models_bot_locale.test.locale_id
+
+  initial_response_setting {
+    code_hook {
+      active                      = true
+      enable_code_hook_invocation = true
+      invocation_label            = "test"
+
+      post_code_hook_specification {
+        failure_conditional {
+          active = true
+
+          conditional_branch {
+            name = %[2]q
+
+            condition {
+              expression_string = "slot1 = \"test\""
+            }
+
+            next_step {
+              dialog_action {
+                type = "CloseIntent"
+                slot_to_elicit = "slot1"
+              }
+
+              session_attributes = {
+                slot1 = "roligt"
+              }
+            }
+
+            response {
+              allow_interrupt = true
+
+              message_group {
+                message {
+                  plain_text_message {
+                    value = %[3]q
+                  }
+                }
+              }
+            }
+          }
+
+          default_branch {
+            next_step {
+              dialog_action {
+                type = "CloseIntent"
+                slot_to_elicit = "slot1"
+              }
+
+              session_attributes = {
+                slot1 = "hallon"
+              }
+            }
+
+            response {
+              allow_interrupt = true
+
+              message_group {
+                message {
+                  plain_text_message {
+                    value = %[4]q
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    initial_response {
+      allow_interrupt = true
+
+      message_group {
+        message {
+          plain_text_message {
+            value = %[5]q
+          }
+        }
+      }
+    }
+  }
+}
+`, rName, branchName, msg1, msg2, msg3))
+}
+
+func testAccIntentConfig_updateFulfillmentCodeHook(rName, msg1 string, freqSec int, msg2, condBranch, intIntValue, msg3 string) string {
+	return acctest.ConfigCompose(
+		testAccIntentConfig_base(rName, 60, true),
+		fmt.Sprintf(`
+resource "aws_lexv2models_intent" "test" {
+  bot_id      = aws_lexv2models_bot.test.id
+  bot_version = aws_lexv2models_bot_locale.test.bot_version
+  name        = %[1]q
+  locale_id   = aws_lexv2models_bot_locale.test.locale_id
+
+  fulfillment_code_hook {
+    active  = true
+    enabled = true
+
+    fulfillment_updates_specification {
+      active             = true
+      timeout_in_seconds = 10
+
+      start_response {
+        allow_interrupt  = true
+        delay_in_seconds = 5
+
+        message_group {
+          message {
+            plain_text_message {
+              value = %[2]q
+            }
+          }
+        }
+      }
+
+      update_response {
+        allow_interrupt      = true
+        frequency_in_seconds = %[3]d
+
+        message_group {
+          message {
+            plain_text_message {
+              value = %[4]q
+            }
+          }
+        }
+      }
+    }
+
+    post_fulfillment_status_specification {
+      failure_conditional {
+        active = true
+
+        conditional_branch {
+          name = %[5]q
+
+          condition {
+            expression_string = "slot1 = \"test\""
+          }
+
+          next_step {
+            session_attributes = {
+              slot1 = "roligt"
+              slot2 = "roligt2"
+            }
+
+            dialog_action {
+              type                  = "CloseIntent"
+              slot_to_elicit        = "slot1"
+              suppress_next_message = true
+            }
+
+            intent {
+              name = "test"
+              slot {
+                map_block_key = "test"
+                shape         = "Scalar"
+
+                value {
+                  interpreted_value = %[6]q
+                }
+              }
+            }
+          }
+
+          response {
+            allow_interrupt = true
+
+            message_group {
+              message {
+                plain_text_message {
+                  value = %[7]q
+                }
+              }
+            }
+          }
+        }
+
+        default_branch {
+          next_step {
+            dialog_action {
+              type = "CloseIntent"
+              slot_to_elicit = "slot1"
+            }
+
+            session_attributes = {
+              slot1 = "hallon"
+            }
+          }
+
+          response {
+            allow_interrupt = true
+
+            message_group {
+              message {
+                plain_text_message {
+                  value = "safriduo"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`, rName, msg1, freqSec, msg2, condBranch, intIntValue, msg3))
+}
+
+func testAccIntentConfig_updateDialogCodeHook(rName string, enabled bool) string {
+	return acctest.ConfigCompose(
+		testAccIntentConfig_base(rName, 60, true),
+		fmt.Sprintf(`
+resource "aws_lexv2models_intent" "test" {
+  bot_id      = aws_lexv2models_bot.test.id
+  bot_version = aws_lexv2models_bot_locale.test.bot_version
+  name        = %[1]q
+  locale_id   = aws_lexv2models_bot_locale.test.locale_id
+
+  dialog_code_hook {
+    enabled = %[2]t
+  }
+}
+`, rName, enabled))
+}
+
+func testAccIntentConfig_updateOutputContext(rName, name1, name2, name3 string) string {
+	return acctest.ConfigCompose(
+		testAccIntentConfig_base(rName, 60, true),
+		fmt.Sprintf(`
+resource "aws_lexv2models_intent" "test" {
+  bot_id      = aws_lexv2models_bot.test.id
+  bot_version = aws_lexv2models_bot_locale.test.bot_version
+  name        = %[1]q
+  locale_id   = aws_lexv2models_bot_locale.test.locale_id
+
+  output_context {
+    name                    = %[2]q
+    time_to_live_in_seconds = 300
+    turns_to_live           = 5
+  }
+
+  output_context {
+    name                    = %[3]q
+    time_to_live_in_seconds = 300
+    turns_to_live           = 5
+  }
+
+  output_context {
+    name                    = %[4]q
+    time_to_live_in_seconds = 300
+    turns_to_live           = 5
+  }
+}
+`, rName, name1, name2, name3))
+}
+
+func testAccIntentConfig_updateSampleUtterance(rName, utter1, utter2, utter3, utter4 string) string {
+	return acctest.ConfigCompose(
+		testAccIntentConfig_base(rName, 60, true),
+		fmt.Sprintf(`
+resource "aws_lexv2models_intent" "test" {
+  bot_id      = aws_lexv2models_bot.test.id
+  bot_version = aws_lexv2models_bot_locale.test.bot_version
+  name        = %[1]q
+  locale_id   = aws_lexv2models_bot_locale.test.locale_id
+
+  sample_utterance {
+    utterance = %[2]q
+  }
+
+  sample_utterance {
+    utterance = %[3]q
+  }
+
+  sample_utterance {
+    utterance = %[4]q
+  }
+
+  sample_utterance {
+    utterance = %[5]q
+  }
+}
+`, rName, utter1, utter2, utter3, utter4))
 }

--- a/internal/service/lexv2models/intent_test.go
+++ b/internal/service/lexv2models/intent_test.go
@@ -1959,8 +1959,8 @@ resource "aws_lexv2models_intent" "test" {
     active = true
 
     prompt_specification {
-      allow_interrupt = true
-      max_retries     = %[2]d
+      allow_interrupt            = true
+      max_retries                = %[2]d
       message_selection_strategy = "Ordered"
 
       message_group {

--- a/internal/service/lexv2models/intent_test.go
+++ b/internal/service/lexv2models/intent_test.go
@@ -181,7 +181,7 @@ func TestIntentAutoFlex(t *testing.T) {
 
 	intentOverrideTF := tflexv2models.IntentOverride{
 		Name: types.StringValue(testString),
-		Slot: fwtypes.NewListNestedObjectValueOfPtr(ctx, &slotValueOverrideMapTF),
+		Slot: fwtypes.NewSetNestedObjectValueOfPtr(ctx, &slotValueOverrideMapTF),
 	}
 	intentOverrideAWS := lextypes.IntentOverride{
 		Name:  aws.String(testString),

--- a/internal/service/lexv2models/intent_test.go
+++ b/internal/service/lexv2models/intent_test.go
@@ -962,7 +962,7 @@ func TestAccLexV2ModelsIntent_disappears(t *testing.T) {
 	})
 }
 
-func TestAccLexV2ModelsIntent_update(t *testing.T) {
+func TestAccLexV2ModelsIntent_updateConfirmationSetting(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var intent lexmodelsv2.DescribeIntentOutput
@@ -1001,7 +1001,7 @@ func TestAccLexV2ModelsIntent_update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccIntentConfig_updateConfirmationSetting(rName, 2, "test2", 650, 660),
+				Config: testAccIntentConfig_updateConfirmationSetting(rName, 1, "test", 650, 660),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIntentExists(ctx, resourceName, &intent),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -1009,11 +1009,11 @@ func TestAccLexV2ModelsIntent_update(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "bot_version", botLocaleName, "bot_version"),
 					resource.TestCheckResourceAttrPair(resourceName, "locale_id", botLocaleName, "locale_id"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "confirmation_setting.*.prompt_specification.*", map[string]string{
-						"max_retries":                "2",
+						"max_retries":                "1",
 						"message_selection_strategy": "Ordered",
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "confirmation_setting.*.prompt_specification.*.message_group.*.message.*.plain_text_message.*", map[string]string{
-						"value": "test2",
+						"value": "test",
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "confirmation_setting.*.prompt_specification.*.prompt_attempts_specification.*.audio_and_dtmf_input_specification.*.audio_specification.*", map[string]string{
 						"end_timeout_ms": "650",

--- a/internal/service/lexv2models/intent_test.go
+++ b/internal/service/lexv2models/intent_test.go
@@ -120,8 +120,8 @@ func TestIntentAutoFlex(t *testing.T) {
 	}
 
 	messageGroupTF := tflexv2models.MessageGroup{
-		Message:    fwtypes.NewListNestedObjectValueOfPtr(ctx, &messageTF),
-		Variations: fwtypes.NewListNestedObjectValueOfValueSlice[tflexv2models.Message](ctx, messagesTF),
+		Message:   fwtypes.NewListNestedObjectValueOfPtr(ctx, &messageTF),
+		Variation: fwtypes.NewListNestedObjectValueOfValueSlice[tflexv2models.Message](ctx, messagesTF),
 	}
 	messageGroupAWS := []lextypes.MessageGroup{
 		{
@@ -1131,44 +1131,44 @@ resource "aws_lexv2models_intent" "test" {
 
   confirmation_setting {
     active = true
-    
-    prompt_specification {
-      allow_interrupt = true
-      max_retries     = 1
-      message_selection_strategy = "Ordered"
 
-      prompt_attempts_specification {
-        map_block_key = "Initial"
-        
-        allowed_input_types {
-          allow_audio_input = true
-          allow_dtmf_input  = true
-        }
+    #prompt_specification {
+      #allow_interrupt = true
+      #max_retries     = 1
+      #message_selection_strategy = "Ordered"
 
-        allow_interrupt = true
+      #prompt_attempts_specification {
+        #map_block_key = "Initial"
 
-        audio_and_dtmf_input_specification {
-          start_timeout_ms = 1
+        #allowed_input_types {
+          #allow_audio_input = true
+          #allow_dtmf_input  = true
+        #}
 
-          audio_specification {
-            end_timeout_ms = 1
-            max_length_ms = 1
-          }
+        #allow_interrupt = true
 
-          dtmf_specification {
-            deletion_character = "#"
-            end_character      = "#"
-            end_timeout_ms     = 1
-            max_length         = 1
-          }
-        }
+        #audio_and_dtmf_input_specification {
+          #start_timeout_ms = 1
 
-        text_input_specification {
-          start_timeout_ms = 1
-        }
-      
-      }
-    }
+          #audio_specification {
+            #end_timeout_ms = 1
+            #max_length_ms = 1
+          #}
+
+          #dtmf_specification {
+            #deletion_character = "#"
+            #end_character      = "#"
+            #end_timeout_ms     = 1
+            #max_length         = 1
+          #}
+        #}
+
+        #text_input_specification {
+          #start_timeout_ms = 1
+        #}
+
+      #}
+    #}
   }
 }
 `, rName))

--- a/internal/service/lexv2models/service_package_gen.go
+++ b/internal/service/lexv2models/service_package_gen.go
@@ -35,6 +35,10 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 			Factory: newResourceBotVersion,
 			Name:    "Bot Version",
 		},
+		{
+			Factory: newResourceIntent,
+			Name:    "Intent",
+		},
 	}
 }
 

--- a/website/docs/r/lexv2models_intent.html.markdown
+++ b/website/docs/r/lexv2models_intent.html.markdown
@@ -1,0 +1,69 @@
+---
+subcategory: "Lex V2 Models"
+layout: "aws"
+page_title: "AWS: aws_lexv2models_intent"
+description: |-
+  Terraform resource for managing an AWS Lex V2 Models Intent.
+---
+<!---
+TIP: A few guiding principles for writing documentation:
+1. Use simple language while avoiding jargon and figures of speech.
+2. Focus on brevity and clarity to keep a reader's attention.
+3. Use active voice and present tense whenever you can.
+4. Document your feature as it exists now; do not mention the future or past if you can help it.
+5. Use accessible and inclusive language.
+--->`
+# Resource: aws_lexv2models_intent
+
+Terraform resource for managing an AWS Lex V2 Models Intent.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_lexv2models_intent" "example" {
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `example_arg` - (Required) Concise argument description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+
+The following arguments are optional:
+
+* `optional_arg` - (Optional) Concise argument description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `arn` - ARN of the Intent. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+* `example_attribute` - Concise description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+* `create` - (Default `60m`)
+* `update` - (Default `180m`)
+* `delete` - (Default `90m`)
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Lex V2 Models Intent using the `example_id_arg`. For example:
+
+```terraform
+import {
+  to = aws_lexv2models_intent.example
+  id = "intent-id-12345678"
+}
+```
+
+Using `terraform import`, import Lex V2 Models Intent using the `example_id_arg`. For example:
+
+```console
+% terraform import aws_lexv2models_intent.example intent-id-12345678
+```

--- a/website/docs/r/lexv2models_intent.html.markdown
+++ b/website/docs/r/lexv2models_intent.html.markdown
@@ -261,6 +261,12 @@ The following arguments are optional:
 * `intent` - (Optional) Configuration block for override settings to configure the intent state. See [`intent`](#intent).
 * `session_attributes` - (Optional) Map of key/value pairs representing session-specific context information. It contains application information passed between Amazon Lex and a client application.
 
+##### `dialog_action`
+
+* `type` - (Required) Action that the bot should execute. Valid values are `ElicitIntent`, `StartIntent`, `ElicitSlot`, `EvaluateConditional`, `InvokeDialogCodeHook`, `ConfirmIntent`, `FulfillIntent`, `CloseIntent`, `EndConversation`.
+* `slot_to_elicit` - (Optional) If the dialog action is `ElicitSlot`, defines the slot to elicit from the user.
+* `suppress_next_message` - (Optional) Whether the next message for the intent is _not_ used.
+
 ##### `intent`
 
 * `name` - (Optional, Required when switching intents) Name of the intent.
@@ -285,7 +291,7 @@ The following arguments are optional:
 * `confirmation_next_step` - (Optional) Configuration block for the next step that the bot executes when the customer confirms the intent. See [`confirmation_next_step`](#confirmation_next_step).
 * `confirmation_response` - (Optional) Configuration block for message groups that Amazon Lex uses to respond the user input. See [`confirmation_response`](#confirmation_response).
 * `declination_conditional` - (Optional) Configuration block for conditional branches to evaluate after the intent is declined. See [`declination_conditional`](#declination_conditional).
-* `declication_next_step` - (Optional) Configuration block for the next step that the bot executes when the customer declines the intent. See [`declication_next_step`](#declication_next_step).
+* `declination_next_step` - (Optional) Configuration block for the next step that the bot executes when the customer declines the intent. See [`declination_next_step`](#declination_next_step).
 * `declination_response` - (Optional) Configuration block for when the user answers "no" to the question defined in `prompt_specification`, Amazon Lex responds with this response to acknowledge that the intent was canceled. See [`declination_response`](#declination_response).
 * `elicitation_code_hook` - (Optional) Configuration block for when the code hook is invoked during confirmation prompt retries. See [`elicitation_code_hook`](#elicitation_code_hook).
 * `failure_conditional` - (Optional) Configuration block for conditional branches. Branches are evaluated in the order that they are entered in the list. The first branch with a condition that evaluates to true is executed. The last branch in the list is the default branch. The default branch should not have any condition expression. The default branch is executed if no other branch has a matching condition. See [`failure_conditional`](#failure_conditional).

--- a/website/docs/r/lexv2models_intent.html.markdown
+++ b/website/docs/r/lexv2models_intent.html.markdown
@@ -70,6 +70,76 @@ resource "aws_lexv2models_intent" "example" {
   bot_version = aws_lexv2models_bot_locale.test.bot_version
   name        = "botens_namn"
   locale_id   = aws_lexv2models_bot_locale.test.locale_id
+
+  confirmation_setting {
+    active = true
+
+    prompt_specification {
+      allow_interrupt = true
+      max_retries     = 1
+      message_selection_strategy = "Ordered"
+
+      prompt_attempts_specification {
+        allow_interrupt = true
+        map_block_key   = "Initial"
+
+        allowed_input_types {
+          allow_audio_input = true
+          allow_dtmf_input  = true
+        }
+
+        audio_and_dtmf_input_specification {
+          start_timeout_ms = 4000
+
+          audio_specification {
+            end_timeout_ms = 640
+            max_length_ms  = 15000
+          }
+
+          dtmf_specification {
+            deletion_character = "*"
+            end_character      = "#"
+            end_timeout_ms     = 5000
+            max_length         = 513
+          }
+        }
+
+        text_input_specification {
+          start_timeout_ms = 30000
+        }
+      }
+
+      prompt_attempts_specification {
+        allow_interrupt = true
+        map_block_key   = "Retry1"
+
+        allowed_input_types {
+          allow_audio_input = true
+          allow_dtmf_input  = true
+        }
+
+        audio_and_dtmf_input_specification {
+          start_timeout_ms = 4000
+
+          audio_specification {
+            end_timeout_ms = 640
+            max_length_ms  = 15000
+          }
+
+          dtmf_specification {
+            deletion_character = "*"
+            end_character      = "#"
+            end_timeout_ms     = 5000
+            max_length         = 513
+          }
+        }
+
+        text_input_specification {
+          start_timeout_ms = 30000
+        }
+      }
+    }
+  }
 }
 ```
 
@@ -85,7 +155,7 @@ The following arguments are required:
 The following arguments are optional:
 
 * `closing_setting` - (Optional) Configuration block for the response that Amazon Lex sends to the user when the intent is closed. See [`closing_setting`](#closing_setting).
-* `confirmation_setting` - (Optional) Configuration block for prompts that Amazon Lex sends to the user to confirm the completion of an intent. If the user answers "no," the settings contain a statement that is sent to the user to end the intent. See [`confirmation_setting`](#confirmation_setting).
+* `confirmation_setting` - (Optional) Configuration block for prompts that Amazon Lex sends to the user to confirm the completion of an intent. If the user answers "no," the settings contain a statement that is sent to the user to end the intent. If you configure this block without `prompt_specification.*.prompt_attempts_specification`, AWS will provide default configurations for `Initial` and `Retry1` `prompt_attempts_specification`s. This will cause Terraform to report differences. Use the `confirmation_setting` configuration above in the [Basic Usage](#basic-usage) example to avoid differences resulting from AWS default configuration. See [`confirmation_setting`](#confirmation_setting).
 * `description` - (Optional) Description of the intent. Use the description to help identify the intent in lists.
 * `dialog_code_hook` - (Optional) Configuration block for invoking the alias Lambda function for each user input. You can invoke this Lambda function to personalize user interaction. See [`dialog_code_hook`](#dialog_code_hook).
 * `fulfillment_code_hook` - (Optional) Configuration block for invoking the alias Lambda function when the intent is ready for fulfillment. You can invoke this function to complete the bot's transaction with the user. See [`fulfillment_code_hook`](#fulfillment_code_hook).

--- a/website/docs/r/lexv2models_intent.html.markdown
+++ b/website/docs/r/lexv2models_intent.html.markdown
@@ -95,7 +95,7 @@ The following arguments are optional:
 * `output_context` - (Optional) Configuration blocks for contexts that the intent activates when it is fulfilled. You can use an output context to indicate the intents that Amazon Lex should consider for the next turn of the conversation with a customer. When you use the outputContextsList property, all of the contexts specified in the list are activated when the intent is fulfilled. You can set up to 10 output contexts. You can also set the number of conversation turns that the context should be active, or the length of time that the context should be active. See [`output_context`](#output_context).
 * `parent_intent_signature` - (Optional) Identifier for the built-in intent to base this intent on.
 * `sample_utterance` - (Optional) Configuration block for strings that a user might say to signal the intent. See [`sample_utterance`](#sample_utterance).
-* `slot_priority` - (Optional) Configuration block for a new list of slots and their priorities that are contained by the intent. See [`slot_priority`](#slot_priority).
+* `slot_priority` - (Optional) Configuration block for a new list of slots and their priorities that are contained by the intent. This is ignored on create and only valid for updates. See [`slot_priority`](#slot_priority).
 
 ### `closing_setting`
 

--- a/website/docs/r/lexv2models_intent.html.markdown
+++ b/website/docs/r/lexv2models_intent.html.markdown
@@ -344,7 +344,7 @@ The following arguments are optional:
 
 #### `post_code_hook_specification`
 
-* `failure_conditional` - (Optional)	Configuration block for conditional branches to evaluate after the dialog code hook throws an exception or returns with the State field of the Intent object set to Failed.
+* `failure_conditional` - (Optional) Configuration block for conditional branches to evaluate after the dialog code hook throws an exception or returns with the State field of the Intent object set to Failed.
 * `failure_next_step` - (Optional) Configuration block for the next step the bot runs after the dialog code hook throws an exception or returns with the State field of the Intent object set to Failed . See [`failure_next_step`](#failure_next_step).
 * `failure_response` - (Optional) Configuration block for message groups that Amazon Lex uses to respond the user input. See [`failure_response`](#failure_response).
 * `success_conditional` - (Optional) Configuration block for conditional branches to evaluate after the dialog code hook finishes successfully. See [`success_conditional`](#success_conditional).

--- a/website/docs/r/lexv2models_intent.html.markdown
+++ b/website/docs/r/lexv2models_intent.html.markdown
@@ -70,6 +70,19 @@ resource "aws_lexv2models_intent" "example" {
   bot_version = aws_lexv2models_bot_locale.test.bot_version
   name        = "botens_namn"
   locale_id   = aws_lexv2models_bot_locale.test.locale_id
+}
+```
+
+### `confirmation_setting` Example
+
+When using `confirmation_setting`, if you do not provide a `prompt_attempts_specification`, AWS Lex will provide default `prompt_attempts_specification`s. As a result, Terraform will report a difference in the configuration. To avoid this behavior, include the default `prompt_attempts_specification` configuration shown below.
+
+```terraform
+resource "aws_lexv2models_intent" "example" {
+  bot_id      = aws_lexv2models_bot.test.id
+  bot_version = aws_lexv2models_bot_locale.test.bot_version
+  name        = "botens_namn"
+  locale_id   = aws_lexv2models_bot_locale.test.locale_id
 
   confirmation_setting {
     active = true

--- a/website/docs/r/lexv2models_intent.html.markdown
+++ b/website/docs/r/lexv2models_intent.html.markdown
@@ -5,14 +5,7 @@ page_title: "AWS: aws_lexv2models_intent"
 description: |-
   Terraform resource for managing an AWS Lex V2 Models Intent.
 ---
-<!---
-TIP: A few guiding principles for writing documentation:
-1. Use simple language while avoiding jargon and figures of speech.
-2. Focus on brevity and clarity to keep a reader's attention.
-3. Use active voice and present tense whenever you can.
-4. Document your feature as it exists now; do not mention the future or past if you can help it.
-5. Use accessible and inclusive language.
---->`
+
 # Resource: aws_lexv2models_intent
 
 Terraform resource for managing an AWS Lex V2 Models Intent.
@@ -22,7 +15,61 @@ Terraform resource for managing an AWS Lex V2 Models Intent.
 ### Basic Usage
 
 ```terraform
+data "aws_partition" "current" {}
+
+resource "aws_iam_role" "test" {
+  name = "botens_namn"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "lexv2.amazonaws.com"
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "test" {
+  role       = aws_iam_role.test.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonLexFullAccess"
+}
+
+resource "aws_lexv2models_bot" "test" {
+  name                        = "botens_namn"
+  idle_session_ttl_in_seconds = 60
+  role_arn                    = aws_iam_role.test.arn
+
+  data_privacy {
+    child_directed = true
+  }
+}
+
+resource "aws_lexv2models_bot_locale" "test" {
+  locale_id                        = "en_US"
+  bot_id                           = aws_lexv2models_bot.test.id
+  bot_version                      = "DRAFT"
+  n_lu_intent_confidence_threshold = 0.7
+}
+
+resource "aws_lexv2models_bot_version" "test" {
+  bot_id = aws_lexv2models_bot.test.id
+  locale_specification = {
+    (aws_lexv2models_bot_locale.test.locale_id) = {
+      source_bot_version = "DRAFT"
+    }
+  }
+}
+
 resource "aws_lexv2models_intent" "example" {
+  bot_id      = aws_lexv2models_bot.test.id
+  bot_version = aws_lexv2models_bot_locale.test.bot_version
+  name        = "botens_namn"
+  locale_id   = aws_lexv2models_bot_locale.test.locale_id
 }
 ```
 
@@ -30,40 +77,399 @@ resource "aws_lexv2models_intent" "example" {
 
 The following arguments are required:
 
-* `example_arg` - (Required) Concise argument description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+* `bot_id` - (Required) Identifier of the bot associated with this intent.
+* `bot_version` - (Required) Version of the bot associated with this intent.
+* `locale_id` - (Required) Identifier of the language and locale where this intent is used. All of the bots, slot types, and slots used by the intent must have the same locale.
+* `name` - (Required) Name of the intent. Intent names must be unique in the locale that contains the intent and cannot match the name of any built-in intent.
 
 The following arguments are optional:
 
-* `optional_arg` - (Optional) Concise argument description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+* `closing_setting` - (Optional) Configuration block for the response that Amazon Lex sends to the user when the intent is closed. See [`closing_setting`](#closing_setting).
+* `confirmation_setting` - (Optional) Configuration block for prompts that Amazon Lex sends to the user to confirm the completion of an intent. If the user answers "no," the settings contain a statement that is sent to the user to end the intent. See [`confirmation_setting`](#confirmation_setting).
+* `description` - (Optional) Description of the intent. Use the description to help identify the intent in lists.
+* `dialog_code_hook` - (Optional) Configuration block for invoking the alias Lambda function for each user input. You can invoke this Lambda function to personalize user interaction. See [`dialog_code_hook`](#dialog_code_hook).
+* `fulfillment_code_hook` - (Optional) Configuration block for invoking the alias Lambda function when the intent is ready for fulfillment. You can invoke this function to complete the bot's transaction with the user. See [`fulfillment_code_hook`](#fulfillment_code_hook).
+* `initial_response_setting` - (Optional) Configuration block for the response that is sent to the user at the beginning of a conversation, before eliciting slot values. See [`initial_response_setting`](#initial_response_setting).
+* `input_context` - (Optional) Configuration blocks for contexts that must be active for this intent to be considered by Amazon Lex. When an intent has an input context list, Amazon Lex only considers using the intent in an interaction with the user when the specified contexts are included in the active context list for the session. If the contexts are not active, then Amazon Lex will not use the intent. A context can be automatically activated using the outputContexts property or it can be set at runtime. See [`input_context`](#input_context).
+* `kendra_configuration` - (Optional) Configuration block for information required to use the AMAZON.KendraSearchIntent intent to connect to an Amazon Kendra index. The AMAZON.KendraSearchIntent intent is called when Amazon Lex can't determine another intent to invoke. See [`kendra_configuration`](#kendra_configuration).
+* `output_context` - (Optional) Configuration blocks for contexts that the intent activates when it is fulfilled. You can use an output context to indicate the intents that Amazon Lex should consider for the next turn of the conversation with a customer. When you use the outputContextsList property, all of the contexts specified in the list are activated when the intent is fulfilled. You can set up to 10 output contexts. You can also set the number of conversation turns that the context should be active, or the length of time that the context should be active. See [`output_context`](#output_context).
+* `parent_intent_signature` - (Optional) Identifier for the built-in intent to base this intent on.
+* `sample_utterance` - (Optional) Configuration block for strings that a user might say to signal the intent. See [`sample_utterance`](#sample_utterance).
+* `slot_priority` - (Optional) Configuration block for a new list of slots and their priorities that are contained by the intent. See [`slot_priority`](#slot_priority).
+
+### `closing_setting`
+
+* `active` - (Optional) Whether an intent's closing response is used. When this field is false, the closing response isn't sent to the user. If the active field isn't specified, the default is true.
+* `closing_response` - (Optional) Configuration block for response that Amazon Lex sends to the user when the intent is complete. See [`closing_response`](#closing_response).
+* `conditional` - (Optional) Configuration block for list of conditional branches associated with the intent's closing response. These branches are executed when the `next_step` attribute is set to `EvalutateConditional`. See [`conditional`](#conditional).
+* `next_step` - (Optional) Next step that the bot executes after playing the intent's closing response. See [`next_step`](#next_step).
+
+#### `closing_response`
+
+* `message_group` - (Required) Configuration blocks for responses that Amazon Lex can send to the user. Amazon Lex chooses the actual response to send at runtime. See [`message_group`](#message_group).
+* `allow_interrupt` - (Optional) Whether the user can interrupt a speech response from Amazon Lex.
+
+##### `message_group`
+
+* `message` - (Required) Configuration block for the primary message that Amazon Lex should send to the user. See [`message`](#message-and-variation).
+* `variation` - (Optional) Configuration blocks for message variations to send to the user. When variations are defined, Amazon Lex chooses the primary message or one of the variations to send to the user. See [`variation`](#message-and-variation).
+
+###### `message` and `variation`
+
+* `custom_payload` - (Optional) Configuration block for a message in a custom format defined by the client application. See [`custom_payload`](#custom_payload).
+* `image_response_card` - (Optional) Configuration block for a message that defines a response card that the client application can show to the user. See [`image_response_card`](#image_response_card).
+* `plain_text_message` - (Optional) Configuration block for a message in plain text format. See [`plain_text_message`](#plain_text_message).
+* `ssml_message` - (Optional) Configuration block for a message in Speech Synthesis Markup Language (SSML). See [`ssml_message`](#ssml_message).
+
+###### `custom_payload`
+
+* `value` - (Required) String that is sent to your application.
+
+###### `image_response_card`
+
+* `title` - (Required) Title to display on the response card. The format of the title is determined by the platform displaying the response card.
+* `button` - (Optional) Configuration blocks for buttons that should be displayed on the response card. The arrangement of the buttons is determined by the platform that displays the button. See [`button`](#button).
+* `image_url` - (Optional) URL of an image to display on the response card. The image URL must be publicly available so that the platform displaying the response card has access to the image.
+* `subtitle` - (Optional) Subtitle to display on the response card. The format of the subtitle is determined by the platform displaying the response card.
+
+###### `button`
+
+* `text` - (Required) Text that appears on the button. Use this to tell the user what value is returned when they choose this button.
+* `value` - (Required) Value returned to Amazon Lex when the user chooses this button. This must be one of the slot values configured for the slot.
+
+###### `plain_text_message`
+
+* `value` - (Required) Message to send to the user.
+
+###### `ssml_message`
+
+* `value` - (Required) SSML text that defines the prompt.
+
+#### `conditional`
+
+* `active` - (Required) Whether a conditional branch is active. When active is false, the conditions are not evaluated.
+* `conditional_branch` - (Required) Configuration blocks for conditional branches. A conditional branch is made up of a condition, a response and a next step. The response and next step are executed when the condition is true. See [`conditional_branch`](#conditional_branch).
+* `default_branch` - (Required) Configuration block for the conditional branch that should be followed when the conditions for other branches are not satisfied. A branch is made up of a condition, a response and a next step. See [`default_branch`](#default_branch).
+
+##### `conditional_branch`
+
+* `condition` - (Required) Configuration block for the expression to evaluate. If the condition is true, the branch's actions are taken. See [`condition`](#condition).
+* `name` - (Required) Name of the branch.
+* `next_step` - (Required) Configuration block for the next step in the conversation. See [`next_step`](#next_step).
+* `response` - (Optional) Configuration block for a list of message groups that Amazon Lex uses to respond to the user input. See [`response`](#response).
+
+###### `condition`
+
+* `expression_string` - (Required) Expression string that is evaluated.
+
+###### `response`
+
+* `message_group` - (Required) Configuration blocks for responses that Amazon Lex can send to the user. Amazon Lex chooses the actual response to send at runtime. See [`message_group`](#message_group).
+* `allow_interrupt` - (Optional) Whether the user can interrupt a speech response from Amazon Lex.
+
+###### `default_branch`
+
+* `next_step` - (Required) Configuration block for the next step in the conversation. See [`next_step`](#next_step).
+* `response` - (Optional) Configuration block for a list of message groups that Amazon Lex uses to respond to the user input. See [`response`](#response).
+
+#### `next_step`
+
+* `dialog_action` - (Optional) Configuration block for action that the bot executes at runtime when the conversation reaches this step. See [`dialog_action`](#dialog_action).
+* `intent` - (Optional) Configuration block for override settings to configure the intent state. See [`intent`](#intent).
+* `session_attributes` - (Optional) Map of key/value pairs representing session-specific context information. It contains application information passed between Amazon Lex and a client application.
+
+##### `intent`
+
+* `name` - (Optional, Required when switching intents) Name of the intent.
+* `slot` - (Optional) Configuration block for all of the slot value overrides for the intent. The name of the slot maps to the value of the slot. Slots that are not included in the map aren't overridden. See [`slot`](#slot).
+
+###### `slot`
+
+* `shape` - (Optional) When the shape value is `List`, `values` contains a list of slot values. When the value is `Scalar`, `value` contains a single value.
+* `value` - (Optional) Configuration block for the current value of the slot. See [`value`](#slot-value).
+* `values` - _Not currently supported._
+
+###### Slot `value`
+
+* `interpreted_value` - (Optional) Value that Amazon Lex determines for the slot. The actual value depends on the setting of the value selection strategy for the bot. You can choose to use the value entered by the user, or you can have Amazon Lex choose the first value in the resolvedValues list.
+
+### `confirmation_setting`
+
+* `prompt_specification` - (Required) Configuration block for prompting the user to confirm the intent. This question should have a yes or no answer. Amazon Lex uses this prompt to ensure that the user acknowledges that the intent is ready for fulfillment. See [`prompt_specification`](#prompt_specification).
+* `active` - (Optional) Whether the intent's confirmation is sent to the user. When this field is false, confirmation and declination responses aren't sent. If the active field isn't specified, the default is true.
+* `code_hook` - (Optional) Configuration block for the intent's confirmation step. The dialog code hook is triggered based on these invocation settings when the confirmation next step or declination next step or failure next step is `invoke_dialog_code_hook`.  See [`code_hook`](#code_hook).
+* `confirmation_conditional` - (Optional) Configuration block for conditional branches to evaluate after the intent is closed. See [`confirmation_conditional`](#confirmation_conditional).
+* `confirmation_next_step` - (Optional) Configuration block for the next step that the bot executes when the customer confirms the intent. See [`confirmation_next_step`](#confirmation_next_step).
+* `confirmation_response` - (Optional) Configuration block for message groups that Amazon Lex uses to respond the user input. See [`confirmation_response`](#confirmation_response).
+* `declination_conditional` - (Optional) Configuration block for conditional branches to evaluate after the intent is declined. See [`declination_conditional`](#declination_conditional).
+* `declication_next_step` - (Optional) Configuration block for the next step that the bot executes when the customer declines the intent. See [`declication_next_step`](#declication_next_step).
+* `declination_response` - (Optional) Configuration block for when the user answers "no" to the question defined in `prompt_specification`, Amazon Lex responds with this response to acknowledge that the intent was canceled. See [`declination_response`](#declination_response).
+* `elicitation_code_hook` - (Optional) Configuration block for when the code hook is invoked during confirmation prompt retries. See [`elicitation_code_hook`](#elicitation_code_hook).
+* `failure_conditional` - (Optional) Configuration block for conditional branches. Branches are evaluated in the order that they are entered in the list. The first branch with a condition that evaluates to true is executed. The last branch in the list is the default branch. The default branch should not have any condition expression. The default branch is executed if no other branch has a matching condition. See [`failure_conditional`](#failure_conditional).
+* `failure_next_step` - (Optional) Configuration block for the next step to take in the conversation if the confirmation step fails. See [`failure_next_step`](#failure_next_step).
+* `failure_response` - (Optional) Configuration block for message groups that Amazon Lex uses to respond the user input. See [`failure_response`](#failure_response).
+
+#### `prompt_specification`
+
+* `max_retries` - (Required) Maximum number of times the bot tries to elicit a response from the user using this prompt.
+* `message_group` - (Required) Configuration block for messages that Amazon Lex can send to the user. Amazon Lex chooses the actual message to send at runtime. See [`message_group`](#message_group).
+* `allow_interrupt` - (Optional) Whether the user can interrupt a speech prompt from the bot.
+* `message_selection_strategy` - (Optional) How a message is selected from a message group among retries. Valid values are `Random` and `Ordered`.
+* `prompt_attempts_specification` - (Optional) Configuration block for advanced settings on each attempt of the prompt. See [`prompt_attempts_specification`](#prompt_attempts_specification).
+
+##### `prompt_attempts_specification`
+
+* `allowed_input_types` - (Required) Configuration block for the allowed input types of the prompt attempt. See [`allowed_input_types`](#allowed_input_types).
+* `map_block_key` - (Required) Which attempt to configure. Valid values are `Initial`, `Retry1`, `Retry2`, `Retry3`, `Retry4`, `Retry5`.
+* `allow_interrupt` - (Optional) Whether the user can interrupt a speech prompt attempt from the bot.
+* `audio_and_dtmf_input_specification` - (Optional) Configuration block for settings on audio and DTMF input. See [`audio_and_dtmf_input_specification`](#audio_and_dtmf_input_specification).
+* `text_input_specification` - (Optional) Configuration block for the settings on text input. See [`text_input_specification`](#text_input_specification).
+
+###### `allowed_input_types`
+
+* `allow_audio_input` - (Required) Whether audio input is allowed.
+* `allow_dtmf_input` - (Required) Whether DTMF input is allowed.
+
+###### `audio_and_dtmf_input_specification`
+
+* `start_timeout_ms` - (Required) Time for which a bot waits before assuming that the customer isn't going to speak or press a key. This timeout is shared between Audio and DTMF inputs.
+* `audio_specification` - (Optional) Configuration block for the settings on audio input. See [`audio_specification`](#audio_specification).
+* `dtmf_specification` - (Optional) Configuration block for the settings on DTMF input. See [`dtmf_specification`](#dtmf_specification).
+
+###### `audio_specification`
+
+* `end_timeout_ms` - (Required) Time for which a bot waits after the customer stops speaking to assume the utterance is finished.
+* `max_length_ms` - (Required) Time for how long Amazon Lex waits before speech input is truncated and the speech is returned to application.
+
+###### `dtmf_specification`
+
+* `deletion_character` - (Required) DTMF character that clears the accumulated DTMF digits and immediately ends the input.
+* `end_character` - (Required) DTMF character that immediately ends input. If the user does not press this character, the input ends after the end timeout.
+* `end_timeout_ms` - (Required) How long the bot should wait after the last DTMF character input before assuming that the input has concluded.
+* `max_length` - (Required) Maximum number of DTMF digits allowed in an utterance.
+
+###### `text_input_specification`
+
+* `start_timeout_ms` - (Required) Time for which a bot waits before re-prompting a customer for text input.
+
+### `code_hook`
+
+* `active` - (Required) Whether a dialog code hook is used when the intent is activated.
+* `enable_code_hook_invocation` - (Required) Whether a Lambda function should be invoked for the dialog.
+* `post_code_hook_specification` - (Required) Configuration block that contains the responses and actions that Amazon Lex takes after the Lambda function is complete. See [`post_code_hook_specification`](#post_code_hook_specification).
+* `invocation_label` - (Optional) Label that indicates the dialog step from which the dialog code hook is happening.
+
+#### `post_code_hook_specification`
+
+* `failure_conditional` - (Optional)	Configuration block for conditional branches to evaluate after the dialog code hook throws an exception or returns with the State field of the Intent object set to Failed.
+* `failure_next_step` - (Optional) Configuration block for the next step the bot runs after the dialog code hook throws an exception or returns with the State field of the Intent object set to Failed . See [`failure_next_step`](#failure_next_step).
+* `failure_response` - (Optional) Configuration block for message groups that Amazon Lex uses to respond the user input. See [`failure_response`](#failure_response).
+* `success_conditional` - (Optional) Configuration block for conditional branches to evaluate after the dialog code hook finishes successfully. See [`success_conditional`](#success_conditional).
+* `success_next_step` - (Optional) Configuration block for the next step the bot runs after the dialog code hook finishes successfully. See [`success_next_step`](#success_next_step).
+* `success_response` - (Optional) Configuration block for message groups that Amazon Lex uses to respond the user input. See [`success_response`](#success_response).
+* `timeout_conditional` - (Optional) Configuration block for conditional branches to evaluate if the code hook times out. See [`timeout_conditional`](#timeout_conditional).
+* `timeout_next_step` - (Optional) Configuration block for the next step that the bot runs when the code hook times out. See [`timeout_next_step`](#timeout_next_step).
+* `timeout_response` - (Optional) Configuration block for a list of message groups that Amazon Lex uses to respond the user input. See [`timeout_response`](#timeout_response).
+
+##### `failure_conditional`
+
+* `active` - (Required) Whether a conditional branch is active. When active is false, the conditions are not evaluated.
+* `conditional_branch` - (Required) Configuration blocks for conditional branches. A conditional branch is made up of a condition, a response and a next step. The response and next step are executed when the condition is true. See [`conditional_branch`](#conditional_branch).
+* `default_branch` - (Required) Configuration block for the conditional branch that should be followed when the conditions for other branches are not satisfied. A branch is made up of a condition, a response and a next step. See [`default_branch`](#default_branch).
+
+##### `failure_next_step`
+
+* `dialog_action` - (Optional) Configuration block for action that the bot executes at runtime when the conversation reaches this step. See [`dialog_action`](#dialog_action).
+* `intent` - (Optional) Configuration block for override settings to configure the intent state. See [`intent`](#intent).
+* `session_attributes` - (Optional) Map of key/value pairs representing session-specific context information. It contains application information passed between Amazon Lex and a client application.
+
+##### `failure_response`
+
+* `message_group` - (Required) Configuration blocks for responses that Amazon Lex can send to the user. Amazon Lex chooses the actual response to send at runtime. See [`message_group`](#message_group).
+* `allow_interrupt` - (Optional) Whether the user can interrupt a speech response from Amazon Lex.
+
+##### `success_conditional`
+
+* `active` - (Required) Whether a conditional branch is active. When active is false, the conditions are not evaluated.
+* `conditional_branch` - (Required) Configuration blocks for conditional branches. A conditional branch is made up of a condition, a response and a next step. The response and next step are executed when the condition is true. See [`conditional_branch`](#conditional_branch).
+* `default_branch` - (Required) Configuration block for the conditional branch that should be followed when the conditions for other branches are not satisfied. A branch is made up of a condition, a response and a next step. See [`default_branch`](#default_branch).
+
+##### `success_next_step`
+
+* `dialog_action` - (Optional) Configuration block for action that the bot executes at runtime when the conversation reaches this step. See [`dialog_action`](#dialog_action).
+* `intent` - (Optional) Configuration block for override settings to configure the intent state. See [`intent`](#intent).
+* `session_attributes` - (Optional) Map of key/value pairs representing session-specific context information. It contains application information passed between Amazon Lex and a client application.
+
+##### `success_response`
+
+* `message_group` - (Required) Configuration blocks for responses that Amazon Lex can send to the user. Amazon Lex chooses the actual response to send at runtime. See [`message_group`](#message_group).
+* `allow_interrupt` - (Optional) Whether the user can interrupt a speech response from Amazon Lex.
+
+##### `timeout_conditional`
+
+* `active` - (Required) Whether a conditional branch is active. When active is false, the conditions are not evaluated.
+* `conditional_branch` - (Required) Configuration blocks for conditional branches. A conditional branch is made up of a condition, a response and a next step. The response and next step are executed when the condition is true. See [`conditional_branch`](#conditional_branch).
+* `default_branch` - (Required) Configuration block for the conditional branch that should be followed when the conditions for other branches are not satisfied. A branch is made up of a condition, a response and a next step. See [`default_branch`](#default_branch).
+
+##### `timeout_next_step`
+
+* `dialog_action` - (Optional) Configuration block for action that the bot executes at runtime when the conversation reaches this step. See [`dialog_action`](#dialog_action).
+* `intent` - (Optional) Configuration block for override settings to configure the intent state. See [`intent`](#intent).
+* `session_attributes` - (Optional) Map of key/value pairs representing session-specific context information. It contains application information passed between Amazon Lex and a client application.
+
+##### `timeout_response`
+
+* `message_group` - (Required) Configuration blocks for responses that Amazon Lex can send to the user. Amazon Lex chooses the actual response to send at runtime. See [`message_group`](#message_group).
+* `allow_interrupt` - (Optional) Whether the user can interrupt a speech response from Amazon Lex.
+
+#### `confirmation_conditional`
+
+* `active` - (Required) Whether a conditional branch is active. When active is false, the conditions are not evaluated.
+* `conditional_branch` - (Required) Configuration blocks for conditional branches. A conditional branch is made up of a condition, a response and a next step. The response and next step are executed when the condition is true. See [`conditional_branch`](#conditional_branch).
+* `default_branch` - (Required) Configuration block for the conditional branch that should be followed when the conditions for other branches are not satisfied. A branch is made up of a condition, a response and a next step. See [`default_branch`](#default_branch).
+
+#### `confirmation_next_step`
+
+* `dialog_action` - (Optional) Configuration block for action that the bot executes at runtime when the conversation reaches this step. See [`dialog_action`](#dialog_action).
+* `intent` - (Optional) Configuration block for override settings to configure the intent state. See [`intent`](#intent).
+* `session_attributes` - (Optional) Map of key/value pairs representing session-specific context information. It contains application information passed between Amazon Lex and a client application.
+
+#### `confirmation_response`
+
+* `message_group` - (Required) Configuration blocks for responses that Amazon Lex can send to the user. Amazon Lex chooses the actual response to send at runtime. See [`message_group`](#message_group).
+* `allow_interrupt` - (Optional) Whether the user can interrupt a speech response from Amazon Lex.
+
+#### `declination_conditional`
+
+* `active` - (Required) Whether a conditional branch is active. When active is false, the conditions are not evaluated.
+* `conditional_branch` - (Required) Configuration blocks for conditional branches. A conditional branch is made up of a condition, a response and a next step. The response and next step are executed when the condition is true. See [`conditional_branch`](#conditional_branch).
+* `default_branch` - (Required) Configuration block for the conditional branch that should be followed when the conditions for other branches are not satisfied. A branch is made up of a condition, a response and a next step. See [`default_branch`](#default_branch).
+
+#### `declination_next_step`
+
+* `dialog_action` - (Optional) Configuration block for action that the bot executes at runtime when the conversation reaches this step. See [`dialog_action`](#dialog_action).
+* `intent` - (Optional) Configuration block for override settings to configure the intent state. See [`intent`](#intent).
+* `session_attributes` - (Optional) Map of key/value pairs representing session-specific context information. It contains application information passed between Amazon Lex and a client application.
+
+#### `declination_response`
+
+* `message_group` - (Required) Configuration blocks for responses that Amazon Lex can send to the user. Amazon Lex chooses the actual response to send at runtime. See [`message_group`](#message_group).
+* `allow_interrupt` - (Optional) Whether the user can interrupt a speech response from Amazon Lex.
+
+#### `elicitation_code_hook`
+
+* `enable_code_hook_invocation` - (Required) Whether a Lambda function should be invoked for the dialog.
+* `invocation_label` - (Optional) Label that indicates the dialog step from which the dialog code hook is happening.
+
+### `dialog_code_hook`
+
+* `enabled` - (Required) Enables the dialog code hook so that it processes user requests.
+
+### `fulfillment_code_hook`
+
+* `enabled` - (Required) Whether a Lambda function should be invoked to fulfill a specific intent.
+* `active` - (Optional) Whether the fulfillment code hook is used. When active is false, the code hook doesn't run.
+* `fulfillment_updates_specification` - (Optional) Configuration block for settings for update messages sent to the user for long-running Lambda fulfillment functions. Fulfillment updates can be used only with streaming conversations. See [`fulfillment_updates_specification`](#fulfillment_updates_specification).
+* `post_fulfillment_status_specification` - (Optional) Configuration block for settings for messages sent to the user for after the Lambda fulfillment function completes. Post-fulfillment messages can be sent for both streaming and non-streaming conversations. See [`post_fulfillment_status_specification`](#post_fulfillment_status_specification).
+
+#### `fulfillment_updates_specification`
+
+* `active` - (Required) Whether fulfillment updates are sent to the user. When this field is true, updates are sent. If the active field is set to true, the `start_response`, `update_response`, and `timeout_in_seconds` fields are required.
+* `start_response` - (Required, if `active`) Configuration block for the message sent to users when the fulfillment Lambda functions starts running.
+* `timeout_in_seconds` - (Required, if `active`) Length of time that the fulfillment Lambda function should run before it times out.
+* `update_response` - (Required, if `active`) Configuration block for messages sent periodically to the user while the fulfillment Lambda function is running.
+
+##### `start_response`
+
+* `delay_in_seconds` - (Required) Delay between when the Lambda fulfillment function starts running and the start message is played. If the Lambda function returns before the delay is over, the start message isn't played.
+* `message_group` - (Required) Between 1-5 configuration block message groups that contain start messages. Amazon Lex chooses one of the messages to play to the user. See [`message_group`](#message_group).
+* `allow_interrupt` - (Optional) Whether the user can interrupt the start message while it is playing.
+
+##### `update_response`
+
+* `frequency_in_seconds` - (Required) Frequency that a message is sent to the user. When the period ends, Amazon Lex chooses a message from the message groups and plays it to the user. If the fulfillment Lambda returns before the first period ends, an update message is not played to the user.
+* `message_group` - (Required) Between 1-5 configuration block message groups that contain start messages. Amazon Lex chooses one of the messages to play to the user. See [`message_group`](#message_group).
+* `allow_interrupt` - (Optional) Whether the user can interrupt the start message while it is playing.
+
+#### `post_fulfillment_status_specification`
+
+* `failure_conditional` - (Optional) Configuration block for conditional branches to evaluate after the dialog code hook throws an exception or returns with the State field of the Intent object set to Failed. See [`failure_conditional`](#failure_conditional).
+* `failure_next_step` - (Optional) Configuration block for the next step the bot runs after the dialog code hook throws an exception or returns with the State field of the Intent object set to Failed. See [`failure_next_step`](#failure_next_step).
+* `failure_response` - (Optional) Configuration block for message groups that Amazon Lex uses to respond the user input. See [`failure_response`](#failure_response).
+* `success_conditional` - (Optional) Configuration block for conditional branches to evaluate after the dialog code hook finishes successfully. See [`success_conditional`](#success_conditional).
+* `success_next_step` - (Optional) Configuration block for the next step the bot runs after the dialog code hook finishes successfully. See [`success_next_step`](#success_next_step).
+* `success_response` - (Optional) Configuration block for message groups that Amazon Lex uses to respond the user input. See [`success_response`](#success_response).
+* `timeout_conditional` - (Optional) Configuration block for conditional branches to evaluate if the code hook times out. See [`timeout_conditional`](#timeout_conditional).
+* `timeout_next_step` - (Optional) Configuration block for the next step that the bot runs when the code hook times out. See [`timeout_next_step`](#timeout_next_step).
+* `timeout_response` - (Optional) Configuration block for a list of message groups that Amazon Lex uses to respond the user input. See [`timeout_response`](#timeout_response).
+
+### `initial_response_setting`
+
+* `code_hook` - (Optional) Configuration block for the dialog code hook that is called by Amazon Lex at a step of the conversation. See [`code_hook`](#code_hook).
+* `conditional` - (Optional) Configuration block for conditional branches. Branches are evaluated in the order that they are entered in the list. The first branch with a condition that evaluates to true is executed. The last branch in the list is the default branch. The default branch should not have any condition expression. The default branch is executed if no other branch has a matching condition. See [`conditional`](#conditional).
+* `initial_response` - (Optional) Configuration block for message groups that Amazon Lex uses to respond the user input. See [`initial_response`](#initial_response).
+* `next_step` - (Optional) Configuration block for the next step in the conversation. See [`next_step`](#next_step).
+
+#### `initial_response`
+
+* `message_group` - (Required) Configuration blocks for responses that Amazon Lex can send to the user. Amazon Lex chooses the actual response to send at runtime. See [`message_group`](#message_group).
+* `allow_interrupt` - (Optional) Whether the user can interrupt a speech response from Amazon Lex.
+
+### `input_context`
+
+* `name` - (Required) Name of the context.
+
+### `kendra_configuration`
+
+* `kendra_index` - (Required) ARN of the Amazon Kendra index that you want the AMAZON.KendraSearchIntent intent to search. The index must be in the same account and Region as the Amazon Lex bot.
+* `query_filter_string` - (Optional) Query filter that Amazon Lex sends to Amazon Kendra to filter the response from a query. The filter is in the format defined by Amazon Kendra. For more information, see [Filtering queries](https://docs.aws.amazon.com/kendra/latest/dg/filtering.html).
+* `query_filter_string_enabled` - (Optional) Whether the AMAZON.KendraSearchIntent intent uses a custom query string to query the Amazon Kendra index.
+
+### `output_context`
+
+* `name` - (Required) Name of the output context.
+* `time_to_live_in_seconds` - (Required) Amount of time, in seconds, that the output context should remain active. The time is figured from the first time the context is sent to the user.
+* `turns_to_live` - (Required) Number of conversation turns that the output context should remain active. The number of turns is counted from the first time that the context is sent to the user.
+
+### `sample_utterance`
+
+* `utterance` - (Required) Sample utterance that Amazon Lex uses to build its machine-learning model to recognize intents.
+
+### `slot_priority`
+
+* `priority` - (Required) Priority that Amazon Lex should apply to the slot.
+* `slot_id` - (Required) Unique identifier of the slot.
 
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `arn` - ARN of the Intent. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
-* `example_attribute` - Concise description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+* `creation_date_time` - Timestamp of the date and time that the intent was created.
+* `id` - Composite identifier of `intent_id:bot_id:bot_version:locale_id`.
+* `intent_id` - Unique identifier for the intent.
+* `last_updated_date_time` - Timestamp of the last time that the intent was modified.
 
 ## Timeouts
 
 [Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
 
-* `create` - (Default `60m`)
-* `update` - (Default `180m`)
-* `delete` - (Default `90m`)
+* `create` - (Default `30m`)
+* `update` - (Default `30m`)
+* `delete` - (Default `30m`)
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Lex V2 Models Intent using the `example_id_arg`. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Lex V2 Models Intent using the `intent_id:bot_id:bot_version:locale_id`. For example:
 
 ```terraform
 import {
   to = aws_lexv2models_intent.example
-  id = "intent-id-12345678"
+  id = "intent-42874:bot-11376:DRAFT:en_US"
 }
 ```
 
-Using `terraform import`, import Lex V2 Models Intent using the `example_id_arg`. For example:
+Using `terraform import`, import Lex V2 Models Intent using the `intent_id:bot_id:bot_version:locale_id`. For example:
 
 ```console
-% terraform import aws_lexv2models_intent.example intent-id-12345678
+% terraform import aws_lexv2models_intent.example intent-42874:bot-11376:DRAFT:en_US
 ```

--- a/website/docs/r/lexv2models_intent.html.markdown
+++ b/website/docs/r/lexv2models_intent.html.markdown
@@ -88,8 +88,8 @@ resource "aws_lexv2models_intent" "example" {
     active = true
 
     prompt_specification {
-      allow_interrupt = true
-      max_retries     = 1
+      allow_interrupt            = true
+      max_retries                = 1
       message_selection_strategy = "Ordered"
 
       prompt_attempts_specification {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #21375

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccLexV2ModelsIntent_ K=lexv2models 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lexv2models/... -v -count 1 -parallel 20 -run='TestAccLexV2ModelsIntent_'  -timeout 360m
=== RUN   TestAccLexV2ModelsIntent_basic
=== PAUSE TestAccLexV2ModelsIntent_basic
=== RUN   TestAccLexV2ModelsIntent_disappears
=== PAUSE TestAccLexV2ModelsIntent_disappears
=== RUN   TestAccLexV2ModelsIntent_updateConfirmationSetting
=== PAUSE TestAccLexV2ModelsIntent_updateConfirmationSetting
=== RUN   TestAccLexV2ModelsIntent_updateClosingSetting
=== PAUSE TestAccLexV2ModelsIntent_updateClosingSetting
=== RUN   TestAccLexV2ModelsIntent_updateInputContext
=== PAUSE TestAccLexV2ModelsIntent_updateInputContext
=== RUN   TestAccLexV2ModelsIntent_updateInitialResponseSetting
=== PAUSE TestAccLexV2ModelsIntent_updateInitialResponseSetting
=== RUN   TestAccLexV2ModelsIntent_updateFulfillmentCodeHook
=== PAUSE TestAccLexV2ModelsIntent_updateFulfillmentCodeHook
=== RUN   TestAccLexV2ModelsIntent_updateDialogCodeHook
=== PAUSE TestAccLexV2ModelsIntent_updateDialogCodeHook
=== RUN   TestAccLexV2ModelsIntent_updateOutputContext
=== PAUSE TestAccLexV2ModelsIntent_updateOutputContext
=== RUN   TestAccLexV2ModelsIntent_updateSampleUtterance
=== PAUSE TestAccLexV2ModelsIntent_updateSampleUtterance
=== CONT  TestAccLexV2ModelsIntent_basic
=== CONT  TestAccLexV2ModelsIntent_updateOutputContext
=== CONT  TestAccLexV2ModelsIntent_updateInputContext
=== CONT  TestAccLexV2ModelsIntent_updateSampleUtterance
=== CONT  TestAccLexV2ModelsIntent_updateFulfillmentCodeHook
=== CONT  TestAccLexV2ModelsIntent_updateDialogCodeHook
=== CONT  TestAccLexV2ModelsIntent_updateInitialResponseSetting
=== CONT  TestAccLexV2ModelsIntent_disappears
=== CONT  TestAccLexV2ModelsIntent_updateConfirmationSetting
=== CONT  TestAccLexV2ModelsIntent_updateClosingSetting
--- PASS: TestAccLexV2ModelsIntent_disappears (53.08s)
--- PASS: TestAccLexV2ModelsIntent_basic (58.27s)
--- PASS: TestAccLexV2ModelsIntent_updateOutputContext (73.59s)
--- PASS: TestAccLexV2ModelsIntent_updateInputContext (75.23s)
--- PASS: TestAccLexV2ModelsIntent_updateDialogCodeHook (75.35s)
--- PASS: TestAccLexV2ModelsIntent_updateSampleUtterance (76.19s)
--- PASS: TestAccLexV2ModelsIntent_updateClosingSetting (76.88s)
--- PASS: TestAccLexV2ModelsIntent_updateConfirmationSetting (80.56s)
--- PASS: TestAccLexV2ModelsIntent_updateInitialResponseSetting (81.90s)
--- PASS: TestAccLexV2ModelsIntent_updateFulfillmentCodeHook (82.12s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lexv2models	84.175s
```