### PR TITLE
Update AMI filter example to use latest Ubuntu LTS

### DIFF
--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -20,7 +20,7 @@ data "aws_ami" "ubuntu" {
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
   }
 
   filter {


### PR DESCRIPTION
### Description
Updates the AMI filter in the aws_instance example code to use the latest available Ubuntu LTS release. This prevents people who are using this example from having to update the AMI filter to use the current LTS release.