### PR TITLE
Add trailing slash in Lambda URL documentation

### DIFF
--- a/internal/service/lambda/function_url.go
+++ b/internal/service/lambda/function_url.go
@@ -222,7 +222,7 @@ func resourceFunctionURLRead(ctx context.Context, d *schema.ResourceData, meta i
 	d.Set("qualifier", qualifier)
 
 	// Function URL endpoints have the following format:
-	// https://<url-id>.lambda-url.<region>.on.aws
+	// https://<url-id>.lambda-url.<region>.on.aws/
 	if v, err := url.Parse(functionURL); err != nil {
 		return sdkdiag.AppendErrorf(diags, "parsing URL (%s): %s", functionURL, err)
 	} else if v := strings.Split(v.Host, "."); len(v) > 0 {

--- a/internal/service/lambda/function_url_data_source.go
+++ b/internal/service/lambda/function_url_data_source.go
@@ -131,7 +131,7 @@ func dataSourceFunctionURLRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set("qualifier", qualifier)
 
 	// Function URL endpoints have the following format:
-	// https://<url-id>.lambda-url.<region>.on.aws
+	// https://<url-id>.lambda-url.<region>.on.aws/
 	if v, err := url.Parse(functionURL); err != nil {
 		return sdkdiag.AppendErrorf(diags, "parsing URL (%s): %s", functionURL, err)
 	} else if v := strings.Split(v.Host, "."); len(v) > 0 {

--- a/website/docs/d/lambda_function_url.html.markdown
+++ b/website/docs/d/lambda_function_url.html.markdown
@@ -37,7 +37,7 @@ This data source exports the following attributes in addition to the arguments a
 * `cors` - The [cross-origin resource sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) settings for the function URL. See the [`aws_lambda_function_url` resource](/docs/providers/aws/r/lambda_function_url.html) documentation for more details.
 * `creation_time` - When the function URL was created, in [ISO-8601 format](https://www.w3.org/TR/NOTE-datetime).
 * `function_arn` - ARN of the function.
-* `function_url` - HTTP URL endpoint for the function in the format `https://<url_id>.lambda-url.<region>.on.aws`.
+* `function_url` - HTTP URL endpoint for the function in the format `https://<url_id>.lambda-url.<region>.on.aws/`.
 * `invoke_mode` - Whether the Lambda function responds in `BUFFERED` or `RESPONSE_STREAM` mode.
 * `last_modified_time` - When the function URL configuration was last updated, in [ISO-8601 format](https://www.w3.org/TR/NOTE-datetime).
 * `url_id` - Generated ID for the endpoint.

--- a/website/docs/r/lambda_function_url.html.markdown
+++ b/website/docs/r/lambda_function_url.html.markdown
@@ -60,7 +60,7 @@ This configuration block supports the following attributes:
 This resource exports the following attributes in addition to the arguments above:
 
 * `function_arn` - The Amazon Resource Name (ARN) of the function.
-* `function_url` - The HTTP URL endpoint for the function in the format `https://<url_id>.lambda-url.<region>.on.aws`.
+* `function_url` - The HTTP URL endpoint for the function in the format `https://<url_id>.lambda-url.<region>.on.aws/`.
 * `url_id` - A generated ID for the endpoint.
 
 ## Import


### PR DESCRIPTION
### Description
Contrary to the AWS documentation, the Lambda URL does include a trailing slash.
Visible with a `aws lambda get-function-url-config` or `terraform state show` :
```
resource "aws_lambda_function_url" "example" {
    authorization_type = "NONE"
    function_arn       = "arn:aws:lambda:eu-central-1:12345:function:example"
    function_name      = "example"
    function_url       = "https://xxxxxsvlvu4esyqomzxe7crnte0xxxxx.lambda-url.eu-central-1.on.aws/"
    id                 = "example"
    invoke_mode        = "BUFFERED"
    url_id             = "xxxxxxxxx"
}
```

### References
[AWS Documentation](https://docs.aws.amazon.com/lambda/latest/dg/lambda-urls.html)


### Output from Acceptance Testing
N/A
