### PR TITLE
Support for respecting filter order in aws_wafv2_web_acl_logging_configuration

### DIFF
--- a/internal/service/wafv2/web_acl_logging_configuration.go
+++ b/internal/service/wafv2/web_acl_logging_configuration.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"sort"
 
 	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go/aws"
@@ -67,6 +68,11 @@ func ResourceWebACLLoggingConfiguration() *schema.Resource {
 								Required: true,
 								Elem: &schema.Resource{
 									Schema: map[string]*schema.Schema{
+										"priority": {
+											Type:     schema.TypeInt,
+											Optional: true,
+											Computed: true,
+										},
 										"behavior": {
 											Type:         schema.TypeString,
 											Required:     true,
@@ -315,6 +321,12 @@ func expandFilters(l []interface{}) []*wafv2.Filter {
 
 	var filters []*wafv2.Filter
 
+	sort.Slice(l, func(i, j int) bool {
+		prio1, _ := l[i].(map[string]interface{})["priority"].(int)
+		prio2, _ := l[j].(map[string]interface{})["priority"].(int)
+		return prio1 < prio2
+	})
+
 	for _, tfMapRaw := range l {
 		tfMap, ok := tfMapRaw.(map[string]interface{})
 		if !ok {
@@ -464,7 +476,7 @@ func flattenFilters(f []*wafv2.Filter) []interface{} {
 
 	var filters []interface{}
 
-	for _, filter := range f {
+	for p, filter := range f {
 		if filter == nil {
 			continue
 		}
@@ -473,6 +485,7 @@ func flattenFilters(f []*wafv2.Filter) []interface{} {
 			"behavior":    aws.StringValue(filter.Behavior),
 			"condition":   flattenFilterConditions(filter.Conditions),
 			"requirement": aws.StringValue(filter.Requirement),
+			"priority":    p,
 		}
 
 		filters = append(filters, m)

--- a/internal/service/wafv2/web_acl_logging_configuration_test.go
+++ b/internal/service/wafv2/web_acl_logging_configuration_test.go
@@ -549,9 +549,9 @@ func TestAccWAFV2WebACLLoggingConfiguration_loggingFilter(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerifyIgnore: []string{"logging_filter.*.filter.*.priority"},
 			},
 			{
 				Config: testAccWebACLLoggingConfigurationConfig_updateFilterTwoFilters(rName),
@@ -585,6 +585,39 @@ func TestAccWAFV2WebACLLoggingConfiguration_loggingFilter(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccWebACLLoggingConfigurationConfig_updateFilterTwoFiltersWithPriority(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWebACLLoggingConfigurationExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "logging_filter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logging_filter.0.default_behavior", "DROP"),
+					resource.TestCheckResourceAttr(resourceName, "logging_filter.0.filter.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "logging_filter.0.filter.*", map[string]string{
+						"behavior":    wafv2.FilterBehaviorKeep,
+						"condition.#": "1",
+						"requirement": wafv2.FilterRequirementMeetsAll,
+						"priority":    "0",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "logging_filter.0.filter.*.condition.*", map[string]string{
+						"action_condition.#":        "1",
+						"action_condition.0.action": wafv2.ActionValueAllow,
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "logging_filter.0.filter.*", map[string]string{
+						"behavior":    wafv2.FilterBehaviorDrop,
+						"condition.#": "2",
+						"requirement": wafv2.FilterRequirementMeetsAny,
+						"priority":    "1",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "logging_filter.0.filter.*.condition.*", map[string]string{
+						"action_condition.#":        "1",
+						"action_condition.0.action": wafv2.ActionValueBlock,
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "logging_filter.0.filter.*.condition.*", map[string]string{
+						"label_name_condition.#":            "1",
+						"label_name_condition.0.label_name": fmt.Sprintf("prefix:test:%s", rName),
+					}),
+				),
+			},
+			{
 				Config: testAccWebACLLoggingConfigurationConfig_updateFilterOneFilter(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWebACLLoggingConfigurationExists(ctx, resourceName, &v),
@@ -603,9 +636,10 @@ func TestAccWAFV2WebACLLoggingConfiguration_loggingFilter(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"logging_filter.*.filter.*.priority"},
 			},
 			{
 				Config: testAccWebACLLoggingConfigurationConfig_basic(rName),
@@ -940,6 +974,44 @@ resource "aws_wafv2_web_acl_logging_configuration" "test" {
 }
 `
 
+const testAccWebACLLoggingConfigurationResource_loggingFilterConfig_twoFiltersWithPriority = `
+resource "aws_wafv2_web_acl_logging_configuration" "test" {
+  resource_arn            = aws_wafv2_web_acl.test.arn
+  log_destination_configs = [aws_kinesis_firehose_delivery_stream.test.arn]
+
+  logging_filter {
+    default_behavior = "DROP"
+
+    filter {
+      behavior = "KEEP"
+	  priority = 0
+      condition {
+        action_condition {
+          action = "ALLOW"
+        }
+      }
+      requirement = "MEETS_ALL"
+    }
+
+    filter {
+      behavior = "DROP"
+	  priority = 1
+      condition {
+        action_condition {
+          action = "BLOCK"
+        }
+      }
+      condition {
+        label_name_condition {
+          label_name = "prefix:test:${aws_wafv2_web_acl.test.name}"
+        }
+      }
+      requirement = "MEETS_ANY"
+    }
+  }
+}
+`
+
 const testAccWebACLLoggingConfigurationResource_loggingFilterConfig_oneFilter = `
 resource "aws_wafv2_web_acl_logging_configuration" "test" {
   resource_arn            = aws_wafv2_web_acl.test.arn
@@ -1029,6 +1101,13 @@ func testAccWebACLLoggingConfigurationConfig_updateFilterTwoFilters(rName string
 		testAccWebACLLoggingConfigurationConfig_base(rName),
 		testAccWebACLLoggingConfigurationConfig_baseKinesis(rName),
 		testAccWebACLLoggingConfigurationResource_loggingFilterConfig_twoFilters)
+}
+
+func testAccWebACLLoggingConfigurationConfig_updateFilterTwoFiltersWithPriority(rName string) string {
+	return acctest.ConfigCompose(
+		testAccWebACLLoggingConfigurationConfig_base(rName),
+		testAccWebACLLoggingConfigurationConfig_baseKinesis(rName),
+		testAccWebACLLoggingConfigurationResource_loggingFilterConfig_twoFiltersWithPriority)
 }
 
 func testAccWebACLLoggingConfigurationConfig_updateFilterOneFilter(rName string) string {

--- a/website/docs/r/wafv2_web_acl_logging_configuration.html.markdown
+++ b/website/docs/r/wafv2_web_acl_logging_configuration.html.markdown
@@ -138,6 +138,7 @@ The `filter` block supports the following arguments:
 
 * `behavior` - (Required) Parameter that determines how to handle logs that meet the conditions and requirements of the filter. The valid values for `behavior` are `KEEP` or `DROP`.
 * `condition` - (Required) Match condition(s) for the filter. See [Condition](#condition) below for more details.
+* `priority` - (Optional) Parameter that controls the order in which the filters are applied (lowest first).
 * `requirement` - (Required) Logic to apply to the filtering conditions. You can specify that a log must match all conditions or at least one condition in order to satisfy the filter. Valid values for `requirement` are `MEETS_ALL` or `MEETS_ANY`.
 
 ### Condition


### PR DESCRIPTION
### Description

Adds an optional `priority` attribute to WAFv2 ACL logging configuration filters that can control the order in which the filters are supplied to the AWS API. This way it provides a non-breaking way to overcome the issue that the API actually represents the filters as an ordered list and the order does affect the behaviour. 

Unfortunately, this is somewhat under-documented on AWS's side as well, but it is made clear on the console where it mentions:

>  If you add multiple filters, AWS WAF evaluates them starting from the top.


### Relations
Closes #32665

### References

 - https://docs.aws.amazon.com/waf/latest/APIReference/API_LoggingConfiguration.html
 - https://docs.aws.amazon.com/waf/latest/APIReference/API_LoggingFilter.html
 - https://docs.aws.amazon.com/waf/latest/developerguide/logging-management.html 

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccWAFV2WebACLLoggingConfiguration_loggingFilter PKG=wafv2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/wafv2/... -v -count 1 -parallel 20 -run='TestAccWAFV2WebACLLoggingConfiguration_loggingFilter'  -timeout 360m
=== RUN   TestAccWAFV2WebACLLoggingConfiguration_loggingFilter
=== PAUSE TestAccWAFV2WebACLLoggingConfiguration_loggingFilter
=== CONT  TestAccWAFV2WebACLLoggingConfiguration_loggingFilter


--- PASS: TestAccWAFV2WebACLLoggingConfiguration_loggingFilter (192.88s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/wafv2      200.140s
...
```
