### PR TITLE
aws_sagemaker_domain: New failing test cases for open bugs

### DIFF
--- a/internal/service/sagemaker/domain_test.go
+++ b/internal/service/sagemaker/domain_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/sagemaker"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -1086,6 +1087,68 @@ func testAccDomain_efs(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccDomainConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "domain_name", rName),
+					resource.TestCheckNoResourceAttr(resourceName, "default_user_settings.0.custom_file_system_config"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"retention_policy"},
+			},
+		},
+	})
+}
+
+func testAccDomain_studioWebPortal(t *testing.T) {
+	ctx := acctest.Context(t)
+	var domain sagemaker.DescribeDomainOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_domain.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, sagemaker.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDomainDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainConfig_studioWebPortalDisabled(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "domain_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.studio_web_portal", "DISABLED"),
+				),
+			},
+			{
+				Config: testAccDomainConfig_studioWebPortalEnabled(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "domain_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.studio_web_portal", "ENABLED"),
+				),
+			},
+			{
+				Config: testAccDomainConfig_studioWebPortalDisabled(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "domain_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.studio_web_portal", "DISABLED"),
+				),
+			},
+			{
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -2037,6 +2100,46 @@ resource "aws_sagemaker_domain" "test" {
         maximum_ebs_volume_size_in_gb = 200
       }
     }
