### PR TITLE
r/aws_datasync_task: allow removal of schedule

### DIFF
--- a/.changelog/35282.txt
+++ b/.changelog/35282.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_datasync_task: Allow `schedule` to be removed successfully
+```

--- a/internal/service/datasync/task.go
+++ b/internal/service/datasync/task.go
@@ -628,7 +628,7 @@ func expandOptions(l []interface{}) *datasync.Options {
 
 func expandTaskSchedule(l []interface{}) *datasync.TaskSchedule {
 	if len(l) == 0 || l[0] == nil {
-		return nil
+		return &datasync.TaskSchedule{ScheduleExpression: aws.String("")} // explicitly set empty object if schedule is nil
 	}
 
 	m := l[0].(map[string]interface{})

--- a/internal/service/datasync/task_test.go
+++ b/internal/service/datasync/task_test.go
@@ -132,6 +132,13 @@ func TestAccDataSyncTask_schedule(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "schedule.0.schedule_expression", "cron(0 12 ? * SUN,MON *)"),
 				),
 			},
+			{
+				Config: testAccTaskConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTaskExists(ctx, resourceName, &task1),
+					resource.TestCheckResourceAttr(resourceName, "schedule.#", "0"),
+				),
+			},
 		},
 	})
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Removing the schedule from a task should clear it completely.

Initial config

```hcl
resource "aws_datasync_task" "test" {
  destination_location_arn = aws_datasync_location_s3.test1.arn
  name                     = local.name1
  source_location_arn      = aws_datasync_location_s3.test2.arn

  options {
    posix_permissions = "NONE"
    verify_mode       = "ONLY_FILES_TRANSFERRED"
    gid               = "NONE"
    uid               = "NONE"
  }

  schedule {
    schedule_expression = "cron(0/60 * * * ? *)"
  }
}
```

update:

```hcl
resource "aws_datasync_task" "test" {
  destination_location_arn = aws_datasync_location_s3.test1.arn
  name                     = local.name1
  source_location_arn      = aws_datasync_location_s3.test2.arn

  options {
    posix_permissions = "NONE"
    verify_mode       = "ONLY_FILES_TRANSFERRED"
    gid               = "NONE"
    uid               = "NONE"
  }
}
```

Should result with a task that does not have a schedule

```console
% make testacc TESTARGS="-run=TestAccDataSyncTask_schedule" PKG=datasync

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/datasync/... -v -count 1 -parallel 20  -run=TestAccDataSyncTask_schedule -timeout 360m
=== RUN   TestAccDataSyncTask_schedule
=== PAUSE TestAccDataSyncTask_schedule
=== CONT  TestAccDataSyncTask_schedule
    task_test.go:108: Step 4/4 error: Check failed: Check 2/2 error: aws_datasync_task.test: Attribute 'schedule.#' expected "0", got "1"
--- FAIL: TestAccDataSyncTask_schedule (211.80s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/datasync	215.445s
FAIL
make: *** [testacc] Error 1
```
### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS="-run=TestAccDataSyncTask_" PKG=datasync

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/datasync/... -v -count 1 -parallel 20  -run=TestAccDataSyncTask_ -timeout 360m
--- PASS: TestAccDataSyncTask_disappears (167.35s)
--- PASS: TestAccDataSyncTask_DefaultSyncOptions_preserveDevices (194.46s)
--- PASS: TestAccDataSyncTask_DefaultSyncOptions_posixPermissions (207.03s)
--- PASS: TestAccDataSyncTask_DefaultSyncOptions_overwriteMode (213.79s)
--- PASS: TestAccDataSyncTask_DefaultSyncOptions_atimeMtime (222.90s)
--- PASS: TestAccDataSyncTask_taskReportConfig (228.46s)
--- PASS: TestAccDataSyncTask_includes (233.07s)
--- PASS: TestAccDataSyncTask_basic (235.71s)
--- PASS: TestAccDataSyncTask_excludes (235.77s)
--- PASS: TestAccDataSyncTask_DefaultSyncOptions_gid (236.73s)
--- PASS: TestAccDataSyncTask_DefaultSyncOptions_objectTags (258.01s)
--- PASS: TestAccDataSyncTask_DefaultSyncOptions_transferMode (260.19s)
--- PASS: TestAccDataSyncTask_DefaultSyncOptions_verifyMode (262.29s)
--- PASS: TestAccDataSyncTask_cloudWatchLogGroupARN (266.44s)
--- PASS: TestAccDataSyncTask_DefaultSyncOptions_preserveDeletedFiles (268.05s)
--- PASS: TestAccDataSyncTask_DefaultSyncOptions_bytesPerSecond (290.96s)
--- PASS: TestAccDataSyncTask_DefaultSyncOptions_uid (307.93s)
--- PASS: TestAccDataSyncTask_schedule (309.96s)
--- PASS: TestAccDataSyncTask_tags (312.68s)
--- PASS: TestAccDataSyncTask_DefaultSyncOptions_taskQueueing (158.72s)
--- PASS: TestAccDataSyncTask_DefaultSyncOptions_logLevel (327.78s)
--- PASS: TestAccDataSyncTask_DefaultSyncOptions_securityDescriptorCopyFlags (3130.11s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/datasync	3328.183s
```
