### PR TITLE
Add support for challenge_config in wafv2_web_acl

### DIFF
--- a/internal/service/wafv2/flex.go
+++ b/internal/service/wafv2/flex.go
@@ -74,6 +74,32 @@ func expandCaptchaConfig(l []interface{}) *wafv2.CaptchaConfig {
 	return configuration
 }
 
+func expandChallengeConfig(l []interface{}) *wafv2.ChallengeConfig {
+	configuration := &wafv2.ChallengeConfig{}
+
+	if len(l) == 0 || l[0] == nil {
+		return configuration
+	}
+
+	m := l[0].(map[string]interface{})
+	if v, ok := m["immunity_time_property"]; ok {
+		inner := v.([]interface{})
+		if len(inner) == 0 || inner[0] == nil {
+			return configuration
+		}
+
+		m = inner[0].(map[string]interface{})
+
+		if v, ok := m["immunity_time"]; ok {
+			configuration.ImmunityTimeProperty = &wafv2.ImmunityTimeProperty{
+				ImmunityTime: aws.Int64(int64(v.(int))),
+			}
+		}
+	}
+
+	return configuration
+}
+
 func expandAssociationConfig(l []interface{}) *wafv2.AssociationConfig {
 	if len(l) == 0 || l[0] == nil {
 		return nil
@@ -1639,6 +1665,23 @@ func flattenCaptcha(a *wafv2.CaptchaAction) []interface{} {
 }
 
 func flattenCaptchaConfig(config *wafv2.CaptchaConfig) interface{} {
+	if config == nil {
+		return []interface{}{}
+	}
+	if config.ImmunityTimeProperty == nil {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"immunity_time_property": []interface{}{map[string]interface{}{
+			"immunity_time": aws.Int64Value(config.ImmunityTimeProperty.ImmunityTime),
+		}},
+	}
+
+	return []interface{}{m}
+}
+
+func flattenChallengeConfig(config *wafv2.ChallengeConfig) interface{} {
 	if config == nil {
 		return []interface{}{}
 	}

--- a/internal/service/wafv2/web_acl.go
+++ b/internal/service/wafv2/web_acl.go
@@ -69,6 +69,7 @@ func ResourceWebACL() *schema.Resource {
 					Computed: true,
 				},
 				"captcha_config":       outerCaptchaConfigSchema(),
+				"challenge_config":     outerCaptchaConfigSchema(),
 				"custom_response_body": customResponseBodySchema(),
 				"default_action": {
 					Type:     schema.TypeList,
@@ -179,6 +180,7 @@ func resourceWebACLCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	input := &wafv2.CreateWebACLInput{
 		AssociationConfig: expandAssociationConfig(d.Get("association_config").([]interface{})),
 		CaptchaConfig:     expandCaptchaConfig(d.Get("captcha_config").([]interface{})),
+		ChallengeConfig:   expandChallengeConfig(d.Get("challenge_config").([]interface{})),
 		DefaultAction:     expandDefaultAction(d.Get("default_action").([]interface{})),
 		Name:              aws.String(name),
 		Rules:             expandWebACLRules(d.Get("rule").(*schema.Set).List()),
@@ -239,6 +241,9 @@ func resourceWebACLRead(ctx context.Context, d *schema.ResourceData, meta interf
 	if err := d.Set("captcha_config", flattenCaptchaConfig(webACL.CaptchaConfig)); err != nil {
 		return diag.Errorf("setting captcha_config: %s", err)
 	}
+	if err := d.Set("challenge_config", flattenChallengeConfig(webACL.ChallengeConfig)); err != nil {
+		return diag.Errorf("setting challenge_config: %s", err)
+	}
 	if err := d.Set("custom_response_body", flattenCustomResponseBodies(webACL.CustomResponseBodies)); err != nil {
 		return diag.Errorf("setting custom_response_body: %s", err)
 	}
@@ -282,6 +287,7 @@ func resourceWebACLUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		input := &wafv2.UpdateWebACLInput{
 			AssociationConfig: expandAssociationConfig(d.Get("association_config").([]interface{})),
 			CaptchaConfig:     expandCaptchaConfig(d.Get("captcha_config").([]interface{})),
+			ChallengeConfig:   expandChallengeConfig(d.Get("challenge_config").([]interface{})),
 			DefaultAction:     expandDefaultAction(d.Get("default_action").([]interface{})),
 			Id:                aws.String(aclID),
 			LockToken:         aws.String(aclLockToken),

--- a/internal/service/wafv2/web_acl_test.go
+++ b/internal/service/wafv2/web_acl_test.go
@@ -2441,6 +2441,7 @@ func TestAccWAFV2WebACL_Custom_requestHandling(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.sampled_requests_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "captcha_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "captcha_config.0.immunity_time_property.0.immunity_time", "120"),
+					resource.TestCheckResourceAttr(resourceName, "challenge_config.0.immunity_time_property.0.immunity_time", "300"),
 				),
 			},
 			{
@@ -3571,6 +3572,12 @@ resource "aws_wafv2_web_acl" "test" {
     immunity_time_property {
       immunity_time = 120
     }
+  }
+
+  challenge_config {
+	immunity_time_property {
+	  immunity_time = 300
+	}
   }
 }
 `, rName, firstHeader, secondHeader)

--- a/website/docs/r/wafv2_web_acl.html.markdown
+++ b/website/docs/r/wafv2_web_acl.html.markdown
@@ -422,6 +422,8 @@ resource "aws_wafv2_web_acl" "test" {
 This resource supports the following arguments:
 
 * `association_config` - (Optional) Specifies custom configurations for the associations between the web ACL and protected resources. See [`association_config`](#association_config-block) below for details.
+* `captcha_config` - (Optional) Specifies how AWS WAF should handle CAPTCHA evaluations on the ACL level (used by [AWS Bot Control](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-bot.html)). See [`captcha_config`](#captcha_config-block) below for details.
+* `challenge_config` - (Optional) Specifies how AWS WAF should handle Challenge evaluations on the ACL level (used by [AWS Bot Control](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-bot.html)). See [`captcha_config`](#captcha_config-block) below for details.
 * `custom_response_body` - (Optional) Defines custom response bodies that can be referenced by `custom_response` actions. See [`custom_response_body`](#custom_response_body-block) below for details.
 * `default_action` - (Required) Action to perform if none of the `rules` contained in the WebACL match. See [`default_action`](#default_action-block) below for details.
 * `description` - (Optional) Friendly description of the WebACL.


### PR DESCRIPTION
### Description

Adds support for the `challenge_config` block on the ACL level (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-challengeconfig.html) for the `wafv2_web_acl` resource.


### Relations

https://github.com/hashicorp/terraform-provider-aws/issues/29071#issuecomment-1588037828

### References

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-challengeconfig.html
https://docs.aws.amazon.com/waf/latest/APIReference/API_WebACL.html


### Output from Acceptance Testing
```console
% make testacc TESTS=TestAccWAFV2WebACL_Custom_requestHandling PKG=wafv2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/wafv2/... -v -count 1 -parallel 20 -run='TestAccWAFV2WebACL_Custom_requestHandling'  -timeout 360m
=== RUN   TestAccWAFV2WebACL_Custom_requestHandling
=== PAUSE TestAccWAFV2WebACL_Custom_requestHandling
=== CONT  TestAccWAFV2WebACL_Custom_requestHandling
--- PASS: TestAccWAFV2WebACL_Custom_requestHandling (65.52s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/wafv2	72.479s
...
```
