### PR TITLE
Update list of valid auth methods for `aws_quicksight_account_subscription`

### DIFF
--- a/website/docs/r/quicksight_account_subscription.html.markdown
+++ b/website/docs/r/quicksight_account_subscription.html.markdown
@@ -26,7 +26,7 @@ resource "aws_quicksight_account_subscription" "subscription" {
 The following arguments are required:
 
 * `account_name` - (Required) Name of your Amazon QuickSight account. This name is unique over all of AWS, and it appears only when users sign in.
-* `authentication_method` - (Required) Method that you want to use to authenticate your Amazon QuickSight account. Currently, the valid values for this parameter are `IAM_AND_QUICKSIGHT`, `IAM_ONLY`, and `ACTIVE_DIRECTORY`.
+* `authentication_method` - (Required) Method that you want to use to authenticate your Amazon QuickSight account. Currently, the valid values for this parameter are `IAM_AND_QUICKSIGHT`, `IAM_ONLY`, `IAM_IDENTITY_CENTER`, and `ACTIVE_DIRECTORY`.
 * `edition` - (Required) Edition of Amazon QuickSight that you want your account to have. Currently, you can choose from `STANDARD`, `ENTERPRISE` or `ENTERPRISE_AND_Q`.
 * `notification_email` - (Required) Email address that you want Amazon QuickSight to send notifications to regarding your Amazon QuickSight account or Amazon QuickSight subscription.
 


### PR DESCRIPTION
### Description

Updates the list of accepted values for `authentication_method` to include the recently added `IAM_IDENTITY_CENTER`. This has been a valid option since 5.27.0 (see references for details)


### Relations

Closes #34801
Closes #34509

### References

- [SDK PR that added the functionality](https://github.com/aws/aws-sdk-go/pull/5082)
- [AWS SDK version bumped via this PR to the provider](https://github.com/hashicorp/terraform-provider-aws/pull/34563)
- [API docs for good measure](https://docs.aws.amazon.com/quicksight/latest/APIReference/API_CreateAccountSubscription.html#QS-CreateAccountSubscription-request-AuthenticationMethod)

### Output from Acceptance Testing

N/a, docs