### PR TITLE
Correct `aws_eks_access_policy_association` example

### DIFF
--- a/website/docs/r/eks_access_policy_association.html.markdown
+++ b/website/docs/r/eks_access_policy_association.html.markdown
@@ -18,7 +18,7 @@ resource "aws_eks_access_policy_association" "example" {
   policy_arn    = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSViewPolicy"
   principal_arn = aws_iam_user.example.arn
 
-  access_scope = {
+  access_scope {
     type       = "namespace"
     namespaces = ["example-namespace"]
   }
@@ -32,17 +32,27 @@ The following arguments are required:
 * `cluster_name` – (Required) Name of the EKS Cluster. Must be between 1-100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (`^[0-9A-Za-z][A-Za-z0-9\-_]+$`).
 * `policy_arn` – (Required) The ARN of the access policy that you're associating.
 * `principal_arn` – (Required) The IAM Princial ARN which requires Authentication access to the EKS cluster.
-* `access_scope` – (Required) The configuration block to determine the scope of the access.
-    * `type` - (Required) Valid values are `namespace` or `cluster`.
-    * `namespaces` - (Optional) The namespaces to which the access scope applies when type is namespace.
+* `access_scope` – (Required) The configuration block to determine the scope of the access. See [`access_scope` Block](#access_scope-block) below.
+
+### `access_scope` Block
+
+The `access_scope` block supports the following arguments.
+
+* `type` - (Required) Valid values are `namespace` or `cluster`.
+* `namespaces` - (Optional) The namespaces to which the access scope applies when type is namespace.
 
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `associated_access_policy` - Configuraion block which consists of
-    * `associated_at` - Date and time in [RFC3339 format](https://tools.ietf.org/html/rfc3339#section-5.8) that the policy was associated.
-    * `modified_at` - Date and time in [RFC3339 format](https://tools.ietf.org/html/rfc3339#section-5.8) that the policy was updated.
+* `associated_access_policy` - Contains information about the access policy associatieon. See [`associated_access_policy` Block](#associated_access_policy-block) below.
+
+### `associated_access_policy` Block
+
+The `associated_access_policy` block has the following attributes.
+
+* `associated_at` - Date and time in [RFC3339 format](https://tools.ietf.org/html/rfc3339#section-5.8) that the policy was associated.
+* `modified_at` - Date and time in [RFC3339 format](https://tools.ietf.org/html/rfc3339#section-5.8) that the policy was updated.
 
 ## Timeouts
 


### PR DESCRIPTION
### Description

Corrects the example in `aws_eks_access_policy_association` to correctly show `access_scope` as a block rather than a map. Also breaks arguments within child blocks out to headers to be more consistent with other documentation.

### Relations

Closes #35459

### References

- [AWS API docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_AssociateAccessPolicy.html)
- [Schema reference](https://github.com/hashicorp/terraform-provider-aws/blob/73bd1c7ecb6b791a1e09da2b2cff15bdcd77bf4b/internal/service/eks/access_policy_association.go#L45-L68)

### Output from Acceptance Testing

N/a, docs
