### PR TITLE
Data Source route53_resolver_rules filter by DomainName

### DIFF
--- a/internal/service/route53resolver/rules_data_source.go
+++ b/internal/service/route53resolver/rules_data_source.go
@@ -27,6 +27,11 @@ func DataSourceRules() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validation.StringIsValidRegExp,
 			},
+			"domain_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsValidRegExp,
+			},
 			"owner_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -68,6 +73,9 @@ func dataSourceRulesRead(ctx context.Context, d *schema.ResourceData, meta inter
 	err := conn.ListResolverRulesPagesWithContext(ctx, input, func(page *route53resolver.ListResolverRulesOutput, lastPage bool) bool {
 		for _, rule := range page.ResolverRules {
 			if v, ok := d.GetOk("name_regex"); ok && !regexache.MustCompile(v.(string)).MatchString(aws.StringValue(rule.Name)) {
+				continue
+			}
+			if v, ok := d.GetOk("domain_regex"); ok && !regexache.MustCompile(v.(string)).MatchString(aws.StringValue(rule.DomainName)) {
 				continue
 			}
 			if v, ok := d.GetOk("owner_id"); ok && aws.StringValue(rule.OwnerId) != v.(string) {

--- a/internal/service/route53resolver/rules_data_source_test.go
+++ b/internal/service/route53resolver/rules_data_source_test.go
@@ -101,6 +101,46 @@ func TestAccRoute53ResolverRulesDataSource_nonExistentNameRegex(t *testing.T) {
 	})
 }
 
+func TestAccRoute53ResolverRulesDataSource_domainRegex(t *testing.T) {
+	ctx := acctest.Context(t)
+	dsResourceName := "data.aws_route53_resolver_rules.test"
+	rCount := 3
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, route53resolver.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRulesDataSourceConfig_domainRegex(rCount, rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dsResourceName, "resolver_rule_ids.#", strconv.Itoa(rCount)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRoute53ResolverRulesDataSource_nonExistentDomainRegex(t *testing.T) {
+	ctx := acctest.Context(t)
+	dsResourceName := "data.aws_route53_resolver_rules.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, route53resolver.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRulesDataSourceConfig_nonExistentDomainRegex,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dsResourceName, "resolver_rule_ids.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 const testAccRulesDataSourceConfig_basic = `
 # The default Internet Resolver rule.
 data "aws_route53_resolver_rules" "test" {
@@ -169,5 +209,28 @@ data "aws_route53_resolver_rules" "test" {
 const testAccRulesDataSourceConfig_nonExistentNameRegex = `
 data "aws_route53_resolver_rules" "test" {
   name_regex = "dne-regex"
+}
+`
+
+func testAccRulesDataSourceConfig_domainRegex(rCount int, rName string) string {
+	return fmt.Sprintf(`
+resource "aws_route53_resolver_rule" "test" {
+  count       = %[1]d
+  domain_name = "%[2]s.example.org"
+  name        = "%[2]s-${count.index}-rule"
+  rule_type   = "SYSTEM"
+}
+
+data "aws_route53_resolver_rules" "test" {
+  name_regex = ".*\.example\.org\."
+
+  depends_on = [aws_route53_resolver_rule.test]
+}
+`, rCount, rName)
+}
+
+const testAccRulesDataSourceConfig_nonExistentDomainRegex = `
+data "aws_route53_resolver_rules" "test" {
+  domain_regex = "dne-regex"
 }
 `

--- a/website/docs/d/route53_resolver_rules.html.markdown
+++ b/website/docs/d/route53_resolver_rules.html.markdown
@@ -41,11 +41,24 @@ data "aws_route53_resolver_rules" "example" {
 }
 ```
 
+### Retrieving rules by domain regex
+
+Resolver rules whose domain contains `abc`.
+
+```terraform
+data "aws_route53_resolver_rules" "example" {
+  domain_regex = ".*abc.*"
+}
+```
+
 ## Argument Reference
 
 The arguments of this data source act as filters for querying the available resolver rules in the current region.
 
 * `name_regex` - (Optional) Regex string to filter resolver rule names.
+  The filtering is done locally, so could have a performance impact if the result is large.
+  This argument should be used along with other arguments to limit the number of results returned.
+* `domain_regex` - (Optional) Regex string to filter resolver rule domains.
   The filtering is done locally, so could have a performance impact if the result is large.
   This argument should be used along with other arguments to limit the number of results returned.
 * `owner_id` (Optional) When the desired resolver rules are shared with another AWS account, the account ID of the account that the rules are shared with.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adding new argument `domain_regex` to `data.aws_route53_resolver_rules` to support retrieving Route53 resolver rules by domain name

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #35397

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
