### PR TITLE
Trigger ACM certificate recreation on all failed statuses

### DIFF
--- a/internal/service/acm/certificate.go
+++ b/internal/service/acm/certificate.go
@@ -807,7 +807,14 @@ func findCertificateByARN(ctx context.Context, conn *acm.Client, arn string) (*t
 		return nil, err
 	}
 
-	if status := output.Status; status == types.CertificateStatusValidationTimedOut {
+	failedStatuses := map[types.CertificateStatus]bool{
+		types.CertificateStatusValidationTimedOut: true,
+		types.CertificateStatusFailed:             true,
+		types.CertificateStatusExpired:            true,
+		types.CertificateStatusRevoked:            true,
+	}
+
+	if status := output.Status; failedStatuses[status] {
 		return nil, &retry.NotFoundError{
 			Message:     string(status),
 			LastRequest: input,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Recreation of ACM certificate extended to Failed, Expired, Revoked statuses. 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #34909 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
Please run the acceptance tests to test for any regressions.
