### PR TITLE
Increase Scaling Group Timeouts to match the FinSpace API.

### DIFF
--- a/internal/service/finspace/kx_scaling_group.go
+++ b/internal/service/finspace/kx_scaling_group.go
@@ -40,9 +40,9 @@ func ResourceKxScalingGroup() *schema.Resource {
 		},
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(45 * time.Minute),
+			Create: schema.DefaultTimeout(4 * time.Hour),
 			Update: schema.DefaultTimeout(30 * time.Minute),
-			Delete: schema.DefaultTimeout(60 * time.Minute),
+			Delete: schema.DefaultTimeout(4 * time.Hour),
 		},
 
 		Schema: map[string]*schema.Schema{


### PR DESCRIPTION
### Description
Increasing the Timeout for Create and Update Scaling Group Operations to match the FinSpace API in order to support customer use-cases. 
