### PR TITLE
feat(efs_file_system): lifecycle_policy transition_to_archive

### DIFF
--- a/.changelog/35096.txt
+++ b/.changelog/35096.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_efs_file_system: Add `lifecycle_policy.transition_to_archive` argument
+```
+
+```release-note:enhancement
+data-source/aws_efs_file_system: Add `lifecycle_policy.transition_to_archive` attribute
+```

--- a/internal/service/efs/file_system.go
+++ b/internal/service/efs/file_system.go
@@ -88,6 +88,11 @@ func ResourceFileSystem() *schema.Resource {
 				MaxItems: 2,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"transition_to_archive": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(efs.TransitionToArchiveRules_Values(), false),
+						},
 						"transition_to_ia": {
 							Type:         schema.TypeString,
 							Optional:     true,
@@ -97,11 +102,6 @@ func ResourceFileSystem() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ValidateFunc: validation.StringInSlice(efs.TransitionToPrimaryStorageClassRules_Values(), false),
-						},
-						"transition_to_archive": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.StringInSlice(efs.TransitionToArchiveRules_Values(), false),
 						},
 					},
 				},
@@ -480,16 +480,16 @@ func flattenFileSystemLifecyclePolicies(apiObjects []*efs.LifecyclePolicy) []int
 
 		tfMap := make(map[string]interface{})
 
+		if apiObject.TransitionToArchive != nil {
+			tfMap["transition_to_archive"] = aws.StringValue(apiObject.TransitionToArchive)
+		}
+
 		if apiObject.TransitionToIA != nil {
 			tfMap["transition_to_ia"] = aws.StringValue(apiObject.TransitionToIA)
 		}
 
 		if apiObject.TransitionToPrimaryStorageClass != nil {
 			tfMap["transition_to_primary_storage_class"] = aws.StringValue(apiObject.TransitionToPrimaryStorageClass)
-		}
-
-		if apiObject.TransitionToArchive != nil {
-			tfMap["transition_to_archive"] = aws.StringValue(apiObject.TransitionToArchive)
 		}
 
 		tfList = append(tfList, tfMap)
@@ -510,16 +510,16 @@ func expandFileSystemLifecyclePolicies(tfList []interface{}) []*efs.LifecyclePol
 
 		apiObject := &efs.LifecyclePolicy{}
 
+		if v, ok := tfMap["transition_to_archive"].(string); ok && v != "" {
+			apiObject.TransitionToArchive = aws.String(v)
+		}
+
 		if v, ok := tfMap["transition_to_ia"].(string); ok && v != "" {
 			apiObject.TransitionToIA = aws.String(v)
 		}
 
 		if v, ok := tfMap["transition_to_primary_storage_class"].(string); ok && v != "" {
 			apiObject.TransitionToPrimaryStorageClass = aws.String(v)
-		}
-
-		if v, ok := tfMap["transition_to_archive"].(string); ok && v != "" {
-			apiObject.TransitionToArchive = aws.String(v)
 		}
 
 		apiObjects = append(apiObjects, apiObject)

--- a/internal/service/efs/file_system.go
+++ b/internal/service/efs/file_system.go
@@ -98,6 +98,11 @@ func ResourceFileSystem() *schema.Resource {
 							Optional:     true,
 							ValidateFunc: validation.StringInSlice(efs.TransitionToPrimaryStorageClassRules_Values(), false),
 						},
+						"transition_to_archive": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(efs.TransitionToArchiveRules_Values(), false),
+						},
 					},
 				},
 			},
@@ -483,6 +488,10 @@ func flattenFileSystemLifecyclePolicies(apiObjects []*efs.LifecyclePolicy) []int
 			tfMap["transition_to_primary_storage_class"] = aws.StringValue(apiObject.TransitionToPrimaryStorageClass)
 		}
 
+		if apiObject.TransitionToArchive != nil {
+			tfMap["transition_to_archive"] = aws.StringValue(apiObject.TransitionToArchive)
+		}
+
 		tfList = append(tfList, tfMap)
 	}
 
@@ -507,6 +516,10 @@ func expandFileSystemLifecyclePolicies(tfList []interface{}) []*efs.LifecyclePol
 
 		if v, ok := tfMap["transition_to_primary_storage_class"].(string); ok && v != "" {
 			apiObject.TransitionToPrimaryStorageClass = aws.String(v)
+		}
+
+		if v, ok := tfMap["transition_to_archive"].(string); ok && v != "" {
+			apiObject.TransitionToArchive = aws.String(v)
 		}
 
 		apiObjects = append(apiObjects, apiObject)

--- a/internal/service/efs/file_system_data_source.go
+++ b/internal/service/efs/file_system_data_source.go
@@ -65,15 +65,15 @@ func DataSourceFileSystem() *schema.Resource {
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"transition_to_archive": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"transition_to_ia": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
 						"transition_to_primary_storage_class": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"transition_to_archive": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},

--- a/internal/service/efs/file_system_data_source.go
+++ b/internal/service/efs/file_system_data_source.go
@@ -73,6 +73,10 @@ func DataSourceFileSystem() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"transition_to_archive": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},

--- a/internal/service/efs/file_system_test.go
+++ b/internal/service/efs/file_system_test.go
@@ -648,7 +648,7 @@ resource "aws_efs_file_system" "test" {
   }
 
   lifecycle_policy {
-	%[3]s = %[4]q
+    %[3]s = %[4]q
   }
 }
 `, lpName1, lpVal1, lpName2, lpVal2)

