### PR TITLE
update the appstream fleet idle timeout per aws docs

### DIFF
--- a/.changelog/35173.txt
+++ b/.changelog/35173.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/appstream: Updated the max idle timeout for appstream fleet to be 360000, from 3600, to match aws documentation. https://docs.aws.amazon.com/appstream2/latest/APIReference/API_Fleet.html See DisconnectTimeoutInSecond
+```

--- a/.changelog/35173.txt
+++ b/.changelog/35173.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/appstream: Updated the max idle timeout for appstream fleet to be 360000, from 3600, to match aws documentation. https://docs.aws.amazon.com/appstream2/latest/APIReference/API_Fleet.html See DisconnectTimeoutInSecond
+resource/aws_appstream_fleet: Increase `idle_disconnect_timeout_in_seconds` max value for validation to 360000
 ```

--- a/internal/service/appstream/fleet.go
+++ b/internal/service/appstream/fleet.go
@@ -138,7 +138,7 @@ func ResourceFleet() *schema.Resource {
 			"idle_disconnect_timeout_in_seconds": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				Default:      60,
+				Default:      0,
 				ValidateFunc: validation.IntBetween(60, 360000),
 			},
 			"image_arn": {

--- a/internal/service/appstream/fleet.go
+++ b/internal/service/appstream/fleet.go
@@ -138,8 +138,8 @@ func ResourceFleet() *schema.Resource {
 			"idle_disconnect_timeout_in_seconds": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				Default:      0,
-				ValidateFunc: validation.IntBetween(60, 3600),
+				Default:      60,
+				ValidateFunc: validation.IntBetween(60, 360000),
 			},
 			"image_arn": {
 				Type:     schema.TypeString,

--- a/website/docs/r/appstream_fleet.html.markdown
+++ b/website/docs/r/appstream_fleet.html.markdown
@@ -56,7 +56,7 @@ The following arguments are optional:
 * `enable_default_internet_access` - (Optional) Enables or disables default internet access for the fleet.
 * `fleet_type` - (Optional) Fleet type. Valid values are: `ON_DEMAND`, `ALWAYS_ON`
 * `iam_role_arn` - (Optional) ARN of the IAM role to apply to the fleet.
-* `idle_disconnect_timeout_in_seconds` - (Optional) Amount of time that users can be idle (inactive) before they are disconnected from their streaming session and the `disconnect_timeout_in_seconds` time interval begins.
+* `idle_disconnect_timeout_in_seconds` - (Optional) Amount of time that users can be idle (inactive) before they are disconnected from their streaming session and the `disconnect_timeout_in_seconds` time interval begins. Defaults to 60 seconds.
 * `image_name` - (Optional) Name of the image used to create the fleet.
 * `image_arn` - (Optional) ARN of the public, private, or shared image to use.
 * `stream_view` - (Optional) AppStream 2.0 view that is displayed to your users when they stream from the fleet. When `APP` is specified, only the windows of applications opened by users display. When `DESKTOP` is specified, the standard desktop that is provided by the operating system displays. If not specified, defaults to `APP`.


### PR DESCRIPTION
### Description
Updated the max idle timeout for appstream fleet to be 360000, from 3600, to match aws documentation. See below

### Relations
Closes #34453 

### References
https://docs.aws.amazon.com/appstream2/latest/APIReference/API_Fleet.html See DisconnectTimeoutInSeconds


