### PR TITLE
Fix warning string in `aws_managed_user_pool_client`

### DIFF
--- a/internal/service/cognitoidp/managed_user_pool_client.go
+++ b/internal/service/cognitoidp/managed_user_pool_client.go
@@ -679,7 +679,7 @@ func (r *resourceManagedUserPoolClient) Delete(ctx context.Context, request reso
 	}
 
 	response.Diagnostics.AddWarning(
-		"Cognito User Pool Client (%s) not deleted",
+		fmt.Sprintf("Cognito User Pool Client (%s) not deleted", state.ID.ValueString()),
 		"User Pool Client is managed by another service and will be deleted when that resource is deleted. Removed from Terraform state.",
 	)
 }


### PR DESCRIPTION
### Description

Fixes a warning string that previous output a literal `%s` rather than interpolating the ID

### Relations

Closes #35426


### Output from Acceptance Testing

I'm not able to run them at the moment