### PR TITLE
Adding owneraccount component to endpointaccess from redshiftserverless

### DIFF
--- a/.changelog/35509.txt
+++ b/.changelog/35509.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_redshiftserverless_endpoint_access: Add `owner_account` argument
+```

--- a/internal/service/redshiftserverless/endpoint_access.go
+++ b/internal/service/redshiftserverless/endpoint_access.go
@@ -111,6 +111,12 @@ func ResourceEndpointAccess() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.StringLenBetween(1, 30),
 			},
+			"owner_account": {
+				Type: 			schema.TypeString,
+				Required:		false,
+				ForceNew:     	true,
+				ValidateFunc: 	verify.ValidAccountID,
+			},
 		},
 	}
 }
@@ -130,6 +136,10 @@ func resourceEndpointAccessCreate(ctx context.Context, d *schema.ResourceData, m
 
 	if v, ok := d.GetOk("subnet_ids"); ok && v.(*schema.Set).Len() > 0 {
 		input.SubnetIds = flex.ExpandStringSet(v.(*schema.Set))
+	}
+
+	if v, ok := d.GetOk("owner_account"); ok {
+		input.OwnerAccount = aws.String(v.(string))
 	}
 
 	out, err := conn.CreateEndpointAccessWithContext(ctx, &input)

--- a/internal/service/redshiftserverless/endpoint_access.go
+++ b/internal/service/redshiftserverless/endpoint_access.go
@@ -112,10 +112,10 @@ func ResourceEndpointAccess() *schema.Resource {
 				ValidateFunc: validation.StringLenBetween(1, 30),
 			},
 			"owner_account": {
-				Type: 			schema.TypeString,
-				Required:		false,
-				ForceNew:     	true,
-				ValidateFunc: 	verify.ValidAccountID,
+				Type:         schema.TypeString,
+				Required:     false,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidAccountID,
 			},
 		},
 	}

--- a/internal/service/redshiftserverless/endpoint_access.go
+++ b/internal/service/redshiftserverless/endpoint_access.go
@@ -16,10 +16,12 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-// @SDKResource("aws_redshiftserverless_endpoint_access")
+// @SDKResource("aws_redshiftserverless_endpoint_access", name="Endpoint Access")
 func ResourceEndpointAccess() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceEndpointAccessCreate,
@@ -32,31 +34,43 @@ func ResourceEndpointAccess() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"address": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"endpoint_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 30),
+			},
+			"owner_account": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidAccountID,
+			},
 			"port": {
 				Type:     schema.TypeInt,
 				Computed: true,
+			},
+			"subnet_ids": {
+				Type:     schema.TypeSet,
+				Required: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
 			},
 			"vpc_endpoint": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"vpc_endpoint_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"vpc_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
 						"network_interface": {
 							Type:     schema.TypeList,
 							Computed: true,
@@ -81,13 +95,16 @@ func ResourceEndpointAccess() *schema.Resource {
 								},
 							},
 						},
+						"vpc_endpoint_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vpc_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
-			},
-			"workgroup_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
 			},
 			"vpc_security_group_ids": {
 				Type:     schema.TypeSet,
@@ -97,25 +114,10 @@ func ResourceEndpointAccess() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-			"subnet_ids": {
-				Type:     schema.TypeSet,
+			"workgroup_name": {
+				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"endpoint_name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 30),
-			},
-			"owner_account": {
-				Type:         schema.TypeString,
-				Required:     false,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidAccountID,
 			},
 		},
 	}
@@ -125,33 +127,34 @@ func resourceEndpointAccessCreate(ctx context.Context, d *schema.ResourceData, m
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RedshiftServerlessConn(ctx)
 
-	input := redshiftserverless.CreateEndpointAccessInput{
+	endpointName := d.Get("endpoint_name").(string)
+	input := &redshiftserverless.CreateEndpointAccessInput{
+		EndpointName:  aws.String(endpointName),
 		WorkgroupName: aws.String(d.Get("workgroup_name").(string)),
-		EndpointName:  aws.String(d.Get("endpoint_name").(string)),
-	}
-
-	if v, ok := d.GetOk("vpc_security_group_ids"); ok && v.(*schema.Set).Len() > 0 {
-		input.VpcSecurityGroupIds = flex.ExpandStringSet(v.(*schema.Set))
-	}
-
-	if v, ok := d.GetOk("subnet_ids"); ok && v.(*schema.Set).Len() > 0 {
-		input.SubnetIds = flex.ExpandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("owner_account"); ok {
 		input.OwnerAccount = aws.String(v.(string))
 	}
 
-	out, err := conn.CreateEndpointAccessWithContext(ctx, &input)
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "creating Redshift Serverless Endpoint Access: %s", err)
+	if v, ok := d.GetOk("subnet_ids"); ok && v.(*schema.Set).Len() > 0 {
+		input.SubnetIds = flex.ExpandStringSet(v.(*schema.Set))
 	}
 
-	d.SetId(aws.StringValue(out.Endpoint.EndpointName))
+	if v, ok := d.GetOk("vpc_security_group_ids"); ok && v.(*schema.Set).Len() > 0 {
+		input.VpcSecurityGroupIds = flex.ExpandStringSet(v.(*schema.Set))
+	}
+
+	output, err := conn.CreateEndpointAccessWithContext(ctx, input)
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "creating Redshift Serverless Endpoint Access (%s): %s", endpointName, err)
+	}
+
+	d.SetId(aws.StringValue(output.Endpoint.EndpointName))
 
 	if _, err := waitEndpointAccessActive(ctx, conn, d.Id()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "waiting for Redshift Serverless Endpoint Access (%s) to be created: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Redshift Serverless Endpoint Access (%s) create: %s", d.Id(), err)
 	}
 
 	return append(diags, resourceEndpointAccessRead(ctx, d, meta)...)
@@ -161,9 +164,10 @@ func resourceEndpointAccessRead(ctx context.Context, d *schema.ResourceData, met
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RedshiftServerlessConn(ctx)
 
-	out, err := FindEndpointAccessByName(ctx, conn, d.Id())
+	endpointAccess, err := FindEndpointAccessByName(ctx, conn, d.Id())
+
 	if !d.IsNewResource() && tfresource.NotFound(err) {
-		log.Printf("[WARN] Redshift Serverless EndpointAccess (%s) not found, removing from state", d.Id())
+		log.Printf("[WARN] Redshift Serverless Endpoint Access (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
 	}
@@ -172,23 +176,18 @@ func resourceEndpointAccessRead(ctx context.Context, d *schema.ResourceData, met
 		return sdkdiag.AppendErrorf(diags, "reading Redshift Serverless Endpoint Access (%s): %s", d.Id(), err)
 	}
 
-	d.Set("address", out.Address)
-	d.Set("port", out.Port)
-	d.Set("arn", out.EndpointArn)
-	d.Set("endpoint_name", out.EndpointName)
-	d.Set("workgroup_name", out.WorkgroupName)
-	d.Set("subnet_ids", flex.FlattenStringSet(out.SubnetIds))
-
-	result := make([]*string, 0, len(out.VpcSecurityGroups))
-
-	for _, v := range out.VpcSecurityGroups {
-		result = append(result, v.VpcSecurityGroupId)
-	}
-	d.Set("vpc_security_group_ids", flex.FlattenStringSet(result))
-
-	if err := d.Set("vpc_endpoint", []interface{}{flattenVPCEndpoint(out.VpcEndpoint)}); err != nil {
+	d.Set("address", endpointAccess.Address)
+	d.Set("arn", endpointAccess.EndpointArn)
+	d.Set("endpoint_name", endpointAccess.EndpointName)
+	d.Set("port", endpointAccess.Port)
+	d.Set("subnet_ids", aws.StringValueSlice(endpointAccess.SubnetIds))
+	if err := d.Set("vpc_endpoint", []interface{}{flattenVPCEndpoint(endpointAccess.VpcEndpoint)}); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting vpc_endpoint: %s", err)
 	}
+	d.Set("vpc_security_group_ids", tfslices.ApplyToAll(endpointAccess.VpcSecurityGroups, func(v *redshiftserverless.VpcSecurityGroupMembership) string {
+		return aws.StringValue(v.VpcSecurityGroupId)
+	}))
+	d.Set("workgroup_name", endpointAccess.WorkgroupName)
 
 	return diags
 }
@@ -206,12 +205,13 @@ func resourceEndpointAccessUpdate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	_, err := conn.UpdateEndpointAccessWithContext(ctx, input)
+
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "updating Redshift Serverless Endpoint Access (%s): %s", d.Id(), err)
 	}
 
 	if _, err := waitEndpointAccessActive(ctx, conn, d.Id()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "waiting for Redshift Serverless Endpoint Access (%s) to be updated: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Redshift Serverless Endpoint Access (%s) update: %s", d.Id(), err)
 	}
 
 	return append(diags, resourceEndpointAccessRead(ctx, d, meta)...)
@@ -221,22 +221,21 @@ func resourceEndpointAccessDelete(ctx context.Context, d *schema.ResourceData, m
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RedshiftServerlessConn(ctx)
 
-	deleteInput := redshiftserverless.DeleteEndpointAccessInput{
+	log.Printf("[DEBUG] Deleting Redshift Serverless Endpoint Access: %s", d.Id())
+	_, err := conn.DeleteEndpointAccessWithContext(ctx, &redshiftserverless.DeleteEndpointAccessInput{
 		EndpointName: aws.String(d.Id()),
+	})
+
+	if tfawserr.ErrCodeEquals(err, redshiftserverless.ErrCodeResourceNotFoundException) {
+		return diags
 	}
 
-	log.Printf("[DEBUG] Deleting Redshift Serverless EndpointAccess: %s", d.Id())
-	_, err := conn.DeleteEndpointAccessWithContext(ctx, &deleteInput)
-
 	if err != nil {
-		if tfawserr.ErrCodeEquals(err, redshiftserverless.ErrCodeResourceNotFoundException) {
-			return diags
-		}
 		return sdkdiag.AppendErrorf(diags, "deleting Redshift Serverless Endpoint Access (%s): %s", d.Id(), err)
 	}
 
 	if _, err := waitEndpointAccessDeleted(ctx, conn, d.Id()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "deleting Redshift Serverless Endpoint Access (%s): waiting for completion: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Redshift Serverless Endpoint Access (%s) delete: %s", d.Id(), err)
 	}
 
 	return diags

--- a/internal/service/redshiftserverless/endpoint_access.go
+++ b/internal/service/redshiftserverless/endpoint_access.go
@@ -179,6 +179,7 @@ func resourceEndpointAccessRead(ctx context.Context, d *schema.ResourceData, met
 	d.Set("address", endpointAccess.Address)
 	d.Set("arn", endpointAccess.EndpointArn)
 	d.Set("endpoint_name", endpointAccess.EndpointName)
+	d.Set("owner_account", d.Get("owner_account"))
 	d.Set("port", endpointAccess.Port)
 	d.Set("subnet_ids", aws.StringValueSlice(endpointAccess.SubnetIds))
 	if err := d.Set("vpc_endpoint", []interface{}{flattenVPCEndpoint(endpointAccess.VpcEndpoint)}); err != nil {

--- a/internal/service/redshiftserverless/endpoint_access_test.go
+++ b/internal/service/redshiftserverless/endpoint_access_test.go
@@ -35,10 +35,11 @@ func TestAccRedshiftServerlessEndpointAccess_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEndpointAccessExists(ctx, resourceName),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "redshift-serverless", regexache.MustCompile("managedvpcendpoint/.+$")),
-					resource.TestCheckResourceAttr(resourceName, "workgroup_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "owner_account", ""),
 					resource.TestCheckResourceAttrSet(resourceName, "port"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "subnet_ids.*", "aws_subnet.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "workgroup_name", rName),
 				),
 			},
 			{
@@ -51,18 +52,19 @@ func TestAccRedshiftServerlessEndpointAccess_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEndpointAccessExists(ctx, resourceName),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "redshift-serverless", regexache.MustCompile("managedvpcendpoint/.+$")),
-					resource.TestCheckResourceAttr(resourceName, "workgroup_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_name", rName),
 					resource.TestCheckResourceAttrSet(resourceName, "port"),
+					resource.TestCheckResourceAttr(resourceName, "owner_account", ""),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "subnet_ids.*", "aws_subnet.test", "id"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "vpc_security_group_ids.*", "aws_security_group.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "workgroup_name", rName),
 				),
 			},
 		},
 	})
 }
 
-func TestAccRedshiftServerlessEndpointAccess_disappears_workgroup(t *testing.T) {
+func TestAccRedshiftServerlessEndpointAccess_Disappears_workgroup(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_redshiftserverless_endpoint_access.test"
 	rName := sdkacctest.RandStringFromCharSet(30, sdkacctest.CharSetAlpha)
@@ -126,7 +128,7 @@ func testAccCheckEndpointAccessDestroy(ctx context.Context) resource.TestCheckFu
 				return err
 			}
 
-			return fmt.Errorf("Redshift Serverless EndpointAccess %s still exists", rs.Primary.ID)
+			return fmt.Errorf("Redshift Serverless Endpoint Access %s still exists", rs.Primary.ID)
 		}
 
 		return nil
@@ -140,10 +142,6 @@ func testAccCheckEndpointAccessExists(ctx context.Context, name string) resource
 			return fmt.Errorf("not found: %s", name)
 		}
 
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("Redshift Serverless EndpointAccess ID is not set")
-		}
-
 		conn := acctest.Provider.Meta().(*conns.AWSClient).RedshiftServerlessConn(ctx)
 
 		_, err := tfredshiftserverless.FindEndpointAccessByName(ctx, conn, rs.Primary.ID)
@@ -152,20 +150,8 @@ func testAccCheckEndpointAccessExists(ctx context.Context, name string) resource
 	}
 }
 
-func testAccEndpointAccessConfig_basic(rName string) string {
-	return acctest.ConfigCompose(
-		acctest.ConfigAvailableAZsNoOptIn(),
-		fmt.Sprintf(`
-resource "aws_vpc" "test" {
-  cidr_block = "10.0.0.0/16"
-}
-
-resource "aws_subnet" "test" {
-  availability_zone = data.aws_availability_zones.available.names[0]
-  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, 0)
-  vpc_id            = aws_vpc.test.id
-}
-
+func testAccEndpointAccessConfig_base(rName string) string {
+	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 1), fmt.Sprintf(`
 resource "aws_redshiftserverless_namespace" "test" {
   namespace_name = %[1]q
 }
@@ -174,47 +160,34 @@ resource "aws_redshiftserverless_workgroup" "test" {
   namespace_name = aws_redshiftserverless_namespace.test.namespace_name
   workgroup_name = %[1]q
 }
+`, rName))
+}
 
