### PR TITLE
resource/aws_secretsmanager_secret_rotation: Fix bug with updates

### DIFF
--- a/.changelog/35024.txt
+++ b/.changelog/35024.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_secretsmanager_secret_rotation: No longer ignores changes to `rotation_rules.automatically_after_days` when `rotation_rules.schedule_expression` is set.
+```

--- a/internal/service/secretsmanager/secret_version.go
+++ b/internal/service/secretsmanager/secret_version.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -78,7 +79,8 @@ func resourceSecretVersionCreate(ctx context.Context, d *schema.ResourceData, me
 	secretID := d.Get("secret_id").(string)
 
 	input := &secretsmanager.PutSecretValueInput{
-		SecretId: aws.String(secretID),
+		ClientRequestToken: aws.String(id.UniqueId()), // Needed because we're handling our own retries
+		SecretId:           aws.String(secretID),
 	}
 
 	if v, ok := d.GetOk("secret_string"); ok {


### PR DESCRIPTION
### Description

Due to a `DiffSuppressFunc`, changes to `rotation_rules.automatically_after_days` were incorrectly ignored if `rotation_rules.schedule_expression` was set.

Also adds required `ClientRequestToken` for idempotent requests.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=secretsmanager TESTS=TestAccSecretsManagerSecretRotation_

--- PASS: TestAccSecretsManagerSecretRotation_basic (41.36s)
--- PASS: TestAccSecretsManagerSecretRotation_scheduleExpressionToDays (52.99s)
--- PASS: TestAccSecretsManagerSecretRotation_scheduleExpression (54.47s)
--- PASS: TestAccSecretsManagerSecretRotation_duration (56.11s)
--- PASS: TestAccSecretsManagerSecretRotation_scheduleExpressionHours (61.52s)
```

```console
% make testacc PKG=secretsmanager TESTS=TestAccSecretsManagerSecret_

--- PASS: TestAccSecretsManagerSecret_withNamePrefix (29.99s)
--- PASS: TestAccSecretsManagerSecret_basic (30.28s)
--- PASS: TestAccSecretsManagerSecret_basicReplica (38.60s)
--- PASS: TestAccSecretsManagerSecret_description (44.14s)
--- PASS: TestAccSecretsManagerSecret_RecoveryWindowInDays_recreate (44.82s)
--- PASS: TestAccSecretsManagerSecret_kmsKeyID (44.85s)
--- PASS: TestAccSecretsManagerSecret_tags (54.74s)
--- PASS: TestAccSecretsManagerSecret_policy (59.23s)
--- PASS: TestAccSecretsManagerSecret_overwriteReplica (89.74s)
```

```console
% make testacc PKG=secretsmanager TESTS=TestAccSecretsManagerSecretVersion_

--- PASS: TestAccSecretsManagerSecretVersion_base64Binary (15.15s)
--- PASS: TestAccSecretsManagerSecretVersion_basicString (15.15s)
--- PASS: TestAccSecretsManagerSecretVersion_versionStages (30.67s)
```
