### PR TITLE
batch job definition remove force new and increment revisions

### DIFF
--- a/.changelog/35149.txt
+++ b/.changelog/35149.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_batch_job_definition: Add update functions instead of ForceNew. Add `deregister_on_new_revision` to allow keeping prior versions ACTIVE when a new revision is published.
+```

--- a/internal/service/batch/findv2.go
+++ b/internal/service/batch/findv2.go
@@ -46,7 +46,7 @@ func ListJobDefinitionsV2ByNameWithStatus(ctx context.Context, conn *batch.Clien
 		out = append(out, page.JobDefinitions...)
 	}
 
-	if out == nil || len(out) == 0 {
+	if len(out) == 0 {
 		return nil, tfresource.NewEmptyResultError(input)
 	}
 

--- a/internal/service/batch/findv2.go
+++ b/internal/service/batch/findv2.go
@@ -1,0 +1,54 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package batch
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/batch"
+	"github.com/aws/aws-sdk-go-v2/service/batch/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func FindJobDefinitionV2ByARN(ctx context.Context, conn *batch.Client, arn string) (*types.JobDefinition, error) {
+	input := &batch.DescribeJobDefinitionsInput{
+		JobDefinitions: []string{arn},
+	}
+
+	out, err := conn.DescribeJobDefinitions(ctx, input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if out == nil || len(out.JobDefinitions) == 0 {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	if count := len(out.JobDefinitions); count > 1 {
+		return nil, tfresource.NewTooManyResultsError(count, input)
+	}
+
+	return &out.JobDefinitions[0], nil
+}
+
+func ListJobDefinitionsV2ByNameWithStatus(ctx context.Context, conn *batch.Client, input *batch.DescribeJobDefinitionsInput) ([]types.JobDefinition, error) {
+	var out []types.JobDefinition
+
+	pages := batch.NewDescribeJobDefinitionsPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, page.JobDefinitions...)
+	}
+
+	if out == nil || len(out) == 0 {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return out, nil
+}

--- a/internal/service/batch/job_definition.go
+++ b/internal/service/batch/job_definition.go
@@ -354,7 +354,6 @@ func ResourceJobDefinition() *schema.Resource {
 						"attempts": {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							ForceNew:     true,
 							ValidateFunc: validation.IntBetween(1, 10),
 						},
 						"evaluate_on_exit": {
@@ -368,7 +367,6 @@ func ResourceJobDefinition() *schema.Resource {
 									"action": {
 										Type:     schema.TypeString,
 										Required: true,
-										ForceNew: true,
 										StateFunc: func(v interface{}) string {
 											return strings.ToLower(v.(string))
 										},
@@ -377,7 +375,6 @@ func ResourceJobDefinition() *schema.Resource {
 									"on_exit_code": {
 										Type:     schema.TypeString,
 										Optional: true,
-										ForceNew: true,
 										ValidateFunc: validation.All(
 											validation.StringLenBetween(1, 512),
 											validation.StringMatch(regexache.MustCompile(`^[0-9]*\*?$`), "must contain only numbers, and can optionally end with an asterisk"),
@@ -386,7 +383,6 @@ func ResourceJobDefinition() *schema.Resource {
 									"on_reason": {
 										Type:     schema.TypeString,
 										Optional: true,
-										ForceNew: true,
 										ValidateFunc: validation.All(
 											validation.StringLenBetween(1, 512),
 											validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z.:\s]*\*?$`), "must contain letters, numbers, periods, colons, and white space, and can optionally end with an asterisk"),
