### PR TITLE
aws_lb: Handle case where no updated attributes are supported

### DIFF
--- a/.changelog/35228.txt
+++ b/.changelog/35228.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_lb: Handle case where no updated attributes are supported in this partition
+resource/aws_lb: Fix `ValidationError: Attributes cannot be empty` errors
 ```

--- a/.changelog/35228.txt
+++ b/.changelog/35228.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lb: Handle case where no updated attributes are supported in this partition
+```

--- a/internal/service/elbv2/load_balancer.go
+++ b/internal/service/elbv2/load_balancer.go
@@ -667,6 +667,10 @@ func modifyLoadBalancerAttributes(ctx context.Context, conn *elbv2.ELBV2, arn st
 
 	// Not all attributes are supported in all partitions.
 	for {
+		if len(input.Attributes) == 0 {
+			return nil
+		}
+
 		_, err := conn.ModifyLoadBalancerAttributesWithContext(ctx, input)
 
 		if err != nil {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

When an update to an LB is desired the provider repeatedly calls `ModifyLoadBalancerAttributesWithContext()`, removing attributes-to-update as needed when the appropriate error is returned, e.g. `InvalidConfigurationRequest: Load balancer attribute key 'dns_record.client_routing_policy' is not supported on load balancers with type 'network'` will cause a retry without the `dns_record.client_routing_policy` attribute.

When there is only one attribute to update and it is not supported in this partition, we hit a case where we'll retry the `Modify...` call with an empty attribute list.  This is the case in the related issue.

The fix is to no-op if the attributes list is pruned to the empty slice.

:information_source:  I'm not sure how to write a new acceptance test for this one because the only way to hit this edge case that I know of (I know very little about the AWS provider to be fair) is to upgrade the provider from version `5.22` to `5.31`, which isn't that easy to test.

### Relations

Closes #35014 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccELBV2LoadBalancer_ PKG=elbv2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2LoadBalancer_'  -timeout 360m
=== RUN   TestAccELBV2LoadBalancer_ALB_basic
=== PAUSE TestAccELBV2LoadBalancer_ALB_basic
=== RUN   TestAccELBV2LoadBalancer_NLB_basic
=== PAUSE TestAccELBV2LoadBalancer_NLB_basic
=== RUN   TestAccELBV2LoadBalancer_LoadBalancerType_gateway
=== PAUSE TestAccELBV2LoadBalancer_LoadBalancerType_gateway
=== RUN   TestAccELBV2LoadBalancer_disappears
=== PAUSE TestAccELBV2LoadBalancer_disappears
=== RUN   TestAccELBV2LoadBalancer_nameGenerated
=== PAUSE TestAccELBV2LoadBalancer_nameGenerated
=== RUN   TestAccELBV2LoadBalancer_nameGeneratedForZeroValue
=== PAUSE TestAccELBV2LoadBalancer_nameGeneratedForZeroValue
=== RUN   TestAccELBV2LoadBalancer_namePrefix
=== PAUSE TestAccELBV2LoadBalancer_namePrefix
=== RUN   TestAccELBV2LoadBalancer_duplicateName
=== PAUSE TestAccELBV2LoadBalancer_duplicateName
=== RUN   TestAccELBV2LoadBalancer_tags
=== PAUSE TestAccELBV2LoadBalancer_tags
=== RUN   TestAccELBV2LoadBalancer_ipv6SubnetMapping
=== PAUSE TestAccELBV2LoadBalancer_ipv6SubnetMapping
=== RUN   TestAccELBV2LoadBalancer_LoadBalancerTypeGateway_enableCrossZoneLoadBalancing
=== PAUSE TestAccELBV2LoadBalancer_LoadBalancerTypeGateway_enableCrossZoneLoadBalancing
=== RUN   TestAccELBV2LoadBalancer_ALB_outpost
=== PAUSE TestAccELBV2LoadBalancer_ALB_outpost
=== RUN   TestAccELBV2LoadBalancer_networkLoadBalancerEIP
=== PAUSE TestAccELBV2LoadBalancer_networkLoadBalancerEIP
=== RUN   TestAccELBV2LoadBalancer_NLB_privateIPv4Address
=== PAUSE TestAccELBV2LoadBalancer_NLB_privateIPv4Address
=== RUN   TestAccELBV2LoadBalancer_backwardsCompatibility
=== PAUSE TestAccELBV2LoadBalancer_backwardsCompatibility
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateCrossZone
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateCrossZone
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateHTTP2
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateHTTP2
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDropInvalidHeaderFields
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDropInvalidHeaderFields
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatePreserveHostHeader
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatePreserveHostHeader
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDeletionProtection
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDeletionProtection
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateWAFFailOpen
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateWAFFailOpen
=== RUN   TestAccELBV2LoadBalancer_updateIPAddressType
=== PAUSE TestAccELBV2LoadBalancer_updateIPAddressType
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatedSecurityGroups
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatedSecurityGroups
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_addSubnet
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_addSubnet
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_deleteSubnet
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_deleteSubnet
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_addSubnetMapping
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_addSubnetMapping
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_deleteSubnetMapping
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_deleteSubnetMapping
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_noSecurityGroup
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_noSecurityGroup
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_accessLogs
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_accessLogs
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_accessLogsPrefix
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_accessLogsPrefix
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_connectionLogs
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_connectionLogs
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_connectionLogsPrefix
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_connectionLogsPrefix
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_accessLogs
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_accessLogs
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_accessLogsPrefix
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_accessLogsPrefix
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateDNSRecordClientRoutingPolicy
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateDNSRecordClientRoutingPolicy
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateSecurityGroups
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateSecurityGroups
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_enforcePrivateLink
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_enforcePrivateLink
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_addSubnet
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_addSubnet
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_deleteSubnet
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_deleteSubnet
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_addSubnetMapping
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_addSubnetMapping
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_deleteSubnetMapping
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_deleteSubnetMapping
=== RUN   TestAccELBV2LoadBalancer_updateDesyncMitigationMode
=== PAUSE TestAccELBV2LoadBalancer_updateDesyncMitigationMode
=== RUN   TestAccELBV2LoadBalancer_ALB_updateTLSVersionAndCipherSuite
=== PAUSE TestAccELBV2LoadBalancer_ALB_updateTLSVersionAndCipherSuite
=== RUN   TestAccELBV2LoadBalancer_ALB_updateXffHeaderProcessingMode
=== PAUSE TestAccELBV2LoadBalancer_ALB_updateXffHeaderProcessingMode
=== RUN   TestAccELBV2LoadBalancer_ALB_updateXffClientPort
=== PAUSE TestAccELBV2LoadBalancer_ALB_updateXffClientPort
=== CONT  TestAccELBV2LoadBalancer_ALB_basic
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_addSubnet
=== CONT  TestAccELBV2LoadBalancer_duplicateName
=== CONT  TestAccELBV2LoadBalancer_networkLoadBalancerEIP
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatedSecurityGroups
=== CONT  TestAccELBV2LoadBalancer_updateIPAddressType
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateWAFFailOpen
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDeletionProtection
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatePreserveHostHeader
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDropInvalidHeaderFields
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateHTTP2
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateCrossZone
=== CONT  TestAccELBV2LoadBalancer_backwardsCompatibility
=== CONT  TestAccELBV2LoadBalancer_NLB_privateIPv4Address
=== CONT  TestAccELBV2LoadBalancer_namePrefix
=== CONT  TestAccELBV2LoadBalancer_ALB_outpost
=== CONT  TestAccELBV2LoadBalancer_LoadBalancerTypeGateway_enableCrossZoneLoadBalancing
=== CONT  TestAccELBV2LoadBalancer_ipv6SubnetMapping
=== CONT  TestAccELBV2LoadBalancer_tags
=== CONT  TestAccELBV2LoadBalancer_ALB_updateXffClientPort
=== NAME  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatedSecurityGroups
    acctest.go:952: skipping tests; current partition (aws-us-gov) not supported
--- SKIP: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatedSecurityGroups (0.45s)
=== CONT  TestAccELBV2LoadBalancer_ALB_updateXffHeaderProcessingMode
=== NAME  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_addSubnet
    acctest.go:952: skipping tests; current partition (aws-us-gov) not supported
--- SKIP: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_addSubnet (0.45s)
=== CONT  TestAccELBV2LoadBalancer_ALB_updateTLSVersionAndCipherSuite
=== NAME  TestAccELBV2LoadBalancer_ALB_outpost
    acctest.go:1156: skipping since no Outposts found
--- SKIP: TestAccELBV2LoadBalancer_ALB_outpost (1.06s)
=== CONT  TestAccELBV2LoadBalancer_updateDesyncMitigationMode
--- PASS: TestAccELBV2LoadBalancer_duplicateName (204.50s)
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_deleteSubnetMapping
    acctest.go:952: skipping tests; current partition (aws-us-gov) not supported
--- SKIP: TestAccELBV2LoadBalancer_NetworkLoadBalancer_deleteSubnetMapping (0.00s)
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_addSubnetMapping
    acctest.go:952: skipping tests; current partition (aws-us-gov) not supported
--- SKIP: TestAccELBV2LoadBalancer_NetworkLoadBalancer_addSubnetMapping (0.00s)
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_deleteSubnet
    acctest.go:952: skipping tests; current partition (aws-us-gov) not supported
--- SKIP: TestAccELBV2LoadBalancer_NetworkLoadBalancer_deleteSubnet (0.00s)
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_addSubnet
    acctest.go:952: skipping tests; current partition (aws-us-gov) not supported
--- SKIP: TestAccELBV2LoadBalancer_NetworkLoadBalancer_addSubnet (0.00s)
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_enforcePrivateLink
--- PASS: TestAccELBV2LoadBalancer_backwardsCompatibility (207.88s)
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateSecurityGroups
--- PASS: TestAccELBV2LoadBalancer_namePrefix (219.83s)
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateDNSRecordClientRoutingPolicy
    acctest.go:952: skipping tests; current partition (aws-us-gov) not supported
--- SKIP: TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateDNSRecordClientRoutingPolicy (0.00s)
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_accessLogsPrefix
--- PASS: TestAccELBV2LoadBalancer_LoadBalancerTypeGateway_enableCrossZoneLoadBalancing (219.84s)
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_accessLogs
--- PASS: TestAccELBV2LoadBalancer_networkLoadBalancerEIP (227.62s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_connectionLogsPrefix
--- PASS: TestAccELBV2LoadBalancer_ALB_basic (254.13s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_connectionLogs
--- PASS: TestAccELBV2LoadBalancer_NLB_privateIPv4Address (255.03s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_accessLogsPrefix
--- PASS: TestAccELBV2LoadBalancer_updateIPAddressType (258.23s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_accessLogs
--- PASS: TestAccELBV2LoadBalancer_ipv6SubnetMapping (259.77s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_noSecurityGroup
--- PASS: TestAccELBV2LoadBalancer_ALB_updateXffHeaderProcessingMode (278.76s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_deleteSubnetMapping
    acctest.go:952: skipping tests; current partition (aws-us-gov) not supported
--- SKIP: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_deleteSubnetMapping (0.00s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_addSubnetMapping
    acctest.go:952: skipping tests; current partition (aws-us-gov) not supported
--- SKIP: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_addSubnetMapping (0.00s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_deleteSubnet
    acctest.go:952: skipping tests; current partition (aws-us-gov) not supported
--- SKIP: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_deleteSubnet (0.00s)
=== CONT  TestAccELBV2LoadBalancer_LoadBalancerType_gateway
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateHTTP2 (279.71s)
=== CONT  TestAccELBV2LoadBalancer_nameGeneratedForZeroValue
--- PASS: TestAccELBV2LoadBalancer_tags (282.26s)
=== CONT  TestAccELBV2LoadBalancer_nameGenerated
--- PASS: TestAccELBV2LoadBalancer_ALB_updateXffClientPort (283.06s)
=== CONT  TestAccELBV2LoadBalancer_disappears
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDeletionProtection (283.83s)
=== CONT  TestAccELBV2LoadBalancer_NLB_basic
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateWAFFailOpen (288.04s)
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatePreserveHostHeader (288.24s)
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateCrossZone (290.82s)
--- PASS: TestAccELBV2LoadBalancer_ALB_updateTLSVersionAndCipherSuite (298.34s)
--- PASS: TestAccELBV2LoadBalancer_updateDesyncMitigationMode (302.57s)
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDropInvalidHeaderFields (320.22s)
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_noSecurityGroup (189.41s)
--- PASS: TestAccELBV2LoadBalancer_disappears (173.42s)
--- PASS: TestAccELBV2LoadBalancer_LoadBalancerType_gateway (180.32s)
--- PASS: TestAccELBV2LoadBalancer_nameGeneratedForZeroValue (181.78s)
--- PASS: TestAccELBV2LoadBalancer_nameGenerated (194.62s)
--- PASS: TestAccELBV2LoadBalancer_NLB_basic (217.68s)
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_connectionLogsPrefix (287.64s)
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancer_enforcePrivateLink (315.63s)
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancer_accessLogsPrefix (319.64s)
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_accessLogsPrefix (288.27s)
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_connectionLogs (320.02s)
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_accessLogs (341.49s)
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancer_accessLogs (383.44s)
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateSecurityGroups (729.47s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elbv2      937.440s
```

### Manual testing

Before the fix, I was able to reproduce the error using a local `make build` of the provider and the minimal reproducing TF configuration from https://github.com/hashicorp/terraform-provider-aws/issues/35014.

After the fix, I am able to upgrade from provider version `5.22` to my build from `main` branch and do the following:

```
$ terraform plan
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - hashicorp/aws in /home/joel/go/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
data.aws_vpc.repro: Reading...
data.aws_vpc.repro: Read complete after 1s [id=vpc-xxx]
data.aws_subnet.repro: Reading...
data.aws_subnet.repro: Read complete after 0s [id=subnet-xxx]
aws_lb.repro: Refreshing state... [id=arn:aws-us-gov:elasticloadbalancing:us-gov-west-1:xxx:loadbalancer/net/repro-nlb/xxx]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # aws_lb.repro will be updated in-place
  ~ resource "aws_lb" "repro" {
      + dns_record_client_routing_policy = "any_availability_zone"
        id                               = "arn:aws-us-gov:elasticloadbalancing:us-gov-west-1:xxx:loadbalancer/net/repro-nlb/xxx"
        name                             = "repro-nlb"
        tags                             = {}
        # (13 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.
$ terraform apply
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - hashicorp/aws in /home/joel/go/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
data.aws_vpc.repro: Reading...
data.aws_vpc.repro: Read complete after 1s [id=vpc-xxx]
data.aws_subnet.repro: Reading...
data.aws_subnet.repro: Read complete after 0s [id=subnet-xxx]
aws_lb.repro: Refreshing state... [id=arn:aws-us-gov:elasticloadbalancing:us-gov-west-1:xxx:loadbalancer/net/repro-nlb/xxx]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # aws_lb.repro will be updated in-place
  ~ resource "aws_lb" "repro" {
      + dns_record_client_routing_policy = "any_availability_zone"
        id                               = "arn:aws-us-gov:elasticloadbalancing:us-gov-west-1:xxx:loadbalancer/net/repro-nlb/xxx"
        name                             = "repro-nlb"
        tags                             = {}
        # (13 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

aws_lb.repro: Modifying... [id=arn:aws-us-gov:elasticloadbalancing:us-gov-west-1:xxx:loadbalancer/net/repro-nlb/xxx]
aws_lb.repro: Still modifying... [id=arn:aws-us-gov:elasticloadbalancing:us-...alancer/net/repro-nlb/xxx, 10s elapsed]
aws_lb.repro: Still modifying... [id=arn:aws-us-gov:elasticloadbalancing:us-...alancer/net/repro-nlb/xxx, 20s elapsed]
aws_lb.repro: Still modifying... [id=arn:aws-us-gov:elasticloadbalancing:us-...alancer/net/repro-nlb/xxx, 30s elapsed]
aws_lb.repro: Modifications complete after 31s [id=arn:aws-us-gov:elasticloadbalancing:us-gov-west-1:xxx:loadbalancer/net/repro-nlb/xxx]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
$ terraform plan
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - hashicorp/aws in /home/joel/go/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
data.aws_vpc.repro: Reading...
data.aws_vpc.repro: Read complete after 1s [id=vpc-xxx]
data.aws_subnet.repro: Reading...
data.aws_subnet.repro: Read complete after 0s [id=subnet-xxx]
aws_lb.repro: Refreshing state... [id=arn:aws-us-gov:elasticloadbalancing:us-gov-west-1:xxx:loadbalancer/net/repro-nlb/xxx]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```