### PR TITLE
Issue 35152: Fix `aws_glue_schema` updates to query the specific schema version

### DIFF
--- a/internal/service/glue/find.go
+++ b/internal/service/glue/find.go
@@ -154,12 +154,29 @@ func FindSchemaByID(ctx context.Context, conn *glue.Glue, id string) (*glue.GetS
 	return output, nil
 }
 
-// FindSchemaVersionByID returns the Schema corresponding to the specified ID.
+// FindSchemaVersionByID returns the latest available Schema corresponding to the specified ID.
 func FindSchemaVersionByID(ctx context.Context, conn *glue.Glue, id string) (*glue.GetSchemaVersionOutput, error) {
 	input := &glue.GetSchemaVersionInput{
 		SchemaId: createSchemaID(id),
 		SchemaVersionNumber: &glue.SchemaVersionNumber{
 			LatestVersion: aws.Bool(true),
+		},
+	}
+
+	output, err := conn.GetSchemaVersionWithContext(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+
+	return output, nil
+}
+
+// FindSchemaVersionByIDAndVersion returns the Schema corresponding to the specified ID and version number.
+func FindSchemaVersionByIDAndVersion(ctx context.Context, conn *glue.Glue, id string, versionNumber *int64) (*glue.GetSchemaVersionOutput, error) {
+	input := &glue.GetSchemaVersionInput{
+		SchemaId: createSchemaID(id),
+		SchemaVersionNumber: &glue.SchemaVersionNumber{
+			VersionNumber: versionNumber,
 		},
 	}
 

--- a/internal/service/glue/schema.go
+++ b/internal/service/glue/schema.go
@@ -221,12 +221,12 @@ func resourceSchemaUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			SchemaDefinition: aws.String(d.Get("schema_definition").(string)),
 		}
 
-		_, err := conn.RegisterSchemaVersionWithContext(ctx, defInput)
+		output, err := conn.RegisterSchemaVersionWithContext(ctx, defInput)
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating Glue Schema Definition (%s): %s", d.Id(), err)
 		}
 
-		_, err = waitSchemaVersionAvailable(ctx, conn, d.Id())
+		_, err = waitSchemaVersionAvailable(ctx, conn, d.Id(), output.VersionNumber)
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for Glue Schema Version (%s) to be Available: %s", d.Id(), err)
 		}

--- a/internal/service/glue/schema_test.go
+++ b/internal/service/glue/schema_test.go
@@ -278,6 +278,43 @@ func TestAccGlueSchema_schemaDefUpdated(t *testing.T) {
 	})
 }
 
