### PR TITLE
Fix unsupported properties for lambda compute types in `codebuild`.

### DIFF
--- a/.changelog/35043.txt
+++ b/.changelog/35043.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_codebuild_project: Prevent erroneous diffs on `build_timeout` and `queued_timeout` for Lambda compute types
+```

--- a/internal/service/codebuild/project.go
+++ b/internal/service/codebuild/project.go
@@ -629,6 +629,15 @@ func ResourceProject() *schema.Resource {
 				Optional:     true,
 				Default:      60,
 				ValidateFunc: validation.IntBetween(5, 480),
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if d.Get("environment.0.type") == codebuild.EnvironmentTypeArmLambdaContainer {
+						return true
+					}
+					if d.Get("environment.0.type") == codebuild.EnvironmentTypeLinuxLambdaContainer {
+						return true
+					}
+					return false
+				},
 			},
 			"queued_timeout": {
 				Type:         schema.TypeInt,

--- a/internal/service/codebuild/project.go
+++ b/internal/service/codebuild/project.go
@@ -635,6 +635,15 @@ func ResourceProject() *schema.Resource {
 				Optional:     true,
 				Default:      480,
 				ValidateFunc: validation.IntBetween(5, 480),
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if d.Get("environment.0.type") == codebuild.EnvironmentTypeArmLambdaContainer {
+						return true
+					}
+					if d.Get("environment.0.type") == codebuild.EnvironmentTypeLinuxLambdaContainer {
+						return true
+					}
+					return false
+				},
 			},
 			"badge_enabled": {
 				Type:     schema.TypeBool,

--- a/internal/service/codebuild/project_test.go
+++ b/internal/service/codebuild/project_test.go
@@ -1684,6 +1684,40 @@ func TestAccCodeBuildProject_armContainer(t *testing.T) {
 	})
 }
 
+func TestAccCodeBuildProject_linuxLambdaContainer(t *testing.T) {
+	ctx := acctest.Context(t)
+	var project codebuild.Project
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_codebuild_project.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, codebuild.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckProjectDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProjectConfig_linuxLambdaContainer(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProjectExists(ctx, resourceName, &project),
+					resource.TestCheckResourceAttr(resourceName, "environment.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "environment.0.compute_type", codebuild.ComputeTypeBuildLambda1gb),
+					resource.TestCheckResourceAttr(resourceName, "environment.0.environment_variable.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "environment.0.image", "aws/codebuild/amazonlinux-x86_64-lambda-standard:go1.21"),
+					resource.TestCheckResourceAttr(resourceName, "environment.0.privileged_mode", "false"),
+					resource.TestCheckResourceAttr(resourceName, "environment.0.image_pull_credentials_type", codebuild.ImagePullCredentialsTypeCodebuild),
+					resource.TestCheckResourceAttr(resourceName, "environment.0.type", codebuild.EnvironmentTypeLinuxLambdaContainer),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccCodeBuildProject_Artifacts_artifactIdentifier(t *testing.T) {
 	ctx := acctest.Context(t)
 	var project codebuild.Project
@@ -4266,6 +4300,30 @@ resource "aws_codebuild_project" "test" {
     compute_type = "BUILD_GENERAL1_LARGE"
     image        = "2"
     type         = "ARM_CONTAINER"
+  }
+
+  source {
+    location = %[2]q
+    type     = "GITHUB"
+  }
+}
+`, rName, testAccGitHubSourceLocationFromEnv()))
+}
+
+func testAccProjectConfig_linuxLambdaContainer(rName string) string {
+	return acctest.ConfigCompose(testAccProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
+resource "aws_codebuild_project" "test" {
+  name         = %[1]q
+  service_role = aws_iam_role.test.arn
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type = "BUILD_LAMBDA_1GB"
+    image        = "aws/codebuild/amazonlinux-x86_64-lambda-standard:go1.21"
+    type         = "LINUX_LAMBDA_CONTAINER"
   }
 
   source {

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -237,7 +237,7 @@ The following arguments are optional:
 
 * `badge_enabled` - (Optional) Generates a publicly-accessible URL for the projects build badge. Available as `badge_url` attribute when enabled.
 * `build_batch_config` - (Optional) Defines the batch build options for the project.
-* `build_timeout` - (Optional) Number of minutes, from 5 to 480 (8 hours), for AWS CodeBuild to wait until timing out any related build that does not get marked as completed. The default is 60 minutes.
+* `build_timeout` - (Optional) Number of minutes, from 5 to 480 (8 hours), for AWS CodeBuild to wait until timing out any related build that does not get marked as completed. The default is 60 minutes. The `build_timeout` property is not available on the `Lambda` compute type.
 * `cache` - (Optional) Configuration block. Detailed below.
 * `concurrent_build_limit` - (Optional) Specify a maximum number of concurrent builds for the project. The value specified must be greater than 0 and less than the account concurrent running builds limit.
 * `description` - (Optional) Short description of the project.
@@ -246,7 +246,7 @@ The following arguments are optional:
 * `logs_config` - (Optional) Configuration block. Detailed below.
 * `project_visibility` - (Optional) Specifies the visibility of the project's builds. Possible values are: `PUBLIC_READ` and `PRIVATE`. Default value is `PRIVATE`.
 * `resource_access_role` - The ARN of the IAM role that enables CodeBuild to access the CloudWatch Logs and Amazon S3 artifacts for the project's builds.
-* `queued_timeout` - (Optional) Number of minutes, from 5 to 480 (8 hours), a build is allowed to be queued before it times out. The default is 8 hours.
+* `queued_timeout` - (Optional) Number of minutes, from 5 to 480 (8 hours), a build is allowed to be queued before it times out. The default is 8 hours. The `queued_timeout` property is not available on the `Lambda` compute type.
 * `secondary_artifacts` - (Optional) Configuration block. Detailed below.
 * `secondary_sources` - (Optional) Configuration block. Detailed below.
 * `secondary_source_version` - (Optional) Configuration block. Detailed below.
@@ -288,13 +288,13 @@ The following arguments are optional:
 ### environment
 
 * `certificate` - (Optional) ARN of the S3 bucket, path prefix and object key that contains the PEM-encoded certificate.
-* `compute_type` - (Required) Information about the compute resources the build project will use. Valid values: `BUILD_GENERAL1_SMALL`, `BUILD_GENERAL1_MEDIUM`, `BUILD_GENERAL1_LARGE`, `BUILD_GENERAL1_2XLARGE`. `BUILD_GENERAL1_SMALL` is only valid if `type` is set to `LINUX_CONTAINER`. When `type` is set to `LINUX_GPU_CONTAINER`, `compute_type` must be `BUILD_GENERAL1_LARGE`.
+* `compute_type` - (Required) Information about the compute resources the build project will use. Valid values: `BUILD_GENERAL1_SMALL`, `BUILD_GENERAL1_MEDIUM`, `BUILD_GENERAL1_LARGE`, `BUILD_GENERAL1_2XLARGE`, `BUILD_LAMBDA_1GB`, `BUILD_LAMBDA_2GB`, `BUILD_LAMBDA_4GB`, `BUILD_LAMBDA_8GB`, `BUILD_LAMBDA_10GB`. `BUILD_GENERAL1_SMALL` is only valid if `type` is set to `LINUX_CONTAINER`. When `type` is set to `LINUX_GPU_CONTAINER`, `compute_type` must be `BUILD_GENERAL1_LARGE`. When `type` is set to `LINUX_LAMBDA_CONTAINER` or `ARM_LAMBDA_CONTAINER`, `compute_type` must be `BUILD_LAMBDA_XGB`.`
 * `environment_variable` - (Optional) Configuration block. Detailed below.
 * `image_pull_credentials_type` - (Optional) Type of credentials AWS CodeBuild uses to pull images in your build. Valid values: `CODEBUILD`, `SERVICE_ROLE`. When you use a cross-account or private registry image, you must use SERVICE_ROLE credentials. When you use an AWS CodeBuild curated image, you must use CodeBuild credentials. Defaults to `CODEBUILD`.
 * `image` - (Required) Docker image to use for this build project. Valid values include [Docker images provided by CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-available.html) (e.g `aws/codebuild/amazonlinux2-x86_64-standard:4.0`), [Docker Hub images](https://hub.docker.com/) (e.g., `hashicorp/terraform:latest`), and full Docker repository URIs such as those for ECR (e.g., `137112412989.dkr.ecr.us-west-2.amazonaws.com/amazonlinux:latest`).
 * `privileged_mode` - (Optional) Whether to enable running the Docker daemon inside a Docker container. Defaults to `false`.
 * `registry_credential` - (Optional) Configuration block. Detailed below.
-* `type` - (Required) Type of build environment to use for related builds. Valid values: `LINUX_CONTAINER`, `LINUX_GPU_CONTAINER`, `WINDOWS_CONTAINER` (deprecated), `WINDOWS_SERVER_2019_CONTAINER`, `ARM_CONTAINER`. For additional information, see the [CodeBuild User Guide](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-compute-types.html).
+* `type` - (Required) Type of build environment to use for related builds. Valid values: `LINUX_CONTAINER`, `LINUX_GPU_CONTAINER`, `WINDOWS_CONTAINER` (deprecated), `WINDOWS_SERVER_2019_CONTAINER`, `ARM_CONTAINER`, `LINUX_LAMBDA_CONTAINER`, `ARM_LAMBDA_CONTAINER`. For additional information, see the [CodeBuild User Guide](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-compute-types.html).
 
 #### environment: environment_variable
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
- In November, AWS CodeBuild released the ability to build using the Lambda runtime.
- Lambda runtime does not have a `queued_timeout` `build_timeout` property.
- However, due to the `build_timeout`, `queue_timeout` default, it tries to assign a default value every time you replace Compute_Type with Lambda, resulting in an error.

```
	"queued_timeout": {
		Type:         schema.TypeInt,
		Optional:     true,
		Default:      480,
...
	"build_timeout": {
		Type:         schema.TypeInt,
		Optional:     true,
		Default:      60,
}
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes 
--->

Closes #34376 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
#### Why doesn't the Lambda runtime have a `build_timeout`, `queued_timeout`?
- Since CodeBuild runs its own Container, it has a `queued_timeout` property that can handle exceptions until the Container runs.
- However, lambdas have a very short warm-up time, so they don't have that property.
URL
- https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/codebuild/types#EnvironmentType


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccCodeBuildProject_queuedTimeout PKG=codebuild
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/codebuild/... -v -count 1 -parallel 20 -run='TestAccCodeBuildProject_queuedTimeout'  -timeout 360m
=== RUN   TestAccCodeBuildProject_queuedTimeout
=== PAUSE TestAccCodeBuildProject_queuedTimeout
=== CONT  TestAccCodeBuildProject_queuedTimeout
--- PASS: TestAccCodeBuildProject_queuedTimeout (44.32s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codebuild  46.363s
...
% make testacc TESTS=TestAccCodeBuildProject_linuxLambdaContainer PKG=codebuild
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/codebuild/... -v -count 1 -parallel 20 -run='TestAccCodeBuildProject_linuxLambdaContainer'  -timeout 360m
=== RUN   TestAccCodeBuildProject_linuxLambdaContainer
=== PAUSE TestAccCodeBuildProject_linuxLambdaContainer
=== CONT  TestAccCodeBuildProject_linuxLambdaContainer
--- PASS: TestAccCodeBuildProject_linuxLambdaContainer (25.80s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codebuild  27.824s
...
```