@@ -395,7 +391,6 @@ func ResourceJobDefinition() *schema.Resource {
 									"on_status_reason": {
 										Type:     schema.TypeString,
 										Optional: true,
-										ForceNew: true,
 										ValidateFunc: validation.All(
 											validation.StringLenBetween(1, 512),
 											validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z.:\s]*\*?$`), "must contain letters, numbers, periods, colons, and white space, and can optionally end with an asterisk"),
@@ -424,14 +419,12 @@ func ResourceJobDefinition() *schema.Resource {
 			"timeout": {
 				Type:     schema.TypeList,
 				Optional: true,
-				ForceNew: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"attempt_duration_seconds": {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							ForceNew:     true,
 							ValidateFunc: validation.IntAtLeast(60),
 						},
 					},

--- a/internal/service/batch/job_definition.go
+++ b/internal/service/batch/job_definition.go
@@ -761,7 +761,7 @@ func FindJobDefinitionByARN(ctx context.Context, conn *batch.Batch, arn string) 
 func ListActiveJobDefinitionByName(ctx context.Context, conn *batch.Batch, name string) ([]*batch.JobDefinition, error) {
 	input := &batch.DescribeJobDefinitionsInput{
 		JobDefinitionName: aws.String(name),
-		Status:            aws.String(JobDefinitionStatusActive),
+		Status:            aws.String(jobDefinitionStatusActive),
 	}
 
 	output, err := conn.DescribeJobDefinitionsWithContext(ctx, input)

--- a/internal/service/batch/job_definition_data_source_test.go
+++ b/internal/service/batch/job_definition_data_source_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/YakDriver/regexache"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
@@ -65,6 +66,10 @@ func TestAccBatchJobDefinitionDataSource_basicARN(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "retry_strategy.0.attempts", "10"),
 					resource.TestCheckResourceAttr(dataSourceName, "revision", "1"),
+					testAccCheckJobDefinitionV2Exists(ctx, dataSourceName, &jd),
+					resource.TestCheckResourceAttr(dataSourceName, "revision", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "retry_strategy.attempts", "10"),
+					acctest.MatchResourceAttrRegionalARN(dataSourceName, "arn", "batch", regexache.MustCompile(fmt.Sprintf(`job-definition/%s:\d+`, rName))),
 				),
 			},
 			{

--- a/internal/service/batch/job_definition_data_source_test.go
+++ b/internal/service/batch/job_definition_data_source_test.go
@@ -66,7 +66,6 @@ func TestAccBatchJobDefinitionDataSource_basicARN(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "retry_strategy.0.attempts", "10"),
 					resource.TestCheckResourceAttr(dataSourceName, "revision", "1"),
-					testAccCheckJobDefinitionV2Exists(ctx, dataSourceName, &jd),
 					resource.TestCheckResourceAttr(dataSourceName, "revision", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "retry_strategy.attempts", "10"),
 					acctest.MatchResourceAttrRegionalARN(dataSourceName, "arn", "batch", regexache.MustCompile(fmt.Sprintf(`job-definition/%s:\d+`, rName))),

--- a/internal/service/batch/job_definition_test.go
+++ b/internal/service/batch/job_definition_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -19,8 +20,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfbatch "github.com/hashicorp/terraform-provider-aws/internal/service/batch"
+<<<<<<< HEAD
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
+=======
+>>>>>>> 1c264545ba (initial remove of ForceNew)
 )
 
 func TestAccBatchJobDefinition_basic(t *testing.T) {
@@ -69,6 +73,100 @@ func TestAccBatchJobDefinition_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"deregister_on_new_revision",
+				},
+			},
+		},
+	})
+}
+
+func TestAccBatchJobDefinition_attributes(t *testing.T) {
+	ctx := acctest.Context(t)
+	var jd batch.JobDefinition
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_batch_job_definition.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckJobDefinitionDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccJobDefinitionConfig_attributes(rName, 2, true, 3, 120, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckJobDefinitionExists(ctx, resourceName, &jd),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "batch", regexache.MustCompile(fmt.Sprintf(`job-definition/%s:\d+`, rName))),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn_prefix", "batch", regexache.MustCompile(fmt.Sprintf(`job-definition/%s`, rName))),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "platform_capabilities.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "platform_capabilities.*", "EC2"),
+					resource.TestCheckResourceAttr(resourceName, "propagate_tags", "true"),
+					resource.TestCheckResourceAttr(resourceName, "retry_strategy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "retry_strategy.0.attempts", "3"),
+					resource.TestCheckResourceAttr(resourceName, "revision", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "timeout.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "timeout.0.attempt_duration_seconds", "120"),
+					resource.TestCheckResourceAttr(resourceName, "type", "container"),
+					resource.TestCheckResourceAttr(resourceName, "scheduling_priority", "2"),
+				),
+			},
+			{
+				Config: testAccJobDefinitionConfig_attributes(rName, 2, true, 4, 120, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckJobDefinitionExists(ctx, resourceName, &jd),
+					testAccCheckJobDefinitionPreviousRegistered(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "revision", "2"),
+				),
+			},
+			{
+				Config: testAccJobDefinitionConfig_name(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckJobDefinitionExists(ctx, resourceName, &jd),
+					testAccCheckJobDefinitionPreviousDeregistered(ctx, resourceName),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "batch", regexache.MustCompile(fmt.Sprintf(`job-definition/%s:\d+`, rName))),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn_prefix", "batch", regexache.MustCompile(fmt.Sprintf(`job-definition/%s`, rName))),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "platform_capabilities.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "retry_strategy.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "revision", "3"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "timeout.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "type", "container"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"deregister_on_new_revision",
+				},
+			},
+			{
+				Config: testAccJobDefinitionConfig_attributes(rName, 1, false, 1, 60, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckJobDefinitionExists(ctx, resourceName, &jd),
+					testAccCheckJobDefinitionPreviousDeregistered(ctx, resourceName),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "batch", regexache.MustCompile(fmt.Sprintf(`job-definition/%s:\d+`, rName))),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn_prefix", "batch", regexache.MustCompile(fmt.Sprintf(`job-definition/%s`, rName))),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "platform_capabilities.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "platform_capabilities.*", "EC2"),
+					resource.TestCheckResourceAttr(resourceName, "propagate_tags", "false"),
+					resource.TestCheckResourceAttr(resourceName, "retry_strategy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "retry_strategy.0.attempts", "1"),
+					resource.TestCheckResourceAttr(resourceName, "revision", "4"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "timeout.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "timeout.0.attempt_duration_seconds", "60"),
+					resource.TestCheckResourceAttr(resourceName, "type", "container"),
+					resource.TestCheckResourceAttr(resourceName, "scheduling_priority", "1"),
+				),
 			},
 		},
 	})
@@ -143,6 +241,9 @@ func TestAccBatchJobDefinition_PlatformCapabilities_ec2(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"deregister_on_new_revision",
+				},
 			},
 		},
 	})
@@ -187,6 +288,9 @@ func TestAccBatchJobDefinition_PlatformCapabilitiesFargate_containerPropertiesDe
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"deregister_on_new_revision",
+				},
 			},
 		},
 	})
@@ -231,6 +335,9 @@ func TestAccBatchJobDefinition_PlatformCapabilities_fargate(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"deregister_on_new_revision",
+				},
 			},
 		},
 	})
@@ -298,6 +405,7 @@ func TestAccBatchJobDefinition_ContainerProperties_advanced(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+<<<<<<< HEAD
 			},
 		},
 	})
@@ -333,6 +441,11 @@ func TestAccBatchJobDefinition_updateForcesNewResource(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+=======
+				ImportStateVerifyIgnore: []string{
+					"deregister_on_new_revision",
+				},
+>>>>>>> 1c264545ba (initial remove of ForceNew)
 			},
 		},
 	})
@@ -362,6 +475,9 @@ func TestAccBatchJobDefinition_tags(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"deregister_on_new_revision",
+				},
 			},
 			{
 				Config: testAccJobDefinitionConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
@@ -455,6 +571,9 @@ func TestAccBatchJobDefinition_ContainerProperties_EmptyField(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"deregister_on_new_revision",
+				},
 			},
 		},
 	})
@@ -529,6 +648,7 @@ func TestAccBatchJobDefinition_NodeProperties_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+<<<<<<< HEAD
 			},
 		},
 	})
@@ -564,6 +684,11 @@ func TestAccBatchJobDefinition_NodePropertiesupdateForcesNewResource(t *testing.
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+=======
+				ImportStateVerifyIgnore: []string{
+					"deregister_on_new_revision",
+				},
+>>>>>>> 1c264545ba (initial remove of ForceNew)
 			},
 		},
 	})
@@ -595,6 +720,9 @@ func TestAccBatchJobDefinition_EKSProperties_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"deregister_on_new_revision",
+				},
 			},
 		},
 	})
@@ -632,6 +760,9 @@ func TestAccBatchJobDefinition_EKSProperties_update(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"deregister_on_new_revision",
+				},
 			},
 		},
 	})
@@ -726,6 +857,78 @@ func testAccCheckJobDefinitionExists(ctx context.Context, n string, jd *batch.Jo
 	}
 }
 
+func testAccCheckJobDefinitionPreviousRegistered(ctx context.Context, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Batch Job Queue ID is set")
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).BatchConn(ctx)
+
+		previousARN := parseJobDefinitionPreviousARN(rs.Primary.ID)
+
+		jobDefinition, err := tfbatch.FindJobDefinitionByARN(ctx, conn, previousARN)
+
+		if err != nil {
+			return err
+		}
+
+		if aws.StringValue(jobDefinition.Status) != "ACTIVE" {
+			return fmt.Errorf("Batch Job Definition %s is a previous revision that is not ACTIVE", previousARN)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckJobDefinitionPreviousDeregistered(ctx context.Context, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Batch Job Queue ID is set")
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).BatchConn(ctx)
+
+		previousARN := parseJobDefinitionPreviousARN(rs.Primary.ID)
+
+		_, err := tfbatch.FindJobDefinitionByARN(ctx, conn, previousARN)
+
+		// FindJobDefinitionByARN returns an error if the job is INACTIVE (deregistered)
+		if err != nil {
+			if err.Error() == "INACTIVE" {
+				return nil
+			}
+			return err
+		}
+
+		return fmt.Errorf("Batch Job Definition %s is a previous revision that is still ACTIVE", previousARN)
+	}
+}
+
+func parseJobDefinitionPreviousARN(currentARN string) (previousARN string) {
+	re := regexache.MustCompile(`job-definition/.*?:(.*)`)
+	revisionCurrentStr := re.FindStringSubmatch(currentARN)[1]
+
+	revisionCurrent, _ := strconv.Atoi(revisionCurrentStr)
+	revisionPrevious := revisionCurrent - 1
+
+	re = regexache.MustCompile(`^(arn:.*:batch:[a-z0-9-]+:[0-9]+:job-definition/[a-z0-9-]+):`)
+	arnPrefix := re.FindStringSubmatch(currentARN)[1]
+	previousARN = fmt.Sprintf("%s:%d", arnPrefix, revisionPrevious)
+
+	return previousARN
+}
+
 func testAccCheckJobDefinitionAttributes(jd *batch.JobDefinition, compare *batch.JobDefinition) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		for _, rs := range s.RootModule().Resources {
@@ -757,15 +960,6 @@ func testAccCheckJobDefinitionAttributes(jd *batch.JobDefinition, compare *batch
 	}
 }
 
-func testAccCheckJobDefinitionRecreated(t *testing.T, before, after *batch.JobDefinition) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if aws.Int64Value(before.Revision) == aws.Int64Value(after.Revision) {
-			t.Fatalf("Expected change of JobDefinition Revisions, but both were %d", aws.Int64Value(before.Revision))
-		}
-		return nil
-	}
-}
-
 func testAccCheckJobDefinitionDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).BatchConn(ctx)
@@ -775,9 +969,12 @@ func testAccCheckJobDefinitionDestroy(ctx context.Context) resource.TestCheckFun
 				continue
 			}
 
-			_, err := tfbatch.FindJobDefinitionByARN(ctx, conn, rs.Primary.ID)
+			re := regexache.MustCompile(`job-definition/(.*?):`)
+			name := re.FindStringSubmatch(rs.Primary.ID)[1]
 
-			if tfresource.NotFound(err) {
+			jds, err := tfbatch.ListActiveJobDefinitionByName(ctx, conn, name)
+
+			if count := len(jds); count == 0 {
 				continue
 			}
 
@@ -785,7 +982,7 @@ func testAccCheckJobDefinitionDestroy(ctx context.Context) resource.TestCheckFun
 				return err
 			}
 
-			return fmt.Errorf("Batch Job Definition %s still exists", rs.Primary.ID)
+			return fmt.Errorf("Batch Job Definition %s has revisions that still exist", name)
 		}
 		return nil
 	}
@@ -1448,4 +1645,31 @@ resource "aws_batch_job_definition" "test" {
   scheduling_priority = %[2]d
 }
 `, rName, priority)
+}
+
+func testAccJobDefinitionConfig_attributes(rName string, sp int, pt bool, rsa int, timeout int, dereg bool) string {
+	return fmt.Sprintf(`
+resource "aws_batch_job_definition" "test" {
+  name = %[1]q
+  type = "container"
+  scheduling_priority = %[2]d
+  propagate_tags      = %[3]t
+  container_properties = jsonencode({
+    command = ["echo", "test"]
+    image   = "busybox"
+    memory  = 128
+    vcpus   = 1
+  })
+  retry_strategy {
+    attempts = %[4]d
+  }
+  timeout {
+    attempt_duration_seconds = %[5]d
+  }
+  deregister_on_new_revision = %[6]t
+  platform_capabilities = [
+    "EC2",
+  ]
+}
+`, rName, sp, pt, rsa, timeout, dereg)
 }

