### PR TITLE
EC2: Make additional (mainly `Create`) API calls idempotent

### DIFF
--- a/internal/service/ec2/ec2_capacity_reservation.go
+++ b/internal/service/ec2/ec2_capacity_reservation.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -124,6 +125,7 @@ func resourceCapacityReservationCreate(ctx context.Context, d *schema.ResourceDa
 
 	input := &ec2.CreateCapacityReservationInput{
 		AvailabilityZone:  aws.String(d.Get("availability_zone").(string)),
+		ClientToken:       aws.String(id.UniqueId()),
 		EndDateType:       aws.String(d.Get("end_date_type").(string)),
 		InstanceCount:     aws.Int64(int64(d.Get("instance_count").(int))),
 		InstancePlatform:  aws.String(d.Get("instance_platform").(string)),
@@ -161,7 +163,6 @@ func resourceCapacityReservationCreate(ctx context.Context, d *schema.ResourceDa
 		input.Tenancy = aws.String(v.(string))
 	}
 
-	log.Printf("[DEBUG] Creating EC2 Capacity Reservation: %s", input)
 	output, err := conn.CreateCapacityReservationWithContext(ctx, input)
 
 	if err != nil {
@@ -234,7 +235,6 @@ func resourceCapacityReservationUpdate(ctx context.Context, d *schema.ResourceDa
 			input.EndDate = aws.Time(v)
 		}
 
-		log.Printf("[DEBUG] Updating EC2 Capacity Reservation: %s", input)
 		_, err := conn.ModifyCapacityReservationWithContext(ctx, input)
 
 		if err != nil {

--- a/internal/service/ec2/ec2_fleet.go
+++ b/internal/service/ec2/ec2_fleet.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -706,6 +707,7 @@ func resourceFleetCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	fleetType := d.Get("type").(string)
 	input := &ec2.CreateFleetInput{
+		ClientToken:                 aws.String(id.UniqueId()),
 		LaunchTemplateConfigs:       expandFleetLaunchTemplateConfigRequests(d.Get("launch_template_config").([]interface{})),
 		TargetCapacitySpecification: expandTargetCapacitySpecificationRequest(d.Get("target_capacity_specification").([]interface{})[0].(map[string]interface{})),
 		TagSpecifications:           getTagSpecificationsIn(ctx, ec2.ResourceTypeFleet),
@@ -901,7 +903,7 @@ func resourceFleetDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	})
 
 	if err == nil && output != nil {
-		err = DeleteFleetsError(output.UnsuccessfulFleetDeletions)
+		err = deleteFleetsError(output.UnsuccessfulFleetDeletions)
 	}
 
 	if tfawserr.ErrCodeEquals(err, errCodeInvalidFleetIdNotFound) {

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -1799,6 +1799,7 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 			instanceCreditSpecification := expandInstanceCreditSpecificationRequest(v.([]interface{})[0].(map[string]interface{}))
 			instanceCreditSpecification.InstanceId = aws.String(d.Id())
 			input := &ec2.ModifyInstanceCreditSpecificationInput{
+				ClientToken:                  aws.String(id.UniqueId()),
 				InstanceCreditSpecifications: []*ec2.InstanceCreditSpecificationRequest{instanceCreditSpecification},
 			}
 

--- a/internal/service/ec2/errors.go
+++ b/internal/service/ec2/errors.go
@@ -145,7 +145,7 @@ func CancelSpotFleetRequestsError(apiObjects []*ec2.CancelSpotFleetRequestsError
 	return errors.Join(errs...)
 }
 
-func DeleteFleetError(apiObject *ec2.DeleteFleetErrorItem) error {
+func deleteFleetError(apiObject *ec2.DeleteFleetErrorItem) error {
 	if apiObject == nil || apiObject.Error == nil {
 		return nil
 	}
@@ -153,11 +153,11 @@ func DeleteFleetError(apiObject *ec2.DeleteFleetErrorItem) error {
 	return awserr.New(aws.StringValue(apiObject.Error.Code), aws.StringValue(apiObject.Error.Message), nil)
 }
 
-func DeleteFleetsError(apiObjects []*ec2.DeleteFleetErrorItem) error {
+func deleteFleetsError(apiObjects []*ec2.DeleteFleetErrorItem) error {
 	var errs []error
 
 	for _, apiObject := range apiObjects {
-		if err := DeleteFleetError(apiObject); err != nil {
+		if err := deleteFleetError(apiObject); err != nil {
 			errs = append(errs, fmt.Errorf("%s: %w", aws.StringValue(apiObject.FleetId), err))
 		}
 	}

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -542,6 +542,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceClientVPNAuthorizationRule,
 			TypeName: "aws_ec2_client_vpn_authorization_rule",
+			Name:     "Client VPN Authorization Rule",
 		},
 		{
 			Factory:  ResourceClientVPNEndpoint,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -560,6 +560,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceClientVPNRoute,
 			TypeName: "aws_ec2_client_vpn_route",
+			Name:     "Client VPN Route",
 		},
 		{
 			Factory:  ResourceFleet,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -1037,6 +1037,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceVPCEndpointConnectionNotification,
 			TypeName: "aws_vpc_endpoint_connection_notification",
+			Name:     "VPC Endpoint Connection Notification",
 		},
 		{
 			Factory:  ResourceVPCEndpointPolicy,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -650,6 +650,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceTrafficMirrorFilterRule,
 			TypeName: "aws_ec2_traffic_mirror_filter_rule",
+			Name:     "Traffic Mirror Filter Rule",
 		},
 		{
 			Factory:  ResourceTrafficMirrorSession,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -554,6 +554,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceClientVPNNetworkAssociation,
 			TypeName: "aws_ec2_client_vpn_network_association",
+			Name:     "Client VPN Network Association",
 		},
 		{
 			Factory:  ResourceClientVPNRoute,

--- a/internal/service/ec2/verifiedaccess_endpoint.go
+++ b/internal/service/ec2/verifiedaccess_endpoint.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -191,6 +192,7 @@ func resourceVerifiedAccessEndpointCreate(ctx context.Context, d *schema.Resourc
 	input := &ec2.CreateVerifiedAccessEndpointInput{
 		ApplicationDomain:     aws.String(d.Get("application_domain").(string)),
 		AttachmentType:        types.VerifiedAccessEndpointAttachmentType(d.Get("attachment_type").(string)),
+		ClientToken:           aws.String(id.UniqueId()),
 		DomainCertificateArn:  aws.String(d.Get("domain_certificate_arn").(string)),
 		EndpointDomainPrefix:  aws.String(d.Get("endpoint_domain_prefix").(string)),
 		EndpointType:          types.VerifiedAccessEndpointType(d.Get("endpoint_type").(string)),
@@ -291,6 +293,7 @@ func resourceVerifiedAccessEndpointUpdate(ctx context.Context, d *schema.Resourc
 
 	if d.HasChangesExcept("policy_document", "tags", "tags_all") {
 		input := &ec2.ModifyVerifiedAccessEndpointInput{
+			ClientToken:              aws.String(id.UniqueId()),
 			VerifiedAccessEndpointId: aws.String(d.Id()),
 		}
 
@@ -349,6 +352,7 @@ func resourceVerifiedAccessEndpointDelete(ctx context.Context, d *schema.Resourc
 
 	log.Printf("[INFO] Deleting Verified Access Endpoint: %s", d.Id())
 	_, err := conn.DeleteVerifiedAccessEndpoint(ctx, &ec2.DeleteVerifiedAccessEndpointInput{
+		ClientToken:              aws.String(id.UniqueId()),
 		VerifiedAccessEndpointId: aws.String(d.Id()),
 	})
 

--- a/internal/service/ec2/verifiedaccess_group.go
+++ b/internal/service/ec2/verifiedaccess_group.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
@@ -85,6 +86,7 @@ func resourceVerifiedAccessGroupCreate(ctx context.Context, d *schema.ResourceDa
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
 	input := &ec2.CreateVerifiedAccessGroupInput{
+		ClientToken:              aws.String(id.UniqueId()),
 		TagSpecifications:        getTagSpecificationsInV2(ctx, types.ResourceTypeVerifiedAccessGroup),
 		VerifiedAccessInstanceId: aws.String(d.Get("verifiedaccess_instance_id").(string)),
 	}
@@ -152,6 +154,7 @@ func resourceVerifiedAccessGroupUpdate(ctx context.Context, d *schema.ResourceDa
 
 	if d.HasChangesExcept("policy_document", "tags", "tags_all") {
 		input := &ec2.ModifyVerifiedAccessGroupInput{
+			ClientToken:           aws.String(id.UniqueId()),
 			VerifiedAccessGroupId: aws.String(d.Id()),
 		}
 
@@ -193,6 +196,7 @@ func resourceVerifiedAccessGroupDelete(ctx context.Context, d *schema.ResourceDa
 
 	log.Printf("[INFO] Deleting Verified Access Group: %s", d.Id())
 	_, err := conn.DeleteVerifiedAccessGroup(ctx, &ec2.DeleteVerifiedAccessGroupInput{
+		ClientToken:           aws.String(id.UniqueId()),
 		VerifiedAccessGroupId: aws.String(d.Id()),
 	})
 

--- a/internal/service/ec2/verifiedaccess_trust_provider.go
+++ b/internal/service/ec2/verifiedaccess_trust_provider.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -145,6 +146,7 @@ func resourceVerifiedAccessTrustProviderCreate(ctx context.Context, d *schema.Re
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
 	input := &ec2.CreateVerifiedAccessTrustProviderInput{
+		ClientToken:         aws.String(id.UniqueId()),
 		PolicyReferenceName: aws.String(d.Get("policy_reference_name").(string)),
 		TagSpecifications:   getTagSpecificationsInV2(ctx, types.ResourceTypeVerifiedAccessTrustProvider),
 		TrustProviderType:   types.TrustProviderType(d.Get("trust_provider_type").(string)),
@@ -228,6 +230,7 @@ func resourceVerifiedAccessTrustProviderUpdate(ctx context.Context, d *schema.Re
 
 	if d.HasChangesExcept("tags", "tags_all") {
 		input := &ec2.ModifyVerifiedAccessTrustProviderInput{
+			ClientToken:                   aws.String(id.UniqueId()),
 			VerifiedAccessTrustProviderId: aws.String(d.Id()),
 		}
 
@@ -257,6 +260,7 @@ func resourceVerifiedAccessTrustProviderDelete(ctx context.Context, d *schema.Re
 
 	log.Printf("[INFO] Deleting Verified Access Trust Provider: %s", d.Id())
 	_, err := conn.DeleteVerifiedAccessTrustProvider(ctx, &ec2.DeleteVerifiedAccessTrustProviderInput{
+		ClientToken:                   aws.String(id.UniqueId()),
 		VerifiedAccessTrustProviderId: aws.String(d.Id()),
 	})
 

--- a/internal/service/ec2/vpc_endpoint_connection_notification.go
+++ b/internal/service/ec2/vpc_endpoint_connection_notification.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
@@ -19,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-// @SDKResource("aws_vpc_endpoint_connection_notification")
+// @SDKResource("aws_vpc_endpoint_connection_notification", name="VPC Endpoint Connection Notification")
 func ResourceVPCEndpointConnectionNotification() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceVPCEndpointConnectionNotificationCreate,
@@ -72,6 +73,7 @@ func resourceVPCEndpointConnectionNotificationCreate(ctx context.Context, d *sch
 	conn := meta.(*conns.AWSClient).EC2Conn(ctx)
 
 	input := &ec2.CreateVpcEndpointConnectionNotificationInput{
+		ClientToken:               aws.String(id.UniqueId()),
 		ConnectionEvents:          flex.ExpandStringSet(d.Get("connection_events").(*schema.Set)),
 		ConnectionNotificationArn: aws.String(d.Get("connection_notification_arn").(string)),
 	}

--- a/internal/service/ec2/vpc_endpoint_service.go
+++ b/internal/service/ec2/vpc_endpoint_service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -155,6 +156,7 @@ func resourceVPCEndpointServiceCreate(ctx context.Context, d *schema.ResourceDat
 
 	input := &ec2.CreateVpcEndpointServiceConfigurationInput{
 		AcceptanceRequired: aws.Bool(d.Get("acceptance_required").(bool)),
+		ClientToken:        aws.String(id.UniqueId()),
 		TagSpecifications:  getTagSpecificationsIn(ctx, ec2.ResourceTypeVpcEndpointService),
 	}
 

--- a/internal/service/ec2/vpc_network_acl.go
+++ b/internal/service/ec2/vpc_network_acl.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -161,11 +162,11 @@ func resourceNetworkACLCreate(ctx context.Context, d *schema.ResourceData, meta 
 	conn := meta.(*conns.AWSClient).EC2Conn(ctx)
 
 	input := &ec2.CreateNetworkAclInput{
+		ClientToken:       aws.String(id.UniqueId()),
 		TagSpecifications: getTagSpecificationsIn(ctx, ec2.ResourceTypeNetworkAcl),
 		VpcId:             aws.String(d.Get("vpc_id").(string)),
 	}
 
-	log.Printf("[DEBUG] Creating EC2 Network ACL: %s", input)
 	output, err := conn.CreateNetworkAclWithContext(ctx, input)
 
 	if err != nil {

--- a/internal/service/ec2/vpc_network_insights_path.go
+++ b/internal/service/ec2/vpc_network_insights_path.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -95,6 +96,7 @@ func resourceNetworkInsightsPathCreate(ctx context.Context, d *schema.ResourceDa
 	conn := meta.(*conns.AWSClient).EC2Conn(ctx)
 
 	input := &ec2.CreateNetworkInsightsPathInput{
+		ClientToken:       aws.String(id.UniqueId()),
 		Destination:       aws.String(d.Get("destination").(string)),
 		Protocol:          aws.String(d.Get("protocol").(string)),
 		Source:            aws.String(d.Get("source").(string)),

--- a/internal/service/ec2/vpc_route_table.go
+++ b/internal/service/ec2/vpc_route_table.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
@@ -168,8 +169,9 @@ func resourceRouteTableCreate(ctx context.Context, d *schema.ResourceData, meta 
 	conn := meta.(*conns.AWSClient).EC2Conn(ctx)
 
 	input := &ec2.CreateRouteTableInput{
-		VpcId:             aws.String(d.Get("vpc_id").(string)),
+		ClientToken:       aws.String(id.UniqueId()),
 		TagSpecifications: getTagSpecificationsIn(ctx, ec2.ResourceTypeRouteTable),
+		VpcId:             aws.String(d.Get("vpc_id").(string)),
 	}
 
 	output, err := conn.CreateRouteTableWithContext(ctx, input)

--- a/internal/service/ec2/vpc_traffic_mirror_filter.go
+++ b/internal/service/ec2/vpc_traffic_mirror_filter.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -68,6 +69,7 @@ func resourceTrafficMirrorFilterCreate(ctx context.Context, d *schema.ResourceDa
 	conn := meta.(*conns.AWSClient).EC2Conn(ctx)
 
 	input := &ec2.CreateTrafficMirrorFilterInput{
+		ClientToken:       aws.String(id.UniqueId()),
 		TagSpecifications: getTagSpecificationsIn(ctx, ec2.ResourceTypeTrafficMirrorFilter),
 	}
 

--- a/internal/service/ec2/vpc_traffic_mirror_filter_rule.go
+++ b/internal/service/ec2/vpc_traffic_mirror_filter_rule.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -22,7 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-// @SDKResource("aws_ec2_traffic_mirror_filter_rule")
+// @SDKResource("aws_ec2_traffic_mirror_filter_rule", name="Traffic Mirror Filter Rule")
 func ResourceTrafficMirrorFilterRule() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceTrafficMirrorFilterRuleCreate,
@@ -123,6 +124,7 @@ func resourceTrafficMirrorFilterRuleCreate(ctx context.Context, d *schema.Resour
 	conn := meta.(*conns.AWSClient).EC2Conn(ctx)
 
 	input := &ec2.CreateTrafficMirrorFilterRuleInput{
+		ClientToken:           aws.String(id.UniqueId()),
 		DestinationCidrBlock:  aws.String(d.Get("destination_cidr_block").(string)),
 		RuleAction:            aws.String(d.Get("rule_action").(string)),
 		RuleNumber:            aws.Int64(int64(d.Get("rule_number").(int))),

--- a/internal/service/ec2/vpc_traffic_mirror_session.go
+++ b/internal/service/ec2/vpc_traffic_mirror_session.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -89,6 +90,7 @@ func resourceTrafficMirrorSessionCreate(ctx context.Context, d *schema.ResourceD
 	conn := meta.(*conns.AWSClient).EC2Conn(ctx)
 
 	input := &ec2.CreateTrafficMirrorSessionInput{
+		ClientToken:           aws.String(id.UniqueId()),
 		NetworkInterfaceId:    aws.String(d.Get("network_interface_id").(string)),
 		TagSpecifications:     getTagSpecificationsIn(ctx, ec2.ResourceTypeTrafficMirrorSession),
 		TrafficMirrorFilterId: aws.String(d.Get("traffic_mirror_filter_id").(string)),

--- a/internal/service/ec2/vpc_traffic_mirror_target.go
+++ b/internal/service/ec2/vpc_traffic_mirror_target.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
@@ -93,6 +94,7 @@ func resourceTrafficMirrorTargetCreate(ctx context.Context, d *schema.ResourceDa
 	conn := meta.(*conns.AWSClient).EC2Conn(ctx)
 
 	input := &ec2.CreateTrafficMirrorTargetInput{
+		ClientToken:       aws.String(id.UniqueId()),
 		TagSpecifications: getTagSpecificationsIn(ctx, ec2.ResourceTypeTrafficMirrorTarget),
 	}
 

--- a/internal/service/ec2/vpnclient_authorization_rule.go
+++ b/internal/service/ec2/vpnclient_authorization_rule.go
@@ -13,7 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
+	sdkid "github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -28,6 +28,7 @@ func ResourceClientVPNAuthorizationRule() *schema.Resource {
 		CreateWithoutTimeout: resourceClientVPNAuthorizationRuleCreate,
 		ReadWithoutTimeout:   resourceClientVPNAuthorizationRuleRead,
 		DeleteWithoutTimeout: resourceClientVPNAuthorizationRuleDelete,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -78,7 +79,7 @@ func resourceClientVPNAuthorizationRuleCreate(ctx context.Context, d *schema.Res
 	endpointID := d.Get("client_vpn_endpoint_id").(string)
 	targetNetworkCIDR := d.Get("target_network_cidr").(string)
 	input := &ec2.AuthorizeClientVpnIngressInput{
-		ClientToken:         aws.String(id.UniqueId()),
+		ClientToken:         aws.String(sdkid.UniqueId()),
 		ClientVpnEndpointId: aws.String(endpointID),
 		TargetNetworkCidr:   aws.String(targetNetworkCIDR),
 	}

--- a/internal/service/ec2/vpnclient_authorization_rule.go
+++ b/internal/service/ec2/vpnclient_authorization_rule.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -21,7 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-// @SDKResource("aws_ec2_client_vpn_authorization_rule")
+// @SDKResource("aws_ec2_client_vpn_authorization_rule", name="Client VPN Authorization Rule")
 func ResourceClientVPNAuthorizationRule() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceClientVPNAuthorizationRuleCreate,
@@ -76,8 +77,8 @@ func resourceClientVPNAuthorizationRuleCreate(ctx context.Context, d *schema.Res
 
 	endpointID := d.Get("client_vpn_endpoint_id").(string)
 	targetNetworkCIDR := d.Get("target_network_cidr").(string)
-
 	input := &ec2.AuthorizeClientVpnIngressInput{
+		ClientToken:         aws.String(id.UniqueId()),
 		ClientVpnEndpointId: aws.String(endpointID),
 		TargetNetworkCidr:   aws.String(targetNetworkCIDR),
 	}
@@ -97,8 +98,6 @@ func resourceClientVPNAuthorizationRuleCreate(ctx context.Context, d *schema.Res
 	}
 
 	id := ClientVPNAuthorizationRuleCreateResourceID(endpointID, targetNetworkCIDR, accessGroupID)
-
-	log.Printf("[DEBUG] Creating EC2 Client VPN Authorization Rule: %s", input)
 	_, err := conn.AuthorizeClientVpnIngressWithContext(ctx, input)
 
 	if err != nil {
@@ -119,9 +118,8 @@ func resourceClientVPNAuthorizationRuleRead(ctx context.Context, d *schema.Resou
 	conn := meta.(*conns.AWSClient).EC2Conn(ctx)
 
 	endpointID, targetNetworkCIDR, accessGroupID, err := ClientVPNAuthorizationRuleParseResourceID(d.Id())
-
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "reading EC2 Client VPN Authorization Rule (%s): %s", d.Id(), err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	rule, err := FindClientVPNAuthorizationRuleByThreePartKey(ctx, conn, endpointID, targetNetworkCIDR, accessGroupID)
@@ -150,9 +148,8 @@ func resourceClientVPNAuthorizationRuleDelete(ctx context.Context, d *schema.Res
 	conn := meta.(*conns.AWSClient).EC2Conn(ctx)
 
 	endpointID, targetNetworkCIDR, accessGroupID, err := ClientVPNAuthorizationRuleParseResourceID(d.Id())
-
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "deleting EC2 Client VPN Authorization Rule (%s): %s", d.Id(), err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	input := &ec2.RevokeClientVpnIngressInput{

--- a/internal/service/ec2/vpnclient_endpoint.go
+++ b/internal/service/ec2/vpnclient_endpoint.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -32,6 +33,7 @@ func ResourceClientVPNEndpoint() *schema.Resource {
 		ReadWithoutTimeout:   resourceClientVPNEndpointRead,
 		DeleteWithoutTimeout: resourceClientVPNEndpointDelete,
 		UpdateWithoutTimeout: resourceClientVPNEndpointUpdate,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -232,6 +234,7 @@ func resourceClientVPNEndpointCreate(ctx context.Context, d *schema.ResourceData
 
 	input := &ec2.CreateClientVpnEndpointInput{
 		ClientCidrBlock:      aws.String(d.Get("client_cidr_block").(string)),
+		ClientToken:          aws.String(id.UniqueId()),
 		ServerCertificateArn: aws.String(d.Get("server_certificate_arn").(string)),
 		SplitTunnel:          aws.Bool(d.Get("split_tunnel").(bool)),
 		TagSpecifications:    getTagSpecificationsIn(ctx, ec2.ResourceTypeClientVpnEndpoint),
@@ -279,7 +282,6 @@ func resourceClientVPNEndpointCreate(ctx context.Context, d *schema.ResourceData
 		input.VpcId = aws.String(v.(string))
 	}
 
-	log.Printf("[DEBUG] Creating EC2 Client VPN Endpoint: %s", input)
 	output, err := conn.CreateClientVpnEndpointWithContext(ctx, input)
 
 	if err != nil {

--- a/internal/service/ec2/vpnclient_network_association.go
+++ b/internal/service/ec2/vpnclient_network_association.go
@@ -13,13 +13,14 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-// @SDKResource("aws_ec2_client_vpn_network_association")
+// @SDKResource("aws_ec2_client_vpn_network_association", name="Client VPN Network Association")
 func ResourceClientVPNNetworkAssociation() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceClientVPNNetworkAssociationCreate,
@@ -64,11 +65,10 @@ func resourceClientVPNNetworkAssociationCreate(ctx context.Context, d *schema.Re
 
 	endpointID := d.Get("client_vpn_endpoint_id").(string)
 	input := &ec2.AssociateClientVpnTargetNetworkInput{
+		ClientToken:         aws.String(id.UniqueId()),
 		ClientVpnEndpointId: aws.String(endpointID),
 		SubnetId:            aws.String(d.Get("subnet_id").(string)),
 	}
-
-	log.Printf("[DEBUG] Creating EC2 Client VPN Network Association: %s", input)
 
 	output, err := conn.AssociateClientVpnTargetNetworkWithContext(ctx, input)
 

--- a/internal/service/ec2/wavelength_carrier_gateway.go
+++ b/internal/service/ec2/wavelength_carrier_gateway.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
@@ -62,6 +63,7 @@ func resourceCarrierGatewayCreate(ctx context.Context, d *schema.ResourceData, m
 	conn := meta.(*conns.AWSClient).EC2Conn(ctx)
 
 	input := &ec2.CreateCarrierGatewayInput{
+		ClientToken:       aws.String(id.UniqueId()),
 		TagSpecifications: getTagSpecificationsIn(ctx, ec2.ResourceTypeCarrierGateway),
 		VpcId:             aws.String(d.Get("vpc_id").(string)),
 	}
@@ -74,9 +76,7 @@ func resourceCarrierGatewayCreate(ctx context.Context, d *schema.ResourceData, m
 
 	d.SetId(aws.StringValue(output.CarrierGateway.CarrierGatewayId))
 
-	_, err = WaitCarrierGatewayCreated(ctx, conn, d.Id())
-
-	if err != nil {
+	if _, err := WaitCarrierGatewayCreated(ctx, conn, d.Id()); err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for EC2 Carrier Gateway (%s) create: %s", d.Id(), err)
 	}
 
@@ -141,9 +141,7 @@ func resourceCarrierGatewayDelete(ctx context.Context, d *schema.ResourceData, m
 		return sdkdiag.AppendErrorf(diags, "deleting EC2 Carrier Gateway (%s): %s", d.Id(), err)
 	}
 
-	_, err = WaitCarrierGatewayDeleted(ctx, conn, d.Id())
-
-	if err != nil {
+	if _, err := WaitCarrierGatewayDeleted(ctx, conn, d.Id()); err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for EC2 Carrier Gateway (%s) delete: %s", d.Id(), err)
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Add `ClientToken` to all EC2 API methods that support it.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/35489.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccVPCRouteTable_basic\|TestAccVPCEndpointConnectionNotification_basic\|TestAccVPCEndpointService_basic\|TestAccVPCNetworkACL_basic\|TestAccWavelengthCarrierGateway_basic\|TestAccVPCManagedPrefixList_basic\|TestAccVPCTrafficMirrorFilterRule_basic' PKG=ec2 ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 3  -run=TestAccVPCRouteTable_basic\|TestAccVPCEndpointConnectionNotification_basic\|TestAccVPCEndpointService_basic\|TestAccVPCNetworkACL_basic\|TestAccWavelengthCarrierGateway_basic\|TestAccVPCManagedPrefixList_basic\|TestAccVPCTrafficMirrorFilterRule_basic -timeout 360m
=== RUN   TestAccVPCEndpointConnectionNotification_basic
=== PAUSE TestAccVPCEndpointConnectionNotification_basic
=== RUN   TestAccVPCEndpointService_basic
=== PAUSE TestAccVPCEndpointService_basic
=== RUN   TestAccVPCManagedPrefixList_basic
=== PAUSE TestAccVPCManagedPrefixList_basic
=== RUN   TestAccVPCNetworkACL_basic
=== PAUSE TestAccVPCNetworkACL_basic
=== RUN   TestAccVPCRouteTable_basic
=== PAUSE TestAccVPCRouteTable_basic
=== RUN   TestAccVPCTrafficMirrorFilterRule_basic
=== PAUSE TestAccVPCTrafficMirrorFilterRule_basic
=== RUN   TestAccWavelengthCarrierGateway_basic
=== PAUSE TestAccWavelengthCarrierGateway_basic
=== CONT  TestAccVPCEndpointConnectionNotification_basic
=== CONT  TestAccVPCRouteTable_basic
=== CONT  TestAccVPCManagedPrefixList_basic
--- PASS: TestAccVPCRouteTable_basic (28.00s)
=== CONT  TestAccVPCNetworkACL_basic
--- PASS: TestAccVPCManagedPrefixList_basic (50.53s)
=== CONT  TestAccWavelengthCarrierGateway_basic
--- PASS: TestAccVPCNetworkACL_basic (23.05s)
=== CONT  TestAccVPCEndpointService_basic
--- PASS: TestAccWavelengthCarrierGateway_basic (24.29s)
=== CONT  TestAccVPCTrafficMirrorFilterRule_basic
--- PASS: TestAccVPCTrafficMirrorFilterRule_basic (55.13s)
--- PASS: TestAccVPCEndpointConnectionNotification_basic (237.69s)
--- PASS: TestAccVPCEndpointService_basic (238.66s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	300.708s
```
