### PR TITLE
r/aws_finspace_kx_dataview: properly set arn, enabling tagging

### DIFF
--- a/.changelog/34998.txt
+++ b/.changelog/34998.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_finspace_kx_dataview: Properly set `arn` attribute on read, resolving persistent differences when `tags` are configured
+```

--- a/internal/service/finspace/kx_dataview.go
+++ b/internal/service/finspace/kx_dataview.go
@@ -6,10 +6,12 @@ package finspace
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/finspace"
 	"github.com/aws/aws-sdk-go-v2/service/finspace/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -140,12 +142,15 @@ func resourceKxDataviewCreate(ctx context.Context, d *schema.ResourceData, meta 
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FinSpaceClient(ctx)
 
-	idParts := []string{
-		d.Get("environment_id").(string),
-		d.Get("database_name").(string),
-		d.Get("name").(string),
-	}
+	environmentID := d.Get("environment_id").(string)
+	databaseName := d.Get("database_name").(string)
+	name := d.Get("name").(string)
 
+	idParts := []string{
+		environmentID,
+		databaseName,
+		name,
+	}
 	rId, err := flex.FlattenResourceId(idParts, kxDataviewIdPartCount, false)
 	if err != nil {
 		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionFlatteningResourceId, ResNameKxDataview, d.Get("name").(string), err)
@@ -153,9 +158,9 @@ func resourceKxDataviewCreate(ctx context.Context, d *schema.ResourceData, meta 
 	d.SetId(rId)
 
 	in := &finspace.CreateKxDataviewInput{
-		DatabaseName:  aws.String(d.Get("database_name").(string)),
-		DataviewName:  aws.String(d.Get("name").(string)),
-		EnvironmentId: aws.String(d.Get("environment_id").(string)),
+		DatabaseName:  aws.String(databaseName),
+		DataviewName:  aws.String(name),
+		EnvironmentId: aws.String(environmentID),
 		AutoUpdate:    d.Get("auto_update").(bool),
 		AzMode:        types.KxAzMode(d.Get("az_mode").(string)),
 		ClientToken:   aws.String(id.UniqueId()),
@@ -190,17 +195,6 @@ func resourceKxDataviewCreate(ctx context.Context, d *schema.ResourceData, meta 
 		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionWaitingForCreation, ResNameKxDataview, d.Get("name").(string), err)
 	}
 
-	// The CreateKxDataview API currently fails to tag the Dataview when the
-	// Tags field is set. Until the API is fixed, tag after creation instead.
-	//
-	// TODO: the identifier passed to createTags here likely needs to be an ARN, but this attribute
-	// is not returned from the create or describe APIs. The ARN may need to be manually constructed
-	// in order for tag after create to function.
-	//
-	// if err := createTags(ctx, conn, aws.ToString(out.DataviewName), getTagsIn(ctx)); err != nil {
-	//     return create.AppendDiagError(diags, names.FinSpace, create.ErrActionCreating, ResNameKxDataview, d.Id(), err)
-	// }
-
 	return append(diags, resourceKxDataviewRead(ctx, d, meta)...)
 }
 
@@ -232,6 +226,19 @@ func resourceKxDataviewRead(ctx context.Context, d *schema.ResourceData, meta in
 	if err := d.Set("segment_configurations", flattenSegmentConfigurations(out.SegmentConfigurations)); err != nil {
 		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionReading, ResNameKxDataview, d.Id(), err)
 	}
+
+	// Manually construct the dataview ARN, which is not returned from the
+	// Create or Describe APIs.
+	//
+	// Ref: https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonfinspace.html#amazonfinspace-resources-for-iam-policies
+	dataviewARN := arn.ARN{
+		Partition: meta.(*conns.AWSClient).Partition,
+		Region:    meta.(*conns.AWSClient).Region,
+		Service:   names.FinSpace,
+		AccountID: meta.(*conns.AWSClient).AccountID,
+		Resource:  fmt.Sprintf("kxEnvironment/%s/kxDatabase/%s/kxDataview/%s", aws.ToString(out.EnvironmentId), aws.ToString(out.DatabaseName), aws.ToString(out.DataviewName)),
+	}.String()
+	d.Set("arn", dataviewARN)
 
 	return diags
 }

--- a/internal/service/finspace/kx_dataview.go
+++ b/internal/service/finspace/kx_dataview.go
@@ -185,9 +185,21 @@ func resourceKxDataviewCreate(ctx context.Context, d *schema.ResourceData, meta 
 	if out == nil || out.DataviewName == nil {
 		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionCreating, ResNameKxDataview, d.Get("name").(string), errors.New("empty output"))
 	}
+
 	if _, err := waitKxDataviewCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
 		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionWaitingForCreation, ResNameKxDataview, d.Get("name").(string), err)
 	}
+
+	// The CreateKxDataview API currently fails to tag the Dataview when the
+	// Tags field is set. Until the API is fixed, tag after creation instead.
+	//
+	// TODO: the identifier passed to createTags here likely needs to be an ARN, but this attribute
+	// is not returned from the create or describe APIs. The ARN may need to be manually constructed
+	// in order for tag after create to function.
+	//
+	// if err := createTags(ctx, conn, aws.ToString(out.DataviewName), getTagsIn(ctx)); err != nil {
+	//     return create.AppendDiagError(diags, names.FinSpace, create.ErrActionCreating, ResNameKxDataview, d.Id(), err)
+	// }
 
 	return append(diags, resourceKxDataviewRead(ctx, d, meta)...)
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -413,6 +413,7 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
     - [`aws_elasticache_cluster` resource](/docs/providers/aws/r/elasticache_cluster.html)
     - [`aws_elb` data source](/docs/providers/aws/d/elb.html)
     - [`aws_elb` resource](/docs/providers/aws/r/elb.html)
+    - [`aws_finspace_kx_dataview` resource](/docs/providers/aws/r/finspace_kx_dataview.html)
     - [`aws_flow_log` resource](/docs/providers/aws/r/flow_log.html)
     - [`aws_glue_catalog_database` resource](/docs/providers/aws/r/glue_catalog_database.html)
     - [`aws_glue_catalog_table` resource](/docs/providers/aws/r/glue_catalog_table.html)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Composes a synthetic `arn` attribute on read to allow transparent tagging to properly list tags for dataview resources. Previously, read always returned an empty map of tags causing a persistent diff when `tags` were set in configuration. If in the future `DataviewArn` is returned from the Describe API, the composed ARN value can be replaced with the value from the API response insead.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #34990
Relates #34828

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=finspace TESTS=TestAccFinSpaceKxDataview_ ACCTEST_PARALELLISM=1
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/finspace/... -v -count 1 -parallel 20 -run='TestAccFinSpaceKxDataview_'  -timeout 360m

--- PASS: TestAccFinSpaceKxDataview_disappears (996.11s)
--- PASS: TestAccFinSpaceKxDataview_basic (1184.87s)
--- PASS: TestAccFinSpaceKxDataview_tags (1185.46s)
--- PASS: TestAccFinSpaceKxDataview_withKxVolume (1848.14s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/finspace   1851.539s
```
