### PR TITLE
Add support for KMS key ARN in AMP Workspace resource

### DIFF
--- a/.changelog/35062.txt
+++ b/.changelog/35062.txt
@@ -3,5 +3,5 @@ resource/aws_prometheus_workspace: Add `kms_key_arn` argument, enabling encrypti
 ```
 
 ```release-note:enhancement
-datasource/aws_prometheus_workspace: Add `kms_key_arn` attribute 
+data-source/aws_prometheus_workspace: Add `kms_key_arn` attribute 
 ```

--- a/.changelog/35062.txt
+++ b/.changelog/35062.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_prometheus_workspace: Add `kms_key_arn` argument, enabling encryption at-rest using AWS KMS Customer Managed Keys (CMK)
+```

--- a/.changelog/35062.txt
+++ b/.changelog/35062.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
 resource/aws_prometheus_workspace: Add `kms_key_arn` argument, enabling encryption at-rest using AWS KMS Customer Managed Keys (CMK)
 ```
+
+```release-note:enhancement
+datasource/aws_prometheus_workspace: Add `kms_key_arn` attribute 
+```

--- a/internal/service/amp/workspace.go
+++ b/internal/service/amp/workspace.go
@@ -51,6 +51,12 @@ func ResourceWorkspace() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"kms_key_arn": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidARN,
+			},
 			"logging_configuration": {
 				Type:     schema.TypeList,
 				MaxItems: 1,
@@ -86,6 +92,10 @@ func resourceWorkspaceCreate(ctx context.Context, d *schema.ResourceData, meta i
 
 	if v, ok := d.GetOk("alias"); ok {
 		input.Alias = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("kms_key_arn"); ok {
+		input.KmsKeyArn = aws.String(v.(string))
 	}
 
 	result, err := conn.CreateWorkspaceWithContext(ctx, input)
@@ -139,6 +149,7 @@ func resourceWorkspaceRead(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	d.Set("alias", ws.Alias)
+	d.Set("kms_key_arn", ws.KmsKeyArn)
 	arn := aws.StringValue(ws.Arn)
 	d.Set("arn", arn)
 	d.Set("prometheus_endpoint", ws.PrometheusEndpoint)

--- a/internal/service/amp/workspace.go
+++ b/internal/service/amp/workspace.go
@@ -149,9 +149,9 @@ func resourceWorkspaceRead(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	d.Set("alias", ws.Alias)
-	d.Set("kms_key_arn", ws.KmsKeyArn)
 	arn := aws.StringValue(ws.Arn)
 	d.Set("arn", arn)
+	d.Set("kms_key_arn", ws.KmsKeyArn)
 	d.Set("prometheus_endpoint", ws.PrometheusEndpoint)
 
 	loggingConfiguration, err := FindLoggingConfigurationByWorkspaceID(ctx, conn, d.Id())

--- a/internal/service/amp/workspace_data_source.go
+++ b/internal/service/amp/workspace_data_source.go
@@ -32,6 +32,10 @@ func DataSourceWorkspace() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"kms_key_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"prometheus_endpoint": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -67,6 +71,7 @@ func dataSourceWorkspaceRead(ctx context.Context, d *schema.ResourceData, meta i
 	d.Set("alias", workspace.Alias)
 	d.Set("arn", workspace.Arn)
 	d.Set("created_date", workspace.CreatedAt.Format(time.RFC3339))
+	d.Set("kms_key_arn", workspace.KmsKeyArn)
 	d.Set("prometheus_endpoint", workspace.PrometheusEndpoint)
 	d.Set("status", workspace.Status.StatusCode)
 

--- a/internal/service/amp/workspace_data_source_test.go
+++ b/internal/service/amp/workspace_data_source_test.go
@@ -34,6 +34,7 @@ func TestAccAMPWorkspaceDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "alias", dataSourceName, "alias"),
 					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "created_date"),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_key_arn", dataSourceName, "kms_key_arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "prometheus_endpoint", dataSourceName, "prometheus_endpoint"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "status"),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.%", dataSourceName, "tags.%"),

--- a/internal/service/amp/workspace_test.go
+++ b/internal/service/amp/workspace_test.go
@@ -39,6 +39,7 @@ func TestAccAMPWorkspace_basic(t *testing.T) {
 					testAccCheckWorkspaceExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "alias", ""),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "kms_key_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.#", "0"),
 					resource.TestCheckResourceAttrSet(resourceName, "prometheus_endpoint"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),

--- a/internal/service/amp/workspace_test.go
+++ b/internal/service/amp/workspace_test.go
@@ -79,6 +79,32 @@ func TestAccAMPWorkspace_disappears(t *testing.T) {
 	})
 }
 
+func TestAccAMPWorkspace_kms(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v prometheusservice.WorkspaceDescription
+	rName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_prometheus_workspace.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, prometheusservice.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, prometheusservice.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckWorkspaceDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWorkspaceConfig_kms(rName1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWorkspaceExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttrSet(resourceName, "kms_key_arn"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAMPWorkspace_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v prometheusservice.WorkspaceDescription
@@ -352,4 +378,18 @@ resource "aws_prometheus_workspace" "test" {
   }
 }
 `, rName, idx)
