### PR TITLE
Add rotate_immediately argument to secret rotation

### DIFF
--- a/.changelog/35105.txt
+++ b/.changelog/35105.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_secretsmanager_secret_rotation: Add `rotate_immediatley` argument.
+```

--- a/.changelog/35105.txt
+++ b/.changelog/35105.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_secretsmanager_secret_rotation: Add `rotate_immediatley` argument.
+resource/aws_secretsmanager_secret_rotation: Add `rotate_immediately` argument.
 ```

--- a/internal/service/secretsmanager/secret_rotation.go
+++ b/internal/service/secretsmanager/secret_rotation.go
@@ -38,6 +38,11 @@ func ResourceSecretRotation() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+			"rotate_immediatley": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
 			"rotation_lambda_arn": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -87,6 +92,7 @@ func resourceSecretRotationCreate(ctx context.Context, d *schema.ResourceData, m
 
 	input := &secretsmanager.RotateSecretInput{
 		ClientRequestToken: aws.String(id.UniqueId()), // Needed because we're handling our own retries
+		RotateImmediately:  aws.Bool(d.Get("rotate_immediatley").(bool)),
 		RotationRules:      expandRotationRules(d.Get("rotation_rules").([]interface{})),
 		SecretId:           aws.String(secretID),
 	}
@@ -149,9 +155,10 @@ func resourceSecretRotationUpdate(ctx context.Context, d *schema.ResourceData, m
 	conn := meta.(*conns.AWSClient).SecretsManagerConn(ctx)
 	secretID := d.Get("secret_id").(string)
 
-	if d.HasChanges("rotation_lambda_arn", "rotation_rules") {
+	if d.HasChanges("rotation_lambda_arn", "rotation_rules", "rotate_immediatley") {
 		input := &secretsmanager.RotateSecretInput{
 			ClientRequestToken: aws.String(id.UniqueId()), // Needed because we're handling our own retries
+			RotateImmediately:  aws.Bool(d.Get("rotate_immediatley").(bool)),
 			RotationRules:      expandRotationRules(d.Get("rotation_rules").([]interface{})),
 			SecretId:           aws.String(secretID),
 		}

--- a/internal/service/secretsmanager/secret_rotation.go
+++ b/internal/service/secretsmanager/secret_rotation.go
@@ -38,7 +38,7 @@ func ResourceSecretRotation() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
-			"rotate_immediatley": {
+			"rotate_immediately": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
@@ -92,7 +92,7 @@ func resourceSecretRotationCreate(ctx context.Context, d *schema.ResourceData, m
 
 	input := &secretsmanager.RotateSecretInput{
 		ClientRequestToken: aws.String(id.UniqueId()), // Needed because we're handling our own retries
-		RotateImmediately:  aws.Bool(d.Get("rotate_immediatley").(bool)),
+		RotateImmediately:  aws.Bool(d.Get("rotate_immediately").(bool)),
 		RotationRules:      expandRotationRules(d.Get("rotation_rules").([]interface{})),
 		SecretId:           aws.String(secretID),
 	}
@@ -155,10 +155,10 @@ func resourceSecretRotationUpdate(ctx context.Context, d *schema.ResourceData, m
 	conn := meta.(*conns.AWSClient).SecretsManagerConn(ctx)
 	secretID := d.Get("secret_id").(string)
 
-	if d.HasChanges("rotation_lambda_arn", "rotation_rules", "rotate_immediatley") {
+	if d.HasChanges("rotation_lambda_arn", "rotation_rules", "rotate_immediately") {
 		input := &secretsmanager.RotateSecretInput{
 			ClientRequestToken: aws.String(id.UniqueId()), // Needed because we're handling our own retries
-			RotateImmediately:  aws.Bool(d.Get("rotate_immediatley").(bool)),
+			RotateImmediately:  aws.Bool(d.Get("rotate_immediately").(bool)),
 			RotationRules:      expandRotationRules(d.Get("rotation_rules").([]interface{})),
 			SecretId:           aws.String(secretID),
 		}

--- a/internal/service/secretsmanager/secret_rotation_test.go
+++ b/internal/service/secretsmanager/secret_rotation_test.go
@@ -421,7 +421,7 @@ resource "aws_secretsmanager_secret_version" "test" {
 resource "aws_secretsmanager_secret_rotation" "test" {
   secret_id           = aws_secretsmanager_secret.test.id
   rotation_lambda_arn = aws_lambda_function.test.arn
-  rotate_immediately  = false 
+  rotate_immediately  = false
 
   rotation_rules {
     automatically_after_days = %[2]d

--- a/website/docs/r/secretsmanager_secret_rotation.html.markdown
+++ b/website/docs/r/secretsmanager_secret_rotation.html.markdown
@@ -38,6 +38,7 @@ To enable automatic secret rotation, the Secrets Manager service requires usage 
 This resource supports the following arguments:
 
 * `secret_id` - (Required) Specifies the secret to which you want to add a new version. You can specify either the Amazon Resource Name (ARN) or the friendly name of the secret. The secret must already exist.
+* `rotate_immediately` - (Optional) Specifies whether to rotate the secret immediately or wait until the next scheduled rotation window. For secrets that use a Lambda rotation function to rotate, if you don't immediately rotate the secret, Secrets Manager tests the rotation configuration by running the testSecret step (https://docs.aws.amazon.com/secretsmanager/latest/userguide/rotate-secrets_how.html) of the Lambda rotation function. The test creates an AWSPENDING version of the secret and then removes it. Defaults to `false`.
 * `rotation_lambda_arn` - (Optional) Specifies the ARN of the Lambda function that can rotate the secret. Must be supplied if the secret is not managed by AWS.
 * `rotation_rules` - (Required) A structure that defines the rotation configuration for this secret. Defined below.
 


### PR DESCRIPTION
### Description
Add support for the `rotate_immediatley` argument for the resource `aws_secretsmanager_secret_rotation`

### Relations

Closes #34961

### References
[AWS SDK V1](https://pkg.go.dev/github.com/aws/aws-sdk-go@v1.49.13/service/secretsmanager#RotateSecretInput)

### Output from Acceptance Testing

```Console
make testacc TESTS=TestAccSecretsManagerSecretRotation_ PKG=secretsmanager
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/secretsmanager/... -v -count 1 -parallel 20 -run='TestAccSecretsManagerSecretRotation_'  -timeout 360m
=== RUN   TestAccSecretsManagerSecretRotation_basic
=== PAUSE TestAccSecretsManagerSecretRotation_basic
=== RUN   TestAccSecretsManagerSecretRotation_rotateImmediately
=== PAUSE TestAccSecretsManagerSecretRotation_rotateImmediately
=== RUN   TestAccSecretsManagerSecretRotation_scheduleExpression
=== PAUSE TestAccSecretsManagerSecretRotation_scheduleExpression
=== RUN   TestAccSecretsManagerSecretRotation_scheduleExpressionToDays
=== PAUSE TestAccSecretsManagerSecretRotation_scheduleExpressionToDays
=== RUN   TestAccSecretsManagerSecretRotation_scheduleExpressionHours
=== PAUSE TestAccSecretsManagerSecretRotation_scheduleExpressionHours
=== RUN   TestAccSecretsManagerSecretRotation_duration
=== PAUSE TestAccSecretsManagerSecretRotation_duration
=== CONT  TestAccSecretsManagerSecretRotation_basic
=== CONT  TestAccSecretsManagerSecretRotation_scheduleExpressionToDays
=== CONT  TestAccSecretsManagerSecretRotation_scheduleExpression
=== CONT  TestAccSecretsManagerSecretRotation_rotateImmediately
=== CONT  TestAccSecretsManagerSecretRotation_duration
=== CONT  TestAccSecretsManagerSecretRotation_scheduleExpressionHours
--- PASS: TestAccSecretsManagerSecretRotation_duration (46.55s)
--- PASS: TestAccSecretsManagerSecretRotation_rotateImmediately (59.33s)
--- PASS: TestAccSecretsManagerSecretRotation_scheduleExpressionHours (64.82s)
--- PASS: TestAccSecretsManagerSecretRotation_basic (65.22s)
--- PASS: TestAccSecretsManagerSecretRotation_scheduleExpression (67.53s)
--- PASS: TestAccSecretsManagerSecretRotation_scheduleExpressionToDays (83.56s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager     83.658s
```
