### PR TITLE
docs(lb_trust_store): fix reference description

### DIFF
--- a/website/docs/cdktf/python/r/lb_trust_store.html.markdown
+++ b/website/docs/cdktf/python/r/lb_trust_store.html.markdown
@@ -54,7 +54,7 @@ class MyConvertedCode(TerraformStack):
 This resource supports the following arguments:
 
 * `ca_certificates_bundle_s3_bucket` - (Required) S3 Bucket name holding the client certificate CA bundle.
-* `ca_certificates_bundle_s3_key` - (Required) S3 Bucket name holding the client certificate CA bundle.
+* `ca_certificates_bundle_s3_key` - (Required) S3 object key holding the client certificate CA bundle.
 * `ca_certificates_bundle_s3_object_version` - (Optional) Version Id of CA bundle S3 bucket object, if versioned, defaults to latest if omitted.
 
 * `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`. Cannot be longer than 6 characters.

--- a/website/docs/cdktf/python/r/lb_trust_store_revocation.html.markdown
+++ b/website/docs/cdktf/python/r/lb_trust_store_revocation.html.markdown
@@ -48,7 +48,7 @@ This resource supports the following arguments:
 
 * `trust_store_arn` - (Required) Trust Store ARN.
 * `revocations_s3_bucket` - (Required) S3 Bucket name holding the client certificate CA bundle.
-* `revocations_s3_key` - (Required) S3 Bucket name holding the client certificate CA bundle.
+* `revocations_s3_key` - (Required) S3 object key holding the client certificate CA bundle.
 * `revocations_s3_object_version` - (Optional) Version Id of CA bundle S3 bucket object, if versioned, defaults to latest if omitted.
 
 ## Attribute Reference

--- a/website/docs/r/lb_trust_store.html.markdown
+++ b/website/docs/r/lb_trust_store.html.markdown
@@ -43,7 +43,7 @@ resource "aws_lb_listener" "example" {
 This resource supports the following arguments:
 
 * `ca_certificates_bundle_s3_bucket` - (Required) S3 Bucket name holding the client certificate CA bundle.
-* `ca_certificates_bundle_s3_key` - (Required) S3 Bucket name holding the client certificate CA bundle.
+* `ca_certificates_bundle_s3_key` - (Required) S3 object key holding the client certificate CA bundle.
 * `ca_certificates_bundle_s3_object_version` - (Optional) Version Id of CA bundle S3 bucket object, if versioned, defaults to latest if omitted.
 
 * `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`. Cannot be longer than 6 characters.

--- a/website/docs/r/lb_trust_store_revocation.html.markdown
+++ b/website/docs/r/lb_trust_store_revocation.html.markdown
@@ -39,7 +39,7 @@ This resource supports the following arguments:
 
 * `trust_store_arn` - (Required) Trust Store ARN.
 * `revocations_s3_bucket` - (Required) S3 Bucket name holding the client certificate CA bundle.
-* `revocations_s3_key` - (Required) S3 Bucket name holding the client certificate CA bundle.
+* `revocations_s3_key` - (Required) S3 object key holding the client certificate CA bundle.
 * `revocations_s3_object_version` - (Optional) Version Id of CA bundle S3 bucket object, if versioned, defaults to latest if omitted.
 
 ## Attribute Reference


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

The `lb_trust_store` docs reference an S3 Bucket name for the `ca_certificates_bundle_s3_key` argument, when it should be an S3 Object key.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #35072

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

As can be confirmed in the test here, it is expected to be an object key, not a bucket name:

[terraform-provider-aws/internal/service/elbv2/trust_store_test.go](https://github.com/hashicorp/terraform-provider-aws/blob/5deca6413355b80d737a33f646223798dc0af2cc/internal/service/elbv2/trust_store_test.go#L304)