+}
+
+func testAccWorkspaceConfig_kms(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_prometheus_workspace" "test" {
+  alias       = %[1]q
+  kms_key_arn = aws_kms_key.test.arn
+}
+
+resource "aws_kms_key" "test" {
+  description             = "Test"
+  deletion_window_in_days = 7
+}
+`, rName)
 }

--- a/website/docs/d/prometheus_workspace.html.markdown
+++ b/website/docs/d/prometheus_workspace.html.markdown
@@ -34,6 +34,6 @@ This data source exports the following attributes in addition to the arguments a
 * `created_date` - Creation date of the Prometheus workspace.
 * `prometheus_endpoint` - Endpoint of the Prometheus workspace.
 * `alias` - Prometheus workspace alias.
-* `kms_key_arn` - ARN of the KMS key used to encrypt data in the Prometheus workspace. 
+* `kms_key_arn` - ARN of the KMS key used to encrypt data in the Prometheus workspace.
 * `status` - Status of the Prometheus workspace.
 * `tags` - Tags assigned to the resource.

--- a/website/docs/d/prometheus_workspace.html.markdown
+++ b/website/docs/d/prometheus_workspace.html.markdown
@@ -34,5 +34,6 @@ This data source exports the following attributes in addition to the arguments a
 * `created_date` - Creation date of the Prometheus workspace.
 * `prometheus_endpoint` - Endpoint of the Prometheus workspace.
 * `alias` - Prometheus workspace alias.
+* `kms_key_arn` - ARN of the KMS key used to encrypt data in the Prometheus workspace. 
 * `status` - Status of the Prometheus workspace.
 * `tags` - Tags assigned to the resource.

--- a/website/docs/r/prometheus_workspace.html.markdown
+++ b/website/docs/r/prometheus_workspace.html.markdown
@@ -36,11 +36,26 @@ resource "aws_prometheus_workspace" "example" {
 }
 ```
 
+### AWS KMS Customer Managed Keys (CMK)
+
+```terraform
+resource "aws_prometheus_workspace" "example" {
+  alias       = "example"
+  kms_key_arn = aws_kms_key.example.arn
+}
+
+resource "aws_kms_key" "example" {
+  description             = "example"
+  deletion_window_in_days = 7
+}
+```
+
 ## Argument Reference
 
 This resource supports the following arguments:
 
 * `alias` - (Optional) The alias of the prometheus workspace. See more [in AWS Docs](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-onboard-create-workspace.html).
+* `kms_key_arn` - (Optional) The ARN for the KMS encryption key. If this argument is not provided, then the AWS owned encryption key will be used to encrypt the data in the workspace. See more [in AWS Docs](https://docs.aws.amazon.com/prometheus/latest/userguide/encryption-at-rest-Amazon-Service-Prometheus.html)
 * `logging_configuration` - (Optional) Logging configuration for the workspace. See [Logging Configuration](#logging-configuration) below for details.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 


### PR DESCRIPTION
### Description
Implements AWS Key Management Service encryption for Amazon Managed Service for Prometheus Workspace

### Relations

Closes #35048

### References
[Encryption at rest](https://docs.aws.amazon.com/prometheus/latest/userguide/encryption-at-rest-Amazon-Service-Prometheus.html)

### Output from Acceptance Testing

```Console
make testacc TESTS=TestAccAMPWorkspace_kms PKG=amp
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/amp/... -v -count 1 -parallel 20 -run='TestAccAMPWorkspace_kms'  -timeout 360m
=== RUN   TestAccAMPWorkspace_kms
=== PAUSE TestAccAMPWorkspace_kms
=== CONT  TestAccAMPWorkspace_kms
--- PASS: TestAccAMPWorkspace_kms (29.89s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/amp        29.997s
```