+func testAccEndpointAccessConfig_basic(rName string) string {
+	return acctest.ConfigCompose(testAccEndpointAccessConfig_base(rName), fmt.Sprintf(`
 resource "aws_redshiftserverless_endpoint_access" "test" {
   workgroup_name = aws_redshiftserverless_workgroup.test.workgroup_name
   endpoint_name  = %[1]q
-  subnet_ids     = [aws_subnet.test.id]
+  subnet_ids     = [aws_subnet.test[0]].id]
 }
 `, rName))
 }
 
 func testAccEndpointAccessConfig_updated(rName string) string {
-	return acctest.ConfigCompose(
-		acctest.ConfigAvailableAZsNoOptIn(),
-		fmt.Sprintf(`
-resource "aws_vpc" "test" {
-  cidr_block = "10.0.0.0/16"
-}
-
+	return acctest.ConfigCompose(testAccEndpointAccessConfig_base(rName), fmt.Sprintf(`
 resource "aws_security_group" "test" {
   name   = %[1]q
   vpc_id = aws_vpc.test.id
-}
 
-resource "aws_subnet" "test" {
-  availability_zone = data.aws_availability_zones.available.names[0]
-  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, 0)
-  vpc_id            = aws_vpc.test.id
-}
-
-resource "aws_redshiftserverless_namespace" "test" {
-  namespace_name = %[1]q
-}
-
-resource "aws_redshiftserverless_workgroup" "test" {
-  namespace_name = aws_redshiftserverless_namespace.test.namespace_name
-  workgroup_name = %[1]q
+  tags = {
+    Name = %[1]q
+  }
 }
 
 resource "aws_redshiftserverless_endpoint_access" "test" {
   workgroup_name         = aws_redshiftserverless_workgroup.test.workgroup_name
   endpoint_name          = %[1]q
-  subnet_ids             = [aws_subnet.test.id]
+  subnet_ids             = [aws_subnet.test[0].id]
   vpc_security_group_ids = [aws_security_group.test.id]
 }
 `, rName))

--- a/internal/service/redshiftserverless/endpoint_access_test.go
+++ b/internal/service/redshiftserverless/endpoint_access_test.go
@@ -38,7 +38,7 @@ func TestAccRedshiftServerlessEndpointAccess_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "endpoint_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "owner_account", ""),
 					resource.TestCheckResourceAttrSet(resourceName, "port"),
-					resource.TestCheckTypeSetElemAttrPair(resourceName, "subnet_ids.*", "aws_subnet.test", "id"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "subnet_ids.*", "aws_subnet.test.0", "id"),
 					resource.TestCheckResourceAttr(resourceName, "workgroup_name", rName),
 				),
 			},
@@ -55,7 +55,7 @@ func TestAccRedshiftServerlessEndpointAccess_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "endpoint_name", rName),
 					resource.TestCheckResourceAttrSet(resourceName, "port"),
 					resource.TestCheckResourceAttr(resourceName, "owner_account", ""),
-					resource.TestCheckTypeSetElemAttrPair(resourceName, "subnet_ids.*", "aws_subnet.test", "id"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "subnet_ids.*", "aws_subnet.test.0", "id"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "vpc_security_group_ids.*", "aws_security_group.test", "id"),
 					resource.TestCheckResourceAttr(resourceName, "workgroup_name", rName),
 				),
@@ -168,7 +168,7 @@ func testAccEndpointAccessConfig_basic(rName string) string {
 resource "aws_redshiftserverless_endpoint_access" "test" {
   workgroup_name = aws_redshiftserverless_workgroup.test.workgroup_name
   endpoint_name  = %[1]q
-  subnet_ids     = [aws_subnet.test[0]].id]
+  subnet_ids     = [aws_subnet.test[0].id]
 }
 `, rName))
 }

