### PR TITLE
r/aws_ssoadmin_application: send application_url only when set

### DIFF
--- a/.changelog/34967.txt
+++ b/.changelog/34967.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ssoadmin_application: Fix `portal_options.sign_in_options.application_url` triggering `ValidationError` when unset
+```

--- a/internal/service/ssoadmin/application.go
+++ b/internal/service/ssoadmin/application.go
@@ -500,8 +500,11 @@ func expandSignInOptions(tfList []signInOptionsData) *awstypes.SignInOptions {
 
 	tfObj := tfList[0]
 	apiObject := &awstypes.SignInOptions{
-		ApplicationUrl: aws.String(tfObj.ApplicationURL.ValueString()),
-		Origin:         awstypes.SignInOrigin(tfObj.Origin.ValueString()),
+		Origin: awstypes.SignInOrigin(tfObj.Origin.ValueString()),
+	}
+
+	if !tfObj.ApplicationURL.IsNull() {
+		apiObject.ApplicationUrl = aws.String(tfObj.ApplicationURL.ValueString())
 	}
 
 	return apiObject


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This fix prevents the portal_options.sign_in_options.application_url argument from being sent on all create and update requests. Now, a value will only be sent when set to a non-nil value.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #34836

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/singlesignon/latest/APIReference/API_SignInOptions.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=ssoadmin TESTS=TestAccSSOAdminApplication_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ssoadmin/... -v -count 1 -parallel 20 -run='TestAccSSOAdminApplication_'  -timeout 360m

--- PASS: TestAccSSOAdminApplication_disappears (11.18s)
--- PASS: TestAccSSOAdminApplication_basic (13.04s)
--- PASS: TestAccSSOAdminApplication_portalOptions (18.73s)
--- PASS: TestAccSSOAdminApplication_description (19.34s)
--- PASS: TestAccSSOAdminApplication_tags (25.20s)
--- PASS: TestAccSSOAdminApplication_status (25.20s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssoadmin   28.411s
```
