### PR TITLE
Mention "cloudfront-js-2.0" now is an available runtime for CloudFront funcs

### DIFF
--- a/website/docs/r/cloudfront_function.html.markdown
+++ b/website/docs/r/cloudfront_function.html.markdown
@@ -21,7 +21,7 @@ See [CloudFront Functions](https://docs.aws.amazon.com/AmazonCloudFront/latest/D
 ```terraform
 resource "aws_cloudfront_function" "test" {
   name    = "test"
-  runtime = "cloudfront-js-1.0"
+  runtime = "cloudfront-js-2.0"
   comment = "my function"
   publish = true
   code    = file("${path.module}/function.js")
@@ -34,7 +34,7 @@ The following arguments are required:
 
 * `name` - (Required) Unique name for your CloudFront Function.
 * `code` - (Required) Source code of the function
-* `runtime` - (Required) Identifier of the function's runtime. Currently only `cloudfront-js-1.0` is valid.
+* `runtime` - (Required) Identifier of the function's runtime. Valid values are `cloudfront-js-1.0` and `cloudfront-js-2.0`.
 
 The following arguments are optional:
 


### PR DESCRIPTION
### Description

This seems to have been a recent addition that hasn't been announced anywhere. It was mentioned in https://aws.amazon.com/blogs/aws/introducing-amazon-cloudfront-keyvaluestore-a-low-latency-datastore-for-cloudfront-functions/ but otherwise it just seems to have appeared in the documentation

I have updated the runtime version shown in the example as I assume most people would prefer to use the more recent runtime version.

### References

https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/functions-javascript-runtime-20.html
https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_FunctionConfig.html

### Output from Acceptance Testing

I have not run this since it's a documentation-only change.