### PR TITLE
[WIP] Fix error when LB Rule action contains both `target_group_arn` and `forward`

### DIFF
--- a/internal/errs/sdkdiag/diags.go
+++ b/internal/errs/sdkdiag/diags.go
@@ -31,12 +31,16 @@ func severityFilter(s diag.Severity) tfslices.Predicate[diag.Diagnostic] {
 	}
 }
 
+func DiagnosticError(diag diag.Diagnostic) error {
+	return errors.New(DiagnosticString(diag))
+}
+
 // DiagnosticsError returns an error containing all Diagnostic with SeverityError
 func DiagnosticsError(diags diag.Diagnostics) error {
 	var errs []error
 
 	for _, d := range Errors(diags) {
-		errs = append(errs, errors.New(DiagnosticString(d)))
+		errs = append(errs, DiagnosticError(d))
 	}
 
 	return errors.Join(errs...)

--- a/internal/service/elbv2/listener_rule.go
+++ b/internal/service/elbv2/listener_rule.go
@@ -509,7 +509,7 @@ func resourceListenerRuleCreate(ctx context.Context, d *schema.ResourceData, met
 
 	var err error
 
-	input.Actions, err = expandLbListenerActions(d.Get("action").([]interface{}))
+	input.Actions, err = expandLbListenerActions(d, d.Get("action").([]any))
 	if err != nil {
 		return sdkdiag.AppendFromErr(diags, err)
 	}
@@ -802,7 +802,7 @@ func resourceListenerRuleUpdate(ctx context.Context, d *schema.ResourceData, met
 
 		if d.HasChange("action") {
 			var err error
-			input.Actions, err = expandLbListenerActions(d.Get("action").([]interface{}))
+			input.Actions, err = expandLbListenerActions(d, d.Get("action").([]interface{}))
 			if err != nil {
 				return sdkdiag.AppendFromErr(diags, err)
 			}


### PR DESCRIPTION
Fixes error when LB Rule action contains both `target_group_arn` and `forward`. While specifying both values is technically valid in the API, the logic in the provider ignores `forward` if `target_group_arn` is set.

This PR will disallow setting both.

Currently implemented for `aws_lb_listener`, but contains errors in plan-time validation. Needs to also be implemented for `aws_lb_listener_rule`

### Relations

Closes #22526

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
