### PR TITLE
Fix typo in elasticache_serverless_cache docs

### DIFF
--- a/website/docs/r/elasticache_serverless_cache.html.markdown
+++ b/website/docs/r/elasticache_serverless_cache.html.markdown
@@ -70,7 +70,7 @@ The following arguments are required:
 The following arguments are optional:
 
 * `cache_usage_limits` - (Optional) Sets the cache usage limits for storage and ElastiCache Processing Units for the cache. See configuration below.
-* `daily_snapshott_time` - (Optional) The daily time that snapshots will be created from the new serverless cache. Only supported for engine type `"redis"`. Defaults to `0`.
+* `daily_snapshot_time` - (Optional) The daily time that snapshots will be created from the new serverless cache. Only supported for engine type `"redis"`. Defaults to `0`.
 * `description` - (Optional) User-provided description for the serverless cache. The default is NULL.
 * `kms_key_id` - (Optional) ARN of the customer managed key for encrypting the data at rest. If no KMS key is provided, a default service key is used.
 * `major_engine_version` – (Optional) The version of the cache engine that will be used to create the serverless cache.


### PR DESCRIPTION
### Description
Fix typo in documentation

### Relations
None

### References
None

### Output from Acceptance Testing
None