### PR TITLE
Remove unnecessary depends_on+hard coded ID of dependency

### DIFF
--- a/website/docs/r/route.html.markdown
+++ b/website/docs/r/route.html.markdown
@@ -18,10 +18,9 @@ Provides a resource to create a routing table entry (a route) in a VPC routing t
 
 ```terraform
 resource "aws_route" "r" {
-  route_table_id            = "rtb-4fbb3ac4"
+  route_table_id            = aws_route_table.testing.id
   destination_cidr_block    = "10.0.1.0/22"
   vpc_peering_connection_id = "pcx-45ff3dc1"
-  depends_on                = [aws_route_table.testing]
 }
 ```
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The current example usage specifies a hard-coded route table ID, and then proceeds to use an explicit `depends_on` on the route table. Besides the fact that logically it doesn’t make sense since if it’s being deployed together you wouldn’t have the ID yet, `depends_on` shouldn’t be promoted in general as it can cause issues when used unnecessarily.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #35084

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->