### PR TITLE
fix(pl): max_entries can be 0

### DIFF
--- a/.changelog/35180.txt
+++ b/.changelog/35180.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ec2_managed_prefix_list: Correct plan-time validation of `max_entries`
+```

--- a/internal/service/ec2/vpc_managed_prefix_list.go
+++ b/internal/service/ec2/vpc_managed_prefix_list.go
@@ -76,7 +76,7 @@ func ResourceManagedPrefixList() *schema.Resource {
 			"max_entries": {
 				Type:         schema.TypeInt,
 				Required:     true,
-				ValidateFunc: validation.IntAtLeast(1),
+				ValidateFunc: validation.IntAtLeast(0),
 			},
 			"name": {
 				Type:         schema.TypeString,

--- a/internal/service/ec2/vpc_managed_prefix_list.go
+++ b/internal/service/ec2/vpc_managed_prefix_list.go
@@ -102,27 +102,18 @@ func resourceManagedPrefixListCreate(ctx context.Context, d *schema.ResourceData
 
 	conn := meta.(*conns.AWSClient).EC2Conn(ctx)
 
+	name := d.Get("name").(string)
 	input := &ec2.CreateManagedPrefixListInput{
+		AddressFamily:     aws.String(d.Get("address_family").(string)),
+		MaxEntries:        aws.Int64(int64(d.Get("max_entries").(int))),
+		PrefixListName:    aws.String(name),
 		TagSpecifications: getTagSpecificationsIn(ctx, ec2.ResourceTypePrefixList),
-	}
-
-	if v, ok := d.GetOk("address_family"); ok {
-		input.AddressFamily = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("entry"); ok && v.(*schema.Set).Len() > 0 {
 		input.Entries = expandAddPrefixListEntries(v.(*schema.Set).List())
 	}
 
-	if v, ok := d.GetOk("max_entries"); ok {
-		input.MaxEntries = aws.Int64(int64(v.(int)))
-	}
-
-	if v, ok := d.GetOk("name"); ok {
-		input.PrefixListName = aws.String(v.(string))
-	}
-
-	log.Printf("[DEBUG] Creating EC2 Managed Prefix List: %s", input)
 	output, err := conn.CreateManagedPrefixListWithContext(ctx, input)
 
 	if err != nil {

--- a/internal/service/ec2/vpc_managed_prefix_list_test.go
+++ b/internal/service/ec2/vpc_managed_prefix_list_test.go
@@ -38,7 +38,7 @@ func TestAccVPCManagedPrefixList_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "address_family", "IPv4"),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexache.MustCompile(`prefix-list/pl-[[:xdigit:]]+`)),
 					resource.TestCheckResourceAttr(resourceName, "entry.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "max_entries", "1"),
+					resource.TestCheckResourceAttr(resourceName, "max_entries", "0"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					acctest.CheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -511,7 +511,7 @@ func testAccVPCManagedPrefixListConfig_name(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_managed_prefix_list" "test" {
   address_family = "IPv4"
-  max_entries    = 1
+  max_entries    = 0
   name           = %[1]q
 }
 `, rName)


### PR DESCRIPTION
### Description
max_entries of ec2_managed_prefix_list can be 0.
when created via AWS Console, it default set to 0.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
