### PR TITLE
autoflex: Add StringEnum capability for MapBlockKeys

### DIFF
--- a/internal/framework/flex/auto_expand_test.go
+++ b/internal/framework/flex/auto_expand_test.go
@@ -578,7 +578,7 @@ func TestExpandGeneric(t *testing.T) {
 		{
 			TestName: "map block key list",
 			Source: &TestFlexMapBlockKeyTF01{
-				BlockMap: fwtypes.NewListNestedObjectValueOfValueSlice[TestFlexMapBlockKeyTF02](ctx, []TestFlexMapBlockKeyTF02{
+				MapBlock: fwtypes.NewListNestedObjectValueOfValueSlice[TestFlexMapBlockKeyTF02](ctx, []TestFlexMapBlockKeyTF02{
 					{
 						MapBlockKey: types.StringValue("x"),
 						Attr1:       types.StringValue("a"),
@@ -593,7 +593,7 @@ func TestExpandGeneric(t *testing.T) {
 			},
 			Target: &TestFlexMapBlockKeyAWS01{},
 			WantTarget: &TestFlexMapBlockKeyAWS01{
-				BlockMap: map[string]TestFlexMapBlockKeyAWS02{
+				MapBlock: map[string]TestFlexMapBlockKeyAWS02{
 					"x": {
 						Attr1: "a",
 						Attr2: "b",
@@ -608,7 +608,7 @@ func TestExpandGeneric(t *testing.T) {
 		{
 			TestName: "map block key set",
 			Source: &TestFlexMapBlockKeyTF03{
-				BlockMap: fwtypes.NewSetNestedObjectValueOfValueSlice[TestFlexMapBlockKeyTF02](ctx, []TestFlexMapBlockKeyTF02{
+				MapBlock: fwtypes.NewSetNestedObjectValueOfValueSlice[TestFlexMapBlockKeyTF02](ctx, []TestFlexMapBlockKeyTF02{
 					{
 						MapBlockKey: types.StringValue("x"),
 						Attr1:       types.StringValue("a"),
@@ -623,7 +623,7 @@ func TestExpandGeneric(t *testing.T) {
 			},
 			Target: &TestFlexMapBlockKeyAWS01{},
 			WantTarget: &TestFlexMapBlockKeyAWS01{
-				BlockMap: map[string]TestFlexMapBlockKeyAWS02{
+				MapBlock: map[string]TestFlexMapBlockKeyAWS02{
 					"x": {
 						Attr1: "a",
 						Attr2: "b",
@@ -638,7 +638,7 @@ func TestExpandGeneric(t *testing.T) {
 		{
 			TestName: "map block key ptr source",
 			Source: &TestFlexMapBlockKeyTF01{
-				BlockMap: fwtypes.NewListNestedObjectValueOfSlice(ctx, []*TestFlexMapBlockKeyTF02{
+				MapBlock: fwtypes.NewListNestedObjectValueOfSlice(ctx, []*TestFlexMapBlockKeyTF02{
 					{
 						MapBlockKey: types.StringValue("x"),
 						Attr1:       types.StringValue("a"),
@@ -653,7 +653,7 @@ func TestExpandGeneric(t *testing.T) {
 			},
 			Target: &TestFlexMapBlockKeyAWS01{},
 			WantTarget: &TestFlexMapBlockKeyAWS01{
-				BlockMap: map[string]TestFlexMapBlockKeyAWS02{
+				MapBlock: map[string]TestFlexMapBlockKeyAWS02{
 					"x": {
 						Attr1: "a",
 						Attr2: "b",
@@ -668,7 +668,7 @@ func TestExpandGeneric(t *testing.T) {
 		{
 			TestName: "map block key ptr both",
 			Source: &TestFlexMapBlockKeyTF01{
-				BlockMap: fwtypes.NewListNestedObjectValueOfSlice(ctx, []*TestFlexMapBlockKeyTF02{
+				MapBlock: fwtypes.NewListNestedObjectValueOfSlice(ctx, []*TestFlexMapBlockKeyTF02{
 					{
 						MapBlockKey: types.StringValue("x"),
 						Attr1:       types.StringValue("a"),
@@ -683,12 +683,42 @@ func TestExpandGeneric(t *testing.T) {
 			},
 			Target: &TestFlexMapBlockKeyAWS03{},
 			WantTarget: &TestFlexMapBlockKeyAWS03{
-				BlockMap: map[string]*TestFlexMapBlockKeyAWS02{
+				MapBlock: map[string]*TestFlexMapBlockKeyAWS02{
 					"x": {
 						Attr1: "a",
 						Attr2: "b",
 					},
 					"y": {
+						Attr1: "c",
+						Attr2: "d",
+					},
+				},
+			},
+		},
+		{
+			TestName: "map block enum key",
+			Source: &TestFlexMapBlockKeyTF04{
+				MapBlock: fwtypes.NewListNestedObjectValueOfValueSlice[TestFlexMapBlockKeyTF05](ctx, []TestFlexMapBlockKeyTF05{
+					{
+						MapBlockKey: fwtypes.StringEnumValue(TestEnumList),
+						Attr1:       types.StringValue("a"),
+						Attr2:       types.StringValue("b"),
+					},
+					{
+						MapBlockKey: fwtypes.StringEnumValue(TestEnumScalar),
+						Attr1:       types.StringValue("c"),
+						Attr2:       types.StringValue("d"),
+					},
+				}),
+			},
+			Target: &TestFlexMapBlockKeyAWS01{},
+			WantTarget: &TestFlexMapBlockKeyAWS01{
+				MapBlock: map[string]TestFlexMapBlockKeyAWS02{
+					string(TestEnumList): {
+						Attr1: "a",
+						Attr2: "b",
+					},
+					string(TestEnumScalar): {
 						Attr1: "c",
 						Attr2: "d",
 					},

--- a/internal/framework/flex/auto_flatten.go
+++ b/internal/framework/flex/auto_flatten.go
@@ -893,15 +893,3 @@ func blockKeyMapSet(to any, key reflect.Value) diag.Diagnostics {
 
 	return diags
 }
-
-func attemptMapBlockKeySet(value reflect.Value, newValue interface{}) (err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			err = fmt.Errorf("panic: %v", r)
-		}
-	}()
-
-	// Attempt to set the value
-	value.Set(reflect.ValueOf(newValue))
-	return nil
-}

--- a/internal/framework/flex/auto_flatten.go
+++ b/internal/framework/flex/auto_flatten.go
@@ -741,7 +741,7 @@ func (flattener autoFlattener) structMapToObjectList(ctx context.Context, vFrom 
 			return diags
 		}
 
-		d = blockKeyMapSet(target, key.String())
+		d = blockKeyMapSet(target, key)
 		diags.Append(d...)
 
 		t.Index(i).Set(reflect.ValueOf(target))
@@ -758,67 +758,6 @@ func (flattener autoFlattener) structMapToObjectList(ctx context.Context, vFrom 
 
 	return diags
 }
-
-/*
-func (flattener autoFlattener) structMapToObjectSet(ctx context.Context, vFrom reflect.Value, tTo fwtypes.NestedObjectType, vTo reflect.Value) diag.Diagnostics {
-	var diags diag.Diagnostics
-
-	if vFrom.IsNil() {
-		val, d := tTo.NullValue(ctx)
-		diags.Append(d...)
-		if diags.HasError() {
-			return diags
-		}
-
-		vTo.Set(reflect.ValueOf(val))
-		return diags
-	}
-
-	n := vFrom.Len()
-	to, d := tTo.NewObjectSlice(ctx, n, n)
-	diags.Append(d...)
-	if diags.HasError() {
-		return diags
-	}
-
-	t := reflect.ValueOf(to)
-
-	i := 0
-	for _, key := range vFrom.MapKeys() {
-		target, d := tTo.NewObjectPtr(ctx)
-		diags.Append(d...)
-		if diags.HasError() {
-			return diags
-		}
-
-		fromInterface := vFrom.MapIndex(key).Interface()
-		if vFrom.MapIndex(key).Kind() == reflect.Ptr {
-			fromInterface = vFrom.MapIndex(key).Elem().Interface()
-		}
-
-		diags.Append(autoFlexConvertStruct(ctx, fromInterface, target, flattener)...)
-		if diags.HasError() {
-			return diags
-		}
-
-		d = blockKeyMapSet(target, key.String())
-		diags.Append(d...)
-
-		t.Index(i).Set(reflect.ValueOf(target))
-		i++
-	}
-
-	val, d := tTo.ValueFromObjectSlice(ctx, to)
-	diags.Append(d...)
-	if diags.HasError() {
-		return diags
-	}
-
-	vTo.Set(reflect.ValueOf(val))
-
-	return diags
-}
-*/
 
 // structToNestedObject copies an AWS API struct value to a compatible Plugin Framework NestedObjectValue value.
 func (flattener autoFlattener) structToNestedObject(ctx context.Context, vFrom reflect.Value, isNullFrom bool, tTo fwtypes.NestedObjectType, vTo reflect.Value) diag.Diagnostics {
@@ -909,7 +848,7 @@ func (flattener autoFlattener) sliceOfStructNestedObject(ctx context.Context, vF
 }
 
 // blockKeyMapSet takes a struct and assigns the value of the `key`
-func blockKeyMapSet(to any, key string) diag.Diagnostics {
+func blockKeyMapSet(to any, key reflect.Value) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	valTo := reflect.ValueOf(to)
@@ -933,8 +872,18 @@ func blockKeyMapSet(to any, key string) diag.Diagnostics {
 		}
 
 		if _, ok := valTo.Field(i).Interface().(basetypes.StringValue); ok {
-			valTo.Field(i).Set(reflect.ValueOf(basetypes.NewStringValue(key)))
+			valTo.Field(i).Set(reflect.ValueOf(basetypes.NewStringValue(key.String())))
 			return diags
+		}
+
+		fieldType := valTo.Field(i).Type()
+
+		method, found := fieldType.MethodByName("StringEnumValue")
+		if found {
+			result := fieldType.Method(method.Index).Func.Call([]reflect.Value{valTo.Field(i), key})
+			if len(result) > 0 {
+				valTo.Field(i).Set(result[0])
+			}
 		}
 
 		return diags
@@ -943,4 +892,16 @@ func blockKeyMapSet(to any, key string) diag.Diagnostics {
 	diags.AddError("AutoFlEx", fmt.Sprintf("unable to find map block key (%s)", MapBlockKey))
 
 	return diags
+}
+
+func attemptMapBlockKeySet(value reflect.Value, newValue interface{}) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic: %v", r)
+		}
+	}()
+
+	// Attempt to set the value
+	value.Set(reflect.ValueOf(newValue))
+	return nil
 }

--- a/internal/framework/flex/auto_flatten_test.go
+++ b/internal/framework/flex/auto_flatten_test.go
@@ -752,7 +752,7 @@ func TestFlattenGeneric(t *testing.T) {
 		{
 			TestName: "map block key list",
 			Source: &TestFlexMapBlockKeyAWS01{
-				BlockMap: map[string]TestFlexMapBlockKeyAWS02{
+				MapBlock: map[string]TestFlexMapBlockKeyAWS02{
 					"x": {
 						Attr1: "a",
 						Attr2: "b",
@@ -761,7 +761,7 @@ func TestFlattenGeneric(t *testing.T) {
 			},
 			Target: &TestFlexMapBlockKeyTF01{},
 			WantTarget: &TestFlexMapBlockKeyTF01{
-				BlockMap: fwtypes.NewListNestedObjectValueOfValueSlice[TestFlexMapBlockKeyTF02](ctx, []TestFlexMapBlockKeyTF02{
+				MapBlock: fwtypes.NewListNestedObjectValueOfValueSlice[TestFlexMapBlockKeyTF02](ctx, []TestFlexMapBlockKeyTF02{
 					{
 						MapBlockKey: types.StringValue("x"),
 						Attr1:       types.StringValue("a"),
@@ -773,7 +773,7 @@ func TestFlattenGeneric(t *testing.T) {
 		{
 			TestName: "map block key set",
 			Source: &TestFlexMapBlockKeyAWS01{
-				BlockMap: map[string]TestFlexMapBlockKeyAWS02{
+				MapBlock: map[string]TestFlexMapBlockKeyAWS02{
 					"x": {
 						Attr1: "a",
 						Attr2: "b",
@@ -782,7 +782,7 @@ func TestFlattenGeneric(t *testing.T) {
 			},
 			Target: &TestFlexMapBlockKeyTF03{},
 			WantTarget: &TestFlexMapBlockKeyTF03{
-				BlockMap: fwtypes.NewSetNestedObjectValueOfValueSlice[TestFlexMapBlockKeyTF02](ctx, []TestFlexMapBlockKeyTF02{
+				MapBlock: fwtypes.NewSetNestedObjectValueOfValueSlice[TestFlexMapBlockKeyTF02](ctx, []TestFlexMapBlockKeyTF02{
 					{
 						MapBlockKey: types.StringValue("x"),
 						Attr1:       types.StringValue("a"),
@@ -794,7 +794,7 @@ func TestFlattenGeneric(t *testing.T) {
 		{
 			TestName: "map block key ptr source",
 			Source: &TestFlexMapBlockKeyAWS03{
-				BlockMap: map[string]*TestFlexMapBlockKeyAWS02{
+				MapBlock: map[string]*TestFlexMapBlockKeyAWS02{
 					"x": {
 						Attr1: "a",
 						Attr2: "b",
@@ -803,7 +803,7 @@ func TestFlattenGeneric(t *testing.T) {
 			},
 			Target: &TestFlexMapBlockKeyTF01{},
 			WantTarget: &TestFlexMapBlockKeyTF01{
-				BlockMap: fwtypes.NewListNestedObjectValueOfValueSlice[TestFlexMapBlockKeyTF02](ctx, []TestFlexMapBlockKeyTF02{
+				MapBlock: fwtypes.NewListNestedObjectValueOfValueSlice[TestFlexMapBlockKeyTF02](ctx, []TestFlexMapBlockKeyTF02{
 					{
 						MapBlockKey: types.StringValue("x"),
 						Attr1:       types.StringValue("a"),
@@ -815,7 +815,7 @@ func TestFlattenGeneric(t *testing.T) {
 		{
 			TestName: "map block key ptr both",
 			Source: &TestFlexMapBlockKeyAWS03{
-				BlockMap: map[string]*TestFlexMapBlockKeyAWS02{
+				MapBlock: map[string]*TestFlexMapBlockKeyAWS02{
 					"x": {
 						Attr1: "a",
 						Attr2: "b",
@@ -824,11 +824,41 @@ func TestFlattenGeneric(t *testing.T) {
 			},
 			Target: &TestFlexMapBlockKeyTF01{},
 			WantTarget: &TestFlexMapBlockKeyTF01{
-				BlockMap: fwtypes.NewListNestedObjectValueOfSlice(ctx, []*TestFlexMapBlockKeyTF02{
+				MapBlock: fwtypes.NewListNestedObjectValueOfSlice(ctx, []*TestFlexMapBlockKeyTF02{
 					{
 						MapBlockKey: types.StringValue("x"),
 						Attr1:       types.StringValue("a"),
 						Attr2:       types.StringValue("b"),
+					},
+				}),
+			},
+		},
+		{
+			TestName: "map block enum key",
+			Source: &TestFlexMapBlockKeyAWS01{
+				MapBlock: map[string]TestFlexMapBlockKeyAWS02{
+					string(TestEnumList): {
+						Attr1: "a",
+						Attr2: "b",
+					},
+					string(TestEnumScalar): {
+						Attr1: "c",
+						Attr2: "d",
+					},
+				},
+			},
+			Target: &TestFlexMapBlockKeyTF04{},
+			WantTarget: &TestFlexMapBlockKeyTF04{
+				MapBlock: fwtypes.NewListNestedObjectValueOfValueSlice[TestFlexMapBlockKeyTF05](ctx, []TestFlexMapBlockKeyTF05{
+					{
+						MapBlockKey: fwtypes.StringEnumValue(TestEnumList),
+						Attr1:       types.StringValue("a"),
+						Attr2:       types.StringValue("b"),
+					},
+					{
+						MapBlockKey: fwtypes.StringEnumValue(TestEnumScalar),
+						Attr1:       types.StringValue("c"),
+						Attr2:       types.StringValue("d"),
 					},
 				}),
 			},

--- a/internal/framework/flex/auto_flatten_test.go
+++ b/internal/framework/flex/auto_flatten_test.go
@@ -841,10 +841,6 @@ func TestFlattenGeneric(t *testing.T) {
 						Attr1: "a",
 						Attr2: "b",
 					},
-					string(TestEnumScalar): {
-						Attr1: "c",
-						Attr2: "d",
-					},
 				},
 			},
 			Target: &TestFlexMapBlockKeyTF04{},
@@ -854,11 +850,6 @@ func TestFlattenGeneric(t *testing.T) {
 						MapBlockKey: fwtypes.StringEnumValue(TestEnumList),
 						Attr1:       types.StringValue("a"),
 						Attr2:       types.StringValue("b"),
-					},
-					{
-						MapBlockKey: fwtypes.StringEnumValue(TestEnumScalar),
-						Attr1:       types.StringValue("c"),
-						Attr2:       types.StringValue("d"),
 					},
 				}),
 			},

--- a/internal/framework/flex/autoflex_test.go
+++ b/internal/framework/flex/autoflex_test.go
@@ -299,7 +299,10 @@ type TestFlexTF18 struct {
 }
 
 type TestFlexMapBlockKeyTF01 struct {
-	BlockMap fwtypes.ListNestedObjectValueOf[TestFlexMapBlockKeyTF02] `tfsdk:"block_map"`
+	MapBlock fwtypes.ListNestedObjectValueOf[TestFlexMapBlockKeyTF02] `tfsdk:"map_block"`
+}
+type TestFlexMapBlockKeyAWS01 struct {
+	MapBlock map[string]TestFlexMapBlockKeyAWS02
 }
 
 type TestFlexMapBlockKeyTF02 struct {
@@ -307,20 +310,24 @@ type TestFlexMapBlockKeyTF02 struct {
 	Attr1       types.String `tfsdk:"attr1"`
 	Attr2       types.String `tfsdk:"attr2"`
 }
-
-type TestFlexMapBlockKeyTF03 struct {
-	BlockMap fwtypes.SetNestedObjectValueOf[TestFlexMapBlockKeyTF02] `tfsdk:"block_map"`
-}
-
-type TestFlexMapBlockKeyAWS01 struct {
-	BlockMap map[string]TestFlexMapBlockKeyAWS02
-}
-
 type TestFlexMapBlockKeyAWS02 struct {
 	Attr1 string
 	Attr2 string
 }
 
+type TestFlexMapBlockKeyTF03 struct {
+	MapBlock fwtypes.SetNestedObjectValueOf[TestFlexMapBlockKeyTF02] `tfsdk:"map_block"`
+}
+
 type TestFlexMapBlockKeyAWS03 struct {
-	BlockMap map[string]*TestFlexMapBlockKeyAWS02
+	MapBlock map[string]*TestFlexMapBlockKeyAWS02
+}
+
+type TestFlexMapBlockKeyTF04 struct {
+	MapBlock fwtypes.ListNestedObjectValueOf[TestFlexMapBlockKeyTF05] `tfsdk:"map_block"`
+}
+type TestFlexMapBlockKeyTF05 struct {
+	MapBlockKey fwtypes.StringEnum[TestEnum] `tfsdk:"map_block_key"`
+	Attr1       types.String                 `tfsdk:"attr1"`
+	Attr2       types.String                 `tfsdk:"attr2"`
 }

--- a/internal/framework/types/string_enum.go
+++ b/internal/framework/types/string_enum.go
@@ -174,3 +174,9 @@ func (v StringEnum[T]) Type(context.Context) attr.Type {
 func (v StringEnum[T]) ValueEnum() T {
 	return T(v.ValueString())
 }
+
+// StringEnumValue is useful if you have a zero value StringEnum but need a
+// way to get a non-zero value such as when flattening.
+func (v StringEnum[T]) StringEnumValue(value string) StringEnum[T] {
+	return StringEnum[T]{StringValue: basetypes.NewStringValue(value)}
+}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% go test ./internal/framework/flex/... -v -count 1 -parallel 2 -run="Test"
=== RUN   TestExpand
=== PAUSE TestExpand
=== RUN   TestExpandGeneric
=== PAUSE TestExpandGeneric
=== RUN   TestFlatten
=== PAUSE TestFlatten
=== RUN   TestFlattenGeneric
=== PAUSE TestFlattenGeneric
=== RUN   TestSet_Difference_strings
=== PAUSE TestSet_Difference_strings
=== RUN   TestBoolFromFramework
=== PAUSE TestBoolFromFramework
=== RUN   TestBoolToFramework
=== PAUSE TestBoolToFramework
=== RUN   TestBoolToFrameworkLegacy
=== PAUSE TestBoolToFrameworkLegacy
=== RUN   TestFloat64ToFramework
=== PAUSE TestFloat64ToFramework
=== RUN   TestFloat64ToFrameworkLegacy
=== PAUSE TestFloat64ToFrameworkLegacy
=== RUN   TestFloat32ToFramework
=== PAUSE TestFloat32ToFramework
=== RUN   TestFloat32ToFrameworkLegacy
=== PAUSE TestFloat32ToFrameworkLegacy
=== RUN   TestInt64FromFramework
=== PAUSE TestInt64FromFramework
=== RUN   TestInt64ToFramework
=== PAUSE TestInt64ToFramework
=== RUN   TestInt64ToFrameworkLegacy
=== PAUSE TestInt64ToFrameworkLegacy
=== RUN   TestInt32ToFramework
=== PAUSE TestInt32ToFramework
=== RUN   TestInt32FromFramework
=== PAUSE TestInt32FromFramework
=== RUN   TestExpandFrameworkStringList
=== PAUSE TestExpandFrameworkStringList
=== RUN   TestExpandFrameworkStringValueList
=== PAUSE TestExpandFrameworkStringValueList
=== RUN   TestFlattenFrameworkStringList
=== PAUSE TestFlattenFrameworkStringList
=== RUN   TestFlattenFrameworkStringListLegacy
=== PAUSE TestFlattenFrameworkStringListLegacy
=== RUN   TestFlattenFrameworkStringValueList
=== PAUSE TestFlattenFrameworkStringValueList
=== RUN   TestFlattenFrameworkStringValueListLegacy
=== PAUSE TestFlattenFrameworkStringValueListLegacy
=== RUN   TestExpandFrameworkStringMap
=== PAUSE TestExpandFrameworkStringMap
=== RUN   TestExpandFrameworkStringValueMap
=== PAUSE TestExpandFrameworkStringValueMap
=== RUN   TestFlattenFrameworkStringMap
=== PAUSE TestFlattenFrameworkStringMap
=== RUN   TestFlattenFrameworkStringValueMap
=== PAUSE TestFlattenFrameworkStringValueMap
=== RUN   TestFlattenFrameworkStringValueMapLegacy
=== PAUSE TestFlattenFrameworkStringValueMapLegacy
=== RUN   TestExpandFrameworkStringSet
=== PAUSE TestExpandFrameworkStringSet
=== RUN   TestExpandFrameworkStringValueSet
=== PAUSE TestExpandFrameworkStringValueSet
=== RUN   TestFlattenFrameworkStringValueSet
=== PAUSE TestFlattenFrameworkStringValueSet
=== RUN   TestFlattenFrameworkStringValueSetLegacy
=== PAUSE TestFlattenFrameworkStringValueSetLegacy
=== RUN   TestStringFromFramework
=== PAUSE TestStringFromFramework
=== RUN   TestStringToFramework
=== PAUSE TestStringToFramework
=== RUN   TestStringToFrameworkLegacy
=== PAUSE TestStringToFrameworkLegacy
=== RUN   TestStringValueToFramework
=== PAUSE TestStringValueToFramework
=== RUN   TestStringValueToFrameworkLegacy
=== PAUSE TestStringValueToFrameworkLegacy
=== RUN   TestARNStringFromFramework
=== PAUSE TestARNStringFromFramework
=== RUN   TestStringToFrameworkARN
=== PAUSE TestStringToFrameworkARN
=== CONT  TestExpand
=== CONT  TestFlattenFrameworkStringListLegacy
=== RUN   TestFlattenFrameworkStringListLegacy/two_elements
=== RUN   TestExpand/nil_Source_and_Target
=== PAUSE TestFlattenFrameworkStringListLegacy/two_elements
=== RUN   TestFlattenFrameworkStringListLegacy/zero_elements
=== PAUSE TestExpand/nil_Source_and_Target
=== PAUSE TestFlattenFrameworkStringListLegacy/zero_elements
=== RUN   TestFlattenFrameworkStringListLegacy/nil_array
=== PAUSE TestFlattenFrameworkStringListLegacy/nil_array
=== RUN   TestExpand/non-pointer_Target
=== CONT  TestFloat32ToFramework
=== PAUSE TestExpand/non-pointer_Target
=== RUN   TestFloat32ToFramework/valid_float32
=== PAUSE TestFloat32ToFramework/valid_float32
=== RUN   TestExpand/non-struct_Source
=== RUN   TestFloat32ToFramework/zero_float32
=== PAUSE TestExpand/non-struct_Source
=== PAUSE TestFloat32ToFramework/zero_float32
=== RUN   TestExpand/non-struct_Target
=== PAUSE TestExpand/non-struct_Target
=== RUN   TestExpand/types.String_to_string
=== RUN   TestFloat32ToFramework/nil_float32
=== PAUSE TestFloat32ToFramework/nil_float32
=== CONT  TestFlattenFrameworkStringList
=== PAUSE TestExpand/types.String_to_string
=== RUN   TestFlattenFrameworkStringList/zero_elements
=== PAUSE TestFlattenFrameworkStringList/zero_elements
=== RUN   TestExpand/empty_struct_Source_and_Target
=== PAUSE TestExpand/empty_struct_Source_and_Target
=== RUN   TestFlattenFrameworkStringList/nil_array
=== PAUSE TestFlattenFrameworkStringList/nil_array
=== RUN   TestExpand/empty_struct_pointer_Source_and_Target
=== RUN   TestFlattenFrameworkStringList/two_elements
=== PAUSE TestFlattenFrameworkStringList/two_elements
=== PAUSE TestExpand/empty_struct_pointer_Source_and_Target
=== RUN   TestExpand/single_string_struct_pointer_Source_and_empty_Target
=== CONT  TestExpandFrameworkStringValueList
=== PAUSE TestExpand/single_string_struct_pointer_Source_and_empty_Target
=== RUN   TestExpandFrameworkStringValueList/two_elements
=== RUN   TestExpand/does_not_implement_attr.Value_Source
=== PAUSE TestExpand/does_not_implement_attr.Value_Source
=== PAUSE TestExpandFrameworkStringValueList/two_elements
=== RUN   TestExpand/single_string_Source_and_single_string_Target
=== RUN   TestExpandFrameworkStringValueList/zero_elements
=== PAUSE TestExpand/single_string_Source_and_single_string_Target
=== PAUSE TestExpandFrameworkStringValueList/zero_elements
=== RUN   TestExpand/single_string_Source_and_single_*string_Target
=== PAUSE TestExpand/single_string_Source_and_single_*string_Target
=== RUN   TestExpandFrameworkStringValueList/invalid_element_type
=== PAUSE TestExpandFrameworkStringValueList/invalid_element_type
=== RUN   TestExpand/single_string_Source_and_single_int64_Target
=== PAUSE TestExpand/single_string_Source_and_single_int64_Target
=== RUN   TestExpandFrameworkStringValueList/null
=== RUN   TestExpand/primtive_types_Source_and_primtive_types_Target
=== PAUSE TestExpandFrameworkStringValueList/null
=== PAUSE TestExpand/primtive_types_Source_and_primtive_types_Target
=== RUN   TestExpandFrameworkStringValueList/unknown
=== RUN   TestExpand/List/Set/Map_of_primitive_types_Source_and_slice/map_of_primtive_types_Target
=== PAUSE TestExpandFrameworkStringValueList/unknown
=== PAUSE TestExpand/List/Set/Map_of_primitive_types_Source_and_slice/map_of_primtive_types_Target
=== CONT  TestExpandFrameworkStringList
=== RUN   TestExpand/plural_field_names
=== PAUSE TestExpand/plural_field_names
=== RUN   TestExpandFrameworkStringList/invalid_element_type
=== RUN   TestExpand/capitalization_field_names
=== PAUSE TestExpand/capitalization_field_names
=== PAUSE TestExpandFrameworkStringList/invalid_element_type
=== RUN   TestExpand/resource_name_prefix
=== RUN   TestExpandFrameworkStringList/null
=== PAUSE TestExpand/resource_name_prefix
=== PAUSE TestExpandFrameworkStringList/null
=== RUN   TestExpand/single_ARN_Source_and_single_string_Target
=== PAUSE TestExpand/single_ARN_Source_and_single_string_Target
=== RUN   TestExpandFrameworkStringList/unknown
=== RUN   TestExpand/single_ARN_Source_and_single_*string_Target
=== PAUSE TestExpand/single_ARN_Source_and_single_*string_Target
=== PAUSE TestExpandFrameworkStringList/unknown
=== RUN   TestExpand/timestamp_pointer
=== RUN   TestExpandFrameworkStringList/two_elements
=== PAUSE TestExpand/timestamp_pointer
=== PAUSE TestExpandFrameworkStringList/two_elements
=== RUN   TestExpandFrameworkStringList/zero_elements
=== RUN   TestExpand/timestamp
=== PAUSE TestExpandFrameworkStringList/zero_elements
=== PAUSE TestExpand/timestamp
=== CONT  TestInt32FromFramework
=== CONT  TestInt32ToFramework
=== RUN   TestInt32FromFramework/valid_int64
=== RUN   TestInt32ToFramework/zero_int64
=== PAUSE TestInt32FromFramework/valid_int64
=== PAUSE TestInt32ToFramework/zero_int64
=== RUN   TestInt32FromFramework/zero_int64
=== RUN   TestInt32ToFramework/nil_int64
=== PAUSE TestInt32FromFramework/zero_int64
=== PAUSE TestInt32ToFramework/nil_int64
=== RUN   TestInt32FromFramework/null_int64
=== RUN   TestInt32ToFramework/valid_int64
=== PAUSE TestInt32ToFramework/valid_int64
=== PAUSE TestInt32FromFramework/null_int64
=== RUN   TestInt32FromFramework/unknown_int64
=== CONT  TestInt64ToFrameworkLegacy
=== PAUSE TestInt32FromFramework/unknown_int64
=== CONT  TestInt64ToFramework
=== RUN   TestInt64ToFrameworkLegacy/valid_int64
=== PAUSE TestInt64ToFrameworkLegacy/valid_int64
=== RUN   TestInt64ToFramework/valid_int64
=== PAUSE TestInt64ToFramework/valid_int64
=== RUN   TestInt64ToFrameworkLegacy/zero_int64
=== RUN   TestInt64ToFramework/zero_int64
=== PAUSE TestInt64ToFrameworkLegacy/zero_int64
=== PAUSE TestInt64ToFramework/zero_int64
=== RUN   TestInt64ToFrameworkLegacy/nil_int64
=== RUN   TestInt64ToFramework/nil_int64
=== PAUSE TestInt64ToFrameworkLegacy/nil_int64
=== PAUSE TestInt64ToFramework/nil_int64
=== CONT  TestInt64FromFramework
=== RUN   TestInt64FromFramework/valid_int64
=== CONT  TestFloat32ToFrameworkLegacy
=== PAUSE TestInt64FromFramework/valid_int64
=== RUN   TestFloat32ToFrameworkLegacy/valid_float32
=== RUN   TestInt64FromFramework/zero_int64
=== PAUSE TestFloat32ToFrameworkLegacy/valid_float32
=== RUN   TestFloat32ToFrameworkLegacy/zero_float32
=== PAUSE TestFloat32ToFrameworkLegacy/zero_float32
=== RUN   TestFloat32ToFrameworkLegacy/nil_float32
=== PAUSE TestFloat32ToFrameworkLegacy/nil_float32
=== PAUSE TestInt64FromFramework/zero_int64
=== CONT  TestFlattenFrameworkStringValueSet
=== RUN   TestInt64FromFramework/null_int64
=== RUN   TestFlattenFrameworkStringValueSet/two_elements
=== PAUSE TestInt64FromFramework/null_int64
=== PAUSE TestFlattenFrameworkStringValueSet/two_elements
=== RUN   TestInt64FromFramework/unknown_int64
=== PAUSE TestInt64FromFramework/unknown_int64
=== RUN   TestFlattenFrameworkStringValueSet/zero_elements
=== CONT  TestStringToFrameworkARN
=== PAUSE TestFlattenFrameworkStringValueSet/zero_elements
=== RUN   TestStringToFrameworkARN/valid_ARN
=== RUN   TestFlattenFrameworkStringValueSet/nil_array
=== PAUSE TestFlattenFrameworkStringValueSet/nil_array
=== PAUSE TestStringToFrameworkARN/valid_ARN
=== RUN   TestStringToFrameworkARN/null_ARN
=== PAUSE TestStringToFrameworkARN/null_ARN
=== CONT  TestARNStringFromFramework
=== CONT  TestStringValueToFrameworkLegacy
=== RUN   TestARNStringFromFramework/valid_ARN
=== PAUSE TestARNStringFromFramework/valid_ARN
=== RUN   TestARNStringFromFramework/null_ARN
=== PAUSE TestARNStringFromFramework/null_ARN
=== RUN   TestStringValueToFrameworkLegacy/valid
=== RUN   TestARNStringFromFramework/unknown_ARN
=== PAUSE TestARNStringFromFramework/unknown_ARN
=== PAUSE TestStringValueToFrameworkLegacy/valid
=== CONT  TestStringValueToFramework
=== RUN   TestStringValueToFramework/valid
=== RUN   TestStringValueToFrameworkLegacy/empty
=== PAUSE TestStringValueToFramework/valid
=== PAUSE TestStringValueToFrameworkLegacy/empty
=== RUN   TestStringValueToFramework/empty
=== CONT  TestStringToFrameworkLegacy
=== PAUSE TestStringValueToFramework/empty
=== RUN   TestStringToFrameworkLegacy/valid_string
=== CONT  TestStringToFramework
=== PAUSE TestStringToFrameworkLegacy/valid_string
=== RUN   TestStringToFrameworkLegacy/empty_string
=== RUN   TestStringToFramework/valid_string
=== PAUSE TestStringToFrameworkLegacy/empty_string
=== PAUSE TestStringToFramework/valid_string
=== RUN   TestStringToFramework/empty_string
=== RUN   TestStringToFrameworkLegacy/nil_string
=== PAUSE TestStringToFramework/empty_string
=== PAUSE TestStringToFrameworkLegacy/nil_string
=== RUN   TestStringToFramework/nil_string
=== PAUSE TestStringToFramework/nil_string
=== CONT  TestStringFromFramework
=== CONT  TestFlattenFrameworkStringValueSetLegacy
=== RUN   TestStringFromFramework/unknown_string
=== PAUSE TestStringFromFramework/unknown_string
=== RUN   TestFlattenFrameworkStringValueSetLegacy/two_elements
=== PAUSE TestFlattenFrameworkStringValueSetLegacy/two_elements
=== RUN   TestStringFromFramework/valid_string
=== PAUSE TestStringFromFramework/valid_string
=== RUN   TestFlattenFrameworkStringValueSetLegacy/zero_elements
=== PAUSE TestFlattenFrameworkStringValueSetLegacy/zero_elements
=== RUN   TestFlattenFrameworkStringValueSetLegacy/nil_array
=== RUN   TestStringFromFramework/empty_string
=== PAUSE TestFlattenFrameworkStringValueSetLegacy/nil_array
=== PAUSE TestStringFromFramework/empty_string
=== CONT  TestFlattenFrameworkStringMap
=== RUN   TestStringFromFramework/null_string
=== RUN   TestFlattenFrameworkStringMap/two_elements
=== PAUSE TestStringFromFramework/null_string
=== PAUSE TestFlattenFrameworkStringMap/two_elements
=== RUN   TestFlattenFrameworkStringMap/zero_elements
=== CONT  TestExpandFrameworkStringValueSet
=== PAUSE TestFlattenFrameworkStringMap/zero_elements
=== RUN   TestExpandFrameworkStringValueSet/null
=== RUN   TestFlattenFrameworkStringMap/nil_map
=== PAUSE TestFlattenFrameworkStringMap/nil_map
=== PAUSE TestExpandFrameworkStringValueSet/null
=== CONT  TestExpandFrameworkStringSet
=== RUN   TestExpandFrameworkStringValueSet/unknown
=== RUN   TestExpandFrameworkStringSet/null
=== PAUSE TestExpandFrameworkStringValueSet/unknown
=== PAUSE TestExpandFrameworkStringSet/null
=== RUN   TestExpandFrameworkStringValueSet/two_elements
=== PAUSE TestExpandFrameworkStringValueSet/two_elements
=== RUN   TestExpandFrameworkStringSet/unknown
=== PAUSE TestExpandFrameworkStringSet/unknown
=== RUN   TestExpandFrameworkStringValueSet/zero_elements
=== RUN   TestExpandFrameworkStringSet/two_elements
=== PAUSE TestExpandFrameworkStringValueSet/zero_elements
=== PAUSE TestExpandFrameworkStringSet/two_elements
=== RUN   TestExpandFrameworkStringValueSet/invalid_element_type
=== PAUSE TestExpandFrameworkStringValueSet/invalid_element_type
=== RUN   TestExpandFrameworkStringSet/zero_elements
=== CONT  TestFlattenFrameworkStringValueMapLegacy
=== PAUSE TestExpandFrameworkStringSet/zero_elements
=== RUN   TestFlattenFrameworkStringValueMapLegacy/two_elements
=== RUN   TestExpandFrameworkStringSet/invalid_element_type
=== PAUSE TestFlattenFrameworkStringValueMapLegacy/two_elements
=== PAUSE TestExpandFrameworkStringSet/invalid_element_type
=== RUN   TestFlattenFrameworkStringValueMapLegacy/zero_elements
=== PAUSE TestFlattenFrameworkStringValueMapLegacy/zero_elements
=== CONT  TestFlattenFrameworkStringValueMap
=== RUN   TestFlattenFrameworkStringValueMapLegacy/nil_map
=== PAUSE TestFlattenFrameworkStringValueMapLegacy/nil_map
=== RUN   TestFlattenFrameworkStringValueMap/two_elements
=== PAUSE TestFlattenFrameworkStringValueMap/two_elements
=== CONT  TestBoolFromFramework
=== RUN   TestFlattenFrameworkStringValueMap/zero_elements
=== PAUSE TestFlattenFrameworkStringValueMap/zero_elements
=== RUN   TestBoolFromFramework/unknown_bool
=== RUN   TestFlattenFrameworkStringValueMap/nil_map
=== PAUSE TestBoolFromFramework/unknown_bool
=== PAUSE TestFlattenFrameworkStringValueMap/nil_map
=== RUN   TestBoolFromFramework/valid_bool
=== PAUSE TestBoolFromFramework/valid_bool
=== CONT  TestFloat64ToFrameworkLegacy
=== RUN   TestBoolFromFramework/null_bool
=== RUN   TestFloat64ToFrameworkLegacy/valid_float64
=== PAUSE TestBoolFromFramework/null_bool
=== PAUSE TestFloat64ToFrameworkLegacy/valid_float64
=== CONT  TestFloat64ToFramework
=== RUN   TestFloat64ToFrameworkLegacy/zero_float64
=== PAUSE TestFloat64ToFrameworkLegacy/zero_float64
=== RUN   TestFloat64ToFramework/valid_float64
=== RUN   TestFloat64ToFrameworkLegacy/nil_float64
=== PAUSE TestFloat64ToFramework/valid_float64
=== PAUSE TestFloat64ToFrameworkLegacy/nil_float64
=== RUN   TestFloat64ToFramework/zero_float64
=== CONT  TestBoolToFrameworkLegacy
=== PAUSE TestFloat64ToFramework/zero_float64
=== RUN   TestBoolToFrameworkLegacy/nil_bool
=== RUN   TestFloat64ToFramework/nil_float64
=== PAUSE TestFloat64ToFramework/nil_float64
=== PAUSE TestBoolToFrameworkLegacy/nil_bool
=== CONT  TestBoolToFramework
=== RUN   TestBoolToFrameworkLegacy/valid_bool
=== PAUSE TestBoolToFrameworkLegacy/valid_bool
=== RUN   TestBoolToFramework/valid_bool
=== PAUSE TestBoolToFramework/valid_bool
=== CONT  TestExpandFrameworkStringMap
=== RUN   TestBoolToFramework/nil_bool
=== PAUSE TestBoolToFramework/nil_bool
=== CONT  TestExpandFrameworkStringValueMap
=== RUN   TestExpandFrameworkStringMap/null
=== PAUSE TestExpandFrameworkStringMap/null
=== RUN   TestExpandFrameworkStringValueMap/two_elements
=== RUN   TestExpandFrameworkStringMap/unknown
=== PAUSE TestExpandFrameworkStringValueMap/two_elements
=== PAUSE TestExpandFrameworkStringMap/unknown
=== RUN   TestExpandFrameworkStringValueMap/zero_elements
=== PAUSE TestExpandFrameworkStringValueMap/zero_elements
=== RUN   TestExpandFrameworkStringValueMap/invalid_element_type
=== RUN   TestExpandFrameworkStringMap/two_elements
=== PAUSE TestExpandFrameworkStringValueMap/invalid_element_type
=== PAUSE TestExpandFrameworkStringMap/two_elements
=== RUN   TestExpandFrameworkStringValueMap/null
=== PAUSE TestExpandFrameworkStringValueMap/null
=== RUN   TestExpandFrameworkStringMap/zero_elements
=== PAUSE TestExpandFrameworkStringMap/zero_elements
=== RUN   TestExpandFrameworkStringValueMap/unknown
=== PAUSE TestExpandFrameworkStringValueMap/unknown
=== RUN   TestExpandFrameworkStringMap/invalid_element_type
=== CONT  TestFlattenGeneric
=== PAUSE TestExpandFrameworkStringMap/invalid_element_type
=== RUN   TestExpandFrameworkStringMap/null_element
=== PAUSE TestExpandFrameworkStringMap/null_element
=== CONT  TestSet_Difference_strings
=== RUN   TestSet_Difference_strings/equal
=== PAUSE TestSet_Difference_strings/equal
=== RUN   TestSet_Difference_strings/difference
=== PAUSE TestSet_Difference_strings/difference
=== RUN   TestSet_Difference_strings/difference_remove
=== PAUSE TestSet_Difference_strings/difference_remove
=== RUN   TestSet_Difference_strings/difference_add
=== PAUSE TestSet_Difference_strings/difference_add
=== RUN   TestSet_Difference_strings/nil
=== PAUSE TestSet_Difference_strings/nil
=== CONT  TestFlattenFrameworkStringValueListLegacy
=== RUN   TestFlattenFrameworkStringValueListLegacy/two_elements
=== PAUSE TestFlattenFrameworkStringValueListLegacy/two_elements
=== RUN   TestFlattenFrameworkStringValueListLegacy/zero_elements
=== PAUSE TestFlattenFrameworkStringValueListLegacy/zero_elements
=== RUN   TestFlattenFrameworkStringValueListLegacy/nil_array
=== PAUSE TestFlattenFrameworkStringValueListLegacy/nil_array
=== CONT  TestFlatten
=== RUN   TestFlatten/nil_Source_and_Target
=== PAUSE TestFlatten/nil_Source_and_Target
=== RUN   TestFlatten/non-pointer_Target
=== PAUSE TestFlatten/non-pointer_Target
=== RUN   TestFlatten/non-struct_Source
=== PAUSE TestFlatten/non-struct_Source
=== RUN   TestFlatten/non-struct_Target
=== PAUSE TestFlatten/non-struct_Target
=== RUN   TestFlatten/empty_struct_Source_and_Target
=== PAUSE TestFlatten/empty_struct_Source_and_Target
=== RUN   TestFlatten/empty_struct_pointer_Source_and_Target
=== PAUSE TestFlatten/empty_struct_pointer_Source_and_Target
=== RUN   TestFlatten/single_string_struct_pointer_Source_and_empty_Target
=== PAUSE TestFlatten/single_string_struct_pointer_Source_and_empty_Target
=== RUN   TestFlatten/does_not_implement_attr.Value_Target
=== PAUSE TestFlatten/does_not_implement_attr.Value_Target
=== RUN   TestFlatten/single_empty_string_Source_and_single_string_Target
=== PAUSE TestFlatten/single_empty_string_Source_and_single_string_Target
=== RUN   TestFlatten/single_string_Source_and_single_string_Target
=== PAUSE TestFlatten/single_string_Source_and_single_string_Target
=== RUN   TestFlatten/single_nil_*string_Source_and_single_string_Target
=== PAUSE TestFlatten/single_nil_*string_Source_and_single_string_Target
=== RUN   TestFlatten/single_*string_Source_and_single_string_Target
=== PAUSE TestFlatten/single_*string_Source_and_single_string_Target
=== RUN   TestFlatten/single_string_Source_and_single_int64_Target
=== PAUSE TestFlatten/single_string_Source_and_single_int64_Target
=== RUN   TestFlatten/zero_value_primtive_types_Source_and_primtive_types_Target
=== PAUSE TestFlatten/zero_value_primtive_types_Source_and_primtive_types_Target
=== RUN   TestFlatten/primtive_types_Source_and_primtive_types_Target
=== PAUSE TestFlatten/primtive_types_Source_and_primtive_types_Target
=== RUN   TestFlatten/zero_value_slice/map_of_primtive_types_Source_and_List/Set/Map_of_primtive_types_Target
=== PAUSE TestFlatten/zero_value_slice/map_of_primtive_types_Source_and_List/Set/Map_of_primtive_types_Target
=== RUN   TestFlatten/slice/map_of_primtive_types_Source_and_List/Set/Map_of_primtive_types_Target
=== PAUSE TestFlatten/slice/map_of_primtive_types_Source_and_List/Set/Map_of_primtive_types_Target
=== RUN   TestFlatten/zero_value_slice/map_of_string_type_Source_and_List/Set/Map_of_string_types_Target
=== PAUSE TestFlatten/zero_value_slice/map_of_string_type_Source_and_List/Set/Map_of_string_types_Target
=== RUN   TestFlatten/slice/map_of_string_types_Source_and_List/Set/Map_of_string_types_Target
=== PAUSE TestFlatten/slice/map_of_string_types_Source_and_List/Set/Map_of_string_types_Target
=== RUN   TestFlatten/plural_ordinary_field_names
=== PAUSE TestFlatten/plural_ordinary_field_names
=== RUN   TestFlatten/plural_field_names
=== PAUSE TestFlatten/plural_field_names
=== RUN   TestFlatten/strange_plurality
=== PAUSE TestFlatten/strange_plurality
=== RUN   TestFlatten/capitalization_field_names
=== PAUSE TestFlatten/capitalization_field_names
=== RUN   TestFlatten/resource_name_prefix
=== PAUSE TestFlatten/resource_name_prefix
=== RUN   TestFlatten/single_string_Source_and_single_ARN_Target
=== PAUSE TestFlatten/single_string_Source_and_single_ARN_Target
=== RUN   TestFlatten/single_*string_Source_and_single_ARN_Target
=== PAUSE TestFlatten/single_*string_Source_and_single_ARN_Target
=== RUN   TestFlatten/single_nil_*string_Source_and_single_ARN_Target
=== PAUSE TestFlatten/single_nil_*string_Source_and_single_ARN_Target
=== RUN   TestFlatten/timestamp_pointer
=== PAUSE TestFlatten/timestamp_pointer
=== RUN   TestFlatten/timestamp
=== PAUSE TestFlatten/timestamp
=== RUN   TestFlatten/timestamp_nil
=== PAUSE TestFlatten/timestamp_nil
=== RUN   TestFlatten/timestamp_empty
=== PAUSE TestFlatten/timestamp_empty
=== CONT  TestExpandGeneric
=== RUN   TestFlattenGeneric/nil_*struct_Source_and_single_list_Target
=== PAUSE TestFlattenGeneric/nil_*struct_Source_and_single_list_Target
=== RUN   TestFlattenGeneric/*struct_Source_and_single_list_Target
=== PAUSE TestFlattenGeneric/*struct_Source_and_single_list_Target
=== RUN   TestFlattenGeneric/*struct_Source_and_single_set_Target
=== PAUSE TestFlattenGeneric/*struct_Source_and_single_set_Target
=== RUN   TestFlattenGeneric/nil_[]struct_and_null_list_Target
=== PAUSE TestFlattenGeneric/nil_[]struct_and_null_list_Target
=== RUN   TestFlattenGeneric/nil_[]struct_and_null_set_Target
=== PAUSE TestFlattenGeneric/nil_[]struct_and_null_set_Target
=== RUN   TestFlattenGeneric/empty_[]struct_and_empty_list_Target
=== PAUSE TestFlattenGeneric/empty_[]struct_and_empty_list_Target
=== RUN   TestFlattenGeneric/empty_[]struct_and_empty_struct_Target
=== PAUSE TestFlattenGeneric/empty_[]struct_and_empty_struct_Target
=== RUN   TestFlattenGeneric/non-empty_[]struct_and_non-empty_list_Target
=== PAUSE TestFlattenGeneric/non-empty_[]struct_and_non-empty_list_Target
=== RUN   TestFlattenGeneric/non-empty_[]struct_and_non-empty_set_Target
=== PAUSE TestFlattenGeneric/non-empty_[]struct_and_non-empty_set_Target
=== RUN   TestFlattenGeneric/nil_[]*struct_and_null_list_Target
=== PAUSE TestFlattenGeneric/nil_[]*struct_and_null_list_Target
=== RUN   TestFlattenGeneric/nil_[]*struct_and_null_set_Target
=== PAUSE TestFlattenGeneric/nil_[]*struct_and_null_set_Target
=== RUN   TestFlattenGeneric/empty_[]*struct_and_empty_list_Target
=== PAUSE TestFlattenGeneric/empty_[]*struct_and_empty_list_Target
=== RUN   TestFlattenGeneric/empty_[]*struct_and_empty_set_Target
=== PAUSE TestFlattenGeneric/empty_[]*struct_and_empty_set_Target
=== RUN   TestFlattenGeneric/non-empty_[]*struct_and_non-empty_list_Target
=== PAUSE TestFlattenGeneric/non-empty_[]*struct_and_non-empty_list_Target
=== RUN   TestFlattenGeneric/non-empty_[]*struct_and_non-empty_set_Target
=== PAUSE TestFlattenGeneric/non-empty_[]*struct_and_non-empty_set_Target
=== RUN   TestFlattenGeneric/complex_Source_and_complex_Target
=== PAUSE TestFlattenGeneric/complex_Source_and_complex_Target
=== RUN   TestFlattenGeneric/map_string
=== PAUSE TestFlattenGeneric/map_string
=== RUN   TestFlattenGeneric/object_map
=== PAUSE TestFlattenGeneric/object_map
=== RUN   TestFlattenGeneric/object_map_ptr_source
=== PAUSE TestFlattenGeneric/object_map_ptr_source
=== RUN   TestFlattenGeneric/object_map_ptr_target
=== PAUSE TestFlattenGeneric/object_map_ptr_target
=== RUN   TestFlattenGeneric/object_map_ptr_source_and_target
=== PAUSE TestFlattenGeneric/object_map_ptr_source_and_target
=== RUN   TestFlattenGeneric/nested_string_map
=== PAUSE TestFlattenGeneric/nested_string_map
=== RUN   TestFlattenGeneric/nested_object_map
=== PAUSE TestFlattenGeneric/nested_object_map
=== RUN   TestFlattenGeneric/map_block_key_list
=== PAUSE TestFlattenGeneric/map_block_key_list
=== RUN   TestFlattenGeneric/map_block_key_set
=== PAUSE TestFlattenGeneric/map_block_key_set
=== RUN   TestFlattenGeneric/map_block_key_ptr_source
=== PAUSE TestFlattenGeneric/map_block_key_ptr_source
=== RUN   TestFlattenGeneric/map_block_key_ptr_both
=== PAUSE TestFlattenGeneric/map_block_key_ptr_both
=== RUN   TestFlattenGeneric/map_block_enum_key
=== PAUSE TestFlattenGeneric/map_block_enum_key
=== RUN   TestFlattenGeneric/complex_nesting
=== PAUSE TestFlattenGeneric/complex_nesting
=== CONT  TestFlattenFrameworkStringValueList
=== RUN   TestFlattenFrameworkStringValueList/zero_elements
=== PAUSE TestFlattenFrameworkStringValueList/zero_elements
=== RUN   TestFlattenFrameworkStringValueList/nil_array
=== PAUSE TestFlattenFrameworkStringValueList/nil_array
=== RUN   TestFlattenFrameworkStringValueList/two_elements
=== PAUSE TestFlattenFrameworkStringValueList/two_elements
=== CONT  TestFlattenFrameworkStringListLegacy/two_elements
=== CONT  TestFlattenFrameworkStringListLegacy/zero_elements
=== RUN   TestExpandGeneric/single_list_Source_and_*struct_Target
=== PAUSE TestExpandGeneric/single_list_Source_and_*struct_Target
=== CONT  TestFlattenFrameworkStringListLegacy/nil_array
=== RUN   TestExpandGeneric/single_set_Source_and_*struct_Target
=== PAUSE TestExpandGeneric/single_set_Source_and_*struct_Target
=== RUN   TestExpandGeneric/empty_list_Source_and_empty_[]struct_Target
=== PAUSE TestExpandGeneric/empty_list_Source_and_empty_[]struct_Target
=== RUN   TestExpandGeneric/non-empty_list_Source_and_non-empty_[]struct_Target
--- PASS: TestFlattenFrameworkStringListLegacy (0.00s)
    --- PASS: TestFlattenFrameworkStringListLegacy/two_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringListLegacy/zero_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringListLegacy/nil_array (0.00s)
=== PAUSE TestExpandGeneric/non-empty_list_Source_and_non-empty_[]struct_Target
=== RUN   TestExpandGeneric/empty_list_Source_and_empty_[]*struct_Target
=== CONT  TestFloat32ToFramework/valid_float32
=== PAUSE TestExpandGeneric/empty_list_Source_and_empty_[]*struct_Target
=== RUN   TestExpandGeneric/non-empty_list_Source_and_non-empty_[]*struct_Target
=== PAUSE TestExpandGeneric/non-empty_list_Source_and_non-empty_[]*struct_Target
=== RUN   TestExpandGeneric/empty_list_Source_and_empty_[]struct_Target#01
=== PAUSE TestExpandGeneric/empty_list_Source_and_empty_[]struct_Target#01
=== RUN   TestExpandGeneric/non-empty_list_Source_and_non-empty_[]struct_Target#01
=== PAUSE TestExpandGeneric/non-empty_list_Source_and_non-empty_[]struct_Target#01
=== RUN   TestExpandGeneric/empty_set_Source_and_empty_[]*struct_Target
=== CONT  TestFloat32ToFramework/zero_float32
=== PAUSE TestExpandGeneric/empty_set_Source_and_empty_[]*struct_Target
=== RUN   TestExpandGeneric/non-empty_set_Source_and_non-empty_[]*struct_Target
=== PAUSE TestExpandGeneric/non-empty_set_Source_and_non-empty_[]*struct_Target
=== RUN   TestExpandGeneric/non-empty_set_Source_and_non-empty_[]struct_Target
=== PAUSE TestExpandGeneric/non-empty_set_Source_and_non-empty_[]struct_Target
=== CONT  TestFloat32ToFramework/nil_float32
=== RUN   TestExpandGeneric/complex_Source_and_complex_Target
=== PAUSE TestExpandGeneric/complex_Source_and_complex_Target
=== RUN   TestExpandGeneric/map_string
=== PAUSE TestExpandGeneric/map_string
=== RUN   TestExpandGeneric/object_map
--- PASS: TestFloat32ToFramework (0.00s)
    --- PASS: TestFloat32ToFramework/valid_float32 (0.00s)
    --- PASS: TestFloat32ToFramework/zero_float32 (0.00s)
    --- PASS: TestFloat32ToFramework/nil_float32 (0.00s)
=== PAUSE TestExpandGeneric/object_map
=== CONT  TestFlattenFrameworkStringList/zero_elements
=== RUN   TestExpandGeneric/object_map_ptr_target
=== PAUSE TestExpandGeneric/object_map_ptr_target
=== RUN   TestExpandGeneric/object_map_ptr_source_and_target
=== PAUSE TestExpandGeneric/object_map_ptr_source_and_target
=== CONT  TestFlattenFrameworkStringList/two_elements
=== RUN   TestExpandGeneric/nested_string_map
=== PAUSE TestExpandGeneric/nested_string_map
=== RUN   TestExpandGeneric/nested_object_map
=== PAUSE TestExpandGeneric/nested_object_map
=== RUN   TestExpandGeneric/map_block_key_list
=== PAUSE TestExpandGeneric/map_block_key_list
=== RUN   TestExpandGeneric/map_block_key_set
=== CONT  TestFlattenFrameworkStringList/nil_array
=== PAUSE TestExpandGeneric/map_block_key_set
=== RUN   TestExpandGeneric/map_block_key_ptr_source
=== PAUSE TestExpandGeneric/map_block_key_ptr_source
--- PASS: TestFlattenFrameworkStringList (0.00s)
    --- PASS: TestFlattenFrameworkStringList/zero_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringList/two_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringList/nil_array (0.00s)
=== RUN   TestExpandGeneric/map_block_key_ptr_both
=== CONT  TestExpandFrameworkStringValueList/two_elements
=== PAUSE TestExpandGeneric/map_block_key_ptr_both
=== RUN   TestExpandGeneric/map_block_enum_key
=== PAUSE TestExpandGeneric/map_block_enum_key
=== RUN   TestExpandGeneric/complex_nesting
=== PAUSE TestExpandGeneric/complex_nesting
=== CONT  TestExpandFrameworkStringValueList/invalid_element_type
=== CONT  TestExpandFrameworkStringValueList/zero_elements
=== CONT  TestExpandFrameworkStringValueList/unknown
=== CONT  TestExpandFrameworkStringValueList/null
=== CONT  TestExpandFrameworkStringList/invalid_element_type
=== CONT  TestExpandFrameworkStringList/zero_elements
--- PASS: TestExpandFrameworkStringValueList (0.00s)
    --- PASS: TestExpandFrameworkStringValueList/invalid_element_type (0.00s)
    --- PASS: TestExpandFrameworkStringValueList/two_elements (0.00s)
    --- PASS: TestExpandFrameworkStringValueList/unknown (0.00s)
    --- PASS: TestExpandFrameworkStringValueList/null (0.00s)
    --- PASS: TestExpandFrameworkStringValueList/zero_elements (0.00s)
=== CONT  TestExpandFrameworkStringList/two_elements
=== CONT  TestExpandFrameworkStringList/unknown
=== CONT  TestExpandFrameworkStringList/null
=== CONT  TestExpand/nil_Source_and_Target
--- PASS: TestExpandFrameworkStringList (0.00s)
    --- PASS: TestExpandFrameworkStringList/invalid_element_type (0.00s)
    --- PASS: TestExpandFrameworkStringList/zero_elements (0.00s)
    --- PASS: TestExpandFrameworkStringList/unknown (0.00s)
    --- PASS: TestExpandFrameworkStringList/two_elements (0.00s)
    --- PASS: TestExpandFrameworkStringList/null (0.00s)
=== CONT  TestExpand/single_string_Source_and_single_int64_Target
=== CONT  TestExpand/timestamp
=== CONT  TestExpand/timestamp_pointer
=== CONT  TestExpand/single_ARN_Source_and_single_*string_Target
=== CONT  TestExpand/single_ARN_Source_and_single_string_Target
=== CONT  TestExpand/resource_name_prefix
=== CONT  TestExpand/capitalization_field_names
=== CONT  TestExpand/plural_field_names
=== CONT  TestExpand/primtive_types_Source_and_primtive_types_Target
=== CONT  TestExpand/empty_struct_pointer_Source_and_Target
=== CONT  TestExpand/single_string_Source_and_single_*string_Target
=== CONT  TestExpand/single_string_Source_and_single_string_Target
=== CONT  TestExpand/does_not_implement_attr.Value_Source
=== CONT  TestExpand/empty_struct_Source_and_Target
=== CONT  TestExpand/single_string_struct_pointer_Source_and_empty_Target
=== CONT  TestExpand/types.String_to_string
=== CONT  TestExpand/non-struct_Target
=== CONT  TestExpand/non-struct_Source
=== CONT  TestExpand/non-pointer_Target
=== CONT  TestExpand/List/Set/Map_of_primitive_types_Source_and_slice/map_of_primtive_types_Target
=== CONT  TestInt32ToFramework/zero_int64
--- PASS: TestExpand (0.00s)
    --- PASS: TestExpand/nil_Source_and_Target (0.00s)
    --- PASS: TestExpand/single_string_Source_and_single_int64_Target (0.00s)
    --- PASS: TestExpand/timestamp (0.00s)
    --- PASS: TestExpand/timestamp_pointer (0.00s)
    --- PASS: TestExpand/single_ARN_Source_and_single_*string_Target (0.00s)
    --- PASS: TestExpand/single_ARN_Source_and_single_string_Target (0.00s)
    --- PASS: TestExpand/capitalization_field_names (0.00s)
    --- PASS: TestExpand/resource_name_prefix (0.00s)
    --- PASS: TestExpand/primtive_types_Source_and_primtive_types_Target (0.00s)
    --- PASS: TestExpand/empty_struct_pointer_Source_and_Target (0.00s)
    --- PASS: TestExpand/single_string_Source_and_single_*string_Target (0.00s)
    --- PASS: TestExpand/single_string_Source_and_single_string_Target (0.00s)
    --- PASS: TestExpand/does_not_implement_attr.Value_Source (0.00s)
    --- PASS: TestExpand/empty_struct_Source_and_Target (0.00s)
    --- PASS: TestExpand/single_string_struct_pointer_Source_and_empty_Target (0.00s)
    --- PASS: TestExpand/types.String_to_string (0.00s)
    --- PASS: TestExpand/non-struct_Target (0.00s)
    --- PASS: TestExpand/non-struct_Source (0.00s)
    --- PASS: TestExpand/non-pointer_Target (0.00s)
    --- PASS: TestExpand/List/Set/Map_of_primitive_types_Source_and_slice/map_of_primtive_types_Target (0.00s)
    --- PASS: TestExpand/plural_field_names (0.00s)
=== CONT  TestInt32ToFramework/valid_int64
=== CONT  TestInt32ToFramework/nil_int64
=== CONT  TestInt32FromFramework/valid_int64
--- PASS: TestInt32ToFramework (0.00s)
    --- PASS: TestInt32ToFramework/zero_int64 (0.00s)
    --- PASS: TestInt32ToFramework/valid_int64 (0.00s)
    --- PASS: TestInt32ToFramework/nil_int64 (0.00s)
=== CONT  TestInt32FromFramework/null_int64
=== CONT  TestInt32FromFramework/unknown_int64
=== CONT  TestInt32FromFramework/zero_int64
=== CONT  TestInt64ToFrameworkLegacy/valid_int64
--- PASS: TestInt32FromFramework (0.00s)
    --- PASS: TestInt32FromFramework/valid_int64 (0.00s)
    --- PASS: TestInt32FromFramework/null_int64 (0.00s)
    --- PASS: TestInt32FromFramework/zero_int64 (0.00s)
    --- PASS: TestInt32FromFramework/unknown_int64 (0.00s)
=== CONT  TestInt64ToFrameworkLegacy/nil_int64
=== CONT  TestInt64ToFrameworkLegacy/zero_int64
=== CONT  TestInt64ToFramework/valid_int64
--- PASS: TestInt64ToFrameworkLegacy (0.00s)
    --- PASS: TestInt64ToFrameworkLegacy/valid_int64 (0.00s)
    --- PASS: TestInt64ToFrameworkLegacy/nil_int64 (0.00s)
    --- PASS: TestInt64ToFrameworkLegacy/zero_int64 (0.00s)
=== CONT  TestInt64ToFramework/nil_int64
=== CONT  TestInt64ToFramework/zero_int64
=== CONT  TestFloat32ToFrameworkLegacy/valid_float32
--- PASS: TestInt64ToFramework (0.00s)
    --- PASS: TestInt64ToFramework/valid_int64 (0.00s)
    --- PASS: TestInt64ToFramework/nil_int64 (0.00s)
    --- PASS: TestInt64ToFramework/zero_int64 (0.00s)
=== CONT  TestFloat32ToFrameworkLegacy/nil_float32
=== CONT  TestFloat32ToFrameworkLegacy/zero_float32
=== CONT  TestInt64FromFramework/valid_int64
=== CONT  TestInt64FromFramework/null_int64
--- PASS: TestFloat32ToFrameworkLegacy (0.00s)
    --- PASS: TestFloat32ToFrameworkLegacy/valid_float32 (0.00s)
    --- PASS: TestFloat32ToFrameworkLegacy/zero_float32 (0.00s)
    --- PASS: TestFloat32ToFrameworkLegacy/nil_float32 (0.00s)
=== CONT  TestInt64FromFramework/unknown_int64
=== CONT  TestInt64FromFramework/zero_int64
=== CONT  TestFlattenFrameworkStringValueSet/nil_array
--- PASS: TestInt64FromFramework (0.00s)
    --- PASS: TestInt64FromFramework/valid_int64 (0.00s)
    --- PASS: TestInt64FromFramework/null_int64 (0.00s)
    --- PASS: TestInt64FromFramework/zero_int64 (0.00s)
    --- PASS: TestInt64FromFramework/unknown_int64 (0.00s)
=== CONT  TestFlattenFrameworkStringValueSet/two_elements
=== CONT  TestFlattenFrameworkStringValueSet/zero_elements
=== CONT  TestStringToFrameworkARN/valid_ARN
--- PASS: TestFlattenFrameworkStringValueSet (0.00s)
    --- PASS: TestFlattenFrameworkStringValueSet/nil_array (0.00s)
    --- PASS: TestFlattenFrameworkStringValueSet/two_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringValueSet/zero_elements (0.00s)
=== CONT  TestStringToFrameworkARN/null_ARN
=== CONT  TestARNStringFromFramework/valid_ARN
--- PASS: TestStringToFrameworkARN (0.00s)
    --- PASS: TestStringToFrameworkARN/valid_ARN (0.00s)
    --- PASS: TestStringToFrameworkARN/null_ARN (0.00s)
=== CONT  TestARNStringFromFramework/unknown_ARN
=== CONT  TestARNStringFromFramework/null_ARN
=== CONT  TestStringValueToFrameworkLegacy/valid
=== CONT  TestStringValueToFrameworkLegacy/empty
--- PASS: TestARNStringFromFramework (0.00s)
    --- PASS: TestARNStringFromFramework/valid_ARN (0.00s)
    --- PASS: TestARNStringFromFramework/unknown_ARN (0.00s)
    --- PASS: TestARNStringFromFramework/null_ARN (0.00s)
=== CONT  TestStringValueToFramework/empty
--- PASS: TestStringValueToFrameworkLegacy (0.00s)
    --- PASS: TestStringValueToFrameworkLegacy/empty (0.00s)
    --- PASS: TestStringValueToFrameworkLegacy/valid (0.00s)
=== CONT  TestStringValueToFramework/valid
=== CONT  TestStringToFrameworkLegacy/valid_string
--- PASS: TestStringValueToFramework (0.00s)
    --- PASS: TestStringValueToFramework/empty (0.00s)
    --- PASS: TestStringValueToFramework/valid (0.00s)
=== CONT  TestStringToFrameworkLegacy/nil_string
=== CONT  TestStringToFrameworkLegacy/empty_string
=== CONT  TestStringToFramework/valid_string
--- PASS: TestStringToFrameworkLegacy (0.00s)
    --- PASS: TestStringToFrameworkLegacy/valid_string (0.00s)
    --- PASS: TestStringToFrameworkLegacy/empty_string (0.00s)
    --- PASS: TestStringToFrameworkLegacy/nil_string (0.00s)
=== CONT  TestStringToFramework/nil_string
=== CONT  TestStringToFramework/empty_string
=== CONT  TestFlattenFrameworkStringValueSetLegacy/two_elements
--- PASS: TestStringToFramework (0.00s)
    --- PASS: TestStringToFramework/valid_string (0.00s)
    --- PASS: TestStringToFramework/nil_string (0.00s)
    --- PASS: TestStringToFramework/empty_string (0.00s)
=== CONT  TestFlattenFrameworkStringValueSetLegacy/nil_array
=== CONT  TestFlattenFrameworkStringValueSetLegacy/zero_elements
=== CONT  TestStringFromFramework/unknown_string
=== CONT  TestStringFromFramework/null_string
=== CONT  TestStringFromFramework/empty_string
=== CONT  TestStringFromFramework/valid_string
=== CONT  TestFlattenFrameworkStringMap/two_elements
=== CONT  TestFlattenFrameworkStringMap/nil_map
--- PASS: TestFlattenFrameworkStringValueSetLegacy (0.00s)
    --- PASS: TestFlattenFrameworkStringValueSetLegacy/two_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringValueSetLegacy/nil_array (0.00s)
    --- PASS: TestFlattenFrameworkStringValueSetLegacy/zero_elements (0.00s)
--- PASS: TestStringFromFramework (0.00s)
    --- PASS: TestStringFromFramework/unknown_string (0.00s)
    --- PASS: TestStringFromFramework/null_string (0.00s)
    --- PASS: TestStringFromFramework/empty_string (0.00s)
    --- PASS: TestStringFromFramework/valid_string (0.00s)
=== CONT  TestExpandFrameworkStringValueSet/null
=== CONT  TestFlattenFrameworkStringMap/zero_elements
=== CONT  TestExpandFrameworkStringValueSet/zero_elements
--- PASS: TestFlattenFrameworkStringMap (0.00s)
    --- PASS: TestFlattenFrameworkStringMap/nil_map (0.00s)
    --- PASS: TestFlattenFrameworkStringMap/two_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringMap/zero_elements (0.00s)
=== CONT  TestExpandFrameworkStringValueSet/invalid_element_type
=== CONT  TestExpandFrameworkStringValueSet/two_elements
=== CONT  TestExpandFrameworkStringValueSet/unknown
=== CONT  TestExpandFrameworkStringSet/null
=== CONT  TestExpandFrameworkStringSet/invalid_element_type
--- PASS: TestExpandFrameworkStringValueSet (0.00s)
    --- PASS: TestExpandFrameworkStringValueSet/null (0.00s)
    --- PASS: TestExpandFrameworkStringValueSet/zero_elements (0.00s)
    --- PASS: TestExpandFrameworkStringValueSet/invalid_element_type (0.00s)
    --- PASS: TestExpandFrameworkStringValueSet/unknown (0.00s)
    --- PASS: TestExpandFrameworkStringValueSet/two_elements (0.00s)
=== CONT  TestExpandFrameworkStringSet/two_elements
=== CONT  TestExpandFrameworkStringSet/zero_elements
=== CONT  TestExpandFrameworkStringSet/unknown
=== CONT  TestFlattenFrameworkStringValueMapLegacy/two_elements
--- PASS: TestExpandFrameworkStringSet (0.00s)
    --- PASS: TestExpandFrameworkStringSet/null (0.00s)
    --- PASS: TestExpandFrameworkStringSet/invalid_element_type (0.00s)
    --- PASS: TestExpandFrameworkStringSet/zero_elements (0.00s)
    --- PASS: TestExpandFrameworkStringSet/unknown (0.00s)
    --- PASS: TestExpandFrameworkStringSet/two_elements (0.00s)
=== CONT  TestFlattenFrameworkStringValueMapLegacy/nil_map
=== CONT  TestFlattenFrameworkStringValueMapLegacy/zero_elements
=== CONT  TestFlattenFrameworkStringValueMap/two_elements
--- PASS: TestFlattenFrameworkStringValueMapLegacy (0.00s)
    --- PASS: TestFlattenFrameworkStringValueMapLegacy/two_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringValueMapLegacy/nil_map (0.00s)
    --- PASS: TestFlattenFrameworkStringValueMapLegacy/zero_elements (0.00s)
=== CONT  TestFlattenFrameworkStringValueMap/nil_map
=== CONT  TestFlattenFrameworkStringValueMap/zero_elements
=== CONT  TestBoolFromFramework/unknown_bool
--- PASS: TestFlattenFrameworkStringValueMap (0.00s)
    --- PASS: TestFlattenFrameworkStringValueMap/two_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringValueMap/zero_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringValueMap/nil_map (0.00s)
=== CONT  TestBoolFromFramework/null_bool
=== CONT  TestBoolFromFramework/valid_bool
=== CONT  TestFloat64ToFrameworkLegacy/valid_float64
--- PASS: TestBoolFromFramework (0.00s)
    --- PASS: TestBoolFromFramework/unknown_bool (0.00s)
    --- PASS: TestBoolFromFramework/null_bool (0.00s)
    --- PASS: TestBoolFromFramework/valid_bool (0.00s)
=== CONT  TestFloat64ToFrameworkLegacy/zero_float64
=== CONT  TestFloat64ToFrameworkLegacy/nil_float64
=== CONT  TestFloat64ToFramework/nil_float64
--- PASS: TestFloat64ToFrameworkLegacy (0.00s)
    --- PASS: TestFloat64ToFrameworkLegacy/valid_float64 (0.00s)
    --- PASS: TestFloat64ToFrameworkLegacy/nil_float64 (0.00s)
    --- PASS: TestFloat64ToFrameworkLegacy/zero_float64 (0.00s)
=== CONT  TestFloat64ToFramework/valid_float64
=== CONT  TestFloat64ToFramework/zero_float64
=== CONT  TestBoolToFrameworkLegacy/nil_bool
--- PASS: TestFloat64ToFramework (0.00s)
    --- PASS: TestFloat64ToFramework/nil_float64 (0.00s)
    --- PASS: TestFloat64ToFramework/zero_float64 (0.00s)
    --- PASS: TestFloat64ToFramework/valid_float64 (0.00s)
=== CONT  TestBoolToFrameworkLegacy/valid_bool
=== CONT  TestBoolToFramework/valid_bool
--- PASS: TestBoolToFrameworkLegacy (0.00s)
    --- PASS: TestBoolToFrameworkLegacy/nil_bool (0.00s)
    --- PASS: TestBoolToFrameworkLegacy/valid_bool (0.00s)
=== CONT  TestExpandFrameworkStringValueMap/two_elements
=== CONT  TestBoolToFramework/nil_bool
--- PASS: TestBoolToFramework (0.00s)
    --- PASS: TestBoolToFramework/valid_bool (0.00s)
    --- PASS: TestBoolToFramework/nil_bool (0.00s)
=== CONT  TestExpandFrameworkStringValueMap/unknown
=== CONT  TestExpandFrameworkStringValueMap/null
=== CONT  TestExpandFrameworkStringValueMap/invalid_element_type
=== CONT  TestExpandFrameworkStringMap/null
=== CONT  TestExpandFrameworkStringValueMap/zero_elements
=== CONT  TestExpandFrameworkStringMap/zero_elements
=== CONT  TestExpandFrameworkStringMap/null_element
--- PASS: TestExpandFrameworkStringValueMap (0.00s)
    --- PASS: TestExpandFrameworkStringValueMap/two_elements (0.00s)
    --- PASS: TestExpandFrameworkStringValueMap/null (0.00s)
    --- PASS: TestExpandFrameworkStringValueMap/unknown (0.00s)
    --- PASS: TestExpandFrameworkStringValueMap/invalid_element_type (0.00s)
    --- PASS: TestExpandFrameworkStringValueMap/zero_elements (0.00s)
=== CONT  TestExpandFrameworkStringMap/invalid_element_type
=== CONT  TestExpandFrameworkStringMap/two_elements
=== CONT  TestExpandFrameworkStringMap/unknown
=== CONT  TestSet_Difference_strings/equal
=== CONT  TestSet_Difference_strings/difference_add
=== CONT  TestSet_Difference_strings/nil
=== CONT  TestSet_Difference_strings/difference_remove
--- PASS: TestExpandFrameworkStringMap (0.00s)
    --- PASS: TestExpandFrameworkStringMap/null (0.00s)
    --- PASS: TestExpandFrameworkStringMap/zero_elements (0.00s)
    --- PASS: TestExpandFrameworkStringMap/invalid_element_type (0.00s)
    --- PASS: TestExpandFrameworkStringMap/null_element (0.00s)
    --- PASS: TestExpandFrameworkStringMap/unknown (0.00s)
    --- PASS: TestExpandFrameworkStringMap/two_elements (0.00s)
=== CONT  TestSet_Difference_strings/difference
=== CONT  TestFlattenFrameworkStringValueListLegacy/two_elements
=== CONT  TestFlattenFrameworkStringValueListLegacy/nil_array
--- PASS: TestSet_Difference_strings (0.00s)
    --- PASS: TestSet_Difference_strings/equal (0.00s)
    --- PASS: TestSet_Difference_strings/difference_add (0.00s)
    --- PASS: TestSet_Difference_strings/nil (0.00s)
    --- PASS: TestSet_Difference_strings/difference_remove (0.00s)
    --- PASS: TestSet_Difference_strings/difference (0.00s)
=== CONT  TestFlattenFrameworkStringValueListLegacy/zero_elements
=== CONT  TestFlatten/nil_Source_and_Target
=== CONT  TestFlatten/timestamp_empty
--- PASS: TestFlattenFrameworkStringValueListLegacy (0.00s)
    --- PASS: TestFlattenFrameworkStringValueListLegacy/two_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringValueListLegacy/nil_array (0.00s)
    --- PASS: TestFlattenFrameworkStringValueListLegacy/zero_elements (0.00s)
=== CONT  TestFlatten/slice/map_of_primtive_types_Source_and_List/Set/Map_of_primtive_types_Target
=== CONT  TestFlatten/timestamp_nil
=== CONT  TestFlatten/timestamp
=== CONT  TestFlatten/timestamp_pointer
=== CONT  TestFlatten/single_nil_*string_Source_and_single_ARN_Target
=== CONT  TestFlatten/single_*string_Source_and_single_ARN_Target
=== CONT  TestFlatten/single_string_Source_and_single_ARN_Target
=== CONT  TestFlatten/resource_name_prefix
=== CONT  TestFlatten/capitalization_field_names
=== CONT  TestFlatten/strange_plurality
=== CONT  TestFlatten/plural_field_names
=== CONT  TestFlatten/plural_ordinary_field_names
=== CONT  TestFlatten/slice/map_of_string_types_Source_and_List/Set/Map_of_string_types_Target
=== CONT  TestFlatten/zero_value_slice/map_of_string_type_Source_and_List/Set/Map_of_string_types_Target
=== CONT  TestFlatten/single_empty_string_Source_and_single_string_Target
=== CONT  TestFlatten/zero_value_slice/map_of_primtive_types_Source_and_List/Set/Map_of_primtive_types_Target
=== CONT  TestFlatten/primtive_types_Source_and_primtive_types_Target
=== CONT  TestFlatten/zero_value_primtive_types_Source_and_primtive_types_Target
=== CONT  TestFlatten/single_string_Source_and_single_int64_Target
=== CONT  TestFlatten/single_*string_Source_and_single_string_Target
=== CONT  TestFlatten/single_nil_*string_Source_and_single_string_Target
=== CONT  TestFlatten/single_string_Source_and_single_string_Target
=== CONT  TestFlatten/empty_struct_Source_and_Target
=== CONT  TestFlatten/single_string_struct_pointer_Source_and_empty_Target
=== CONT  TestFlatten/empty_struct_pointer_Source_and_Target
=== CONT  TestFlatten/non-struct_Source
=== CONT  TestFlatten/non-struct_Target
=== CONT  TestFlatten/non-pointer_Target
=== CONT  TestFlatten/does_not_implement_attr.Value_Target
=== CONT  TestFlattenGeneric/nil_*struct_Source_and_single_list_Target
--- PASS: TestFlatten (0.00s)
    --- PASS: TestFlatten/nil_Source_and_Target (0.00s)
    --- PASS: TestFlatten/timestamp_empty (0.00s)
    --- PASS: TestFlatten/timestamp_nil (0.00s)
    --- PASS: TestFlatten/slice/map_of_primtive_types_Source_and_List/Set/Map_of_primtive_types_Target (0.00s)
    --- PASS: TestFlatten/timestamp (0.00s)
    --- PASS: TestFlatten/timestamp_pointer (0.00s)
    --- PASS: TestFlatten/single_nil_*string_Source_and_single_ARN_Target (0.00s)
    --- PASS: TestFlatten/single_string_Source_and_single_ARN_Target (0.00s)
    --- PASS: TestFlatten/single_*string_Source_and_single_ARN_Target (0.00s)
    --- PASS: TestFlatten/capitalization_field_names (0.00s)
    --- PASS: TestFlatten/strange_plurality (0.00s)
    --- PASS: TestFlatten/resource_name_prefix (0.00s)
    --- PASS: TestFlatten/plural_ordinary_field_names (0.00s)
    --- PASS: TestFlatten/slice/map_of_string_types_Source_and_List/Set/Map_of_string_types_Target (0.00s)
    --- PASS: TestFlatten/zero_value_slice/map_of_string_type_Source_and_List/Set/Map_of_string_types_Target (0.00s)
    --- PASS: TestFlatten/single_empty_string_Source_and_single_string_Target (0.00s)
    --- PASS: TestFlatten/zero_value_slice/map_of_primtive_types_Source_and_List/Set/Map_of_primtive_types_Target (0.00s)
    --- PASS: TestFlatten/primtive_types_Source_and_primtive_types_Target (0.00s)
    --- PASS: TestFlatten/plural_field_names (0.00s)
    --- PASS: TestFlatten/zero_value_primtive_types_Source_and_primtive_types_Target (0.00s)
    --- PASS: TestFlatten/single_string_Source_and_single_int64_Target (0.00s)
    --- PASS: TestFlatten/single_*string_Source_and_single_string_Target (0.00s)
    --- PASS: TestFlatten/single_nil_*string_Source_and_single_string_Target (0.00s)
    --- PASS: TestFlatten/empty_struct_Source_and_Target (0.00s)
    --- PASS: TestFlatten/single_string_Source_and_single_string_Target (0.00s)
    --- PASS: TestFlatten/empty_struct_pointer_Source_and_Target (0.00s)
    --- PASS: TestFlatten/non-struct_Source (0.00s)
    --- PASS: TestFlatten/non-struct_Target (0.00s)
    --- PASS: TestFlatten/non-pointer_Target (0.00s)
    --- PASS: TestFlatten/does_not_implement_attr.Value_Target (0.00s)
    --- PASS: TestFlatten/single_string_struct_pointer_Source_and_empty_Target (0.00s)
=== CONT  TestFlattenGeneric/complex_Source_and_complex_Target
=== CONT  TestFlattenGeneric/complex_nesting
=== CONT  TestFlattenGeneric/map_block_enum_key
=== CONT  TestFlattenGeneric/map_block_key_ptr_both
=== CONT  TestFlattenGeneric/map_block_key_ptr_source
=== CONT  TestFlattenGeneric/map_block_key_set
=== CONT  TestFlattenGeneric/map_block_key_list
=== CONT  TestFlattenGeneric/nested_object_map
=== CONT  TestFlattenGeneric/nested_string_map
=== CONT  TestFlattenGeneric/object_map_ptr_source_and_target
=== CONT  TestFlattenGeneric/object_map_ptr_target
=== CONT  TestFlattenGeneric/map_string
=== CONT  TestFlattenGeneric/object_map_ptr_source
=== CONT  TestFlattenGeneric/non-empty_[]struct_and_non-empty_set_Target
=== CONT  TestFlattenGeneric/non-empty_[]*struct_and_non-empty_set_Target
=== CONT  TestFlattenGeneric/non-empty_[]*struct_and_non-empty_list_Target
=== CONT  TestFlattenGeneric/empty_[]*struct_and_empty_set_Target
=== CONT  TestFlattenGeneric/empty_[]*struct_and_empty_list_Target
=== CONT  TestFlattenGeneric/nil_[]*struct_and_null_set_Target
=== CONT  TestFlattenGeneric/nil_[]*struct_and_null_list_Target
=== CONT  TestFlattenGeneric/object_map
=== CONT  TestFlattenGeneric/nil_[]struct_and_null_set_Target
=== CONT  TestFlattenGeneric/empty_[]struct_and_empty_list_Target
=== CONT  TestFlattenGeneric/non-empty_[]struct_and_non-empty_list_Target
=== CONT  TestFlattenGeneric/*struct_Source_and_single_set_Target
=== CONT  TestFlattenGeneric/nil_[]struct_and_null_list_Target
=== CONT  TestFlattenGeneric/empty_[]struct_and_empty_struct_Target
=== CONT  TestFlattenGeneric/*struct_Source_and_single_list_Target
=== CONT  TestFlattenFrameworkStringValueList/zero_elements
=== CONT  TestFlattenFrameworkStringValueList/two_elements
=== CONT  TestFlattenFrameworkStringValueList/nil_array
=== CONT  TestExpandGeneric/single_list_Source_and_*struct_Target
--- PASS: TestFlattenGeneric (0.00s)
    --- PASS: TestFlattenGeneric/nil_*struct_Source_and_single_list_Target (0.00s)
    --- PASS: TestFlattenGeneric/complex_Source_and_complex_Target (0.00s)
    --- PASS: TestFlattenGeneric/map_block_enum_key (0.00s)
    --- PASS: TestFlattenGeneric/complex_nesting (0.00s)
    --- PASS: TestFlattenGeneric/map_block_key_ptr_both (0.00s)
    --- PASS: TestFlattenGeneric/map_block_key_ptr_source (0.00s)
    --- PASS: TestFlattenGeneric/map_block_key_list (0.00s)
    --- PASS: TestFlattenGeneric/map_block_key_set (0.00s)
    --- PASS: TestFlattenGeneric/nested_string_map (0.00s)
    --- PASS: TestFlattenGeneric/nested_object_map (0.00s)
    --- PASS: TestFlattenGeneric/object_map_ptr_source_and_target (0.00s)
    --- PASS: TestFlattenGeneric/object_map_ptr_target (0.00s)
    --- PASS: TestFlattenGeneric/map_string (0.00s)
    --- PASS: TestFlattenGeneric/object_map_ptr_source (0.00s)
    --- PASS: TestFlattenGeneric/non-empty_[]struct_and_non-empty_set_Target (0.00s)
    --- PASS: TestFlattenGeneric/non-empty_[]*struct_and_non-empty_set_Target (0.00s)
    --- PASS: TestFlattenGeneric/non-empty_[]*struct_and_non-empty_list_Target (0.00s)
    --- PASS: TestFlattenGeneric/empty_[]*struct_and_empty_set_Target (0.00s)
    --- PASS: TestFlattenGeneric/nil_[]*struct_and_null_set_Target (0.00s)
    --- PASS: TestFlattenGeneric/empty_[]*struct_and_empty_list_Target (0.00s)
    --- PASS: TestFlattenGeneric/nil_[]*struct_and_null_list_Target (0.00s)
    --- PASS: TestFlattenGeneric/object_map (0.00s)
    --- PASS: TestFlattenGeneric/nil_[]struct_and_null_set_Target (0.00s)
    --- PASS: TestFlattenGeneric/empty_[]struct_and_empty_list_Target (0.00s)
    --- PASS: TestFlattenGeneric/non-empty_[]struct_and_non-empty_list_Target (0.00s)
    --- PASS: TestFlattenGeneric/*struct_Source_and_single_set_Target (0.00s)
    --- PASS: TestFlattenGeneric/nil_[]struct_and_null_list_Target (0.00s)
    --- PASS: TestFlattenGeneric/empty_[]struct_and_empty_struct_Target (0.00s)
    --- PASS: TestFlattenGeneric/*struct_Source_and_single_list_Target (0.00s)
--- PASS: TestFlattenFrameworkStringValueList (0.00s)
    --- PASS: TestFlattenFrameworkStringValueList/zero_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringValueList/two_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringValueList/nil_array (0.00s)
=== CONT  TestExpandGeneric/map_string
=== CONT  TestExpandGeneric/map_block_enum_key
=== CONT  TestExpandGeneric/complex_nesting
=== CONT  TestExpandGeneric/map_block_key_ptr_both
=== CONT  TestExpandGeneric/map_block_key_ptr_source
=== CONT  TestExpandGeneric/map_block_key_set
=== CONT  TestExpandGeneric/map_block_key_list
=== CONT  TestExpandGeneric/nested_object_map
=== CONT  TestExpandGeneric/nested_string_map
=== CONT  TestExpandGeneric/object_map_ptr_source_and_target
=== CONT  TestExpandGeneric/object_map_ptr_target
=== CONT  TestExpandGeneric/empty_list_Source_and_empty_[]struct_Target#01
=== CONT  TestExpandGeneric/object_map
=== CONT  TestExpandGeneric/complex_Source_and_complex_Target
=== CONT  TestExpandGeneric/non-empty_set_Source_and_non-empty_[]struct_Target
=== CONT  TestExpandGeneric/non-empty_set_Source_and_non-empty_[]*struct_Target
=== CONT  TestExpandGeneric/empty_set_Source_and_empty_[]*struct_Target
=== CONT  TestExpandGeneric/non-empty_list_Source_and_non-empty_[]struct_Target#01
=== CONT  TestExpandGeneric/non-empty_list_Source_and_non-empty_[]struct_Target
=== CONT  TestExpandGeneric/empty_list_Source_and_empty_[]*struct_Target
=== CONT  TestExpandGeneric/single_set_Source_and_*struct_Target
=== CONT  TestExpandGeneric/empty_list_Source_and_empty_[]struct_Target
=== CONT  TestExpandGeneric/non-empty_list_Source_and_non-empty_[]*struct_Target
--- PASS: TestExpandGeneric (0.00s)
    --- PASS: TestExpandGeneric/map_string (0.00s)
    --- PASS: TestExpandGeneric/single_list_Source_and_*struct_Target (0.00s)
    --- PASS: TestExpandGeneric/map_block_enum_key (0.00s)
    --- PASS: TestExpandGeneric/complex_nesting (0.00s)
    --- PASS: TestExpandGeneric/map_block_key_ptr_both (0.00s)
    --- PASS: TestExpandGeneric/map_block_key_ptr_source (0.00s)
    --- PASS: TestExpandGeneric/map_block_key_set (0.00s)
    --- PASS: TestExpandGeneric/map_block_key_list (0.00s)
    --- PASS: TestExpandGeneric/nested_object_map (0.00s)
    --- PASS: TestExpandGeneric/nested_string_map (0.00s)
    --- PASS: TestExpandGeneric/object_map_ptr_source_and_target (0.00s)
    --- PASS: TestExpandGeneric/object_map_ptr_target (0.00s)
    --- PASS: TestExpandGeneric/empty_list_Source_and_empty_[]struct_Target#01 (0.00s)
    --- PASS: TestExpandGeneric/object_map (0.00s)
    --- PASS: TestExpandGeneric/non-empty_set_Source_and_non-empty_[]struct_Target (0.00s)
    --- PASS: TestExpandGeneric/complex_Source_and_complex_Target (0.00s)
    --- PASS: TestExpandGeneric/empty_set_Source_and_empty_[]*struct_Target (0.00s)
    --- PASS: TestExpandGeneric/non-empty_set_Source_and_non-empty_[]*struct_Target (0.00s)
    --- PASS: TestExpandGeneric/non-empty_list_Source_and_non-empty_[]struct_Target#01 (0.00s)
    --- PASS: TestExpandGeneric/empty_list_Source_and_empty_[]*struct_Target (0.00s)
    --- PASS: TestExpandGeneric/non-empty_list_Source_and_non-empty_[]struct_Target (0.00s)
    --- PASS: TestExpandGeneric/empty_list_Source_and_empty_[]struct_Target (0.00s)
    --- PASS: TestExpandGeneric/single_set_Source_and_*struct_Target (0.00s)
    --- PASS: TestExpandGeneric/non-empty_list_Source_and_non-empty_[]*struct_Target (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/framework/flex	3.638s
```