### PR TITLE
kx_volume & kx_dataview framework migration

### DIFF
--- a/internal/service/finspace/exports_test.go
+++ b/internal/service/finspace/exports_test.go
@@ -1,0 +1,9 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package finspace
+
+var (
+	ResourceKxDataview = newResourceKxDataview
+	ResourceKxVolume   = newResourceKxVolume
+)

--- a/internal/service/finspace/kx_dataview.go
+++ b/internal/service/finspace/kx_dataview.go
@@ -7,130 +7,167 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/finspace"
-	"github.com/aws/aws-sdk-go-v2/service/finspace/types"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/finspace/types"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
-	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_finspace_kx_dataview", name="Kx Dataview")
+// @FrameworkResource(name="Kx Dataview")
 // @Tags(identifierAttribute="arn")
-func ResourceKxDataview() *schema.Resource {
-	return &schema.Resource{
-		CreateWithoutTimeout: resourceKxDataviewCreate,
-		ReadWithoutTimeout:   resourceKxDataviewRead,
-		UpdateWithoutTimeout: resourceKxDataviewUpdate,
-		DeleteWithoutTimeout: resourceKxDataviewDelete,
+func newResourceKxDataview(context.Context) (resource.ResourceWithConfigure, error) {
+	r := &resourceKxDataview{}
+	r.SetDefaultCreateTimeout(30 * time.Minute)
+	r.SetDefaultReadTimeout(30 * time.Minute)
+	r.SetDefaultDeleteTimeout(30 * time.Minute)
+	r.SetMigratedFromPluginSDK(true)
 
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
+	return r, nil
+}
 
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(4 * time.Hour),
-			Update: schema.DefaultTimeout(4 * time.Hour),
-			Delete: schema.DefaultTimeout(4 * time.Hour),
-		},
-		Schema: map[string]*schema.Schema{
-			"arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"auto_update": {
-				Type:     schema.TypeBool,
-				ForceNew: true,
+type resourceKxDataview struct {
+	framework.ResourceWithConfigure
+	framework.WithTimeouts
+}
+
+func (r *resourceKxDataview) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "aws_finspace_kx_dataview"
+}
+
+func (r *resourceKxDataview) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func (r *resourceKxDataview) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id":  framework.IDAttribute(),
+			"arn": framework.ARNAttributeComputedOnly(),
+			"name": schema.StringAttribute{
 				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(3, 63),
+				},
 			},
-			"availability_zone_id": {
-				Type:     schema.TypeString,
-				ForceNew: true,
+			"environment_id": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(3, 63),
+				},
+			},
+			"database_name": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(3, 63),
+				},
+			},
+			"description": schema.StringAttribute{
+				Optional: true,
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 1000),
+				},
+			},
+			"auto_update": schema.BoolAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.RequiresReplace(),
+				},
+			},
+			"changeset_id": schema.StringAttribute{
 				Optional: true,
 			},
-			"az_mode": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[types.KxAzMode](),
+			"az_mode": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.OneOf(string(awstypes.KxAzModeSingle), string(awstypes.KxAzModeMulti)),
+				},
 			},
-			"changeset_id": {
-				Type:     schema.TypeString,
+			"availability_zone_id": schema.StringAttribute{
 				Optional: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 32),
+				},
 			},
-			"created_timestamp": {
-				Type:     schema.TypeString,
+			"status": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			names.AttrTags:    tftags.TagsAttribute(),
+			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
+			"created_timestamp": schema.StringAttribute{
 				Computed: true,
 			},
-			"database_name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(3, 63),
-			},
-			"description": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(1, 1000),
-			},
-			"environment_id": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(3, 63),
-			},
-			"last_modified_timestamp": {
-				Type:     schema.TypeString,
+			"last_modified_timestamp": schema.StringAttribute{
 				Computed: true,
 			},
-			"name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(3, 63),
-			},
-			"segment_configurations": {
-				Type: schema.TypeList,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"volume_name": {
-							Type:     schema.TypeString,
-							Required: true,
+		},
+		Blocks: map[string]schema.Block{
+			"segment_configurations": schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"db_paths": schema.ListAttribute{
+							ElementType: types.StringType,
+							Required:    true,
 						},
-						"db_paths": {
-							Type: schema.TypeList,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
+						"volume_name": schema.StringAttribute{
 							Required: true,
 						},
 					},
 				},
-				Optional: true,
 			},
-			"status": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			names.AttrTimeouts: timeouts.Block(ctx, timeouts.Opts{
+				Create: true,
+				Update: true,
+				Delete: true,
+			}),
 		},
-		CustomizeDiff: verify.SetTagsDiff,
 	}
