### PR TITLE
autoflex: Add block key map

### DIFF
--- a/internal/framework/flex/auto_expand.go
+++ b/internal/framework/flex/auto_expand.go
@@ -531,13 +531,13 @@ func (expander autoExpander) nestedObject(ctx context.Context, vFrom fwtypes.Nes
 			//
 			// types.List(OfObject) -> map[string]struct
 			//
-			diags.Append(expander.nestedKeyObjectToMap(ctx, vFrom, tTo, tElem, vTo)...)
+			diags.Append(expander.nestedKeyObjectToMap(ctx, vFrom, tElem, vTo)...)
 			return diags
 		case reflect.Ptr:
 			//
 			// types.List(OfObject) -> map[string]*struct
 			//
-			diags.Append(expander.nestedKeyObjectToMap(ctx, vFrom, tTo, tElem, vTo)...)
+			diags.Append(expander.nestedKeyObjectToMap(ctx, vFrom, tElem, vTo)...)
 			return diags
 		}
 
@@ -631,7 +631,7 @@ func (expander autoExpander) nestedObjectToSlice(ctx context.Context, vFrom fwty
 }
 
 // nestedKeyObjectToMap copies a Plugin Framework NestedObjectValue to a compatible AWS API map[string]struct value.
-func (expander autoExpander) nestedKeyObjectToMap(ctx context.Context, vFrom fwtypes.NestedObjectValue, tSlice, tElem reflect.Type, vTo reflect.Value) diag.Diagnostics {
+func (expander autoExpander) nestedKeyObjectToMap(ctx context.Context, vFrom fwtypes.NestedObjectValue, tElem reflect.Type, vTo reflect.Value) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	// Get the nested Objects as a slice.
@@ -656,7 +656,7 @@ func (expander autoExpander) nestedKeyObjectToMap(ctx context.Context, vFrom fwt
 			return diags
 		}
 
-		key, d := blockKeyMap(ctx, f.Index(i).Interface())
+		key, d := blockKeyMap(f.Index(i).Interface())
 		diags.Append(d...)
 		if diags.HasError() {
 			return diags
@@ -747,7 +747,7 @@ func (expander autoExpander) mappedObjectToStruct(ctx context.Context, vFrom fwt
 }
 
 // blockKeyMap takes a struct and extracts the value of the `key`
-func blockKeyMap(ctx context.Context, from any) (reflect.Value, diag.Diagnostics) {
+func blockKeyMap(from any) (reflect.Value, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	valFrom := reflect.ValueOf(from)

--- a/internal/framework/flex/auto_expand_test.go
+++ b/internal/framework/flex/auto_expand_test.go
@@ -606,6 +606,36 @@ func TestExpandGeneric(t *testing.T) {
 			},
 		},
 		{
+			TestName: "block set key map",
+			Source: &TestFlexBlockKeyMapTF03{
+				BlockMap: fwtypes.NewSetNestedObjectValueOfValueSlice[TestFlexBlockKeyMapTF02](ctx, []TestFlexBlockKeyMapTF02{
+					{
+						TFBlockKeyMap: types.StringValue("x"),
+						Attr1:         types.StringValue("a"),
+						Attr2:         types.StringValue("b"),
+					},
+					{
+						TFBlockKeyMap: types.StringValue("y"),
+						Attr1:         types.StringValue("c"),
+						Attr2:         types.StringValue("d"),
+					},
+				}),
+			},
+			Target: &TestFlexBlockKeyMapAWS01{},
+			WantTarget: &TestFlexBlockKeyMapAWS01{
+				BlockMap: map[string]TestFlexBlockKeyMapAWS02{
+					"x": {
+						Attr1: "a",
+						Attr2: "b",
+					},
+					"y": {
+						Attr1: "c",
+						Attr2: "d",
+					},
+				},
+			},
+		},
+		{
 			TestName: "block key map ptr source",
 			Source: &TestFlexBlockKeyMapTF01{
 				BlockMap: fwtypes.NewListNestedObjectValueOfSlice(ctx, []*TestFlexBlockKeyMapTF02{

--- a/internal/framework/flex/auto_expand_test.go
+++ b/internal/framework/flex/auto_expand_test.go
@@ -576,6 +576,96 @@ func TestExpandGeneric(t *testing.T) {
 			},
 		},
 		{
+			TestName: "block key map",
+			Source: &TestFlexBlockKeyMapTF01{
+				BlockMap: fwtypes.NewListNestedObjectValueOfValueSlice[TestFlexBlockKeyMapTF02](ctx, []TestFlexBlockKeyMapTF02{
+					{
+						TFBlockKeyMap: types.StringValue("x"),
+						Attr1:         types.StringValue("a"),
+						Attr2:         types.StringValue("b"),
+					},
+					{
+						TFBlockKeyMap: types.StringValue("y"),
+						Attr1:         types.StringValue("c"),
+						Attr2:         types.StringValue("d"),
+					},
+				}),
+			},
+			Target: &TestFlexBlockKeyMapAWS01{},
+			WantTarget: &TestFlexBlockKeyMapAWS01{
+				BlockMap: map[string]TestFlexBlockKeyMapAWS02{
+					"x": {
+						Attr1: "a",
+						Attr2: "b",
+					},
+					"y": {
+						Attr1: "c",
+						Attr2: "d",
+					},
+				},
+			},
+		},
+		{
+			TestName: "block key map ptr source",
+			Source: &TestFlexBlockKeyMapTF01{
+				BlockMap: fwtypes.NewListNestedObjectValueOfSlice(ctx, []*TestFlexBlockKeyMapTF02{
+					{
+						TFBlockKeyMap: types.StringValue("x"),
+						Attr1:         types.StringValue("a"),
+						Attr2:         types.StringValue("b"),
+					},
+					{
+						TFBlockKeyMap: types.StringValue("y"),
+						Attr1:         types.StringValue("c"),
+						Attr2:         types.StringValue("d"),
+					},
+				}),
+			},
+			Target: &TestFlexBlockKeyMapAWS01{},
+			WantTarget: &TestFlexBlockKeyMapAWS01{
+				BlockMap: map[string]TestFlexBlockKeyMapAWS02{
+					"x": {
+						Attr1: "a",
+						Attr2: "b",
+					},
+					"y": {
+						Attr1: "c",
+						Attr2: "d",
+					},
+				},
+			},
+		},
+		{
+			TestName: "block key map ptr both",
+			Source: &TestFlexBlockKeyMapTF01{
+				BlockMap: fwtypes.NewListNestedObjectValueOfSlice(ctx, []*TestFlexBlockKeyMapTF02{
+					{
+						TFBlockKeyMap: types.StringValue("x"),
+						Attr1:         types.StringValue("a"),
+						Attr2:         types.StringValue("b"),
+					},
+					{
+						TFBlockKeyMap: types.StringValue("y"),
+						Attr1:         types.StringValue("c"),
+						Attr2:         types.StringValue("d"),
+					},
+				}),
+			},
+			Target: &TestFlexBlockKeyMapAWS03{},
+			WantTarget: &TestFlexBlockKeyMapAWS03{
+				BlockMap: map[string]*TestFlexBlockKeyMapAWS02{
+					"x": {
+						Attr1: "a",
+						Attr2: "b",
+					},
+					"y": {
+						Attr1: "c",
+						Attr2: "d",
+					},
+				},
+			},
+		},
+		{
 			TestName: "complex nesting",
 			Source: &TestFlexComplexNestTF01{
 				DialogAction: fwtypes.NewListNestedObjectValueOfPtr(ctx, &TestFlexComplexNestTF02{

--- a/internal/framework/flex/auto_flatten.go
+++ b/internal/framework/flex/auto_flatten.go
@@ -870,7 +870,6 @@ func blockKeyMapSet(ctx context.Context, to any, key string) diag.Diagnostics {
 			continue // Skip unexported fields.
 		}
 
-		// go to StringValue to string
 		if field.Name != BlockKeyMap {
 			continue
 		}

--- a/internal/framework/flex/auto_flatten.go
+++ b/internal/framework/flex/auto_flatten.go
@@ -739,7 +739,7 @@ func (flattener autoFlattener) structMapToObjectList(ctx context.Context, vFrom 
 			return diags
 		}
 
-		d = blockKeyMapSet(ctx, target, key.String())
+		d = blockKeyMapSet(target, key.String())
 		diags.Append(d...)
 
 		t.Index(i).Set(reflect.ValueOf(target))
@@ -851,7 +851,7 @@ func (flattener autoFlattener) sliceOfStructNestedObject(ctx context.Context, vF
 }
 
 // blockKeyMapSet takes a struct and assigns the value of the `key`
-func blockKeyMapSet(ctx context.Context, to any, key string) diag.Diagnostics {
+func blockKeyMapSet(to any, key string) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	valTo := reflect.ValueOf(to)

--- a/internal/framework/flex/auto_flatten.go
+++ b/internal/framework/flex/auto_flatten.go
@@ -715,14 +715,8 @@ func (flattener autoFlattener) structMapToObjectList(ctx context.Context, vFrom 
 
 	t := reflect.ValueOf(to)
 
-	//tStruct := t.Type().Elem()
-	//if tStruct.Kind() == reflect.Ptr {
-	//	tStruct = tStruct.Elem()
-	//}
-
 	i := 0
 	for _, key := range vFrom.MapKeys() {
-		//target := reflect.New(tStruct)
 		target, d := tTo.NewObjectPtr(ctx)
 		diags.Append(d...)
 		if diags.HasError() {
@@ -744,11 +738,6 @@ func (flattener autoFlattener) structMapToObjectList(ctx context.Context, vFrom 
 
 		t.Index(i).Set(reflect.ValueOf(target))
 		i++
-		//if t.Type().Elem().Kind() == reflect.Struct {
-		//	t.SetMapIndex(key, target.Elem())
-		//} else {
-		//	t.SetMapIndex(key, target)
-		//}
 	}
 
 	val, d := tTo.ValueFromObjectSlice(ctx, to)

--- a/internal/framework/flex/auto_flatten_test.go
+++ b/internal/framework/flex/auto_flatten_test.go
@@ -5,11 +5,13 @@ package flex
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -902,11 +904,13 @@ func TestFlattenGeneric(t *testing.T) {
 				t.Errorf("gotErr = %v, wantErr = %v", gotErr, testCase.WantErr)
 			}
 
+			less := func(a, b any) bool { return fmt.Sprint(a) < fmt.Sprint(b) }
+
 			if gotErr {
 				if !testCase.WantErr {
 					t.Errorf("err = %q", err)
 				}
-			} else if diff := cmp.Diff(testCase.Target, testCase.WantTarget); diff != "" {
+			} else if diff := cmp.Diff(testCase.Target, testCase.WantTarget, cmpopts.SortSlices(less)); diff != "" {
 				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
 			}
 		})

--- a/internal/framework/flex/auto_flatten_test.go
+++ b/internal/framework/flex/auto_flatten_test.go
@@ -748,6 +748,96 @@ func TestFlattenGeneric(t *testing.T) {
 			},
 		},
 		{
+			TestName: "block key map",
+			Source: &TestFlexBlockKeyMapAWS01{
+				BlockMap: map[string]TestFlexBlockKeyMapAWS02{
+					"x": {
+						Attr1: "a",
+						Attr2: "b",
+					},
+					"y": {
+						Attr1: "c",
+						Attr2: "d",
+					},
+				},
+			},
+			Target: &TestFlexBlockKeyMapTF01{},
+			WantTarget: &TestFlexBlockKeyMapTF01{
+				BlockMap: fwtypes.NewListNestedObjectValueOfValueSlice[TestFlexBlockKeyMapTF02](ctx, []TestFlexBlockKeyMapTF02{
+					{
+						TFBlockKeyMap: types.StringValue("x"),
+						Attr1:         types.StringValue("a"),
+						Attr2:         types.StringValue("b"),
+					},
+					{
+						TFBlockKeyMap: types.StringValue("y"),
+						Attr1:         types.StringValue("c"),
+						Attr2:         types.StringValue("d"),
+					},
+				}),
+			},
+		},
+		{
+			TestName: "block key map ptr source",
+			Source: &TestFlexBlockKeyMapAWS03{
+				BlockMap: map[string]*TestFlexBlockKeyMapAWS02{
+					"x": {
+						Attr1: "a",
+						Attr2: "b",
+					},
+					"y": {
+						Attr1: "c",
+						Attr2: "d",
+					},
+				},
+			},
+			Target: &TestFlexBlockKeyMapTF01{},
+			WantTarget: &TestFlexBlockKeyMapTF01{
+				BlockMap: fwtypes.NewListNestedObjectValueOfValueSlice[TestFlexBlockKeyMapTF02](ctx, []TestFlexBlockKeyMapTF02{
+					{
+						TFBlockKeyMap: types.StringValue("x"),
+						Attr1:         types.StringValue("a"),
+						Attr2:         types.StringValue("b"),
+					},
+					{
+						TFBlockKeyMap: types.StringValue("y"),
+						Attr1:         types.StringValue("c"),
+						Attr2:         types.StringValue("d"),
+					},
+				}),
+			},
+		},
+		{
+			TestName: "block key map ptr both",
+			Source: &TestFlexBlockKeyMapAWS03{
+				BlockMap: map[string]*TestFlexBlockKeyMapAWS02{
+					"x": {
+						Attr1: "a",
+						Attr2: "b",
+					},
+					"y": {
+						Attr1: "c",
+						Attr2: "d",
+					},
+				},
+			},
+			Target: &TestFlexBlockKeyMapTF01{},
+			WantTarget: &TestFlexBlockKeyMapTF01{
+				BlockMap: fwtypes.NewListNestedObjectValueOfSlice(ctx, []*TestFlexBlockKeyMapTF02{
+					{
+						TFBlockKeyMap: types.StringValue("x"),
+						Attr1:         types.StringValue("a"),
+						Attr2:         types.StringValue("b"),
+					},
+					{
+						TFBlockKeyMap: types.StringValue("y"),
+						Attr1:         types.StringValue("c"),
+						Attr2:         types.StringValue("d"),
+					},
+				}),
+			},
+		},
+		{
 			TestName: "complex nesting",
 			Source: &TestFlexComplexNestAWS01{
 				DialogAction: &TestFlexComplexNestAWS02{

--- a/internal/framework/flex/auto_flatten_test.go
+++ b/internal/framework/flex/auto_flatten_test.go
@@ -757,10 +757,6 @@ func TestFlattenGeneric(t *testing.T) {
 						Attr1: "a",
 						Attr2: "b",
 					},
-					"y": {
-						Attr1: "c",
-						Attr2: "d",
-					},
 				},
 			},
 			Target: &TestFlexBlockKeyMapTF01{},
@@ -770,11 +766,6 @@ func TestFlattenGeneric(t *testing.T) {
 						TFBlockKeyMap: types.StringValue("x"),
 						Attr1:         types.StringValue("a"),
 						Attr2:         types.StringValue("b"),
-					},
-					{
-						TFBlockKeyMap: types.StringValue("y"),
-						Attr1:         types.StringValue("c"),
-						Attr2:         types.StringValue("d"),
 					},
 				}),
 			},
@@ -787,10 +778,6 @@ func TestFlattenGeneric(t *testing.T) {
 						Attr1: "a",
 						Attr2: "b",
 					},
-					"y": {
-						Attr1: "c",
-						Attr2: "d",
-					},
 				},
 			},
 			Target: &TestFlexBlockKeyMapTF01{},
@@ -800,11 +787,6 @@ func TestFlattenGeneric(t *testing.T) {
 						TFBlockKeyMap: types.StringValue("x"),
 						Attr1:         types.StringValue("a"),
 						Attr2:         types.StringValue("b"),
-					},
-					{
-						TFBlockKeyMap: types.StringValue("y"),
-						Attr1:         types.StringValue("c"),
-						Attr2:         types.StringValue("d"),
 					},
 				}),
 			},
@@ -904,7 +886,7 @@ func TestFlattenGeneric(t *testing.T) {
 				t.Errorf("gotErr = %v, wantErr = %v", gotErr, testCase.WantErr)
 			}
 
-			less := func(a, b any) bool { return fmt.Sprint(a) < fmt.Sprint(b) }
+			less := func(a, b any) bool { return fmt.Sprintf("%+v", a) < fmt.Sprintf("%+v", b) }
 
 			if gotErr {
 				if !testCase.WantErr {

--- a/internal/framework/flex/auto_flatten_test.go
+++ b/internal/framework/flex/auto_flatten_test.go
@@ -799,10 +799,6 @@ func TestFlattenGeneric(t *testing.T) {
 						Attr1: "a",
 						Attr2: "b",
 					},
-					"y": {
-						Attr1: "c",
-						Attr2: "d",
-					},
 				},
 			},
 			Target: &TestFlexBlockKeyMapTF01{},
@@ -812,11 +808,6 @@ func TestFlattenGeneric(t *testing.T) {
 						TFBlockKeyMap: types.StringValue("x"),
 						Attr1:         types.StringValue("a"),
 						Attr2:         types.StringValue("b"),
-					},
-					{
-						TFBlockKeyMap: types.StringValue("y"),
-						Attr1:         types.StringValue("c"),
-						Attr2:         types.StringValue("d"),
 					},
 				}),
 			},

--- a/internal/framework/flex/auto_flatten_test.go
+++ b/internal/framework/flex/auto_flatten_test.go
@@ -771,6 +771,27 @@ func TestFlattenGeneric(t *testing.T) {
 			},
 		},
 		{
+			TestName: "block key set map",
+			Source: &TestFlexBlockKeyMapAWS01{
+				BlockMap: map[string]TestFlexBlockKeyMapAWS02{
+					"x": {
+						Attr1: "a",
+						Attr2: "b",
+					},
+				},
+			},
+			Target: &TestFlexBlockKeyMapTF03{},
+			WantTarget: &TestFlexBlockKeyMapTF03{
+				BlockMap: fwtypes.NewSetNestedObjectValueOfValueSlice[TestFlexBlockKeyMapTF02](ctx, []TestFlexBlockKeyMapTF02{
+					{
+						TFBlockKeyMap: types.StringValue("x"),
+						Attr1:         types.StringValue("a"),
+						Attr2:         types.StringValue("b"),
+					},
+				}),
+			},
+		},
+		{
 			TestName: "block key map ptr source",
 			Source: &TestFlexBlockKeyMapAWS03{
 				BlockMap: map[string]*TestFlexBlockKeyMapAWS02{

--- a/internal/framework/flex/autoflex.go
+++ b/internal/framework/flex/autoflex.go
@@ -18,6 +18,7 @@ type ResourcePrefixCtxKey string
 const (
 	ResourcePrefix        ResourcePrefixCtxKey = "RESOURCE_PREFIX"
 	ResourcePrefixRecurse ResourcePrefixCtxKey = "RESOURCE_PREFIX_RECURSE"
+	BlockKeyMap                                = "TFBlockKeyMap"
 )
 
 // Expand  = TF -->  AWS
@@ -94,6 +95,10 @@ func autoFlexConvertStruct(ctx context.Context, from any, to any, flexer autoFle
 		if fieldName == "Tags" {
 			continue // Resource tags are handled separately.
 		}
+		if fieldName == BlockKeyMap {
+			continue
+		}
+
 		toFieldVal := findFieldFuzzy(ctx, fieldName, valTo, valFrom)
 		if !toFieldVal.IsValid() {
 			continue // Corresponding field not found in to.

--- a/internal/framework/flex/autoflex_test.go
+++ b/internal/framework/flex/autoflex_test.go
@@ -297,3 +297,26 @@ type TestFlexTF18 struct {
 	Field5 fwtypes.MapValueOf[types.String]  `tfsdk:"field5"`
 	Field6 fwtypes.MapValueOf[types.String]  `tfsdk:"field6"`
 }
+
+type TestFlexBlockKeyMapTF01 struct {
+	BlockMap fwtypes.ListNestedObjectValueOf[TestFlexBlockKeyMapTF02] `tfsdk:"block_map"`
+}
+
+type TestFlexBlockKeyMapTF02 struct {
+	TFBlockKeyMap types.String `tfsdk:"block_key_map"`
+	Attr1         types.String `tfsdk:"attr1"`
+	Attr2         types.String `tfsdk:"attr2"`
+}
+
+type TestFlexBlockKeyMapAWS01 struct {
+	BlockMap map[string]TestFlexBlockKeyMapAWS02
+}
+
+type TestFlexBlockKeyMapAWS02 struct {
+	Attr1 string
+	Attr2 string
+}
+
+type TestFlexBlockKeyMapAWS03 struct {
+	BlockMap map[string]*TestFlexBlockKeyMapAWS02
+}

--- a/internal/framework/flex/autoflex_test.go
+++ b/internal/framework/flex/autoflex_test.go
@@ -308,6 +308,10 @@ type TestFlexBlockKeyMapTF02 struct {
 	Attr2         types.String `tfsdk:"attr2"`
 }
 
+type TestFlexBlockKeyMapTF03 struct {
+	BlockMap fwtypes.SetNestedObjectValueOf[TestFlexBlockKeyMapTF02] `tfsdk:"block_map"`
+}
+
 type TestFlexBlockKeyMapAWS01 struct {
 	BlockMap map[string]TestFlexBlockKeyMapAWS02
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% go test ./internal/framework/flex/... -v -count 1 -parallel 20 -run='TestFlat'  
=== RUN   TestFlatten
=== PAUSE TestFlatten
=== RUN   TestFlattenGeneric
=== PAUSE TestFlattenGeneric
=== RUN   TestFlattenFrameworkStringList
=== PAUSE TestFlattenFrameworkStringList
=== RUN   TestFlattenFrameworkStringListLegacy
=== PAUSE TestFlattenFrameworkStringListLegacy
=== RUN   TestFlattenFrameworkStringValueList
=== PAUSE TestFlattenFrameworkStringValueList
=== RUN   TestFlattenFrameworkStringValueListLegacy
=== PAUSE TestFlattenFrameworkStringValueListLegacy
=== RUN   TestFlattenFrameworkStringMap
=== PAUSE TestFlattenFrameworkStringMap
=== RUN   TestFlattenFrameworkStringValueMap
=== PAUSE TestFlattenFrameworkStringValueMap
=== RUN   TestFlattenFrameworkStringValueMapLegacy
=== PAUSE TestFlattenFrameworkStringValueMapLegacy
=== RUN   TestFlattenFrameworkStringValueSet
=== PAUSE TestFlattenFrameworkStringValueSet
=== RUN   TestFlattenFrameworkStringValueSetLegacy
=== PAUSE TestFlattenFrameworkStringValueSetLegacy
=== CONT  TestFlatten
=== CONT  TestFlattenFrameworkStringMap
=== CONT  TestFlattenFrameworkStringValueSetLegacy
=== CONT  TestFlattenFrameworkStringListLegacy
=== CONT  TestFlattenFrameworkStringValueListLegacy
=== CONT  TestFlattenFrameworkStringValueMapLegacy
=== CONT  TestFlattenFrameworkStringValueMap
=== CONT  TestFlattenFrameworkStringValueList
=== RUN   TestFlattenFrameworkStringValueList/two_elements
=== CONT  TestFlattenFrameworkStringList
=== CONT  TestFlattenGeneric
=== CONT  TestFlattenFrameworkStringValueSet
=== RUN   TestFlattenFrameworkStringMap/two_elements
=== RUN   TestFlattenFrameworkStringListLegacy/nil_array
=== RUN   TestFlattenFrameworkStringValueListLegacy/nil_array
=== RUN   TestFlattenFrameworkStringValueMapLegacy/two_elements
=== RUN   TestFlattenFrameworkStringValueMap/two_elements
=== PAUSE TestFlattenFrameworkStringValueMapLegacy/two_elements
=== PAUSE TestFlattenFrameworkStringValueMap/two_elements
=== RUN   TestFlattenFrameworkStringValueSetLegacy/two_elements
=== RUN   TestFlattenFrameworkStringValueMapLegacy/zero_elements
=== PAUSE TestFlattenFrameworkStringValueList/two_elements
=== PAUSE TestFlattenFrameworkStringValueMapLegacy/zero_elements
=== PAUSE TestFlattenFrameworkStringMap/two_elements
=== PAUSE TestFlattenFrameworkStringValueSetLegacy/two_elements
=== RUN   TestFlatten/nil_Source_and_Target
=== PAUSE TestFlatten/nil_Source_and_Target
=== RUN   TestFlattenFrameworkStringList/two_elements
=== RUN   TestFlattenFrameworkStringValueSetLegacy/zero_elements
=== PAUSE TestFlattenFrameworkStringValueSetLegacy/zero_elements
=== RUN   TestFlattenFrameworkStringValueMap/zero_elements
=== RUN   TestFlattenFrameworkStringValueSetLegacy/nil_array
=== PAUSE TestFlattenFrameworkStringValueSetLegacy/nil_array
=== CONT  TestFlattenFrameworkStringValueSetLegacy/two_elements
=== CONT  TestFlattenFrameworkStringValueSetLegacy/nil_array
=== RUN   TestFlatten/non-pointer_Target
=== PAUSE TestFlattenFrameworkStringList/two_elements
=== CONT  TestFlattenFrameworkStringValueSetLegacy/zero_elements
=== RUN   TestFlattenFrameworkStringList/zero_elements
=== PAUSE TestFlattenFrameworkStringList/zero_elements
=== PAUSE TestFlattenFrameworkStringListLegacy/nil_array
=== RUN   TestFlattenFrameworkStringList/nil_array
=== PAUSE TestFlattenFrameworkStringList/nil_array
=== PAUSE TestFlattenFrameworkStringValueListLegacy/nil_array
=== CONT  TestFlattenFrameworkStringList/two_elements
=== RUN   TestFlattenFrameworkStringValueSet/two_elements
=== CONT  TestFlattenFrameworkStringList/nil_array
=== PAUSE TestFlattenFrameworkStringValueSet/two_elements
=== RUN   TestFlattenFrameworkStringValueListLegacy/two_elements
=== RUN   TestFlattenFrameworkStringValueList/zero_elements
=== RUN   TestFlattenFrameworkStringValueSet/zero_elements
=== RUN   TestFlattenFrameworkStringListLegacy/two_elements
=== PAUSE TestFlattenFrameworkStringValueSet/zero_elements
=== PAUSE TestFlattenFrameworkStringValueListLegacy/two_elements
=== RUN   TestFlattenFrameworkStringValueSet/nil_array
=== PAUSE TestFlattenFrameworkStringValueSet/nil_array
=== PAUSE TestFlattenFrameworkStringValueList/zero_elements
=== PAUSE TestFlattenFrameworkStringListLegacy/two_elements
=== RUN   TestFlattenFrameworkStringValueListLegacy/zero_elements
=== PAUSE TestFlattenFrameworkStringValueListLegacy/zero_elements
=== PAUSE TestFlattenFrameworkStringValueMap/zero_elements
=== RUN   TestFlattenFrameworkStringListLegacy/zero_elements
=== PAUSE TestFlattenFrameworkStringListLegacy/zero_elements
=== PAUSE TestFlatten/non-pointer_Target
=== CONT  TestFlattenFrameworkStringListLegacy/two_elements
=== RUN   TestFlatten/non-struct_Source
=== RUN   TestFlattenFrameworkStringValueMap/nil_map
=== PAUSE TestFlatten/non-struct_Source
=== RUN   TestFlatten/non-struct_Target
=== CONT  TestFlattenFrameworkStringList/zero_elements
=== PAUSE TestFlattenFrameworkStringValueMap/nil_map
=== PAUSE TestFlatten/non-struct_Target
=== CONT  TestFlattenFrameworkStringValueMap/two_elements
=== RUN   TestFlatten/empty_struct_Source_and_Target
=== PAUSE TestFlatten/empty_struct_Source_and_Target
=== RUN   TestFlattenFrameworkStringMap/zero_elements
=== RUN   TestFlatten/empty_struct_pointer_Source_and_Target
=== CONT  TestFlattenFrameworkStringValueMap/zero_elements
=== PAUSE TestFlatten/empty_struct_pointer_Source_and_Target
=== CONT  TestFlattenFrameworkStringValueSet/two_elements
=== RUN   TestFlatten/single_string_struct_pointer_Source_and_empty_Target
=== PAUSE TestFlatten/single_string_struct_pointer_Source_and_empty_Target
=== RUN   TestFlatten/does_not_implement_attr.Value_Target
=== CONT  TestFlattenFrameworkStringValueSet/nil_array
=== PAUSE TestFlatten/does_not_implement_attr.Value_Target
=== RUN   TestFlatten/single_empty_string_Source_and_single_string_Target
=== PAUSE TestFlatten/single_empty_string_Source_and_single_string_Target
=== RUN   TestFlatten/single_string_Source_and_single_string_Target
=== PAUSE TestFlatten/single_string_Source_and_single_string_Target
=== CONT  TestFlattenFrameworkStringValueSet/zero_elements
=== RUN   TestFlatten/single_nil_*string_Source_and_single_string_Target
=== PAUSE TestFlatten/single_nil_*string_Source_and_single_string_Target
=== RUN   TestFlattenFrameworkStringValueMapLegacy/nil_map
=== RUN   TestFlatten/single_*string_Source_and_single_string_Target
=== PAUSE TestFlatten/single_*string_Source_and_single_string_Target
=== PAUSE TestFlattenFrameworkStringValueMapLegacy/nil_map
=== RUN   TestFlatten/single_string_Source_and_single_int64_Target
=== PAUSE TestFlatten/single_string_Source_and_single_int64_Target
=== CONT  TestFlattenFrameworkStringValueMapLegacy/zero_elements
=== RUN   TestFlatten/zero_value_primtive_types_Source_and_primtive_types_Target
=== PAUSE TestFlatten/zero_value_primtive_types_Source_and_primtive_types_Target
=== CONT  TestFlattenFrameworkStringValueMapLegacy/two_elements
=== RUN   TestFlatten/primtive_types_Source_and_primtive_types_Target
=== PAUSE TestFlatten/primtive_types_Source_and_primtive_types_Target
=== RUN   TestFlatten/zero_value_slice/map_of_primtive_types_Source_and_List/Set/Map_of_primtive_types_Target
=== PAUSE TestFlatten/zero_value_slice/map_of_primtive_types_Source_and_List/Set/Map_of_primtive_types_Target
=== RUN   TestFlattenFrameworkStringValueList/nil_array
=== RUN   TestFlatten/slice/map_of_primtive_types_Source_and_List/Set/Map_of_primtive_types_Target
=== CONT  TestFlattenFrameworkStringValueListLegacy/two_elements
=== PAUSE TestFlatten/slice/map_of_primtive_types_Source_and_List/Set/Map_of_primtive_types_Target
--- PASS: TestFlattenFrameworkStringValueSetLegacy (0.00s)
    --- PASS: TestFlattenFrameworkStringValueSetLegacy/two_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringValueSetLegacy/zero_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringValueSetLegacy/nil_array (0.00s)
=== CONT  TestFlattenFrameworkStringListLegacy/nil_array
=== CONT  TestFlattenFrameworkStringListLegacy/zero_elements
=== PAUSE TestFlattenFrameworkStringMap/zero_elements
=== RUN   TestFlattenFrameworkStringMap/nil_map
=== CONT  TestFlattenFrameworkStringValueMap/nil_map
=== PAUSE TestFlattenFrameworkStringMap/nil_map
=== CONT  TestFlattenFrameworkStringMap/two_elements
=== CONT  TestFlattenFrameworkStringMap/nil_map
=== CONT  TestFlattenFrameworkStringMap/zero_elements
=== CONT  TestFlattenFrameworkStringValueListLegacy/nil_array
=== CONT  TestFlattenFrameworkStringValueListLegacy/zero_elements
=== CONT  TestFlattenFrameworkStringValueMapLegacy/nil_map
=== PAUSE TestFlattenFrameworkStringValueList/nil_array
=== CONT  TestFlattenFrameworkStringValueList/two_elements
=== CONT  TestFlattenFrameworkStringValueList/zero_elements
=== CONT  TestFlattenFrameworkStringValueList/nil_array
--- PASS: TestFlattenFrameworkStringList (0.00s)
    --- PASS: TestFlattenFrameworkStringList/two_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringList/nil_array (0.00s)
    --- PASS: TestFlattenFrameworkStringList/zero_elements (0.00s)
=== RUN   TestFlatten/zero_value_slice/map_of_string_type_Source_and_List/Set/Map_of_string_types_Target
=== PAUSE TestFlatten/zero_value_slice/map_of_string_type_Source_and_List/Set/Map_of_string_types_Target
--- PASS: TestFlattenFrameworkStringValueSet (0.00s)
    --- PASS: TestFlattenFrameworkStringValueSet/two_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringValueSet/nil_array (0.00s)
    --- PASS: TestFlattenFrameworkStringValueSet/zero_elements (0.00s)
=== RUN   TestFlatten/slice/map_of_string_types_Source_and_List/Set/Map_of_string_types_Target
--- PASS: TestFlattenFrameworkStringListLegacy (0.00s)
    --- PASS: TestFlattenFrameworkStringListLegacy/two_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringListLegacy/nil_array (0.00s)
    --- PASS: TestFlattenFrameworkStringListLegacy/zero_elements (0.00s)
--- PASS: TestFlattenFrameworkStringValueMap (0.00s)
    --- PASS: TestFlattenFrameworkStringValueMap/zero_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringValueMap/two_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringValueMap/nil_map (0.00s)
=== PAUSE TestFlatten/slice/map_of_string_types_Source_and_List/Set/Map_of_string_types_Target
--- PASS: TestFlattenFrameworkStringMap (0.00s)
    --- PASS: TestFlattenFrameworkStringMap/two_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringMap/zero_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringMap/nil_map (0.00s)
=== RUN   TestFlatten/plural_ordinary_field_names
=== PAUSE TestFlatten/plural_ordinary_field_names
--- PASS: TestFlattenFrameworkStringValueListLegacy (0.00s)
    --- PASS: TestFlattenFrameworkStringValueListLegacy/two_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringValueListLegacy/nil_array (0.00s)
    --- PASS: TestFlattenFrameworkStringValueListLegacy/zero_elements (0.00s)
=== RUN   TestFlatten/plural_field_names
=== PAUSE TestFlatten/plural_field_names
--- PASS: TestFlattenFrameworkStringValueMapLegacy (0.00s)
    --- PASS: TestFlattenFrameworkStringValueMapLegacy/zero_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringValueMapLegacy/two_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringValueMapLegacy/nil_map (0.00s)
=== RUN   TestFlatten/strange_plurality
=== PAUSE TestFlatten/strange_plurality
--- PASS: TestFlattenFrameworkStringValueList (0.00s)
    --- PASS: TestFlattenFrameworkStringValueList/two_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringValueList/nil_array (0.00s)
    --- PASS: TestFlattenFrameworkStringValueList/zero_elements (0.00s)
=== RUN   TestFlatten/capitalization_field_names
=== PAUSE TestFlatten/capitalization_field_names
=== RUN   TestFlatten/resource_name_prefix
=== PAUSE TestFlatten/resource_name_prefix
=== RUN   TestFlatten/single_string_Source_and_single_ARN_Target
=== PAUSE TestFlatten/single_string_Source_and_single_ARN_Target
=== RUN   TestFlatten/single_*string_Source_and_single_ARN_Target
=== PAUSE TestFlatten/single_*string_Source_and_single_ARN_Target
=== RUN   TestFlatten/single_nil_*string_Source_and_single_ARN_Target
=== PAUSE TestFlatten/single_nil_*string_Source_and_single_ARN_Target
=== RUN   TestFlatten/timestamp_pointer
=== PAUSE TestFlatten/timestamp_pointer
=== RUN   TestFlatten/timestamp
=== PAUSE TestFlatten/timestamp
=== RUN   TestFlatten/timestamp_nil
=== PAUSE TestFlatten/timestamp_nil
=== RUN   TestFlatten/timestamp_empty
=== PAUSE TestFlatten/timestamp_empty
=== CONT  TestFlatten/nil_Source_and_Target
=== CONT  TestFlatten/slice/map_of_primtive_types_Source_and_List/Set/Map_of_primtive_types_Target
=== CONT  TestFlatten/zero_value_slice/map_of_primtive_types_Source_and_List/Set/Map_of_primtive_types_Target
=== CONT  TestFlatten/single_empty_string_Source_and_single_string_Target
=== CONT  TestFlatten/single_string_Source_and_single_ARN_Target
=== CONT  TestFlatten/empty_struct_Source_and_Target
=== CONT  TestFlatten/single_string_struct_pointer_Source_and_empty_Target
=== CONT  TestFlatten/empty_struct_pointer_Source_and_Target
=== CONT  TestFlatten/non-struct_Source
=== CONT  TestFlatten/resource_name_prefix
=== CONT  TestFlatten/single_nil_*string_Source_and_single_string_Target
=== CONT  TestFlatten/single_string_Source_and_single_string_Target
=== CONT  TestFlatten/non-pointer_Target
=== CONT  TestFlatten/timestamp
=== CONT  TestFlatten/non-struct_Target
=== CONT  TestFlatten/single_nil_*string_Source_and_single_ARN_Target
=== CONT  TestFlatten/strange_plurality
=== CONT  TestFlatten/single_*string_Source_and_single_string_Target
=== CONT  TestFlatten/timestamp_empty
=== CONT  TestFlatten/timestamp_nil
=== CONT  TestFlatten/plural_ordinary_field_names
=== CONT  TestFlatten/zero_value_primtive_types_Source_and_primtive_types_Target
=== CONT  TestFlatten/does_not_implement_attr.Value_Target
=== CONT  TestFlatten/single_string_Source_and_single_int64_Target
=== CONT  TestFlatten/primtive_types_Source_and_primtive_types_Target
=== RUN   TestFlattenGeneric/nil_*struct_Source_and_single_list_Target
=== CONT  TestFlatten/timestamp_pointer
=== PAUSE TestFlattenGeneric/nil_*struct_Source_and_single_list_Target
=== RUN   TestFlattenGeneric/*struct_Source_and_single_list_Target
=== PAUSE TestFlattenGeneric/*struct_Source_and_single_list_Target
=== CONT  TestFlatten/single_*string_Source_and_single_ARN_Target
=== CONT  TestFlatten/plural_field_names
=== CONT  TestFlatten/zero_value_slice/map_of_string_type_Source_and_List/Set/Map_of_string_types_Target
=== CONT  TestFlatten/slice/map_of_string_types_Source_and_List/Set/Map_of_string_types_Target
=== CONT  TestFlatten/capitalization_field_names
=== RUN   TestFlattenGeneric/*struct_Source_and_single_set_Target
=== PAUSE TestFlattenGeneric/*struct_Source_and_single_set_Target
=== RUN   TestFlattenGeneric/nil_[]struct_and_null_list_Target
=== PAUSE TestFlattenGeneric/nil_[]struct_and_null_list_Target
=== RUN   TestFlattenGeneric/nil_[]struct_and_null_set_Target
=== PAUSE TestFlattenGeneric/nil_[]struct_and_null_set_Target
=== RUN   TestFlattenGeneric/empty_[]struct_and_empty_list_Target
=== PAUSE TestFlattenGeneric/empty_[]struct_and_empty_list_Target
=== RUN   TestFlattenGeneric/empty_[]struct_and_empty_struct_Target
=== PAUSE TestFlattenGeneric/empty_[]struct_and_empty_struct_Target
=== RUN   TestFlattenGeneric/non-empty_[]struct_and_non-empty_list_Target
=== PAUSE TestFlattenGeneric/non-empty_[]struct_and_non-empty_list_Target
=== RUN   TestFlattenGeneric/non-empty_[]struct_and_non-empty_set_Target
=== PAUSE TestFlattenGeneric/non-empty_[]struct_and_non-empty_set_Target
=== RUN   TestFlattenGeneric/nil_[]*struct_and_null_list_Target
=== PAUSE TestFlattenGeneric/nil_[]*struct_and_null_list_Target
=== RUN   TestFlattenGeneric/nil_[]*struct_and_null_set_Target
=== PAUSE TestFlattenGeneric/nil_[]*struct_and_null_set_Target
=== RUN   TestFlattenGeneric/empty_[]*struct_and_empty_list_Target
=== PAUSE TestFlattenGeneric/empty_[]*struct_and_empty_list_Target
=== RUN   TestFlattenGeneric/empty_[]*struct_and_empty_set_Target
=== PAUSE TestFlattenGeneric/empty_[]*struct_and_empty_set_Target
=== RUN   TestFlattenGeneric/non-empty_[]*struct_and_non-empty_list_Target
=== PAUSE TestFlattenGeneric/non-empty_[]*struct_and_non-empty_list_Target
=== RUN   TestFlattenGeneric/non-empty_[]*struct_and_non-empty_set_Target
=== PAUSE TestFlattenGeneric/non-empty_[]*struct_and_non-empty_set_Target
=== RUN   TestFlattenGeneric/complex_Source_and_complex_Target
=== PAUSE TestFlattenGeneric/complex_Source_and_complex_Target
=== RUN   TestFlattenGeneric/map_string
=== PAUSE TestFlattenGeneric/map_string
=== RUN   TestFlattenGeneric/object_map
=== PAUSE TestFlattenGeneric/object_map
=== RUN   TestFlattenGeneric/object_map_ptr_source
=== PAUSE TestFlattenGeneric/object_map_ptr_source
=== RUN   TestFlattenGeneric/object_map_ptr_target
=== PAUSE TestFlattenGeneric/object_map_ptr_target
=== RUN   TestFlattenGeneric/object_map_ptr_source_and_target
=== PAUSE TestFlattenGeneric/object_map_ptr_source_and_target
=== RUN   TestFlattenGeneric/nested_string_map
=== PAUSE TestFlattenGeneric/nested_string_map
=== RUN   TestFlattenGeneric/nested_object_map
=== PAUSE TestFlattenGeneric/nested_object_map
=== RUN   TestFlattenGeneric/block_key_map
=== PAUSE TestFlattenGeneric/block_key_map
=== RUN   TestFlattenGeneric/block_key_map_ptr_source
=== PAUSE TestFlattenGeneric/block_key_map_ptr_source
=== RUN   TestFlattenGeneric/block_key_map_ptr_both
=== PAUSE TestFlattenGeneric/block_key_map_ptr_both
=== RUN   TestFlattenGeneric/complex_nesting
=== PAUSE TestFlattenGeneric/complex_nesting
=== CONT  TestFlattenGeneric/nil_*struct_Source_and_single_list_Target
=== CONT  TestFlattenGeneric/non-empty_[]*struct_and_non-empty_set_Target
=== CONT  TestFlattenGeneric/non-empty_[]struct_and_non-empty_list_Target
=== CONT  TestFlattenGeneric/empty_[]*struct_and_empty_list_Target
=== CONT  TestFlattenGeneric/nil_[]*struct_and_null_list_Target
=== CONT  TestFlattenGeneric/empty_[]struct_and_empty_struct_Target
=== CONT  TestFlattenGeneric/nil_[]*struct_and_null_set_Target
=== CONT  TestFlattenGeneric/non-empty_[]struct_and_non-empty_set_Target
=== CONT  TestFlattenGeneric/nil_[]struct_and_null_list_Target
=== CONT  TestFlattenGeneric/*struct_Source_and_single_set_Target
=== CONT  TestFlattenGeneric/non-empty_[]*struct_and_non-empty_list_Target
=== CONT  TestFlattenGeneric/empty_[]*struct_and_empty_set_Target
=== CONT  TestFlattenGeneric/*struct_Source_and_single_list_Target
=== CONT  TestFlattenGeneric/block_key_map_ptr_source
=== CONT  TestFlattenGeneric/empty_[]struct_and_empty_list_Target
=== CONT  TestFlattenGeneric/object_map_ptr_target
=== CONT  TestFlattenGeneric/block_key_map
=== CONT  TestFlattenGeneric/nested_object_map
=== CONT  TestFlattenGeneric/nil_[]struct_and_null_set_Target
=== CONT  TestFlattenGeneric/nested_string_map
=== CONT  TestFlattenGeneric/complex_nesting
=== CONT  TestFlattenGeneric/object_map_ptr_source
=== CONT  TestFlattenGeneric/block_key_map_ptr_both
=== CONT  TestFlattenGeneric/object_map_ptr_source_and_target
=== CONT  TestFlattenGeneric/complex_Source_and_complex_Target
=== CONT  TestFlattenGeneric/object_map
=== CONT  TestFlattenGeneric/map_string
--- PASS: TestFlatten (0.00s)
    --- PASS: TestFlatten/nil_Source_and_Target (0.00s)
    --- PASS: TestFlatten/slice/map_of_primtive_types_Source_and_List/Set/Map_of_primtive_types_Target (0.00s)
    --- PASS: TestFlatten/empty_struct_Source_and_Target (0.00s)
    --- PASS: TestFlatten/empty_struct_pointer_Source_and_Target (0.00s)
    --- PASS: TestFlatten/zero_value_slice/map_of_primtive_types_Source_and_List/Set/Map_of_primtive_types_Target (0.00s)
    --- PASS: TestFlatten/non-struct_Source (0.00s)
    --- PASS: TestFlatten/non-pointer_Target (0.00s)
    --- PASS: TestFlatten/non-struct_Target (0.00s)
    --- PASS: TestFlatten/single_string_Source_and_single_string_Target (0.00s)
    --- PASS: TestFlatten/single_nil_*string_Source_and_single_ARN_Target (0.00s)
    --- PASS: TestFlatten/single_empty_string_Source_and_single_string_Target (0.00s)
    --- PASS: TestFlatten/single_string_struct_pointer_Source_and_empty_Target (0.00s)
    --- PASS: TestFlatten/timestamp_empty (0.00s)
    --- PASS: TestFlatten/single_string_Source_and_single_ARN_Target (0.00s)
    --- PASS: TestFlatten/timestamp (0.00s)
    --- PASS: TestFlatten/single_nil_*string_Source_and_single_string_Target (0.00s)
    --- PASS: TestFlatten/single_*string_Source_and_single_string_Target (0.00s)
    --- PASS: TestFlatten/strange_plurality (0.00s)
    --- PASS: TestFlatten/timestamp_nil (0.00s)
    --- PASS: TestFlatten/resource_name_prefix (0.00s)
    --- PASS: TestFlatten/does_not_implement_attr.Value_Target (0.00s)
    --- PASS: TestFlatten/single_string_Source_and_single_int64_Target (0.00s)
    --- PASS: TestFlatten/zero_value_primtive_types_Source_and_primtive_types_Target (0.00s)
    --- PASS: TestFlatten/primtive_types_Source_and_primtive_types_Target (0.00s)
    --- PASS: TestFlatten/timestamp_pointer (0.00s)
    --- PASS: TestFlatten/single_*string_Source_and_single_ARN_Target (0.00s)
    --- PASS: TestFlatten/capitalization_field_names (0.00s)
    --- PASS: TestFlatten/zero_value_slice/map_of_string_type_Source_and_List/Set/Map_of_string_types_Target (0.00s)
    --- PASS: TestFlatten/plural_ordinary_field_names (0.00s)
    --- PASS: TestFlatten/slice/map_of_string_types_Source_and_List/Set/Map_of_string_types_Target (0.00s)
    --- PASS: TestFlatten/plural_field_names (0.00s)
--- PASS: TestFlattenGeneric (0.00s)
    --- PASS: TestFlattenGeneric/nil_*struct_Source_and_single_list_Target (0.00s)
    --- PASS: TestFlattenGeneric/nil_[]*struct_and_null_list_Target (0.00s)
    --- PASS: TestFlattenGeneric/empty_[]struct_and_empty_struct_Target (0.00s)
    --- PASS: TestFlattenGeneric/empty_[]*struct_and_empty_list_Target (0.00s)
    --- PASS: TestFlattenGeneric/nil_[]struct_and_null_list_Target (0.00s)
    --- PASS: TestFlattenGeneric/nil_[]*struct_and_null_set_Target (0.00s)
    --- PASS: TestFlattenGeneric/non-empty_[]struct_and_non-empty_list_Target (0.00s)
    --- PASS: TestFlattenGeneric/non-empty_[]*struct_and_non-empty_set_Target (0.00s)
    --- PASS: TestFlattenGeneric/empty_[]*struct_and_empty_set_Target (0.00s)
    --- PASS: TestFlattenGeneric/empty_[]struct_and_empty_list_Target (0.00s)
    --- PASS: TestFlattenGeneric/*struct_Source_and_single_set_Target (0.00s)
    --- PASS: TestFlattenGeneric/non-empty_[]struct_and_non-empty_set_Target (0.00s)
    --- PASS: TestFlattenGeneric/nil_[]struct_and_null_set_Target (0.00s)
    --- PASS: TestFlattenGeneric/non-empty_[]*struct_and_non-empty_list_Target (0.00s)
    --- PASS: TestFlattenGeneric/object_map_ptr_source (0.00s)
    --- PASS: TestFlattenGeneric/object_map (0.00s)
    --- PASS: TestFlattenGeneric/*struct_Source_and_single_list_Target (0.00s)
    --- PASS: TestFlattenGeneric/nested_object_map (0.00s)
    --- PASS: TestFlattenGeneric/nested_string_map (0.00s)
    --- PASS: TestFlattenGeneric/map_string (0.00s)
    --- PASS: TestFlattenGeneric/block_key_map_ptr_both (0.00s)
    --- PASS: TestFlattenGeneric/block_key_map (0.00s)
    --- PASS: TestFlattenGeneric/block_key_map_ptr_source (0.00s)
    --- PASS: TestFlattenGeneric/object_map_ptr_target (0.00s)
    --- PASS: TestFlattenGeneric/object_map_ptr_source_and_target (0.00s)
    --- PASS: TestFlattenGeneric/complex_Source_and_complex_Target (0.00s)
    --- PASS: TestFlattenGeneric/complex_nesting (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/framework/flex	0.087s
% go test ./internal/framework/flex/... -v -count 1 -parallel 20 -run='TestExpand'
=== RUN   TestExpand
=== PAUSE TestExpand
=== RUN   TestExpandGeneric
=== PAUSE TestExpandGeneric
=== RUN   TestExpandFrameworkStringList
=== PAUSE TestExpandFrameworkStringList
=== RUN   TestExpandFrameworkStringValueList
=== PAUSE TestExpandFrameworkStringValueList
=== RUN   TestExpandFrameworkStringMap
=== PAUSE TestExpandFrameworkStringMap
=== RUN   TestExpandFrameworkStringValueMap
=== PAUSE TestExpandFrameworkStringValueMap
=== RUN   TestExpandFrameworkStringSet
=== PAUSE TestExpandFrameworkStringSet
=== RUN   TestExpandFrameworkStringValueSet
=== PAUSE TestExpandFrameworkStringValueSet
=== CONT  TestExpand
=== CONT  TestExpandFrameworkStringMap
=== CONT  TestExpandFrameworkStringValueSet
=== RUN   TestExpandFrameworkStringValueSet/null
=== CONT  TestExpandFrameworkStringValueMap
=== PAUSE TestExpandFrameworkStringValueSet/null
=== CONT  TestExpandGeneric
=== RUN   TestExpandFrameworkStringValueMap/null
=== CONT  TestExpandFrameworkStringValueList
=== RUN   TestExpandFrameworkStringValueSet/unknown
=== PAUSE TestExpandFrameworkStringValueSet/unknown
=== CONT  TestExpandFrameworkStringSet
=== RUN   TestExpand/nil_Source_and_Target
=== RUN   TestExpandFrameworkStringMap/zero_elements
=== RUN   TestExpandFrameworkStringSet/unknown
=== PAUSE TestExpandFrameworkStringSet/unknown
=== CONT  TestExpandFrameworkStringList
=== PAUSE TestExpandFrameworkStringValueMap/null
=== RUN   TestExpandFrameworkStringValueList/two_elements
=== RUN   TestExpandFrameworkStringSet/two_elements
=== PAUSE TestExpand/nil_Source_and_Target
=== RUN   TestExpandFrameworkStringList/two_elements
=== PAUSE TestExpandFrameworkStringList/two_elements
=== RUN   TestExpandFrameworkStringValueSet/two_elements
=== PAUSE TestExpandFrameworkStringValueSet/two_elements
=== PAUSE TestExpandFrameworkStringValueList/two_elements
=== PAUSE TestExpandFrameworkStringSet/two_elements
=== PAUSE TestExpandFrameworkStringMap/zero_elements
=== RUN   TestExpand/non-pointer_Target
=== RUN   TestExpandFrameworkStringSet/zero_elements
=== PAUSE TestExpand/non-pointer_Target
=== RUN   TestExpandFrameworkStringList/zero_elements
=== PAUSE TestExpandFrameworkStringList/zero_elements
=== PAUSE TestExpandFrameworkStringSet/zero_elements
=== RUN   TestExpandFrameworkStringValueSet/zero_elements
=== RUN   TestExpandFrameworkStringValueMap/unknown
=== PAUSE TestExpandFrameworkStringValueSet/zero_elements
=== RUN   TestExpandFrameworkStringList/invalid_element_type
=== PAUSE TestExpandFrameworkStringList/invalid_element_type
=== RUN   TestExpandFrameworkStringSet/invalid_element_type
=== PAUSE TestExpandFrameworkStringSet/invalid_element_type
=== RUN   TestExpandFrameworkStringValueList/zero_elements
=== PAUSE TestExpandFrameworkStringValueList/zero_elements
=== RUN   TestExpandFrameworkStringSet/null
=== RUN   TestExpandFrameworkStringValueList/invalid_element_type
=== PAUSE TestExpandFrameworkStringSet/null
=== RUN   TestExpandFrameworkStringMap/invalid_element_type
=== CONT  TestExpandFrameworkStringSet/two_elements
=== PAUSE TestExpandFrameworkStringMap/invalid_element_type
=== RUN   TestExpandFrameworkStringList/null
=== PAUSE TestExpandFrameworkStringList/null
=== RUN   TestExpandFrameworkStringMap/null_element
=== RUN   TestExpand/non-struct_Source
=== RUN   TestExpandFrameworkStringList/unknown
=== PAUSE TestExpand/non-struct_Source
=== PAUSE TestExpandFrameworkStringList/unknown
=== RUN   TestExpand/non-struct_Target
=== CONT  TestExpandFrameworkStringList/two_elements
=== CONT  TestExpandFrameworkStringList/unknown
=== PAUSE TestExpand/non-struct_Target
=== PAUSE TestExpandFrameworkStringValueMap/unknown
=== RUN   TestExpand/types.String_to_string
=== RUN   TestExpandFrameworkStringValueMap/two_elements
=== PAUSE TestExpand/types.String_to_string
=== PAUSE TestExpandFrameworkStringValueMap/two_elements
=== CONT  TestExpandFrameworkStringList/null
=== RUN   TestExpand/empty_struct_Source_and_Target
=== RUN   TestExpandFrameworkStringValueMap/zero_elements
=== PAUSE TestExpand/empty_struct_Source_and_Target
=== PAUSE TestExpandFrameworkStringValueMap/zero_elements
=== PAUSE TestExpandFrameworkStringValueList/invalid_element_type
=== CONT  TestExpandFrameworkStringSet/unknown
=== CONT  TestExpandFrameworkStringSet/null
=== CONT  TestExpandFrameworkStringSet/invalid_element_type
=== RUN   TestExpandFrameworkStringValueList/null
=== CONT  TestExpandFrameworkStringSet/zero_elements
=== PAUSE TestExpandFrameworkStringValueList/null
=== RUN   TestExpandFrameworkStringValueList/unknown
--- PASS: TestExpandFrameworkStringSet (0.00s)
    --- PASS: TestExpandFrameworkStringSet/two_elements (0.00s)
    --- PASS: TestExpandFrameworkStringSet/unknown (0.00s)
    --- PASS: TestExpandFrameworkStringSet/null (0.00s)
    --- PASS: TestExpandFrameworkStringSet/invalid_element_type (0.00s)
    --- PASS: TestExpandFrameworkStringSet/zero_elements (0.00s)
=== PAUSE TestExpandFrameworkStringValueList/unknown
=== CONT  TestExpandFrameworkStringValueList/two_elements
=== CONT  TestExpandFrameworkStringValueList/null
=== CONT  TestExpandFrameworkStringValueList/invalid_element_type
=== CONT  TestExpandFrameworkStringValueList/unknown
=== CONT  TestExpandFrameworkStringValueList/zero_elements
=== RUN   TestExpandFrameworkStringValueSet/invalid_element_type
=== CONT  TestExpandFrameworkStringList/invalid_element_type
--- PASS: TestExpandFrameworkStringValueList (0.00s)
    --- PASS: TestExpandFrameworkStringValueList/null (0.00s)
    --- PASS: TestExpandFrameworkStringValueList/two_elements (0.00s)
    --- PASS: TestExpandFrameworkStringValueList/unknown (0.00s)
    --- PASS: TestExpandFrameworkStringValueList/invalid_element_type (0.00s)
    --- PASS: TestExpandFrameworkStringValueList/zero_elements (0.00s)
=== CONT  TestExpandFrameworkStringList/zero_elements
=== RUN   TestExpand/empty_struct_pointer_Source_and_Target
--- PASS: TestExpandFrameworkStringList (0.00s)
    --- PASS: TestExpandFrameworkStringList/unknown (0.00s)
    --- PASS: TestExpandFrameworkStringList/null (0.00s)
    --- PASS: TestExpandFrameworkStringList/two_elements (0.00s)
    --- PASS: TestExpandFrameworkStringList/invalid_element_type (0.00s)
    --- PASS: TestExpandFrameworkStringList/zero_elements (0.00s)
=== RUN   TestExpandFrameworkStringValueMap/invalid_element_type
=== PAUSE TestExpand/empty_struct_pointer_Source_and_Target
=== PAUSE TestExpandFrameworkStringValueMap/invalid_element_type
=== CONT  TestExpandFrameworkStringValueMap/null
=== PAUSE TestExpandFrameworkStringMap/null_element
=== CONT  TestExpandFrameworkStringValueMap/unknown
=== PAUSE TestExpandFrameworkStringValueSet/invalid_element_type
=== CONT  TestExpandFrameworkStringValueSet/null
=== CONT  TestExpandFrameworkStringValueSet/invalid_element_type
=== CONT  TestExpandFrameworkStringValueSet/zero_elements
=== CONT  TestExpandFrameworkStringValueMap/zero_elements
=== CONT  TestExpandFrameworkStringValueMap/two_elements
=== RUN   TestExpand/single_string_struct_pointer_Source_and_empty_Target
=== PAUSE TestExpand/single_string_struct_pointer_Source_and_empty_Target
=== CONT  TestExpandFrameworkStringValueMap/invalid_element_type
=== RUN   TestExpand/does_not_implement_attr.Value_Source
=== PAUSE TestExpand/does_not_implement_attr.Value_Source
--- PASS: TestExpandFrameworkStringValueMap (0.00s)
    --- PASS: TestExpandFrameworkStringValueMap/null (0.00s)
    --- PASS: TestExpandFrameworkStringValueMap/unknown (0.00s)
    --- PASS: TestExpandFrameworkStringValueMap/zero_elements (0.00s)
    --- PASS: TestExpandFrameworkStringValueMap/two_elements (0.00s)
    --- PASS: TestExpandFrameworkStringValueMap/invalid_element_type (0.00s)
=== RUN   TestExpand/single_string_Source_and_single_string_Target
=== PAUSE TestExpand/single_string_Source_and_single_string_Target
=== CONT  TestExpandFrameworkStringValueSet/two_elements
=== RUN   TestExpand/single_string_Source_and_single_*string_Target
=== PAUSE TestExpand/single_string_Source_and_single_*string_Target
=== RUN   TestExpand/single_string_Source_and_single_int64_Target
=== PAUSE TestExpand/single_string_Source_and_single_int64_Target
=== RUN   TestExpandFrameworkStringMap/null
=== RUN   TestExpand/primtive_types_Source_and_primtive_types_Target
=== PAUSE TestExpand/primtive_types_Source_and_primtive_types_Target
=== CONT  TestExpandFrameworkStringValueSet/unknown
=== PAUSE TestExpandFrameworkStringMap/null
=== RUN   TestExpand/List/Set/Map_of_primitive_types_Source_and_slice/map_of_primtive_types_Target
--- PASS: TestExpandFrameworkStringValueSet (0.00s)
    --- PASS: TestExpandFrameworkStringValueSet/null (0.00s)
    --- PASS: TestExpandFrameworkStringValueSet/invalid_element_type (0.00s)
    --- PASS: TestExpandFrameworkStringValueSet/zero_elements (0.00s)
    --- PASS: TestExpandFrameworkStringValueSet/two_elements (0.00s)
    --- PASS: TestExpandFrameworkStringValueSet/unknown (0.00s)
=== RUN   TestExpandFrameworkStringMap/unknown
=== PAUSE TestExpand/List/Set/Map_of_primitive_types_Source_and_slice/map_of_primtive_types_Target
=== RUN   TestExpand/plural_field_names
=== PAUSE TestExpandFrameworkStringMap/unknown
=== PAUSE TestExpand/plural_field_names
=== RUN   TestExpandFrameworkStringMap/two_elements
=== PAUSE TestExpandFrameworkStringMap/two_elements
=== RUN   TestExpand/capitalization_field_names
=== CONT  TestExpandFrameworkStringMap/zero_elements
=== PAUSE TestExpand/capitalization_field_names
=== CONT  TestExpandFrameworkStringMap/invalid_element_type
=== CONT  TestExpandFrameworkStringMap/null_element
=== RUN   TestExpand/resource_name_prefix
=== CONT  TestExpandFrameworkStringMap/null
=== PAUSE TestExpand/resource_name_prefix
=== CONT  TestExpandFrameworkStringMap/two_elements
=== RUN   TestExpand/single_ARN_Source_and_single_string_Target
=== PAUSE TestExpand/single_ARN_Source_and_single_string_Target
=== CONT  TestExpandFrameworkStringMap/unknown
=== RUN   TestExpand/single_ARN_Source_and_single_*string_Target
=== PAUSE TestExpand/single_ARN_Source_and_single_*string_Target
=== RUN   TestExpand/timestamp_pointer
=== PAUSE TestExpand/timestamp_pointer
--- PASS: TestExpandFrameworkStringMap (0.00s)
    --- PASS: TestExpandFrameworkStringMap/zero_elements (0.00s)
    --- PASS: TestExpandFrameworkStringMap/invalid_element_type (0.00s)
    --- PASS: TestExpandFrameworkStringMap/null (0.00s)
    --- PASS: TestExpandFrameworkStringMap/unknown (0.00s)
    --- PASS: TestExpandFrameworkStringMap/null_element (0.00s)
    --- PASS: TestExpandFrameworkStringMap/two_elements (0.00s)
=== RUN   TestExpand/timestamp
=== PAUSE TestExpand/timestamp
=== CONT  TestExpand/nil_Source_and_Target
=== CONT  TestExpand/single_string_Source_and_single_int64_Target
=== CONT  TestExpand/single_string_Source_and_single_*string_Target
=== CONT  TestExpand/resource_name_prefix
=== CONT  TestExpand/empty_struct_Source_and_Target
=== CONT  TestExpand/single_string_Source_and_single_string_Target
=== CONT  TestExpand/timestamp_pointer
=== CONT  TestExpand/non-pointer_Target
=== CONT  TestExpand/plural_field_names
=== CONT  TestExpand/types.String_to_string
=== CONT  TestExpand/List/Set/Map_of_primitive_types_Source_and_slice/map_of_primtive_types_Target
=== CONT  TestExpand/single_string_struct_pointer_Source_and_empty_Target
=== CONT  TestExpand/timestamp
=== CONT  TestExpand/empty_struct_pointer_Source_and_Target
=== CONT  TestExpand/single_ARN_Source_and_single_*string_Target
=== CONT  TestExpand/capitalization_field_names
=== CONT  TestExpand/non-struct_Source
=== CONT  TestExpand/single_ARN_Source_and_single_string_Target
=== CONT  TestExpand/primtive_types_Source_and_primtive_types_Target
=== CONT  TestExpand/non-struct_Target
=== CONT  TestExpand/does_not_implement_attr.Value_Source
=== RUN   TestExpandGeneric/single_list_Source_and_*struct_Target
=== PAUSE TestExpandGeneric/single_list_Source_and_*struct_Target
=== RUN   TestExpandGeneric/single_set_Source_and_*struct_Target
=== PAUSE TestExpandGeneric/single_set_Source_and_*struct_Target
=== RUN   TestExpandGeneric/empty_list_Source_and_empty_[]struct_Target
=== PAUSE TestExpandGeneric/empty_list_Source_and_empty_[]struct_Target
--- PASS: TestExpand (0.00s)
    --- PASS: TestExpand/nil_Source_and_Target (0.00s)
    --- PASS: TestExpand/empty_struct_Source_and_Target (0.00s)
    --- PASS: TestExpand/single_string_Source_and_single_string_Target (0.00s)
    --- PASS: TestExpand/single_string_Source_and_single_*string_Target (0.00s)
    --- PASS: TestExpand/non-pointer_Target (0.00s)
    --- PASS: TestExpand/single_string_Source_and_single_int64_Target (0.00s)
    --- PASS: TestExpand/types.String_to_string (0.00s)
    --- PASS: TestExpand/empty_struct_pointer_Source_and_Target (0.00s)
    --- PASS: TestExpand/non-struct_Source (0.00s)
    --- PASS: TestExpand/single_ARN_Source_and_single_*string_Target (0.00s)
    --- PASS: TestExpand/single_ARN_Source_and_single_string_Target (0.00s)
    --- PASS: TestExpand/non-struct_Target (0.00s)
    --- PASS: TestExpand/primtive_types_Source_and_primtive_types_Target (0.00s)
    --- PASS: TestExpand/resource_name_prefix (0.00s)
    --- PASS: TestExpand/capitalization_field_names (0.00s)
    --- PASS: TestExpand/timestamp_pointer (0.00s)
    --- PASS: TestExpand/does_not_implement_attr.Value_Source (0.00s)
    --- PASS: TestExpand/timestamp (0.00s)
    --- PASS: TestExpand/List/Set/Map_of_primitive_types_Source_and_slice/map_of_primtive_types_Target (0.00s)
    --- PASS: TestExpand/single_string_struct_pointer_Source_and_empty_Target (0.00s)
    --- PASS: TestExpand/plural_field_names (0.00s)
=== RUN   TestExpandGeneric/non-empty_list_Source_and_non-empty_[]struct_Target
=== PAUSE TestExpandGeneric/non-empty_list_Source_and_non-empty_[]struct_Target
=== RUN   TestExpandGeneric/empty_list_Source_and_empty_[]*struct_Target
=== PAUSE TestExpandGeneric/empty_list_Source_and_empty_[]*struct_Target
=== RUN   TestExpandGeneric/non-empty_list_Source_and_non-empty_[]*struct_Target
=== PAUSE TestExpandGeneric/non-empty_list_Source_and_non-empty_[]*struct_Target
=== RUN   TestExpandGeneric/empty_list_Source_and_empty_[]struct_Target#01
=== PAUSE TestExpandGeneric/empty_list_Source_and_empty_[]struct_Target#01
=== RUN   TestExpandGeneric/non-empty_list_Source_and_non-empty_[]struct_Target#01
=== PAUSE TestExpandGeneric/non-empty_list_Source_and_non-empty_[]struct_Target#01
=== RUN   TestExpandGeneric/empty_set_Source_and_empty_[]*struct_Target
=== PAUSE TestExpandGeneric/empty_set_Source_and_empty_[]*struct_Target
=== RUN   TestExpandGeneric/non-empty_set_Source_and_non-empty_[]*struct_Target
=== PAUSE TestExpandGeneric/non-empty_set_Source_and_non-empty_[]*struct_Target
=== RUN   TestExpandGeneric/non-empty_set_Source_and_non-empty_[]struct_Target
=== PAUSE TestExpandGeneric/non-empty_set_Source_and_non-empty_[]struct_Target
=== RUN   TestExpandGeneric/complex_Source_and_complex_Target
=== PAUSE TestExpandGeneric/complex_Source_and_complex_Target
=== RUN   TestExpandGeneric/map_string
=== PAUSE TestExpandGeneric/map_string
=== RUN   TestExpandGeneric/object_map
=== PAUSE TestExpandGeneric/object_map
=== RUN   TestExpandGeneric/object_map_ptr_target
=== PAUSE TestExpandGeneric/object_map_ptr_target
=== RUN   TestExpandGeneric/object_map_ptr_source_and_target
=== PAUSE TestExpandGeneric/object_map_ptr_source_and_target
=== RUN   TestExpandGeneric/nested_string_map
=== PAUSE TestExpandGeneric/nested_string_map
=== RUN   TestExpandGeneric/nested_object_map
=== PAUSE TestExpandGeneric/nested_object_map
=== RUN   TestExpandGeneric/block_key_map
=== PAUSE TestExpandGeneric/block_key_map
=== RUN   TestExpandGeneric/block_key_map_ptr_source
=== PAUSE TestExpandGeneric/block_key_map_ptr_source
=== RUN   TestExpandGeneric/block_key_map_ptr_both
=== PAUSE TestExpandGeneric/block_key_map_ptr_both
=== RUN   TestExpandGeneric/complex_nesting
=== PAUSE TestExpandGeneric/complex_nesting
=== CONT  TestExpandGeneric/single_list_Source_and_*struct_Target
=== CONT  TestExpandGeneric/complex_Source_and_complex_Target
=== CONT  TestExpandGeneric/nested_object_map
=== CONT  TestExpandGeneric/object_map_ptr_target
=== CONT  TestExpandGeneric/empty_list_Source_and_empty_[]struct_Target#01
=== CONT  TestExpandGeneric/non-empty_list_Source_and_non-empty_[]struct_Target
=== CONT  TestExpandGeneric/map_string
=== CONT  TestExpandGeneric/object_map_ptr_source_and_target
=== CONT  TestExpandGeneric/empty_list_Source_and_empty_[]*struct_Target
=== CONT  TestExpandGeneric/non-empty_list_Source_and_non-empty_[]struct_Target#01
=== CONT  TestExpandGeneric/empty_list_Source_and_empty_[]struct_Target
=== CONT  TestExpandGeneric/block_key_map_ptr_both
=== CONT  TestExpandGeneric/single_set_Source_and_*struct_Target
=== CONT  TestExpandGeneric/complex_nesting
=== CONT  TestExpandGeneric/nested_string_map
=== CONT  TestExpandGeneric/non-empty_list_Source_and_non-empty_[]*struct_Target
=== CONT  TestExpandGeneric/object_map
=== CONT  TestExpandGeneric/block_key_map_ptr_source
=== CONT  TestExpandGeneric/non-empty_set_Source_and_non-empty_[]*struct_Target
=== CONT  TestExpandGeneric/block_key_map
=== CONT  TestExpandGeneric/non-empty_set_Source_and_non-empty_[]struct_Target
=== CONT  TestExpandGeneric/empty_set_Source_and_empty_[]*struct_Target
--- PASS: TestExpandGeneric (0.01s)
    --- PASS: TestExpandGeneric/single_list_Source_and_*struct_Target (0.00s)
    --- PASS: TestExpandGeneric/empty_list_Source_and_empty_[]struct_Target#01 (0.00s)
    --- PASS: TestExpandGeneric/empty_list_Source_and_empty_[]*struct_Target (0.00s)
    --- PASS: TestExpandGeneric/map_string (0.00s)
    --- PASS: TestExpandGeneric/non-empty_list_Source_and_non-empty_[]struct_Target (0.00s)
    --- PASS: TestExpandGeneric/nested_object_map (0.00s)
    --- PASS: TestExpandGeneric/object_map_ptr_source_and_target (0.00s)
    --- PASS: TestExpandGeneric/object_map_ptr_target (0.00s)
    --- PASS: TestExpandGeneric/empty_list_Source_and_empty_[]struct_Target (0.00s)
    --- PASS: TestExpandGeneric/non-empty_list_Source_and_non-empty_[]struct_Target#01 (0.00s)
    --- PASS: TestExpandGeneric/complex_Source_and_complex_Target (0.00s)
    --- PASS: TestExpandGeneric/single_set_Source_and_*struct_Target (0.00s)
    --- PASS: TestExpandGeneric/block_key_map_ptr_both (0.00s)
    --- PASS: TestExpandGeneric/nested_string_map (0.00s)
    --- PASS: TestExpandGeneric/non-empty_list_Source_and_non-empty_[]*struct_Target (0.00s)
    --- PASS: TestExpandGeneric/object_map (0.00s)
    --- PASS: TestExpandGeneric/block_key_map_ptr_source (0.00s)
    --- PASS: TestExpandGeneric/non-empty_set_Source_and_non-empty_[]*struct_Target (0.00s)
    --- PASS: TestExpandGeneric/complex_nesting (0.00s)
    --- PASS: TestExpandGeneric/empty_set_Source_and_empty_[]*struct_Target (0.00s)
    --- PASS: TestExpandGeneric/non-empty_set_Source_and_non-empty_[]struct_Target (0.00s)
    --- PASS: TestExpandGeneric/block_key_map (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/framework/flex	0.362s
```
