### PR TITLE
r/aws_fis_expermient_template: remove validation for target properties

### DIFF
--- a/.changelog/35254.txt
+++ b/.changelog/35254.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_fis_experiment_template: Fix validation error when not using `target.resource_arns` or `target.resource_tag` attributes.
+```

--- a/internal/service/fis/experiment_template.go
+++ b/internal/service/fis/experiment_template.go
@@ -633,7 +633,6 @@ func expandExperimentTemplateTargets(l *schema.Set) (map[string]types.CreateExpe
 		raw := m.(map[string]interface{})
 		config := types.CreateExperimentTemplateTargetInput{}
 		var hasSeenResourceArns bool
-		var hasSeenResourceTag bool
 
 		if v, ok := raw["filter"].([]interface{}); ok && len(v) > 0 {
 			config.Filters = expandExperimentTemplateTargetFilters(v)
@@ -651,11 +650,6 @@ func expandExperimentTemplateTargets(l *schema.Set) (map[string]types.CreateExpe
 				return nil, errors.New("Only one of resource_arns, resource_tag can be set in a target block")
 			}
 			config.ResourceTags = expandExperimentTemplateTargetResourceTags(v)
-			hasSeenResourceTag = true
-		}
-
-		if !hasSeenResourceArns && !hasSeenResourceTag {
-			return nil, errors.New("A target block requires one of resource_arns, resource_tag")
 		}
 
 		if v, ok := raw["resource_type"].(string); ok && v != "" {
@@ -689,7 +683,6 @@ func expandExperimentTemplateTargetsForUpdate(l *schema.Set) (map[string]types.U
 		raw := m.(map[string]interface{})
 		config := types.UpdateExperimentTemplateTargetInput{}
 		var hasSeenResourceArns bool
-		var hasSeenResourceTag bool
 
 		if v, ok := raw["filter"].([]interface{}); ok && len(v) > 0 {
 			config.Filters = expandExperimentTemplateTargetFilters(v)
@@ -707,11 +700,6 @@ func expandExperimentTemplateTargetsForUpdate(l *schema.Set) (map[string]types.U
 				return nil, errors.New("Only one of resource_arns, resource_tag can be set in a target block")
 			}
 			config.ResourceTags = expandExperimentTemplateTargetResourceTags(v)
-			hasSeenResourceTag = true
-		}
-
-		if !hasSeenResourceArns && !hasSeenResourceTag {
-			return nil, errors.New("A target block requires one of resource_arns, resource_tag")
 		}
 
 		if v, ok := raw["resource_type"].(string); ok && v != "" {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Resource type `aws:eks:pod` can be created in a target and does not require `resource_arns` or `resource_tags`. Remove validation to allow operation to complete.

```hcl 
resource "aws_fis_experiment_template" "test" {
  description = "test"
  role_arn    = aws_iam_role.test.arn

  stop_condition {
    source = "none"
  }

  action {
    name        = "Memory-Stress-1"
    action_id   = "aws:eks:pod-memory-stress"
    description = "EKS token service memory stress"

    parameter {
      key   = "duration"
      value = "PT15M"
    }

    parameter {
      key   = "kubernetesServiceAccount"
      value = "fis-experiment"
    }

    target {
      key   = "Pods"
      value = "Pod-Target-1"
    }
  }

  target {
    name           = "Pod-Target-1"
    resource_type  = "aws:eks:pod"
    selection_mode = "ALL"

    parameters = {
      "clusterIdentifier" = "test"
      "namespace"         = "default"
      "selectorType"      = "labelSelector"
      "selectorValue"     = "app=nginx"
    }
  }
}
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #32281

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccFISExperimentTemplate_' PKG=fis

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/fis/... -v -count 1 -parallel 20  -run=TestAccFISExperimentTemplate_ -timeout 360m
--- PASS: TestAccFISExperimentTemplate_spot (14.58s)
--- PASS: TestAccFISExperimentTemplate_disappears (14.97s)
--- PASS: TestAccFISExperimentTemplate_basic (17.04s)
--- PASS: TestAccFISExperimentTemplate_update (25.43s)
--- PASS: TestAccFISExperimentTemplate_ebsParameters (35.68s)
--- PASS: TestAccFISExperimentTemplate_ebs (35.70s)
--- PASS: TestAccFISExperimentTemplate_loggingConfiguration (46.57s)
--- PASS: TestAccFISExperimentTemplate_eks (616.51s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/fis	620.270s.
```
