### PR TITLE
feat(r/aws_autoscaling_group): add max_healthy_percentage arg

### DIFF
--- a/.changelog/34929.txt
+++ b/.changelog/34929.txt
@@ -1,0 +1,4 @@
+```release-note:enhancement
+resource/aws_autoscaling_group: Add `max_healthy_percentage` attribute to instance_refresh.preferences configuration block
+```
+

--- a/internal/service/autoscaling/group.go
+++ b/internal/service/autoscaling/group.go
@@ -250,6 +250,12 @@ func ResourceGroup() *schema.Resource {
 										Optional:     true,
 										ValidateFunc: nullable.ValidateTypeStringNullableIntAtLeast(0),
 									},
+									"max_healthy_percentage": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      100,
+										ValidateFunc: validation.IntBetween(100, 200),
+									},
 									"min_healthy_percentage": {
 										Type:         schema.TypeInt,
 										Optional:     true,

--- a/website/docs/r/autoscaling_group.html.markdown
+++ b/website/docs/r/autoscaling_group.html.markdown
@@ -662,6 +662,7 @@ This configuration block supports the following:
     - `checkpoint_delay` - (Optional) Number of seconds to wait after a checkpoint. Defaults to `3600`.
     - `checkpoint_percentages` - (Optional) List of percentages for each checkpoint. Values must be unique and in ascending order. To replace all instances, the final number must be `100`.
     - `instance_warmup` - (Optional) Number of seconds until a newly launched instance is configured and ready to use. Default behavior is to use the Auto Scaling Group's health check grace period.
+    - `max_healthy_percentage` - (Optional) Amount of capacity in the Auto Scaling group that can be in service and healthy, or pending, to support your workload when an instance refresh is in place, as a percentage of the desired capacity of the Auto Scaling group. Values must be between `100` and `200`, defaults to `100`.
     - `min_healthy_percentage` - (Optional) Amount of capacity in the Auto Scaling group that must remain healthy during an instance refresh to allow the operation to continue, as a percentage of the desired capacity of the Auto Scaling group. Defaults to `90`.
     - `skip_matching` - (Optional) Replace instances that already have your desired configuration. Defaults to `false`.
     - `auto_rollback` - (Optional) Automatically rollback if instance refresh fails. Defaults to `false`. This option may only be set to `true` when specifying a `launch_template` or `mixed_instances_policy`.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The aws_autoscaling_group resource doesn't supports the attribute max_healthy_percentage at instance_refresh.preferences, which restricts the sensibility of instance-refresh operations.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
-  ([StartInstanceRefresh API spec](https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_StartInstanceRefresh.html)) describes the expected behaviour for this field.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
make testacc TESTS=TestAccAutoScalingGroup_InstanceRefresh PKG=autoscaling
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/autoscaling/... -v -count 1 -parallel 20 -run='TestAccAutoScalingGroup_InstanceRefresh'  -timeout 360m
=== RUN   TestAccAutoScalingGroup_InstanceRefresh_basic
=== PAUSE TestAccAutoScalingGroup_InstanceRefresh_basic
=== RUN   TestAccAutoScalingGroup_InstanceRefresh_start
=== PAUSE TestAccAutoScalingGroup_InstanceRefresh_start
=== RUN   TestAccAutoScalingGroup_InstanceRefresh_triggers
=== PAUSE TestAccAutoScalingGroup_InstanceRefresh_triggers
=== RUN   TestAccAutoScalingGroup_InstanceRefresh_autoRollback
=== PAUSE TestAccAutoScalingGroup_InstanceRefresh_autoRollback
=== CONT  TestAccAutoScalingGroup_InstanceRefresh_basic
=== CONT  TestAccAutoScalingGroup_InstanceRefresh_triggers
=== CONT  TestAccAutoScalingGroup_InstanceRefresh_start
=== CONT  TestAccAutoScalingGroup_InstanceRefresh_autoRollback
--- PASS: TestAccAutoScalingGroup_InstanceRefresh_start (139.94s)
--- PASS: TestAccAutoScalingGroup_InstanceRefresh_autoRollback (148.68s)
--- PASS: TestAccAutoScalingGroup_InstanceRefresh_triggers (157.52s)
--- PASS: TestAccAutoScalingGroup_InstanceRefresh_basic (218.46s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/autoscaling        220.709s
...
```

### Comments:
- My organization policy doesn't allow me to grant write access to external users in this PR