### PR TITLE
Add target_file_size field to AppFlow

### DIFF
--- a/.changelog/35215.txt
+++ b/.changelog/35215.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_appflow_flow: Add `destination_connector_properties.s3.s3_output_format_config.target_file_size` argument
+```

--- a/internal/service/appflow/flow.go
+++ b/internal/service/appflow/flow.go
@@ -366,6 +366,12 @@ func resourceFlow() *schema.Resource {
 																			Computed:         true,
 																			ValidateDiagFunc: enum.Validate[types.AggregationType](),
 																		},
+																		"target_file_size": {
+																			Type:         schema.TypeInt,
+																			Optional:     true,
+																			Computed:     true,
+																			ValidateFunc: validation.IntBetween(1, 1024*1024*1024),
+																		},
 																	},
 																},
 															},
@@ -1509,6 +1515,10 @@ func expandAggregationConfig(tfMap map[string]interface{}) *types.AggregationCon
 		a.AggregationType = types.AggregationType(v)
 	}
 
+	if v, ok := tfMap["target_file_size"].(int); ok && v != 0 {
+		a.TargetFileSize = aws.Int64(int64(v))
+	}
+
 	return a
 }
 
@@ -2639,6 +2649,7 @@ func flattenAggregationConfig(aggregationConfig *types.AggregationConfig) map[st
 	m := map[string]interface{}{}
 
 	m["aggregation_type"] = aggregationConfig.AggregationType
+	m["target_file_size"] = aggregationConfig.TargetFileSize
 
 	return m
 }

--- a/internal/service/appflow/flow.go
+++ b/internal/service/appflow/flow.go
@@ -367,10 +367,9 @@ func resourceFlow() *schema.Resource {
 																			ValidateDiagFunc: enum.Validate[types.AggregationType](),
 																		},
 																		"target_file_size": {
-																			Type:         schema.TypeInt,
-																			Optional:     true,
-																			Computed:     true,
-																			ValidateFunc: validation.IntBetween(1, 1024*1024*1024),
+																			Type:     schema.TypeInt,
+																			Optional: true,
+																			Computed: true,
 																		},
 																	},
 																},

--- a/website/docs/cdktf/python/r/appflow_flow.html.markdown
+++ b/website/docs/cdktf/python/r/appflow_flow.html.markdown
@@ -250,6 +250,7 @@ EventBridge, Honeycode, and Marketo destination properties all support the follo
 ###### Aggregation Config
 
 * `aggregation_type` - (Optional) Whether Amazon AppFlow aggregates the flow records into a single file, or leave them unaggregated. Valid values are `None` and `SingleFile`.
+* `target_file_size` - (Optional) The desired file size, in MB, for each output file that Amazon AppFlow writes to the flow destination. Integer value.
 
 ###### Prefix Config
 

--- a/website/docs/r/appflow_flow.html.markdown
+++ b/website/docs/r/appflow_flow.html.markdown
@@ -247,6 +247,7 @@ EventBridge, Honeycode, and Marketo destination properties all support the follo
 ###### Aggregation Config
 
 * `aggregation_type` - (Optional) Whether Amazon AppFlow aggregates the flow records into a single file, or leave them unaggregated. Valid values are `None` and `SingleFile`.
+* `target_file_size` - (Optional) The desired file size, in MB, for each output file that Amazon AppFlow writes to the flow destination. Integer value.
 
 ###### Prefix Config
 


### PR DESCRIPTION
### Description

This pull request adds the `target_file_size` field to the `resourceFlow` function and the `AppFlow` flow configuration. The `target_file_size` field is an optional property that specifies the desired file size, in MB, for each output file that Amazon AppFlow writes to the flow destination.

### Relations
closes https://github.com/hashicorp/terraform-provider-aws/issues/34635

### References
https://docs.aws.amazon.com/appflow/1.0/APIReference/API_AggregationConfig.html

### Output from Acceptance Testing
n/a - test passed on private account