+func TestAccGlueSchema_incompatibleSchemaDef(t *testing.T) {
+	ctx := acctest.Context(t)
+	var schema glue.GetSchemaOutput
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_glue_schema.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckSchema(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, glue.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSchemaDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSchemaConfig_compatibility(rName, "FORWARD"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSchemaExists(ctx, resourceName, &schema),
+					resource.TestCheckResourceAttr(resourceName, "compatibility", "FORWARD"),
+					resource.TestCheckResourceAttr(resourceName, "schema_definition", "{\"type\": \"record\", \"name\": \"r1\", \"fields\": [ {\"name\": \"f1\", \"type\": \"int\"}, {\"name\": \"f2\", \"type\": \"string\"} ]}"),
+					resource.TestCheckResourceAttr(resourceName, "latest_schema_version", "1"),
+					resource.TestCheckResourceAttr(resourceName, "next_schema_version", "2"),
+				),
+			},
+			{
+				Config: testAccSchemaConfig_compatibility_definitionUpdated(rName, "FORWARD"),
+
+				// TODO: Assert that this update fails
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccGlueSchema_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var schema glue.GetSchemaOutput
@@ -499,6 +536,18 @@ resource "aws_glue_schema" "test" {
   }
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}
+
+func testAccSchemaConfig_compatibility_definitionUpdated(rName, compat string) string {
+	return testAccSchemaBase(rName) + fmt.Sprintf(`
+resource "aws_glue_schema" "test" {
+  schema_name       = %[1]q
+  registry_arn      = aws_glue_registry.test.arn
+  data_format       = "AVRO"
+  compatibility     = %[2]q
+  schema_definition = "{\"type\": \"record\", \"name\": \"r1\", \"fields\": [ {\"name\": \"f1\", \"type\": \"int\"} ]}"
+}
+`, rName, compat)
 }
 
 func testAccSchemaConfig_definitionUpdated(rName string) string {

--- a/internal/service/glue/status.go
+++ b/internal/service/glue/status.go
@@ -74,9 +74,9 @@ func statusSchema(ctx context.Context, conn *glue.Glue, id string) retry.StateRe
 }
 
 // statusSchemaVersion fetches the Schema Version and its Status
-func statusSchemaVersion(ctx context.Context, conn *glue.Glue, id string) retry.StateRefreshFunc {
+func statusSchemaVersion(ctx context.Context, conn *glue.Glue, id string, versionNumber *int64) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		output, err := FindSchemaVersionByID(ctx, conn, id)
+		output, err := FindSchemaVersionByIDAndVersion(ctx, conn, id, versionNumber)
 		if err != nil {
 			return nil, schemaVersionStatusUnknown, err
 		}

--- a/internal/service/glue/wait.go
+++ b/internal/service/glue/wait.go
@@ -98,11 +98,11 @@ func waitSchemaDeleted(ctx context.Context, conn *glue.Glue, registryID string) 
 }
 
 // waitSchemaVersionAvailable waits for a Schema to return Available
-func waitSchemaVersionAvailable(ctx context.Context, conn *glue.Glue, registryID string) (*glue.GetSchemaVersionOutput, error) {
+func waitSchemaVersionAvailable(ctx context.Context, conn *glue.Glue, registryID string, versionNumber *int64) (*glue.GetSchemaVersionOutput, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{glue.SchemaVersionStatusPending},
 		Target:  []string{glue.SchemaVersionStatusAvailable},
-		Refresh: statusSchemaVersion(ctx, conn, registryID),
+		Refresh: statusSchemaVersion(ctx, conn, registryID, versionNumber),
 		Timeout: schemaVersionAvailableTimeout,
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Updating `aws_glue_schema` with an incompatible schema definition should cause the apply to fail. This currently succeeds, but the newly created schema version has status "failed" and is unusable. See issue #35152 for more detail.

✋ The test here results in an error when the fix is applied which is the correct behavior IMO, but I don't see any way to write an "expect error" style test with the existing framework. If that's possible I'd be happy to include it

### Relations

Closes #35152

### References

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccGlueSchema_incompatibleSchemaDef PKG=glue
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/glue/... -v -count 1 -parallel 20 -run='TestAccGlueSchema_incompatibleSchemaDef'  -timeout 360m
=== RUN   TestAccGlueSchema_incompatibleSchemaDef
=== PAUSE TestAccGlueSchema_incompatibleSchemaDef
=== CONT  TestAccGlueSchema_incompatibleSchemaDef
    schema_test.go:288: Step 2/3 error: Error running apply: exit status 1
        
        Error: waiting for Glue Schema Version (arn:aws:glue:us-west-2:[REDACTED]:schema/tf-acc-test-324370135059144384/tf-acc-test-324370135059144384) to be Available: unexpected state 'FAILURE', wanted target 'AVAILABLE'. last error: %!s(<nil>)
        
          with aws_glue_schema.test,
          on terraform_plugin_test.tf line 16, in resource "aws_glue_schema" "test":
          16: resource "aws_glue_schema" "test" {
        
--- FAIL: TestAccGlueSchema_incompatibleSchemaDef (16.40s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/glue	18.871s
FAIL
make: *** [testacc] Error 1
```
