### PR TITLE
WORKING: f-aws-computeoptimizer-recommendation-preferences new resource

### DIFF
--- a/internal/service/computeoptimizer/recommendation_preferences.go
+++ b/internal/service/computeoptimizer/recommendation_preferences.go
@@ -1,0 +1,688 @@
+package computeoptimizer
+// **PLEASE DELETE THIS AND ALL TIP COMMENTS BEFORE SUBMITTING A PR FOR REVIEW!**
+//
+// TIP: ==== INTRODUCTION ====
+// Thank you for trying the skaff tool!
+//
+// You have opted to include these helpful comments. They all include "TIP:"
+// to help you find and remove them when you're done with them.
+//
+// While some aspects of this file are customized to your input, the
+// scaffold tool does *not* look at the AWS API and ensure it has correct
+// function, structure, and variable names. It makes guesses based on
+// commonalities. You will need to make significant adjustments.
+//
+// In other words, as generated, this is a rough outline of the work you will
+// need to do. If something doesn't make sense for your situation, get rid of
+// it.
+
+import (
+	// TIP: ==== IMPORTS ====
+	// This is a common set of imports but not customized to your code since
+	// your code hasn't been written yet. Make sure you, your IDE, or
+	// goimports -w <file> fixes these imports.
+	//
+	// The provider linter wants your imports to be in two groups: first,
+	// standard library (i.e., "fmt" or "strings"), second, everything else.
+	//
+	// Also, AWS Go SDK v2 may handle nested structures differently than v1,
+	// using the services/computeoptimizer/types package. If so, you'll
+	// need to import types and reference the nested types, e.g., as
+	// types.<Type Name>.
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"reflect"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/computeoptimizer"
+	"github.com/aws/aws-sdk-go-v2/service/computeoptimizer/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// TIP: ==== FILE STRUCTURE ====
+// All resources should follow this basic outline. Improve this resource's
+// maintainability by sticking to it.
+//
+// 1. Package declaration
+// 2. Imports
+// 3. Main resource function with schema
+// 4. Create, read, update, delete functions (in that order)
+// 5. Other functions (flatteners, expanders, waiters, finders, etc.)
+
+// Function annotations are used for resource registration to the Provider. DO NOT EDIT.
+// @SDKResource("aws_computeoptimizer_recommendation_preferences", name="Recommendation Preferences")
+func ResourceRecommendationPreferences() *schema.Resource {
+	return &schema.Resource{
+		// TIP: ==== ASSIGN CRUD FUNCTIONS ====
+		// These 4 functions handle CRUD responsibilities below.
+		CreateWithoutTimeout: resourceRecommendationPreferencesCreate,
+		ReadWithoutTimeout:   resourceRecommendationPreferencesRead,
+		UpdateWithoutTimeout: resourceRecommendationPreferencesUpdate,
+		DeleteWithoutTimeout: resourceRecommendationPreferencesDelete,
+		
+		// TIP: ==== TERRAFORM IMPORTING ====
+		// If Read can get all the information it needs from the Identifier
+		// (i.e., d.Id()), you can use the Passthrough importer. Otherwise,
+		// you'll need a custom import function.
+		//
+		// See more:
+		// https://hashicorp.github.io/terraform-provider-aws/add-import-support/
+		// https://hashicorp.github.io/terraform-provider-aws/data-handling-and-conversion/#implicit-state-passthrough
+		// https://hashicorp.github.io/terraform-provider-aws/data-handling-and-conversion/#virtual-attributes
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		
+		// TIP: ==== CONFIGURABLE TIMEOUTS ====
+		// Users can configure timeout lengths but you need to use the times they
+		// provide. Access the timeout they configure (or the defaults) using,
+		// e.g., d.Timeout(schema.TimeoutCreate) (see below). The times here are
+		// the defaults if they don't configure timeouts.
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+		
+		// TIP: ==== SCHEMA ====
+		// In the schema, add each of the attributes in snake case (e.g.,
+		// delete_automated_backups).
+		//
+		// Formatting rules:
+		// * Alphabetize attributes to make them easier to find.
+		// * Do not add a blank line between attributes.
+		//
+		// Attribute basics:
+		// * If a user can provide a value ("configure a value") for an
+		//   attribute (e.g., instances = 5), we call the attribute an
+		//   "argument."
+		// * You change the way users interact with attributes using:
+		//     - Required
+		//     - Optional
+		//     - Computed
+		// * There are only four valid combinations:
+		//
+		// 1. Required only - the user must provide a value
+		// Required: true,
+		//
+		// 2. Optional only - the user can configure or omit a value; do not
+		//    use Default or DefaultFunc
+		// Optional: true,
+		//
+		// 3. Computed only - the provider can provide a value but the user
+		//    cannot, i.e., read-only
+		// Computed: true,
+		//
+		// 4. Optional AND Computed - the provider or user can provide a value;
+		//    use this combination if you are using Default or DefaultFunc
+		// Optional: true,
+		// Computed: true,
+		//
+		// You will typically find arguments in the input struct
+		// (e.g., CreateDBInstanceInput) for the create operation. Sometimes
+		// they are only in the input struct (e.g., ModifyDBInstanceInput) for
+		// the modify operation.
+		//
+		// For more about schema options, visit
+		// https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema#Schema
+		Schema: map[string]*schema.Schema{
+			"arn": { // TIP: Many, but not all, resources have an `arn` attribute.
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"replace_with_arguments": { // TIP: Add all your arguments and attributes.
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"complex_argument": { // TIP: See setting, getting, flattening, expanding examples below for this complex argument.
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"sub_field_one": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringLenBetween(1, 2048),
+						},
+						"sub_field_two": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+const (
+	ResNameRecommendationPreferences = "Recommendation Preferences"
+)
+
+func resourceRecommendationPreferencesCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	// TIP: ==== RESOURCE CREATE ====
+	// Generally, the Create function should do the following things. Make
+	// sure there is a good reason if you don't do one of these.
+	//
+	// 1. Get a client connection to the relevant service
+	// 2. Populate a create input structure
+	// 3. Call the AWS create/put function
+	// 4. Using the output from the create function, set the minimum arguments
+	//    and attributes for the Read function to work. At a minimum, set the
+	//    resource ID. E.g., d.SetId(<Identifier, such as AWS ID or ARN>)
+	// 5. Use a waiter to wait for create to complete
+	// 6. Call the Read function in the Create return
+
+	// TIP: -- 1. Get a client connection to the relevant service
+	conn := meta.(*conns.AWSClient).ComputeOptimizerClient(ctx)
+	
+	// TIP: -- 2. Populate a create input structure
+	in := &computeoptimizer.CreateRecommendationPreferencesInput{
+		// TIP: Mandatory or fields that will always be present can be set when
+		// you create the Input structure. (Replace these with real fields.)
+		RecommendationPreferencesName: aws.String(d.Get("name").(string)),
+		RecommendationPreferencesType: aws.String(d.Get("type").(string)),
+		
+		// TIP: Not all resources support tags and tags don't always make sense. If
+		// your resource doesn't need tags, you can remove the tags lines here and
+		// below. Many resources do include tags so this a reminder to include them
+		// where possible.
+	}
+
+	if v, ok := d.GetOk("max_size"); ok {
+		// TIP: Optional fields should be set based on whether or not they are
+		// used.
+		in.MaxSize = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("complex_argument"); ok && len(v.([]interface{})) > 0 {
+		// TIP: Use an expander to assign a complex argument.
+		in.ComplexArguments = expandComplexArguments(v.([]interface{}))
+	}
+
+	
+	// TIP: -- 3. Call the AWS create function
+	out, err := conn.CreateRecommendationPreferences(ctx, in)
+	if err != nil {
+		// TIP: Since d.SetId() has not been called yet, you cannot use d.Id()
+		// in error messages at this point.
+		return append(diags, create.DiagError(names.ComputeOptimizer, create.ErrActionCreating, ResNameRecommendationPreferences, d.Get("name").(string), err)...)
+	}
+
+	if out == nil || out.RecommendationPreferences == nil {
+		return append(diags, create.DiagError(names.ComputeOptimizer, create.ErrActionCreating, ResNameRecommendationPreferences, d.Get("name").(string), errors.New("empty output"))...)
+	}
+	
+	// TIP: -- 4. Set the minimum arguments and/or attributes for the Read function to
+	// work.
+	d.SetId(aws.ToString(out.RecommendationPreferences.RecommendationPreferencesID))
+	
+	// TIP: -- 5. Use a waiter to wait for create to complete
+	if _, err := waitRecommendationPreferencesCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
+		return append(diags, create.DiagError(names.ComputeOptimizer, create.ErrActionWaitingForCreation, ResNameRecommendationPreferences, d.Id(), err)...)
+	}
+	
+	// TIP: -- 6. Call the Read function in the Create return
+	return append(diags, resourceRecommendationPreferencesRead(ctx, d, meta)...)
+}
+
+func resourceRecommendationPreferencesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	// TIP: ==== RESOURCE READ ====
+	// Generally, the Read function should do the following things. Make
+	// sure there is a good reason if you don't do one of these.
+	//
+	// 1. Get a client connection to the relevant service
+	// 2. Get the resource from AWS
+	// 3. Set ID to empty where resource is not new and not found
+	// 4. Set the arguments and attributes
+	// 5. Set the tags
+	// 6. Return diags
+
+	// TIP: -- 1. Get a client connection to the relevant service
+	conn := meta.(*conns.AWSClient).ComputeOptimizerClient(ctx)
+	
+	// TIP: -- 2. Get the resource from AWS using an API Get, List, or Describe-
+	// type function, or, better yet, using a finder.
+	out, err := findRecommendationPreferencesByID(ctx, conn, d.Id())
+	
+	// TIP: -- 3. Set ID to empty where resource is not new and not found
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] ComputeOptimizer RecommendationPreferences (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return diags
+	}
+
+	if err != nil {
+		return append(diags, create.DiagError(names.ComputeOptimizer, create.ErrActionReading, ResNameRecommendationPreferences, d.Id(), err)...)
+	}
+	
+	// TIP: -- 4. Set the arguments and attributes
+	//
+	// For simple data types (i.e., schema.TypeString, schema.TypeBool,
+	// schema.TypeInt, and schema.TypeFloat), a simple Set call (e.g.,
+	// d.Set("arn", out.Arn) is sufficient. No error or nil checking is
+	// necessary.
+	//
+	// However, there are some situations where more handling is needed.
+	// a. Complex data types (e.g., schema.TypeList, schema.TypeSet)
+	// b. Where errorneous diffs occur. For example, a schema.TypeString may be
+	//    a JSON. AWS may return the JSON in a slightly different order but it
+	//    is equivalent to what is already set. In that case, you may check if
+	//    it is equivalent before setting the different JSON.
+	d.Set("arn", out.Arn)
+	d.Set("name", out.Name)
+	
+	// TIP: Setting a complex type.
+	// For more information, see:
+	// https://hashicorp.github.io/terraform-provider-aws/data-handling-and-conversion/#data-handling-and-conversion
+	// https://hashicorp.github.io/terraform-provider-aws/data-handling-and-conversion/#flatten-functions-for-blocks
+	// https://hashicorp.github.io/terraform-provider-aws/data-handling-and-conversion/#root-typeset-of-resource-and-aws-list-of-structure
+	if err := d.Set("complex_argument", flattenComplexArguments(out.ComplexArguments)); err != nil {
+		return append(diags, create.DiagError(names.ComputeOptimizer, create.ErrActionSetting, ResNameRecommendationPreferences, d.Id(), err)...)
+	}
+	
+	// TIP: Setting a JSON string to avoid errorneous diffs.
+	p, err := verify.SecondJSONUnlessEquivalent(d.Get("policy").(string), aws.ToString(out.Policy))
+	if err != nil {
+		return append(diags, create.DiagError(names.ComputeOptimizer, create.ErrActionSetting, ResNameRecommendationPreferences, d.Id(), err)...)
+	}
+
+	p, err = structure.NormalizeJsonString(p)
+	if err != nil {
+		return append(diags, create.DiagError(names.ComputeOptimizer, create.ErrActionSetting, ResNameRecommendationPreferences, d.Id(), err)...)
+	}
+
+	d.Set("policy", p)
+
+	
+	// TIP: -- 6. Return diags
+	return diags
+}
+
+func resourceRecommendationPreferencesUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	// TIP: ==== RESOURCE UPDATE ====
+	// Not all resources have Update functions. There are a few reasons:
+	// a. The AWS API does not support changing a resource
+	// b. All arguments have ForceNew: true, set
+	// c. The AWS API uses a create call to modify an existing resource
+	//
+	// In the cases of a. and b., the main resource function will not have a
+	// UpdateWithoutTimeout defined. In the case of c., Update and Create are
+	// the same.
+	//
+	// The rest of the time, there should be an Update function and it should
+	// do the following things. Make sure there is a good reason if you don't
+	// do one of these.
+	//
+	// 1. Get a client connection to the relevant service
+	// 2. Populate a modify input structure and check for changes
+	// 3. Call the AWS modify/update function
+	// 4. Use a waiter to wait for update to complete
+	// 5. Call the Read function in the Update return
+
+	// TIP: -- 1. Get a client connection to the relevant service
+	conn := meta.(*conns.AWSClient).ComputeOptimizerClient(ctx)
+	
+	// TIP: -- 2. Populate a modify input structure and check for changes
+	//
+	// When creating the input structure, only include mandatory fields. Other
+	// fields are set as needed. You can use a flag, such as update below, to
+	// determine if a certain portion of arguments have been changed and
+	// whether to call the AWS update function.
+	update := false
+
+	in := &computeoptimizer.UpdateRecommendationPreferencesInput{
+		Id: aws.String(d.Id()),
+	}
+
+	if d.HasChanges("an_argument") {
+		in.AnArgument = aws.String(d.Get("an_argument").(string))
+		update = true
+	}
+
+	if !update {
+		// TIP: If update doesn't do anything at all, which is rare, you can
+		// return diags. Otherwise, return a read call, as below.
+		return diags
+	}
+	
+	// TIP: -- 3. Call the AWS modify/update function
+	log.Printf("[DEBUG] Updating ComputeOptimizer RecommendationPreferences (%s): %#v", d.Id(), in)
+	out, err := conn.UpdateRecommendationPreferences(ctx, in)
+	if err != nil {
+		return append(diags, create.DiagError(names.ComputeOptimizer, create.ErrActionUpdating, ResNameRecommendationPreferences, d.Id(), err)...)
+	}
+	
+	// TIP: -- 4. Use a waiter to wait for update to complete
+	if _, err := waitRecommendationPreferencesUpdated(ctx, conn, aws.ToString(out.OperationId), d.Timeout(schema.TimeoutUpdate)); err != nil {
+		return append(diags, create.DiagError(names.ComputeOptimizer, create.ErrActionWaitingForUpdate, ResNameRecommendationPreferences, d.Id(), err)...)
+	}
+	
+	// TIP: -- 5. Call the Read function in the Update return
+	return append(diags, resourceRecommendationPreferencesRead(ctx, d, meta)...)
+}
+
+func resourceRecommendationPreferencesDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	// TIP: ==== RESOURCE DELETE ====
+	// Most resources have Delete functions. There are rare situations
+	// where you might not need a delete:
+	// a. The AWS API does not provide a way to delete the resource
+	// b. The point of your resource is to perform an action (e.g., reboot a
+	//    server) and deleting serves no purpose.
+	//
+	// The Delete function should do the following things. Make sure there
+	// is a good reason if you don't do one of these.
+	//
+	// 1. Get a client connection to the relevant service
+	// 2. Populate a delete input structure
+	// 3. Call the AWS delete function
+	// 4. Use a waiter to wait for delete to complete
+	// 5. Return diags
+
+	// TIP: -- 1. Get a client connection to the relevant service
+	conn := meta.(*conns.AWSClient).ComputeOptimizerClient(ctx)
+	
+	// TIP: -- 2. Populate a delete input structure
+	log.Printf("[INFO] Deleting ComputeOptimizer RecommendationPreferences %s", d.Id())
+	
+	// TIP: -- 3. Call the AWS delete function
+	_, err := conn.DeleteRecommendationPreferences(ctx, &computeoptimizer.DeleteRecommendationPreferencesInput{
+		Id: aws.String(d.Id()),
+	})
+	
+	// TIP: On rare occassions, the API returns a not found error after deleting a
+	// resource. If that happens, we don't want it to show up as an error.
+	if errs.IsA[*types.ResourceNotFoundException](err){
+		return diags
+	}
+	if err != nil {
+		return append(diags, create.DiagError(names.ComputeOptimizer, create.ErrActionDeleting, ResNameRecommendationPreferences, d.Id(), err)...)
+	}
+	
+	// TIP: -- 4. Use a waiter to wait for delete to complete
+	if _, err := waitRecommendationPreferencesDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
+		return append(diags, create.DiagError(names.ComputeOptimizer, create.ErrActionWaitingForDeletion, ResNameRecommendationPreferences, d.Id(), err)...)
+	}
+	
+	// TIP: -- 5. Return diags
+	return diags
+}
+
+// TIP: ==== STATUS CONSTANTS ====
+// Create constants for states and statuses if the service does not
+// already have suitable constants. We prefer that you use the constants
+// provided in the service if available (e.g., amp.WorkspaceStatusCodeActive).
+const (
+	statusChangePending = "Pending"
+	statusDeleting      = "Deleting"
+	statusNormal        = "Normal"
+	statusUpdated       = "Updated"
+)
+
+// TIP: ==== WAITERS ====
+// Some resources of some services have waiters provided by the AWS API.
+// Unless they do not work properly, use them rather than defining new ones
+// here.
+//
+// Sometimes we define the wait, status, and find functions in separate
+// files, wait.go, status.go, and find.go. Follow the pattern set out in the
+// service and define these where it makes the most sense.
+//
+// If these functions are used in the _test.go file, they will need to be
+// exported (i.e., capitalized).
+//
+// You will need to adjust the parameters and names to fit the service.
+
+func waitRecommendationPreferencesCreated(ctx context.Context, conn *computeoptimizer.Client, id string, timeout time.Duration) (*computeoptimizer.RecommendationPreferences, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending:                   []string{},
+		Target:                    []string{statusNormal},
+		Refresh:                   statusRecommendationPreferences(ctx, conn, id),
+		Timeout:                   timeout,
+		NotFoundChecks:            20,
+		ContinuousTargetOccurence: 2,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if out, ok := outputRaw.(*computeoptimizer.RecommendationPreferences); ok {
+		return out, err
+	}
+
+	return nil, err
+}
+
+// TIP: It is easier to determine whether a resource is updated for some
+// resources than others. The best case is a status flag that tells you when
+// the update has been fully realized. Other times, you can check to see if a
+// key resource argument is updated to a new value or not.
+
+func waitRecommendationPreferencesUpdated(ctx context.Context, conn *computeoptimizer.Client, id string, timeout time.Duration) (*computeoptimizer.RecommendationPreferences, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending:                   []string{statusChangePending},
+		Target:                    []string{statusUpdated},
+		Refresh:                   statusRecommendationPreferences(ctx, conn, id),
+		Timeout:                   timeout,
+		NotFoundChecks:            20,
+		ContinuousTargetOccurence: 2,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if out, ok := outputRaw.(*computeoptimizer.RecommendationPreferences); ok {
+		return out, err
+	}
+
+	return nil, err
+}
+
+// TIP: A deleted waiter is almost like a backwards created waiter. There may
+// be additional pending states, however.
+
+func waitRecommendationPreferencesDeleted(ctx context.Context, conn *computeoptimizer.Client, id string, timeout time.Duration) (*computeoptimizer.RecommendationPreferences, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending:                   []string{statusDeleting, statusNormal},
+		Target:                    []string{},
+		Refresh:                   statusRecommendationPreferences(ctx, conn, id),
+		Timeout:                   timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if out, ok := outputRaw.(*computeoptimizer.RecommendationPreferences); ok {
+		return out, err
+	}
+
+	return nil, err
+}
+
+// TIP: ==== STATUS ====
+// The status function can return an actual status when that field is
+// available from the API (e.g., out.Status). Otherwise, you can use custom
+// statuses to communicate the states of the resource.
+//
+// Waiters consume the values returned by status functions. Design status so
+// that it can be reused by a create, update, and delete waiter, if possible.
+
+func statusRecommendationPreferences(ctx context.Context, conn *computeoptimizer.Client, id string) retry.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		out, err := findRecommendationPreferencesByID(ctx, conn, id)
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return out, aws.ToString(out.Status), nil
+	}
+}
+
+// TIP: ==== FINDERS ====
+// The find function is not strictly necessary. You could do the API
+// request from the status function. However, we have found that find often
+// comes in handy in other places besides the status function. As a result, it
+// is good practice to define it separately.
+
+func findRecommendationPreferencesByID(ctx context.Context, conn *computeoptimizer.Client, id string) (*computeoptimizer.RecommendationPreferences, error) {
+	in := &computeoptimizer.GetRecommendationPreferencesInput{
+		Id: aws.String(id),
+	}
+	out, err := conn.GetRecommendationPreferences(ctx, in)
+	if errs.IsA[*types.ResourceNotFoundException](err){
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: in,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if out == nil || out.RecommendationPreferences == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return out.RecommendationPreferences, nil
+}
+
+// TIP: ==== FLEX ====
+// Flatteners and expanders ("flex" functions) help handle complex data
+// types. Flatteners take an API data type and return something you can use in
+// a d.Set() call. In other words, flatteners translate from AWS -> Terraform.
+//
+// On the other hand, expanders take a Terraform data structure and return
+// something that you can send to the AWS API. In other words, expanders
+// translate from Terraform -> AWS.
+//
+// See more:
+// https://hashicorp.github.io/terraform-provider-aws/data-handling-and-conversion/
+func flattenComplexArgument(apiObject *computeoptimizer.ComplexArgument) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	m := map[string]interface{}{}
+
+	if v := apiObject.SubFieldOne; v != nil {
+		m["sub_field_one"] = aws.ToString(v)
+	}
+
+	if v := apiObject.SubFieldTwo; v != nil {
+		m["sub_field_two"] = aws.ToString(v)
+	}
+
+	return m
+}
+
+// TIP: Often the AWS API will return a slice of structures in response to a
+// request for information. Sometimes you will have set criteria (e.g., the ID)
+// that means you'll get back a one-length slice. This plural function works
+// brilliantly for that situation too.
+func flattenComplexArguments(apiObjects []*computeoptimizer.ComplexArgument) []interface{} {
+	if len(apiObjects) == 0 {
+		return nil
+	}
+
+	var l []interface{}
+
+	for _, apiObject := range apiObjects {
+		if apiObject == nil {
+			continue
+		}
+
+		l = append(l, flattenComplexArgument(apiObject))
+	}
+
+	return l
+}
+
+// TIP: Remember, as mentioned above, expanders take a Terraform data structure
+// and return something that you can send to the AWS API. In other words,
+// expanders translate from Terraform -> AWS.
+//
+// See more:
+// https://hashicorp.github.io/terraform-provider-aws/data-handling-and-conversion/
+func expandComplexArgument(tfMap map[string]interface{}) *computeoptimizer.ComplexArgument {
+	if tfMap == nil {
+		return nil
+	}
+
+	a := &computeoptimizer.ComplexArgument{}
+
+	if v, ok := tfMap["sub_field_one"].(string); ok && v != "" {
+		a.SubFieldOne = aws.String(v)
+	}
+
+	if v, ok := tfMap["sub_field_two"].(string); ok && v != "" {
+		a.SubFieldTwo = aws.String(v)
+	}
+
+	return a
+}
+
+// TIP: Even when you have a list with max length of 1, this plural function
+// works brilliantly. However, if the AWS API takes a structure rather than a
+// slice of structures, you will not need it.
+func expandComplexArguments(tfList []interface{}) []*computeoptimizer.ComplexArgument {
+	// TIP: The AWS API can be picky about whether you send a nil or zero-
+	// length for an argument that should be cleared. For example, in some
+	// cases, if you send a nil value, the AWS API interprets that as "make no
+	// changes" when what you want to say is "remove everything." Sometimes
+	// using a zero-length list will cause an error.
+	//
+	// As a result, here are two options. Usually, option 1, nil, will work as
+	// expected, clearing the field. But, test going from something to nothing
+	// to make sure it works. If not, try the second option.
+	
+	// TIP: Option 1: Returning nil for zero-length list
+    if len(tfList) == 0 {
+        return nil
+    }
+
+    var s []*computeoptimizer.ComplexArgument
+	
+	// TIP: Option 2: Return zero-length list for zero-length list. If option 1 does
+	// not work, after testing going from something to nothing (if that is
+	// possible), uncomment out the next line and remove option 1.
+	//
+	// s := make([]*computeoptimizer.ComplexArgument, 0)
+
+	for _, r := range tfList {
+		m, ok := r.(map[string]interface{})
+
+		if !ok {
+			continue
+		}
+
+		a := expandComplexArgument(m)
+
+		if a == nil {
+			continue
+		}
+
+		s = append(s, a)
+	}
+
+	return s
+}