+  }
+
+  retention_policy {
+    home_efs_file_system = "Delete"
+  }
+}
+`, rName))
+}
+
+func testAccDomainConfig_studioWebPortalDisabled(rName string) string {
+	return acctest.ConfigCompose(testAccDomainConfig_base(rName), fmt.Sprintf(`
+resource "aws_sagemaker_domain" "test" {
+  domain_name = %[1]q
+  auth_mode   = "IAM"
+  vpc_id      = aws_vpc.test.id
+  subnet_ids  = aws_subnet.test[*].id
+  
+  default_user_settings {
+    execution_role    = aws_iam_role.test.arn
+	studio_web_portal = "DISABLED"
+  }
+
+  retention_policy {
+    home_efs_file_system = "Delete"
+  }
+}
+`, rName))
+}
+
+func testAccDomainConfig_studioWebPortalEnabled(rName string) string {
+	return acctest.ConfigCompose(testAccDomainConfig_base(rName), fmt.Sprintf(`
+resource "aws_sagemaker_domain" "test" {
+  domain_name = %[1]q
+  auth_mode   = "IAM"
+  vpc_id      = aws_vpc.test.id
+  subnet_ids  = aws_subnet.test[*].id
+
+  default_user_settings {
+    execution_role    = aws_iam_role.test.arn
+	studio_web_portal = "ENABLED"
   }
 
   retention_policy {

--- a/internal/service/sagemaker/sagemaker_test.go
+++ b/internal/service/sagemaker/sagemaker_test.go
@@ -68,6 +68,7 @@ func TestAccSageMaker_serial(t *testing.T) {
 			"efs":                                                    testAccDomain_efs,
 			"posix":                                                  testAccDomain_posix,
 			"spaceStorageSettings":                                   testAccDomain_spaceStorageSettings,
+			"studioWebPortal":                                        testAccDomain_studioWebPortal,
 		},
 		"FlowDefinition": {
 			"basic":                          testAccFlowDefinition_basic,


### PR DESCRIPTION
### Description
Contributing two failing test cases for two bugs that we identified:

1. studio_web_portal cannot be disabled. It throws an error, that indicates that the DefaultLandingUri doesn't match the expected value (Issue: )
2.  custom_file_system_config is not removed properly. Need to send an empty array to the API to remove it. (Issue: #35503 ) 


### Relations
Relates #35503 
Relates #0000


### References
https://docs.aws.amazon.com/sagemaker/latest/dg/studio-updated-migrate.html#:~:text=StudioWebPortal%3A%20DISABLED




### Output from Acceptance Testing
The tests fail as expected:

```console
% Running tool: /usr/local/go/bin/go test -timeout 120m -run ^TestAccDomain_studioWebPortal$ github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker -test.v

=== RUN   TestAccDomain_studioWebPortal
2024-01-26T15:51:25.532+0100 [ERROR] sdk.proto: Response contains error diagnostic:
  diagnostic_summary=
  | updating SageMaker Domain: ValidationException: StudioWebPortal is disabled for this domain/user.
  | \tstatus code: 400, request id: fe98acde-996b-4aab-aa78-68f49d7483a7
   diagnostic_detail="" diagnostic_severity=ERROR tf_proto_version=5.4 tf_rpc=ApplyResourceChange tf_provider_addr=registry.terraform.io/hashicorp/aws tf_resource_type=aws_sagemaker_domain tf_req_id=7902c77d-8391-49fe-2958-499d973903a1
2024-01-26T15:51:25.564+0100 [WARN]  sdk.helper_resource: Error running Terraform CLI command: test_step_number=3 test_working_directory=/var/folders/w7/9kn8wg7d1f7fcj8709265ql40000gp/T/plugintest1161867331 test_terraform_path=/Users/fabianbrakowski/bin/terraform test_name=TestAccDomain_studioWebPortal
  error=
  | exit status 1
  |
  | Error: updating SageMaker Domain: ValidationException: StudioWebPortal is disabled for this domain/user.
  | \tstatus code: 400, request id: fe98acde-996b-4aab-aa78-68f49d7483a7
  |
  |   with aws_sagemaker_domain.test,
  |   on terraform_plugin_test.tf line 66, in resource "aws_sagemaker_domain" "test":
  |   66: resource "aws_sagemaker_domain" "test" {
  |

2024-01-26T15:51:25.564+0100 [ERROR] sdk.helper_resource: Unexpected error: test_name=TestAccDomain_studioWebPortal test_step_number=3 test_working_directory=/var/folders/w7/9kn8wg7d1f7fcj8709265ql40000gp/T/plugintest1161867331
  error=
  | Error running apply: exit status 1
  |
  | Error: updating SageMaker Domain: ValidationException: StudioWebPortal is disabled for this domain/user.
  | \tstatus code: 400, request id: fe98acde-996b-4aab-aa78-68f49d7483a7
  |
  |   with aws_sagemaker_domain.test,
  |   on terraform_plugin_test.tf line 66, in resource "aws_sagemaker_domain" "test":
  |   66: resource "aws_sagemaker_domain" "test" {
  |
   test_terraform_path=/Users/fabianbrakowski/bin/terraform
    /Users/fabianbrakowski/code/hashicorp/terraform-provider-aws/internal/service/sagemaker/domain_test.go:1121: Step 3/4 error: Error running apply: exit status 1

        Error: updating SageMaker Domain: ValidationException: StudioWebPortal is disabled for this domain/user.
                status code: 400, request id: fe98acde-996b-4aab-aa78-68f49d7483a7

          with aws_sagemaker_domain.test,
          on terraform_plugin_test.tf line 66, in resource "aws_sagemaker_domain" "test":
          66: resource "aws_sagemaker_domain" "test" {

2024-01-26T15:51:26.767+0100 [WARN]  sdk.helper_schema: Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.: tf_req_id=331da447-52e1-2a4a-f7d2-be169f25d34a tf_rpc=ConfigureProvider tf_mux_provider="*schema.GRPCProviderServer" tf_provider_addr=registry.terraform.io/hashicorp/aws
--- FAIL: TestAccDomain_studioWebPortal (248.53s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker  255.008s




% Running tool: /usr/local/go/bin/go test -timeout 120m -run ^TestAccDomain_efs$ github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker -test.v

=== RUN   TestAccDomain_efs
2024-01-26T16:42:41.288+0100 [ERROR] sdk.helper_resource: Unexpected error: error="Check failed: Check 3/3 error: aws_sagemaker_domain.test: Attribute 'default_user_settings.0.custom_file_system_config.#' expected \"0\", got \"1\"" test_working_directory=/var/folders/w7/9kn8wg7d1f7fcj8709265ql40000gp/T/plugintest4203844875 test_name=TestAccDomain_efs test_terraform_path=/Users/fabianbrakowski/bin/terraform test_step_number=3
    /Users/fabianbrakowski/code/hashicorp/terraform-provider-aws/internal/service/sagemaker/domain_test.go:1072: Step 3/3 error: Check failed: Check 3/3 error: aws_sagemaker_domain.test: Attribute 'default_user_settings.0.custom_file_system_config.#' expected "0", got "1"
2024-01-26T16:42:42.463+0100 [WARN]  sdk.helper_schema: Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.: tf_req_id=f3c2ed3d-1306-c511-40b4-7de73d7ef242 tf_provider_addr=registry.terraform.io/hashicorp/aws tf_rpc=ConfigureProvider tf_mux_provider="*schema.GRPCProviderServer"
--- FAIL: TestAccDomain_efs (332.12s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker	338.584s
FAIL

...
```
