### PR TITLE
Updates documentation around Blue/Green Deployments with DB Instances with replicas

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -14,6 +14,11 @@ ul-indent:
 no-hard-tabs:
   code_blocks: false
 
+# MD033
+no-inline-html:
+  allowed_elements:
+    - br
+
 # Disabled Rules
 # https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md
 

--- a/docs/design-decisions/rds-bluegreen-deployments.md
+++ b/docs/design-decisions/rds-bluegreen-deployments.md
@@ -1,7 +1,8 @@
 # RDS Blue/Green Deployments
 
-**Summary:** Discussion of which resource types can support RDS Blue/Green Deployments for updates
-**Created:** 2023-11-24
+**Summary:** Discussion of which resource types can support RDS Blue/Green Deployments for updates<br>
+**Created:** 2023-11-24<br>
+**Updated:** 2024-01-24
 
 ---
 
@@ -27,6 +28,12 @@ When the `blue_green_update.enabled` parameter is set, the AWS Provider will use
 According to [AWS documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/blue-green-deployments-overview.html), "switchover typically takes under a minute".
 
 The update takes place in a single `terraform apply`, and the Blue/Green Deployment object is not exposed by the provider, since it is only an implementation detail.
+
+### `aws_db_instance` Replicas
+
+Creating replica RDS DB Instance involves one source `aws_db_instance` resource and one or more replica `aws_db_instance` resources.
+Because multiple resources are involved, Terraform cannot treat the source Instance and its replicas as a single unit.
+Therefore, Terraform cannot use a Blue/Green Deployment for updating an Instance and its replicas.
 
 ### `aws_rds_cluster`
 

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -41,6 +41,7 @@ Low-downtime updates minimize service interruptions by performing the updates wi
 
 Low-downtime updates are only available for DB Instances using MySQL and MariaDB,
 as other engines are not supported by RDS Blue/Green deployments.
+They cannot be used with DB Instances with replicas.
 
 Backups must be enabled to use low-downtime updates.
 


### PR DESCRIPTION
### Description

Updates documentation to indicate that the `aws_db_instance` field `blue_green_update` cannot be used for low-downtime-updates for DB Instances with replicas.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #33702
