### PR TITLE
docs: Mark aws_vpc_ipam_pool attrs as required correctly

### DIFF
--- a/website/docs/r/vpc_ipam_pool.html.markdown
+++ b/website/docs/r/vpc_ipam_pool.html.markdown
@@ -69,7 +69,7 @@ resource "aws_vpc_ipam_pool_cidr" "child_test" {
 
 This resource supports the following arguments:
 
-* `address_family` - (Optional) The IP protocol assigned to this pool. You must choose either IPv4 or IPv6 protocol for a pool.
+* `address_family` - (Required) The IP protocol assigned to this pool. You must choose either IPv4 or IPv6 protocol for a pool.
 * `allocation_default_netmask_length` - (Optional) A default netmask length for allocations added to this pool. If, for example, the CIDR assigned to this pool is 10.0.0.0/8 and you enter 16 here, new allocations will default to 10.0.0.0/16 (unless you provide a different netmask value when you create the new allocation).
 * `allocation_max_netmask_length` - (Optional) The maximum netmask length that will be required for CIDR allocations in this pool.
 * `allocation_min_netmask_length` - (Optional) The minimum netmask length that will be required for CIDR allocations in this pool.
@@ -78,7 +78,7 @@ This resource supports the following arguments:
 within the CIDR range in the pool.
 * `aws_service` - (Optional) Limits which AWS service the pool can be used in. Only useable on public scopes. Valid Values: `ec2`.
 * `description` - (Optional) A description for the IPAM pool.
-* `ipam_scope_id` - (Optional) The ID of the scope in which you would like to create the IPAM pool.
+* `ipam_scope_id` - (Required) The ID of the scope in which you would like to create the IPAM pool.
 * `locale` - (Optional) The locale in which you would like to create the IPAM pool. Locale is the Region where you want to make an IPAM pool available for allocations. You can only create pools with locales that match the operating Regions of the IPAM. You can only create VPCs from a pool whose locale matches the VPC's Region. Possible values: Any AWS region, such as `us-east-1`.
 * `publicly_advertisable` - (Optional) Defines whether or not IPv6 pool space is publicly advertisable over the internet. This argument is required if `address_family = "ipv6"` and `public_ip_source = "byoip"`, default is `false`. This option is not available for IPv4 pool space or if `public_ip_source = "amazon"`.
 * `public_ip_source` - (Optional) The IP address source for pools in the public scope. Only used for provisioning IP address CIDRs to pools in the public scope. Valid values are `byoip` or `amazon`. Default is `byoip`.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is used to correctly mark the `address_family` and `ipam_scope_id` attributes as required for the `aws_vpc_ipam_pool` resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #35044

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
The [CreateIpamPool API reference](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateIpamPool.html) is used as the official guide for whether attributes are required for cross-checking with the Terraform resource code and doc.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
n/a