### PR TITLE
docs: Identify cfg blocks more explicitly for option and param group docs

### DIFF
--- a/website/docs/r/db_option_group.html.markdown
+++ b/website/docs/r/db_option_group.html.markdown
@@ -67,21 +67,21 @@ This resource supports the following arguments:
 * `option_group_description` - (Optional) Description of the option group. Defaults to "Managed by Terraform".
 * `engine_name` - (Required) Specifies the name of the engine that this option group should be associated with.
 * `major_engine_version` - (Required) Specifies the major version of the engine that this option group should be associated with.
-* `option` - (Optional) The options to apply. See [Option](#option) below for more details.
+* `option` - (Optional) The options to apply. See [`option` Block](#option-block) below for more details.
 * `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
-### Option
+### `option` Block
 
 The `option` blocks support the following arguments:
 
 * `option_name` - (Required) Name of the option (e.g., MEMCACHED).
-* `option_settings` - (Optional) The option settings to apply. See [Option Settings](#option-settings) below for more details.
+* `option_settings` - (Optional) The option settings to apply. See [`option_settings` Block](#option_settings-block) below for more details.
 * `port` - (Optional) Port number when connecting to the option (e.g., 11211). Leaving out or removing `port` from your configuration does not remove or clear a port from the option in AWS. AWS may assign a default port. Not including `port` in your configuration means that the AWS provider will ignore a previously set value, a value set by AWS, and any port changes.
 * `version` - (Optional) Version of the option (e.g., 13.1.0.0). Leaving out or removing `version` from your configuration does not remove or clear a version from the option in AWS. AWS may assign a default version. Not including `version` in your configuration means that the AWS provider will ignore a previously set value, a value set by AWS, and any version changes.
 * `db_security_group_memberships` - (Optional) List of DB Security Groups for which the option is enabled.
 * `vpc_security_group_memberships` - (Optional) List of VPC Security Groups for which the option is enabled.
 
-#### Option Settings
+#### `option_settings` Block
 
 The `option_settings` blocks support the following arguments:
 

--- a/website/docs/r/db_option_group.html.markdown
+++ b/website/docs/r/db_option_group.html.markdown
@@ -67,19 +67,23 @@ This resource supports the following arguments:
 * `option_group_description` - (Optional) Description of the option group. Defaults to "Managed by Terraform".
 * `engine_name` - (Required) Specifies the name of the engine that this option group should be associated with.
 * `major_engine_version` - (Required) Specifies the major version of the engine that this option group should be associated with.
-* `option` - (Optional) List of options to apply.
+* `option` - (Optional) The options to apply. See [Option](#option) below for more details.
 * `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
-`option` blocks support the following:
+### Option
+
+The `option` blocks support the following arguments:
 
 * `option_name` - (Required) Name of the option (e.g., MEMCACHED).
-* `option_settings` - (Optional) List of option settings to apply.
+* `option_settings` - (Optional) The option settings to apply. See [Option Settings](#option-settings) below for more details.
 * `port` - (Optional) Port number when connecting to the option (e.g., 11211). Leaving out or removing `port` from your configuration does not remove or clear a port from the option in AWS. AWS may assign a default port. Not including `port` in your configuration means that the AWS provider will ignore a previously set value, a value set by AWS, and any port changes.
 * `version` - (Optional) Version of the option (e.g., 13.1.0.0). Leaving out or removing `version` from your configuration does not remove or clear a version from the option in AWS. AWS may assign a default version. Not including `version` in your configuration means that the AWS provider will ignore a previously set value, a value set by AWS, and any version changes.
 * `db_security_group_memberships` - (Optional) List of DB Security Groups for which the option is enabled.
 * `vpc_security_group_memberships` - (Optional) List of VPC Security Groups for which the option is enabled.
 
-`option_settings` blocks support the following:
+#### Option Settings
+
+The `option_settings` blocks support the following arguments:
 
 * `name` - (Optional) Name of the setting.
 * `value` - (Optional) Value of the setting.

--- a/website/docs/r/db_parameter_group.html.markdown
+++ b/website/docs/r/db_parameter_group.html.markdown
@@ -83,10 +83,10 @@ This resource supports the following arguments:
 * `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `family` - (Required, Forces new resource) The family of the DB parameter group.
 * `description` - (Optional, Forces new resource) The description of the DB parameter group. Defaults to "Managed by Terraform".
-* `parameter` - (Optional) The DB parameters to apply. See [Parameter](#parameter) below for more details. Note that parameters may differ from a family to an other. Full list of all parameters can be discovered via [`aws rds describe-db-parameters`](https://docs.aws.amazon.com/cli/latest/reference/rds/describe-db-parameters.html) after initial creation of the group.
+* `parameter` - (Optional) The DB parameters to apply. See [`parameter` Block](#parameter-block) below for more details. Note that parameters may differ from a family to an other. Full list of all parameters can be discovered via [`aws rds describe-db-parameters`](https://docs.aws.amazon.com/cli/latest/reference/rds/describe-db-parameters.html) after initial creation of the group.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
-### Parameter
+### `parameter` Block
 
 The `parameter` blocks support the following arguments:
 

--- a/website/docs/r/db_parameter_group.html.markdown
+++ b/website/docs/r/db_parameter_group.html.markdown
@@ -83,10 +83,12 @@ This resource supports the following arguments:
 * `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `family` - (Required, Forces new resource) The family of the DB parameter group.
 * `description` - (Optional, Forces new resource) The description of the DB parameter group. Defaults to "Managed by Terraform".
-* `parameter` - (Optional) A list of DB parameters to apply. Note that parameters may differ from a family to an other. Full list of all parameters can be discovered via [`aws rds describe-db-parameters`](https://docs.aws.amazon.com/cli/latest/reference/rds/describe-db-parameters.html) after initial creation of the group.
+* `parameter` - (Optional) The DB parameters to apply. See [Parameter](#parameter) below for more details. Note that parameters may differ from a family to an other. Full list of all parameters can be discovered via [`aws rds describe-db-parameters`](https://docs.aws.amazon.com/cli/latest/reference/rds/describe-db-parameters.html) after initial creation of the group.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
-Parameter blocks support the following:
+### Parameter
+
+The `parameter` blocks support the following arguments:
 
 * `name` - (Required) The name of the DB parameter.
 * `value` - (Required) The value of the DB parameter.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add more clarity to the configuration block arguments in the `aws_db_option_group` and `aws_db_parameter_group` resource documentation.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #33887

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Used the [aws_vpn_connection resource doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpn_connection) as guidance for better structuring the configuration block descriptions.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
n/a