+}
+
+func (r *resourceKxDataview) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	r.SetTagsAll(ctx, req, resp)
 }
 
 const (
@@ -138,165 +175,222 @@ const (
 	kxDataviewIdPartCount = 3
 )
 
-func resourceKxDataviewCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).FinSpaceClient(ctx)
-
-	environmentID := d.Get("environment_id").(string)
-	databaseName := d.Get("database_name").(string)
-	name := d.Get("name").(string)
-
+func (r *resourceKxDataview) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan resourceKxDataviewData
+	conn := r.Meta().FinSpaceClient(ctx)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 	idParts := []string{
-		environmentID,
-		databaseName,
-		name,
+		plan.EnvironmentId.ValueString(),
+		plan.DatabaseName.ValueString(),
+		plan.Name.ValueString(),
 	}
 	rId, err := flex.FlattenResourceId(idParts, kxDataviewIdPartCount, false)
+	plan.ID = fwflex.StringValueToFramework(ctx, rId)
+
+	var configs []segmentConfigData
+	resp.Diagnostics.Append(plan.SegmentConfigurations.ElementsAs(ctx, &configs, false)...)
+
+	createReq := &finspace.CreateKxDataviewInput{
+		DatabaseName:       aws.String(plan.DatabaseName.ValueString()),
+		DataviewName:       aws.String(plan.Name.ValueString()),
+		EnvironmentId:      aws.String(plan.EnvironmentId.ValueString()),
+		AutoUpdate:         plan.AutoUpdate.ValueBool(),
+		AzMode:             awstypes.KxAzMode(plan.AzMode.ValueString()),
+		AvailabilityZoneId: aws.String(plan.AvailabilityZoneId.ValueString()),
+		Tags:               getTagsIn(ctx),
+		ClientToken:        aws.String(id.UniqueId()),
+	}
+
+	if !(plan.Description.IsNull() || plan.Description.IsUnknown()) {
+		createReq.Description = aws.String(plan.Description.ValueString())
+	}
+	if !plan.SegmentConfigurations.IsNull() && len(plan.SegmentConfigurations.Elements()) > 0 {
+		createReq.SegmentConfigurations = expandSegmentConfigurations(ctx, configs)
+	}
+
+	dataview, err := conn.CreateKxDataview(ctx, createReq)
 	if err != nil {
-		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionFlatteningResourceId, ResNameKxDataview, d.Get("name").(string), err)
+		resp.Diagnostics.AddError("Error creating dataview", err.Error())
+		return
 	}
