### PR TITLE
`r/aws_route53_resolver_endpoint`: add `protocols`

### DIFF
--- a/.changelog/35098.txt
+++ b/.changelog/35098.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
-resource/aws_route53_resolver_endpoint: Add `protocols` attribute
+resource/aws_route53_resolver_endpoint: Add `protocols` argument
+```
+
+```release-note:enhancement
+data-source/aws_route53_resolver_endpoint: Add `protocols` attribute
 ```

--- a/.changelog/35098.txt
+++ b/.changelog/35098.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_route53_resolver_endpoint: Add `protocols` attribute
+```

--- a/internal/service/route53resolver/endpoint.go
+++ b/internal/service/route53resolver/endpoint.go
@@ -97,6 +97,7 @@ func ResourceEndpoint() *schema.Resource {
 			"protocols": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				MinItems: 1,
 				MaxItems: 2,
 				Elem: &schema.Schema{

--- a/internal/service/route53resolver/endpoint.go
+++ b/internal/service/route53resolver/endpoint.go
@@ -97,10 +97,16 @@ func ResourceEndpoint() *schema.Resource {
 			"protocols": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				ForceNew: true,
 				MinItems: 1,
 				MaxItems: 2,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					ValidateFunc: validation.StringInSlice([]string{
+						route53resolver.ProtocolDo53,
+						route53resolver.ProtocolDoH,
+						route53resolver.ProtocolDoHFips,
+					}, false),
+				},
 			},
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),

--- a/internal/service/route53resolver/endpoint_data_source.go
+++ b/internal/service/route53resolver/endpoint_data_source.go
@@ -54,6 +54,11 @@ func DataSourceEndpoint() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"protocols": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
 			"resolver_endpoint_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -115,6 +120,7 @@ func dataSourceEndpointRead(ctx context.Context, d *schema.ResourceData, meta in
 	d.Set("arn", ep.Arn)
 	d.Set("direction", ep.Direction)
 	d.Set("name", ep.Name)
+	d.Set("protocols", aws.StringValueSlice(ep.Protocols))
 	d.Set("resolver_endpoint_id", ep.Id)
 	d.Set("status", ep.Status)
 	d.Set("vpc_id", ep.HostVPCId)

--- a/internal/service/route53resolver/endpoint_data_source_test.go
+++ b/internal/service/route53resolver/endpoint_data_source_test.go
@@ -31,6 +31,7 @@ func TestAccRoute53ResolverEndpointDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, "id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(datasourceName, "ip_addresses.#", resourceName, "ip_address.#"),
 					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "protocols.#", resourceName, "protocols.#"),
 					resource.TestCheckResourceAttrPair(datasourceName, "resolver_endpoint_id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(datasourceName, "vpc_id", resourceName, "host_vpc_id"),
 				),

--- a/internal/service/route53resolver/endpoint_test.go
+++ b/internal/service/route53resolver/endpoint_test.go
@@ -152,6 +152,7 @@ func TestAccRoute53ResolverEndpoint_updateOutbound(t *testing.T) {
 					testAccCheckEndpointExists(ctx, resourceName, &ep),
 					resource.TestCheckResourceAttr(resourceName, "direction", "OUTBOUND"),
 					resource.TestCheckResourceAttr(resourceName, "ip_address.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "protocols.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
 				),
 			},
@@ -377,6 +378,7 @@ resource "aws_route53_resolver_endpoint" "test" {
   ip_address {
     subnet_id = aws_subnet.test[0].id
   }
+  protocols = ["Do53", "DoH"]
 }
 `, name))
 }

--- a/internal/service/route53resolver/endpoint_test.go
+++ b/internal/service/route53resolver/endpoint_test.go
@@ -40,6 +40,7 @@ func TestAccRoute53ResolverEndpoint_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "host_vpc_id", vpcResourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "ip_address.#", "3"),
 					resource.TestCheckResourceAttr(resourceName, "name", ""),
+					resource.TestCheckResourceAttr(resourceName, "protocols.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "security_group_ids.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
@@ -144,6 +145,7 @@ func TestAccRoute53ResolverEndpoint_updateOutbound(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "direction", "OUTBOUND"),
 					resource.TestCheckResourceAttr(resourceName, "ip_address.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "name", initialName),
+					resource.TestCheckResourceAttr(resourceName, "protocols.#", "1"),
 				),
 			},
 			{
@@ -152,8 +154,8 @@ func TestAccRoute53ResolverEndpoint_updateOutbound(t *testing.T) {
 					testAccCheckEndpointExists(ctx, resourceName, &ep),
 					resource.TestCheckResourceAttr(resourceName, "direction", "OUTBOUND"),
 					resource.TestCheckResourceAttr(resourceName, "ip_address.#", "3"),
-					resource.TestCheckResourceAttr(resourceName, "protocols.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "protocols.#", "2"),
 				),
 			},
 		},
@@ -378,6 +380,7 @@ resource "aws_route53_resolver_endpoint" "test" {
   ip_address {
     subnet_id = aws_subnet.test[0].id
   }
+
   protocols = ["Do53", "DoH"]
 }
 `, name))

