### PR TITLE
r/aws_quicksight_dashboard: Fix error reading state with Table visuals 

### DIFF
--- a/internal/service/quicksight/schema/visual_table.go
+++ b/internal/service/quicksight/schema/visual_table.go
@@ -1091,7 +1091,7 @@ func flattenTableFieldOption(apiObject []*quicksight.TableFieldOption) []interfa
 			tfMap["url_styling"] = flattenTableFieldURLConfiguration(config.URLStyling)
 		}
 		if config.Visibility != nil {
-			tfMap["visbility"] = aws.StringValue(config.Visibility)
+			tfMap["visibility"] = aws.StringValue(config.Visibility)
 		}
 		if config.Width != nil {
 			tfMap["width"] = aws.StringValue(config.Width)


### PR DESCRIPTION
### Description
This fixes a bug where the aws_quicksight_dashboard resource would fail on refreshing/reading the state with certain configurations of Table visuals due to a typo.


```
Error: setting definition: Invalid address to set: []string{"definition", "0", "sheets", "5", "visuals", "2", "table_visual", "0", "chart_configuration", "0", "field_options", "0", "selected_field_options", "2", "visbility"}
```

<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #33463

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccQuickSightDashboard PKG=quicksight
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/quicksight/... -v -count 1 -parallel 20 -run='TestAccQuickSightDashboard'  -timeout 360m
?       github.com/hashicorp/terraform-provider-aws/internal/service/quicksight/schema  [no test files]
=== RUN   TestAccQuickSightDashboard_basic
=== PAUSE TestAccQuickSightDashboard_basic
=== RUN   TestAccQuickSightDashboard_disappears
=== PAUSE TestAccQuickSightDashboard_disappears
=== RUN   TestAccQuickSightDashboard_sourceEntity
=== PAUSE TestAccQuickSightDashboard_sourceEntity
=== RUN   TestAccQuickSightDashboard_updateVersionNumber
=== PAUSE TestAccQuickSightDashboard_updateVersionNumber
=== RUN   TestAccQuickSightDashboard_dashboardSpecificConfig
=== PAUSE TestAccQuickSightDashboard_dashboardSpecificConfig
=== CONT  TestAccQuickSightDashboard_basic
=== CONT  TestAccQuickSightDashboard_updateVersionNumber
=== CONT  TestAccQuickSightDashboard_sourceEntity
=== CONT  TestAccQuickSightDashboard_disappears
=== CONT  TestAccQuickSightDashboard_dashboardSpecificConfig
--- PASS: TestAccQuickSightDashboard_disappears (52.92s)
--- PASS: TestAccQuickSightDashboard_dashboardSpecificConfig (57.75s)
--- PASS: TestAccQuickSightDashboard_basic (58.20s)
--- PASS: TestAccQuickSightDashboard_sourceEntity (59.45s)
--- PASS: TestAccQuickSightDashboard_updateVersionNumber (101.51s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/quicksight 104.880s
...
```