-	d.SetId(rId)
-
-	in := &finspace.CreateKxDataviewInput{
-		DatabaseName:  aws.String(databaseName),
-		DataviewName:  aws.String(name),
-		EnvironmentId: aws.String(environmentID),
-		AutoUpdate:    d.Get("auto_update").(bool),
-		AzMode:        types.KxAzMode(d.Get("az_mode").(string)),
-		ClientToken:   aws.String(id.UniqueId()),
-		Tags:          getTagsIn(ctx),
+	if dataview == nil || dataview.DataviewName == nil {
+		resp.Diagnostics.AddError("Error creating dataview", "empty output")
+		return
 	}
 
-	if v, ok := d.GetOk("description"); ok {
-		in.Description = aws.String(v.(string))
-	}
+	state := plan
+	state.EnvironmentId = fwflex.StringToFramework(ctx, dataview.EnvironmentId)
+	state.DatabaseName = fwflex.StringToFramework(ctx, dataview.DatabaseName)
+	state.Name = fwflex.StringToFramework(ctx, dataview.DataviewName)
 
-	if v, ok := d.GetOk("changeset_id"); ok {
-		in.ChangesetId = aws.String(v.(string))
+	state.AutoUpdate = types.BoolValue(dataview.AutoUpdate)
+	state.ChangesetId = fwflex.StringToFramework(ctx, dataview.ChangesetId)
+	state.AvailabilityZoneId = fwflex.StringToFramework(ctx, dataview.AvailabilityZoneId)
+	state.AzMode = fwflex.StringValueToFramework(ctx, dataview.AzMode)
+	state.CreatedTimestamp = fwflex.StringValueToFramework(ctx, dataview.CreatedTimestamp.String())
+	if dataview.Description != nil {
+		state.Description = fwflex.StringToFramework(ctx, dataview.Description)
 	}
-
-	if v, ok := d.GetOk("availability_zone_id"); ok {
-		in.AvailabilityZoneId = aws.String(v.(string))
+	if dataview.SegmentConfigurations != nil {
+		state.SegmentConfigurations = flattenSegmentConfigurations(ctx, dataview.SegmentConfigurations, &resp.Diagnostics)
 	}
-
-	if v, ok := d.GetOk("segment_configurations"); ok && len(v.([]interface{})) > 0 {
-		in.SegmentConfigurations = expandSegmentConfigurations(v.([]interface{}))
+	//resp.Diagnostics.Append(state.refreshFromOutput(ctx, dataview)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
-
-	out, err := conn.CreateKxDataview(ctx, in)
-	if err != nil {
-		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionCreating, ResNameKxDataview, d.Get("name").(string), err)
+	createTimeout := r.CreateTimeout(ctx, plan.Timeouts)
+	createdDv, waitErr := waitKxDataviewCreated(ctx, conn, plan.ID.ValueString(), createTimeout)
+	state.LastModifiedTimestamp = fwflex.StringValueToFramework(ctx, createdDv.LastModifiedTimestamp.String())
+	if waitErr != nil {
+		resp.Diagnostics.AddError("Error waiting for dataview creation", err.Error())
+		return
 	}
-	if out == nil || out.DataviewName == nil {
-		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionCreating, ResNameKxDataview, d.Get("name").(string), errors.New("empty output"))
+	state.Status = fwflex.StringValueToFramework(ctx, createdDv.Status)
+	arnParts := []interface{}{
+		aws.ToString(createdDv.EnvironmentId),
+		aws.ToString(createdDv.DatabaseName),
+		aws.ToString(createdDv.DataviewName),
 	}
-
-	if _, err := waitKxDataviewCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionWaitingForCreation, ResNameKxDataview, d.Get("name").(string), err)
-	}
-
-	return append(diags, resourceKxDataviewRead(ctx, d, meta)...)
-}
-
-func resourceKxDataviewRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).FinSpaceClient(ctx)
-
-	out, err := FindKxDataviewById(ctx, conn, d.Id())
-	if !d.IsNewResource() && tfresource.NotFound(err) {
-		log.Printf("[WARN] FinSpace KxDataview (%s) not found, removing from state", d.Id())
-		d.SetId("")
-		return diags
-	}
-
-	if err != nil {
-		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionReading, ResNameKxDataview, d.Id(), err)
-	}
-	d.Set("name", out.DataviewName)
-	d.Set("description", out.Description)
-	d.Set("auto_update", out.AutoUpdate)
-	d.Set("changeset_id", out.ChangesetId)
-	d.Set("availability_zone_id", out.AvailabilityZoneId)
-	d.Set("status", out.Status)
-	d.Set("created_timestamp", out.CreatedTimestamp.String())
-	d.Set("last_modified_timestamp", out.LastModifiedTimestamp.String())
-	d.Set("database_name", out.DatabaseName)
-	d.Set("environment_id", out.EnvironmentId)
-	d.Set("az_mode", out.AzMode)
-	if err := d.Set("segment_configurations", flattenSegmentConfigurations(out.SegmentConfigurations)); err != nil {
-		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionReading, ResNameKxDataview, d.Id(), err)
-	}
-
-	// Manually construct the dataview ARN, which is not returned from the
-	// Create or Describe APIs.
-	//
-	// Ref: https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonfinspace.html#amazonfinspace-resources-for-iam-policies
-	dataviewARN := arn.ARN{
-		Partition: meta.(*conns.AWSClient).Partition,
-		Region:    meta.(*conns.AWSClient).Region,
-		Service:   names.FinSpace,
-		AccountID: meta.(*conns.AWSClient).AccountID,
-		Resource:  fmt.Sprintf("kxEnvironment/%s/kxDatabase/%s/kxDataview/%s", aws.ToString(out.EnvironmentId), aws.ToString(out.DatabaseName), aws.ToString(out.DataviewName)),
+	dvArn := arn.ARN{
+		Partition: r.Meta().Partition,
+		Service:   "finspace",
+		Region:    r.Meta().Region,
+		AccountID: r.Meta().AccountID,
+		Resource:  fmt.Sprintf("kxEnvironment/%s/kxDatabase/%s/kxDataview/%s", arnParts...),
 	}.String()
-	d.Set("arn", dataviewARN)
-
-	return diags
+	state.ARN = fwflex.StringValueToFramework(ctx, dvArn)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
+func (r *resourceKxDataview) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state resourceKxDataviewData
+	conn := r.Meta().FinSpaceClient(ctx)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-func resourceKxDataviewUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).FinSpaceClient(ctx)
-	in := &finspace.UpdateKxDataviewInput{
-		EnvironmentId: aws.String(d.Get("environment_id").(string)),
-		DatabaseName:  aws.String(d.Get("database_name").(string)),
-		DataviewName:  aws.String(d.Get("name").(string)),
+	dataview, err := FindKxDataviewById(ctx, conn, state.ID.ValueString())
+	if tfresource.NotFound(err) {
+		create.LogNotFoundRemoveState(names.FinSpace, create.ErrActionReading, ResNameKxDataview, state.ID.ValueString())
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.Append(create.DiagErrorFramework(names.FinSpace, create.ErrActionReading, ResNameKxDataview, state.ID.ValueString(), err))
+		return
+	}
+	arnParts := []interface{}{
+		aws.ToString(dataview.EnvironmentId),
+		aws.ToString(dataview.DatabaseName),
+		aws.ToString(dataview.DataviewName),
+	}
+	dvArn := arn.ARN{
+		Partition: r.Meta().Partition,
+		Service:   "finspace",
+		Region:    r.Meta().Region,
+		AccountID: r.Meta().AccountID,
+		Resource:  fmt.Sprintf("kxEnvironment/%s/kxDatabase/%s/kxDataview/%s", arnParts...),
+	}.String()
+	state.ARN = fwflex.StringValueToFramework(ctx, dvArn)
+	state.Name = fwflex.StringToFramework(ctx, dataview.DataviewName)
+	state.DatabaseName = fwflex.StringToFramework(ctx, dataview.DatabaseName)
+	state.EnvironmentId = fwflex.StringToFramework(ctx, dataview.EnvironmentId)
+	state.AutoUpdate = types.BoolValue(dataview.AutoUpdate)
+	state.AvailabilityZoneId = fwflex.StringToFramework(ctx, dataview.AvailabilityZoneId)
+	state.AzMode = fwflex.StringValueToFramework(ctx, dataview.AzMode)
+	state.Status = fwflex.StringValueToFramework(ctx, dataview.Status)
+	state.CreatedTimestamp = fwflex.StringValueToFramework(ctx, dataview.CreatedTimestamp.String())
+	state.ChangesetId = fwflex.StringToFramework(ctx, dataview.ChangesetId)
+	state.LastModifiedTimestamp = fwflex.StringValueToFramework(ctx, dataview.LastModifiedTimestamp.String())
+	if dataview.Description != nil {
+		state.Description = fwflex.StringToFramework(ctx, dataview.Description)
+	}
+	if dataview.SegmentConfigurations != nil {
+		state.SegmentConfigurations = flattenSegmentConfigurations(ctx, dataview.SegmentConfigurations, &resp.Diagnostics)
+	}
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+func (r *resourceKxDataview) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan, state resourceKxDataviewData
+	conn := r.Meta().FinSpaceClient(ctx)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	updateReq := &finspace.UpdateKxDataviewInput{
+		EnvironmentId: aws.String(plan.EnvironmentId.ValueString()),
+		DatabaseName:  aws.String(plan.DatabaseName.ValueString()),
+		DataviewName:  aws.String(plan.Name.ValueString()),
 		ClientToken:   aws.String(id.UniqueId()),
 	}
 
-	if v, ok := d.GetOk("changeset_id"); ok && d.HasChange("changeset_id") && !d.Get("auto_update").(bool) {
-		in.ChangesetId = aws.String(v.(string))
+	if !(plan.ChangesetId.IsNull() || plan.ChangesetId.IsUnknown()) && !plan.ChangesetId.Equal(plan.ChangesetId) && !state.AutoUpdate.ValueBool() {
+		updateReq.ChangesetId = aws.String(plan.ChangesetId.ValueString())
+	}
+	if !plan.SegmentConfigurations.IsNull() && len(plan.SegmentConfigurations.Elements()) > 0 && !plan.SegmentConfigurations.Equal(state.SegmentConfigurations) {
+		var configs []segmentConfigData
+		resp.Diagnostics.Append(plan.SegmentConfigurations.ElementsAs(ctx, &configs, false)...)
+		updateReq.SegmentConfigurations = expandSegmentConfigurations(ctx, configs)
 	}
 
-	if v, ok := d.GetOk("segment_configurations"); ok && len(v.([]interface{})) > 0 && d.HasChange("segment_configurations") {
-		in.SegmentConfigurations = expandSegmentConfigurations(v.([]interface{}))
+	if _, err := conn.UpdateKxDataview(ctx, updateReq); err != nil {
+		resp.Diagnostics.AddError("Error updating dataview", err.Error())
+		return
 	}
 
-	if _, err := conn.UpdateKxDataview(ctx, in); err != nil {
-		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionUpdating, ResNameKxDataview, d.Get("name").(string), err)
+	updateTimeout := r.UpdateTimeout(ctx, state.Timeouts)
+	dataview, err := waitKxDataviewUpdated(ctx, conn, state.ID.ValueString(), updateTimeout)
+	if err != nil {
+		resp.Diagnostics.AddError("Error waiting for dataview update", err.Error())
+		return
 	}
 
-	if _, err := waitKxDataviewUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionWaitingForUpdate, ResNameKxDataview, d.Get("name").(string), err)
-	}
-
-	return append(diags, resourceKxDataviewRead(ctx, d, meta)...)
+	plan.ChangesetId = fwflex.StringToFramework(ctx, dataview.ChangesetId)
+	plan.SegmentConfigurations = flattenSegmentConfigurations(ctx, dataview.SegmentConfigurations, &resp.Diagnostics)
+	plan.Status = fwflex.StringValueToFramework(ctx, dataview.Status)
+	plan.LastModifiedTimestamp = fwflex.StringValueToFramework(ctx, dataview.LastModifiedTimestamp.String())
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
-
-func resourceKxDataviewDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).FinSpaceClient(ctx)
+func (r *resourceKxDataview) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state resourceKxDataviewData
+	conn := r.Meta().FinSpaceClient(ctx)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	_, err := conn.DeleteKxDataview(ctx, &finspace.DeleteKxDataviewInput{
-		EnvironmentId: aws.String(d.Get("environment_id").(string)),
-		DatabaseName:  aws.String(d.Get("database_name").(string)),
-		DataviewName:  aws.String(d.Get("name").(string)),
+		EnvironmentId: aws.String(state.EnvironmentId.ValueString()),
+		DatabaseName:  aws.String(state.DatabaseName.ValueString()),
+		DataviewName:  aws.String(state.Name.ValueString()),
 		ClientToken:   aws.String(id.UniqueId()),
 	})
 
 	if err != nil {
-		var nfe *types.ResourceNotFoundException
+		var nfe *awstypes.ResourceNotFoundException
 		if errors.As(err, &nfe) {
-			return diags
+			return
 		}
-		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionDeleting, ResNameKxDataview, d.Get("name").(string), err)
+		resp.Diagnostics.AddError("Error deleting dataview", err.Error())
+		return
 	}
 