--- a/internal/service/batch/job_definition_test.go
+++ b/internal/service/batch/job_definition_test.go
@@ -84,7 +84,7 @@ func TestAccBatchJobDefinition_attributes(t *testing.T) {
 	resourceName := "aws_batch_job_definition.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckJobDefinitionDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -630,7 +630,7 @@ func TestAccBatchJobDefinition_NodeProperties_advanced(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, batch.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckJobDefinitionDestroy(ctx),
 		Steps: []resource.TestStep{

--- a/internal/service/batch/job_definition_test.go
+++ b/internal/service/batch/job_definition_test.go
@@ -578,6 +578,7 @@ func TestAccBatchJobDefinition_NodeProperties_basic(t *testing.T) {
 									"vcpus": 1,
 									"volumes": []
 								},
+								"instanceTypes": [],
 								"targetNodes": "0:"
 							},
 							{
@@ -593,6 +594,7 @@ func TestAccBatchJobDefinition_NodeProperties_basic(t *testing.T) {
 									"vcpus": 1,
 									"volumes": []
 								},
+								"instanceTypes": [],
 								"targetNodes": "1:"
 							}
 						],
@@ -655,6 +657,7 @@ func TestAccBatchJobDefinition_NodeProperties_advanced(t *testing.T) {
 									"vcpus": 1,
 									"volumes": [{"host":{"sourcePath":"/tmp"},"name":"tmp"}]
 								},
