### PR TITLE
vpc/eni_sg_attach: Add configurable timeouts

### DIFF
--- a/.changelog/35435.txt
+++ b/.changelog/35435.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_network_interface_sg_attachment: Increase default timeouts to 3 minutes and allow them to be configured
+```

--- a/internal/service/ec2/vpc_network_interface_sg_attachment.go
+++ b/internal/service/ec2/vpc_network_interface_sg_attachment.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -25,8 +26,16 @@ func ResourceNetworkInterfaceSGAttachment() *schema.Resource {
 		CreateWithoutTimeout: resourceNetworkInterfaceSGAttachmentCreate,
 		ReadWithoutTimeout:   resourceNetworkInterfaceSGAttachmentRead,
 		DeleteWithoutTimeout: resourceNetworkInterfaceSGAttachmentDelete,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceNetworkInterfaceSGAttachmentImport,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(3 * time.Minute),
+			Read:   schema.DefaultTimeout(3 * time.Minute),
+			Update: schema.DefaultTimeout(3 * time.Minute),
+			Delete: schema.DefaultTimeout(3 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -99,7 +108,7 @@ func resourceNetworkInterfaceSGAttachmentRead(ctx context.Context, d *schema.Res
 
 	networkInterfaceID := d.Get("network_interface_id").(string)
 	sgID := d.Get("security_group_id").(string)
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, maxDuration(ec2PropagationTimeout, d.Timeout(schema.TimeoutRead)), func() (interface{}, error) {
 		return FindNetworkInterfaceSecurityGroup(ctx, conn, networkInterfaceID, sgID)
 	}, d.IsNewResource())
 
@@ -119,6 +128,14 @@ func resourceNetworkInterfaceSGAttachmentRead(ctx context.Context, d *schema.Res
 	d.Set("security_group_id", groupIdentifier.GroupId)
 
 	return diags
+}
+
+func maxDuration(a, b time.Duration) time.Duration {
+	if a >= b {
+		return a
+	}
+
+	return b
 }
 
 func resourceNetworkInterfaceSGAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/service/ec2/vpc_network_interface_sg_attachment.go
+++ b/internal/service/ec2/vpc_network_interface_sg_attachment.go
@@ -34,7 +34,6 @@ func ResourceNetworkInterfaceSGAttachment() *schema.Resource {
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(3 * time.Minute),
 			Read:   schema.DefaultTimeout(3 * time.Minute),
-			Update: schema.DefaultTimeout(3 * time.Minute),
 			Delete: schema.DefaultTimeout(3 * time.Minute),
 		},
 

--- a/internal/service/ec2/vpc_network_interface_sg_attachment_test.go
+++ b/internal/service/ec2/vpc_network_interface_sg_attachment_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccVPCNetworkInterfaceSgAttachment_basic(t *testing.T) {
+func TestAccVPCNetworkInterfaceSGAttachment_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	networkInterfaceResourceName := "aws_network_interface.test"
 	securityGroupResourceName := "aws_security_group.test"
@@ -49,7 +49,7 @@ func TestAccVPCNetworkInterfaceSgAttachment_basic(t *testing.T) {
 	})
 }
 
-func TestAccVPCNetworkInterfaceSgAttachment_disappears(t *testing.T) {
+func TestAccVPCNetworkInterfaceSGAttachment_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_network_interface_sg_attachment.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -72,7 +72,7 @@ func TestAccVPCNetworkInterfaceSgAttachment_disappears(t *testing.T) {
 	})
 }
 
-func TestAccVPCNetworkInterfaceSgAttachment_instance(t *testing.T) {
+func TestAccVPCNetworkInterfaceSGAttachment_instance(t *testing.T) {
 	ctx := acctest.Context(t)
 	instanceResourceName := "aws_instance.test"
 	securityGroupResourceName := "aws_security_group.test"
@@ -97,7 +97,7 @@ func TestAccVPCNetworkInterfaceSgAttachment_instance(t *testing.T) {
 	})
 }
 
-func TestAccVPCNetworkInterfaceSgAttachment_multiple(t *testing.T) {
+func TestAccVPCNetworkInterfaceSGAttachment_multiple(t *testing.T) {
 	ctx := acctest.Context(t)
 	networkInterfaceResourceName := "aws_network_interface.test"
 	securityGroupResourceName1 := "aws_security_group.test.0"

--- a/website/docs/r/network_interface_sg_attachment.html.markdown
+++ b/website/docs/r/network_interface_sg_attachment.html.markdown
@@ -93,6 +93,15 @@ resource "aws_network_interface_sg_attachment" "sg_attachment" {
 
 This resource exports no additional attributes.
 
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+- `create` - (Default `3m`)
+- `read` - (Default `3m`)
+- `update` - (Default `3m`)
+- `delete` - (Default `3m`)
+
 ## Import
 
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Network Interface Security Group attachments using the associated network interface ID and security group ID, separated by an underscore (`_`). For example:

--- a/website/docs/r/network_interface_sg_attachment.html.markdown
+++ b/website/docs/r/network_interface_sg_attachment.html.markdown
@@ -99,7 +99,6 @@ This resource exports no additional attributes.
 
 - `create` - (Default `3m`)
 - `read` - (Default `3m`)
-- `update` - (Default `3m`)
 - `delete` - (Default `3m`)
 
 ## Import


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Add configurable timeouts to `aws_network_interface_sg_attachment`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #35436

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccVPCNetworkInterfaceSGAttachment_ K=vpc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCNetworkInterfaceSGAttachment_'  -timeout 360m
=== RUN   TestAccVPCNetworkInterfaceSGAttachment_basic
=== PAUSE TestAccVPCNetworkInterfaceSGAttachment_basic
=== RUN   TestAccVPCNetworkInterfaceSGAttachment_disappears
=== PAUSE TestAccVPCNetworkInterfaceSGAttachment_disappears
=== RUN   TestAccVPCNetworkInterfaceSGAttachment_instance
=== PAUSE TestAccVPCNetworkInterfaceSGAttachment_instance
=== RUN   TestAccVPCNetworkInterfaceSGAttachment_multiple
=== PAUSE TestAccVPCNetworkInterfaceSGAttachment_multiple
=== CONT  TestAccVPCNetworkInterfaceSGAttachment_basic
=== CONT  TestAccVPCNetworkInterfaceSGAttachment_instance
=== CONT  TestAccVPCNetworkInterfaceSGAttachment_multiple
=== CONT  TestAccVPCNetworkInterfaceSGAttachment_disappears
--- PASS: TestAccVPCNetworkInterfaceSGAttachment_disappears (26.57s)
--- PASS: TestAccVPCNetworkInterfaceSGAttachment_basic (28.68s)
--- PASS: TestAccVPCNetworkInterfaceSGAttachment_multiple (31.72s)
--- PASS: TestAccVPCNetworkInterfaceSGAttachment_instance (324.42s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	326.588s
```