### PR TITLE
Update vpc_peering_connection.html.markdown

### DIFF
--- a/website/docs/r/vpc_peering_connection.html.markdown
+++ b/website/docs/r/vpc_peering_connection.html.markdown
@@ -105,9 +105,9 @@ more information.
 
 This argument supports the following arguments:
 
-* `peer_owner_id` - (Optional) The AWS account ID of the owner of the peer VPC.
-   Defaults to the account ID the [AWS provider][1] is currently connected to.
-* `peer_vpc_id` - (Required) The ID of the VPC with which you are creating the VPC Peering Connection.
+* `peer_owner_id` - (Optional) The AWS account ID of the target peer VPC.
+   Defaults to the account ID the [AWS provider][1] is currently connected to, so must be managed if connecting cross-account.
+* `peer_vpc_id` - (Required) The ID of the target VPC with which you are creating the VPC Peering Connection.
 * `vpc_id` - (Required) The ID of the requester VPC.
 * `auto_accept` - (Optional) Accept the peering (both VPCs need to be in the same AWS account and region).
 * `peer_region` - (Optional) The region of the accepter VPC of the VPC Peering Connection. `auto_accept` must be `false`,


### PR DESCRIPTION
Disambiguate the peer / target documentation

### Description
Many hours wasted with the 'owner' attribute which owns nothing. Instead using the more intuitive jargon 'target'.

### Output from Acceptance Testing
Failure to set the peer_owner_id  attribute when needed will try and fail to find the cross account VPC ID locally, erroring with:
```
Error: creating EC2 VPC Peering Connection: InvalidVpcID.NotFound: The vpc ID 'vpc-xxxxx' does not exist status code: 400, request id: xxx
```

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
