### PR TITLE
r/aws_datasync_agent: remove ExactlyOneOf activation_key, ip_address

### DIFF
--- a/.changelog/35150.txt
+++ b/.changelog/35150.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_datasync_agent: Fix import of agents created with `activation_key` by removing requirement for one of `ip_address` or `activation_key` to be set
+```

--- a/internal/service/datasync/agent.go
+++ b/internal/service/datasync/agent.go
@@ -52,15 +52,14 @@ func ResourceAgent() *schema.Resource {
 				Optional:      true,
 				Computed:      true,
 				ForceNew:      true,
-				ExactlyOneOf:  []string{"activation_key", "ip_address"},
-				ConflictsWith: []string{"private_link_endpoint"},
+				ConflictsWith: []string{"private_link_endpoint", "ip_address"},
 			},
 			"ip_address": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ExactlyOneOf: []string{"activation_key", "ip_address"},
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"activation_key"},
 			},
 			"private_link_endpoint": {
 				Type:          schema.TypeString,
@@ -107,6 +106,10 @@ func resourceAgentCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	// Perform one time fetch of activation key from gateway IP address.
 	if activationKey == "" {
+		if agentIpAddress == "" {
+			return sdkdiag.AppendErrorf(diags, "one of activation_key or ip_address is required")
+		}
+
 		client := &http.Client{
 			CheckRedirect: func(req *http.Request, via []*http.Request) error {
 				return http.ErrUseLastResponse


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This requirement previously prevented successful import of agents initialized with an `activation_key`. The `activation_key` is not returned by the read operation, so setting this required value in configuration always forced a new resource on the next apply. Practitioners could work around the issue with an `ignore_changes` lifecycle argument, but removing the `ExactlyOneOf` condition in favor of a `ConflictsWith` condition allows agents created with an activation key to be imported _without_ requiring the attribute to be set in the corresponding Terraform configuration.

An import statement can now look like:

```hcl
import {
  to = aws_datasync_agent.example
  id = "arn:aws:datasync:us-east-1:123456789012:agent/agent-12345678901234567"
}

resource "aws_datasync_agent" "example" {
  # activation_key no longer required here!
  name = "example"
}
```

To replace the removed functionality, an apply-time check has been added to the create operation which verifies at least one of `ip_address` or `activation_key` is set. The downside is this requirement won't be checked at plan time as before, but moving the logic here enables import to behave as expected.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #33458

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=datasync TESTS=TestAccDataSyncAgent_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/datasync/... -v -count 1 -parallel 20 -run='TestAccDataSyncAgent_'  -timeout 360m

--- PASS: TestAccDataSyncAgent_disappears (108.38s)
--- PASS: TestAccDataSyncAgent_agentName (115.58s)
--- PASS: TestAccDataSyncAgent_tags (119.54s)
--- PASS: TestAccDataSyncAgent_basic (122.91s)
--- PASS: TestAccDataSyncAgent_vpcEndpointID (293.69s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/datasync   297.241s
```
