### PR TITLE
docs: Improve response models and params descs for aws_api_gateway_method_response

### DIFF
--- a/website/docs/r/api_gateway_method_response.html.markdown
+++ b/website/docs/r/api_gateway_method_response.html.markdown
@@ -8,9 +8,11 @@ description: |-
 
 # Resource: aws_api_gateway_method_response
 
-Provides an HTTP Method Response for an API Gateway Resource.
+Provides an HTTP Method Response for an API Gateway Resource. More information about API Gateway method responses can be found in the [Amazon API Gateway Developer Guide](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-method-settings-method-response.html).
 
 ## Example Usage
+
+### Basic Response
 
 ```terraform
 resource "aws_api_gateway_rest_api" "MyDemoAPI" {
@@ -46,18 +48,78 @@ resource "aws_api_gateway_method_response" "response_200" {
 }
 ```
 
+### Response with Custom Header and Model
+
+```terraform
+resource "aws_api_gateway_rest_api" "MyDemoAPI" {
+  name        = "MyDemoAPI"
+  description = "This is my API for demonstration purposes"
+}
+
+resource "aws_api_gateway_resource" "MyDemoResource" {
+  rest_api_id = aws_api_gateway_rest_api.MyDemoAPI.id
+  parent_id   = aws_api_gateway_rest_api.MyDemoAPI.root_resource_id
+  path_part   = "mydemoresource"
+}
+
+resource "aws_api_gateway_method" "MyDemoMethod" {
+  rest_api_id   = aws_api_gateway_rest_api.MyDemoAPI.id
+  resource_id   = aws_api_gateway_resource.MyDemoResource.id
+  http_method   = "GET"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "MyDemoIntegration" {
+  rest_api_id = aws_api_gateway_rest_api.MyDemoAPI.id
+  resource_id = aws_api_gateway_resource.MyDemoResource.id
+  http_method = aws_api_gateway_method.MyDemoMethod.http_method
+  type        = "MOCK"
+}
+
+resource "aws_api_gateway_model" "MyDemoResponseModel" {
+  rest_api_id  = aws_api_gateway_rest_api.MyDemoAPI.id
+  name         = "MyDemoResponseModel"
+  description  = "API response for MyDemoMethod"
+  content_type = "application/json"
+  schema = jsonencode({
+    "$schema" = "http://json-schema.org/draft-04/schema#"
+    title     = "MyDemoResponse"
+    type      = "object"
+    properties = {
+      Message = {
+        type = "string"
+      }
+    }
+  })
+}
+
+resource "aws_api_gateway_method_response" "response_200" {
+  rest_api_id = aws_api_gateway_rest_api.MyDemoAPI.id
+  resource_id = aws_api_gateway_resource.MyDemoResource.id
+  http_method = aws_api_gateway_method.MyDemoMethod.http_method
+  status_code = "200"
+  response_models = {
+    "application-json" = "MyDemoResponseModel"
+  }
+  response_parameters = {
+    "method.response.header.Content-Type"     = false
+    "method-response-header.X-My-Demo-Header" = false
+  }
+}
+```
+
 ## Argument Reference
 
 This resource supports the following arguments:
 
-* `rest_api_id` - (Required) ID of the associated REST API
-* `resource_id` - (Required) API resource ID
-* `http_method` - (Required) HTTP Method (`GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTIONS`, `ANY`)
-* `status_code` - (Required) HTTP status code
-* `response_models` - (Optional) Map of the API models used for the response's content type
-* `response_parameters` - (Optional) Map of response parameters that can be sent to the caller.
-   For example: `response_parameters = { "method.response.header.X-Some-Header" = true }`
-   would define that the header `X-Some-Header` can be provided on the response.
+* `rest_api_id` - (Required) The string identifier of the associated REST API.
+* `resource_id` - (Required) The Resource identifier for the method resource.
+* `http_method` - (Required) The HTTP verb of the method resource (`GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTIONS`, `ANY`).
+* `status_code` - (Required) The method response's status code.
+* `response_models` - (Optional) A map specifying the model resources used for the response's content type. Response models are represented as a key/value map, with a content type as the key and a Model name as the value.
+* `response_parameters` - (Optional) A map specifying required or optional response parameters that API Gateway can send back to the caller. A key defines a method response header name and the associated value is a boolean flag indicating whether the method response parameter is required. The method response header names must match the pattern of `method.response.header.{name}`, where `name` is a valid and unique header name.
+
+  The response parameter names defined here are available in the integration response to be mapped from an integration response header expressed in `integration.response.header.{name}`, a static value enclosed within a pair of single quotes (e.g., '`application/json'`), or a JSON expression from the back-end response payload in the form of `integration.response.body.{JSON-expression}`, where `JSON-expression` is a valid JSON expression without the `$` prefix.)
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR aims to improve the description of the `response_models` and `response_parameters` and provide a sample usage on how to use them.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #31614

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Used the [MethodResponse API data type documentation](https://docs.aws.amazon.com/apigateway/latest/api/API_MethodResponse.html#responseParameters) for reference on wordings.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
n/a