### PR TITLE
make EKS access entry user_name and type configurable

### DIFF
--- a/.changelog/35391.txt
+++ b/.changelog/35391.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_eks_access_entry: Support `type` and `user_name` configuration
+```

--- a/.changelog/35391.txt
+++ b/.changelog/35391.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_eks_access_entry: Support `type` and `user_name` configuration
+resource/aws_eks_access_entry: Mark `type` and `user_name` as Optional, allowing values to be configured
 ```

--- a/.changelog/35391.txt
+++ b/.changelog/35391.txt
@@ -1,3 +1,7 @@
 ```release-note:bug
 resource/aws_eks_access_entry: Mark `type` and `user_name` as Optional, allowing values to be configured
 ```
+
+```release-note:bug
+resource/aws_eks_access_entry: Mark `kubernetes_groups` as Computed
+```

--- a/internal/service/eks/access_entry.go
+++ b/internal/service/eks/access_entry.go
@@ -82,16 +82,11 @@ func resourceAccessEntry() *schema.Resource {
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "STANDARD",
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"EC2_LINUX",
-					"EC2_WINDOWS",
-					"STANDARD",
-					"FARGATE_LINUX",
-				}, false),
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      accessEntryTypeStandard,
+				ValidateFunc: validation.StringInSlice(accessEntryType_Values(), false),
 			},
 			"user_name": {
 				Type:     schema.TypeString,

--- a/internal/service/eks/access_entry.go
+++ b/internal/service/eks/access_entry.go
@@ -65,6 +65,7 @@ func resourceAccessEntry() *schema.Resource {
 			"kubernetes_groups": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},

--- a/internal/service/eks/access_entry.go
+++ b/internal/service/eks/access_entry.go
@@ -103,21 +103,20 @@ func resourceAccessEntryCreate(ctx context.Context, d *schema.ResourceData, meta
 
 	clusterName := d.Get("cluster_name").(string)
 	principalARN := d.Get("principal_arn").(string)
-	entryType := d.Get("type").(string)
 	id := accessEntryCreateResourceID(clusterName, principalARN)
 	input := &eks.CreateAccessEntryInput{
 		ClusterName:  aws.String(clusterName),
 		PrincipalArn: aws.String(principalARN),
-		Type:         aws.String(entryType),
 		Tags:         getTagsIn(ctx),
-	}
-
-	if v, ok := d.GetOk("user_name"); ok {
-		input.Username = aws.String(v.(string))
+		Type:         aws.String(d.Get("type").(string)),
 	}
 
 	if v, ok := d.GetOk("kubernetes_groups"); ok {
 		input.KubernetesGroups = flex.ExpandStringValueSet(v.(*schema.Set))
+	}
+
+	if v, ok := d.GetOk("user_name"); ok {
+		input.Username = aws.String(v.(string))
 	}
 
 	_, err := conn.CreateAccessEntry(ctx, input)
@@ -181,12 +180,12 @@ func resourceAccessEntryUpdate(ctx context.Context, d *schema.ResourceData, meta
 			PrincipalArn: aws.String(principalARN),
 		}
 
-		if d.HasChange("user_name") {
-			input.Username = aws.String(d.Get("user_name").(string))
-		}
-
 		if d.HasChange("kubernetes_groups") {
 			input.KubernetesGroups = flex.ExpandStringValueSet(d.Get("kubernetes_groups").(*schema.Set))
+		}
+
+		if d.HasChange("user_name") {
+			input.Username = aws.String(d.Get("user_name").(string))
 		}
 
 		_, err = conn.UpdateAccessEntry(ctx, input)

--- a/internal/service/eks/access_entry_test.go
+++ b/internal/service/eks/access_entry_test.go
@@ -199,6 +199,7 @@ func TestAccEKSAccessEntry_type(t *testing.T) {
 				Config: testAccAccessEntryConfig_type(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAccessEntryExists(ctx, resourceName, &accessentry),
+					acctest.CheckResourceAttrGreaterThanOrEqualValue(resourceName, "kubernetes_groups.#", 1),
 					resource.TestCheckResourceAttr(resourceName, "type", "EC2_LINUX"),
 					resource.TestCheckResourceAttrSet(resourceName, "user_name"),
 				),

--- a/internal/service/eks/access_entry_test.go
+++ b/internal/service/eks/access_entry_test.go
@@ -392,7 +392,7 @@ resource "aws_eks_access_entry" "test" {
   cluster_name  = aws_eks_cluster.test.name
   principal_arn = aws_iam_user.test.arn
 
-  type      = "EC2_LINUX"
+  type      = "STANDARD"
   user_name = %[2]q
 }
 `, rName, username))

--- a/internal/service/eks/access_entry_test.go
+++ b/internal/service/eks/access_entry_test.go
@@ -47,7 +47,7 @@ func TestAccEKSAccessEntry_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "kubernetes_groups.#", "0"),
 					acctest.CheckResourceAttrRFC3339(resourceName, "modified_at"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
-					resource.TestCheckResourceAttrSet(resourceName, "type"),
+					resource.TestCheckResourceAttr(resourceName, "type", "STANDARD"),
 					resource.TestCheckResourceAttrSet(resourceName, "user_name"),
 				),
 			},
@@ -170,6 +170,50 @@ func TestAccEKSAccessEntry_tags(t *testing.T) {
 					testAccCheckAccessEntryExists(ctx, resourceName, &accessentry),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEKSAccessEntry_username(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var accessentry types.AccessEntry
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_eks_access_entry.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.EKSEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAccessEntryDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAccessEntryConfig_username(rName, "user1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccessEntryExists(ctx, resourceName, &accessentry),
+					resource.TestCheckResourceAttr(resourceName, "type", "STANDARD"),
+					resource.TestCheckResourceAttr(resourceName, "user_name", "user1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAccessEntryConfig_username(rName, "user2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccessEntryExists(ctx, resourceName, &accessentry),
+					resource.TestCheckResourceAttr(resourceName, "type", "STANDARD"),
+					resource.TestCheckResourceAttr(resourceName, "user_name", "user2"),
 				),
 			},
 		},
@@ -336,4 +380,20 @@ resource "aws_eks_access_entry" "test" {
   }
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2))
+}
+
+func testAccAccessEntryConfig_username(rName, username string) string {
+	return acctest.ConfigCompose(testAccAccessEntryConfig_base(rName), fmt.Sprintf(`
+resource "aws_iam_user" "test" {
+  name = %[1]q
+}
+
+resource "aws_eks_access_entry" "test" {
+  cluster_name  = aws_eks_cluster.test.name
+  principal_arn = aws_iam_user.test.arn
+
+  type      = "EC2_LINUX"
+  user_name = %[2]q
+}
+`, rName, username))
 }

--- a/internal/service/eks/cluster.go
+++ b/internal/service/eks/cluster.go
@@ -136,7 +136,7 @@ func resourceCluster() *schema.Resource {
 							Required: true,
 							Elem: &schema.Schema{
 								Type:         schema.TypeString,
-								ValidateFunc: validation.StringInSlice(Resources_Values(), false),
+								ValidateFunc: validation.StringInSlice(resources_Values(), false),
 							},
 						},
 					},

--- a/internal/service/eks/consts.go
+++ b/internal/service/eks/consts.go
@@ -8,19 +8,35 @@ import (
 )
 
 const (
-	IdentityProviderConfigTypeOIDC = "oidc"
+	identityProviderConfigTypeOIDC = "oidc"
 )
 
 const (
-	ResourcesSecrets = "secrets"
+	resourcesSecrets = "secrets"
 )
 
-func Resources_Values() []string {
+func resources_Values() []string {
 	return []string{
-		ResourcesSecrets,
+		resourcesSecrets,
 	}
 }
 
 const (
 	propagationTimeout = 2 * time.Minute
 )
+
+const (
+	accessEntryTypeEC2Linux     = "EC2_LINUX"
+	accessEntryTypeEC2Windows   = "EC2_WINDOWS"
+	accessEntryTypeFargateLinux = "FARGATE_LINUX"
+	accessEntryTypeStandard     = "STANDARD"
+)
+
+func accessEntryType_Values() []string {
+	return []string{
+		accessEntryTypeEC2Linux,
+		accessEntryTypeEC2Windows,
+		accessEntryTypeFargateLinux,
+		accessEntryTypeStandard,
+	}
+}

--- a/internal/service/eks/find.go
+++ b/internal/service/eks/find.go
@@ -195,7 +195,7 @@ func FindOIDCIdentityProviderConfigByClusterNameAndConfigName(ctx context.Contex
 		ClusterName: aws.String(clusterName),
 		IdentityProviderConfig: &types.IdentityProviderConfig{
 			Name: aws.String(configName),
-			Type: aws.String(IdentityProviderConfigTypeOIDC),
+			Type: aws.String(identityProviderConfigTypeOIDC),
 		},
 	}
 

--- a/internal/service/eks/identity_provider_config.go
+++ b/internal/service/eks/identity_provider_config.go
@@ -214,7 +214,7 @@ func resourceIdentityProviderConfigDelete(ctx context.Context, d *schema.Resourc
 		ClusterName: aws.String(clusterName),
 		IdentityProviderConfig: &types.IdentityProviderConfig{
 			Name: aws.String(configName),
-			Type: aws.String(IdentityProviderConfigTypeOIDC),
+			Type: aws.String(identityProviderConfigTypeOIDC),
 		},
 	})
 
@@ -242,7 +242,7 @@ func findOIDCIdentityProviderConfigByTwoPartKey(ctx context.Context, conn *eks.C
 		ClusterName: aws.String(clusterName),
 		IdentityProviderConfig: &types.IdentityProviderConfig{
 			Name: aws.String(configName),
-			Type: aws.String(IdentityProviderConfigTypeOIDC),
+			Type: aws.String(identityProviderConfigTypeOIDC),
 		},
 	}
 

--- a/website/docs/r/eks_access_entry.html.markdown
+++ b/website/docs/r/eks_access_entry.html.markdown
@@ -17,6 +17,7 @@ resource "aws_eks_access_entry" "example" {
   cluster_name      = aws_eks_cluster.example.name
   principal_arn     = aws_iam_role.example.arn
   kubernetes_groups = ["group-1", "group-2"]
+  type              = "STANDARD"
 }
 ```
 
@@ -31,6 +32,8 @@ The following arguments are optional:
 
 * `kubernetes_groups` – (Optional) List of string which can optionally specify the Kubernetes groups the user would belong to when creating an access entry.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `type` - (Optional) Defaults to STANDARD which provides the standard workflow. EC2_LINUX, EC2_WINDOWS, FARGATE_LINUX types disallow users to input a username or groups, and prevent associations.
+* `user_name` - (Optional) Defaults to principal ARN if user is principal else defaults to assume-role/session-name is role is used.
 
 ## Attribute Reference
 
@@ -39,8 +42,6 @@ This resource exports the following attributes in addition to the arguments abov
 * `access_entry_arn` - Amazon Resource Name (ARN) of the Access Entry.
 * `created_at` - Date and time in [RFC3339 format](https://tools.ietf.org/html/rfc3339#section-5.8) that the EKS add-on was created.
 * `modified_at` - Date and time in [RFC3339 format](https://tools.ietf.org/html/rfc3339#section-5.8) that the EKS add-on was updated.
-* `user_name` - Defaults to principal ARN if user is principal else defaults to assume-role/session-name is role is used.
-* `type` - Defaults to STANDARD which provides the standard workflow. EC2_LINUX, EC2_WINDOWS, FARGATE_LINUX types disallow users to input a username or groups, and prevent associations.
 * `tags_all` - (Optional) Key-value map of resource tags, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Timeouts


### PR DESCRIPTION
### Description
currently `type` and `user_name` properties of `aws_eks_access_entry`, which makes it impossible to utilize this resource for nodes. fixed it

Relates https://github.com/hashicorp/terraform-provider-aws/pull/35037.