### PR TITLE
Correct `prefix_list_id` argument description in `aws_ec2_managed_prefix_list_entry`

### DIFF
--- a/website/docs/r/ec2_managed_prefix_list_entry.html.markdown
+++ b/website/docs/r/ec2_managed_prefix_list_entry.html.markdown
@@ -42,7 +42,7 @@ This resource supports the following arguments:
 
 * `cidr` - (Required) CIDR block of this entry.
 * `description` - (Optional) Description of this entry. Please note that due to API limitations, updating only the description of an entry will require recreating the entry.
-* `prefix_list_id` - (Required) CIDR block of this entry.
+* `prefix_list_id` - (Required) The ID of the prefix list.
 
 ## Attribute Reference
 


### PR DESCRIPTION
### Description

This PR corrects an incorrect copy/paste of the description of `aws_ec2_managed_prefix_list_entry.prefix_list_id`.

### Relations

Closes #34963

### Output from Acceptance Testing

N/a, docs