--- a/internal/service/efs/file_system_test.go
+++ b/internal/service/efs/file_system_test.go
@@ -351,7 +351,9 @@ func TestAccEFSFileSystem_lifecyclePolicy(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFileSystem(ctx, resourceName, &desc),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.0.transition_to_archive", ""),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.0.transition_to_ia", efs.TransitionToIARulesAfter30Days),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.0.transition_to_primary_storage_class", ""),
 				),
 			},
 			{
@@ -367,6 +369,8 @@ func TestAccEFSFileSystem_lifecyclePolicy(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFileSystem(ctx, resourceName, &desc),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.0.transition_to_archive", ""),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.0.transition_to_ia", ""),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.0.transition_to_primary_storage_class", efs.TransitionToPrimaryStorageClassRulesAfter1Access),
 				),
 			},
@@ -387,8 +391,12 @@ func TestAccEFSFileSystem_lifecyclePolicy(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFileSystem(ctx, resourceName, &desc),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.0.transition_to_archive", ""),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.0.transition_to_ia", ""),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.0.transition_to_primary_storage_class", efs.TransitionToPrimaryStorageClassRulesAfter1Access),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.1.transition_to_archive", ""),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.1.transition_to_ia", efs.TransitionToIARulesAfter30Days),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.1.transition_to_primary_storage_class", ""),
 				),
 			},
 			{
@@ -401,8 +409,12 @@ func TestAccEFSFileSystem_lifecyclePolicy(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFileSystem(ctx, resourceName, &desc),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.0.transition_to_archive", ""),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.0.transition_to_ia", efs.TransitionToIARulesAfter30Days),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.0.transition_to_primary_storage_class", ""),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.1.transition_to_archive", efs.TransitionToArchiveRulesAfter60Days),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.1.transition_to_ia", ""),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.1.transition_to_primary_storage_class", ""),
 				),
 			},
 		},
@@ -439,9 +451,6 @@ func testAccCheckFileSystem(ctx context.Context, n string, v *efs.FileSystemDesc
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
-		}
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No EFS file system ID is set")
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).EFSConn(ctx)

--- a/internal/service/efs/file_system_test.go
+++ b/internal/service/efs/file_system_test.go
@@ -391,6 +391,20 @@ func TestAccEFSFileSystem_lifecyclePolicy(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.1.transition_to_ia", efs.TransitionToIARulesAfter30Days),
 				),
 			},
+			{
+				Config: testAccFileSystemConfig_lifecyclePolicyTransitionToArchive(
+					"transition_to_ia",
+					efs.TransitionToIARulesAfter30Days,
+					"transition_to_archive",
+					efs.TransitionToArchiveRulesAfter60Days,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFileSystem(ctx, resourceName, &desc),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.0.transition_to_ia", efs.TransitionToIARulesAfter30Days),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.1.transition_to_archive", efs.TransitionToArchiveRulesAfter60Days),
+				),
+			},
 		},
 	})
 }
@@ -619,6 +633,22 @@ resource "aws_efs_file_system" "test" {
 
   lifecycle_policy {
     %[3]s = %[4]q
+  }
+}
+`, lpName1, lpVal1, lpName2, lpVal2)
+}
+
+func testAccFileSystemConfig_lifecyclePolicyTransitionToArchive(lpName1, lpVal1, lpName2, lpVal2 string) string {
+	return fmt.Sprintf(`
+resource "aws_efs_file_system" "test" {
+  throughput_mode = "elastic"
+
+  lifecycle_policy {
+    %[1]s = %[2]q
+  }
+
+  lifecycle_policy {
+	%[3]s = %[4]q
   }
 }
 `, lpName1, lpVal1, lpName2, lpVal2)

--- a/website/docs/r/efs_file_system.html.markdown
+++ b/website/docs/r/efs_file_system.html.markdown
@@ -59,6 +59,7 @@ user guide for more information.
 
 * `transition_to_ia` - (Optional) Indicates how long it takes to transition files to the IA storage class. Valid values: `AFTER_1_DAY`, `AFTER_7_DAYS`, `AFTER_14_DAYS`, `AFTER_30_DAYS`, `AFTER_60_DAYS`, or `AFTER_90_DAYS`.
 * `transition_to_primary_storage_class` - (Optional) Describes the policy used to transition a file from infequent access storage to primary storage. Valid values: `AFTER_1_ACCESS`.
+* `transition_to_archive` - (Optional) Indicates how long it takes to transition files to the archive storage class. Requires transition_to_ia, Elastic Throughput and General Purpose performance mode. Valid values: `AFTER_1_DAY`, `AFTER_7_DAYS`, `AFTER_14_DAYS`, `AFTER_30_DAYS`, `AFTER_60_DAYS`, or `AFTER_90_DAYS`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
### Description
Implement transition_to_archive lifecycle policy in efs_file_system.


### Relations
Closes #35082 


```console
❯ make testacc TESTARGS="-run=TestAccEFSFileSystem_lifecyclePolicy\|TestAccEFSFileSystemDataSource_id" PKG=efs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/efs/... -v -count 1 -parallel 20  -run=TestAccEFSFileSystem_lifecyclePolicy\|TestAccEFSFileSystemDataSource_id -timeout 360m
=== RUN   TestAccEFSFileSystemDataSource_id
=== PAUSE TestAccEFSFileSystemDataSource_id
=== RUN   TestAccEFSFileSystem_lifecyclePolicy
=== PAUSE TestAccEFSFileSystem_lifecyclePolicy
=== CONT  TestAccEFSFileSystemDataSource_id
=== CONT  TestAccEFSFileSystem_lifecyclePolicy
--- PASS: TestAccEFSFileSystemDataSource_id (31.59s)
--- PASS: TestAccEFSFileSystem_lifecyclePolicy (101.01s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/efs        103.811s
```
