### PR TITLE
r/aws_ecr_image: fix regression for most recent

### DIFF
--- a/.changelog/35269.txt
+++ b/.changelog/35269.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_ecr_image: Fix error when `most_recent` is not also `latest`
+```

--- a/internal/service/ecr/image_data_source.go
+++ b/internal/service/ecr/image_data_source.go
@@ -102,18 +102,6 @@ func dataSourceImageRead(ctx context.Context, d *schema.ResourceData, meta inter
 		}
 	}
 
-	if v, ok := d.Get("most_recent").(bool); ok && v {
-		if len(input.ImageIds) == 0 {
-			input.ImageIds = []*ecr.ImageIdentifier{
-				{
-					ImageTag: aws.String("latest"),
-				},
-			}
-		} else {
-			input.ImageIds[0].ImageTag = aws.String("latest")
-		}
-	}
-
 	if v, ok := d.GetOk("registry_id"); ok {
 		input.RegistryId = aws.String(v.(string))
 	}

--- a/internal/service/ecr/image_data_source_test.go
+++ b/internal/service/ecr/image_data_source_test.go
@@ -38,7 +38,6 @@ func TestAccECRImageDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceByDigest, "image_uri"),
 					resource.TestCheckResourceAttrSet(resourceByMostRecent, "image_pushed_at"),
 					resource.TestCheckResourceAttrSet(resourceByMostRecent, "image_size_in_bytes"),
-					resource.TestCheckTypeSetElemAttr(resourceByMostRecent, "image_tags.*", tag),
 				),
 			},
 		},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Most recent image can be different than the imaged tagged as `latest` and do not share the same tags.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #35263.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/24526.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS="-run=TestAccECRImageDataSource_basic" PKG=ecr

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecr/... -v -count 1 -parallel 20  -run=TestAccECRImageDataSource_basic -timeout 360m
=== RUN   TestAccECRImageDataSource_basic
=== PAUSE TestAccECRImageDataSource_basic
=== CONT  TestAccECRImageDataSource_basic
--- PASS: TestAccECRImageDataSource_basic (11.67s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecr	15.495s
```
