### PR TITLE
r/aws_glue_catalog_database: handle disappearing resources on delete

### DIFF
--- a/.changelog/35195.txt
+++ b/.changelog/35195.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_glue_catalog_database: Properly handle out-of-band resource deletion
+```

--- a/internal/service/glue/catalog_database.go
+++ b/internal/service/glue/catalog_database.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/glue"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -282,6 +283,9 @@ func resourceCatalogDatabaseDelete(ctx context.Context, d *schema.ResourceData, 
 		Name:      aws.String(d.Get("name").(string)),
 		CatalogId: aws.String(d.Get("catalog_id").(string)),
 	})
+	if tfawserr.ErrCodeEquals(err, glue.ErrCodeEntityNotFoundException) {
+		return diags
+	}
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "deleting Glue Catalog Database (%s): %s", d.Id(), err)
 	}


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Previously `EntityNotFound` exceptions were not handled during deletion, resulting in a hard error message where the provider should instead proceed without error.

Before:

```console
% make testacc PKG=glue TESTS=TestAccGlueCatalogDatabase_disappears
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/glue/... -v -count 1 -parallel 20 -run='TestAccGlueCatalogDatabase_disappears'  -timeout 360m
=== RUN   TestAccGlueCatalogDatabase_disappears
=== PAUSE TestAccGlueCatalogDatabase_disappears
=== CONT  TestAccGlueCatalogDatabase_disappears
    testing_new.go:91: Error running post-test destroy, there may be dangling resources: exit status 1

        Error: deleting Glue Catalog Database (727561393803:tf-acc-test-7599062601241076411): EntityNotFoundException: Database tf-acc-test-7599062601241076411 not found.
        {
          RespMetadata: {
            StatusCode: 400,
            RequestID: "5a571db3-3511-4307-9e75-c6ce46449f8c"
          },
          Message_: "Database tf-acc-test-7599062601241076411 not found."
        }

--- FAIL: TestAccGlueCatalogDatabase_disappears (10.33s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/glue       13.857s
```

After: 

```console
% make testacc PKG=glue TESTS=TestAccGlueCatalogDatabase_disappears
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/glue/... -v -count 1 -parallel 20 -run='TestAccGlueCatalogDatabase_disappears'  -timeout 360m
=== RUN   TestAccGlueCatalogDatabase_disappears
=== PAUSE TestAccGlueCatalogDatabase_disappears
=== CONT  TestAccGlueCatalogDatabase_disappears
--- PASS: TestAccGlueCatalogDatabase_disappears (14.69s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/glue       18.327s
```



### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=glue TESTS=TestAccGlueCatalogDatabase_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/glue/... -v -count 1 -parallel 20 -run='TestAccGlueCatalogDatabase_'  -timeout 360m

--- PASS: TestAccGlueCatalogDatabase_disappears (12.15s)
--- PASS: TestAccGlueCatalogDatabase_targetDatabaseWithRegion (20.03s)
--- PASS: TestAccGlueCatalogDatabase_createTablePermission (22.43s)
--- PASS: TestAccGlueCatalogDatabase_targetDatabase (24.49s)
--- PASS: TestAccGlueCatalogDatabase_full (29.71s)
--- PASS: TestAccGlueCatalogDatabase_tags (30.15s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/glue       33.622s
```
