### PR TITLE
fix: Add missing aws_ecr_lifecycle_policy tagPatternList change detection

### DIFF
--- a/.changelog/35231.txt
+++ b/.changelog/35231.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ecr_lifecycle_policy: Add missing `tagPatternList` change detection in policy JSON
+```

--- a/internal/service/ecr/lifecycle_policy.go
+++ b/internal/service/ecr/lifecycle_policy.go
@@ -188,11 +188,12 @@ func resourceLifecyclePolicyDelete(ctx context.Context, d *schema.ResourceData, 
 }
 
 type lifecyclePolicyRuleSelection struct {
-	TagStatus     *string   `locationName:"tagStatus" type:"string" enum:"tagStatus" required:"true"`
-	TagPrefixList []*string `locationName:"tagPrefixList" type:"list"`
-	CountType     *string   `locationName:"countType" type:"string" enum:"countType" required:"true"`
-	CountUnit     *string   `locationName:"countUnit" type:"string" enum:"countType"`
-	CountNumber   *int64    `locationName:"countNumber" min:"1" type:"integer"`
+	TagStatus      *string   `locationName:"tagStatus" type:"string" enum:"tagStatus" required:"true"`
+	TagPatternList []*string `locationName:"tagPatternList" type:"list"`
+	TagPrefixList  []*string `locationName:"tagPrefixList" type:"list"`
+	CountType      *string   `locationName:"countType" type:"string" enum:"countType" required:"true"`
+	CountUnit      *string   `locationName:"countUnit" type:"string" enum:"countType"`
+	CountNumber    *int64    `locationName:"countNumber" min:"1" type:"integer"`
 }
 
 type lifecyclePolicyRuleAction struct {
@@ -221,6 +222,14 @@ func (lp *lifecyclePolicy) reduce() {
 }
 
 func (lprs *lifecyclePolicyRuleSelection) reduce() {
+	sort.Slice(lprs.TagPatternList, func(i, j int) bool {
+		return aws.StringValue(lprs.TagPatternList[i]) < aws.StringValue(lprs.TagPatternList[j])
+	})
+
+	if len(lprs.TagPatternList) == 0 {
+		lprs.TagPatternList = nil
+	}
+
 	sort.Slice(lprs.TagPrefixList, func(i, j int) bool {
 		return aws.StringValue(lprs.TagPrefixList[i]) < aws.StringValue(lprs.TagPrefixList[j])
 	})

--- a/internal/service/ecr/lifecycle_policy_test.go
+++ b/internal/service/ecr/lifecycle_policy_test.go
@@ -143,6 +143,32 @@ func testAccCheckLifecyclePolicyExists(ctx context.Context, name string) resourc
 	}
 }
 
+func TestAccECRLifecyclePolicy_detectTagPatternListDiff(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_ecr_lifecycle_policy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ecr.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLifecyclePolicyDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLifecyclePolicyConfig_tagPatternList(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLifecyclePolicyExists(ctx, resourceName),
+				),
+			},
+			{
+				Config:             testAccLifecyclePolicyConfig_tagPatternListChanged(rName),
+				ExpectNonEmptyPlan: true,
+				PlanOnly:           true,
+			},
+		},
+	})
+}
+
 func testAccLifecyclePolicyConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecr_repository" "test" {
@@ -297,6 +323,72 @@ resource "aws_ecr_lifecycle_policy" "test" {
           type = "expire"
         }
       },
+    ]
+  })
+}
+`, rName)
+}
+
+func testAccLifecyclePolicyConfig_tagPatternList(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ecr_repository" "test" {
+  name = "%s"
+}
+
+resource "aws_ecr_lifecycle_policy" "test" {
+  repository = aws_ecr_repository.test.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Expire tagged images older than 14 days"
+        selection = {
+          tagStatus = "tagged"
+          tagPatternList = [
+            "alpha-*"
+          ]
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 14
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}
+`, rName)
+}
+
+func testAccLifecyclePolicyConfig_tagPatternListChanged(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ecr_repository" "test" {
+  name = "%s"
+}
+
+resource "aws_ecr_lifecycle_policy" "test" {
+  repository = aws_ecr_repository.test.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Expire tagged images older than 14 days"
+        selection = {
+          tagStatus = "tagged"
+          tagPatternList = [
+            "beta-*"
+          ]
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 14
+        }
+        action = {
+          type = "expire"
+        }
+      }
     ]
   })
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR is to fix change detection issues (specifically the lack of it) with the `tagPatternList` attribute in the ECR lifecycle policy JSON for the `aws_ecr_lifecycle_policy` resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #35184

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
[Lifecycle policies](https://docs.aws.amazon.com/AmazonECR/latest/userguide/LifecyclePolicies.html) provides more details on the syntax of the policy JSON.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
Note: `TestAccECRLifecyclePolicy_detectTagPatternListDiff` is a new test case.

```console
$ make testacc TESTS=TestAccECRLifecyclePolicy_ PKG=ecr
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecr/... -v -count 1 -parallel 20 -run='TestAccECRLifecyclePolicy_'  -timeout 360m
=== RUN   TestAccECRLifecyclePolicy_basic
=== PAUSE TestAccECRLifecyclePolicy_basic
=== RUN   TestAccECRLifecyclePolicy_ignoreEquivalent
=== PAUSE TestAccECRLifecyclePolicy_ignoreEquivalent
=== RUN   TestAccECRLifecyclePolicy_detectDiff
=== PAUSE TestAccECRLifecyclePolicy_detectDiff
=== RUN   TestAccECRLifecyclePolicy_detectTagPatternListDiff
=== PAUSE TestAccECRLifecyclePolicy_detectTagPatternListDiff
=== CONT  TestAccECRLifecyclePolicy_basic
=== CONT  TestAccECRLifecyclePolicy_detectDiff
=== CONT  TestAccECRLifecyclePolicy_ignoreEquivalent
=== CONT  TestAccECRLifecyclePolicy_detectTagPatternListDiff
--- PASS: TestAccECRLifecyclePolicy_basic (80.98s)
--- PASS: TestAccECRLifecyclePolicy_ignoreEquivalent (101.03s)
--- PASS: TestAccECRLifecyclePolicy_detectDiff (101.06s)
--- PASS: TestAccECRLifecyclePolicy_detectTagPatternListDiff (101.07s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecr        101.351s
$
```