+								"instanceTypes": [],
 								"targetNodes": "0:"
 							},
 							{
@@ -670,6 +673,7 @@ func TestAccBatchJobDefinition_NodeProperties_advanced(t *testing.T) {
 									"vcpus":1,
 									"volumes": []
 								},
+								"instanceTypes": [],
 								"targetNodes": "1:"
 							}
 						],
@@ -706,6 +710,7 @@ func TestAccBatchJobDefinition_NodeProperties_advanced(t *testing.T) {
 									"vcpus": 1,
 									"volumes": []
 								},
+								"instanceTypes": [],
 								"targetNodes": "0:"
 							},
 							{
@@ -721,6 +726,7 @@ func TestAccBatchJobDefinition_NodeProperties_advanced(t *testing.T) {
 									"vcpus": 1,
 									"volumes": []
 								},
+								"instanceTypes": [],
 								"targetNodes": "1:"
 							}
 						],

--- a/internal/service/batch/job_definition_test.go
+++ b/internal/service/batch/job_definition_test.go
@@ -827,6 +827,9 @@ func TestAccBatchJobDefinition_schedulingPriority(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"deregister_on_new_revision",
+				},
 			},
 		},
 	})

--- a/internal/service/batch/job_definition_test.go
+++ b/internal/service/batch/job_definition_test.go
@@ -20,11 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfbatch "github.com/hashicorp/terraform-provider-aws/internal/service/batch"
-<<<<<<< HEAD
-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
-=======
->>>>>>> 1c264545ba (initial remove of ForceNew)
 )
 
 func TestAccBatchJobDefinition_basic(t *testing.T) {

--- a/internal/service/batch/job_definition_test.go
+++ b/internal/service/batch/job_definition_test.go
@@ -405,47 +405,9 @@ func TestAccBatchJobDefinition_ContainerProperties_advanced(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-<<<<<<< HEAD
-			},
-		},
-	})
-}
-
-func TestAccBatchJobDefinition_updateForcesNewResource(t *testing.T) {
-	ctx := acctest.Context(t)
-	var before, after batch.JobDefinition
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_batch_job_definition.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckJobDefinitionDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccJobDefinitionConfig_containerPropertiesAdvanced(rName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckJobDefinitionExists(ctx, resourceName, &before),
-					testAccCheckJobDefinitionAttributes(&before, nil),
-				),
-			},
-			{
-				Config: testAccJobDefinitionConfig_containerPropertiesAdvancedUpdate(rName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckJobDefinitionExists(ctx, resourceName, &after),
-					testAccCheckJobDefinitionRecreated(t, &before, &after),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-=======
 				ImportStateVerifyIgnore: []string{
 					"deregister_on_new_revision",
 				},
->>>>>>> 1c264545ba (initial remove of ForceNew)
 			},
 			{
 				Config: testAccJobDefinitionConfig_containerPropertiesAdvancedUpdate(rName),
@@ -656,47 +618,9 @@ func TestAccBatchJobDefinition_NodeProperties_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-<<<<<<< HEAD
-			},
-		},
-	})
-}
-
-func TestAccBatchJobDefinition_NodePropertiesupdateForcesNewResource(t *testing.T) {
-	ctx := acctest.Context(t)
-	var before, after batch.JobDefinition
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_batch_job_definition.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckJobDefinitionDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccJobDefinitionConfig_nodePropertiesAdvanced(rName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckJobDefinitionExists(ctx, resourceName, &before),
-					testAccCheckJobDefinitionAttributes(&before, nil),
-				),
-			},
-			{
-				Config: testAccJobDefinitionConfig_nodePropertiesAdvancedUpdate(rName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckJobDefinitionExists(ctx, resourceName, &after),
-					testAccCheckJobDefinitionRecreated(t, &before, &after),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-=======
 				ImportStateVerifyIgnore: []string{
 					"deregister_on_new_revision",
 				},
->>>>>>> 1c264545ba (initial remove of ForceNew)
 			},
 		},
 	})

