### PR TITLE
r/aws_s3_object: Additional cross-region tests

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/YakDriver/regexache"
+	accounttypes "github.com/aws/aws-sdk-go-v2/service/account/types"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/inspector2"
 	inspector2types "github.com/aws/aws-sdk-go-v2/service/inspector2/types"
@@ -47,6 +48,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/provider"
+	tfaccount "github.com/hashicorp/terraform-provider-aws/internal/service/account"
 	tfacmpca "github.com/hashicorp/terraform-provider-aws/internal/service/acmpca"
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
@@ -1027,6 +1029,18 @@ func PreCheckOrganizationMemberAccount(ctx context.Context, t *testing.T) {
 
 	if aws.StringValue(organization.MasterAccountId) == aws.StringValue(callerIdentity.Account) {
 		t.Skip("this AWS account must not be the management account of an AWS Organization")
+	}
+}
+
+func PreCheckRegionOptIn(ctx context.Context, t *testing.T, region string) {
+	output, err := tfaccount.FindRegionOptInStatus(ctx, Provider.Meta().(*conns.AWSClient).AccountClient(ctx), "", region)
+
+	if err != nil {
+		t.Fatalf("reading Region (%s) opt-in status: %s", region, err)
+	}
+
+	if status := output.RegionOptStatus; status != accounttypes.RegionOptStatusEnabled && status != accounttypes.RegionOptStatusEnabledByDefault {
+		t.Skipf("Region (%s) opt-in status: %s", region, status)
 	}
 }
 

--- a/internal/service/account/region.go
+++ b/internal/service/account/region.go
@@ -1,0 +1,31 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package account
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/account"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func FindRegionOptInStatus(ctx context.Context, conn *account.Client, accountID, region string) (*account.GetRegionOptStatusOutput, error) {
+	input := &account.GetRegionOptStatusInput{}
+	if accountID != "" {
+		input.AccountId = aws.String(accountID)
+	}
+
+	output, err := conn.GetRegionOptStatus(ctx, input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output, nil
+}

--- a/internal/service/account/region.go
+++ b/internal/service/account/region.go
@@ -12,7 +12,9 @@ import (
 )
 
 func FindRegionOptInStatus(ctx context.Context, conn *account.Client, accountID, region string) (*account.GetRegionOptStatusOutput, error) {
-	input := &account.GetRegionOptStatusInput{}
+	input := &account.GetRegionOptStatusInput{
+		RegionName: aws.String(region),
+	}
 	if accountID != "" {
 		input.AccountId = aws.String(accountID)
 	}

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -50,7 +50,7 @@ const (
 
 // @SDKResource("aws_s3_bucket", name="Bucket")
 // @Tags
-func ResourceBucket() *schema.Resource {
+func resourceBucket() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceBucketCreate,
 		ReadWithoutTimeout:   resourceBucketRead,
@@ -1142,7 +1142,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 	// Bucket Tags.
 	//
 	tags, err := retryWhenNoSuchBucketError(ctx, d.Timeout(schema.TimeoutRead), func() (tftags.KeyValueTags, error) {
-		return BucketListTags(ctx, conn, d.Id())
+		return bucketListTags(ctx, conn, d.Id())
 	})
 
 	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, errCodeNoSuchBucket) {
@@ -1565,7 +1565,7 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 
 		// Retry due to S3 eventual consistency.
 		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
-			terr := BucketUpdateTags(ctx, conn, d.Id(), o, n)
+			terr := bucketUpdateTags(ctx, conn, d.Id(), o, n)
 			return nil, terr
 		}, errCodeNoSuchBucket)
 

--- a/internal/service/s3/bucket_accelerate_configuration.go
+++ b/internal/service/s3/bucket_accelerate_configuration.go
@@ -21,8 +21,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-// @SDKResource("aws_s3_bucket_accelerate_configuration")
-func ResourceBucketAccelerateConfiguration() *schema.Resource {
+// @SDKResource("aws_s3_bucket_accelerate_configuration", name="Bucket Accelerate Configuration")
+func resourceBucketAccelerateConfiguration() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceBucketAccelerateConfigurationCreate,
 		ReadWithoutTimeout:   resourceBucketAccelerateConfigurationRead,

--- a/internal/service/s3/bucket_acl.go
+++ b/internal/service/s3/bucket_acl.go
@@ -28,8 +28,8 @@ import (
 
 const BucketACLSeparator = ","
 
-// @SDKResource("aws_s3_bucket_acl")
-func ResourceBucketACL() *schema.Resource {
+// @SDKResource("aws_s3_bucket_acl", name="Bucket ACL")
+func resourceBucketACL() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceBucketACLCreate,
 		ReadWithoutTimeout:   resourceBucketACLRead,

--- a/internal/service/s3/bucket_analytics_configuration.go
+++ b/internal/service/s3/bucket_analytics_configuration.go
@@ -24,8 +24,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-// @SDKResource("aws_s3_bucket_analytics_configuration")
-func ResourceBucketAnalyticsConfiguration() *schema.Resource {
+// @SDKResource("aws_s3_bucket_analytics_configuration", name="Bucket Analytics Configuration")
+func resourceBucketAnalyticsConfiguration() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceBucketAnalyticsConfigurationPut,
 		ReadWithoutTimeout:   resourceBucketAnalyticsConfigurationRead,

--- a/internal/service/s3/bucket_cors_configuration.go
+++ b/internal/service/s3/bucket_cors_configuration.go
@@ -21,8 +21,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-// @SDKResource("aws_s3_bucket_cors_configuration")
-func ResourceBucketCorsConfiguration() *schema.Resource {
+// @SDKResource("aws_s3_bucket_cors_configuration", name="Bucket CORS Configuration")
+func resourceBucketCorsConfiguration() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceBucketCorsConfigurationCreate,
 		ReadWithoutTimeout:   resourceBucketCorsConfigurationRead,

--- a/internal/service/s3/bucket_data_source.go
+++ b/internal/service/s3/bucket_data_source.go
@@ -77,12 +77,16 @@ func dataSourceBucketRead(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	d.SetId(bucket)
-	arn := arn.ARN{
-		Partition: awsClient.Partition,
-		Service:   "s3",
-		Resource:  bucket,
-	}.String()
-	d.Set("arn", arn)
+	if arn.IsARN(bucket) {
+		d.Set("arn", bucket)
+	} else {
+		arn := arn.ARN{
+			Partition: awsClient.Partition,
+			Service:   "s3",
+			Resource:  bucket,
+		}.String()
+		d.Set("arn", arn)
+	}
 	d.Set("bucket_domain_name", awsClient.PartitionHostname(fmt.Sprintf("%s.s3", bucket)))
 	d.Set("bucket_regional_domain_name", bucketRegionalDomainName(bucket, region))
 	if hostedZoneID, err := hostedZoneIDForRegion(region); err == nil {

--- a/internal/service/s3/bucket_data_source.go
+++ b/internal/service/s3/bucket_data_source.go
@@ -18,8 +18,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_s3_bucket")
-func DataSourceBucket() *schema.Resource {
+// @SDKDataSource("aws_s3_bucket", name="Bucket")
+func dataSourceBucket() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceBucketRead,
 

--- a/internal/service/s3/bucket_data_source_test.go
+++ b/internal/service/s3/bucket_data_source_test.go
@@ -16,9 +16,11 @@ import (
 
 func TestAccS3BucketDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	bucketName := sdkacctest.RandomWithPrefix("tf-test-bucket")
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	region := acctest.Region()
 	hostedZoneID, _ := tfs3.HostedZoneIDForRegion(region)
+	resourceName := "aws_s3_bucket.test"
+	dataSourceName := "data.aws_s3_bucket.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -26,15 +28,14 @@ func TestAccS3BucketDataSource_basic(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBucketDataSourceConfig_basic(bucketName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBucketExists(ctx, "data.aws_s3_bucket.bucket"),
-					resource.TestCheckResourceAttrPair("data.aws_s3_bucket.bucket", "arn", "aws_s3_bucket.bucket", "arn"),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket.bucket", "region", region),
-					testAccCheckBucketDomainName("data.aws_s3_bucket.bucket", "bucket_domain_name", bucketName),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket.bucket", "bucket_regional_domain_name", testAccBucketRegionalDomainName(bucketName, region)),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket.bucket", "hosted_zone_id", hostedZoneID),
-					resource.TestCheckNoResourceAttr("data.aws_s3_bucket.bucket", "website_endpoint"),
+				Config: testAccBucketDataSourceConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttr(dataSourceName, "region", region),
+					testAccCheckBucketDomainName(dataSourceName, "bucket_domain_name", rName),
+					resource.TestCheckResourceAttr(dataSourceName, "bucket_regional_domain_name", testAccBucketRegionalDomainName(rName, region)),
+					resource.TestCheckResourceAttr(dataSourceName, "hosted_zone_id", hostedZoneID),
+					resource.TestCheckNoResourceAttr(dataSourceName, "website_endpoint"),
 				),
 			},
 		},
@@ -43,7 +44,10 @@ func TestAccS3BucketDataSource_basic(t *testing.T) {
 
 func TestAccS3BucketDataSource_website(t *testing.T) {
 	ctx := acctest.Context(t)
-	bucketName := sdkacctest.RandomWithPrefix("tf-test-bucket")
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket.test"
+	websiteConfigurationResourceName := "aws_s3_bucket_website_configuration.test"
+	dataSourceName := "data.aws_s3_bucket.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -51,38 +55,58 @@ func TestAccS3BucketDataSource_website(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBucketDataSourceConfig_website(bucketName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBucketExists(ctx, "data.aws_s3_bucket.bucket"),
-					resource.TestCheckResourceAttrPair("data.aws_s3_bucket.bucket", "bucket", "aws_s3_bucket.bucket", "id"),
-					resource.TestCheckResourceAttrPair("data.aws_s3_bucket.bucket", "website_domain", "aws_s3_bucket_website_configuration.test", "website_domain"),
-					resource.TestCheckResourceAttrPair("data.aws_s3_bucket.bucket", "website_endpoint", "aws_s3_bucket_website_configuration.test", "website_endpoint"),
+				Config: testAccBucketDataSourceConfig_website(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "website_domain", websiteConfigurationResourceName, "website_domain"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "website_endpoint", websiteConfigurationResourceName, "website_endpoint"),
 				),
 			},
 		},
 	})
 }
 
-func testAccBucketDataSourceConfig_basic(bucketName string) string {
+func TestAccS3BucketDataSource_accessPoint(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	accessPointResourceName := "aws_s3_access_point.test"
+	dataSourceName := "data.aws_s3_bucket.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3EndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketDataSourceConfig_accessPoint(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", accessPointResourceName, "arn"),
+				),
+			},
+		},
+	})
+}
+
+func testAccBucketDataSourceConfig_basic(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_s3_bucket" "bucket" {
+resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-data "aws_s3_bucket" "bucket" {
-  bucket = aws_s3_bucket.bucket.id
+data "aws_s3_bucket" "test" {
+  bucket = aws_s3_bucket.test.id
 }
-`, bucketName)
+`, rName)
 }
 