--- a/website/docs/d/route53_resolver_endpoint.html.markdown
+++ b/website/docs/d/route53_resolver_endpoint.html.markdown
@@ -41,6 +41,7 @@ In addition to all arguments above, the following attributes are exported:
 * `arn` - Computed ARN of the Route53 Resolver Endpoint.
 * `direction` - Direction of the queries to or from the Resolver Endpoint .
 * `ip_addresses` - List of IPaddresses that have been associated with the Resolver Endpoint.
+* `protocols` - The protocols used by Resolver endpoint.
 * `status` - Current status of the Resolver Endpoint.
 * `vpc_id` - ID of the Host VPC that the Resolver Endpoint resides in.
 

--- a/website/docs/r/route53_resolver_endpoint.html.markdown
+++ b/website/docs/r/route53_resolver_endpoint.html.markdown
@@ -50,7 +50,7 @@ or `OUTBOUND` (resolver forwards DNS queries from the DNS service for a VPC to y
 to your network (for outbound endpoints) or on the way from your network to your VPCs (for inbound endpoints). Described below.
 * `security_group_ids` - (Required) The ID of one or more security groups that you want to use to control access to this VPC.
 * `name` - (Optional) The friendly name of the Route 53 Resolver endpoint.
-* `protocols` - (Optional) The protocols you want to use for the Route 53 Resolver endpoint. 
+* `protocols` - (Optional) The protocols you want to use for the Route 53 Resolver endpoint.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 The `ip_address` object supports the following:

--- a/website/docs/r/route53_resolver_endpoint.html.markdown
+++ b/website/docs/r/route53_resolver_endpoint.html.markdown
@@ -31,6 +31,8 @@ resource "aws_route53_resolver_endpoint" "foo" {
     ip        = "10.0.64.4"
   }
 
+  protocols = ["Do53", "DoH"]
+
   tags = {
     Environment = "Prod"
   }
@@ -48,6 +50,7 @@ or `OUTBOUND` (resolver forwards DNS queries from the DNS service for a VPC to y
 to your network (for outbound endpoints) or on the way from your network to your VPCs (for inbound endpoints). Described below.
 * `security_group_ids` - (Required) The ID of one or more security groups that you want to use to control access to this VPC.
 * `name` - (Optional) The friendly name of the Route 53 Resolver endpoint.
+* `protocols` - (Optional) The protocols you want to use for the Route 53 Resolver endpoint. 
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 The `ip_address` object supports the following:

--- a/website/docs/r/route53_resolver_endpoint.html.markdown
+++ b/website/docs/r/route53_resolver_endpoint.html.markdown
@@ -50,7 +50,7 @@ or `OUTBOUND` (resolver forwards DNS queries from the DNS service for a VPC to y
 to your network (for outbound endpoints) or on the way from your network to your VPCs (for inbound endpoints). Described below.
 * `security_group_ids` - (Required) The ID of one or more security groups that you want to use to control access to this VPC.
 * `name` - (Optional) The friendly name of the Route 53 Resolver endpoint.
-* `protocols` - (Optional) The protocols you want to use for the Route 53 Resolver endpoint.
+* `protocols` - (Optional) The protocols you want to use for the Route 53 Resolver endpoint. Valid values: `DoH`, `Do53`, `DoH-FIPS`.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 The `ip_address` object supports the following:


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

Adds `protocols` as an option in `aws_route53_resolver_endpoint`.

Closes #35047

### References
[UpdateResolverEndpoint API](https://docs.aws.amazon.com/Route53/latest/APIReference/API_route53resolver_UpdateResolverEndpoint.html#API_route53resolver_UpdateResolverEndpoint_RequestSyntax)

### Output from Acceptance Testing
```console
% make testacc TESTS=TestAccRoute53ResolverEndpoint_updateOutbound PKG=route53resolver
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/route53resolver/... -v -count 1 -parallel 20 -run='TestAccRoute53ResolverEndpoint_updateOutbound'  -timeout 360m
=== RUN   TestAccRoute53ResolverEndpoint_updateOutbound
=== PAUSE TestAccRoute53ResolverEndpoint_updateOutbound
=== CONT  TestAccRoute53ResolverEndpoint_updateOutbound
--- PASS: TestAccRoute53ResolverEndpoint_updateOutbound (386.94s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53resolver    388.899s
```
