### PR TITLE
fix: ElastiCache version value

### DIFF
--- a/internal/service/elasticache/engine_version.go
+++ b/internal/service/elasticache/engine_version.go
@@ -177,7 +177,7 @@ func setEngineVersionRedis(d *schema.ResourceData, version *string) error {
 	} else {
 		// Handle major-only version number
 		configVersion := d.Get("engine_version").(string)
-		if t, _ := regexp.MatchString(`[6-9]\.x`, configVersion); t {
+		if t, _ := regexp.MatchString(`6\.x`, configVersion); t {
 			d.Set("engine_version", fmt.Sprintf("%d.x", engineVersion.Segments()[0]))
 		} else {
 			d.Set("engine_version", fmt.Sprintf("%d.%d", engineVersion.Segments()[0], engineVersion.Segments()[1]))


### PR DESCRIPTION
### Description
This small update tries to fix a bug where ElastiCache redis engine_version of "7.x" is being used while it is not a valid version.

What will it affect?
AWS ElastiCache redis

When does it happen?
Say current version in terraform state is 6.x and truth version is 7.0.2, 
the code in question tries to treat the truth vesion as 7.x while it is invalid.
y.x version style is only appliable for 6.x