### PR TITLE
docs: Fix S3 example for aws_lakeformation_permissions resource

### DIFF
--- a/website/docs/r/lakeformation_permissions.html.markdown
+++ b/website/docs/r/lakeformation_permissions.html.markdown
@@ -102,7 +102,7 @@ If the `principal` is also a data lake administrator, AWS grants implicit permis
 ```terraform
 resource "aws_lakeformation_permissions" "example" {
   principal   = aws_iam_role.workflow_role.arn
-  permissions = ["ALL"]
+  permissions = ["DATA_LOCATION_ACCESS"]
 
   data_location {
     arn = aws_lakeformation_resource.example.arn


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR fixes the permissions attribute in the example usage for LF S3 resource. Only DATA_LOCATION_ACCESS is allowed.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #33751

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [Granting data location permissions](https://docs.aws.amazon.com/lake-formation/latest/dg/granting-location-permissions.html) in the LF Developer Guide to confirm options.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
n/a