### PR TITLE
Fix Docs for importing eks_access_policy_association

### DIFF
--- a/website/docs/r/eks_access_policy_association.html.markdown
+++ b/website/docs/r/eks_access_policy_association.html.markdown
@@ -54,17 +54,17 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import EKS add-on using the `cluster_name`, `policy_arn` and `principal_arn` separated by a colon (`:`). For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import EKS add-on using the `cluster_name`, `principal_arn`and `policy_arn` separated by a colon (`#`). For example:
 
 ```terraform
 import {
   to = aws_eks_access_policy_association.my_eks_entry
-  id = "my_cluster_name:my_policy_arn:my_principal_arn"
+  id = "my_cluster_name#my_principal_arn#my_policy_arn"
 }
 ```
 
-Using `terraform import`, import EKS access entry using the `cluster_name` `policy_arn` and `principal_arn` separated by a colon (`:`). For example:
+Using `terraform import`, import EKS access entry using the `cluster_name` `principal_arn` and `policy_arn` separated by a colon (`#`). For example:
 
 ```console
-% terraform import aws_eks_access_policy_association.my_eks_access_entry my_cluster_name:my_policy_arn:my_principal_arn
+% terraform import aws_eks_access_policy_association.my_eks_access_entry my_cluster_name#my_principal_arn#my_policy_arn
 ```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
The documentation for importing aws_eks_access_policy_association specifies the wrong id format for the import. It states the id should be `my_cluster_name:my_policy_arn:my_principal_arn` but this causes a validation error:
```
│ Error: unexpected format for ID (<cluster-name>:arn:aws:eks::aws:cluster-access-policy/AmazonEKSViewPolicy:arn:aws:iam::<account-id>:role/<IAM-role), expected cluster-name#principal-arn#policy-arn
```

Looking at the code [here](https://github.com/hashicorp/terraform-provider-aws/blob/43bd19db00807459b8c5ae3b4faaa91a183d3a7f/internal/service/eks/access_policy_association.go#L186)
```go
const accessPolicyAssociationResourceIDSeparator = "#"

func accessPolicyAssociationCreateResourceID(clusterName, principalARN, policyARN string) string {
	parts := []string{clusterName, principalARN, policyARN}
	id := strings.Join(parts, accessPolicyAssociationResourceIDSeparator)
```
we can see the expected format is supposed to be `my_cluster_name#my_principal_arn#my_policy_arn`. Retrying the import
with this format was successful.

This PR updates the `eks_access_policy_association` documentation to reflect the correct id format for importing these resources.
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

I haven't created an issue for this but would be happy to if that is helpful.


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Reference to code that validates the id format found [here](https://github.com/hashicorp/terraform-provider-aws/blob/43bd19db00807459b8c5ae3b4faaa91a183d3a7f/internal/service/eks/access_policy_association.go#L186)


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

This is a documentation change with no tests that would be affected.
