### PR TITLE
internal/framework/flex: use ValueFromList for nil slice and map values

### DIFF
--- a/internal/framework/flex/auto_flatten.go
+++ b/internal/framework/flex/auto_flatten.go
@@ -332,7 +332,13 @@ func (flattener autoFlattener) slice(ctx context.Context, vFrom reflect.Value, t
 			// []string -> types.List(OfString).
 			//
 			if vFrom.IsNil() {
-				vTo.Set(reflect.ValueOf(types.ListNull(types.StringType)))
+				to, d := tTo.ValueFromList(ctx, types.ListNull(types.StringType))
+				diags.Append(d...)
+				if diags.HasError() {
+					return diags
+				}
+
+				vTo.Set(reflect.ValueOf(to))
 				return diags
 			}
 
@@ -360,7 +366,13 @@ func (flattener autoFlattener) slice(ctx context.Context, vFrom reflect.Value, t
 			// []string -> types.Set(OfString).
 			//
 			if vFrom.IsNil() {
-				vTo.Set(reflect.ValueOf(types.SetNull(types.StringType)))
+				to, d := tTo.ValueFromSet(ctx, types.SetNull(types.StringType))
+				diags.Append(d...)
+				if diags.HasError() {
+					return diags
+				}
+
+				vTo.Set(reflect.ValueOf(to))
 				return diags
 			}
 
@@ -393,7 +405,13 @@ func (flattener autoFlattener) slice(ctx context.Context, vFrom reflect.Value, t
 				// []*string -> types.List(OfString).
 				//
 				if vFrom.IsNil() {
-					vTo.Set(reflect.ValueOf(types.ListNull(types.StringType)))
+					to, d := tTo.ValueFromList(ctx, types.ListNull(types.StringType))
+					diags.Append(d...)
+					if diags.HasError() {
+						return diags
+					}
+
+					vTo.Set(reflect.ValueOf(to))
 					return diags
 				}
 
@@ -422,7 +440,13 @@ func (flattener autoFlattener) slice(ctx context.Context, vFrom reflect.Value, t
 				// []string -> types.Set(OfString).
 				//
 				if vFrom.IsNil() {
-					vTo.Set(reflect.ValueOf(types.SetNull(types.StringType)))
+					to, d := tTo.ValueFromSet(ctx, types.SetNull(types.StringType))
+					diags.Append(d...)
+					if diags.HasError() {
+						return diags
+					}
+
+					vTo.Set(reflect.ValueOf(to))
 					return diags
 				}
 
@@ -500,7 +524,13 @@ func (flattener autoFlattener) map_(ctx context.Context, vFrom reflect.Value, tT
 				// map[string]string -> types.Map(OfString).
 				//
 				if vFrom.IsNil() {
-					vTo.Set(reflect.ValueOf(types.MapNull(types.StringType)))
+					to, d := tTo.ValueFromMap(ctx, types.MapNull(types.StringType))
+					diags.Append(d...)
+					if diags.HasError() {
+						return diags
+					}
+
+					vTo.Set(reflect.ValueOf(to))
 					return diags
 				}
 
@@ -542,7 +572,13 @@ func (flattener autoFlattener) map_(ctx context.Context, vFrom reflect.Value, tT
 					// map[string]*string -> types.Map(OfString).
 					//
 					if vFrom.IsNil() {
-						vTo.Set(reflect.ValueOf(types.MapNull(types.StringType)))
+						to, d := tTo.ValueFromMap(ctx, types.MapNull(types.StringType))
+						diags.Append(d...)
+						if diags.HasError() {
+							return diags
+						}
+
+						vTo.Set(reflect.ValueOf(to))
 						return diags
 					}
 

--- a/internal/framework/flex/auto_flatten_test.go
+++ b/internal/framework/flex/auto_flatten_test.go
@@ -166,7 +166,7 @@ func TestFlatten(t *testing.T) {
 			},
 		},
 		{
-			TestName: "zero value slice/map of primtive primtive types Source and List/Set/Map of primtive types Target",
+			TestName: "zero value slice/map of primtive types Source and List/Set/Map of primtive types Target",
 			Source:   &TestFlexAWS05{},
 			Target:   &TestFlexTF04{},
 			WantTarget: &TestFlexTF04{
@@ -179,7 +179,7 @@ func TestFlatten(t *testing.T) {
 			},
 		},
 		{
-			TestName: "slice/map of primtive primtive types Source and List/Set/Map of primtive types Target",
+			TestName: "slice/map of primtive types Source and List/Set/Map of primtive types Target",
 			Source: &TestFlexAWS05{
 				Field1: []string{"a", "b"},
 				Field2: aws.StringSlice([]string{"a", "b"}),
@@ -211,6 +211,57 @@ func TestFlatten(t *testing.T) {
 					"B": types.StringValue("b"),
 				}),
 				Field6: types.MapValueMust(types.StringType, map[string]attr.Value{
+					"A": types.StringValue("a"),
+					"B": types.StringValue("b"),
+				}),
+			},
+		},
+		{
+			TestName: "zero value slice/map of string type Source and List/Set/Map of string types Target",
+			Source:   &TestFlexAWS05{},
+			Target:   &TestFlexTF18{},
+			WantTarget: &TestFlexTF18{
+				Field1: fwtypes.NewListValueOfNull[types.String](ctx),
+				Field2: fwtypes.NewListValueOfNull[types.String](ctx),
+				Field3: fwtypes.NewSetValueOfNull[types.String](ctx),
+				Field4: fwtypes.NewSetValueOfNull[types.String](ctx),
+				Field5: fwtypes.NewMapValueOfNull[types.String](ctx),
+				Field6: fwtypes.NewMapValueOfNull[types.String](ctx),
+			},
+		},
+		{
+			TestName: "slice/map of string types Source and List/Set/Map of string types Target",
+			Source: &TestFlexAWS05{
+				Field1: []string{"a", "b"},
+				Field2: aws.StringSlice([]string{"a", "b"}),
+				Field3: []string{"a", "b"},
+				Field4: aws.StringSlice([]string{"a", "b"}),
+				Field5: map[string]string{"A": "a", "B": "b"},
+				Field6: aws.StringMap(map[string]string{"A": "a", "B": "b"}),
+			},
+			Target: &TestFlexTF18{},
+			WantTarget: &TestFlexTF18{
+				Field1: fwtypes.NewListValueOfMust[types.String](ctx, []attr.Value{
+					types.StringValue("a"),
+					types.StringValue("b"),
+				}),
+				Field2: fwtypes.NewListValueOfMust[types.String](ctx, []attr.Value{
+					types.StringValue("a"),
+					types.StringValue("b"),
+				}),
+				Field3: fwtypes.NewSetValueOfMust[types.String](ctx, []attr.Value{
+					types.StringValue("a"),
+					types.StringValue("b"),
+				}),
+				Field4: fwtypes.NewSetValueOfMust[types.String](ctx, []attr.Value{
+					types.StringValue("a"),
+					types.StringValue("b"),
+				}),
+				Field5: fwtypes.NewMapValueOf[types.String](ctx, map[string]basetypes.StringValue{
+					"A": types.StringValue("a"),
+					"B": types.StringValue("b"),
+				}),
+				Field6: fwtypes.NewMapValueOf[types.String](ctx, map[string]basetypes.StringValue{
 					"A": types.StringValue("a"),
 					"B": types.StringValue("b"),
 				}),

--- a/internal/framework/flex/autoflex_test.go
+++ b/internal/framework/flex/autoflex_test.go
@@ -287,3 +287,13 @@ type TestFlexPluralityAWS01 struct {
 type TestFlexTF17 struct {
 	Field1 fwtypes.ARN `tfsdk:"field1"`
 }
+
+// List/Set/Map of string types.
+type TestFlexTF18 struct {
+	Field1 fwtypes.ListValueOf[types.String] `tfsdk:"field1"`
+	Field2 fwtypes.ListValueOf[types.String] `tfsdk:"field2"`
+	Field3 fwtypes.SetValueOf[types.String]  `tfsdk:"field3"`
+	Field4 fwtypes.SetValueOf[types.String]  `tfsdk:"field4"`
+	Field5 fwtypes.MapValueOf[types.String]  `tfsdk:"field5"`
+	Field6 fwtypes.MapValueOf[types.String]  `tfsdk:"field6"`
+}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This should prevent panics for list/sets/maps of string/*string types when nil values are returned from the AWS API and custom [List/Set/Map]Of types are used in the underlying Terraform data structures.

Before:
```console
% go test -count=1 ./internal/framework/flex/...
--- FAIL: TestFlatten (0.01s)
    --- FAIL: TestFlatten/zero_value_slice/map_of_string_type_Source_and_List/Set/Map_of_string_types_Target (0.00s)
panic: reflect.Set: value of type basetypes.ListValue is not assignable to type types.ListValueOf[github.com/hashicorp/terraform-plugin-framework/types/basetypes.StringValue] [recovered]
        panic: reflect.Set: value of type basetypes.ListValue is not assignable to type types.ListValueOf[github.com/hashicorp/terraform-plugin-framework/types/basetypes.StringValue]

goroutine 305 [running]:
testing.tRunner.func1.2({0x104ba4460, 0x1400048f070})
        /opt/homebrew/Cellar/go/1.21.3/libexec/src/testing/testing.go:1545 +0x1c8
testing.tRunner.func1()
        /opt/homebrew/Cellar/go/1.21.3/libexec/src/testing/testing.go:1548 +0x360
panic({0x104ba4460?, 0x1400048f070?})
        /opt/homebrew/Cellar/go/1.21.3/libexec/src/runtime/panic.go:914 +0x218
reflect.Value.assignTo({0x104c24ec0?, 0x140004c40f0?, 0x30?}, {0x1047f195b, 0xb}, 0x104c1d680, 0x0)
        /opt/homebrew/Cellar/go/1.21.3/libexec/src/reflect/value.go:3307 +0x20c
reflect.Value.Set({0x104c1d680?, 0x140003a6400?, 0x1400048f060?}, {0x104c24ec0?, 0x140004c40f0?, 0x10474ccb4?})
        /opt/homebrew/Cellar/go/1.21.3/libexec/src/reflect/value.go:2260 +0xc8
github.com/hashicorp/terraform-provider-aws/internal/framework/flex.autoFlattener.slice({}, {0x104c45800, 0x105086000}, {0x104ba01a0?, 0x1400050c230?, 0x197?}, {0x104c46a68?, 0x1400048f060}, {0x104c1d680?, 0x140003a6400?, ...})
        /Users/jaredbaker/development/_worktrees/f-polly_voices/internal/framework/flex/auto_flatten.go:335 +0x278
github.com/hashicorp/terraform-provider-aws/internal/framework/flex.autoFlattener.convert({}, {0x104c45800, 0x105086000}, {0x104ba01a0?, 0x1400050c230?, 0x1400062a738?}, {0x104c1d680?, 0x140003a6400?, 0x1047850a0?})
        /Users/jaredbaker/development/_worktrees/f-polly_voices/internal/framework/flex/auto_flatten.go:80 +0x2a4
github.com/hashicorp/terraform-provider-aws/internal/framework/flex.autoFlexConvertStruct({0x104c45800, 0x105086000}, {0x104b94fa0?, 0x1400050c230?}, {0x104b95820?, 0x140003a6400?}, {0x104c41d68, 0x105086000})
        /Users/jaredbaker/development/_worktrees/f-polly_voices/internal/framework/flex/autoflex.go:105 +0x284
github.com/hashicorp/terraform-provider-aws/internal/framework/flex.autoFlexConvert({0x104c45800, 0x105086000}, {0x104b94fa0, 0x1400050c230}, {0x104b95820, 0x140003a6400}, {0x104c41d68?, 0x105086000?})
        /Users/jaredbaker/development/_worktrees/f-polly_voices/internal/framework/flex/autoflex.go:47 +0x1c8
github.com/hashicorp/terraform-provider-aws/internal/framework/flex.Flatten({0x104c45800, 0x105086000}, {0x104b94fa0, 0x1400050c230}, {0x104b95820, 0x140003a6400}, {0x0, 0x0, 0x1400053df18?})
        /Users/jaredbaker/development/_worktrees/f-polly_voices/internal/framework/flex/auto_flatten.go:36 +0xb0
github.com/hashicorp/terraform-provider-aws/internal/framework/flex.TestFlatten.func1(0x14000527a00)
        /Users/jaredbaker/development/_worktrees/f-polly_voices/internal/framework/flex/auto_flatten_test.go:444 +0x8c
testing.tRunner(0x14000527a00, 0x1400050cfc0)
        /opt/homebrew/Cellar/go/1.21.3/libexec/src/testing/testing.go:1595 +0xe8
created by testing.(*T).Run in goroutine 21
        /opt/homebrew/Cellar/go/1.21.3/libexec/src/testing/testing.go:1648 +0x33c
FAIL    github.com/hashicorp/terraform-provider-aws/internal/framework/flex     0.461s
```

After:
```console
% go test -count=1 ./internal/framework/flex/...
ok      github.com/hashicorp/terraform-provider-aws/internal/framework/flex     0.270s
```