-func testAccBucketDataSourceConfig_website(bucketName string) string {
+func testAccBucketDataSourceConfig_website(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_s3_bucket" "bucket" {
+resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
 resource "aws_s3_bucket_website_configuration" "test" {
-  bucket = aws_s3_bucket.bucket.id
+  bucket = aws_s3_bucket.test.id
   index_document {
     suffix = "index.html"
   }
@@ -91,9 +115,34 @@ resource "aws_s3_bucket_website_configuration" "test" {
   }
 }
 
-data "aws_s3_bucket" "bucket" {
+data "aws_s3_bucket" "test" {
   # Must have bucket website configured first
   bucket = aws_s3_bucket_website_configuration.test.id
 }
-`, bucketName)
+`, rName)
+}
+
+func testAccBucketDataSourceConfig_accessPoint(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_s3_bucket_versioning" "test" {
+  bucket = aws_s3_bucket.test.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_access_point" "test" {
+  # Must have bucket versioning enabled first
+  bucket = aws_s3_bucket_versioning.test.bucket
+  name   = %[1]q
+}
+
+data "aws_s3_bucket" "test" {
+  bucket = aws_s3_access_point.test.arn
+}
+`, rName)
 }

--- a/internal/service/s3/bucket_intelligent_tiering_configuration.go
+++ b/internal/service/s3/bucket_intelligent_tiering_configuration.go
@@ -23,8 +23,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-// @SDKResource("aws_s3_bucket_intelligent_tiering_configuration")
-func ResourceBucketIntelligentTieringConfiguration() *schema.Resource {
+// @SDKResource("aws_s3_bucket_intelligent_tiering_configuration", name="Bucket Intelligent-Tiering Configuration")
+func resourceBucketIntelligentTieringConfiguration() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceBucketIntelligentTieringConfigurationPut,
 		ReadWithoutTimeout:   resourceBucketIntelligentTieringConfigurationRead,

--- a/internal/service/s3/bucket_inventory.go
+++ b/internal/service/s3/bucket_inventory.go
@@ -25,8 +25,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-// @SDKResource("aws_s3_bucket_inventory")
-func ResourceBucketInventory() *schema.Resource {
+// @SDKResource("aws_s3_bucket_inventory", name="Bucket Inventory")
+func resourceBucketInventory() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceBucketInventoryPut,
 		ReadWithoutTimeout:   resourceBucketInventoryRead,

--- a/internal/service/s3/bucket_lifecycle_configuration.go
+++ b/internal/service/s3/bucket_lifecycle_configuration.go
@@ -28,8 +28,8 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-// @SDKResource("aws_s3_bucket_lifecycle_configuration")
-func ResourceBucketLifecycleConfiguration() *schema.Resource {
+// @SDKResource("aws_s3_bucket_lifecycle_configuration", name="Bucket Lifecycle Configuration")
+func resourceBucketLifecycleConfiguration() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceBucketLifecycleConfigurationCreate,
 		ReadWithoutTimeout:   resourceBucketLifecycleConfigurationRead,

--- a/internal/service/s3/bucket_logging.go
+++ b/internal/service/s3/bucket_logging.go
@@ -22,8 +22,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-// @SDKResource("aws_s3_bucket_logging")
-func ResourceBucketLogging() *schema.Resource {
+// @SDKResource("aws_s3_bucket_logging", name="Bucket Logging")
+func resourceBucketLogging() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceBucketLoggingCreate,
 		ReadWithoutTimeout:   resourceBucketLoggingRead,

--- a/internal/service/s3/bucket_metric.go
+++ b/internal/service/s3/bucket_metric.go
@@ -23,8 +23,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-// @SDKResource("aws_s3_bucket_metric")
-func ResourceBucketMetric() *schema.Resource {
+// @SDKResource("aws_s3_bucket_metric", name="Bucket Metric")
+func resourceBucketMetric() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceBucketMetricPut,
 		ReadWithoutTimeout:   resourceBucketMetricRead,

--- a/internal/service/s3/bucket_notification.go
+++ b/internal/service/s3/bucket_notification.go
@@ -141,6 +141,9 @@ func ResourceBucketNotification() *schema.Resource {
 }
 
 func resourceBucketNotificationPut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	const (
+		filterRulesSliceStartLen = 2
+	)
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 	bucket := d.Get("bucket").(string)

--- a/internal/service/s3/bucket_notification.go
+++ b/internal/service/s3/bucket_notification.go
@@ -23,8 +23,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-// @SDKResource("aws_s3_bucket_notification")
-func ResourceBucketNotification() *schema.Resource {
+// @SDKResource("aws_s3_bucket_notification", name="Bucket Notification")
+func resourceBucketNotification() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceBucketNotificationPut,
 		ReadWithoutTimeout:   resourceBucketNotificationRead,

--- a/internal/service/s3/bucket_object.go
+++ b/internal/service/s3/bucket_object.go
@@ -513,9 +513,9 @@ func resourceBucketObjectSetKMS(ctx context.Context, d *schema.ResourceData, met
 	if sseKMSKeyId != nil {
 		// retrieve S3 KMS Default Master Key
 		conn := meta.(*conns.AWSClient).KMSConn(ctx)
-		keyMetadata, err := kms.FindKeyByID(ctx, conn, DefaultKMSKeyAlias)
+		keyMetadata, err := kms.FindKeyByID(ctx, conn, defaultKMSKeyAlias)
 		if err != nil {
-			return fmt.Errorf("Failed to describe default S3 KMS key (%s): %s", DefaultKMSKeyAlias, err)
+			return fmt.Errorf("Failed to describe default S3 KMS key (%s): %s", defaultKMSKeyAlias, err)
 		}
 
 		if kmsKeyID := aws.ToString(sseKMSKeyId); kmsKeyID != aws.ToString(keyMetadata.Arn) {

--- a/internal/service/s3/bucket_object.go
+++ b/internal/service/s3/bucket_object.go
@@ -37,9 +37,9 @@ import (
 	"github.com/mitchellh/go-homedir"
 )
 
-// @SDKResource("aws_s3_bucket_object", name="Object")
+// @SDKResource("aws_s3_bucket_object", name="Bucket Object")
 // @Tags
-func ResourceBucketObject() *schema.Resource {
+func resourceBucketObject() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceBucketObjectCreate,
 		ReadWithoutTimeout:   resourceBucketObjectRead,
@@ -246,7 +246,7 @@ func resourceBucketObjectRead(ctx context.Context, d *schema.ResourceData, meta 
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	tags, err := ObjectListTags(ctx, conn, bucket, key)
+	tags, err := objectListTags(ctx, conn, bucket, key)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "listing tags for S3 Bucket (%s) Object (%s): %s", bucket, key, err)
@@ -328,7 +328,7 @@ func resourceBucketObjectUpdate(ctx context.Context, d *schema.ResourceData, met
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
 
-		if err := ObjectUpdateTags(ctx, conn, bucket, key, o, n); err != nil {
+		if err := objectUpdateTags(ctx, conn, bucket, key, o, n); err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating tags: %s", err)
 		}
 	}

--- a/internal/service/s3/bucket_object_data_source.go
+++ b/internal/service/s3/bucket_object_data_source.go
@@ -23,8 +23,8 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 )
 
-// @SDKDataSource("aws_s3_bucket_object")
-func DataSourceBucketObject() *schema.Resource {
+// @SDKDataSource("aws_s3_bucket_object", name="Bucket Object")
+func dataSourceBucketObject() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceBucketObjectRead,
 
@@ -228,7 +228,7 @@ func dataSourceBucketObjectRead(ctx context.Context, d *schema.ResourceData, met
 		d.Set("body", buf.String())
 	}
 
-	tags, err := ObjectListTags(ctx, conn, bucket, key)
+	tags, err := objectListTags(ctx, conn, bucket, key)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "listing tags for S3 Bucket (%s) Object (%s): %s", bucket, key, err)

--- a/internal/service/s3/bucket_object_lock_configuration.go
+++ b/internal/service/s3/bucket_object_lock_configuration.go
@@ -22,8 +22,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-// @SDKResource("aws_s3_bucket_object_lock_configuration")
-func ResourceBucketObjectLockConfiguration() *schema.Resource {
+// @SDKResource("aws_s3_bucket_object_lock_configuration", name="Bucket Object Lock Configuration")
+func resourceBucketObjectLockConfiguration() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceBucketObjectLockConfigurationCreate,
 		ReadWithoutTimeout:   resourceBucketObjectLockConfigurationRead,

--- a/internal/service/s3/bucket_objects_data_source.go
+++ b/internal/service/s3/bucket_objects_data_source.go
@@ -19,8 +19,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 )
 
-// @SDKDataSource("aws_s3_bucket_objects")
-func DataSourceBucketObjects() *schema.Resource {
+// @SDKDataSource("aws_s3_bucket_objects", name="Bucket Objects")
+func dataSourceBucketObjects() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceBucketObjectsRead,
 

--- a/internal/service/s3/bucket_ownership_controls.go
+++ b/internal/service/s3/bucket_ownership_controls.go
@@ -22,8 +22,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-// @SDKResource("aws_s3_bucket_ownership_controls")
-func ResourceBucketOwnershipControls() *schema.Resource {
+// @SDKResource("aws_s3_bucket_ownership_controls", name="Bucket Ownership Controls")
+func resourceBucketOwnershipControls() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceBucketOwnershipControlsCreate,
 		ReadWithoutTimeout:   resourceBucketOwnershipControlsRead,

--- a/internal/service/s3/bucket_policy.go
+++ b/internal/service/s3/bucket_policy.go
@@ -21,8 +21,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-// @SDKResource("aws_s3_bucket_policy")
-func ResourceBucketPolicy() *schema.Resource {
+// @SDKResource("aws_s3_bucket_policy", name="Bucket Policy")
+func resourceBucketPolicy() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceBucketPolicyPut,
 		ReadWithoutTimeout:   resourceBucketPolicyRead,

--- a/internal/service/s3/bucket_policy_data_source.go
+++ b/internal/service/s3/bucket_policy_data_source.go
@@ -12,8 +12,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
 
-// @SDKDataSource("aws_s3_bucket_policy")
-func DataSourceBucketPolicy() *schema.Resource {
+// @SDKDataSource("aws_s3_bucket_policy", name="Bucket Policy")
+func dataSourceBucketPolicy() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceBucketPolicyRead,
 

--- a/internal/service/s3/bucket_public_access_block.go
+++ b/internal/service/s3/bucket_public_access_block.go
@@ -19,8 +19,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-// @SDKResource("aws_s3_bucket_public_access_block")
-func ResourceBucketPublicAccessBlock() *schema.Resource {
+// @SDKResource("aws_s3_bucket_public_access_block", name="Bucket Public Access Block")
+func resourceBucketPublicAccessBlock() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceBucketPublicAccessBlockCreate,
 		ReadWithoutTimeout:   resourceBucketPublicAccessBlockRead,

--- a/internal/service/s3/bucket_replication_configuration.go
+++ b/internal/service/s3/bucket_replication_configuration.go
@@ -23,8 +23,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-// @SDKResource("aws_s3_bucket_replication_configuration")
-func ResourceBucketReplicationConfiguration() *schema.Resource {
+// @SDKResource("aws_s3_bucket_replication_configuration", name="Bucket Replication Configuration")
+func resourceBucketReplicationConfiguration() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceBucketReplicationConfigurationCreate,
 		ReadWithoutTimeout:   resourceBucketReplicationConfigurationRead,

--- a/internal/service/s3/bucket_request_payment_configuration.go
+++ b/internal/service/s3/bucket_request_payment_configuration.go
@@ -21,8 +21,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-// @SDKResource("aws_s3_bucket_request_payment_configuration")
-func ResourceBucketRequestPaymentConfiguration() *schema.Resource {
+// @SDKResource("aws_s3_bucket_request_payment_configuration", name="Bucket Request Payment Configuration")
+func resourceBucketRequestPaymentConfiguration() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceBucketRequestPaymentConfigurationCreate,
 		ReadWithoutTimeout:   resourceBucketRequestPaymentConfigurationRead,

--- a/internal/service/s3/bucket_server_side_encryption_configuration.go
+++ b/internal/service/s3/bucket_server_side_encryption_configuration.go
@@ -21,8 +21,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-// @SDKResource("aws_s3_bucket_server_side_encryption_configuration")
-func ResourceBucketServerSideEncryptionConfiguration() *schema.Resource {
+// @SDKResource("aws_s3_bucket_server_side_encryption_configuration", name="Bucket Server-side Encryption Configuration")
+func resourceBucketServerSideEncryptionConfiguration() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceBucketServerSideEncryptionConfigurationCreate,
 		ReadWithoutTimeout:   resourceBucketServerSideEncryptionConfigurationRead,

--- a/internal/service/s3/bucket_website_configuration.go
+++ b/internal/service/s3/bucket_website_configuration.go
@@ -23,8 +23,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-// @SDKResource("aws_s3_bucket_website_configuration")
-func ResourceBucketWebsiteConfiguration() *schema.Resource {
+// @SDKResource("aws_s3_bucket_website_configuration", name="Bucket Website Configuration")
+func resourceBucketWebsiteConfiguration() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceBucketWebsiteConfigurationCreate,
 		ReadWithoutTimeout:   resourceBucketWebsiteConfigurationRead,

--- a/internal/service/s3/canonical_user_id_data_source.go
+++ b/internal/service/s3/canonical_user_id_data_source.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 )
 
-// @SDKDataSource("aws_canonical_user_id")
+// @SDKDataSource("aws_canonical_user_id", name="Canonical User ID")
 func dataSourceCanonicalUserID() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceCanonicalUserIDRead,

--- a/internal/service/s3/consts.go
+++ b/internal/service/s3/consts.go
@@ -1,8 +1,0 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
-package s3
-
-const (
-	filterRulesSliceStartLen = 2
-)

--- a/internal/service/s3/directory_bucket.go
+++ b/internal/service/s3/directory_bucket.go
@@ -34,7 +34,7 @@ var (
 )
 
 func isDirectoryBucket(bucket string) bool {
-	return directoryBucketNameRegex.MatchString(bucket)
+	return bucketNameTypeFor(bucket) == bucketNameTypeDirectoryBucket
 }
 
 // @FrameworkResource(name="Directory Bucket")

--- a/internal/service/s3/directory_buckets_data_source.go
+++ b/internal/service/s3/directory_buckets_data_source.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @FrameworkDataSource
+// @FrameworkDataSource(name="Directory Buckets")
 func newDirectoryBucketsDataSource(context.Context) (datasource.DataSourceWithConfigure, error) {
 	d := &directoryBucketsDataSource{}
 

--- a/internal/service/s3/enum.go
+++ b/internal/service/s3/enum.go
@@ -3,4 +3,48 @@
 
 package s3
 
-const DefaultKMSKeyAlias = "alias/aws/s3"
+import (
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+)
+
+const defaultKMSKeyAlias = "alias/aws/s3"
+
+type bucketNameType int
+
+const (
+	bucketNameTypeGeneralPurposeBucket bucketNameType = iota
+	bucketNameTypeDirectoryBucket
+	bucketNameTypeAccessPointAlias
+	bucketNameTypeAccessPointARN
+	bucketNameTypeObjectLambdaAccessPointAlias
+	bucketNameTypeObjectLambdaAccessPointARN
+	bucketNameTypeMultiRegionAccessPointARN
+)
+
+func bucketNameTypeFor(bucket string) bucketNameType {
+	switch {
+	case arn.IsARN(bucket):
+		switch v, _ := arn.Parse(bucket); v.Resource {
+		case "accesspoint":
+			switch v.Service {
+			case "s3":
+				if v.Region == "" {
+					return bucketNameTypeMultiRegionAccessPointARN
+				}
+				return bucketNameTypeAccessPointARN
+			case "s3-object-lambda":
+				return bucketNameTypeObjectLambdaAccessPointARN
+			}
+		}
+	case directoryBucketNameRegex.MatchString(bucket):
+		return bucketNameTypeDirectoryBucket
+	case strings.HasSuffix(bucket, "-s3alias"):
+		return bucketNameTypeAccessPointAlias
+	case strings.HasSuffix(bucket, "--ol-s3"):
+		return bucketNameTypeObjectLambdaAccessPointAlias
+	}
+
+	return bucketNameTypeDirectoryBucket
+}

--- a/internal/service/s3/errors.go
+++ b/internal/service/s3/errors.go
@@ -15,6 +15,7 @@ const (
 	errCodeBucketAlreadyExists                  = "BucketAlreadyExists"
 	errCodeBucketAlreadyOwnedByYou              = "BucketAlreadyOwnedByYou"
 	errCodeBucketNotEmpty                       = "BucketNotEmpty"
+	errCodeIllegalLocationConstraintException   = "IllegalLocationConstraintException"
 	errCodeInvalidArgument                      = "InvalidArgument"
 	errCodeInvalidBucketState                   = "InvalidBucketState"
 	errCodeInvalidRequest                       = "InvalidRequest"

--- a/internal/service/s3/exports.go
+++ b/internal/service/s3/exports.go
@@ -1,0 +1,10 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package s3
+
+// Exports for use in other packages.
+var (
+	ResourceBucket = resourceBucket
+	ResourceObject = resourceObject
+)

--- a/internal/service/s3/exports_test.go
+++ b/internal/service/s3/exports_test.go
@@ -25,9 +25,7 @@ var (
 	ResourceBucketServerSideEncryptionConfiguration = resourceBucketServerSideEncryptionConfiguration
 	ResourceBucketVersioning                        = resourceBucketVersioning
 	ResourceBucketWebsiteConfiguration              = resourceBucketWebsiteConfiguration
-	ResourceBucket                                  = resourceBucket
 	ResourceDirectoryBucket                         = newDirectoryBucketResource
-	ResourceObject                                  = resourceObject
 	ResourceObjectCopy                              = resourceObjectCopy
 
 	BucketListTags                        = bucketListTags

--- a/internal/service/s3/exports_test.go
+++ b/internal/service/s3/exports_test.go
@@ -5,8 +5,33 @@ package s3
 
 // Exports for use in tests only.
 var (
-	ResourceDirectoryBucket = newDirectoryBucketResource
+	ResourceBucketAccelerateConfiguration           = resourceBucketAccelerateConfiguration
+	ResourceBucketACL                               = resourceBucketACL
+	ResourceBucketAnalyticsConfiguration            = resourceBucketAnalyticsConfiguration
+	ResourceBucketCorsConfiguration                 = resourceBucketCorsConfiguration
+	ResourceBucketIntelligentTieringConfiguration   = resourceBucketIntelligentTieringConfiguration
+	ResourceBucketInventory                         = resourceBucketInventory
+	ResourceBucketLifecycleConfiguration            = resourceBucketLifecycleConfiguration
+	ResourceBucketLogging                           = resourceBucketLogging
+	ResourceBucketMetric                            = resourceBucketMetric
+	ResourceBucketNotification                      = resourceBucketNotification
+	ResourceBucketObjectLockConfiguration           = resourceBucketObjectLockConfiguration
+	ResourceBucketObject                            = resourceBucketObject
+	ResourceBucketOwnershipControls                 = resourceBucketOwnershipControls
+	ResourceBucketPolicy                            = resourceBucketPolicy
+	ResourceBucketPublicAccessBlock                 = resourceBucketPublicAccessBlock
+	ResourceBucketReplicationConfiguration          = resourceBucketReplicationConfiguration
+	ResourceBucketRequestPaymentConfiguration       = resourceBucketRequestPaymentConfiguration
+	ResourceBucketServerSideEncryptionConfiguration = resourceBucketServerSideEncryptionConfiguration
+	ResourceBucketVersioning                        = resourceBucketVersioning
+	ResourceBucketWebsiteConfiguration              = resourceBucketWebsiteConfiguration
+	ResourceBucket                                  = resourceBucket
+	ResourceDirectoryBucket                         = newDirectoryBucketResource
+	ResourceObject                                  = resourceObject
+	ResourceObjectCopy                              = resourceObjectCopy
 
+	BucketListTags                        = bucketListTags
+	BucketUpdateTags                      = bucketUpdateTags
 	BucketRegionalDomainName              = bucketRegionalDomainName
 	BucketWebsiteEndpointAndDomain        = bucketWebsiteEndpointAndDomain
 	DeleteAllObjectVersions               = deleteAllObjectVersions
@@ -34,10 +59,13 @@ var (
 	FindServerSideEncryptionConfiguration = findServerSideEncryptionConfiguration
 	HostedZoneIDForRegion                 = hostedZoneIDForRegion
 	IsDirectoryBucket                     = isDirectoryBucket
+	ObjectListTags                        = objectListTags
+	ObjectUpdateTags                      = objectUpdateTags
 	SDKv1CompatibleCleanKey               = sdkv1CompatibleCleanKey
 	ValidBucketName                       = validBucketName
 
 	BucketPropagationTimeout       = bucketPropagationTimeout
+	BucketVersioningStatusDisabled = bucketVersioningStatusDisabled
 	ErrCodeBucketAlreadyExists     = errCodeBucketAlreadyExists
 	ErrCodeBucketAlreadyOwnedByYou = errCodeBucketAlreadyOwnedByYou
 	ErrCodeNoSuchCORSConfiguration = errCodeNoSuchCORSConfiguration

--- a/internal/service/s3/object.go
+++ b/internal/service/s3/object.go
@@ -607,10 +607,10 @@ func resourceObjectSetKMS(ctx context.Context, meta interface{}, d *schema.Resou
 	// Only set non-default KMS key ID (one that doesn't match default).
 	if sseKMSKeyID != "" {
 		// Read S3 KMS default master key.
-		keyMetadata, err := kms.FindKeyByID(ctx, meta.(*conns.AWSClient).KMSConn(ctx), DefaultKMSKeyAlias)
+		keyMetadata, err := kms.FindKeyByID(ctx, meta.(*conns.AWSClient).KMSConn(ctx), defaultKMSKeyAlias)
 
 		if err != nil {
-			return fmt.Errorf("reading default S3 KMS key (%s): %s", DefaultKMSKeyAlias, err)
+			return fmt.Errorf("reading default S3 KMS key (%s): %s", defaultKMSKeyAlias, err)
 		}
 
 		if sseKMSKeyID != aws.ToString(keyMetadata.Arn) {

--- a/internal/service/s3/object.go
+++ b/internal/service/s3/object.go
@@ -41,7 +41,7 @@ import (
 
 // @SDKResource("aws_s3_object", name="Object")
 // @Tags
-func ResourceObject() *schema.Resource {
+func resourceObject() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceObjectCreate,
 		ReadWithoutTimeout:   resourceObjectRead,
@@ -302,11 +302,11 @@ func resourceObjectRead(ctx context.Context, d *schema.ResourceData, meta interf
 	d.Set("version_id", output.VersionId)
 	d.Set("website_redirect", output.WebsiteRedirectLocation)
 
-	if err := resourceObjectSetKMS(ctx, meta, d, aws.ToString(output.SSEKMSKeyId)); err != nil {
+	if err := setObjectKMSKeyID(ctx, meta, d, aws.ToString(output.SSEKMSKeyId)); err != nil {
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	if tags, err := ObjectListTags(ctx, conn, bucket, key, optFns...); err == nil {
+	if tags, err := objectListTags(ctx, conn, bucket, key, optFns...); err == nil {
 		setTagsOut(ctx, Tags(tags))
 	} else if !tfawserr.ErrHTTPStatusCodeEquals(err, http.StatusNotImplemented) { // Directory buckets return HTTP status code 501, NotImplemented.
 		return sdkdiag.AppendErrorf(diags, "listing tags for S3 Bucket (%s) Object (%s): %s", bucket, key, err)
@@ -394,7 +394,7 @@ func resourceObjectUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
 
-		if err := ObjectUpdateTags(ctx, conn, bucket, key, o, n, optFns...); err != nil {
+		if err := objectUpdateTags(ctx, conn, bucket, key, o, n, optFns...); err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating tags: %s", err)
 		}
 	}
@@ -603,7 +603,7 @@ func resourceObjectUpload(ctx context.Context, d *schema.ResourceData, meta inte
 	return append(diags, resourceObjectRead(ctx, d, meta)...)
 }
 
-func resourceObjectSetKMS(ctx context.Context, meta interface{}, d *schema.ResourceData, sseKMSKeyID string) error {
+func setObjectKMSKeyID(ctx context.Context, meta interface{}, d *schema.ResourceData, sseKMSKeyID string) error {
 	// Only set non-default KMS key ID (one that doesn't match default).
 	if sseKMSKeyID != "" {
 		// Read S3 KMS default master key.

--- a/internal/service/s3/object_copy.go
+++ b/internal/service/s3/object_copy.go
@@ -31,9 +31,9 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_s3_object_copy", name="Object")
+// @SDKResource("aws_s3_object_copy", name="Object Copy")
 // @Tags
-func ResourceObjectCopy() *schema.Resource {
+func resourceObjectCopy() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceObjectCopyCreate,
 		ReadWithoutTimeout:   resourceObjectCopyRead,
@@ -387,11 +387,11 @@ func resourceObjectCopyRead(ctx context.Context, d *schema.ResourceData, meta in
 	d.Set("version_id", output.VersionId)
 	d.Set("website_redirect", output.WebsiteRedirectLocation)
 
-	if err := resourceObjectSetKMS(ctx, meta, d, aws.ToString(output.SSEKMSKeyId)); err != nil {
+	if err := setObjectKMSKeyID(ctx, meta, d, aws.ToString(output.SSEKMSKeyId)); err != nil {
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	if tags, err := ObjectListTags(ctx, conn, bucket, key, optFns...); err == nil {
+	if tags, err := objectListTags(ctx, conn, bucket, key, optFns...); err == nil {
 		setTagsOut(ctx, Tags(tags))
 	} else if !tfawserr.ErrHTTPStatusCodeEquals(err, http.StatusNotImplemented) { // Directory buckets return HTTP status code 501, NotImplemented.
 		return sdkdiag.AppendErrorf(diags, "listing tags for S3 Bucket (%s) Object (%s): %s", bucket, key, err)

--- a/internal/service/s3/object_data_source.go
+++ b/internal/service/s3/object_data_source.go
@@ -26,8 +26,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_s3_object")
-func DataSourceObject() *schema.Resource {
+// @SDKDataSource("aws_s3_object", name="Object")
+func dataSourceObject() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceObjectRead,
 
@@ -261,7 +261,7 @@ func dataSourceObjectRead(ctx context.Context, d *schema.ResourceData, meta inte
 		d.Set("body", string(buf.Bytes()))
 	}
 
-	if tags, err := ObjectListTags(ctx, conn, bucket, key, optFns...); err == nil {
+	if tags, err := objectListTags(ctx, conn, bucket, key, optFns...); err == nil {
 		if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
 		}

--- a/internal/service/s3/object_test.go
+++ b/internal/service/s3/object_test.go
@@ -1857,8 +1857,6 @@ func TestAccS3Object_prefix(t *testing.T) {
 // S3 bucket is created in the alternate Region.
 func TestAccS3Object_crossRegion(t *testing.T) {
 	ctx := acctest.Context(t)
-	var obj s3.GetObjectOutput
-	resourceName := "aws_s3_object.object"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1871,19 +1869,8 @@ func TestAccS3Object_crossRegion(t *testing.T) {
 		CheckDestroy:             testAccCheckObjectDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccObjectConfig_crossRegion(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckObjectExists(ctx, resourceName, &obj),
-					resource.TestCheckResourceAttr(resourceName, "bucket", rName),
-					resource.TestCheckResourceAttr(resourceName, "key", "test-key"),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy"},
-				ImportStateId:           fmt.Sprintf("s3://%s/test-key", rName),
+				Config:      testAccObjectConfig_crossRegion(rName),
+				ExpectError: regexache.MustCompile(`PermanentRedirect`),
 			},
 		},
 	})

--- a/internal/service/s3/object_test.go
+++ b/internal/service/s3/object_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -1856,8 +1857,6 @@ func TestAccS3Object_prefix(t *testing.T) {
 // https://github.com/hashicorp/terraform-provider-aws/issues/35325.
 func TestAccS3Object_optInRegion(t *testing.T) {
 	ctx := acctest.Context(t)
-	var obj s3.GetObjectOutput
-	resourceName := "aws_s3_object.object"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	optInRegion := names.APEast1RegionID // Hong Kong.
 	providers := make(map[string]*schema.Provider)
@@ -1874,12 +1873,8 @@ func TestAccS3Object_optInRegion(t *testing.T) {
 		CheckDestroy:             testAccCheckObjectDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccObjectConfig_optInRegion(rName, optInRegion),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckObjectExists(ctx, resourceName, &obj),
-					resource.TestCheckResourceAttr(resourceName, "content_type", "application/x-directory"),
-					resource.TestCheckResourceAttr(resourceName, "key", "pfx/"),
-				),
+				Config:      testAccObjectConfig_optInRegion(rName, optInRegion),
+				ExpectError: regexache.MustCompile(`IllegalLocationConstraintException`),
 			},
 		},
 	})

--- a/internal/service/s3/objects_data_source.go
+++ b/internal/service/s3/objects_data_source.go
@@ -20,8 +20,8 @@ import (
 
 const keyRequestPageSize = 1000
 
-// @SDKDataSource("aws_s3_objects")
-func DataSourceObjects() *schema.Resource {
+// @SDKDataSource("aws_s3_objects", name="Objects")
+func dataSourceObjects() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceObjectsRead,
 

--- a/internal/service/s3/service_package_gen.go
+++ b/internal/service/s3/service_package_gen.go
@@ -16,6 +16,7 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.Serv
 	return []*types.ServicePackageFrameworkDataSource{
 		{
 			Factory: newDirectoryBucketsDataSource,
+			Name:    "Directory Buckets",
 		},
 	}
 }
@@ -34,30 +35,37 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  dataSourceCanonicalUserID,
 			TypeName: "aws_canonical_user_id",
+			Name:     "Canonical User ID",
 		},
 		{
-			Factory:  DataSourceBucket,
+			Factory:  dataSourceBucket,
 			TypeName: "aws_s3_bucket",
+			Name:     "Bucket",
 		},
 		{
-			Factory:  DataSourceBucketObject,
+			Factory:  dataSourceBucketObject,
 			TypeName: "aws_s3_bucket_object",
+			Name:     "Bucket Object",
 		},
 		{
-			Factory:  DataSourceBucketObjects,
+			Factory:  dataSourceBucketObjects,
 			TypeName: "aws_s3_bucket_objects",
+			Name:     "Bucket Objects",
 		},
 		{
-			Factory:  DataSourceBucketPolicy,
+			Factory:  dataSourceBucketPolicy,
 			TypeName: "aws_s3_bucket_policy",
+			Name:     "Bucket Policy",
 		},
 		{
-			Factory:  DataSourceObject,
+			Factory:  dataSourceObject,
 			TypeName: "aws_s3_object",
+			Name:     "Object",
 		},
 		{
-			Factory:  DataSourceObjects,
+			Factory:  dataSourceObjects,
 			TypeName: "aws_s3_objects",
+			Name:     "Objects",
 		},
 	}
 }
@@ -65,103 +73,122 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePackageSDKResource {
 	return []*types.ServicePackageSDKResource{
 		{
-			Factory:  ResourceBucket,
+			Factory:  resourceBucket,
 			TypeName: "aws_s3_bucket",
 			Name:     "Bucket",
 			Tags:     &types.ServicePackageResourceTags{},
 		},
 		{
-			Factory:  ResourceBucketAccelerateConfiguration,
+			Factory:  resourceBucketAccelerateConfiguration,
 			TypeName: "aws_s3_bucket_accelerate_configuration",
+			Name:     "Bucket Accelerate Configuration",
 		},
 		{
-			Factory:  ResourceBucketACL,
+			Factory:  resourceBucketACL,
 			TypeName: "aws_s3_bucket_acl",
+			Name:     "Bucket ACL",
 		},
 		{
-			Factory:  ResourceBucketAnalyticsConfiguration,
+			Factory:  resourceBucketAnalyticsConfiguration,
 			TypeName: "aws_s3_bucket_analytics_configuration",
+			Name:     "Bucket Analytics Configuration",
 		},
 		{
-			Factory:  ResourceBucketCorsConfiguration,
+			Factory:  resourceBucketCorsConfiguration,
 			TypeName: "aws_s3_bucket_cors_configuration",
+			Name:     "Bucket CORS Configuration",
 		},
 		{
-			Factory:  ResourceBucketIntelligentTieringConfiguration,
+			Factory:  resourceBucketIntelligentTieringConfiguration,
 			TypeName: "aws_s3_bucket_intelligent_tiering_configuration",
+			Name:     "Bucket Intelligent-Tiering Configuration",
 		},
 		{
-			Factory:  ResourceBucketInventory,
+			Factory:  resourceBucketInventory,
 			TypeName: "aws_s3_bucket_inventory",
+			Name:     "Bucket Inventory",
 		},
 		{
-			Factory:  ResourceBucketLifecycleConfiguration,
+			Factory:  resourceBucketLifecycleConfiguration,
 			TypeName: "aws_s3_bucket_lifecycle_configuration",
+			Name:     "Bucket Lifecycle Configuration",
 		},
 		{
-			Factory:  ResourceBucketLogging,
+			Factory:  resourceBucketLogging,
 			TypeName: "aws_s3_bucket_logging",
+			Name:     "Bucket Logging",
 		},
 		{
-			Factory:  ResourceBucketMetric,
+			Factory:  resourceBucketMetric,
 			TypeName: "aws_s3_bucket_metric",
+			Name:     "Bucket Metric",
 		},
 		{
-			Factory:  ResourceBucketNotification,
+			Factory:  resourceBucketNotification,
 			TypeName: "aws_s3_bucket_notification",
+			Name:     "Bucket Notification",
 		},
 		{
-			Factory:  ResourceBucketObject,
+			Factory:  resourceBucketObject,
 			TypeName: "aws_s3_bucket_object",
-			Name:     "Object",
+			Name:     "Bucket Object",
 			Tags:     &types.ServicePackageResourceTags{},
 		},
 		{
-			Factory:  ResourceBucketObjectLockConfiguration,
+			Factory:  resourceBucketObjectLockConfiguration,
 			TypeName: "aws_s3_bucket_object_lock_configuration",
+			Name:     "Bucket Object Lock Configuration",
 		},
 		{
-			Factory:  ResourceBucketOwnershipControls,
+			Factory:  resourceBucketOwnershipControls,
 			TypeName: "aws_s3_bucket_ownership_controls",
+			Name:     "Bucket Ownership Controls",
 		},
 		{
-			Factory:  ResourceBucketPolicy,
+			Factory:  resourceBucketPolicy,
 			TypeName: "aws_s3_bucket_policy",
+			Name:     "Bucket Policy",
 		},
 		{
-			Factory:  ResourceBucketPublicAccessBlock,
+			Factory:  resourceBucketPublicAccessBlock,
 			TypeName: "aws_s3_bucket_public_access_block",
+			Name:     "Bucket Public Access Block",
 		},
 		{
-			Factory:  ResourceBucketReplicationConfiguration,
+			Factory:  resourceBucketReplicationConfiguration,
 			TypeName: "aws_s3_bucket_replication_configuration",
+			Name:     "Bucket Replication Configuration",
 		},
 		{
-			Factory:  ResourceBucketRequestPaymentConfiguration,
+			Factory:  resourceBucketRequestPaymentConfiguration,
 			TypeName: "aws_s3_bucket_request_payment_configuration",
+			Name:     "Bucket Request Payment Configuration",
 		},
 		{
-			Factory:  ResourceBucketServerSideEncryptionConfiguration,
+			Factory:  resourceBucketServerSideEncryptionConfiguration,
 			TypeName: "aws_s3_bucket_server_side_encryption_configuration",
+			Name:     "Bucket Server-side Encryption Configuration",
 		},
 		{
-			Factory:  ResourceBucketVersioning,
+			Factory:  resourceBucketVersioning,
 			TypeName: "aws_s3_bucket_versioning",
+			Name:     "Bucket Versioning",
 		},
 		{
-			Factory:  ResourceBucketWebsiteConfiguration,
+			Factory:  resourceBucketWebsiteConfiguration,
 			TypeName: "aws_s3_bucket_website_configuration",
+			Name:     "Bucket Website Configuration",
 		},
 		{
-			Factory:  ResourceObject,
+			Factory:  resourceObject,
 			TypeName: "aws_s3_object",
 			Name:     "Object",
 			Tags:     &types.ServicePackageResourceTags{},
 		},
 		{
-			Factory:  ResourceObjectCopy,
+			Factory:  resourceObjectCopy,
 			TypeName: "aws_s3_object_copy",
-			Name:     "Object",
+			Name:     "Object Copy",
 			Tags:     &types.ServicePackageResourceTags{},
 		},
 	}

--- a/internal/service/s3/sweep.go
+++ b/internal/service/s3/sweep.go
@@ -195,7 +195,7 @@ func sweepBuckets(region string) error {
 	for _, bucket := range buckets {
 		name := aws.ToString(bucket.Name)
 
-		r := ResourceBucket()
+		r := resourceBucket()
 		d := r.Data(nil)
 		d.SetId(name)
 

--- a/internal/service/s3/tags.go
+++ b/internal/service/s3/tags.go
@@ -19,9 +19,9 @@ import (
 
 // Custom S3 tag service update functions using the same format as generated code.
 
-// BucketListTags lists S3 bucket tags.
+// bucketListTags lists S3 bucket tags.
 // The identifier is the bucket name.
-func BucketListTags(ctx context.Context, conn *s3.Client, identifier string, optFns ...func(*s3.Options)) (tftags.KeyValueTags, error) {
+func bucketListTags(ctx context.Context, conn *s3.Client, identifier string, optFns ...func(*s3.Options)) (tftags.KeyValueTags, error) {
 	input := &s3.GetBucketTaggingInput{
 		Bucket: aws.String(identifier),
 	}
@@ -42,14 +42,14 @@ func BucketListTags(ctx context.Context, conn *s3.Client, identifier string, opt
 	return keyValueTags(ctx, output.TagSet), nil
 }
 
-// BucketUpdateTags updates S3 bucket tags.
+// bucketUpdateTags updates S3 bucket tags.
 // The identifier is the bucket name.
-func BucketUpdateTags(ctx context.Context, conn *s3.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*s3.Options)) error {
+func bucketUpdateTags(ctx context.Context, conn *s3.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*s3.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
 	// We need to also consider any existing ignored tags.
-	allTags, err := BucketListTags(ctx, conn, identifier, optFns...)
+	allTags, err := bucketListTags(ctx, conn, identifier, optFns...)
 
 	if err != nil {
 		return fmt.Errorf("listing resource tags (%s): %w", identifier, err)
@@ -85,8 +85,8 @@ func BucketUpdateTags(ctx context.Context, conn *s3.Client, identifier string, o
 	return nil
 }
 
-// ObjectListTags lists S3 object tags.
-func ObjectListTags(ctx context.Context, conn *s3.Client, bucket, key string, optFns ...func(*s3.Options)) (tftags.KeyValueTags, error) {
+// objectListTags lists S3 object tags.
+func objectListTags(ctx context.Context, conn *s3.Client, bucket, key string, optFns ...func(*s3.Options)) (tftags.KeyValueTags, error) {
 	input := &s3.GetObjectTaggingInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
@@ -105,13 +105,13 @@ func ObjectListTags(ctx context.Context, conn *s3.Client, bucket, key string, op
 	return keyValueTags(ctx, output.TagSet), nil
 }
 
-// ObjectUpdateTags updates S3 object tags.
-func ObjectUpdateTags(ctx context.Context, conn *s3.Client, bucket, key string, oldTagsMap, newTagsMap any, optFns ...func(*s3.Options)) error {
+// objectUpdateTags updates S3 object tags.
+func objectUpdateTags(ctx context.Context, conn *s3.Client, bucket, key string, oldTagsMap, newTagsMap any, optFns ...func(*s3.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
 	// We need to also consider any existing ignored tags.
-	allTags, err := ObjectListTags(ctx, conn, bucket, key, optFns...)
+	allTags, err := objectListTags(ctx, conn, bucket, key, optFns...)
 
 	if err != nil {
 		return fmt.Errorf("listing resource tags (%s/%s): %w", bucket, key, err)

--- a/names/names.go
+++ b/names/names.go
@@ -185,6 +185,23 @@ func DNSSuffixForPartition(partition string) string {
 	}
 }
 
+func IsOptInRegion(region string) bool {
+	switch region {
+	case AFSouth1RegionID,
+		APEast1RegionID, APSouth2RegionID,
+		APSoutheast3RegionID, APSoutheast4RegionID,
+		CAWest1RegionID,
+		EUCentral2RegionID,
+		EUSouth1RegionID, EUSouth2RegionID,
+		ILCentral1RegionID,
+		MECentral1RegionID,
+		MESouth1RegionID:
+		return true
+	default:
+		return false
+	}
+}
+
 func PartitionForRegion(region string) string {
 	switch region {
 	case "":

--- a/names/names_test.go
+++ b/names/names_test.go
@@ -58,6 +58,53 @@ func TestDNSSuffixForPartition(t *testing.T) {
 	}
 }
 
+func TestIsOptInRegion(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{
+			name:     "empty",
+			input:    "",
+			expected: false,
+		},
+		{
+			name:     "China",
+			input:    CNNorth1RegionID,
+			expected: false,
+		},
+		{
+			name:     "GovCloud",
+			input:    USGovWest1RegionID,
+			expected: false,
+		},
+		{
+			name:     "standard opt-in",
+			input:    CAWest1RegionID,
+			expected: true,
+		},
+		{
+			name:     "standard not opt-in",
+			input:    CACentral1RegionID,
+			expected: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got, want := IsOptInRegion(testCase.input), testCase.expected; got != want {
+				t.Errorf("got: %t, expected: %t", got, want)
+			}
+		})
+	}
+}
+
 func TestPartitionForRegion(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Additional tests for cross-region (bucket is in alternate Region) scenarios.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/35325.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccS3Object_' PKG=s3 ACCTEST_PARALLELISM=3       
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 3  -run=TestAccS3Object_ -timeout 360m
=== RUN   TestAccS3Object_basic
=== PAUSE TestAccS3Object_basic
=== RUN   TestAccS3Object_disappears
=== PAUSE TestAccS3Object_disappears
=== RUN   TestAccS3Object_Disappears_bucket
=== PAUSE TestAccS3Object_Disappears_bucket
=== RUN   TestAccS3Object_source
=== PAUSE TestAccS3Object_source
=== RUN   TestAccS3Object_content
=== PAUSE TestAccS3Object_content
=== RUN   TestAccS3Object_etagEncryption
=== PAUSE TestAccS3Object_etagEncryption
=== RUN   TestAccS3Object_contentBase64
=== PAUSE TestAccS3Object_contentBase64
=== RUN   TestAccS3Object_sourceHashTrigger
=== PAUSE TestAccS3Object_sourceHashTrigger
=== RUN   TestAccS3Object_withContentCharacteristics
=== PAUSE TestAccS3Object_withContentCharacteristics
=== RUN   TestAccS3Object_nonVersioned
=== PAUSE TestAccS3Object_nonVersioned
=== RUN   TestAccS3Object_updates
=== PAUSE TestAccS3Object_updates
=== RUN   TestAccS3Object_updateSameFile
=== PAUSE TestAccS3Object_updateSameFile
=== RUN   TestAccS3Object_updatesWithVersioning
=== PAUSE TestAccS3Object_updatesWithVersioning
=== RUN   TestAccS3Object_updatesWithVersioningViaAccessPoint
=== PAUSE TestAccS3Object_updatesWithVersioningViaAccessPoint
=== RUN   TestAccS3Object_kms
=== PAUSE TestAccS3Object_kms
=== RUN   TestAccS3Object_sse
=== PAUSE TestAccS3Object_sse
=== RUN   TestAccS3Object_acl
=== PAUSE TestAccS3Object_acl
=== RUN   TestAccS3Object_metadata
=== PAUSE TestAccS3Object_metadata
=== RUN   TestAccS3Object_storageClass
=== PAUSE TestAccS3Object_storageClass
=== RUN   TestAccS3Object_tags
=== PAUSE TestAccS3Object_tags
=== RUN   TestAccS3Object_tagsLeadingSingleSlash
=== PAUSE TestAccS3Object_tagsLeadingSingleSlash
=== RUN   TestAccS3Object_tagsLeadingMultipleSlashes
=== PAUSE TestAccS3Object_tagsLeadingMultipleSlashes
=== RUN   TestAccS3Object_tagsMultipleSlashes
=== PAUSE TestAccS3Object_tagsMultipleSlashes
=== RUN   TestAccS3Object_DefaultTags_providerOnly
=== PAUSE TestAccS3Object_DefaultTags_providerOnly
=== RUN   TestAccS3Object_DefaultTags_providerAndResource
=== PAUSE TestAccS3Object_DefaultTags_providerAndResource
=== RUN   TestAccS3Object_DefaultTags_providerAndResourceWithOverride
=== PAUSE TestAccS3Object_DefaultTags_providerAndResourceWithOverride
=== RUN   TestAccS3Object_objectLockLegalHoldStartWithNone
=== PAUSE TestAccS3Object_objectLockLegalHoldStartWithNone
=== RUN   TestAccS3Object_objectLockLegalHoldStartWithOn
=== PAUSE TestAccS3Object_objectLockLegalHoldStartWithOn
=== RUN   TestAccS3Object_objectLockRetentionStartWithNone
=== PAUSE TestAccS3Object_objectLockRetentionStartWithNone
=== RUN   TestAccS3Object_objectLockRetentionStartWithSet
=== PAUSE TestAccS3Object_objectLockRetentionStartWithSet
=== RUN   TestAccS3Object_objectBucketKeyEnabled
=== PAUSE TestAccS3Object_objectBucketKeyEnabled
=== RUN   TestAccS3Object_bucketBucketKeyEnabled
=== PAUSE TestAccS3Object_bucketBucketKeyEnabled
=== RUN   TestAccS3Object_defaultBucketSSE
=== PAUSE TestAccS3Object_defaultBucketSSE
=== RUN   TestAccS3Object_ignoreTags
=== PAUSE TestAccS3Object_ignoreTags
=== RUN   TestAccS3Object_checksumAlgorithm
=== PAUSE TestAccS3Object_checksumAlgorithm
=== RUN   TestAccS3Object_directoryBucket
=== PAUSE TestAccS3Object_directoryBucket
=== RUN   TestAccS3Object_DirectoryBucket_disappears
=== PAUSE TestAccS3Object_DirectoryBucket_disappears
=== RUN   TestAccS3Object_DirectoryBucket_DefaultTags_providerOnly
=== PAUSE TestAccS3Object_DirectoryBucket_DefaultTags_providerOnly
=== RUN   TestAccS3Object_prefix
=== PAUSE TestAccS3Object_prefix
=== RUN   TestAccS3Object_crossRegion
=== PAUSE TestAccS3Object_crossRegion
=== RUN   TestAccS3Object_optInRegion
=== PAUSE TestAccS3Object_optInRegion
=== CONT  TestAccS3Object_basic
=== CONT  TestAccS3Object_tagsLeadingMultipleSlashes
=== CONT  TestAccS3Object_defaultBucketSSE
--- PASS: TestAccS3Object_defaultBucketSSE (24.85s)
=== CONT  TestAccS3Object_DirectoryBucket_disappears
--- PASS: TestAccS3Object_basic (27.99s)
=== CONT  TestAccS3Object_optInRegion
--- PASS: TestAccS3Object_DirectoryBucket_disappears (22.15s)
=== CONT  TestAccS3Object_crossRegion
--- PASS: TestAccS3Object_optInRegion (23.33s)
=== CONT  TestAccS3Object_prefix
--- PASS: TestAccS3Object_crossRegion (14.01s)
=== CONT  TestAccS3Object_DirectoryBucket_DefaultTags_providerOnly
--- PASS: TestAccS3Object_prefix (26.79s)
=== CONT  TestAccS3Object_objectLockLegalHoldStartWithOn
--- PASS: TestAccS3Object_DirectoryBucket_DefaultTags_providerOnly (21.92s)
=== CONT  TestAccS3Object_bucketBucketKeyEnabled
--- PASS: TestAccS3Object_tagsLeadingMultipleSlashes (85.34s)
=== CONT  TestAccS3Object_objectBucketKeyEnabled
--- PASS: TestAccS3Object_bucketBucketKeyEnabled (20.96s)
=== CONT  TestAccS3Object_objectLockRetentionStartWithSet
--- PASS: TestAccS3Object_objectBucketKeyEnabled (19.97s)
=== CONT  TestAccS3Object_objectLockRetentionStartWithNone
--- PASS: TestAccS3Object_objectLockLegalHoldStartWithOn (43.64s)
=== CONT  TestAccS3Object_DefaultTags_providerAndResource
--- PASS: TestAccS3Object_DefaultTags_providerAndResource (44.57s)
=== CONT  TestAccS3Object_objectLockLegalHoldStartWithNone
--- PASS: TestAccS3Object_objectLockRetentionStartWithNone (66.17s)
=== CONT  TestAccS3Object_DefaultTags_providerAndResourceWithOverride
--- PASS: TestAccS3Object_objectLockRetentionStartWithSet (85.62s)
=== CONT  TestAccS3Object_directoryBucket
--- PASS: TestAccS3Object_DefaultTags_providerAndResourceWithOverride (43.36s)
=== CONT  TestAccS3Object_DefaultTags_providerOnly
--- PASS: TestAccS3Object_objectLockLegalHoldStartWithNone (63.10s)
=== CONT  TestAccS3Object_tagsMultipleSlashes
--- PASS: TestAccS3Object_directoryBucket (26.36s)
=== CONT  TestAccS3Object_etagEncryption
--- PASS: TestAccS3Object_DefaultTags_providerOnly (24.09s)
=== CONT  TestAccS3Object_nonVersioned
    acctest.go:1696: skipping test; environment variable TF_ACC_ASSUME_ROLE_ARN must be set. Usage: Amazon Resource Name (ARN) of existing IAM Role to assume for testing restricted permissions
--- SKIP: TestAccS3Object_nonVersioned (0.00s)
=== CONT  TestAccS3Object_withContentCharacteristics
--- PASS: TestAccS3Object_etagEncryption (25.97s)
=== CONT  TestAccS3Object_sourceHashTrigger
--- PASS: TestAccS3Object_withContentCharacteristics (22.77s)
=== CONT  TestAccS3Object_contentBase64
--- PASS: TestAccS3Object_contentBase64 (21.98s)
=== CONT  TestAccS3Object_updates
--- PASS: TestAccS3Object_sourceHashTrigger (43.73s)
=== CONT  TestAccS3Object_acl
--- PASS: TestAccS3Object_tagsMultipleSlashes (84.31s)
=== CONT  TestAccS3Object_tagsLeadingSingleSlash
--- PASS: TestAccS3Object_updates (48.30s)
=== CONT  TestAccS3Object_sse
--- PASS: TestAccS3Object_sse (25.33s)
=== CONT  TestAccS3Object_tags
--- PASS: TestAccS3Object_acl (68.47s)
=== CONT  TestAccS3Object_kms
--- PASS: TestAccS3Object_kms (28.30s)
=== CONT  TestAccS3Object_storageClass
--- PASS: TestAccS3Object_tagsLeadingSingleSlash (90.02s)
=== CONT  TestAccS3Object_updatesWithVersioningViaAccessPoint
--- PASS: TestAccS3Object_tags (89.95s)
=== CONT  TestAccS3Object_metadata
--- PASS: TestAccS3Object_updatesWithVersioningViaAccessPoint (49.25s)
=== CONT  TestAccS3Object_updatesWithVersioning
--- PASS: TestAccS3Object_storageClass (94.58s)
=== CONT  TestAccS3Object_updateSameFile
--- PASS: TestAccS3Object_updatesWithVersioning (52.11s)
=== CONT  TestAccS3Object_content
--- PASS: TestAccS3Object_metadata (62.53s)
=== CONT  TestAccS3Object_Disappears_bucket
--- PASS: TestAccS3Object_Disappears_bucket (21.81s)
=== CONT  TestAccS3Object_disappears
--- PASS: TestAccS3Object_content (25.92s)
=== CONT  TestAccS3Object_checksumAlgorithm
--- PASS: TestAccS3Object_updateSameFile (48.91s)
=== CONT  TestAccS3Object_source
--- PASS: TestAccS3Object_disappears (24.04s)
=== CONT  TestAccS3Object_ignoreTags
--- PASS: TestAccS3Object_source (27.67s)
--- PASS: TestAccS3Object_checksumAlgorithm (43.97s)
--- PASS: TestAccS3Object_ignoreTags (44.45s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	610.305s
```
