### PR TITLE
docs: Improve access_endpoint attr desc for aws_appstream_image_builder

### DIFF
--- a/website/docs/r/appstream_image_builder.html.markdown
+++ b/website/docs/r/appstream_image_builder.html.markdown
@@ -56,8 +56,8 @@ The following arguments are optional:
 
 The `access_endpoint` block supports the following arguments:
 
-* `endpoint_type` - (Required) Type of interface endpoint.
-* `vpce_id` - (Optional) Identifier (ID) of the VPC in which the interface endpoint is used.
+* `endpoint_type` - (Required) Type of interface endpoint. Valid values: `STREAMING`
+* `vpce_id` - (Optional) Identifier (ID) of the interface VPC endpoint.
 
 ### `domain_join_info`
 
@@ -80,7 +80,7 @@ This resource exports the following attributes in addition to the arguments abov
 * `arn` - ARN of the appstream image builder.
 * `created_time` -  Date and time, in UTC and extended RFC 3339 format, when the image builder was created.
 * `id` - Name of the image builder.
-* `state` - State of the image builder. Can be: `PENDING`, `UPDATING_AGENT`, `RUNNING`, `STOPPING`, `STOPPED`, `REBOOTING`, `SNAPSHOTTING`, `DELETING`, `FAILED`, `UPDATING`, `PENDING_QUALIFICATION`
+* `state` - State of the image builder. Valid values: `PENDING`, `UPDATING_AGENT`, `RUNNING`, `STOPPING`, `STOPPED`, `REBOOTING`, `SNAPSHOTTING`, `DELETING`, `FAILED`, `UPDATING`, `PENDING_QUALIFICATION`
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Import

--- a/website/docs/r/appstream_image_builder.html.markdown
+++ b/website/docs/r/appstream_image_builder.html.markdown
@@ -56,7 +56,7 @@ The following arguments are optional:
 
 The `access_endpoint` block supports the following arguments:
 
-* `endpoint_type` - (Required) Type of interface endpoint. Valid values: `STREAMING`
+* `endpoint_type` - (Required) Type of interface endpoint. For valid values, refer to the [AWS documentation](https://docs.aws.amazon.com/appstream2/latest/APIReference/API_AccessEndpoint.html).
 * `vpce_id` - (Optional) Identifier (ID) of the interface VPC endpoint.
 
 ### `domain_join_info`
@@ -80,7 +80,7 @@ This resource exports the following attributes in addition to the arguments abov
 * `arn` - ARN of the appstream image builder.
 * `created_time` -  Date and time, in UTC and extended RFC 3339 format, when the image builder was created.
 * `id` - Name of the image builder.
-* `state` - State of the image builder. Valid values: `PENDING`, `UPDATING_AGENT`, `RUNNING`, `STOPPING`, `STOPPED`, `REBOOTING`, `SNAPSHOTTING`, `DELETING`, `FAILED`, `UPDATING`, `PENDING_QUALIFICATION`
+* `state` - State of the image builder. For valid values, refer to the [AWS documentation](https://docs.aws.amazon.com/appstream2/latest/APIReference/API_ImageBuilder.html#AppStream2-Type-ImageBuilder-State).
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Import


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to improve the description of the `access_endpoint` config block attributes for the `aws_appstream_image_builder` resource. What I noticed is that the description for `vpce_id` is consistently incorrect in AWS documentations, so I just used my own wordings for more accuracy. Also, the schema seems to set a lot of attributes to optional but in fact they would be required. For consistency, I still left `vpce_id` as optional.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #33029

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [CreateImageBuilder](https://docs.aws.amazon.com/appstream2/latest/APIReference/API_CreateImageBuilder.html#AppStream2-CreateImageBuilder-request-DomainJoinInfo) in the API reference for schema and descriptions.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
n/a