### PR TITLE
docs: Clarify protection attr descs for aws_networkfirewall_firewall

### DIFF
--- a/website/docs/d/networkfirewall_firewall.html.markdown
+++ b/website/docs/d/networkfirewall_firewall.html.markdown
@@ -49,13 +49,13 @@ One or more of the following arguments are required:
 This data source exports the following attributes in addition to the arguments above:
 
 * `arn` - ARN of the firewall.
-* `delete_protection` - Boolean flag indicating whether it is possible to delete the firewall.
+* `delete_protection` - A flag indicating whether the firewall is protected against deletion.
 * `description` - Description of the firewall.
 * `encryption_configuration` - AWS Key Management Service (AWS KMS) encryption settings for the firewall.
     * `key_id` - The ID of the AWS Key Management Service (AWS KMS) customer managed key.
     * `type` - The type of the AWS Key Management Service (AWS KMS) key use by the firewall.
 * `firewall_policy_arn` - ARN of the VPC Firewall policy.
-* `firewall_policy_change_protection` - A boolean flag indicating whether it is possible to change the associated firewall policy.
+* `firewall_policy_change_protection` - A flag indicating whether the firewall is protected against a change to the firewall policy association.
 * `firewall_status` - Nested list of information about the current status of the firewall.
     * `sync_states` - Set of subnets configured for use by the firewall.
         * `attachment` - Nested list describing the attachment status of the firewall's association with a single VPC subnet.
@@ -71,7 +71,7 @@ This data source exports the following attributes in addition to the arguments a
     * `configuration_sync_state_summary` - Summary of sync states for all availability zones in which the firewall is configured.
 * `id` - ARN that identifies the firewall.
 * `name` - Descriptive name of the firewall.
-* `subnet_change_protection` - A boolean flag indicating whether it is possible to change the associated subnet(s).
+* `subnet_change_protection` - A flag indicating whether the firewall is protected against changes to the subnet associations.
 * `subnet_mapping` - Set of configuration blocks describing the public subnets. Each subnet must belong to a different Availability Zone in the VPC. AWS Network Firewall creates a firewall endpoint in each subnet.
     * `subnet_id` - The unique identifier for the subnet.
 * `tags` - Map of resource tags to associate with the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.

--- a/website/docs/r/networkfirewall_firewall.html.markdown
+++ b/website/docs/r/networkfirewall_firewall.html.markdown
@@ -38,7 +38,7 @@ resource "aws_networkfirewall_firewall" "example" {
 
 This resource supports the following arguments:
 
-* `delete_protection` - (Optional) A boolean flag indicating whether it is possible to delete the firewall. Defaults to `false`.
+* `delete_protection` - (Optional) A flag indicating whether the firewall is protected against deletion. Use this setting to protect against accidentally deleting a firewall that is in use. Defaults to `false`.
 
 * `description` - (Optional) A friendly description of the firewall.
 
@@ -46,11 +46,11 @@ This resource supports the following arguments:
 
 * `firewall_policy_arn` - (Required) The Amazon Resource Name (ARN) of the VPC Firewall policy.
 
-* `firewall_policy_change_protection` - (Option) A boolean flag indicating whether it is possible to change the associated firewall policy. Defaults to `false`.
+* `firewall_policy_change_protection` - (Optional) A flag indicating whether the firewall is protected against a change to the firewall policy association. Use this setting to protect against accidentally modifying the firewall policy for a firewall that is in use. Defaults to `false`.
 
 * `name` - (Required, Forces new resource) A friendly name of the firewall.
 
-* `subnet_change_protection` - (Optional) A boolean flag indicating whether it is possible to change the associated subnet(s). Defaults to `false`.
+* `subnet_change_protection` - (Optional) A flag indicating whether the firewall is protected against changes to the subnet associations. Use this setting to protect against accidentally modifying the subnet associations for a firewall that is in use. Defaults to `false`.
 
 * `subnet_mapping` - (Required) Set of configuration blocks describing the public subnets. Each subnet must belong to a different Availability Zone in the VPC. AWS Network Firewall creates a firewall endpoint in each subnet. See [Subnet Mapping](#subnet-mapping) below for details.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR enhances the description of the protection-related flags/attributes for the `aws_netwrokfirewall_firewall` resource and data source. Note that the API reference still used confusing wordings for the `deletion_protection` field but the other protection-related fields are fine, so for consistency the latter wordings are used to update the `deletion_protection` description.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #35136

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
The wordings in the [Firewall API reference](https://docs.aws.amazon.com/network-firewall/latest/APIReference/API_Firewall.html) is used to clarify the Terraform target documentation in this PR.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
n/a