### PR TITLE
Update ecs_service.html.markdown

### DIFF
--- a/website/docs/r/ecs_service.html.markdown
+++ b/website/docs/r/ecs_service.html.markdown
@@ -113,7 +113,7 @@ resource "aws_ecs_service" "example" {
   force_new_deployment = true
 
   triggers = {
-    redeployment = timestamp()
+    redeployment = plantimestamp()
   }
 }
 ```
@@ -151,7 +151,7 @@ The following arguments are optional:
 * `service_registries` - (Optional) Service discovery registries for the service. The maximum number of `service_registries` blocks is `1`. See below.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `task_definition` - (Optional) Family and revision (`family:revision`) or full ARN of the task definition that you want to run in your service. Required unless using the `EXTERNAL` deployment controller. If a revision is not specified, the latest `ACTIVE` revision is used.
-* `triggers` - (Optional) Map of arbitrary keys and values that, when changed, will trigger an in-place update (redeployment). Useful with `timestamp()`. See example above.
+* `triggers` - (Optional) Map of arbitrary keys and values that, when changed, will trigger an in-place update (redeployment). Useful with `plantimestamp()`. See example above.
 * `wait_for_steady_state` - (Optional) If `true`, Terraform will wait for the service to reach a steady state (like [`aws ecs wait services-stable`](https://docs.aws.amazon.com/cli/latest/reference/ecs/wait/services-stable.html)) before continuing. Default `false`.
 
 ### alarms


### PR DESCRIPTION
### Description
The example for using `timestamp()` as a trigger to force a new deployment doesn't work because `timestamp()` is evaluated once the plan is applied.

This update replaces `timestamp()` with `plantimestamp(),` which will change for every plan operation.

### Relations
Closes #35410 


### References
[timestamp()](https://developer.hashicorp.com/terraform/language/functions/timestamp)
[plantimestamp()](https://developer.hashicorp.com/terraform/language/functions/plantimestamp)
[Original documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service#redeploy-service-on-every-apply)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
