### PR TITLE
Remove AWS SDK for Go v1 STS connection

### DIFF
--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -229,7 +229,6 @@ import (
 	simpledb_sdkv1 "github.com/aws/aws-sdk-go/service/simpledb"
 	ssm_sdkv1 "github.com/aws/aws-sdk-go/service/ssm"
 	storagegateway_sdkv1 "github.com/aws/aws-sdk-go/service/storagegateway"
-	sts_sdkv1 "github.com/aws/aws-sdk-go/service/sts"
 	synthetics_sdkv1 "github.com/aws/aws-sdk-go/service/synthetics"
 	transfer_sdkv1 "github.com/aws/aws-sdk-go/service/transfer"
 	waf_sdkv1 "github.com/aws/aws-sdk-go/service/waf"
@@ -1042,10 +1041,6 @@ func (c *AWSClient) SSMSAPClient(ctx context.Context) *ssmsap_sdkv2.Client {
 
 func (c *AWSClient) SSOAdminClient(ctx context.Context) *ssoadmin_sdkv2.Client {
 	return errs.Must(client[*ssoadmin_sdkv2.Client](ctx, c, names.SSOAdmin, make(map[string]any)))
-}
-
-func (c *AWSClient) STSConn(ctx context.Context) *sts_sdkv1.STS {
-	return errs.Must(conn[*sts_sdkv1.STS](ctx, c, names.STS, make(map[string]any)))
 }
 
 func (c *AWSClient) STSClient(ctx context.Context) *sts_sdkv2.Client {

--- a/internal/provider/provider_acc_test.go
+++ b/internal/provider/provider_acc_test.go
@@ -569,7 +569,7 @@ func testAccCheckRegion(ctx context.Context, t *testing.T, p **schema.Provider, 
 	}
 }
 
-func testAccCheckSTSRegion(ctx context.Context, t *testing.T, p **schema.Provider, expectedRegion string) resource.TestCheckFunc { //nolint:unparam
+func testAccCheckSTSRegion(ctx context.Context, t *testing.T, p **schema.Provider, expectedRegion string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if p == nil || *p == nil || (*p).Meta() == nil || (*p).Meta().(*conns.AWSClient) == nil {
 			return fmt.Errorf("provider not initialized")

--- a/internal/provider/provider_acc_test.go
+++ b/internal/provider/provider_acc_test.go
@@ -5,13 +5,17 @@ package provider_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
 	"testing"
 
+	awsmiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
+	sts_sdkv2 "github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/smithy-go/middleware"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -571,7 +575,22 @@ func testAccCheckSTSRegion(ctx context.Context, t *testing.T, p **schema.Provide
 			return fmt.Errorf("provider not initialized")
 		}
 
-		stsRegion := aws.StringValue((*p).Meta().(*conns.AWSClient).STSConn(ctx).Config.Region)
+		var stsRegion string
+
+		stsClient := (*p).Meta().(*conns.AWSClient).STSClient(ctx)
+		_, err := stsClient.GetCallerIdentity(ctx, &sts_sdkv2.GetCallerIdentityInput{},
+			func(opts *sts_sdkv2.Options) {
+				opts.APIOptions = append(opts.APIOptions,
+					addRegionRetrieverMiddleware(&stsRegion),
+					addCancelRequestMiddleware(),
+				)
+			},
+		)
+		if err == nil {
+			t.Fatal("Expected an error, got none")
+		} else if !errors.Is(err, errCancelOperation) {
+			t.Fatalf("Unexpected error: %s", err)
+		}
 
 		if stsRegion != expectedRegion {
 			return fmt.Errorf("expected STS Region (%s), got: %s", expectedRegion, stsRegion)
@@ -579,6 +598,45 @@ func testAccCheckSTSRegion(ctx context.Context, t *testing.T, p **schema.Provide
 
 		return nil
 	}
+}
+
+var errCancelOperation = fmt.Errorf("Test: Cancelling request")
+
+func addCancelRequestMiddleware() func(*middleware.Stack) error {
+	return func(stack *middleware.Stack) error {
+		return stack.Finalize.Add(
+			cancelRequestMiddleware(),
+			middleware.After,
+		)
+	}
+}
+
+func cancelRequestMiddleware() middleware.FinalizeMiddleware {
+	return middleware.FinalizeMiddlewareFunc(
+		"Test: Cancel Requests",
+		func(_ context.Context, in middleware.FinalizeInput, next middleware.FinalizeHandler) (middleware.FinalizeOutput, middleware.Metadata, error) {
+			return middleware.FinalizeOutput{}, middleware.Metadata{}, errCancelOperation
+		})
+}
+
+func addRegionRetrieverMiddleware(region *string) func(*middleware.Stack) error {
+	return func(stack *middleware.Stack) error {
+		return stack.Serialize.Add(
+			retrieveRegionMiddleware(region),
+			middleware.After,
+		)
+	}
+}
+
+func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
+	return middleware.SerializeMiddlewareFunc(
+		"Test: Retrieve Region",
+		func(ctx context.Context, in middleware.SerializeInput, next middleware.SerializeHandler) (middleware.SerializeOutput, middleware.Metadata, error) {
+			*region = awsmiddleware.GetRegion(ctx)
+
+			return next.HandleSerialize(ctx, in)
+		},
+	)
 }
 
 func testAccCheckReverseDNSPrefix(ctx context.Context, t *testing.T, p **schema.Provider, expectedReverseDnsPrefix string) resource.TestCheckFunc { //nolint:unparam

--- a/internal/service/eks/cluster_auth_data_source.go
+++ b/internal/service/eks/cluster_auth_data_source.go
@@ -35,7 +35,7 @@ func dataSourceClusterAuth() *schema.Resource {
 
 func dataSourceClusterAuthRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).STSConn(ctx)
+	conn := meta.(*conns.AWSClient).STSClient(ctx)
 
 	name := d.Get("name").(string)
 	generator, err := NewGenerator(false, false)

--- a/internal/service/eks/cluster_auth_data_source_test.go
+++ b/internal/service/eks/cluster_auth_data_source_test.go
@@ -25,7 +25,7 @@ func TestAccEKSClusterAuthDataSource_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterAuthDataSourceConfig_basic,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceResourceName, "name", "foobar"),
 					resource.TestCheckResourceAttrSet(dataSourceResourceName, "token"),
 					testAccCheckClusterAuthToken(dataSourceResourceName),

--- a/internal/service/eks/token.go
+++ b/internal/service/eks/token.go
@@ -12,6 +12,7 @@ With the following modifications:
  - Ignore errorlint reports
  - Refactor deprecated io/ioutil in Go 1.16
  - Adds context parameter
+ - Updated to use the AWS SDK for Go v2
 */
 
 /*
@@ -46,7 +47,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/aws/smithy-go/middleware"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 )
 
 // Identity is returned on successful Verify() results. It contains a parsed
@@ -100,8 +103,7 @@ const (
 
 // Token is generated and used by Kubernetes client-go to authenticate with a Kubernetes cluster.
 type Token struct {
-	Token      string
-	Expiration time.Time
+	Token string
 }
 
 // FormatError is returned when there is a problem with token that is
@@ -159,7 +161,7 @@ type getCallerIdentityWrapper struct {
 // Generator provides new tokens for the AWS IAM Authenticator.
 type Generator interface {
 	// GetWithSTS returns a token valid for clusterID using the given STS client.
-	GetWithSTS(ctx context.Context, clusterID string, stsAPI *sts.STS) (Token, error)
+	GetWithSTS(ctx context.Context, clusterID string, stsAPI *sts.Client) (Token, error)
 }
 
 type generator struct {
@@ -176,27 +178,80 @@ func NewGenerator(forwardSessionName bool, cache bool) (Generator, error) {
 }
 
 // GetWithSTS returns a token valid for clusterID using the given STS client.
-func (g generator) GetWithSTS(ctx context.Context, clusterID string, stsAPI *sts.STS) (Token, error) {
-	// generate an sts:GetCallerIdentity request and add our custom cluster ID header
-	request, _ := stsAPI.GetCallerIdentityRequest(&sts.GetCallerIdentityInput{})
-	request.SetContext(ctx)
-	request.HTTPRequest.Header.Add(clusterIDHeader, clusterID)
-
+func (g generator) GetWithSTS(ctx context.Context, clusterID string, stsAPI *sts.Client) (Token, error) {
 	// Sign the request.  The expires parameter (sets the x-amz-expires header) is
-	// currently ignored by STS, and the token expires 15 minutes after the x-amz-date
-	// timestamp regardless.  We set it to 60 seconds for backwards compatibility (the
-	// parameter is a required argument to Presign(), and authenticators 0.3.0 and older are expecting a value between
-	// 0 and 60 on the server side).
-	// https://github.com/aws/aws-sdk-go/issues/2167
-	presignedURLString, err := request.Presign(requestPresignParam)
+	// not supported by the STS presigner.  We set it to 60 [nano]seconds for backwards compatibility (the
+	// parameter was a required argument to AWS SDK v1's Presign(), and authenticators 0.3.0 and older are
+	// expecting a value between 0 and 60 on the server side).
+	presigner := sts.NewPresignClient(stsAPI, func(po *sts.PresignOptions) {
+		po.ClientOptions = []func(*sts.Options){
+			func(o *sts.Options) {
+				o.APIOptions = []func(*middleware.Stack) error{
+					addClusterIdHeaderMiddleware(clusterID),
+					addExpiryHeaderMiddleware(requestPresignParam),
+				}
+			},
+		}
+	})
+
+	request, err := presigner.PresignGetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
 	if err != nil {
 		return Token{}, err
 	}
 
-	// Set token expiration to 1 minute before the presigned URL expires for some cushion
-	tokenExpiration := time.Now().Local().Add(presignedURLExpiration - 1*time.Minute)
-	// TODO: this may need to be a constant-time base64 encoding
-	return Token{v1Prefix + base64.RawURLEncoding.EncodeToString([]byte(presignedURLString)), tokenExpiration}, nil
+	return Token{v1Prefix + base64.RawURLEncoding.EncodeToString([]byte(request.URL))}, nil
+}
+
+func addClusterIdHeaderMiddleware(clusterID string) func(*middleware.Stack) error {
+	return func(stack *middleware.Stack) error {
+		return stack.Build.Add(
+			clusterIdHeaderMiddleware(clusterID),
+			middleware.After,
+		)
+	}
+}
+
+func clusterIdHeaderMiddleware(clusterID string) middleware.BuildMiddleware {
+	return middleware.BuildMiddlewareFunc(
+		"foobar",
+		func(ctx context.Context, in middleware.BuildInput, next middleware.BuildHandler) (out middleware.BuildOutput, metadata middleware.Metadata, err error) {
+			switch req := in.Request.(type) {
+			case *smithyhttp.Request:
+				req.Header.Add(clusterIDHeader, clusterID)
+			default:
+				return out, metadata, fmt.Errorf("unknown transport type %T", in.Request)
+			}
+
+			return next.HandleBuild(ctx, in)
+		},
+	)
+}
+
+func addExpiryHeaderMiddleware(expire time.Duration) func(*middleware.Stack) error {
+	return func(stack *middleware.Stack) error {
+		return stack.Build.Add(
+			ExpiryHeaderMiddleware(expire),
+			middleware.After,
+		)
+	}
+}
+
+func ExpiryHeaderMiddleware(expire time.Duration) middleware.BuildMiddleware {
+	return middleware.BuildMiddlewareFunc(
+		"foobaz",
+		func(ctx context.Context, in middleware.BuildInput, next middleware.BuildHandler) (out middleware.BuildOutput, metadata middleware.Metadata, err error) {
+			switch req := in.Request.(type) {
+			case *smithyhttp.Request:
+				query := req.URL.Query()
+				query.Set("X-Amz-Expires", strconv.FormatInt(int64(expire/time.Second), 10))
+				req.URL.RawQuery = query.Encode()
+			default:
+				return out, metadata, fmt.Errorf("unknown transport type %T", in.Request)
+			}
+
+			return next.HandleBuild(ctx, in)
+		},
+	)
 }
 
 // Verifier validates tokens by calling STS and returning the associated identity.

--- a/internal/service/eks/token.go
+++ b/internal/service/eks/token.go
@@ -187,8 +187,8 @@ func (g generator) GetWithSTS(ctx context.Context, clusterID string, stsAPI *sts
 		po.ClientOptions = []func(*sts.Options){
 			func(o *sts.Options) {
 				o.APIOptions = []func(*middleware.Stack) error{
-					addClusterIdHeaderMiddleware(clusterID),
-					addExpiryHeaderMiddleware(requestPresignParam),
+					addClusterIdHeaderSetterMiddleware(clusterID),
+					addExpiryParamSetterMiddleware(requestPresignParam),
 				}
 			},
 		}
@@ -202,18 +202,18 @@ func (g generator) GetWithSTS(ctx context.Context, clusterID string, stsAPI *sts
 	return Token{v1Prefix + base64.RawURLEncoding.EncodeToString([]byte(request.URL))}, nil
 }
 
-func addClusterIdHeaderMiddleware(clusterID string) func(*middleware.Stack) error {
+func addClusterIdHeaderSetterMiddleware(clusterID string) func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {
 		return stack.Build.Add(
-			clusterIdHeaderMiddleware(clusterID),
+			setClusterIdHeaderMiddleware(clusterID),
 			middleware.After,
 		)
 	}
 }
 
-func clusterIdHeaderMiddleware(clusterID string) middleware.BuildMiddleware {
+func setClusterIdHeaderMiddleware(clusterID string) middleware.BuildMiddleware {
 	return middleware.BuildMiddlewareFunc(
-		"foobar",
+		"Test: Set ClusterId",
 		func(ctx context.Context, in middleware.BuildInput, next middleware.BuildHandler) (out middleware.BuildOutput, metadata middleware.Metadata, err error) {
 			switch req := in.Request.(type) {
 			case *smithyhttp.Request:
@@ -227,18 +227,18 @@ func clusterIdHeaderMiddleware(clusterID string) middleware.BuildMiddleware {
 	)
 }
 
-func addExpiryHeaderMiddleware(expire time.Duration) func(*middleware.Stack) error {
+func addExpiryParamSetterMiddleware(expire time.Duration) func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {
 		return stack.Build.Add(
-			ExpiryHeaderMiddleware(expire),
+			setExpiryParamMiddleware(expire),
 			middleware.After,
 		)
 	}
 }
 
-func ExpiryHeaderMiddleware(expire time.Duration) middleware.BuildMiddleware {
+func setExpiryParamMiddleware(expire time.Duration) middleware.BuildMiddleware {
 	return middleware.BuildMiddlewareFunc(
-		"foobaz",
+		"Test: Set ExpiryParam",
 		func(ctx context.Context, in middleware.BuildInput, next middleware.BuildHandler) (out middleware.BuildOutput, metadata middleware.Metadata, err error) {
 			switch req := in.Request.(type) {
 			case *smithyhttp.Request:

--- a/internal/service/emrcontainers/job_template.go
+++ b/internal/service/emrcontainers/job_template.go
@@ -335,6 +335,11 @@ func resourceJobTemplateDelete(ctx context.Context, d *schema.ResourceData, meta
 		return diags
 	}
 
+	// Not actually a validation exception
+	if tfawserr.ErrMessageContains(err, emrcontainers.ErrCodeValidationException, "Template does not exist") {
+		return diags
+	}
+
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "deleting EMR Containers Job Template (%s): %s", d.Id(), err)
 	}

--- a/internal/service/emrcontainers/virtual_cluster.go
+++ b/internal/service/emrcontainers/virtual_cluster.go
@@ -188,6 +188,16 @@ func resourceVirtualClusterDelete(ctx context.Context, d *schema.ResourceData, m
 		return diags
 	}
 
+	// Not actually a validation exception
+	if tfawserr.ErrMessageContains(err, emrcontainers.ErrCodeValidationException, "not found") {
+		return diags
+	}
+
+	// Not actually a validation exception
+	if tfawserr.ErrMessageContains(err, emrcontainers.ErrCodeValidationException, "already terminated") {
+		return diags
+	}
+
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "deleting EMR Containers Virtual Cluster (%s): %s", d.Id(), err)
 	}

--- a/names/data/names_data.csv
+++ b/names/data/names_data.csv
@@ -348,7 +348,7 @@ sso-admin,ssoadmin,ssoadmin,ssoadmin,,ssoadmin,,,SSOAdmin,SSOAdmin,x,,2,,aws_sso
 identitystore,identitystore,identitystore,identitystore,,identitystore,,,IdentityStore,IdentityStore,,,2,,aws_identitystore_,,identitystore_,SSO Identity Store,AWS,,,,,,,identitystore,,,
 sso-oidc,ssooidc,ssooidc,ssooidc,,ssooidc,,,SSOOIDC,SSOOIDC,,1,,,aws_ssooidc_,,ssooidc_,SSO OIDC,AWS,,x,,,,,SSO OIDC,,,
 storagegateway,storagegateway,storagegateway,storagegateway,,storagegateway,,,StorageGateway,StorageGateway,,1,,,aws_storagegateway_,,storagegateway_,Storage Gateway,AWS,,,,,,,Storage Gateway,,,
-sts,sts,sts,sts,,sts,,,STS,STS,x,1,2,aws_caller_identity,aws_sts_,,caller_identity,STS (Security Token),AWS,,,,,AWS_STS_ENDPOINT,TF_AWS_STS_ENDPOINT,STS,,,
+sts,sts,sts,sts,,sts,,,STS,STS,x,,2,aws_caller_identity,aws_sts_,,caller_identity,STS (Security Token),AWS,,,,,AWS_STS_ENDPOINT,TF_AWS_STS_ENDPOINT,STS,,,
 ,,,,,,,,,,,,,,,,,Sumerian,Amazon,x,,,,,,,,,No SDK support
 support,support,support,support,,support,,,Support,Support,,1,,,aws_support_,,support_,Support,AWS,,x,,,,,Support,,,
 swf,swf,swf,swf,,swf,,,SWF,SWF,,,2,,aws_swf_,,swf_,SWF (Simple Workflow),Amazon,,,,,,,SWF,,,


### PR DESCRIPTION
### Description

The AWS SDK for Go v1 STS connection was only used for generating presigned STS URLs for EKS. Updates presigning to use the `sts.PresignClient` for AWS SDK for Go v2.

Also fixes `disappears` tests from `emrcontainers`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #35333

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=eks TESTS=TestAccEKSClusterAuthDataSource_

--- PASS: TestAccEKSClusterAuthDataSource_basic (7.78s)
```

```console
% make testacc PKG=batch TESTS=TestAccBatchComputeEnvironment_eksConfiguration

--- PASS: TestAccBatchComputeEnvironment_eksConfiguration (684.76s)
```

```console
% make testacc PKG=emrcontainers

--- PASS: TestAccEMRContainersJobTemplate_disappears (18.71s)
--- PASS: TestAccEMRContainersJobTemplate_basic (22.15s)
--- PASS: TestAccEMRContainersJobTemplate_tags (23.88s)
--- PASS: TestAccEMRContainersVirtualCluster_basic (1097.06s)
--- PASS: TestAccEMRContainersVirtualCluster_tags (1190.35s)
--- PASS: TestAccEMRContainersVirtualClusterDataSource_basic (1231.85s)
--- PASS: TestAccEMRContainersVirtualCluster_disappears (1394.59s)
```
