### PR TITLE
Increase Dataview operation Timeouts to match the FinSpace API.

### DIFF
--- a/.changelog/35207.txt
+++ b/.changelog/35207.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_finspace_kx_dataview: Increase default create, update, and delete timeouts to 4 hours
+```

--- a/internal/service/finspace/kx_dataview.go
+++ b/internal/service/finspace/kx_dataview.go
@@ -43,9 +43,9 @@ func ResourceKxDataview() *schema.Resource {
 		},
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(30 * time.Minute),
-			Update: schema.DefaultTimeout(30 * time.Minute),
-			Delete: schema.DefaultTimeout(30 * time.Minute),
+			Create: schema.DefaultTimeout(4 * time.Hour),
+			Update: schema.DefaultTimeout(4 * time.Hour),
+			Delete: schema.DefaultTimeout(4 * time.Hour),
 		},
 		Schema: map[string]*schema.Schema{
 			"arn": {

--- a/website/docs/r/finspace_kx_dataview.html.markdown
+++ b/website/docs/r/finspace_kx_dataview.html.markdown
@@ -28,6 +28,14 @@ resource "aws_finspace_kx_dataview" "example" {
     volume_name = aws_finspace_kx_volume.example.name
     db_paths    = ["/*"]
   }
+
+  # Depending on the type of cache and size of the Kx Volume, create/update timeouts 
+  # may need to be increased up to a potential maximum of 24 hours and the delete timeout to 12 hours.
+  timeouts {
+    create = "24h"
+    update = "24h"
+    delete = "12h"
+  }
 }
 ```
 

--- a/website/docs/r/finspace_kx_dataview.html.markdown
+++ b/website/docs/r/finspace_kx_dataview.html.markdown
@@ -78,9 +78,9 @@ This resource exports the following attributes in addition to the arguments abov
 
 [Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
 
-* `create` - (Default `30m`)
-* `update` - (Default `30m`)
-* `delete` - (Default `30m`)
+* `create` - (Default `4h`)
+* `update` - (Default `4h`)
+* `delete` - (Default `4h`)
 
 ## Import
 


### PR DESCRIPTION
### Description

Increasing the Timeout for Dataview Operations to match the FinSpace API in order to support customer use-cases.

