### PR TITLE
chore(iot_indexing_configuration): fix reserved shadow regex

### DIFF
--- a/.changelog/35225.txt
+++ b/.changelog/35225.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_iot_indexing_configuration: Correct plan-time validation of `thing_indexing_configuration.filter.named_shadow_names`
+```

--- a/internal/service/iot/indexing_configuration.go
+++ b/internal/service/iot/indexing_configuration.go
@@ -126,7 +126,7 @@ func ResourceIndexingConfiguration() *schema.Resource {
 											Type: schema.TypeString,
 											ValidateFunc: validation.All(
 												validation.StringLenBetween(1, 64),
-												validation.StringMatch(regexache.MustCompile(`^[a-zA-Z0-9:_-]+`), "must contain only alphanumeric characters, underscores, colons, and hyphens"),
+												validation.StringMatch(regexache.MustCompile(`^[$a-zA-Z0-9:_-]+`), "must contain only alphanumeric characters, underscores, colons, and hyphens (^[$a-zA-Z0-9:_-]+)"),
 											),
 										},
 									},

--- a/internal/service/iot/indexing_configuration_test.go
+++ b/internal/service/iot/indexing_configuration_test.go
@@ -93,8 +93,9 @@ func testAccIndexingConfiguration_allAttributes(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "thing_indexing_configuration.0.named_shadow_indexing_mode", "ON"),
 					resource.TestCheckResourceAttr(resourceName, "thing_indexing_configuration.0.thing_connectivity_indexing_mode", "STATUS"),
 					resource.TestCheckResourceAttr(resourceName, "thing_indexing_configuration.0.thing_indexing_mode", "REGISTRY_AND_SHADOW"),
-					resource.TestCheckResourceAttr(resourceName, "thing_indexing_configuration.0.filter.0.named_shadow_names.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "thing_indexing_configuration.0.filter.0.named_shadow_names.0", "thing1shadow"),
+					resource.TestCheckResourceAttr(resourceName, "thing_indexing_configuration.0.filter.0.named_shadow_names.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "thing_indexing_configuration.0.filter.0.named_shadow_names.*", "thing1shadow"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "thing_indexing_configuration.0.filter.0.named_shadow_names.*", "$package"),
 				),
 			},
 			{
@@ -131,7 +132,7 @@ resource "aws_iot_indexing_configuration" "test" {
     named_shadow_indexing_mode       = "ON"
 
     filter {
-      named_shadow_names = ["thing1shadow"]
+      named_shadow_names = ["thing1shadow", "$package"]
     }
 
     custom_field {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Add missing '$' to regex validation

### Relations
Closes #35201 

### Output from Acceptance Testing

```console
❯ make testacc TESTARGS="-run=TestAccIoTIndexingConfiguration_serial" PKG=iot
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iot/... -v -count 1 -parallel 20  -run=TestAccIoTIndexingConfiguration_serial -timeout 360m
=== RUN   TestAccIoTIndexingConfiguration_serial
=== PAUSE TestAccIoTIndexingConfiguration_serial
=== CONT  TestAccIoTIndexingConfiguration_serial
=== RUN   TestAccIoTIndexingConfiguration_serial/basic
=== RUN   TestAccIoTIndexingConfiguration_serial/allAttributes
--- PASS: TestAccIoTIndexingConfiguration_serial (44.24s)
    --- PASS: TestAccIoTIndexingConfiguration_serial/basic (22.32s)
    --- PASS: TestAccIoTIndexingConfiguration_serial/allAttributes (21.92s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iot        46.875s
```
