### PR TITLE
docs: correct variable block in shield_application_layer_automatic_response documentation

### DIFF
--- a/website/docs/r/shield_application_layer_automatic_response.html.markdown
+++ b/website/docs/r/shield_application_layer_automatic_response.html.markdown
@@ -19,7 +19,7 @@ data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 
-var "distribution_id" {
+variable "distribution_id" {
   type        = "string"
   description = "The Cloudfront Distribution on which to enable the Application Layer Automatic Response."
 }


### PR DESCRIPTION
### Description
Corrects the `var` block in `aws_shield_application_layer_automatic_response` documentation page.

### Relations
Closes #35372

### References
https://developer.hashicorp.com/terraform/language/values/variables


### Output from Acceptance Testing

n/a