--- a/internal/service/batch/job_definition_test.go
+++ b/internal/service/batch/job_definition_test.go
@@ -639,7 +639,42 @@ func TestAccBatchJobDefinition_NodeProperties_advanced(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckJobDefinitionExists(ctx, resourceName, &jd),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "batch", regexache.MustCompile(fmt.Sprintf(`job-definition/%s:\d+`, rName))),
-					acctest.CheckResourceAttrEquivalentJSON(resourceName, "node_properties", `{"mainNode":1,"nodeRangeProperties":[{"container":{"command":["ls","-la"],"environment":[{"name":"VARNAME","value":"VARVAL"}],"image":"busybox","memory":512,"mountPoints":[{"containerPath":"/tmp","readOnly":false,"sourceVolume":"tmp"}],"resourceRequirements":[],"secrets":[],"ulimits":[{"hardLimit":1024,"name":"nofile","softLimit":1024}],"vcpus":1,"volumes":[{"host":{"sourcePath":"/tmp"},"name":"tmp"}]},"targetNodes":"0:"},{"container":{"command":["echo","test"],"environment":[],"image":"busybox","memory":128,"mountPoints":[],"resourceRequirements":[],"secrets":[],"ulimits":[],"vcpus":1,"volumes":[]},"targetNodes":"1:"}],"numNodes":4}`),
+					acctest.CheckResourceAttrEquivalentJSON(resourceName, "node_properties", `{
+						"mainNode": 1,
+						"nodeRangeProperties": [
+							{
+								"container": {
+									"command": ["ls","-la"],
+									"environment": [{"name":"VARNAME","value":"VARVAL"}],
+									"image": "busybox",
+									"memory": 512,
+									"mountPoints": [{"containerPath":"/tmp","readOnly":false,"sourceVolume":"tmp"}],
+									"resourceRequirements": [],
+									"secrets": [],
+									"ulimits": [{"hardLimit":1024,"name":"nofile","softLimit":1024}],
+									"vcpus": 1,
+									"volumes": [{"host":{"sourcePath":"/tmp"},"name":"tmp"}]
+								},
+								"targetNodes": "0:"
+							},
+							{
+								"container": {
+									"command": ["echo","test"],
+									"environment": [],
+									"image": "busybox",
+									"memory": 128,
+									"mountPoints": [],
+									"resourceRequirements": [],
+									"secrets": [],
+									"ulimits": [],
+									"vcpus":1,
+									"volumes": []
+								},
+								"targetNodes": "1:"
+							}
+						],
+						"numNodes":4
+					}`),
 				),
 			},
 			{
@@ -655,7 +690,42 @@ func TestAccBatchJobDefinition_NodeProperties_advanced(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckJobDefinitionExists(ctx, resourceName, &jd),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "batch", regexache.MustCompile(fmt.Sprintf(`job-definition/%s:\d+`, rName))),
-					acctest.CheckResourceAttrEquivalentJSON(resourceName, "node_properties", `{"mainNode":1,"nodeRangeProperties":[{"container":{"command":["ls","-la"],"environment":[],"image":"busybox","memory":512,"mountPoints":[],"resourceRequirements":[],"secrets":[],"ulimits":[],"vcpus":1,"volumes":[]},"targetNodes":"0:"},{"container":{"command":["echo","test"],"environment":[],"image":"busybox","memory":128,"mountPoints":[],"resourceRequirements":[],"secrets":[],"ulimits":[],"vcpus":1,"volumes":[]},"targetNodes":"1:"}],"numNodes":4}`),
+					acctest.CheckResourceAttrEquivalentJSON(resourceName, "node_properties", `{
+						"mainNode": 1,
+						"nodeRangeProperties": [
+							{
+								"container": {
+									"command": ["ls","-la"],
+									"environment": [],
+									"image": "busybox",
+									"memory": 512,
+									"mountPoints": [],
+									"resourceRequirements": [],
+									"secrets": [],
+									"ulimits": [],
+									"vcpus": 1,
+									"volumes": []
+								},
+								"targetNodes": "0:"
+							},
+							{
+								"container": {
+									"command": ["echo","test"],
+									"environment": [],
+									"image": "busybox",
+									"memory": 128,
+									"mountPoints": [],
+									"resourceRequirements": [],
+									"secrets": [],
+									"ulimits": [],
+									"vcpus": 1,
+									"volumes": []
+								},
+								"targetNodes": "1:"
+							}
+						],
+						"numNodes":4
+					}`),
 					testAccCheckJobDefinitionPreviousDeregistered(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "revision", "2"),
 				),

