### PR TITLE
Remove leading `./` from S3 object key name -- AWS SDK for Go v1 compatibility

### DIFF
--- a/.changelog/35223.txt
+++ b/.changelog/35223.txt
@@ -1,0 +1,19 @@
+```release-note:bug
+resource/aws_s3_object: Remove any leading `./` from `key` to maintain AWS SDK for Go v1 (pre-v5.17.0) compatibility
+```
+
+```release-note:bug
+data-source/aws_s3_object: Remove any leading `./` from `key` to maintain AWS SDK for Go v1 (pre-v5.17.0) compatibility
+```
+
+```release-note:bug
+data-source/aws_s3_bucket_object: Remove any leading `./` from `key` to maintain AWS SDK for Go v1 (pre-v5.17.0) compatibility
+```
+
+```release-note:bug
+resource/aws_s3_object_copy: Remove any leading `./` from `key` to maintain AWS SDK for Go v1 (pre-v5.17.0) compatibility
+```
+
+```release-note:bug
+resource/aws_s3_bucket_object: Remove any leading `./` from `key` to maintain AWS SDK for Go v1 (pre-v5.17.0) compatibility
+```

--- a/internal/service/s3/object.go
+++ b/internal/service/s3/object.go
@@ -733,6 +733,8 @@ func flattenObjectDate(t *time.Time) string {
 // See https://docs.aws.amazon.com/sdk-for-go/api/service/s3/#hdr-Automatic_URI_cleaning.
 // See https://github.com/aws/aws-sdk-go/blob/cf903c8c543034654bb8f53b5f9d6454fdb2117f/private/protocol/rest/build.go#L247-L258.
 func sdkv1CompatibleCleanKey(key string) string {
+	// Remove leading './'.
+	key = strings.TrimPrefix(key, "./")
 	// We are effectively ignoring all leading '/'s and treating multiple '/'s as a single '/'.
 	key = strings.TrimLeft(key, "/")
 	key = regexache.MustCompile(`/+`).ReplaceAllString(key, "/")

--- a/internal/service/s3/object_data_source_test.go
+++ b/internal/service/s3/object_data_source_test.go
@@ -414,6 +414,51 @@ func TestAccS3ObjectDataSource_leadingDotSlash(t *testing.T) {
 	})
 }
 
+func TestAccS3ObjectDataSource_leadingMultipleSlashes(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_object.test"
+	dataSourceName1 := "data.aws_s3_object.test1"
+	dataSourceName2 := "data.aws_s3_object.test2"
+	dataSourceName3 := "data.aws_s3_object.test3"
+
+	resourceOnlyConf, conf := testAccObjectDataSourceConfig_leadingMultipleSlashes(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                  func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:                acctest.ErrorCheck(t, names.S3EndpointID),
+		ProtoV5ProviderFactories:  acctest.ProtoV5ProviderFactories,
+		PreventPostDestroyRefresh: true,
+		Steps: []resource.TestStep{
+			{ // nosemgrep:ci.test-config-funcs-correct-form
+				Config: resourceOnlyConf,
+			},
+			{ // nosemgrep:ci.test-config-funcs-correct-form
+				Config: conf,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName1, "body", "yes"),
+					resource.TestCheckResourceAttr(dataSourceName1, "content_length", "3"),
+					resource.TestCheckResourceAttrPair(dataSourceName1, "content_type", resourceName, "content_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName1, "etag", resourceName, "etag"),
+					resource.TestMatchResourceAttr(dataSourceName1, "last_modified", regexache.MustCompile(rfc1123RegexPattern)),
+
+					resource.TestCheckResourceAttr(dataSourceName2, "body", "yes"),
+					resource.TestCheckResourceAttr(dataSourceName2, "content_length", "3"),
+					resource.TestCheckResourceAttrPair(dataSourceName2, "content_type", resourceName, "content_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName2, "etag", resourceName, "etag"),
+					resource.TestMatchResourceAttr(dataSourceName2, "last_modified", regexache.MustCompile(rfc1123RegexPattern)),
+
+					resource.TestCheckResourceAttr(dataSourceName3, "body", "yes"),
+					resource.TestCheckResourceAttr(dataSourceName3, "content_length", "3"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "content_type", resourceName, "content_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "etag", resourceName, "etag"),
+					resource.TestMatchResourceAttr(dataSourceName3, "last_modified", regexache.MustCompile(rfc1123RegexPattern)),
+				),
+			},
+		},
+	})
+}
+
 func TestAccS3ObjectDataSource_checksumMode(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -766,7 +811,7 @@ resource "aws_s3_bucket" "test" {
 
 resource "aws_s3_object" "test" {
   bucket       = aws_s3_bucket.test.bucket
-  key          = "//%[1]s-key"
+  key          = "/%[1]s-key"
   content      = "yes"
   content_type = "text/plain"
 }
@@ -870,6 +915,40 @@ data "aws_s3_object" "test1" {
 data "aws_s3_object" "test2" {
   bucket = aws_s3_bucket.test.bucket
   key    = "/%[1]s-key"
+}
+`, rName))
+
+	return resources, both
+}
+
+func testAccObjectDataSourceConfig_leadingMultipleSlashes(rName string) (string, string) {
+	resources := fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_s3_object" "test" {
+  bucket       = aws_s3_bucket.test.bucket
+  key          = "///%[1]s-key"
+  content      = "yes"
+  content_type = "text/plain"
+}
+`, rName)
+
+	both := acctest.ConfigCompose(resources, fmt.Sprintf(`
+data "aws_s3_object" "test1" {
+  bucket = aws_s3_bucket.test.bucket
+  key    = "%[1]s-key"
+}
+
+data "aws_s3_object" "test2" {
+  bucket = aws_s3_bucket.test.bucket
+  key    = "/%[1]s-key"
+}
+
+data "aws_s3_object" "test3" {
+  bucket = aws_s3_bucket.test.bucket
+  key    = "//%[1]s-key"
 }
 `, rName))
 

--- a/internal/service/s3/object_data_source_test.go
+++ b/internal/service/s3/object_data_source_test.go
@@ -376,6 +376,44 @@ func TestAccS3ObjectDataSource_singleSlashAsKey(t *testing.T) {
 	})
 }
 
