### PR TITLE
Add Policy-Min-TLS-1-2-PFS-2023-10 in opensearch docs, tests, config examples

### DIFF
--- a/.changelog/35368.txt
+++ b/.changelog/35368.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_opensearch_domain: Add new `Policy-Min-TLS-1-2-PFS-2023-10` possible value for `tls_security_policy` option
+```

--- a/internal/service/firehose/delivery_stream_test.go
+++ b/internal/service/firehose/delivery_stream_test.go
@@ -4039,7 +4039,7 @@ resource "aws_opensearch_domain" "test_cluster" {
 
   domain_endpoint_options {
     enforce_https       = true
-    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+    tls_security_policy = "Policy-Min-TLS-1-2-PFS-2023-10"
   }
 
   ebs_options {

--- a/internal/service/opensearch/domain_saml_options_test.go
+++ b/internal/service/opensearch/domain_saml_options_test.go
@@ -256,7 +256,7 @@ resource "aws_opensearch_domain" "test" {
 
   domain_endpoint_options {
     enforce_https       = true
-    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+    tls_security_policy = "Policy-Min-TLS-1-2-PFS-2023-10"
   }
 
   node_to_node_encryption {
@@ -313,7 +313,7 @@ resource "aws_opensearch_domain" "test" {
 
   domain_endpoint_options {
     enforce_https       = true
-    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+    tls_security_policy = "Policy-Min-TLS-1-2-PFS-2023-10"
   }
 
   node_to_node_encryption {
@@ -371,7 +371,7 @@ resource "aws_opensearch_domain" "test" {
 
   domain_endpoint_options {
     enforce_https       = true
-    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+    tls_security_policy = "Policy-Min-TLS-1-2-PFS-2023-10"
   }
 
   node_to_node_encryption {

--- a/internal/service/opensearch/domain_test.go
+++ b/internal/service/opensearch/domain_test.go
@@ -201,6 +201,19 @@ func TestAccOpenSearchDomain_requireHTTPS(t *testing.T) {
 					testAccCheckDomainEndpointOptions(true, "Policy-Min-TLS-1-2-2019-07", &domain),
 				),
 			},
+			{
+				ResourceName:      "aws_opensearch_domain.test",
+				ImportState:       true,
+				ImportStateId:     rName,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDomainConfig_endpointOptions(rName, true, "Policy-Min-TLS-1-2-PFS-2023-10"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, "aws_opensearch_domain.test", &domain),
+					testAccCheckDomainEndpointOptions(true, "Policy-Min-TLS-1-2-PFS-2023-10", &domain),
+				),
+			},
 		},
 	})
 }

--- a/internal/service/opensearch/domain_test.go
+++ b/internal/service/opensearch/domain_test.go
@@ -239,7 +239,7 @@ func TestAccOpenSearchDomain_customEndpoint(t *testing.T) {
 		CheckDestroy:             testAccCheckDomainDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainConfig_customEndpoint(rName, true, "Policy-Min-TLS-1-0-2019-07", true, customEndpoint, certKey, certificate),
+				Config: testAccDomainConfig_customEndpoint(rName, true, "Policy-Min-TLS-1-2-PFS-2023-10", true, customEndpoint, certKey, certificate),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(ctx, resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "domain_endpoint_options.#", "1"),
@@ -255,18 +255,18 @@ func TestAccOpenSearchDomain_customEndpoint(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccDomainConfig_customEndpoint(rName, true, "Policy-Min-TLS-1-0-2019-07", true, customEndpoint, certKey, certificate),
+				Config: testAccDomainConfig_customEndpoint(rName, true, "Policy-Min-TLS-1-2-PFS-2023-10", true, customEndpoint, certKey, certificate),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(ctx, resourceName, &domain),
-					testAccCheckDomainEndpointOptions(true, "Policy-Min-TLS-1-0-2019-07", &domain),
+					testAccCheckDomainEndpointOptions(true, "Policy-Min-TLS-1-2-PFS-2023-10", &domain),
 					testAccCheckCustomEndpoint(resourceName, true, customEndpoint, &domain),
 				),
 			},
 			{
-				Config: testAccDomainConfig_customEndpoint(rName, true, "Policy-Min-TLS-1-0-2019-07", false, customEndpoint, certKey, certificate),
+				Config: testAccDomainConfig_customEndpoint(rName, true, "Policy-Min-TLS-1-2-PFS-2023-10", false, customEndpoint, certKey, certificate),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(ctx, resourceName, &domain),
-					testAccCheckDomainEndpointOptions(true, "Policy-Min-TLS-1-0-2019-07", &domain),
+					testAccCheckDomainEndpointOptions(true, "Policy-Min-TLS-1-2-PFS-2023-10", &domain),
 					testAccCheckCustomEndpoint(resourceName, false, customEndpoint, &domain),
 				),
 			},
@@ -2448,7 +2448,7 @@ resource "aws_opensearch_domain" "test" {
 
   domain_endpoint_options {
     enforce_https       = true
-    tls_security_policy = "Policy-Min-TLS-1-0-2019-07"
+    tls_security_policy = "Policy-Min-TLS-1-2-PFS-2023-10"
   }
 
   ebs_options {
@@ -3232,7 +3232,7 @@ resource "aws_opensearch_domain" "test" {
 
   domain_endpoint_options {
     enforce_https       = true
-    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+    tls_security_policy = "Policy-Min-TLS-1-2-PFS-2023-10"
   }
 
   node_to_node_encryption {
@@ -3273,7 +3273,7 @@ resource "aws_opensearch_domain" "test" {
 
   domain_endpoint_options {
     enforce_https       = true
-    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+    tls_security_policy = "Policy-Min-TLS-1-2-PFS-2023-10"
   }
 
   node_to_node_encryption {
@@ -3316,7 +3316,7 @@ resource "aws_opensearch_domain" "test" {
 
   domain_endpoint_options {
     enforce_https       = true
-    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+    tls_security_policy = "Policy-Min-TLS-1-2-PFS-2023-10"
   }
 
   node_to_node_encryption {
@@ -3356,7 +3356,7 @@ resource "aws_opensearch_domain" "test" {
 
   domain_endpoint_options {
     enforce_https       = true
-    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+    tls_security_policy = "Policy-Min-TLS-1-2-PFS-2023-10"
   }
 
   node_to_node_encryption {
@@ -3418,7 +3418,7 @@ func testAccDomainConfig_logPublishingOptions(rName, logType string) string {
 	
 		domain_endpoint_options {
 	  		enforce_https       = true
-	  		tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+	  		tls_security_policy = "Policy-Min-TLS-1-2-PFS-2023-10"
 		}
 	
 		encrypt_at_rest {

--- a/internal/service/opensearch/inbound_connection_accepter_test.go
+++ b/internal/service/opensearch/inbound_connection_accepter_test.go
@@ -106,7 +106,7 @@ resource "aws_opensearch_domain" "domain_1" {
 
   domain_endpoint_options {
     enforce_https       = true
-    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+    tls_security_policy = "Policy-Min-TLS-1-2-PFS-2023-10"
   }
 }
 
@@ -142,7 +142,7 @@ resource "aws_opensearch_domain" "domain_2" {
 
   domain_endpoint_options {
     enforce_https       = true
-    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+    tls_security_policy = "Policy-Min-TLS-1-2-PFS-2023-10"
   }
 }
 

--- a/internal/service/opensearch/outbound_connection_test.go
+++ b/internal/service/opensearch/outbound_connection_test.go
@@ -283,7 +283,7 @@ resource "aws_opensearch_domain" "domain_1" {
 
   domain_endpoint_options {
     enforce_https       = true
-    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+    tls_security_policy = "Policy-Min-TLS-1-2-PFS-2023-10"
   }
 }
 

--- a/internal/service/opensearch/outbound_connection_test.go
+++ b/internal/service/opensearch/outbound_connection_test.go
@@ -139,7 +139,7 @@ resource "aws_opensearch_domain" "domain_1" {
 
   domain_endpoint_options {
     enforce_https       = true
-    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+    tls_security_policy = "Policy-Min-TLS-1-2-PFS-2023-10"
   }
 }
 
@@ -175,7 +175,7 @@ resource "aws_opensearch_domain" "domain_2" {
 
   domain_endpoint_options {
     enforce_https       = true
-    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+    tls_security_policy = "Policy-Min-TLS-1-2-PFS-2023-10"
   }
 }
 

--- a/website/docs/cdktf/python/r/opensearch_domain.html.markdown
+++ b/website/docs/cdktf/python/r/opensearch_domain.html.markdown
@@ -471,7 +471,7 @@ AWS documentation: [Amazon Cognito Authentication for Dashboard](https://docs.aw
 * `custom_endpoint_enabled` - (Optional) Whether to enable custom endpoint for the OpenSearch domain.
 * `custom_endpoint` - (Optional) Fully qualified domain for your custom endpoint.
 * `enforce_https` - (Optional) Whether or not to require HTTPS. Defaults to `true`.
-* `tls_security_policy` - (Optional) Name of the TLS security policy that needs to be applied to the HTTPS endpoint. Valid values:  `Policy-Min-TLS-1-0-2019-07` and `Policy-Min-TLS-1-2-2019-07`. Terraform will only perform drift detection if a configuration value is provided.
+* `tls_security_policy` - (Optional) Name of the TLS security policy that needs to be applied to the HTTPS endpoint. Valid values:  `Policy-Min-TLS-1-0-2019-07`, `Policy-Min-TLS-1-2-2019-07` and `Policy-Min-TLS-1-2-PFS-2023-10`. Terraform will only perform drift detection if a configuration value is provided.
 
 ### ebs_options
 

--- a/website/docs/cdktf/python/r/opensearch_domain.html.markdown
+++ b/website/docs/cdktf/python/r/opensearch_domain.html.markdown
@@ -311,7 +311,7 @@ class MyConvertedCode(TerraformStack):
             ),
             domain_endpoint_options=OpensearchDomainDomainEndpointOptions(
                 enforce_https=True,
-                tls_security_policy="Policy-Min-TLS-1-2-2019-07"
+                tls_security_policy="Policy-Min-TLS-1-2-PFS-2023-10"
             ),
             domain_name="ggkitty",
             ebs_options=OpensearchDomainEbsOptions(
@@ -359,7 +359,7 @@ class MyConvertedCode(TerraformStack):
             ),
             domain_endpoint_options=OpensearchDomainDomainEndpointOptions(
                 enforce_https=True,
-                tls_security_policy="Policy-Min-TLS-1-2-2019-07"
+                tls_security_policy="Policy-Min-TLS-1-2-PFS-2023-10"
             ),
             domain_name="ggkitty",
             ebs_options=OpensearchDomainEbsOptions(

--- a/website/docs/cdktf/typescript/r/opensearch_domain.html.markdown
+++ b/website/docs/cdktf/typescript/r/opensearch_domain.html.markdown
@@ -361,7 +361,7 @@ class MyConvertedCode extends TerraformStack {
       },
       domainEndpointOptions: {
         enforceHttps: true,
-        tlsSecurityPolicy: "Policy-Min-TLS-1-2-2019-07",
+        tlsSecurityPolicy: "Policy-Min-TLS-1-2-PFS-2023-10",
       },
       domainName: "ggkitty",
       ebsOptions: {
@@ -412,7 +412,7 @@ class MyConvertedCode extends TerraformStack {
       },
       domainEndpointOptions: {
         enforceHttps: true,
-        tlsSecurityPolicy: "Policy-Min-TLS-1-2-2019-07",
+        tlsSecurityPolicy: "Policy-Min-TLS-1-2-PFS-2023-10",
       },
       domainName: "ggkitty",
       ebsOptions: {
@@ -527,7 +527,7 @@ AWS documentation: [Amazon Cognito Authentication for Dashboard](https://docs.aw
 * `customEndpointEnabled` - (Optional) Whether to enable custom endpoint for the OpenSearch domain.
 * `customEndpoint` - (Optional) Fully qualified domain for your custom endpoint.
 * `enforceHttps` - (Optional) Whether or not to require HTTPS. Defaults to `true`.
-* `tlsSecurityPolicy` - (Optional) Name of the TLS security policy that needs to be applied to the HTTPS endpoint. Valid values:  `Policy-Min-TLS-1-0-2019-07` and `Policy-Min-TLS-1-2-2019-07`. Terraform will only perform drift detection if a configuration value is provided.
+* `tlsSecurityPolicy` - (Optional) Name of the TLS security policy that needs to be applied to the HTTPS endpoint. Valid values:  `Policy-Min-TLS-1-0-2019-07`, `Policy-Min-TLS-1-2-2019-07` and `Policy-Min-TLS-1-2-PFS-2023-10`. Terraform will only perform drift detection if a configuration value is provided.
 
 ### ebs_options
 

--- a/website/docs/r/opensearch_domain.html.markdown
+++ b/website/docs/r/opensearch_domain.html.markdown
@@ -255,7 +255,7 @@ resource "aws_opensearch_domain" "example" {
 
   domain_endpoint_options {
     enforce_https       = true
-    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+    tls_security_policy = "Policy-Min-TLS-1-2-PFS-2023-10"
   }
 
   node_to_node_encryption {
@@ -298,7 +298,7 @@ resource "aws_opensearch_domain" "example" {
 
   domain_endpoint_options {
     enforce_https       = true
-    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+    tls_security_policy = "Policy-Min-TLS-1-2-PFS-2023-10"
   }
 
   node_to_node_encryption {
@@ -407,7 +407,7 @@ AWS documentation: [Amazon Cognito Authentication for Dashboard](https://docs.aw
 * `custom_endpoint_enabled` - (Optional) Whether to enable custom endpoint for the OpenSearch domain.
 * `custom_endpoint` - (Optional) Fully qualified domain for your custom endpoint.
 * `enforce_https` - (Optional) Whether or not to require HTTPS. Defaults to `true`.
-* `tls_security_policy` - (Optional) Name of the TLS security policy that needs to be applied to the HTTPS endpoint. Valid values:  `Policy-Min-TLS-1-0-2019-07` and `Policy-Min-TLS-1-2-2019-07`. Terraform will only perform drift detection if a configuration value is provided.
+* `tls_security_policy` - (Optional) Name of the TLS security policy that needs to be applied to the HTTPS endpoint. Valid values:  `Policy-Min-TLS-1-0-2019-07`, `Policy-Min-TLS-1-2-2019-07` and `Policy-Min-TLS-1-2-PFS-2023-10`. Terraform will only perform drift detection if a configuration value is provided.
 
 ### ebs_options
 


### PR DESCRIPTION
### Description

Hi everyone,

I just noticed that when creating an OpenSearch instance : 

* [The provider documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/opensearch_domain#tls_security_policy) states that the only possible values are `Policy-Min-TLS-1-0-2019-07` and `Policy-Min-TLS-1-2-2019-07`
* [The API documentation](https://docs.aws.amazon.com/opensearch-service/latest/APIReference/API_DomainEndpointOptions.html#opensearchservice-Type-DomainEndpointOptions-TLSSecurityPolicy) states that the possible values are `Policy-Min-TLS-1-0-2019-07`, `Policy-Min-TLS-1-2-2019-07`, `Policy-Min-TLS-1-2-PFS-2023-10`

I tried actually using this new parameter, and it works with latest provider version (`5.33.0`). (This support was added very recently, as version `5.31.0` rejects this value at validation. I'm assuming this came unnoticed during a sdk update, as the validation function comes from the sdk)

This PR : 
* Updates documentation to reflect the new allowed value
* Extends the `TestAccOpenSearchDomain_requireHTTPS` test, to explicitly check for all 3 possible values
* Updates every other test explicitly setting this parameter to the newest value

Please note that some of the edited documentation sections include cdktf-generated documentation. I have been unable to figure out how to regenerate those ; if this is a mandatory way to do it, please let me know how I should proceed.


### Relations
N/A

### References
Please note that `Policy-Min-TLS-1-0-2019-07` and `Policy-Min-TLS-1-2-2019-07` are also used by cloudsearch and elasticsearch, none of which have been updated to include the new value : 
* https://docs.aws.amazon.com/cloudsearch/latest/developerguide/API_DomainEndpointOptions.html
* https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticsearch-domain-domainendpointoptions.html


### Output from Acceptance Testing
```console
% make testacc PKG=opensearch TESTS=TestAccOpenSearchDomain_requireHTTPS
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/opensearch/... -v -count 1 -parallel 20 -run='TestAccOpenSearchDomain_requireHTTPS'  -timeout 360m
=== RUN   TestAccOpenSearchDomain_requireHTTPS
=== PAUSE TestAccOpenSearchDomain_requireHTTPS
=== CONT  TestAccOpenSearchDomain_requireHTTPS
--- PASS: TestAccOpenSearchDomain_requireHTTPS (1985.52s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/opensearch 1985.605s
```
