### PR TITLE
Restore use of latest `semgrep` image in CI

### DIFF
--- a/.github/workflows/semgrep-ci.yml
+++ b/.github/workflows/semgrep-ci.yml
@@ -21,7 +21,7 @@ jobs:
     name: Code Quality Scan
     runs-on: ubuntu-latest
     container:
-      image: "returntocorp/semgrep:1.52.0"
+      image: returntocorp/semgrep
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - run: |
@@ -43,7 +43,7 @@ jobs:
     name: Naming Scan Caps/AWS/EC2
     runs-on: ubuntu-latest
     container:
-      image: "returntocorp/semgrep:1.52.0"
+      image: returntocorp/semgrep
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -54,7 +54,7 @@ jobs:
     name: Test Configs Scan
     runs-on: ubuntu-latest
     container:
-      image: "returntocorp/semgrep:1.52.0"
+      image: returntocorp/semgrep
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -65,7 +65,7 @@ jobs:
     name: Service Name Scan A-C
     runs-on: ubuntu-latest
     container:
-      image: "returntocorp/semgrep:1.52.0"
+      image: returntocorp/semgrep
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -76,7 +76,7 @@ jobs:
     name: Service Name Scan C-I
     runs-on: ubuntu-latest
     container:
-      image: "returntocorp/semgrep:1.52.0"
+      image: returntocorp/semgrep
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -87,7 +87,7 @@ jobs:
     name: Service Name Scan I-Q
     runs-on: ubuntu-latest
     container:
-      image: "returntocorp/semgrep:1.52.0"
+      image: returntocorp/semgrep
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -98,7 +98,7 @@ jobs:
     name: Service Name Scan Q-Z
     runs-on: ubuntu-latest
     container:
-      image: "returntocorp/semgrep:1.52.0"
+      image: returntocorp/semgrep
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

**v1.55.1** of `semgrep` is fine running locally. Test in CI.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/34962.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/34964.