### PR TITLE
r/aws_finspace_kx_volume(test): add tags test

### DIFF
--- a/internal/service/finspace/kx_volume_test.go
+++ b/internal/service/finspace/kx_volume_test.go
@@ -88,6 +88,62 @@ func TestAccFinSpaceKxVolume_disappears(t *testing.T) {
 	})
 }
 
+func TestAccFinSpaceKxVolume_tags(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	ctx := acctest.Context(t)
+	var volume finspace.GetKxVolumeOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_finspace_kx_volume.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, finspace.ServiceID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, finspace.ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckKxVolumeDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKxVolumeConfig_tags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKxVolumeExists(ctx, resourceName, &volume),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccKxVolumeConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKxVolumeExists(ctx, resourceName, &volume),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccKxVolumeConfig_tags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKxVolumeExists(ctx, resourceName, &volume),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckKxVolumeDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).FinSpaceClient(ctx)
@@ -263,4 +319,49 @@ resource "aws_finspace_kx_volume" "test" {
   }
 }
 `, rName))
+}
+
+func testAccKxVolumeConfig_tags1(rName, key1, value1 string) string {
+	return acctest.ConfigCompose(
+		testAccKxVolumeConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_finspace_kx_volume" "test" {
+  name               = %[1]q
+  environment_id     = aws_finspace_kx_environment.test.id
+  availability_zones = [aws_finspace_kx_environment.test.availability_zones[0]]
+  az_mode            = "SINGLE"
+  type               = "NAS_1"
+  nas1_configuration {
+    type = "SSD_250"
+    size = 1200
+  }
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, key1, value1))
+}
+
+func testAccKxVolumeConfig_tags2(rName, key1, value1, key2, value2 string) string {
+	return acctest.ConfigCompose(
+		testAccKxVolumeConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_finspace_kx_volume" "test" {
+  name               = %[1]q
+  environment_id     = aws_finspace_kx_environment.test.id
+  availability_zones = [aws_finspace_kx_environment.test.availability_zones[0]]
+  az_mode            = "SINGLE"
+  type               = "NAS_1"
+  nas1_configuration {
+    type = "SSD_250"
+    size = 1200
+  }
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, key1, value1, key2, value2))
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds missed commit from #34833 .

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #34833 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccFinSpaceKxVolume_tags PKG=finspace ACCTEST_PARALLELISM=1
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/finspace/... -v -count 1 -parallel 1 -run='TestAccFinSpaceKxVolume_tags'  -timeout 360m
=== RUN   TestAccFinSpaceKxVolume_tags
=== PAUSE TestAccFinSpaceKxVolume_tags
=== CONT  TestAccFinSpaceKxVolume_tags
--- PASS: TestAccFinSpaceKxVolume_tags (1626.74s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/finspace   1630.055s
```
