### PR TITLE
r/aws_fis_experiment_template: Add all supported action targets

### DIFF
--- a/.changelog/35300.txt
+++ b/.changelog/35300.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_fis_experiment_template: Add support for `AutoScalingGroups`, `Buckets`, `ReplicationGroups`, `Tables` and `TransitGateways` to `action.*.target`
+```

--- a/internal/service/fis/experiment_template.go
+++ b/internal/service/fis/experiment_template.go
@@ -984,16 +984,21 @@ func validExperimentTemplateStopConditionSource() schema.SchemaValidateFunc {
 func validExperimentTemplateActionTargetKey() schema.SchemaValidateFunc {
 	// See https://docs.aws.amazon.com/fis/latest/userguide/actions.html#action-targets
 	allowedStopConditionSources := []string{
+		"AutoScalingGroups",
+		"Buckets",
 		"Cluster",
 		"Clusters",
 		"DBInstances",
 		"Instances",
 		"Nodegroups",
 		"Pods",
+		"ReplicationGroups",
 		"Roles",
 		"SpotInstances",
 		"Subnets",
+		"Tables",
 		"Tasks",
+		"TransitGateways",
 		"Volumes",
 	}
 

--- a/internal/service/fis/experiment_template.go
+++ b/internal/service/fis/experiment_template.go
@@ -983,7 +983,7 @@ func validExperimentTemplateStopConditionSource() schema.SchemaValidateFunc {
 
 func validExperimentTemplateActionTargetKey() schema.SchemaValidateFunc {
 	// See https://docs.aws.amazon.com/fis/latest/userguide/actions.html#action-targets
-	allowedStopConditionSources := []string{
+	allowedActionTargets := []string{
 		"AutoScalingGroups",
 		"Buckets",
 		"Cluster",
@@ -1004,6 +1004,6 @@ func validExperimentTemplateActionTargetKey() schema.SchemaValidateFunc {
 
 	return validation.All(
 		validation.StringLenBetween(0, 64),
-		validation.StringInSlice(allowedStopConditionSources, false),
+		validation.StringInSlice(allowedActionTargets, false),
 	)
 }

--- a/website/docs/r/fis_experiment_template.html.markdown
+++ b/website/docs/r/fis_experiment_template.html.markdown
@@ -81,7 +81,7 @@ For a list of parameters supported by each action, see [AWS FIS actions referenc
 
 #### `target` (`action.*.target`)
 
-* `key` - (Required) Target type. Valid values are `Cluster` (EKS Cluster), `Clusters` (ECS Clusters), `DBInstances` (RDS DB Instances), `Instances` (EC2 Instances), `Nodegroups` (EKS Node groups), `Roles` (IAM Roles), `SpotInstances` (EC2 Spot Instances), `Subnets` (VPC Subnets), `Volumes` (EBS Volumes) , `Pods` (EKS Pods), `Tasks` (ECS Tasks). See the [documentation](https://docs.aws.amazon.com/fis/latest/userguide/actions.html#action-targets) for more details.
+* `key` - (Required) Target type. Valid values are `AutoScalingGroups` (EC2 Auto Scaling groups), `Buckets` (S3 Buckets), `Cluster` (EKS Cluster), `Clusters` (ECS Clusters), `DBInstances` (RDS DB Instances), `Instances` (EC2 Instances), `Nodegroups` (EKS Node groups), `Pods` (EKS Pods), `ReplicationGroups`(ElastiCache Redis Replication Groups), `Roles` (IAM Roles), `SpotInstances` (EC2 Spot Instances), `Subnets` (VPC Subnets), `Tables` (DynamoDB encrypted global tables), `Tasks` (ECS Tasks), `TransitGateways` (Transit gateways), `Volumes` (EBS Volumes). See the [documentation](https://docs.aws.amazon.com/fis/latest/userguide/actions.html#action-targets) for more details.
 * `value` - (Required) Target name, referencing a corresponding target.
 
 ### `stop_condition`


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Add all remaining action targets supported by AWS FIS service:

- Auto Scaling groups – Amazon EC2 Auto Scaling groups
- Buckets – Amazon S3 buckets
- Encrypted global tables – Amazon DynamoDB; global tables encrypted with a customer managed key
- ReplicationGroups – ElastiCache Redis Replication Groups
- TransitGateways – Transit gateways


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #35299

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

[AWS FIS - Action targets](https://docs.aws.amazon.com/fis/latest/userguide/actions.html#action-targets)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS="-run=TestAccFISExperimentTemplate_basic" PKG=fis
TF_ACC=1 go test ./internal/service/fis/... -v -count 1 -parallel 20  -run=TestAccFISExperimentTemplate_basic -timeout 360m
=== RUN   TestAccFISExperimentTemplate_basic
=== PAUSE TestAccFISExperimentTemplate_basic
=== CONT  TestAccFISExperimentTemplate_basic
--- PASS: TestAccFISExperimentTemplate_basic (35.91s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/fis        38.430s
...
```