--- a/internal/service/computeoptimizer/recommendation_preferences.go
+++ b/internal/service/computeoptimizer/recommendation_preferences.go
@@ -1,34 +1,6 @@
 package computeoptimizer
-// **PLEASE DELETE THIS AND ALL TIP COMMENTS BEFORE SUBMITTING A PR FOR REVIEW!**
-//
-// TIP: ==== INTRODUCTION ====
-// Thank you for trying the skaff tool!
-//
-// You have opted to include these helpful comments. They all include "TIP:"
-// to help you find and remove them when you're done with them.
-//
-// While some aspects of this file are customized to your input, the
-// scaffold tool does *not* look at the AWS API and ensure it has correct
-// function, structure, and variable names. It makes guesses based on
-// commonalities. You will need to make significant adjustments.
-//
-// In other words, as generated, this is a rough outline of the work you will
-// need to do. If something doesn't make sense for your situation, get rid of
-// it.
 
 import (
-	// TIP: ==== IMPORTS ====
-	// This is a common set of imports but not customized to your code since
-	// your code hasn't been written yet. Make sure you, your IDE, or
-	// goimports -w <file> fixes these imports.
-	//
-	// The provider linter wants your imports to be in two groups: first,
-	// standard library (i.e., "fmt" or "strings"), second, everything else.
-	//
-	// Also, AWS Go SDK v2 may handle nested structures differently than v1,
-	// using the services/computeoptimizer/types package. If so, you'll
-	// need to import types and reference the nested types, e.g., as
-	// types.<Type Name>.
 	"context"
 	"errors"
 	"fmt"
@@ -48,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
@@ -56,121 +29,189 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// TIP: ==== FILE STRUCTURE ====
-// All resources should follow this basic outline. Improve this resource's
-// maintainability by sticking to it.
-//
-// 1. Package declaration
-// 2. Imports
-// 3. Main resource function with schema
-// 4. Create, read, update, delete functions (in that order)
-// 5. Other functions (flatteners, expanders, waiters, finders, etc.)
-
 // Function annotations are used for resource registration to the Provider. DO NOT EDIT.
 // @SDKResource("aws_computeoptimizer_recommendation_preferences", name="Recommendation Preferences")
 func ResourceRecommendationPreferences() *schema.Resource {
 	return &schema.Resource{
-		// TIP: ==== ASSIGN CRUD FUNCTIONS ====
-		// These 4 functions handle CRUD responsibilities below.
 		CreateWithoutTimeout: resourceRecommendationPreferencesCreate,
 		ReadWithoutTimeout:   resourceRecommendationPreferencesRead,
 		UpdateWithoutTimeout: resourceRecommendationPreferencesUpdate,
 		DeleteWithoutTimeout: resourceRecommendationPreferencesDelete,
 		
-		// TIP: ==== TERRAFORM IMPORTING ====
-		// If Read can get all the information it needs from the Identifier
-		// (i.e., d.Id()), you can use the Passthrough importer. Otherwise,
-		// you'll need a custom import function.
-		//
-		// See more:
-		// https://hashicorp.github.io/terraform-provider-aws/add-import-support/
-		// https://hashicorp.github.io/terraform-provider-aws/data-handling-and-conversion/#implicit-state-passthrough
-		// https://hashicorp.github.io/terraform-provider-aws/data-handling-and-conversion/#virtual-attributes
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 		
-		// TIP: ==== CONFIGURABLE TIMEOUTS ====
-		// Users can configure timeout lengths but you need to use the times they
-		// provide. Access the timeout they configure (or the defaults) using,
-		// e.g., d.Timeout(schema.TimeoutCreate) (see below). The times here are
-		// the defaults if they don't configure timeouts.
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),
 			Update: schema.DefaultTimeout(30 * time.Minute),
 			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 		
-		// TIP: ==== SCHEMA ====
-		// In the schema, add each of the attributes in snake case (e.g.,
-		// delete_automated_backups).
-		//
-		// Formatting rules:
-		// * Alphabetize attributes to make them easier to find.
-		// * Do not add a blank line between attributes.
-		//
-		// Attribute basics:
-		// * If a user can provide a value ("configure a value") for an
-		//   attribute (e.g., instances = 5), we call the attribute an
-		//   "argument."
-		// * You change the way users interact with attributes using:
-		//     - Required
-		//     - Optional
-		//     - Computed
-		// * There are only four valid combinations:
-		//
-		// 1. Required only - the user must provide a value
-		// Required: true,
-		//
-		// 2. Optional only - the user can configure or omit a value; do not
-		//    use Default or DefaultFunc
-		// Optional: true,
-		//
-		// 3. Computed only - the provider can provide a value but the user
-		//    cannot, i.e., read-only
-		// Computed: true,
-		//
-		// 4. Optional AND Computed - the provider or user can provide a value;
-		//    use this combination if you are using Default or DefaultFunc
-		// Optional: true,
-		// Computed: true,
-		//
-		// You will typically find arguments in the input struct
-		// (e.g., CreateDBInstanceInput) for the create operation. Sometimes
-		// they are only in the input struct (e.g., ModifyDBInstanceInput) for
-		// the modify operation.
-		//
-		// For more about schema options, visit
-		// https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema#Schema
 		Schema: map[string]*schema.Schema{
-			"arn": { // TIP: Many, but not all, resources have an `arn` attribute.
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"replace_with_arguments": { // TIP: Add all your arguments and attributes.
-				Type:     schema.TypeString,
+			"enhanced_infrastructure_metrics": {
+				Type:        schema.TypeString,
 				Optional: true,
+				Description: "The status of the enhanced infrastructure metrics recommendation preference to create or update.",
+				// TODO Verify validation function type
+				// Valid choices: "Active", "Inactive",				
+				ValidateDiagFunc: enum.Validate[types.EnhancedInfrastructureMetrics](),
 			},
-			"complex_argument": { // TIP: See setting, getting, flattening, expanding examples below for this complex argument.
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
+			"external_metrics_preference": {
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Description: "The provider of the external metrics recommendation preference to create or update.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"sub_field_one": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringLenBetween(1, 2048),
-						},
-						"sub_field_two": {
-							Type:     schema.TypeString,
-							Optional: true,
+						"source": {
+							Type:        schema.TypeString,
+							// TODO Verify this is required.
+							// Required:    true,
+							// Option: true,
+							Description: "The external metrics source.",
+							// TODO Validate function requirements
+							// Only used when ResoureceType == Ec2Instances
+							// ValidateFunc: validation.All(),
 						},
 					},
 				},
 			},
+			"id": {
+				Type: schema.TypeString,
+				Computed: true,
+			},
+			"inferred_workload_types": {
+				Type: schema.TypeString,
+				Optional: true,
+				Description: "The provider of the external metrics recommendation preference to create or update.",
+				// TODO Verify validation function type
+				// Valid choices: "Active", "Inactive",
+				ValidateDiagFunc: enum.Validate[types.InferredWorkloadTypesPreference](),
+			},
+			"look_back_period": {
+				Type: schema.TypeString,
+				Optional: true,
+				Description: "The preference to control the number of days the utilization metrics of the AWS resource are analyzed.",
+				// TODO Verify validation function type
+				// Valid choices: "DAYS_14", "DAYS_32", "DAYS_93",
+				// Default: "DAYS_14",
+				ValidateDiagFunc: enum.Validate[types.LookBackPeriodPreference](),
+			},
+			"preferred_resources": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "The preferred resources.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"exclude_list": {
+							Type: schema.TypeList,
+							Optional: true,
+							Description: "The preference to control which resource type values are considered when generating rightsizing recommendations.",
+							Elem: &schema.Schema{
+								// TODO Validate appropriate attribute for values.
+								"name": {
+									Type:        schema.TypeString,
+									Description: "The name of the resource.",
+								},
+							},
+						},
+						"include_list": {
+							Type: schema.TypeList,
+							Optional: true,
+							Description: "The preferred resource type values to include in the recommendation candidates.",
+							Elem: &schema.Schema{
+								// TODO Validate appropriate attribute for values.
+								"name": {
+									Type:        schema.TypeString,
+									Description: "The name of the resource.",
+								},
+							},
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Description: "The type of preferred resource to customize.",
+							Optional: true,
+							// TODO Verify validation function type
+							ValidateDiagFunc: enum.Validate[types.PreferredResourceName](),
+						},
+					},
+				},
+			},
+			"savings_estimation_mode": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The status of the savings estimation mode preference to create or update.",
+				// TODO Verify validation function type
+				ValidateDiagFunc: enum.Validate[types.SavingsEstimationMode](),
+
+			},
+			"scope": {
+				Type: schema.TypeSet,
+				Optional: true,
+				Description: "An object that describes the scope of the recommendation preference to create.",
+				Elem: &schema.Schema{
+					"name": {
+						Type: schema.TypeString,
+						Optional: true,
+						Description: "The name of the scope.",
+						// TODO Verify validation function type
+						ValidateDiagFunc: enum.Validate[types.ScopeName](),
+					},
+					"value": {
+						Type: schema.TypeString,
+						Optional: true,
+						Description: "The value of the scope.",
+						// TODO Verify validation function type
+						ValidateDiagFunc: enum.Validate[types.ScopeValue](),
+					},
+				},
+			},
+			"resource_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				//TODO Validate name type for EC2 Instance Build
+				// Valid choices: "Ec2Instances", "AutoScalingGroup"
+				ValidateDiagFunc: enum.Validate[types.ResourceType](),
+			},
+			"utilization_preferences": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "The preference to control the resource’s CPU utilization thresholds - threshold and headroom.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"metric_name": {
+							Type:        schema.TypeString,
+							Optional: true,
+							Description: "The name of the metric.",
+						},
+						"metric_parameters": {
+							Type: schema.TypeSet,
+							Optional: true,
+							Description: "The metric parameters.",
+							Elem: &schema.Schema{
+								"headroom":{
+									Type: schema.TypeString,
+									Optional: true,
+									Description: "The headroom percentage.",
+									// TODO Verify validation function type
+									ValidateDiagFunc: enum.EnumValues[types.CustomizableMetricHeadroom](),
+								},
+								"threshold": {
+									Type: schema.TypeString,
+									Optional: true,
+									Description: "The threshold percentage.",
+									// TODO Verify validation function type
+									ValidateDiagFunc: enum.EnumValues[types.CustomizableMetricThreshold](),
+								},
+							},
+						},
+					},
+				},
+
+			},
 		},
