### PR TITLE
r/aws_ses_configuration_set: reflect `tracking_options` in state

### DIFF
--- a/.changelog/35056.txt
+++ b/.changelog/35056.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ses_configuration_set: Fix `tracking_options` being omitted from state and resulting in persistent diff
+```

--- a/internal/service/ses/configuration_set.go
+++ b/internal/service/ses/configuration_set.go
@@ -168,7 +168,9 @@ func resourceConfigurationSetRead(ctx context.Context, d *schema.ResourceData, m
 		ConfigurationSetName: aws.String(d.Id()),
 		ConfigurationSetAttributeNames: aws.StringSlice([]string{
 			ses.ConfigurationSetAttributeDeliveryOptions,
-			ses.ConfigurationSetAttributeReputationOptions}),
+			ses.ConfigurationSetAttributeReputationOptions,
+			ses.ConfigurationSetAttributeTrackingOptions,
+		}),
 	}
 
 	response, err := conn.DescribeConfigurationSetWithContext(ctx, configSetInput)

--- a/website/docs/r/ses_configuration_set.html.markdown
+++ b/website/docs/r/ses_configuration_set.html.markdown
@@ -12,6 +12,8 @@ Provides an SES configuration set resource.
 
 ## Example Usage
 
+### Basic Example
+
 ```terraform
 resource "aws_ses_configuration_set" "test" {
   name = "some-configuration-set-test"
@@ -26,6 +28,18 @@ resource "aws_ses_configuration_set" "test" {
 
   delivery_options {
     tls_policy = "Require"
+  }
+}
+```
+
+### Tracking Options
+
+```terraform
+resource "aws_ses_configuration_set" "test" {
+  name = "some-configuration-set-test"
+
+  tracking_options {
+    custom_redirect_domain = "sub.example.com"
   }
 }
 ```


### PR DESCRIPTION
### Description

This PR fixes a bug that caused omitting `tracking_options` from `aws_ses_configuration_set` state and resulted in persistent diff.

No acceptance tests added/updated as this functionality is best-effort. Tests would require a verified SES domain identity. Please see:
https://github.com/hashicorp/terraform-provider-aws/blob/5deca6413355b80d737a33f646223798dc0af2cc/internal/service/ses/configuration_set_test.go#L319-L320

Performed manual test instead:

```terraform
terraform {
  required_providers {
    aws = {
      source  = "hashicorp/aws"
      version = "~> 5.0"
    }
  }
}

provider "aws" {
  region = "eu-central-1"
}

variable "domain" {
  type = string
}

resource "aws_route53_zone" "this" {
  name = var.domain
}

resource "aws_ses_domain_identity" "this" {
  domain = var.domain
}

resource "aws_ses_domain_dkim" "this" {
  domain = aws_ses_domain_identity.this.domain
}

resource "aws_route53_record" "dkim_record" {
  count   = 3
  zone_id = aws_route53_zone.this.zone_id
  name    = "${aws_ses_domain_dkim.this.dkim_tokens[count.index]}._domainkey"
  type    = "CNAME"
  ttl     = "600"
  records = ["${aws_ses_domain_dkim.this.dkim_tokens[count.index]}.dkim.amazonses.com"]
}

resource "aws_ses_configuration_set" "this" {
  name  = "some-configuration-set-test"

  tracking_options {
    custom_redirect_domain = var.domain
  }
}
```

### Relations
Closes #26229.


### Output from Acceptance Testing
```console
% make testacc TESTARGS="-run=TestAccSESConfigurationSet_" PKG=ses 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ses/... -v -count 1 -parallel 20  -run=TestAccSESConfigurationSet_ -timeout 360m
=== RUN   TestAccSESConfigurationSet_basic
=== PAUSE TestAccSESConfigurationSet_basic
=== RUN   TestAccSESConfigurationSet_sendingEnabled
=== PAUSE TestAccSESConfigurationSet_sendingEnabled
=== RUN   TestAccSESConfigurationSet_reputationMetricsEnabled
=== PAUSE TestAccSESConfigurationSet_reputationMetricsEnabled
=== RUN   TestAccSESConfigurationSet_deliveryOptions
=== PAUSE TestAccSESConfigurationSet_deliveryOptions
=== RUN   TestAccSESConfigurationSet_Update_deliveryOptions
=== PAUSE TestAccSESConfigurationSet_Update_deliveryOptions
=== RUN   TestAccSESConfigurationSet_emptyDeliveryOptions
=== PAUSE TestAccSESConfigurationSet_emptyDeliveryOptions
=== RUN   TestAccSESConfigurationSet_Update_emptyDeliveryOptions
=== PAUSE TestAccSESConfigurationSet_Update_emptyDeliveryOptions
=== RUN   TestAccSESConfigurationSet_disappears
=== PAUSE TestAccSESConfigurationSet_disappears
=== CONT  TestAccSESConfigurationSet_basic
=== CONT  TestAccSESConfigurationSet_Update_deliveryOptions
=== CONT  TestAccSESConfigurationSet_disappears
=== CONT  TestAccSESConfigurationSet_reputationMetricsEnabled
=== CONT  TestAccSESConfigurationSet_deliveryOptions
=== CONT  TestAccSESConfigurationSet_emptyDeliveryOptions
=== CONT  TestAccSESConfigurationSet_sendingEnabled
=== CONT  TestAccSESConfigurationSet_Update_emptyDeliveryOptions
--- PASS: TestAccSESConfigurationSet_disappears (70.23s)
--- PASS: TestAccSESConfigurationSet_emptyDeliveryOptions (80.14s)
--- PASS: TestAccSESConfigurationSet_deliveryOptions (84.93s)
--- PASS: TestAccSESConfigurationSet_basic (85.04s)
--- PASS: TestAccSESConfigurationSet_sendingEnabled (152.32s)
--- PASS: TestAccSESConfigurationSet_reputationMetricsEnabled (153.95s)
--- PASS: TestAccSESConfigurationSet_Update_emptyDeliveryOptions (159.98s)
--- PASS: TestAccSESConfigurationSet_Update_deliveryOptions (187.10s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ses        189.370s
```