--- a/internal/service/redshiftserverless/service_package_gen.go
+++ b/internal/service/redshiftserverless/service_package_gen.go
@@ -45,6 +45,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceEndpointAccess,
 			TypeName: "aws_redshiftserverless_endpoint_access",
+			Name:     "Endpoint Access",
 		},
 		{
 			Factory:  ResourceNamespace,

--- a/website/docs/r/redshiftserverless_endpoint_access.html.markdown
+++ b/website/docs/r/redshiftserverless_endpoint_access.html.markdown
@@ -24,10 +24,10 @@ resource "aws_redshiftserverless_endpoint_access" "example" {
 This resource supports the following arguments:
 
 * `endpoint_name` - (Required) The name of the endpoint.
+* `owner_account` - (Optional) The owner Amazon Web Services account for the Amazon Redshift Serverless workgroup.
 * `subnet_ids` - (Required) An array of VPC subnet IDs to associate with the endpoint.
 * `vpc_security_group_ids` - (Optional) An array of security group IDs to associate with the workgroup.
 * `workgroup_name` - (Required) The name of the workgroup.
-* `owner_account` - (Optional) The owner Amazon Web Services account for the Amazon Redshift Serverless workgroup.
 
 ## Attribute Reference
 

--- a/website/docs/r/redshiftserverless_endpoint_access.html.markdown
+++ b/website/docs/r/redshiftserverless_endpoint_access.html.markdown
@@ -27,6 +27,7 @@ This resource supports the following arguments:
 * `subnet_ids` - (Required) An array of VPC subnet IDs to associate with the endpoint.
 * `vpc_security_group_ids` - (Optional) An array of security group IDs to associate with the workgroup.
 * `workgroup_name` - (Required) The name of the workgroup.
+* `owner_account` - (Optional) The owner Amazon Web Services account for the Amazon Redshift Serverless workgroup.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
I have added owner_account component to endpoint_access in redshiftserverless.
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #35347

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Added component - 
https://github.com/aws/aws-sdk-go/blob/main/service/redshiftserverless/api.go#L6057 

There is no way to get OwnerAccount from redshiftserverless AWS API -
https://docs.aws.amazon.com/redshift-serverless/latest/APIReference/API_GetEndpointAccess.html#API_GetEndpointAccess_ResponseElements 

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=redshiftserverless_test PKG=redshiftserverless

...
```
