### PR TITLE
docs: Add access_control_translation cfg block desc to aws_s3_bucket resource doc

### DIFF
--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -220,10 +220,16 @@ The `destination` configuration block supports the following arguments:
 * `storage_class` - (Optional) The [storage class](https://docs.aws.amazon.com/AmazonS3/latest/API/API_Destination.html#AmazonS3-Type-Destination-StorageClass) used to store the object. By default, Amazon S3 uses the storage class of the source object to create the object replica.
 * `replica_kms_key_id` - (Optional) Destination KMS encryption key ARN for SSE-KMS replication. Must be used in conjunction with
   `sse_kms_encrypted_objects` source selection criteria.
-* `access_control_translation` - (Optional) Specifies the overrides to use for object owners on replication. Must be used in conjunction with `account_id` owner override configuration.
+* `access_control_translation` - (Optional) Specifies the overrides to use for object owners on replication ([documented below](#access-control-translation)). Must be used in conjunction with `account_id` owner override configuration.
 * `account_id` - (Optional) Account ID to use for overriding the object owner on replication. Must be used in conjunction with `access_control_translation` override configuration.
 * `replication_time` - (Optional) Enables S3 Replication Time Control (S3 RTC) ([documented below](#replication-time)).
 * `metrics` - (Optional) Enables replication metrics (required for S3 RTC) ([documented below](#metrics)).
+
+#### Access Control Translation
+
+The `access_control_translation` configuration block supports the following arguments:
+
+* `owner` - (Required) Specifies the replica ownership. For default and valid values, see [PUT bucket replication](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketReplication.html) in the Amazon S3 API Reference. The only valid value is `Destination`.
 
 #### Replication Time
 

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -220,12 +220,12 @@ The `destination` configuration block supports the following arguments:
 * `storage_class` - (Optional) The [storage class](https://docs.aws.amazon.com/AmazonS3/latest/API/API_Destination.html#AmazonS3-Type-Destination-StorageClass) used to store the object. By default, Amazon S3 uses the storage class of the source object to create the object replica.
 * `replica_kms_key_id` - (Optional) Destination KMS encryption key ARN for SSE-KMS replication. Must be used in conjunction with
   `sse_kms_encrypted_objects` source selection criteria.
-* `access_control_translation` - (Optional) Specifies the overrides to use for object owners on replication ([documented below](#access-control-translation)). Must be used in conjunction with `account_id` owner override configuration.
+* `access_control_translation` - (Optional) Specifies the overrides to use for object owners on replication ([documented below](#access_control_translation-block)). Must be used in conjunction with `account_id` owner override configuration.
 * `account_id` - (Optional) Account ID to use for overriding the object owner on replication. Must be used in conjunction with `access_control_translation` override configuration.
 * `replication_time` - (Optional) Enables S3 Replication Time Control (S3 RTC) ([documented below](#replication-time)).
 * `metrics` - (Optional) Enables replication metrics (required for S3 RTC) ([documented below](#metrics)).
 
-#### Access Control Translation
+#### `access_control_translation` Block
 
 The `access_control_translation` configuration block supports the following arguments:
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR adds more details for the `access_control_translation` configuration block that is relevant to replication configuration for the `aws_s3_bucket` resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #33894

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referenced the [AccessControlTranslation API data type](https://docs.aws.amazon.com/AmazonS3/latest/API/API_AccessControlTranslation.html) for wordings.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
n/a