--- a/website/docs/r/batch_job_definition.html.markdown
+++ b/website/docs/r/batch_job_definition.html.markdown
@@ -202,6 +202,7 @@ The following arguments are optional:
 
 * `container_properties` - (Optional) A valid [container properties](http://docs.aws.amazon.com/batch/latest/APIReference/API_RegisterJobDefinition.html)
     provided as a single valid JSON document. This parameter is only valid if the `type` parameter is `container`.
+* `deregister_on_new_revision` - (Optional) When updating a job definition a new revision is created. This parameter determines if the previous version is `deregistered` (`INACTIVE`) or left  `ACTIVE`. Defaults to `true`.
 * `node_properties` - (Optional) A valid [node properties](http://docs.aws.amazon.com/batch/latest/APIReference/API_RegisterJobDefinition.html)
     provided as a single valid JSON document. This parameter is required if the `type` parameter is `multinode`.
 * `eks_properties` - (Optional) A valid [eks properties](#eks_properties). This parameter is only valid if the `type` parameter is `container`.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

This change first started as a [larger PR](https://github.com/hashicorp/terraform-provider-aws/pull/34281) and the commits were pulled into a separate PR for isolation

## Summary

`job_definition` (JD) was previously a ForceNew resource on all parameters. This was interesting because when a JD is deleted in AWS the revision still lasts but is marked as inactive. In some ways, the ForceNew didnt matter because a new revision was being created. This PR modifies the behavior so that instead of deleting each revision as a new is created, we merely add a new one. 

### Design decisions
- old revisions are deactivated by default (prior behavior). This can be disabled by new param `deregister_on_new_revision`
- delete now deregisters all JDs with the associated name
- testing delete function (`testAccCheckJobDefinitionDestroy`) now checks to see if any revisions exist and fails accordingly
- Added new functions in testing `testAccCheckJobDefinitionPreviousRegistered` and `testAccCheckJobDefinitionPreviousDeregistered` to validate change from ForceNew to rev updates

### Testing changes
- removed test: `_updateForcesNewResource` -> coverage by `_attributes`
- removed test: `_NodePropertiesupdateForcesNewResource` -> coverage by `_NodeProperties_basic`
- modified function: `testAccCheckJobDefinitionDestroy` now checks for all revisions to be deregistered

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/29819
### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$  make testacc TESTS=TestAccBatchJobDefinition_ PKG=batch     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/batch/... -v -count 1 -parallel 20 -run='TestAccBatchJobDefinition_'  -timeout 360m

--- PASS: TestAccBatchJobDefinition_createTypeMultiNodeWithContainerProperties (27.55s)
--- PASS: TestAccBatchJobDefinition_createTypeContainerWithNodeProperties (27.66s)
--- PASS: TestAccBatchJobDefinition_propagateTags (71.25s)
--- PASS: TestAccBatchJobDefinition_ContainerProperties_EmptyField (77.16s)
--- PASS: TestAccBatchJobDefinition_schedulingPriority (77.66s)
--- PASS: TestAccBatchJobDefinition_EKSProperties_basic (77.86s)
--- PASS: TestAccBatchJobDefinition_NodeProperties_basic (79.69s)
--- PASS: TestAccBatchJobDefinition_basic (79.72s)
--- PASS: TestAccBatchJobDefinition_disappears (83.39s)
--- PASS: TestAccBatchJobDefinition_ContainerProperties_advanced (83.50s)
--- PASS: TestAccBatchJobDefinition_PlatformCapabilities_ec2 (84.21s)
--- PASS: TestAccBatchJobDefinition_EKSProperties_update (99.79s)
--- PASS: TestAccBatchJobDefinition_tags (117.38s)
--- PASS: TestAccBatchJobDefinition_PlatformCapabilitiesFargate_containerPropertiesDefaults (133.64s)
--- PASS: TestAccBatchJobDefinition_PlatformCapabilities_fargate (133.68s)
--- PASS: TestAccBatchJobDefinition_attributes (134.86s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/batch      137.241s
...
```
