### PR TITLE
docs: Rename IAM resource names for clarity in aws_iot_topic_rule example

### DIFF
--- a/website/docs/r/iot_topic_rule.html.markdown
+++ b/website/docs/r/iot_topic_rule.html.markdown
@@ -8,6 +8,8 @@ description: |-
 
 # Resource: aws_iot_topic_rule
 
+Creates and manages an AWS IoT topic rule.
+
 ## Example Usage
 
 ```terraform
@@ -54,12 +56,12 @@ data "aws_iam_policy_document" "assume_role" {
   }
 }
 
-resource "aws_iam_role" "role" {
+resource "aws_iam_role" "myrole" {
   name               = "myrole"
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
-data "aws_iam_policy_document" "iam_policy_for_lambda" {
+data "aws_iam_policy_document" "mypolicy" {
   statement {
     effect    = "Allow"
     actions   = ["sns:Publish"]
@@ -67,10 +69,10 @@ data "aws_iam_policy_document" "iam_policy_for_lambda" {
   }
 }
 
-resource "aws_iam_role_policy" "iam_policy_for_lambda" {
+resource "aws_iam_role_policy" "mypolicy" {
   name   = "mypolicy"
-  role   = aws_iam_role.role.id
-  policy = data.aws_iam_policy_document.iam_policy_for_lambda.json
+  role   = aws_iam_role.myrole.id
+  policy = data.aws_iam_policy_document.mypolicy.json
 }
 ```
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR renames the IAM resources in the usage example of the `aws_iot_topic_rule` resource for better consistency. I also noticed that the resource description is missing, so I added that in as well.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #27234

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referenced [Granting an AWS IoT rule the access it requires](https://docs.aws.amazon.com/iot/latest/developerguide/iot-create-role.html) in the AWS IoT Developer Guide.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
n/a