### PR TITLE
r/aws_lakeformation_resource: add `use_service_linked_role` argument

### DIFF
--- a/.changelog/35284.txt
+++ b/.changelog/35284.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_lakeformation_resource: Add `use_service_linked_role` argument
+```

--- a/internal/service/lakeformation/resource_test.go
+++ b/internal/service/lakeformation/resource_test.go
@@ -305,7 +305,8 @@ resource "aws_s3_bucket" "test" {
 }
 
 resource "aws_lakeformation_resource" "test" {
-  arn = aws_s3_bucket.test.arn
+  arn                     = aws_s3_bucket.test.arn
+  use_service_linked_role = true
 }
 `, rName)
 }

--- a/website/docs/r/lakeformation_resource.html.markdown
+++ b/website/docs/r/lakeformation_resource.html.markdown
@@ -10,7 +10,10 @@ description: |-
 
 Registers a Lake Formation resource (e.g., S3 bucket) as managed by the Data Catalog. In other words, the S3 path is added to the data lake.
 
-Choose a role that has read/write access to the chosen Amazon S3 path or use the service-linked role. When you register the S3 path, the service-linked role and a new inline policy are created on your behalf. Lake Formation adds the first path to the inline policy and attaches it to the service-linked role. When you register subsequent paths, Lake Formation adds the path to the existing policy.
+Choose a role that has read/write access to the chosen Amazon S3 path or use the service-linked role.
+When you register the S3 path, the service-linked role and a new inline policy are created on your behalf.
+Lake Formation adds the first path to the inline policy and attaches it to the service-linked role.
+When you register subsequent paths, Lake Formation adds the path to the existing policy.
 
 ## Example Usage
 
@@ -26,8 +29,14 @@ resource "aws_lakeformation_resource" "example" {
 
 ## Argument Reference
 
-* `arn` – (Required) Amazon Resource Name (ARN) of the resource, an S3 path.
-* `role_arn` – (Optional) Role that has read/write access to the resource. If not provided, the Lake Formation service-linked role must exist and is used.
+The following arguments are required:
+
+* `arn` – (Required) Amazon Resource Name (ARN) of the resource.
+
+The following arguments are optional:
+
+* `role_arn` – (Optional) Role that has read/write access to the resource.
+* `use_service_linked_role` - (Optional) Designates an AWS Identity and Access Management (IAM) service-linked role by registering this role with the Data Catalog.
 
 ~> **NOTE:** AWS does not support registering an S3 location with an IAM role and subsequently updating the S3 location registration to a service-linked role.
 
@@ -35,4 +44,4 @@ resource "aws_lakeformation_resource" "example" {
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `last_modified` - (Optional) The date and time the resource was last modified in [RFC 3339 format](https://tools.ietf.org/html/rfc3339#section-5.8).
+* `last_modified` - Date and time the resource was last modified in [RFC 3339 format](https://tools.ietf.org/html/rfc3339#section-5.8).


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This argument will allow pracitioners to explicitly configure whether the value of `UseServiceLinkedRole` boolean in the underlying AWS RegisterResource API. Also fixes a bug where deleted resource registrations were not handled correctly by the destroy operation.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #35283

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/lake-formation/latest/APIReference/API_RegisterResource.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=lakeformation TESTS=TestAccLakeFormationResource_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lakeformation/... -v -count 1 -parallel 20 -run='TestAccLakeFormationResource_'  -timeout 360m

--- PASS: TestAccLakeFormationResource_basic (15.66s)
--- PASS: TestAccLakeFormationResource_disappears (16.16s)
--- PASS: TestAccLakeFormationResource_serviceLinkedRole (16.32s)
--- PASS: TestAccLakeFormationResource_updateRoleToRole (26.47s)
--- PASS: TestAccLakeFormationResource_updateSLRToRole (27.72s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lakeformation      31.253s
```
