### PR TITLE
Update `aws_quicksight_iam_policy_assignment` documentation

### DIFF
--- a/website/docs/r/quicksight_iam_policy_assignment.html.markdown
+++ b/website/docs/r/quicksight_iam_policy_assignment.html.markdown
@@ -35,13 +35,13 @@ The following arguments are required:
 The following arguments are optional:
 
 * `aws_account_id` - (Optional) AWS account ID.
-* `identities` - (Optional) Amazon QuickSight users, groups, or both to assign the policy to. See [`identities`](#identities).
+* `identities` - (Optional) Amazon QuickSight users, groups, or both to assign the policy to. See [`identities` block](#identities-block).
 * `namespace` - (Optional) Namespace that contains the assignment. Defaults to `default`.
 * `policy_arn` - (Optional) ARN of the IAM policy to apply to the Amazon QuickSight users and groups specified in this assignment.
 
-### identities
+### `identities` block
 
-* `groups` - (Optional) Array of Quicksight group names to assign the policy to.
+* `group` - (Optional) Array of Quicksight group names to assign the policy to.
 * `user` - (Optional) Array of Quicksight user names to assign the policy to.
 
 ## Attribute Reference


### PR DESCRIPTION
### Description

Updates the `aws_quicksight_iam_policy_assignment` to:

- Fix a typo in `identities.group`
- Correct an issue where the header links are broken due to a collision

### Relations

Closes #34485

### References

[Schema](https://github.com/hashicorp/terraform-provider-aws/blob/43bd19db00807459b8c5ae3b4faaa91a183d3a7f/internal/service/quicksight/iam_policy_assignment.go#L106)

### Output from Acceptance Testing

N/a, docs