-	if _, err := waitKxDataviewDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil && !tfresource.NotFound(err) {
-		return create.AppendDiagError(diags, names.FinSpace, create.ErrActionWaitingForDeletion, ResNameKxDataview, d.Id(), err)
+	deleteTimeout := r.DeleteTimeout(ctx, state.Timeouts)
+	if _, err := waitKxDataviewDeleted(ctx, conn, state.ID.ValueString(), deleteTimeout); err != nil && !tfresource.NotFound(err) {
+		resp.Diagnostics.AddError("Error waiting for dataview deletion", err.Error())
+		return
 	}
-	return diags
 }
-
 func FindKxDataviewById(ctx context.Context, conn *finspace.Client, id string) (*finspace.GetKxDataviewOutput, error) {
 	idParts, err := flex.ExpandResourceId(id, kxDataviewIdPartCount, false)
 	if err != nil {
@@ -311,7 +405,7 @@ func FindKxDataviewById(ctx context.Context, conn *finspace.Client, id string) (
 
 	out, err := conn.GetKxDataview(ctx, in)
 	if err != nil {
-		var nfe *types.ResourceNotFoundException
+		var nfe *awstypes.ResourceNotFoundException
 
 		if errors.As(err, &nfe) {
 			return nil, &retry.NotFoundError{
@@ -330,12 +424,10 @@ func FindKxDataviewById(ctx context.Context, conn *finspace.Client, id string) (
 
 func waitKxDataviewCreated(ctx context.Context, conn *finspace.Client, id string, timeout time.Duration) (*finspace.GetKxDataviewOutput, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending:                   enum.Slice(types.KxDataviewStatusCreating),
-		Target:                    enum.Slice(types.KxDataviewStatusActive),
-		Refresh:                   statusKxDataview(ctx, conn, id),
-		Timeout:                   timeout,
-		NotFoundChecks:            20,
-		ContinuousTargetOccurence: 2,
+		Pending: enum.Slice(awstypes.KxDataviewStatusCreating),
+		Target:  enum.Slice(awstypes.KxDataviewStatusActive, awstypes.KxDataviewStatusFailed),
+		Refresh: statusKxDataview(ctx, conn, id),
+		Timeout: timeout,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
@@ -347,12 +439,10 @@ func waitKxDataviewCreated(ctx context.Context, conn *finspace.Client, id string
 
 func waitKxDataviewUpdated(ctx context.Context, conn *finspace.Client, id string, timeout time.Duration) (*finspace.GetKxDataviewOutput, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending:                   enum.Slice(types.KxDataviewStatusUpdating),
-		Target:                    enum.Slice(types.KxDataviewStatusActive),
-		Refresh:                   statusKxDataview(ctx, conn, id),
-		Timeout:                   timeout,
-		NotFoundChecks:            20,
-		ContinuousTargetOccurence: 2,
+		Pending: enum.Slice(awstypes.KxDataviewStatusUpdating),
+		Target:  enum.Slice(awstypes.KxDataviewStatusActive),
+		Refresh: statusKxDataview(ctx, conn, id),
+		Timeout: timeout,
 	}
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
@@ -364,7 +454,7 @@ func waitKxDataviewUpdated(ctx context.Context, conn *finspace.Client, id string
 
 func waitKxDataviewDeleted(ctx context.Context, conn *finspace.Client, id string, timeout time.Duration) (*finspace.GetKxDataviewOutput, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending: enum.Slice(types.KxDataviewStatusDeleting),
+		Pending: enum.Slice(awstypes.KxDataviewStatusDeleting),
 		Target:  []string{},
 		Refresh: statusKxDataview(ctx, conn, id),
 		Timeout: timeout,
@@ -391,55 +481,98 @@ func statusKxDataview(ctx context.Context, conn *finspace.Client, id string) ret
 	}
 }
 
-func expandDBPath(tfList []interface{}) []string {
+func expandDBPath(tfList []attr.Value) []string {
 	if tfList == nil {
 		return nil
 	}
 	var s []string
 
 	for _, v := range tfList {
-		s = append(s, v.(string))
+		s = append(s, v.String())
 	}
 	return s
 }
 
-func expandSegmentConfigurations(tfList []interface{}) []types.KxDataviewSegmentConfiguration {
+func expandSegmentConfigurations(ctx context.Context, tfList []segmentConfigData) []awstypes.KxDataviewSegmentConfiguration {
 	if tfList == nil {
 		return nil
 	}
-	var s []types.KxDataviewSegmentConfiguration
+	configs := make([]awstypes.KxDataviewSegmentConfiguration, len(tfList))
 
-	for _, v := range tfList {
-		m := v.(map[string]interface{})
-		s = append(s, types.KxDataviewSegmentConfiguration{
-			VolumeName: aws.String(m["volume_name"].(string)),
-			DbPaths:    expandDBPath(m["db_paths"].([]interface{})),
-		})
+	for i, v := range tfList {
+		configs[i] = awstypes.KxDataviewSegmentConfiguration{
+			VolumeName: aws.String(v.VolumeName.ValueString()),
+			DbPaths:    fwflex.ExpandFrameworkStringValueList(ctx, v.DbPaths),
+		}
 	}
 
-	return s
+	return configs
 }
-func flattenSegmentConfiguration(apiObject *types.KxDataviewSegmentConfiguration) map[string]interface{} {
+
+type segmentConfigData struct {
+	VolumeName types.String `tfsdk:"volume_name"`
+	DbPaths    types.List   `tfsdk:"db_paths"`
+}
+
+func flattenSegmentConfiguration(ctx context.Context, apiObject *awstypes.KxDataviewSegmentConfiguration) *segmentConfigData {
 	if apiObject == nil {
 		return nil
 	}
-	m := map[string]interface{}{}
-	if v := apiObject.VolumeName; aws.ToString(v) != "" {
-		m["volume_name"] = aws.ToString(v)
+	//var m segmentConfigData
+	//if v := apiObject.VolumeName; aws.ToString(v) != "" {
+	//	m.VolumeName = aws.ToString(v)
+	//}
+	//if v := apiObject.DbPaths; v != nil {
+	//	m.DbPaths = v
+	//}
+	return &segmentConfigData{
+		VolumeName: fwflex.StringToFramework(ctx, apiObject.VolumeName),
+		DbPaths:    fwflex.FlattenFrameworkStringValueList(ctx, apiObject.DbPaths),
 	}
-	if v := apiObject.DbPaths; v != nil {
-		m["db_paths"] = v
-	}
-	return m
 }
 
-func flattenSegmentConfigurations(apiObjects []types.KxDataviewSegmentConfiguration) []interface{} {
+func flattenSegmentConfigurations(ctx context.Context, apiObjects []awstypes.KxDataviewSegmentConfiguration, diags *diag.Diagnostics) types.List {
+	attributeTypes := fwtypes.AttributeTypesMust[segmentConfigData](ctx)
+	attributeTypes["db_paths"] = types.ListType{ElemType: types.StringType}
+	elemType := types.ObjectType{AttrTypes: attributeTypes}
 	if apiObjects == nil {
-		return nil
+		return types.ListNull(elemType)
 	}
-	var l []interface{}
+
+	//var l = make([]segmentConfigData, len(apiObjects))
+	//
+	//for _, apiObject := range apiObjects {
+	//	l = append(l, *flattenSegmentConfiguration(ctx, &apiObject))
+	//}
+	attrs := make([]attr.Value, 0, len(apiObjects))
 	for _, apiObject := range apiObjects {
-		l = append(l, flattenSegmentConfiguration(&apiObject))
+		attr := map[string]attr.Value{}
+		attr["volume_name"] = fwflex.StringToFramework(ctx, apiObject.VolumeName)
+		attr["db_paths"] = fwflex.FlattenFrameworkStringValueList(ctx, apiObject.DbPaths)
+		val := types.ObjectValueMust(attributeTypes, attr)
+		attrs = append(attrs, val)
 	}
-	return l
+	result, d := types.ListValueFrom(ctx, elemType, attrs)
+	diags.Append(d...)
+	return result
+}
+
+type resourceKxDataviewData struct {
+	ID                    types.String   `tfsdk:"id"`
+	ARN                   types.String   `tfsdk:"arn"`
+	EnvironmentId         types.String   `tfsdk:"environment_id"`
+	DatabaseName          types.String   `tfsdk:"database_name"`
+	Name                  types.String   `tfsdk:"name"`
+	Description           types.String   `tfsdk:"description"`
+	AutoUpdate            types.Bool     `tfsdk:"auto_update"`
+	ChangesetId           types.String   `tfsdk:"changeset_id"`
+	AvailabilityZoneId    types.String   `tfsdk:"availability_zone_id"`
+	AzMode                types.String   `tfsdk:"az_mode"`
+	Status                types.String   `tfsdk:"status"`
+	CreatedTimestamp      types.String   `tfsdk:"created_timestamp"`
+	LastModifiedTimestamp types.String   `tfsdk:"last_modified_timestamp"`
+	SegmentConfigurations types.List     `tfsdk:"segment_configurations"`
+	Timeouts              timeouts.Value `tfsdk:"timeouts"`
+	Tags                  types.Map      `tfsdk:"tags"`
+	TagsAll               types.Map      `tfsdk:"tags_all"`
 }

--- a/internal/service/finspace/kx_dataview_test.go
+++ b/internal/service/finspace/kx_dataview_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/finspace"

--- a/internal/service/finspace/kx_dataview_test.go
+++ b/internal/service/finspace/kx_dataview_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/finspace"
@@ -15,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	tffinspace "github.com/hashicorp/terraform-provider-aws/internal/service/finspace"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -80,7 +80,7 @@ func TestAccFinSpaceKxDataview_disappears(t *testing.T) {
 				Config: testAccKxDataviewConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKxDataviewExists(ctx, resourceName, &dataview),
-					acctest.CheckResourceDisappears(ctx, acctest.Provider, tffinspace.ResourceKxDataview(), resourceName),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tffinspace.ResourceKxDataview, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -201,12 +201,11 @@ func testAccCheckKxDataviewExists(ctx context.Context, name string, dataview *fi
 
 func testAccCheckKxDataviewDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).FinSpaceClient(ctx)
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_finspace_kx_dataview" {
 				continue
 			}
-
-			conn := acctest.Provider.Meta().(*conns.AWSClient).FinSpaceClient(ctx)
 
 			_, err := tffinspace.FindKxDataviewById(ctx, conn, rs.Primary.ID)
 			if err != nil {

--- a/internal/service/finspace/kx_volume_test.go
+++ b/internal/service/finspace/kx_volume_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/finspace"

--- a/internal/service/finspace/kx_volume_test.go
+++ b/internal/service/finspace/kx_volume_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/finspace"
@@ -15,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	tffinspace "github.com/hashicorp/terraform-provider-aws/internal/service/finspace"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -80,7 +80,7 @@ func TestAccFinSpaceKxVolume_disappears(t *testing.T) {
 				Config: testAccKxVolumeConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKxVolumeExists(ctx, resourceName, &volume),
-					acctest.CheckResourceDisappears(ctx, acctest.Provider, tffinspace.ResourceKxVolume(), resourceName),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tffinspace.ResourceKxVolume, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -353,6 +353,7 @@ resource "aws_finspace_kx_volume" "test" {
   availability_zones = [aws_finspace_kx_environment.test.availability_zones[0]]
   az_mode            = "SINGLE"
   type               = "NAS_1"
+
   nas1_configuration {
     type = "SSD_250"
     size = 1200

--- a/internal/service/finspace/service_package_gen.go
+++ b/internal/service/finspace/service_package_gen.go
@@ -19,7 +19,22 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.Serv
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.ServicePackageFrameworkResource {
-	return []*types.ServicePackageFrameworkResource{}
+	return []*types.ServicePackageFrameworkResource{
+		{
+			Factory: newResourceKxDataview,
+			Name:    "Kx Dataview",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
+		},
+		{
+			Factory: newResourceKxVolume,
+			Name:    "Kx Volume",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
+		},
+	}
 }
 
 func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePackageSDKDataSource {
@@ -45,14 +60,6 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			},
 		},
 		{
-			Factory:  ResourceKxDataview,
-			TypeName: "aws_finspace_kx_dataview",
-			Name:     "Kx Dataview",
-			Tags: &types.ServicePackageResourceTags{
-				IdentifierAttribute: "arn",
-			},
-		},
-		{
 			Factory:  ResourceKxEnvironment,
 			TypeName: "aws_finspace_kx_environment",
 			Name:     "Kx Environment",
@@ -72,14 +79,6 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			Factory:  ResourceKxUser,
 			TypeName: "aws_finspace_kx_user",
 			Name:     "Kx User",
-			Tags: &types.ServicePackageResourceTags{
-				IdentifierAttribute: "arn",
-			},
-		},
-		{
-			Factory:  ResourceKxVolume,
-			TypeName: "aws_finspace_kx_volume",
-			Name:     "Kx Volume",
 			Tags: &types.ServicePackageResourceTags{
 				IdentifierAttribute: "arn",
 			},

--- a/internal/service/finspace/tags_gen.go
+++ b/internal/service/finspace/tags_gen.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/finspace"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	//"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/logging"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/types/option"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Migrates Terraform plugin sdk v2 to Terraform plugin framework for `kx_dataview` & `kx_volume`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

N/A
### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
#### Kx Dataview
```console
TF_ACC=1 go test ./internal/service/finspace/... -v -count 1 -parallel 10 -run='TestAccFinSpaceKxDataview_basic'  -timeout 360m
Live child 0x600001208000 (testacc) PID 46204
=== RUN   TestAccFinSpaceKxDataview_basic
=== PAUSE TestAccFinSpaceKxDataview_basic
=== CONT  TestAccFinSpaceKxDataview_basic
--- PASS: TestAccFinSpaceKxDataview_basic (1142.28s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/finspace	1147.822s
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/finspace/... -v -count 1 -parallel 10 -run='TestAccFinSpaceKxDataview_withKxVolume'  -timeout 360m
=== RUN   TestAccFinSpaceKxDataview_withKxVolume
=== PAUSE TestAccFinSpaceKxDataview_withKxVolume
=== CONT  TestAccFinSpaceKxDataview_withKxVolume
--- PASS: TestAccFinSpaceKxDataview_withKxVolume (1552.82s)
PASS
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/finspace/... -v -count 1 -parallel 10 -run='TestAccFinSpaceKxDataview_disappears'  -timeout 360m
=== RUN   TestAccFinSpaceKxDataview_disappears
=== PAUSE TestAccFinSpaceKxDataview_disappears
=== CONT  TestAccFinSpaceKxDataview_disappears
--- PASS: TestAccFinSpaceKxDataview_disappears (1059.23s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/finspace	1069.529s
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/finspace/... -v -count 1 -parallel 10 -run='TestAccFinSpaceKxDataview_tags'  -timeout 360m
=== RUN   TestAccFinSpaceKxDataview_tags
=== PAUSE TestAccFinSpaceKxDataview_tags
=== CONT  TestAccFinSpaceKxDataview_tags
--- PASS: TestAccFinSpaceKxDataview_tags (1234.62s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/finspace	1245.016s
```
#### Kx Volume
```console
1368 ± : make testacc TESTS=TestAccFinSpaceKxVolume_basic PKG=finspace                                                                                                  ⏎ [19d1h54m] ✹ ✚
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/finspace/... -v -count 1 -parallel 10 -run='TestAccFinSpaceKxVolume_basic'  -timeout 360m
=== RUN   TestAccFinSpaceKxVolume_basic
=== PAUSE TestAccFinSpaceKxVolume_basic
=== CONT  TestAccFinSpaceKxVolume_basic
--- PASS: TestAccFinSpaceKxVolume_basic (1569.29s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/finspace	1579.897s

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/finspace/... -v -count 1 -parallel 10 -run='TestAccFinSpaceKxVolume_disappears'  -timeout 360m
=== RUN   TestAccFinSpaceKxVolume_disappears
=== PAUSE TestAccFinSpaceKxVolume_disappears
=== CONT  TestAccFinSpaceKxVolume_disappears
--- PASS: TestAccFinSpaceKxVolume_disappears (1570.77s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/finspace	1581.228s
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/finspace/... -v -count 1 -parallel 10 -run='TestAccFinSpaceKxVolume_tags'  -timeout 360m
=== RUN   TestAccFinSpaceKxVolume_tags
=== PAUSE TestAccFinSpaceKxVolume_tags
=== CONT  TestAccFinSpaceKxVolume_tags
--- PASS: TestAccFinSpaceKxVolume_tags (2020.71s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/finspace	2031.617s
```