-	}
+	},
 }
 
 const (
@@ -179,95 +220,88 @@ const (
 
 func resourceRecommendationPreferencesCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	// TIP: ==== RESOURCE CREATE ====
-	// Generally, the Create function should do the following things. Make
-	// sure there is a good reason if you don't do one of these.
-	//
-	// 1. Get a client connection to the relevant service
+	// Sections with questions	
 	// 2. Populate a create input structure
-	// 3. Call the AWS create/put function
 	// 4. Using the output from the create function, set the minimum arguments
 	//    and attributes for the Read function to work. At a minimum, set the
 	//    resource ID. E.g., d.SetId(<Identifier, such as AWS ID or ARN>)
-	// 5. Use a waiter to wait for create to complete
-	// 6. Call the Read function in the Create return
 
-	// TIP: -- 1. Get a client connection to the relevant service
 	conn := meta.(*conns.AWSClient).ComputeOptimizerClient(ctx)
 	
 	// TIP: -- 2. Populate a create input structure
-	in := &computeoptimizer.CreateRecommendationPreferencesInput{
-		// TIP: Mandatory or fields that will always be present can be set when
-		// you create the Input structure. (Replace these with real fields.)
-		RecommendationPreferencesName: aws.String(d.Get("name").(string)),
-		RecommendationPreferencesType: aws.String(d.Get("type").(string)),
-		
-		// TIP: Not all resources support tags and tags don't always make sense. If
-		// your resource doesn't need tags, you can remove the tags lines here and
-		// below. Many resources do include tags so this a reminder to include them
-		// where possible.
+	in := &computeoptimizer.PutRecommendationPreferencesInput{
+		ResourceType: types.ResourceType(d.Get("resource_type").(string)),
 	}
 
-	if v, ok := d.GetOk("max_size"); ok {
-		// TIP: Optional fields should be set based on whether or not they are
-		// used.
-		in.MaxSize = aws.Int64(int64(v.(int)))
+	if v, ok := d.GetOk("enhanced_infrastructure_metrics"); ok {
+		in.EnhancedInfrastructureMetrics = types.EnhancedInfrastructureMetrics(v.(string))
 	}
 
-	if v, ok := d.GetOk("complex_argument"); ok && len(v.([]interface{})) > 0 {
-		// TIP: Use an expander to assign a complex argument.
-		in.ComplexArguments = expandComplexArguments(v.([]interface{}))
+	if v, ok := d.GetOk("external_metrics_preference"); ok && len(v.([]interface{})) > 0 {
+		in.ExternalMetricsPreference = expandExternalMetricsPreference(v.([]interface{}))
 	}
 
+	if v, ok := d.GetOk("inferred_workload_types"); ok {
+		in.InferredWorkloadTypes = types.InferredWorkloadTypesPreference(v.(string))
+	}
+
+	if v, ok := d.GetOk("look_back_period"); ok {
+		in.LookBackPeriod = types.LookBackPeriodPreference(v.(string))
+	}
+
+	if v, ok := d.GetOk("preferred_resources"); ok && len(v.([]interface{})) > 0 {
+		in.PreferredResources = expandPreferredResources(v.([]interface{}))
+	// Issue with expansion
+	}
+
+	if v, ok := d.GetOk("savings_estimation_mode"); ok {
+		in.SavingsEstimationMode = types.SavingsEstimationMode(v.(string))
+	}
+
+	if v, ok := d.GetOk("scope"); ok && len(v.([]interface{})) > 0 {
+		in.Scope = expandScope(v.([]interface{}))
+	// Check expansion
+	}
+
+	if v, ok := d.GetOk("utilization_preferences"); ok && len(v.([]interface{})) > 0 {
+		in.UtilizationPreferences = expandUtilizationPreferences(v.([]interface{}))
+		// Issue with expansion
+	}
 	
 	// TIP: -- 3. Call the AWS create function
-	out, err := conn.CreateRecommendationPreferences(ctx, in)
+	out, err := conn.PutRecommendationPreferences(ctx, in)
 	if err != nil {
-		// TIP: Since d.SetId() has not been called yet, you cannot use d.Id()
-		// in error messages at this point.
 		return append(diags, create.DiagError(names.ComputeOptimizer, create.ErrActionCreating, ResNameRecommendationPreferences, d.Get("name").(string), err)...)
 	}
 
-	if out == nil || out.RecommendationPreferences == nil {
+	// TODO - Is `out.ResultMetadata == nil` logic needed?
+	if out == nil || out.ResultMetadata == nil {
 		return append(diags, create.DiagError(names.ComputeOptimizer, create.ErrActionCreating, ResNameRecommendationPreferences, d.Get("name").(string), errors.New("empty output"))...)
 	}
 	
-	// TIP: -- 4. Set the minimum arguments and/or attributes for the Read function to
-	// work.
-	d.SetId(aws.ToString(out.RecommendationPreferences.RecommendationPreferencesID))
+	// TODO What ID type should be used?
+	// d.SetId("accountID")
+	d.SetId(d.Get("resource_type").(string))
 	
-	// TIP: -- 5. Use a waiter to wait for create to complete
 	if _, err := waitRecommendationPreferencesCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
 		return append(diags, create.DiagError(names.ComputeOptimizer, create.ErrActionWaitingForCreation, ResNameRecommendationPreferences, d.Id(), err)...)
 	}
 	
-	// TIP: -- 6. Call the Read function in the Create return
 	return append(diags, resourceRecommendationPreferencesRead(ctx, d, meta)...)
 }
 
 func resourceRecommendationPreferencesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	// TIP: ==== RESOURCE READ ====
-	// Generally, the Read function should do the following things. Make
-	// sure there is a good reason if you don't do one of these.
-	//
-	// 1. Get a client connection to the relevant service
-	// 2. Get the resource from AWS
-	// 3. Set ID to empty where resource is not new and not found
+	// Sections with questions
 	// 4. Set the arguments and attributes
-	// 5. Set the tags
 	// 6. Return diags
 
-	// TIP: -- 1. Get a client connection to the relevant service
 	conn := meta.(*conns.AWSClient).ComputeOptimizerClient(ctx)
 	
-	// TIP: -- 2. Get the resource from AWS using an API Get, List, or Describe-
-	// type function, or, better yet, using a finder.
 	out, err := findRecommendationPreferencesByID(ctx, conn, d.Id())
 	
-	// TIP: -- 3. Set ID to empty where resource is not new and not found
 	if !d.IsNewResource() && tfresource.NotFound(err) {
-		log.Printf("[WARN] ComputeOptimizer RecommendationPreferences (%s) not found, removing from state", d.Id())
+		log.Printf("[WARN] Compute Optimizer Recommendation Preferences (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
 	}
@@ -276,144 +310,79 @@ func resourceRecommendationPreferencesRead(ctx context.Context, d *schema.Resour
 		return append(diags, create.DiagError(names.ComputeOptimizer, create.ErrActionReading, ResNameRecommendationPreferences, d.Id(), err)...)
 	}
 	
-	// TIP: -- 4. Set the arguments and attributes
-	//
-	// For simple data types (i.e., schema.TypeString, schema.TypeBool,
-	// schema.TypeInt, and schema.TypeFloat), a simple Set call (e.g.,
-	// d.Set("arn", out.Arn) is sufficient. No error or nil checking is
-	// necessary.
-	//
-	// However, there are some situations where more handling is needed.
-	// a. Complex data types (e.g., schema.TypeList, schema.TypeSet)
-	// b. Where errorneous diffs occur. For example, a schema.TypeString may be
-	//    a JSON. AWS may return the JSON in a slightly different order but it
-	//    is equivalent to what is already set. In that case, you may check if
-	//    it is equivalent before setting the different JSON.
-	d.Set("arn", out.Arn)
-	d.Set("name", out.Name)
+	// TODO Verify data types
+	d.Set("enhanced_infrastructure_metrics", out.EnhancedInfrastructureMetrics)
+	d.Set("inferred_workload_types", *out.InferredWorkloadTypes)
+	d.Set("look_back_period", out.LookBackPeriod)
+	d.Set("resource_type", out.ResourceType)
+	d.Set("savings_estimation_mode", out.SavingsEstimationMode)
 	
-	// TIP: Setting a complex type.
-	// For more information, see:
-	// https://hashicorp.github.io/terraform-provider-aws/data-handling-and-conversion/#data-handling-and-conversion
-	// https://hashicorp.github.io/terraform-provider-aws/data-handling-and-conversion/#flatten-functions-for-blocks
-	// https://hashicorp.github.io/terraform-provider-aws/data-handling-and-conversion/#root-typeset-of-resource-and-aws-list-of-structure
-	if err := d.Set("complex_argument", flattenComplexArguments(out.ComplexArguments)); err != nil {
-		return append(diags, create.DiagError(names.ComputeOptimizer, create.ErrActionSetting, ResNameRecommendationPreferences, d.Id(), err)...)
+	if err := d.Set("external_metrics_source", flattenExternalMetricsPreference(out.ExternalMetricsPreference)); err != nil {
+		return append(diags, create.DiagError(names.ComputeOptimizer, create.ErrActionSetting, ResNameComputeOptimizerPreferences, d.Id(), err)...)
 	}
 	
-	// TIP: Setting a JSON string to avoid errorneous diffs.
-	p, err := verify.SecondJSONUnlessEquivalent(d.Get("policy").(string), aws.ToString(out.Policy))
-	if err != nil {
-		return append(diags, create.DiagError(names.ComputeOptimizer, create.ErrActionSetting, ResNameRecommendationPreferences, d.Id(), err)...)
+	if err := d.Set("preferred_resources", flattenPreferredResources(out.PreferredResource)); err != nil {
+		return append(diags, create.DiagError(names.ComputeOptimizer, create.ErrActionSetting, ResNameComputeOptimizerPreferences, d.Id(), err)...)
 	}
 
-	p, err = structure.NormalizeJsonString(p)
-	if err != nil {
-		return append(diags, create.DiagError(names.ComputeOptimizer, create.ErrActionSetting, ResNameRecommendationPreferences, d.Id(), err)...)
+	if err := d.Set("scope", flattenScope(out.Scope)); err != nil {
+		return append(diags, create.DiagError(names.ComputeOptimizer, create.ErrActionSetting, ResNameComputeOptimizerPreferences, d.Id(), err)...)
 	}
 
-	d.Set("policy", p)
-
-	
-	// TIP: -- 6. Return diags
+	if err := d.Set("utilization_preferences", flattenUtilizationPreferences(out.UtilizationPreference)); err != nil {
+		return append(diags, create.DiagError(names.ComputeOptimizer, create.ErrActionSetting, ResNameComputeOptimizerPreferences, d.Id(), err)...)
+	}
+		
 	return diags
 }
 
 func resourceRecommendationPreferencesUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	// TIP: ==== RESOURCE UPDATE ====
-	// Not all resources have Update functions. There are a few reasons:
-	// a. The AWS API does not support changing a resource
-	// b. All arguments have ForceNew: true, set
-	// c. The AWS API uses a create call to modify an existing resource
-	//
-	// In the cases of a. and b., the main resource function will not have a
-	// UpdateWithoutTimeout defined. In the case of c., Update and Create are
-	// the same.
-	//
-	// The rest of the time, there should be an Update function and it should
-	// do the following things. Make sure there is a good reason if you don't
-	// do one of these.
-	//
-	// 1. Get a client connection to the relevant service
-	// 2. Populate a modify input structure and check for changes
-	// 3. Call the AWS modify/update function
+	// Sections with questions	
 	// 4. Use a waiter to wait for update to complete
-	// 5. Call the Read function in the Update return
 
-	// TIP: -- 1. Get a client connection to the relevant service
 	conn := meta.(*conns.AWSClient).ComputeOptimizerClient(ctx)
 	
-	// TIP: -- 2. Populate a modify input structure and check for changes
-	//
-	// When creating the input structure, only include mandatory fields. Other
-	// fields are set as needed. You can use a flag, such as update below, to
-	// determine if a certain portion of arguments have been changed and
-	// whether to call the AWS update function.
 	update := false
 
-	in := &computeoptimizer.UpdateRecommendationPreferencesInput{
-		Id: aws.String(d.Id()),
-	}
-
-	if d.HasChanges("an_argument") {
-		in.AnArgument = aws.String(d.Get("an_argument").(string))
-		update = true
+	in := &computeoptimizer.PutRecommendationPreferencesInput{
+		ResourceType: types.ResourceType(d.Id()),
 	}
 
 	if !update {
-		// TIP: If update doesn't do anything at all, which is rare, you can
-		// return diags. Otherwise, return a read call, as below.
 		return diags
 	}
 	
-	// TIP: -- 3. Call the AWS modify/update function
-	log.Printf("[DEBUG] Updating ComputeOptimizer RecommendationPreferences (%s): %#v", d.Id(), in)
-	out, err := conn.UpdateRecommendationPreferences(ctx, in)
+	log.Printf("[DEBUG] Updating Compute Optimizer Recommendation Preferences (%s): %#v", d.Id(), in)
+	out, err := conn.PutRecommendationPreferences(ctx, in)
 	if err != nil {
 		return append(diags, create.DiagError(names.ComputeOptimizer, create.ErrActionUpdating, ResNameRecommendationPreferences, d.Id(), err)...)
 	}
 	
 	// TIP: -- 4. Use a waiter to wait for update to complete
-	if _, err := waitRecommendationPreferencesUpdated(ctx, conn, aws.ToString(out.OperationId), d.Timeout(schema.TimeoutUpdate)); err != nil {
+	// TODO PutRecommendationPreferences returns a 200 if set. What out value should be listed?
+	if _, err := waitRecommendationPreferencesUpdated(ctx, conn, aws.ToString(out.ResultMetadata), d.Timeout(schema.TimeoutUpdate)); err != nil {
 		return append(diags, create.DiagError(names.ComputeOptimizer, create.ErrActionWaitingForUpdate, ResNameRecommendationPreferences, d.Id(), err)...)
 	}
 	
-	// TIP: -- 5. Call the Read function in the Update return
 	return append(diags, resourceRecommendationPreferencesRead(ctx, d, meta)...)
 }
 
 func resourceRecommendationPreferencesDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	// TIP: ==== RESOURCE DELETE ====
-	// Most resources have Delete functions. There are rare situations
-	// where you might not need a delete:
-	// a. The AWS API does not provide a way to delete the resource
-	// b. The point of your resource is to perform an action (e.g., reboot a
-	//    server) and deleting serves no purpose.
-	//
-	// The Delete function should do the following things. Make sure there
-	// is a good reason if you don't do one of these.
-	//
-	// 1. Get a client connection to the relevant service
-	// 2. Populate a delete input structure
 	// 3. Call the AWS delete function
-	// 4. Use a waiter to wait for delete to complete
-	// 5. Return diags
 
-	// TIP: -- 1. Get a client connection to the relevant service
 	conn := meta.(*conns.AWSClient).ComputeOptimizerClient(ctx)
 	
-	// TIP: -- 2. Populate a delete input structure
-	log.Printf("[INFO] Deleting ComputeOptimizer RecommendationPreferences %s", d.Id())
+	log.Printf("[INFO] Deleting Compute Optimizer Recommendation Preferences %s", d.Id())
 	
 	// TIP: -- 3. Call the AWS delete function
 	_, err := conn.DeleteRecommendationPreferences(ctx, &computeoptimizer.DeleteRecommendationPreferencesInput{
-		Id: aws.String(d.Id()),
+		// TODO Validate Recommendation Preference Name
+		RecommendationPreferenceNames: types.RecommendationPreferenceName(d.State().Attributes["enhanced_infrastructure_metrics", "external_metrics_preference". "inferred_workload_types", "look_back_period", "preferred_resources"]),
+		ResourceType: types.ResourceType(d.Id()),
 	})
 	
-	// TIP: On rare occassions, the API returns a not found error after deleting a
-	// resource. If that happens, we don't want it to show up as an error.
 	if errs.IsA[*types.ResourceNotFoundException](err){
 		return diags
 	}
@@ -421,39 +390,19 @@ func resourceRecommendationPreferencesDelete(ctx context.Context, d *schema.Reso
 		return append(diags, create.DiagError(names.ComputeOptimizer, create.ErrActionDeleting, ResNameRecommendationPreferences, d.Id(), err)...)
 	}
 	
-	// TIP: -- 4. Use a waiter to wait for delete to complete
 	if _, err := waitRecommendationPreferencesDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
 		return append(diags, create.DiagError(names.ComputeOptimizer, create.ErrActionWaitingForDeletion, ResNameRecommendationPreferences, d.Id(), err)...)
 	}
 	
-	// TIP: -- 5. Return diags
 	return diags
 }
 
-// TIP: ==== STATUS CONSTANTS ====
-// Create constants for states and statuses if the service does not
-// already have suitable constants. We prefer that you use the constants
-// provided in the service if available (e.g., amp.WorkspaceStatusCodeActive).
 const (
 	statusChangePending = "Pending"
 	statusDeleting      = "Deleting"
 	statusNormal        = "Normal"
 	statusUpdated       = "Updated"
 )
-
-// TIP: ==== WAITERS ====
-// Some resources of some services have waiters provided by the AWS API.
-// Unless they do not work properly, use them rather than defining new ones
-// here.
-//
-// Sometimes we define the wait, status, and find functions in separate
-// files, wait.go, status.go, and find.go. Follow the pattern set out in the
-// service and define these where it makes the most sense.
-//
-// If these functions are used in the _test.go file, they will need to be
-// exported (i.e., capitalized).
-//
-// You will need to adjust the parameters and names to fit the service.
 
 func waitRecommendationPreferencesCreated(ctx context.Context, conn *computeoptimizer.Client, id string, timeout time.Duration) (*computeoptimizer.RecommendationPreferences, error) {
 	stateConf := &retry.StateChangeConf{
@@ -473,11 +422,6 @@ func waitRecommendationPreferencesCreated(ctx context.Context, conn *computeopti
 	return nil, err
 }
 
-// TIP: It is easier to determine whether a resource is updated for some
-// resources than others. The best case is a status flag that tells you when
-// the update has been fully realized. Other times, you can check to see if a
-// key resource argument is updated to a new value or not.
-
 func waitRecommendationPreferencesUpdated(ctx context.Context, conn *computeoptimizer.Client, id string, timeout time.Duration) (*computeoptimizer.RecommendationPreferences, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending:                   []string{statusChangePending},
@@ -496,9 +440,6 @@ func waitRecommendationPreferencesUpdated(ctx context.Context, conn *computeopti
 	return nil, err
 }
 
-// TIP: A deleted waiter is almost like a backwards created waiter. There may
-// be additional pending states, however.
-
 func waitRecommendationPreferencesDeleted(ctx context.Context, conn *computeoptimizer.Client, id string, timeout time.Duration) (*computeoptimizer.RecommendationPreferences, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending:                   []string{statusDeleting, statusNormal},
@@ -515,14 +456,6 @@ func waitRecommendationPreferencesDeleted(ctx context.Context, conn *computeopti
 	return nil, err
 }
 
-// TIP: ==== STATUS ====
-// The status function can return an actual status when that field is
-// available from the API (e.g., out.Status). Otherwise, you can use custom
-// statuses to communicate the states of the resource.
-//
-// Waiters consume the values returned by status functions. Design status so
-// that it can be reused by a create, update, and delete waiter, if possible.
-
 func statusRecommendationPreferences(ctx context.Context, conn *computeoptimizer.Client, id string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		out, err := findRecommendationPreferencesByID(ctx, conn, id)
@@ -538,15 +471,9 @@ func statusRecommendationPreferences(ctx context.Context, conn *computeoptimizer
 	}
 }
 
-// TIP: ==== FINDERS ====
-// The find function is not strictly necessary. You could do the API
-// request from the status function. However, we have found that find often
-// comes in handy in other places besides the status function. As a result, it
-// is good practice to define it separately.
-
 func findRecommendationPreferencesByID(ctx context.Context, conn *computeoptimizer.Client, id string) (*computeoptimizer.RecommendationPreferences, error) {
 	in := &computeoptimizer.GetRecommendationPreferencesInput{
-		Id: aws.String(id),
+		ResourceType: types.ResourceType(id),
 	}
 	out, err := conn.GetRecommendationPreferences(ctx, in)
 	if errs.IsA[*types.ResourceNotFoundException](err){
@@ -566,123 +493,150 @@ func findRecommendationPreferencesByID(ctx context.Context, conn *computeoptimiz
 	return out.RecommendationPreferences, nil
 }
 
-// TIP: ==== FLEX ====
-// Flatteners and expanders ("flex" functions) help handle complex data
-// types. Flatteners take an API data type and return something you can use in
-// a d.Set() call. In other words, flatteners translate from AWS -> Terraform.
-//
-// On the other hand, expanders take a Terraform data structure and return
-// something that you can send to the AWS API. In other words, expanders
-// translate from Terraform -> AWS.
-//
-// See more:
-// https://hashicorp.github.io/terraform-provider-aws/data-handling-and-conversion/
-func flattenComplexArgument(apiObject *computeoptimizer.ComplexArgument) map[string]interface{} {
+// TODO Validate flex functions
+func flattenExternalMetricsPreference(apiObject *types.ExternalMetricsPreference) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}
 
 	m := map[string]interface{}{}
 
-	if v := apiObject.SubFieldOne; v != nil {
-		m["sub_field_one"] = aws.ToString(v)
-	}
-
-	if v := apiObject.SubFieldTwo; v != nil {
-		m["sub_field_two"] = aws.ToString(v)
+	if v := apiObject.Source; v != nil {
+		m["Source"] = aws.ToString(v)
 	}
 
 	return m
 }
 
-// TIP: Often the AWS API will return a slice of structures in response to a
-// request for information. Sometimes you will have set criteria (e.g., the ID)
-// that means you'll get back a one-length slice. This plural function works
-// brilliantly for that situation too.
-func flattenComplexArguments(apiObjects []*computeoptimizer.ComplexArgument) []interface{} {
-	if len(apiObjects) == 0 {
+func flattenPreferredResources(apiObject *types.PreferredResource) map[string]interface{} {
+	if apiObject == nil {
 		return nil
 	}
 
-	var l []interface{}
+	m := map[string]interface{}{}
 
-	for _, apiObject := range apiObjects {
-		if apiObject == nil {
-			continue
-		}
-
-		l = append(l, flattenComplexArgument(apiObject))
+	if v := apiObject.ExcludeList; v != nil {
+		m["exclude_list"] = aws.ToString(v)
 	}
 
-	return l
+	if v := apiObject.IncludeList; v != nil {
+		m["include_list"] = aws.ToString(v)
+	}
+
+	if v := apiObject.Name; v != nil {
+		m["name"] = aws.ToString(v)
+	}
+
+	return m
 }
 
-// TIP: Remember, as mentioned above, expanders take a Terraform data structure
-// and return something that you can send to the AWS API. In other words,
-// expanders translate from Terraform -> AWS.
-//
-// See more:
-// https://hashicorp.github.io/terraform-provider-aws/data-handling-and-conversion/
-func expandComplexArgument(tfMap map[string]interface{}) *computeoptimizer.ComplexArgument {
-	if tfMap == nil {
+func flattenScope(apiObject *types.Scope) map[string]interface{} {
+	if apiObject == nil {
 		return nil
 	}
 
-	a := &computeoptimizer.ComplexArgument{}
+	m := map[string]interface{}{}
 
-	if v, ok := tfMap["sub_field_one"].(string); ok && v != "" {
-		a.SubFieldOne = aws.String(v)
+	if v := apiObject.Name; v != nil {
+		m["name"] = aws.ToString(v)
 	}
 
-	if v, ok := tfMap["sub_field_two"].(string); ok && v != "" {
-		a.SubFieldTwo = aws.String(v)
+	if v := apiObject.Value; v != nil {
+		m["value"] = aws.ToString(v)
 	}
 
-	return a
+	return m
 }
 
-// TIP: Even when you have a list with max length of 1, this plural function
-// works brilliantly. However, if the AWS API takes a structure rather than a
-// slice of structures, you will not need it.
-func expandComplexArguments(tfList []interface{}) []*computeoptimizer.ComplexArgument {
-	// TIP: The AWS API can be picky about whether you send a nil or zero-
-	// length for an argument that should be cleared. For example, in some
-	// cases, if you send a nil value, the AWS API interprets that as "make no
-	// changes" when what you want to say is "remove everything." Sometimes
-	// using a zero-length list will cause an error.
-	//
-	// As a result, here are two options. Usually, option 1, nil, will work as
-	// expected, clearing the field. But, test going from something to nothing
-	// to make sure it works. If not, try the second option.
-	
-	// TIP: Option 1: Returning nil for zero-length list
-    if len(tfList) == 0 {
-        return nil
-    }
-
-    var s []*computeoptimizer.ComplexArgument
-	
-	// TIP: Option 2: Return zero-length list for zero-length list. If option 1 does
-	// not work, after testing going from something to nothing (if that is
-	// possible), uncomment out the next line and remove option 1.
-	//
-	// s := make([]*computeoptimizer.ComplexArgument, 0)
-
-	for _, r := range tfList {
-		m, ok := r.(map[string]interface{})
-
-		if !ok {
-			continue
-		}
-
-		a := expandComplexArgument(m)
-
-		if a == nil {
-			continue
-		}
-
-		s = append(s, a)
+func flattenUtilizationPreferences(apiObject *types.UtilizationPreference) map[string]interface{} {
+	if apiObject == nil {
+		return nil
 	}
 
-	return s
+	m := map[string]interface{}{}
+
+	if v := apiObject.MetricName; v != nil {
+		m["metric_name"] = aws.ToString(v)
+	}
+
+	if v := apiObject.MetricParameters; v != nil {
+		m["metric_parameters"] = v
+	}
+
+	return m
+}
+
+func expandExternalMetricsPreference(tfList []interface{}) *types.ExternalMetricsPreference {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
+	}
+
+	p, ok := tfList[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	externalMetricsConfig := &types.ExternalMetricsPreference{
+		Source: types.ExternalMetricsSource(p["external_metrics_source"].(string)),
+	}
+
+	return externalMetricsConfig
+}
+
+func expandPreferredResources(tfList []interface{}) *types.PreferredResource {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
+	}
+
+	p, ok := tfList[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	preferredResourceConfig := &types.PreferredResource{
+		ExcludeList: []string{p["exclude_list"]},
+		IncludeList: []string{p["include_list"]},
+		Name:        types.PreferredResourceName(p["name"].(string)),
+	}
+
+	return preferredResourceConfig
+}
+
+func expandScope(tfList []interface{}) *types.Scope {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
+	}
+
+	p, ok := tfList[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	scopeConfig := &types.Scope{
+		Name:        types.ScopeName(p["name"].(string)),
+		Value:       aws.String(p["value"].(string)),
+	}
+
+	return scopeConfig
+}
+
+func expandUtilizationPreferences(tfList []interface{}) *types.UtilizationPreference {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
+	}
+
+	p, ok := tfList[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	utilizationPreferenceConfig := &types.UtilizationPreference{
+		MetricName:        *types.CustomizableMetricHeadroom(p["metric_name"].(string)),
+		MetricParameters:       &types.CustomizableMetricParameters{
+			Headroom: *types.CustomizableMetricHeadroom(p["metric_parameters"]["headroom"].(map[string]interface{})),
+			Threshold: *types.CustomizableMetricThreshold(p["metric_parameters"]["threshold"].(map[string]interface{})),
+		},
+	}
+
+	return utilizationPreferenceConfig
 }

--- a/internal/service/computeoptimizer/recommendation_preferences_test.go
+++ b/internal/service/computeoptimizer/recommendation_preferences_test.go
@@ -1,0 +1,323 @@
+package computeoptimizer_test
+// **PLEASE DELETE THIS AND ALL TIP COMMENTS BEFORE SUBMITTING A PR FOR REVIEW!**
+//
+// TIP: ==== INTRODUCTION ====
+// Thank you for trying the skaff tool!
+//
+// You have opted to include these helpful comments. They all include "TIP:"
+// to help you find and remove them when you're done with them.
+//
+// While some aspects of this file are customized to your input, the
+// scaffold tool does *not* look at the AWS API and ensure it has correct
+// function, structure, and variable names. It makes guesses based on
+// commonalities. You will need to make significant adjustments.
+//
+// In other words, as generated, this is a rough outline of the work you will
+// need to do. If something doesn't make sense for your situation, get rid of
+// it.
+
+import (
+	// TIP: ==== IMPORTS ====
+	// This is a common set of imports but not customized to your code since
+	// your code hasn't been written yet. Make sure you, your IDE, or
+	// goimports -w <file> fixes these imports.
+	//
+	// The provider linter wants your imports to be in two groups: first,
+	// standard library (i.e., "fmt" or "strings"), second, everything else.
+	//
+	// Also, AWS Go SDK v2 may handle nested structures differently than v1,
+	// using the services/computeoptimizer/types package. If so, you'll
+	// need to import types and reference the nested types, e.g., as
+	// types.<Type Name>.
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/computeoptimizer"
+	"github.com/aws/aws-sdk-go-v2/service/computeoptimizer/types"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/names"
+
+	// TIP: You will often need to import the package that this test file lives
+	// in. Since it is in the "test" context, it must import the package to use
+	// any normal context constants, variables, or functions.
+	tfcomputeoptimizer "github.com/hashicorp/terraform-provider-aws/internal/service/computeoptimizer"
+)
+
+// TIP: File Structure. The basic outline for all test files should be as
+// follows. Improve this resource's maintainability by following this
+// outline.
+//
+// 1. Package declaration (add "_test" since this is a test file)
+// 2. Imports
+// 3. Unit tests
+// 4. Basic test
+// 5. Disappears test
+// 6. All the other tests
+// 7. Helper functions (exists, destroy, check, etc.)
+// 8. Functions that return Terraform configurations
+
+// TIP: ==== UNIT TESTS ====
+// This is an example of a unit test. Its name is not prefixed with
+// "TestAcc" like an acceptance test.
+//
+// Unlike acceptance tests, unit tests do not access AWS and are focused on a
+// function (or method). Because of this, they are quick and cheap to run.
+//
+// In designing a resource's implementation, isolate complex bits from AWS bits
+// so that they can be tested through a unit test. We encourage more unit tests
+// in the provider.
+//
+// Cut and dry functions using well-used patterns, like typical flatteners and
+// expanders, don't need unit testing. However, if they are complex or
+// intricate, they should be unit tested.
+func TestRecommendationPreferencesExampleUnitTest(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		TestName string
+		Input    string
+		Expected string
+		Error    bool
+	}{
+		{
+			TestName: "empty",
+			Input:    "",
+			Expected: "",
+			Error:    true,
+		},
+		{
+			TestName: "descriptive name",
+			Input:    "some input",
+			Expected: "some output",
+			Error:    false,
+		},
+		{
+			TestName: "another descriptive name",
+			Input:    "more input",
+			Expected: "more output",
+			Error:    false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.TestName, func(t *testing.T) {
+			t.Parallel()
+			got, err := tfcomputeoptimizer.FunctionFromResource(testCase.Input)
+
+			if err != nil && !testCase.Error {
+				t.Errorf("got error (%s), expected no error", err)
+			}
+
+			if err == nil && testCase.Error {
+				t.Errorf("got (%s) and no error, expected error", got)
+			}
+
+			if got != testCase.Expected {
+				t.Errorf("got %s, expected %s", got, testCase.Expected)
+			}
+		})
+	}
+}
+
+// TIP: ==== ACCEPTANCE TESTS ====
+// This is an example of a basic acceptance test. This should test as much of
+// standard functionality of the resource as possible, and test importing, if
+// applicable. We prefix its name with "TestAcc", the service, and the
+// resource name.
+//
+// Acceptance test access AWS and cost money to run.
+func TestAccComputeOptimizerRecommendationPreferences_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	// TIP: This is a long-running test guard for tests that run longer than
+	// 300s (5 min) generally.
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var recommendationpreferences computeoptimizer.DescribeRecommendationPreferencesResponse
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_computeoptimizer_recommendation_preferences.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.ComputeOptimizerEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ComputeOptimizerEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRecommendationPreferencesDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRecommendationPreferencesConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRecommendationPreferencesExists(ctx, resourceName, &recommendationpreferences),
+					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "maintenance_window_start_time.0.day_of_week"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
+						"console_access": "false",
+						"groups.#":       "0",
+						"username":       "Test",
+						"password":       "TestTest1234",
+					}),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "computeoptimizer", regexp.MustCompile(`recommendationpreferences:+.`)),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately", "user"},
+			},
+		},
+	})
+}
+
+func TestAccComputeOptimizerRecommendationPreferences_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var recommendationpreferences computeoptimizer.DescribeRecommendationPreferencesResponse
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_computeoptimizer_recommendation_preferences.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.ComputeOptimizerEndpointID)
+			testAccPreCheck(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ComputeOptimizerEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRecommendationPreferencesDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRecommendationPreferencesConfig_basic(rName, testAccRecommendationPreferencesVersionNewer),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRecommendationPreferencesExists(ctx, resourceName, &recommendationpreferences),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfcomputeoptimizer.ResourceRecommendationPreferences(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckRecommendationPreferencesDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ComputeOptimizerClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_computeoptimizer_recommendation_preferences" {
+				continue
+			}
+
+			input := &computeoptimizer.DescribeRecommendationPreferencesInput{
+				RecommendationPreferencesId: aws.String(rs.Primary.ID),
+			}
+			_, err := conn.DescribeRecommendationPreferences(ctx, &computeoptimizer.DescribeRecommendationPreferencesInput{
+				RecommendationPreferencesId: aws.String(rs.Primary.ID),
+			})
+			if errs.IsA[*types.ResourceNotFoundException](err){
+				return nil
+			}
+			if err != nil {
+				return nil
+			}
+
+			return create.Error(names.ComputeOptimizer, create.ErrActionCheckingDestroyed, tfcomputeoptimizer.ResNameRecommendationPreferences, rs.Primary.ID, errors.New("not destroyed"))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckRecommendationPreferencesExists(ctx context.Context, name string, recommendationpreferences *computeoptimizer.DescribeRecommendationPreferencesResponse) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.ComputeOptimizer, create.ErrActionCheckingExistence, tfcomputeoptimizer.ResNameRecommendationPreferences, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.ComputeOptimizer, create.ErrActionCheckingExistence, tfcomputeoptimizer.ResNameRecommendationPreferences, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ComputeOptimizerClient(ctx)
+		resp, err := conn.DescribeRecommendationPreferences(ctx, &computeoptimizer.DescribeRecommendationPreferencesInput{
+			RecommendationPreferencesId: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return create.Error(names.ComputeOptimizer, create.ErrActionCheckingExistence, tfcomputeoptimizer.ResNameRecommendationPreferences, rs.Primary.ID, err)
+		}
+
+		*recommendationpreferences = *resp
+
+		return nil
+	}
+}
+
+func testAccPreCheck(ctx context.Context, t *testing.T) {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).ComputeOptimizerClient(ctx)
+
+	input := &computeoptimizer.ListRecommendationPreferencessInput{}
+	_, err := conn.ListRecommendationPreferencess(ctx, input)
+
+	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func testAccCheckRecommendationPreferencesNotRecreated(before, after *computeoptimizer.DescribeRecommendationPreferencesResponse) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if before, after := aws.ToString(before.RecommendationPreferencesId), aws.ToString(after.RecommendationPreferencesId); before != after {
+			return create.Error(names.ComputeOptimizer, create.ErrActionCheckingNotRecreated, tfcomputeoptimizer.ResNameRecommendationPreferences, aws.ToString(before.RecommendationPreferencesId), errors.New("recreated"))
+		}
+
+		return nil
+	}
+}
+
+func testAccRecommendationPreferencesConfig_basic(rName, version string) string {
+	return fmt.Sprintf(`
+resource "aws_security_group" "test" {
+  name = %[1]q
+}
+
+resource "aws_computeoptimizer_recommendation_preferences" "test" {
+  recommendation_preferences_name             = %[1]q
+  engine_type             = "ActiveComputeOptimizer"
+  engine_version          = %[2]q
+  host_instance_type      = "computeoptimizer.t2.micro"
+  security_groups         = [aws_security_group.test.id]
+  authentication_strategy = "simple"
+  storage_type            = "efs"
+
+  logs {
+    general = true
+  }
+
+  user {
+    username = "Test"
+    password = "TestTest1234"
+  }
+}
+`, rName, version)
+}

--- a/website/docs/r/computeoptimizer_recommendation_preferences.html.markdown
+++ b/website/docs/r/computeoptimizer_recommendation_preferences.html.markdown
@@ -1,0 +1,69 @@
+---
+subcategory: "Compute Optimizer"
+layout: "aws"
+page_title: "AWS: aws_computeoptimizer_recommendation_preferences"
+description: |-
+  Terraform resource for managing an AWS Compute Optimizer Recommendation Preferences.
+---
+<!---
+TIP: A few guiding principles for writing documentation:
+1. Use simple language while avoiding jargon and figures of speech.
+2. Focus on brevity and clarity to keep a reader's attention.
+3. Use active voice and present tense whenever you can.
+4. Document your feature as it exists now; do not mention the future or past if you can help it.
+5. Use accessible and inclusive language.
+--->`
+# Resource: aws_computeoptimizer_recommendation_preferences
+
+Terraform resource for managing an AWS Compute Optimizer Recommendation Preferences.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_computeoptimizer_recommendation_preferences" "example" {
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `example_arg` - (Required) Concise argument description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+
+The following arguments are optional:
+
+* `optional_arg` - (Optional) Concise argument description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `arn` - ARN of the Recommendation Preferences. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+* `example_attribute` - Concise description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+* `create` - (Default `60m`)
+* `update` - (Default `180m`)
+* `delete` - (Default `90m`)
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Compute Optimizer Recommendation Preferences using the `example_id_arg`. For example:
+
+```terraform
+import {
+  to = aws_computeoptimizer_recommendation_preferences.example
+  id = "recommendation_preferences-id-12345678"
+}
+```
+
+Using `terraform import`, import Compute Optimizer Recommendation Preferences using the `example_id_arg`. For example:
+
+```console
+% terraform import aws_computeoptimizer_recommendation_preferences.example recommendation_preferences-id-12345678
+```

--- a/website/docs/r/computeoptimizer_recommendation_preferences.html.markdown
+++ b/website/docs/r/computeoptimizer_recommendation_preferences.html.markdown
@@ -23,6 +23,21 @@ Terraform resource for managing an AWS Compute Optimizer Recommendation Preferen
 
 ```terraform
 resource "aws_computeoptimizer_recommendation_preferences" "example" {
+  enhanced_infrastructure_metrics = "Active" 
+	external_metrics_preference = "DataDog"
+ 	inferred_workload_types          = "Active"
+	lookback_period = "DAYS_14"
+	preferred_resources = [
+		""
+	]
+	resource_type                    = "Ec2Instance"
+	savings_estimation_mode = "AfterDiscounts"
+
+	utilization_prefrences = "P99_5"
+	scope = {
+	  name  = "ResourceARN"
+	  value = aws_autoscaling_group.web.arn
+	}
 }
 ```
 
@@ -30,40 +45,49 @@ resource "aws_computeoptimizer_recommendation_preferences" "example" {
 
 The following arguments are required:
 
-* `example_arg` - (Required) Concise argument description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+* `resource_type` - (Required) Target resource type.
 
 The following arguments are optional:
 
-* `optional_arg` - (Optional) Concise argument description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+* `enhanced_infrastructure_metrics` - (Optional) Enhanced infrastructure metrics.
+
+* `external_metrics_preference` - (Optional) External metrics provider.
+
+* `inferred_workload_types` - (Optional) Inferred workload status.
+
+* `look_back_period` - (Optional) Number of days analyzed.
+
+* `preferred_resources` - (Optional) Resource types considered.
+
+* `savings_estimation_mode` - (Optional) Savings estimation status.
+
+* `scope` - (Optional) Recommendation preferences.
+
+* `utilization_preferences` - (Optional) CPU utilization thresholds.
 
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `arn` - ARN of the Recommendation Preferences. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
-* `example_attribute` - Concise description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+* `id` - AWS Account the recommendation is created in.
+# TODO - Verify attribute references.
+* `recommendation_preference_names` - Recommendation preference created.
+* `resource_type` - Resource types monitored.
 
-## Timeouts
-
-[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
-
-* `create` - (Default `60m`)
-* `update` - (Default `180m`)
-* `delete` - (Default `90m`)
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Compute Optimizer Recommendation Preferences using the `example_id_arg`. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Compute Optimizer Recommendation Preferences using the `resource_type`, and `recommendation_preference_names` separated by a colon (`:`). For example:
 
 ```terraform
 import {
   to = aws_computeoptimizer_recommendation_preferences.example
-  id = "recommendation_preferences-id-12345678"
+  id = "Ec2Instance:UtilizationPreferences"
 }
 ```
 
 Using `terraform import`, import Compute Optimizer Recommendation Preferences using the `example_id_arg`. For example:
 
 ```console
-% terraform import aws_computeoptimizer_recommendation_preferences.example recommendation_preferences-id-12345678
+% terraform import aws_computeoptimizer_recommendation_preferences.example Ec2Instance:UtilizationPreferences
 ```


### PR DESCRIPTION
### Description
Creates new AWS Compute Optimizer Resource to put recommendation preferences.

### Relations
Closes (#23945)[https://github.com/hashicorp/terraform-provider-aws/issues/23945]

### References
* AWS Compute Optimizer Recommendations API: [docs](https://docs.aws.amazon.com/compute-optimizer/latest/APIReference/API_PutRecommendationPreferences.html#computeoptimizer-PutRecommendationPreferences-request-utilizationPreferences)
* AWS Compute Optimizer Recommendations Go V2: [docs](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/computeoptimizer@v1.31.6#pkg-overview)


### Output from Acceptance Testing
CURRENTLY WORKING - OPEN QUESTIONS BEFORE TESTS CAN BE PUSHED.

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
