### PR TITLE
docs(lambda): add java21 support for snap_start

### DIFF
--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -334,7 +334,7 @@ Advanced logging settings. See [Configuring advanced logging controls for your L
 
 ### snap_start
 
-Snap start settings for low-latency startups. This feature is currently only supported for `java11` and `java17` runtimes. Remove this block to delete the associated settings (rather than setting `apply_on = "None"`).
+Snap start settings for low-latency startups. This feature is currently only supported for `java11`, `java17` and `java21` runtimes. Remove this block to delete the associated settings (rather than setting `apply_on = "None"`).
 
 * `apply_on` - (Required) Conditions where snap start is enabled. Valid values are `PublishedVersions`.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
In order to align the documentation with the new released updates, this pull request includes **Java21** among the runtimes specified as being supported by snap_start.

### Relations
Closes #35312

### References
Check this : 
- [Improving startup performance with Lambda SnapStart](https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html#snapstart-runtimes)

> SnapStart supports Java 11 and later [Java managed runtimes](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html).

### Output from Acceptance Testing
N/A, docs.