+func TestAccS3ObjectDataSource_leadingDotSlash(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_object.test"
+	dataSourceName1 := "data.aws_s3_object.test1"
+	dataSourceName2 := "data.aws_s3_object.test2"
+
+	resourceOnlyConf, conf := testAccObjectDataSourceConfig_leadingDotSlash(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                  func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:                acctest.ErrorCheck(t, names.S3EndpointID),
+		ProtoV5ProviderFactories:  acctest.ProtoV5ProviderFactories,
+		PreventPostDestroyRefresh: true,
+		Steps: []resource.TestStep{
+			{ // nosemgrep:ci.test-config-funcs-correct-form
+				Config: resourceOnlyConf,
+			},
+			{ // nosemgrep:ci.test-config-funcs-correct-form
+				Config: conf,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName1, "body", "yes"),
+					resource.TestCheckResourceAttr(dataSourceName1, "content_length", "3"),
+					resource.TestCheckResourceAttrPair(dataSourceName1, "content_type", resourceName, "content_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName1, "etag", resourceName, "etag"),
+					resource.TestMatchResourceAttr(dataSourceName1, "last_modified", regexache.MustCompile(rfc1123RegexPattern)),
+
+					resource.TestCheckResourceAttr(dataSourceName2, "body", "yes"),
+					resource.TestCheckResourceAttr(dataSourceName2, "content_length", "3"),
+					resource.TestCheckResourceAttrPair(dataSourceName2, "content_type", resourceName, "content_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName2, "etag", resourceName, "etag"),
+					resource.TestMatchResourceAttr(dataSourceName2, "last_modified", regexache.MustCompile(rfc1123RegexPattern)),
+				),
+			},
+		},
+	})
+}
+
 func TestAccS3ObjectDataSource_checksumMode(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -807,6 +845,35 @@ data "aws_s3_object" "test" {
   key    = "/"
 }
 `, rName)
+}
+
+func testAccObjectDataSourceConfig_leadingDotSlash(rName string) (string, string) {
+	resources := fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_s3_object" "test" {
+  bucket       = aws_s3_bucket.test.bucket
+  key          = "./%[1]s-key"
+  content      = "yes"
+  content_type = "text/plain"
+}
+`, rName)
+
+	both := acctest.ConfigCompose(resources, fmt.Sprintf(`
+data "aws_s3_object" "test1" {
+  bucket = aws_s3_bucket.test.bucket
+  key    = "%[1]s-key"
+}
+
+data "aws_s3_object" "test2" {
+  bucket = aws_s3_bucket.test.bucket
+  key    = "/%[1]s-key"
+}
+`, rName))
+
+	return resources, both
 }
 
 func testAccObjectDataSourceConfig_checksumMode(rName string) string {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Removes any leading `./` from S3 object key names to maintain AWS SDK for Go v1 compatibility.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/33358.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/35220.
Relates https://github.com/hashicorp/terraform/issues/34279.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccS3ObjectDataSource_' PKG=s3 ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 2  -run=TestAccS3ObjectDataSource_ -timeout 360m
=== RUN   TestAccS3ObjectDataSource_basic
=== PAUSE TestAccS3ObjectDataSource_basic
=== RUN   TestAccS3ObjectDataSource_basicViaAccessPoint
=== PAUSE TestAccS3ObjectDataSource_basicViaAccessPoint
=== RUN   TestAccS3ObjectDataSource_readableBody
=== PAUSE TestAccS3ObjectDataSource_readableBody
=== RUN   TestAccS3ObjectDataSource_kmsEncrypted
=== PAUSE TestAccS3ObjectDataSource_kmsEncrypted
=== RUN   TestAccS3ObjectDataSource_bucketKeyEnabled
=== PAUSE TestAccS3ObjectDataSource_bucketKeyEnabled
=== RUN   TestAccS3ObjectDataSource_allParams
=== PAUSE TestAccS3ObjectDataSource_allParams
=== RUN   TestAccS3ObjectDataSource_objectLockLegalHoldOff
=== PAUSE TestAccS3ObjectDataSource_objectLockLegalHoldOff
=== RUN   TestAccS3ObjectDataSource_objectLockLegalHoldOn
=== PAUSE TestAccS3ObjectDataSource_objectLockLegalHoldOn
=== RUN   TestAccS3ObjectDataSource_leadingSlash
=== PAUSE TestAccS3ObjectDataSource_leadingSlash
=== RUN   TestAccS3ObjectDataSource_multipleSlashes
=== PAUSE TestAccS3ObjectDataSource_multipleSlashes
=== RUN   TestAccS3ObjectDataSource_singleSlashAsKey
=== PAUSE TestAccS3ObjectDataSource_singleSlashAsKey
=== RUN   TestAccS3ObjectDataSource_leadingDotSlash
=== PAUSE TestAccS3ObjectDataSource_leadingDotSlash
=== RUN   TestAccS3ObjectDataSource_leadingMultipleSlashes
=== PAUSE TestAccS3ObjectDataSource_leadingMultipleSlashes
=== RUN   TestAccS3ObjectDataSource_checksumMode
=== PAUSE TestAccS3ObjectDataSource_checksumMode
=== RUN   TestAccS3ObjectDataSource_metadata
=== PAUSE TestAccS3ObjectDataSource_metadata
=== RUN   TestAccS3ObjectDataSource_metadataUppercaseKey
=== PAUSE TestAccS3ObjectDataSource_metadataUppercaseKey
=== RUN   TestAccS3ObjectDataSource_directoryBucket
=== PAUSE TestAccS3ObjectDataSource_directoryBucket
=== CONT  TestAccS3ObjectDataSource_basic
=== CONT  TestAccS3ObjectDataSource_multipleSlashes
--- PASS: TestAccS3ObjectDataSource_basic (20.61s)
=== CONT  TestAccS3ObjectDataSource_checksumMode
--- PASS: TestAccS3ObjectDataSource_multipleSlashes (33.81s)
=== CONT  TestAccS3ObjectDataSource_directoryBucket
--- PASS: TestAccS3ObjectDataSource_checksumMode (20.36s)
=== CONT  TestAccS3ObjectDataSource_metadataUppercaseKey
--- PASS: TestAccS3ObjectDataSource_directoryBucket (22.10s)
=== CONT  TestAccS3ObjectDataSource_metadata
--- PASS: TestAccS3ObjectDataSource_metadataUppercaseKey (33.31s)
=== CONT  TestAccS3ObjectDataSource_leadingDotSlash
--- PASS: TestAccS3ObjectDataSource_metadata (20.68s)
=== CONT  TestAccS3ObjectDataSource_leadingMultipleSlashes
=== CONT  TestAccS3ObjectDataSource_singleSlashAsKey
--- PASS: TestAccS3ObjectDataSource_leadingDotSlash (32.12s)
--- PASS: TestAccS3ObjectDataSource_leadingMultipleSlashes (32.66s)
=== CONT  TestAccS3ObjectDataSource_allParams
--- PASS: TestAccS3ObjectDataSource_singleSlashAsKey (11.18s)
=== CONT  TestAccS3ObjectDataSource_leadingSlash
--- PASS: TestAccS3ObjectDataSource_allParams (25.11s)
=== CONT  TestAccS3ObjectDataSource_objectLockLegalHoldOn
--- PASS: TestAccS3ObjectDataSource_leadingSlash (33.39s)
=== CONT  TestAccS3ObjectDataSource_objectLockLegalHoldOff
--- PASS: TestAccS3ObjectDataSource_objectLockLegalHoldOn (25.34s)
=== CONT  TestAccS3ObjectDataSource_kmsEncrypted
--- PASS: TestAccS3ObjectDataSource_objectLockLegalHoldOff (24.41s)
=== CONT  TestAccS3ObjectDataSource_bucketKeyEnabled
--- PASS: TestAccS3ObjectDataSource_kmsEncrypted (21.59s)
=== CONT  TestAccS3ObjectDataSource_readableBody
--- PASS: TestAccS3ObjectDataSource_bucketKeyEnabled (21.17s)
=== CONT  TestAccS3ObjectDataSource_basicViaAccessPoint
--- PASS: TestAccS3ObjectDataSource_readableBody (20.90s)
--- PASS: TestAccS3ObjectDataSource_basicViaAccessPoint (19.96s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	222.361s
```
