### PR TITLE
r/aws_eks_addon: fix and enhance `configuration_values`

### DIFF
--- a/internal/service/eks/addon.go
+++ b/internal/service/eks/addon.go
@@ -189,7 +189,7 @@ func resourceAddonCreate(ctx context.Context, d *schema.ResourceData, meta inter
 		//
 		// Addon resource is tainted after failed creation, thus will be deleted and created again.
 		// Re-creating like this will resolve the error, but it will also purge any
-		// configurations that were applied by the user (that were conflicting). This might we an unwanted
+		// configurations that were applied by the user (that were conflicting). This might be an unwanted
 		// side effect and should be left for the user to decide how to handle it.
 		diags = sdkdiag.AppendErrorf(diags, "waiting for EKS Add-On (%s) create: %s", d.Id(), err)
 		return sdkdiag.AppendWarningf(diags, "Running terraform apply again will remove the kubernetes add-on and attempt to create it again effectively purging previous add-on configuration")
@@ -223,7 +223,7 @@ func resourceAddonRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	d.Set("addon_version", addon.AddonVersion)
 	d.Set("arn", addon.AddonArn)
 	d.Set("cluster_name", addon.ClusterName)
-	d.Set("configuration_values", addon.ConfigurationValues)
+	d.Set("configuration_values", strings.TrimSuffix(aws.ToString(addon.ConfigurationValues), `\n`))
 	d.Set("created_at", aws.ToTime(addon.CreatedAt).Format(time.RFC3339))
 	d.Set("modified_at", aws.ToTime(addon.ModifiedAt).Format(time.RFC3339))
 	d.Set("service_account_role_arn", addon.ServiceAccountRoleArn)
@@ -254,7 +254,7 @@ func resourceAddonUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		}
 
 		if d.HasChange("configuration_values") {
-			input.ConfigurationValues = aws.String(d.Get("configuration_values").(string))
+			input.ConfigurationValues = aws.String(strings.TrimSuffix(d.Get("configuration_values").(string), `\n`))
 		}
 
 		var conflictResolutionAttr string

--- a/internal/service/eks/addon_test.go
+++ b/internal/service/eks/addon_test.go
@@ -305,6 +305,8 @@ func TestAccEKSAddon_configurationValues(t *testing.T) {
 	resourceName := "aws_eks_addon.test"
 	configurationValues := "{\"env\": {\"WARM_ENI_TARGET\":\"2\",\"ENABLE_POD_ENI\":\"true\"},\"resources\": {\"limits\":{\"cpu\":\"100m\",\"memory\":\"100Mi\"},\"requests\":{\"cpu\":\"100m\",\"memory\":\"100Mi\"}}}"
 	updateConfigurationValues := "{\"env\": {\"WARM_ENI_TARGET\":\"2\",\"ENABLE_POD_ENI\":\"true\"},\"resources\": {\"limits\":{\"cpu\":\"200m\",\"memory\":\"150Mi\"},\"requests\":{\"cpu\":\"200m\",\"memory\":\"150Mi\"}}}"
+	trailingNewlineConfigurationValues := "{\"env\": {\"WARM_ENI_TARGET\":\"2\",\"ENABLE_POD_ENI\":\"true\"},\"resources\": {\"limits\":{\"cpu\":\"100m\",\"memory\":\"100Mi\"},\"requests\":{\"cpu\":\"100m\",\"memory\":\"100Mi\"}}}\\n"
+	yamlConfigurationValues := "controller:\\r\\n  podAnnotations:\\r\\n    fluentbit.io/exclude: \\\"true\\"
 	emptyConfigurationValues := "{}"
 	invalidConfigurationValues := "{\"env\": {\"INVALID_FIELD\":\"2\"}}"
 	addonName := "vpc-cni"
@@ -321,6 +323,20 @@ func TestAccEKSAddon_configurationValues(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAddonExists(ctx, resourceName, &addon),
 					resource.TestCheckResourceAttr(resourceName, "configuration_values", configurationValues),
+				),
+			},
+			{
+				Config: testAccAddonConfig_configurationValues(rName, addonName, addonVersion, trailingNewlineConfigurationValues, string(types.ResolveConflictsOverwrite)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAddonExists(ctx, resourceName, &addon),
+					resource.TestCheckResourceAttr(resourceName, "configuration_values", configurationValues),
+				),
+			},
+			{
+				Config: testAccAddonConfig_configurationValues(rName, addonName, addonVersion, yamlConfigurationValues, string(types.ResolveConflictsOverwrite)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAddonExists(ctx, resourceName, &addon),
+					resource.TestCheckResourceAttr(resourceName, "configuration_values", yamlConfigurationValues),
 				),
 			},
 			{


### PR DESCRIPTION
Signed-off-by: smcavallo <smcavallo@hotmail.com>

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
strip any trailing newlines from `configuration_values`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
