### PR TITLE
feat: Add header_order field support to aws_wafv2_webacl and rule_group

### DIFF
--- a/.changelog/35521.txt
+++ b/.changelog/35521.txt
@@ -1,0 +1,4 @@
+```release-note:enhancement
+resource/aws_wafv2_rule_group: Add `header_order` block support to `field_to_match` in rule statements
+resource/aws_wafv2_web_acl: Add `header_order` block support to `field_to_match` in rule statements
+```

--- a/.changelog/35521.txt
+++ b/.changelog/35521.txt
@@ -1,4 +1,7 @@
 ```release-note:enhancement
-resource/aws_wafv2_rule_group: Add `header_order` block support to `field_to_match` in rule statements
-resource/aws_wafv2_web_acl: Add `header_order` block support to `field_to_match` in rule statements
+resource/aws_wafv2_rule_group: Add `header_order` to `field_to_match` configuration blocks
+```
+
+```release-note:enhancement
+resource/aws_wafv2_web_acl: Add `header_order`to `field_to_match` configuration blocks
 ```

--- a/internal/service/wafv2/flex.go
+++ b/internal/service/wafv2/flex.go
@@ -531,6 +531,10 @@ func expandFieldToMatch(l []interface{}) *wafv2.FieldToMatch {
 		f.Cookies = expandCookies(m["cookies"].([]interface{}))
 	}
 
+	if v, ok := m["header_order"]; ok && len(v.([]interface{})) > 0 {
+		f.HeaderOrder = expandHeaderOrder(m["header_order"].([]interface{}))
+	}
+
 	if v, ok := m["headers"]; ok && len(v.([]interface{})) > 0 {
 		f.Headers = expandHeaders(m["headers"].([]interface{}))
 	}
@@ -904,6 +908,18 @@ func expandXSSMatchStatement(l []interface{}) *wafv2.XssMatchStatement {
 	return &wafv2.XssMatchStatement{
 		FieldToMatch:        expandFieldToMatch(m["field_to_match"].([]interface{})),
 		TextTransformations: expandTextTransformations(m["text_transformation"].(*schema.Set).List()),
+	}
+}
+
+func expandHeaderOrder(l []interface{}) *wafv2.HeaderOrder {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	return &wafv2.HeaderOrder{
+		OversizeHandling: aws.String(m["oversize_handling"].(string)),
 	}
 }
 
@@ -1958,6 +1974,10 @@ func flattenFieldToMatch(f *wafv2.FieldToMatch) interface{} {
 		m["cookies"] = flattenCookies(f.Cookies)
 	}
 
+	if f.HeaderOrder != nil {
+		m["header_order"] = flattenHeaderOrder(f.HeaderOrder)
+	}
+
 	if f.Headers != nil {
 		m["headers"] = flattenHeaders(f.Headers)
 	}
@@ -2282,6 +2302,18 @@ func flattenVisibilityConfig(config *wafv2.VisibilityConfig) interface{} {
 		"cloudwatch_metrics_enabled": aws.BoolValue(config.CloudWatchMetricsEnabled),
 		"metric_name":                aws.StringValue(config.MetricName),
 		"sampled_requests_enabled":   aws.BoolValue(config.SampledRequestsEnabled),
+	}
+
+	return []interface{}{m}
+}
+
+func flattenHeaderOrder(s *wafv2.HeaderOrder) interface{} {
+	if s == nil {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"oversize_handling": aws.StringValue(s.OversizeHandling),
 	}
 
 	return []interface{}{m}

--- a/internal/service/wafv2/rule_group_test.go
+++ b/internal/service/wafv2/rule_group_test.go
@@ -461,7 +461,9 @@ func TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch(t *testing.T) {
 						"statement.0.byte_match_statement.0.field_to_match.0.all_query_arguments.#":   "1",
 						"statement.0.byte_match_statement.0.field_to_match.0.body.#":                  "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.cookies.#":               "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.header_order.#":          "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.headers.#":               "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.ja3_fingerprint.#":       "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.json_body.#":             "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.method.#":                "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.query_string.#":          "0",
@@ -484,7 +486,9 @@ func TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch(t *testing.T) {
 						"statement.0.byte_match_statement.0.field_to_match.0.all_query_arguments.#":   "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.body.#":                  "1",
 						"statement.0.byte_match_statement.0.field_to_match.0.cookies.#":               "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.header_order.#":          "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.headers.#":               "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.ja3_fingerprint.#":       "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.json_body.#":             "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.method.#":                "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.query_string.#":          "0",
@@ -512,7 +516,9 @@ func TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch(t *testing.T) {
 						"statement.0.byte_match_statement.0.field_to_match.0.cookies.0.match_pattern.#":                    "1",
 						"statement.0.byte_match_statement.0.field_to_match.0.cookies.0.match_pattern.0.included_cookies.0": "test",
 						"statement.0.byte_match_statement.0.field_to_match.0.cookies.0.match_pattern.0.included_cookies.1": "cookie_test",
+						"statement.0.byte_match_statement.0.field_to_match.0.header_order.#":                               "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.headers.#":                                    "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.ja3_fingerprint.#":                            "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.json_body.#":                                  "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.method.#":                                     "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.query_string.#":                               "0",
@@ -544,6 +550,32 @@ func TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccRuleGroupConfig_byteMatchStatementFieldToMatchHeaderOrder(ruleGroupName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRuleGroupExists(ctx, resourceName, &v),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexache.MustCompile(`regional/rulegroup/.+$`)),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"statement.#":                                         "1",
+						"statement.0.byte_match_statement.#":                  "1",
+						"statement.0.byte_match_statement.0.field_to_match.#": "1",
+						"statement.0.byte_match_statement.0.field_to_match.0.all_query_arguments.#":            "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.body.#":                           "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.cookies.#":                        "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.header_order.#":                   "1",
+						"statement.0.byte_match_statement.0.field_to_match.0.header_order.0.oversize_handling": "MATCH",
+						"statement.0.byte_match_statement.0.field_to_match.0.headers.#":                        "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.ja3_fingerprint.#":                "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.json_body.#":                      "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.method.#":                         "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.query_string.#":                   "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.single_header.#":                  "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.single_query_argument.#":          "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.uri_path.#":                       "0",
+					}),
+				),
+			},
+			{
 				Config: testAccRuleGroupConfig_byteMatchStatementFieldToMatchHeadersMatchPatternAll(ruleGroupName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRuleGroupExists(ctx, resourceName, &v),
@@ -556,6 +588,7 @@ func TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch(t *testing.T) {
 						"statement.0.byte_match_statement.0.field_to_match.0.all_query_arguments.#":                        "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.body.#":                                       "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.cookies.#":                                    "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.header_order.#":                               "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.headers.#":                                    "1",
 						"statement.0.byte_match_statement.0.field_to_match.0.headers.0.oversize_handling":                  "MATCH",
 						"statement.0.byte_match_statement.0.field_to_match.0.headers.0.match_scope":                        "ALL",
@@ -563,6 +596,7 @@ func TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch(t *testing.T) {
 						"statement.0.byte_match_statement.0.field_to_match.0.headers.0.match_pattern.0.all.#":              "1",
 						"statement.0.byte_match_statement.0.field_to_match.0.headers.0.match_pattern.0.included_headers.#": "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.headers.0.match_pattern.0.excluded_headers.#": "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.ja3_fingerprint.#":                            "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.json_body.#":                                  "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.method.#":                                     "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.query_string.#":                               "0",
@@ -585,6 +619,7 @@ func TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch(t *testing.T) {
 						"statement.0.byte_match_statement.0.field_to_match.0.all_query_arguments.#":                        "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.body.#":                                       "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.cookies.#":                                    "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.header_order.#":                               "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.headers.#":                                    "1",
 						"statement.0.byte_match_statement.0.field_to_match.0.headers.0.oversize_handling":                  "MATCH",
 						"statement.0.byte_match_statement.0.field_to_match.0.headers.0.match_scope":                        "ALL",
@@ -594,6 +629,7 @@ func TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch(t *testing.T) {
 						"statement.0.byte_match_statement.0.field_to_match.0.headers.0.match_pattern.0.included_headers.0": "session",
 						"statement.0.byte_match_statement.0.field_to_match.0.headers.0.match_pattern.0.included_headers.1": "session-id",
 						"statement.0.byte_match_statement.0.field_to_match.0.headers.0.match_pattern.0.excluded_headers.#": "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.ja3_fingerprint.#":                            "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.json_body.#":                                  "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.method.#":                                     "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.query_string.#":                               "0",
@@ -616,6 +652,7 @@ func TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch(t *testing.T) {
 						"statement.0.byte_match_statement.0.field_to_match.0.all_query_arguments.#":                        "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.body.#":                                       "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.cookies.#":                                    "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.header_order.#":                               "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.headers.#":                                    "1",
 						"statement.0.byte_match_statement.0.field_to_match.0.headers.0.oversize_handling":                  "MATCH",
 						"statement.0.byte_match_statement.0.field_to_match.0.headers.0.match_scope":                        "ALL",
@@ -625,6 +662,7 @@ func TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch(t *testing.T) {
 						"statement.0.byte_match_statement.0.field_to_match.0.headers.0.match_pattern.0.excluded_headers.0": "session",
 						"statement.0.byte_match_statement.0.field_to_match.0.headers.0.match_pattern.0.excluded_headers.1": "session-id",
 						"statement.0.byte_match_statement.0.field_to_match.0.headers.0.match_pattern.0.included_headers.#": "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.ja3_fingerprint.#":                            "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.json_body.#":                                  "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.method.#":                                     "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.query_string.#":                               "0",
@@ -651,7 +689,9 @@ func TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch(t *testing.T) {
 						"statement.0.byte_match_statement.0.field_to_match.0.all_query_arguments.#":   "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.body.#":                  "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.cookies.#":               "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.header_order.#":          "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.headers.#":               "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.ja3_fingerprint.#":       "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.json_body.#":             "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.method.#":                "1",
 						"statement.0.byte_match_statement.0.field_to_match.0.query_string.#":          "0",
@@ -674,7 +714,9 @@ func TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch(t *testing.T) {
 						"statement.0.byte_match_statement.0.field_to_match.0.all_query_arguments.#":   "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.body.#":                  "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.cookies.#":               "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.header_order.#":          "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.headers.#":               "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.ja3_fingerprint.#":       "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.json_body.#":             "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.method.#":                "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.query_string.#":          "1",
@@ -697,7 +739,9 @@ func TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch(t *testing.T) {
 						"statement.0.byte_match_statement.0.field_to_match.0.all_query_arguments.#":   "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.body.#":                  "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.cookies.#":               "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.header_order.#":          "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.headers.#":               "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.ja3_fingerprint.#":       "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.json_body.#":             "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.method.#":                "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.query_string.#":          "0",
@@ -721,7 +765,9 @@ func TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch(t *testing.T) {
 						"statement.0.byte_match_statement.0.field_to_match.0.all_query_arguments.#":        "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.body.#":                       "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.cookies.#":                    "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.header_order.#":               "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.headers.#":                    "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.ja3_fingerprint.#":            "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.json_body.#":                  "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.method.#":                     "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.query_string.#":               "0",
@@ -745,7 +791,9 @@ func TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch(t *testing.T) {
 						"statement.0.byte_match_statement.0.field_to_match.0.all_query_arguments.#":   "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.body.#":                  "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.cookies.#":               "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.header_order.#":          "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.headers.#":               "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.ja3_fingerprint.#":       "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.json_body.#":             "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.method.#":                "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.query_string.#":          "0",
@@ -3275,6 +3323,53 @@ resource "aws_wafv2_rule_group" "test" {
           priority = 1
           type     = "NONE"
         }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "friendly-rule-metric-name"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}
+`, rName)
+}
+
+func testAccRuleGroupConfig_byteMatchStatementFieldToMatchHeaderOrder(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_rule_group" "test" {
+  capacity = 50
+  name     = %[1]q
+  scope    = "REGIONAL"
+
+  rule {
+    name     = "rule-1"
+    priority = 1
+
+    action {
+      allow {}
+    }
+
+    statement {
+      byte_match_statement {
+        search_string = "host:user-agent:accept:authorization:referer"
+        field_to_match {
+          header_order {
+            oversize_handling = "MATCH"
+          }
+        }
+        text_transformation {
+          priority = 0
+          type     = "NONE"
+        }
+        positional_constraint = "STARTS_WITH"
       }
     }
 

--- a/internal/service/wafv2/schemas.go
+++ b/internal/service/wafv2/schemas.go
@@ -342,6 +342,7 @@ func fieldToMatchBaseSchema() *schema.Resource {
 			"all_query_arguments": emptySchema(),
 			"body":                bodySchema(),
 			"cookies":             cookiesSchema(),
+			"header_order":        headerOrderSchema(),
 			"headers":             headersSchema(),
 			"ja3_fingerprint":     ja3fingerprintSchema(),
 			"json_body":           jsonBodySchema(),
@@ -867,6 +868,18 @@ func matchScopeSchema() *schema.Schema {
 		Type:         schema.TypeString,
 		Required:     true,
 		ValidateFunc: validation.StringInSlice(wafv2.MapMatchScope_Values(), false),
+	}
+}
+
+func headerOrderSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"oversize_handling": oversizeHandlingRequiredSchema(),
+			},
+		},
 	}
 }
 

--- a/internal/service/wafv2/web_acl_test.go
+++ b/internal/service/wafv2/web_acl_test.go
@@ -127,6 +127,10 @@ func TestAccWAFV2WebACL_Update_rule(t *testing.T) {
 						"statement.0.size_constraint_statement.0.field_to_match.0.all_query_arguments.#":   "0",
 						"statement.0.size_constraint_statement.0.field_to_match.0.body.#":                  "0",
 						"statement.0.size_constraint_statement.0.field_to_match.0.cookies.#":               "0",
+						"statement.0.size_constraint_statement.0.field_to_match.0.header_order.#":          "0",
+						"statement.0.size_constraint_statement.0.field_to_match.0.headers.#":               "0",
+						"statement.0.size_constraint_statement.0.field_to_match.0.ja3_fingerprint.#":       "0",
+						"statement.0.size_constraint_statement.0.field_to_match.0.json_body.#":             "0",
 						"statement.0.size_constraint_statement.0.field_to_match.0.method.#":                "0",
 						"statement.0.size_constraint_statement.0.field_to_match.0.query_string.#":          "1",
 						"statement.0.size_constraint_statement.0.field_to_match.0.single_header.#":         "0",
@@ -1300,6 +1304,54 @@ func TestAccWAFV2WebACL_ByteMatchStatement_body(t *testing.T) {
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.0.byte_match_statement.0.field_to_match.0.body.#":                   "1",
 						"statement.0.byte_match_statement.0.field_to_match.0.body.0.oversize_handling": "CONTINUE",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccWebACLImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func TestAccWAFV2WebACL_ByteMatchStatement_headerOrder(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v wafv2.WebACL
+	webACLName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_wafv2_web_acl.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckScopeRegional(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, wafv2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckWebACLDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWebACLConfig_byteMatchStatementHeaderOrder(webACLName, wafv2.OversizeHandlingMatch),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWebACLExists(ctx, resourceName, &v),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexache.MustCompile(`regional/webacl/.+$`)),
+					resource.TestCheckResourceAttr(resourceName, "name", webACLName),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"statement.0.byte_match_statement.0.field_to_match.0.header_order.#":                   "1",
+						"statement.0.byte_match_statement.0.field_to_match.0.header_order.0.oversize_handling": "MATCH",
+					}),
+				),
+			},
+			{
+				Config: testAccWebACLConfig_byteMatchStatementHeaderOrder(webACLName, wafv2.OversizeHandlingNoMatch),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWebACLExists(ctx, resourceName, &v),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexache.MustCompile(`regional/webacl/.+$`)),
+					resource.TestCheckResourceAttr(resourceName, "name", webACLName),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"statement.0.byte_match_statement.0.field_to_match.0.header_order.#":                   "1",
+						"statement.0.byte_match_statement.0.field_to_match.0.header_order.0.oversize_handling": "NO_MATCH",
 					}),
 				),
 			},
@@ -3279,6 +3331,57 @@ resource "aws_wafv2_web_acl" "test" {
           priority = 0
           type     = "NONE"
         }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "friendly-rule-metric-name"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}
+`, rName, oversizeHandling)
+}
+
+func testAccWebACLConfig_byteMatchStatementHeaderOrder(rName, oversizeHandling string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_web_acl" "test" {
+  name        = %[1]q
+  description = %[1]q
+  scope       = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "rule-1"
+    priority = 1
+
+    action {
+      count {}
+    }
+
+    statement {
+      byte_match_statement {
+        search_string = "host:user-agent:accept:authorization:referer"
+        field_to_match {
+          header_order {
+            oversize_handling = %[2]q
+          }
+        }
+        text_transformation {
+          priority = 0
+          type     = "NONE"
+        }
+        positional_constraint = "STARTS_WITH"
       }
     }
 

--- a/website/docs/r/wafv2_rule_group.html.markdown
+++ b/website/docs/r/wafv2_rule_group.html.markdown
@@ -576,12 +576,13 @@ The part of a web request that you want AWS WAF to inspect. Include the single `
 
 The `field_to_match` block supports the following arguments:
 
-~> **NOTE:** Only one of `all_query_arguments`, `body`, `cookies`, `headers`, `json_body`, `method`, `query_string`, `single_header`, `single_query_argument`, or `uri_path` can be specified.
+~> **NOTE:** Only one of `all_query_arguments`, `body`, `cookies`, `header_order`, `headers`, `json_body`, `method`, `query_string`, `single_header`, `single_query_argument`, or `uri_path` can be specified.
 An empty configuration block `{}` should be used when specifying `all_query_arguments`, `body`, `method`, or `query_string` attributes.
 
 * `all_query_arguments` - (Optional) Inspect all query arguments.
 * `body` - (Optional) Inspect the request body, which immediately follows the request headers.
 * `cookies` - (Optional) Inspect the cookies in the web request. See [Cookies](#cookies) below for details.
+* `header_order` - (Optional) Inspect the request headers. See [Header Order](#header-order) below for details.
 * `headers` - (Optional) Inspect the request headers. See [Headers](#headers) below for details.
 * `json_body` - (Optional) Inspect the request body as JSON. See [JSON Body](#json-body) for details.
 * `method` - (Optional) Inspect the HTTP method. The method indicates the type of operation that the request is asking the origin to perform.
@@ -610,6 +611,14 @@ The `ip_set_forwarded_ip_config` block supports the following arguments:
 * `fallback_behavior` - (Required) - The match status to assign to the web request if the request doesn't have a valid IP address in the specified position. Valid values include: `MATCH` or `NO_MATCH`.
 * `header_name` - (Required) - The name of the HTTP header to use for the IP address.
 * `position` - (Required) - The position in the header to search for the IP address. Valid values include: `FIRST`, `LAST`, or `ANY`. If `ANY` is specified and the header contains more than 10 IP addresses, AWS WAFv2 inspects the last 10.
+
+### Header Order
+
+Inspect a string containing the list of the request's header names, ordered as they appear in the web request that AWS WAF receives for inspection. AWS WAF generates the string and then uses that as the field to match component in its inspection. AWS WAF separates the header names in the string using colons and no added spaces, for example `host:user-agent:accept:authorization:referer`.
+
+The `header_order` block supports the following arguments:
+
+* `oversize_handling` - (Required) Oversize handling tells AWS WAF what to do with a web request when the request component that the rule inspects is over the limits. Valid values include the following: `CONTINUE`, `MATCH`, `NO_MATCH`. See the AWS [documentation](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html) for more information.
 
 ### Headers
 

--- a/website/docs/r/wafv2_web_acl.html.markdown
+++ b/website/docs/r/wafv2_web_acl.html.markdown
@@ -816,11 +816,12 @@ The part of a web request that you want AWS WAF to inspect. Include the single `
 
 The `field_to_match` block supports the following arguments:
 
-~> **Note** Only one of `all_query_arguments`, `body`, `cookies`, `headers`, `ja3_fingerprint`, `json_body`, `method`, `query_string`, `single_header`, `single_query_argument`, or `uri_path` can be specified. An empty configuration block `{}` should be used when specifying `all_query_arguments`, `method`, or `query_string` attributes.
+~> **Note** Only one of `all_query_arguments`, `body`, `cookies`, `header_order`, `headers`, `ja3_fingerprint`, `json_body`, `method`, `query_string`, `single_header`, `single_query_argument`, or `uri_path` can be specified. An empty configuration block `{}` should be used when specifying `all_query_arguments`, `method`, or `query_string` attributes.
 
 * `all_query_arguments` - (Optional) Inspect all query arguments.
 * `body` - (Optional) Inspect the request body, which immediately follows the request headers. See [`body`](#body-block) below for details.
 * `cookies` - (Optional) Inspect the cookies in the web request. See [`cookies`](#cookies-block) below for details.
+* `header_order` - (Optional) Inspect a string containing the list of the request's header names, ordered as they appear in the web request that AWS WAF receives for inspection. See [`header_order`](#header_order-block) below for details.
 * `headers` - (Optional) Inspect the request headers. See [`headers`](#headers-block) below for details.
 * `ja3_fingerprint` - (Optional) Inspect the JA3 fingerprint. See [`ja3_fingerprint`](#ja3_fingerprint-block) below for details.
 * `json_body` - (Optional) Inspect the request body as JSON. See [`json_body`](#json_body-block) for details.
@@ -848,6 +849,14 @@ The `ip_set_forwarded_ip_config` block supports the following arguments:
 * `fallback_behavior` - (Required) - Match status to assign to the web request if the request doesn't have a valid IP address in the specified position. Valid values include: `MATCH` or `NO_MATCH`.
 * `header_name` - (Required) - Name of the HTTP header to use for the IP address.
 * `position` - (Required) - Position in the header to search for the IP address. Valid values include: `FIRST`, `LAST`, or `ANY`. If `ANY` is specified and the header contains more than 10 IP addresses, AWS WAFv2 inspects the last 10.
+
+### `header_order` Block
+
+Inspect a string containing the list of the request's header names, ordered as they appear in the web request that AWS WAF receives for inspection. AWS WAF generates the string and then uses that as the field to match component in its inspection. AWS WAF separates the header names in the string using colons and no added spaces, for example `host:user-agent:accept:authorization:referer`.
+
+The `header_order` block supports the following arguments:
+
+* `oversize_handling` - (Required) Oversize handling tells AWS WAF what to do with a web request when the request component that the rule inspects is over the limits. Valid values include the following: `CONTINUE`, `MATCH`, `NO_MATCH`. See the AWS [documentation](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html) for more information.
 
 ### `headers` Block
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add support for the `header_order` field to match for `aws_wafv2_rule_group` and `aws_wafv2_web_acl` rules.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #35377

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referenced [Request component options](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-fields-list.html#waf-rule-statement-request-component-header-order) for details about the feature, and [CreateRuleGroup](https://docs.aws.amazon.com/waf/latest/APIReference/API_CreateRuleGroup.html) and other pages in the API reference to confirm syntax and behavior.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
Tests for `aws_wafv2_rule_group`:
```console
$ make testacc TESTS=TestAccWAFV2RuleGroup_ PKG=wafv2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/wafv2/... -v -count 1 -parallel 20 -run='TestAccWAFV2RuleGroup_'  -timeout 360m
=== RUN   TestAccWAFV2RuleGroup_basic
=== PAUSE TestAccWAFV2RuleGroup_basic
=== RUN   TestAccWAFV2RuleGroup_nameGenerated
=== PAUSE TestAccWAFV2RuleGroup_nameGenerated
=== RUN   TestAccWAFV2RuleGroup_namePrefix
=== PAUSE TestAccWAFV2RuleGroup_namePrefix
=== RUN   TestAccWAFV2RuleGroup_updateRule
=== PAUSE TestAccWAFV2RuleGroup_updateRule
=== RUN   TestAccWAFV2RuleGroup_updateRuleProperties
=== PAUSE TestAccWAFV2RuleGroup_updateRuleProperties
=== RUN   TestAccWAFV2RuleGroup_byteMatchStatement
=== PAUSE TestAccWAFV2RuleGroup_byteMatchStatement
=== RUN   TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch
=== PAUSE TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch
=== RUN   TestAccWAFV2RuleGroup_changeNameForceNew
=== PAUSE TestAccWAFV2RuleGroup_changeNameForceNew
=== RUN   TestAccWAFV2RuleGroup_changeCapacityForceNew
=== PAUSE TestAccWAFV2RuleGroup_changeCapacityForceNew
=== RUN   TestAccWAFV2RuleGroup_changeMetricNameForceNew
=== PAUSE TestAccWAFV2RuleGroup_changeMetricNameForceNew
=== RUN   TestAccWAFV2RuleGroup_disappears
=== PAUSE TestAccWAFV2RuleGroup_disappears
=== RUN   TestAccWAFV2RuleGroup_RuleLabels
=== PAUSE TestAccWAFV2RuleGroup_RuleLabels
=== RUN   TestAccWAFV2RuleGroup_geoMatchStatement
=== PAUSE TestAccWAFV2RuleGroup_geoMatchStatement
=== RUN   TestAccWAFV2RuleGroup_GeoMatchStatement_forwardedIP
=== PAUSE TestAccWAFV2RuleGroup_GeoMatchStatement_forwardedIP
=== RUN   TestAccWAFV2RuleGroup_LabelMatchStatement
=== PAUSE TestAccWAFV2RuleGroup_LabelMatchStatement
=== RUN   TestAccWAFV2RuleGroup_ipSetReferenceStatement
=== PAUSE TestAccWAFV2RuleGroup_ipSetReferenceStatement
=== RUN   TestAccWAFV2RuleGroup_IPSetReferenceStatement_ipsetForwardedIP
=== PAUSE TestAccWAFV2RuleGroup_IPSetReferenceStatement_ipsetForwardedIP
=== RUN   TestAccWAFV2RuleGroup_logicalRuleStatements
=== PAUSE TestAccWAFV2RuleGroup_logicalRuleStatements
=== RUN   TestAccWAFV2RuleGroup_minimal
=== PAUSE TestAccWAFV2RuleGroup_minimal
=== RUN   TestAccWAFV2RuleGroup_regexMatchStatement
=== PAUSE TestAccWAFV2RuleGroup_regexMatchStatement
=== RUN   TestAccWAFV2RuleGroup_regexPatternSetReferenceStatement
=== PAUSE TestAccWAFV2RuleGroup_regexPatternSetReferenceStatement
=== RUN   TestAccWAFV2RuleGroup_ruleAction
=== PAUSE TestAccWAFV2RuleGroup_ruleAction
=== RUN   TestAccWAFV2RuleGroup_RuleAction_customRequestHandling
=== PAUSE TestAccWAFV2RuleGroup_RuleAction_customRequestHandling
=== RUN   TestAccWAFV2RuleGroup_RuleAction_customResponse
=== PAUSE TestAccWAFV2RuleGroup_RuleAction_customResponse
=== RUN   TestAccWAFV2RuleGroup_sizeConstraintStatement
=== PAUSE TestAccWAFV2RuleGroup_sizeConstraintStatement
=== RUN   TestAccWAFV2RuleGroup_sqliMatchStatement
=== PAUSE TestAccWAFV2RuleGroup_sqliMatchStatement
=== RUN   TestAccWAFV2RuleGroup_tags
=== PAUSE TestAccWAFV2RuleGroup_tags
=== RUN   TestAccWAFV2RuleGroup_xssMatchStatement
=== PAUSE TestAccWAFV2RuleGroup_xssMatchStatement
=== RUN   TestAccWAFV2RuleGroup_rateBasedStatement
=== PAUSE TestAccWAFV2RuleGroup_rateBasedStatement
=== RUN   TestAccWAFV2RuleGroup_RateBased_maxNested
=== PAUSE TestAccWAFV2RuleGroup_RateBased_maxNested
=== RUN   TestAccWAFV2RuleGroup_Operators_maxNested
=== PAUSE TestAccWAFV2RuleGroup_Operators_maxNested
=== CONT  TestAccWAFV2RuleGroup_basic
=== CONT  TestAccWAFV2RuleGroup_IPSetReferenceStatement_ipsetForwardedIP
=== CONT  TestAccWAFV2RuleGroup_changeCapacityForceNew
=== CONT  TestAccWAFV2RuleGroup_ipSetReferenceStatement
=== CONT  TestAccWAFV2RuleGroup_LabelMatchStatement
=== CONT  TestAccWAFV2RuleGroup_RuleAction_customResponse
=== CONT  TestAccWAFV2RuleGroup_GeoMatchStatement_forwardedIP
=== CONT  TestAccWAFV2RuleGroup_RuleAction_customRequestHandling
=== CONT  TestAccWAFV2RuleGroup_geoMatchStatement
=== CONT  TestAccWAFV2RuleGroup_ruleAction
=== CONT  TestAccWAFV2RuleGroup_RuleLabels
=== CONT  TestAccWAFV2RuleGroup_regexPatternSetReferenceStatement
=== CONT  TestAccWAFV2RuleGroup_changeMetricNameForceNew
=== CONT  TestAccWAFV2RuleGroup_disappears
=== CONT  TestAccWAFV2RuleGroup_regexMatchStatement
=== CONT  TestAccWAFV2RuleGroup_minimal
=== CONT  TestAccWAFV2RuleGroup_updateRuleProperties
=== CONT  TestAccWAFV2RuleGroup_logicalRuleStatements
=== CONT  TestAccWAFV2RuleGroup_changeNameForceNew
=== CONT  TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch
--- PASS: TestAccWAFV2RuleGroup_disappears (283.70s)
=== CONT  TestAccWAFV2RuleGroup_byteMatchStatement
--- PASS: TestAccWAFV2RuleGroup_minimal (299.29s)
=== CONT  TestAccWAFV2RuleGroup_namePrefix
--- PASS: TestAccWAFV2RuleGroup_basic (323.85s)
=== CONT  TestAccWAFV2RuleGroup_updateRule
--- PASS: TestAccWAFV2RuleGroup_ipSetReferenceStatement (351.56s)
=== CONT  TestAccWAFV2RuleGroup_nameGenerated
--- PASS: TestAccWAFV2RuleGroup_regexMatchStatement (359.68s)
=== CONT  TestAccWAFV2RuleGroup_rateBasedStatement
--- PASS: TestAccWAFV2RuleGroup_regexPatternSetReferenceStatement (361.26s)
=== CONT  TestAccWAFV2RuleGroup_Operators_maxNested
--- PASS: TestAccWAFV2RuleGroup_changeMetricNameForceNew (534.38s)
=== CONT  TestAccWAFV2RuleGroup_RateBased_maxNested
--- PASS: TestAccWAFV2RuleGroup_changeNameForceNew (543.52s)
=== CONT  TestAccWAFV2RuleGroup_tags
--- PASS: TestAccWAFV2RuleGroup_changeCapacityForceNew (564.01s)
=== CONT  TestAccWAFV2RuleGroup_xssMatchStatement
--- PASS: TestAccWAFV2RuleGroup_GeoMatchStatement_forwardedIP (593.53s)
=== CONT  TestAccWAFV2RuleGroup_sqliMatchStatement
--- PASS: TestAccWAFV2RuleGroup_geoMatchStatement (602.07s)
=== CONT  TestAccWAFV2RuleGroup_sizeConstraintStatement
--- PASS: TestAccWAFV2RuleGroup_RuleAction_customRequestHandling (602.89s)
--- PASS: TestAccWAFV2RuleGroup_RuleLabels (610.78s)
--- PASS: TestAccWAFV2RuleGroup_LabelMatchStatement (624.90s)
--- PASS: TestAccWAFV2RuleGroup_namePrefix (339.68s)
--- PASS: TestAccWAFV2RuleGroup_nameGenerated (329.55s)
--- PASS: TestAccWAFV2RuleGroup_Operators_maxNested (345.19s)
--- PASS: TestAccWAFV2RuleGroup_RuleAction_customResponse (795.01s)
--- PASS: TestAccWAFV2RuleGroup_ruleAction (803.22s)
--- PASS: TestAccWAFV2RuleGroup_updateRuleProperties (816.05s)
--- PASS: TestAccWAFV2RuleGroup_RateBased_maxNested (290.62s)
--- PASS: TestAccWAFV2RuleGroup_byteMatchStatement (547.39s)
--- PASS: TestAccWAFV2RuleGroup_logicalRuleStatements (832.09s)
--- PASS: TestAccWAFV2RuleGroup_updateRule (520.99s)
--- PASS: TestAccWAFV2RuleGroup_IPSetReferenceStatement_ipsetForwardedIP (918.25s)
--- PASS: TestAccWAFV2RuleGroup_xssMatchStatement (361.11s)
--- PASS: TestAccWAFV2RuleGroup_sqliMatchStatement (338.43s)
--- PASS: TestAccWAFV2RuleGroup_sizeConstraintStatement (331.64s)
--- PASS: TestAccWAFV2RuleGroup_tags (413.28s)
--- PASS: TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch (1216.62s)
--- PASS: TestAccWAFV2RuleGroup_rateBasedStatement (889.19s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/wafv2      1249.070s
$
```

Tests for `aws_wafv2_web_acl`:
```console
$ make testacc TESTS=TestAccWAFV2WebACL_ PKG=wafv2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/wafv2/... -v -count 1 -parallel 20 -run='TestAccWAFV2WebACL_'  -timeout 360m
=== RUN   TestAccWAFV2WebACL_basic
=== PAUSE TestAccWAFV2WebACL_basic
=== RUN   TestAccWAFV2WebACL_Update_rule
=== PAUSE TestAccWAFV2WebACL_Update_rule
=== RUN   TestAccWAFV2WebACL_Update_ruleProperties
=== PAUSE TestAccWAFV2WebACL_Update_ruleProperties
=== RUN   TestAccWAFV2WebACL_Update_nameForceNew
=== PAUSE TestAccWAFV2WebACL_Update_nameForceNew
=== RUN   TestAccWAFV2WebACL_disappears
=== PAUSE TestAccWAFV2WebACL_disappears
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_basic
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_basic
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion
=== RUN   TestAccWAFV2WebACL_minimal
=== PAUSE TestAccWAFV2WebACL_minimal
=== RUN   TestAccWAFV2WebACL_RateBased_basic
=== PAUSE TestAccWAFV2WebACL_RateBased_basic
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_basic
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_basic
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_jsonBody
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_jsonBody
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_body
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_body
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_headerOrder
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_headerOrder
=== RUN   TestAccWAFV2WebACL_GeoMatch_basic
=== PAUSE TestAccWAFV2WebACL_GeoMatch_basic
=== RUN   TestAccWAFV2WebACL_GeoMatch_forwardedIP
=== PAUSE TestAccWAFV2WebACL_GeoMatch_forwardedIP
=== RUN   TestAccWAFV2WebACL_LabelMatchStatement
=== PAUSE TestAccWAFV2WebACL_LabelMatchStatement
=== RUN   TestAccWAFV2WebACL_RuleLabels
=== PAUSE TestAccWAFV2WebACL_RuleLabels
=== RUN   TestAccWAFV2WebACL_IPSetReference_basic
=== PAUSE TestAccWAFV2WebACL_IPSetReference_basic
=== RUN   TestAccWAFV2WebACL_IPSetReference_forwardedIP
=== PAUSE TestAccWAFV2WebACL_IPSetReference_forwardedIP
=== RUN   TestAccWAFV2WebACL_RateBased_customKeys
=== PAUSE TestAccWAFV2WebACL_RateBased_customKeys
=== RUN   TestAccWAFV2WebACL_RateBased_forwardedIP
=== PAUSE TestAccWAFV2WebACL_RateBased_forwardedIP
=== RUN   TestAccWAFV2WebACL_RuleGroupReference_basic
=== PAUSE TestAccWAFV2WebACL_RuleGroupReference_basic
=== RUN   TestAccWAFV2WebACL_RuleGroupReference_shieldMitigation
=== PAUSE TestAccWAFV2WebACL_RuleGroupReference_shieldMitigation
=== RUN   TestAccWAFV2WebACL_RuleGroupReference_manageShieldMitigationRule
=== PAUSE TestAccWAFV2WebACL_RuleGroupReference_manageShieldMitigationRule
=== RUN   TestAccWAFV2WebACL_Custom_requestHandling
=== PAUSE TestAccWAFV2WebACL_Custom_requestHandling
=== RUN   TestAccWAFV2WebACL_Custom_response
=== PAUSE TestAccWAFV2WebACL_Custom_response
=== RUN   TestAccWAFV2WebACL_tags
=== PAUSE TestAccWAFV2WebACL_tags
=== RUN   TestAccWAFV2WebACL_RateBased_maxNested
=== PAUSE TestAccWAFV2WebACL_RateBased_maxNested
=== RUN   TestAccWAFV2WebACL_Operators_maxNested
=== PAUSE TestAccWAFV2WebACL_Operators_maxNested
=== RUN   TestAccWAFV2WebACL_tokenDomains
=== PAUSE TestAccWAFV2WebACL_tokenDomains
=== RUN   TestAccWAFV2WebACL_associationConfig
=== PAUSE TestAccWAFV2WebACL_associationConfig
=== RUN   TestAccWAFV2WebACL_CloudFrontScope
=== PAUSE TestAccWAFV2WebACL_CloudFrontScope
=== CONT  TestAccWAFV2WebACL_basic
=== CONT  TestAccWAFV2WebACL_GeoMatch_forwardedIP
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_jsonBody
=== CONT  TestAccWAFV2WebACL_CloudFrontScope
=== CONT  TestAccWAFV2WebACL_GeoMatch_basic
=== CONT  TestAccWAFV2WebACL_associationConfig
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_headerOrder
=== CONT  TestAccWAFV2WebACL_tokenDomains
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_body
=== CONT  TestAccWAFV2WebACL_Operators_maxNested
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_basic
=== CONT  TestAccWAFV2WebACL_RateBased_maxNested
=== CONT  TestAccWAFV2WebACL_tags
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet
=== CONT  TestAccWAFV2WebACL_Custom_response
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet
=== CONT  TestAccWAFV2WebACL_Custom_requestHandling
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig
=== CONT  TestAccWAFV2WebACL_RuleGroupReference_manageShieldMitigationRule
=== NAME  TestAccWAFV2WebACL_CloudFrontScope
    acctest.go:925: skipping tests; AWS_DEFAULT_REGION (us-west-2) not supported. Supported: [us-east-1]
--- SKIP: TestAccWAFV2WebACL_CloudFrontScope (0.28s)
=== CONT  TestAccWAFV2WebACL_RateBased_customKeys
=== NAME  TestAccWAFV2WebACL_associationConfig
    acctest.go:925: skipping tests; AWS_DEFAULT_REGION (us-west-2) not supported. Supported: [us-east-1]
--- SKIP: TestAccWAFV2WebACL_associationConfig (0.28s)
=== CONT  TestAccWAFV2WebACL_RuleGroupReference_shieldMitigation
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl (322.18s)
=== CONT  TestAccWAFV2WebACL_RuleGroupReference_basic
--- PASS: TestAccWAFV2WebACL_tokenDomains (356.55s)
=== CONT  TestAccWAFV2WebACL_RateBased_forwardedIP
--- PASS: TestAccWAFV2WebACL_basic (362.25s)
=== CONT  TestAccWAFV2WebACL_Update_nameForceNew
--- PASS: TestAccWAFV2WebACL_RateBased_maxNested (382.15s)
=== CONT  TestAccWAFV2WebACL_disappears
--- PASS: TestAccWAFV2WebACL_Operators_maxNested (393.99s)
=== CONT  TestAccWAFV2WebACL_Update_ruleProperties
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig (640.05s)
=== CONT  TestAccWAFV2WebACL_IPSetReference_basic
--- PASS: TestAccWAFV2WebACL_GeoMatch_basic (648.34s)
=== CONT  TestAccWAFV2WebACL_IPSetReference_forwardedIP
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet (655.71s)
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_basic
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_body (663.20s)
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_headerOrder (664.02s)
=== CONT  TestAccWAFV2WebACL_RuleLabels
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_jsonBody (675.71s)
=== CONT  TestAccWAFV2WebACL_RateBased_basic
--- PASS: TestAccWAFV2WebACL_GeoMatch_forwardedIP (676.93s)
=== CONT  TestAccWAFV2WebACL_LabelMatchStatement
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet (687.31s)
=== CONT  TestAccWAFV2WebACL_minimal
--- PASS: TestAccWAFV2WebACL_disappears (332.05s)
=== CONT  TestAccWAFV2WebACL_Update_rule
--- PASS: TestAccWAFV2WebACL_RuleGroupReference_shieldMitigation (860.45s)
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion
--- PASS: TestAccWAFV2WebACL_tags (884.01s)
--- PASS: TestAccWAFV2WebACL_Custom_response (912.96s)
--- PASS: TestAccWAFV2WebACL_Update_nameForceNew (604.70s)
--- PASS: TestAccWAFV2WebACL_minimal (303.02s)
--- PASS: TestAccWAFV2WebACL_RateBased_forwardedIP (634.81s)
--- PASS: TestAccWAFV2WebACL_IPSetReference_basic (361.31s)
--- PASS: TestAccWAFV2WebACL_RuleGroupReference_manageShieldMitigationRule (1050.27s)
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_basic (1090.73s)
--- PASS: TestAccWAFV2WebACL_RuleGroupReference_basic (798.98s)
--- PASS: TestAccWAFV2WebACL_Custom_requestHandling (1126.36s)
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_basic (529.59s)
--- PASS: TestAccWAFV2WebACL_RateBased_basic (512.62s)
--- PASS: TestAccWAFV2WebACL_LabelMatchStatement (512.26s)
--- PASS: TestAccWAFV2WebACL_RuleLabels (526.16s)
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint (527.98s)
--- PASS: TestAccWAFV2WebACL_Update_ruleProperties (805.29s)
--- PASS: TestAccWAFV2WebACL_Update_rule (487.74s)
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion (361.15s)
--- PASS: TestAccWAFV2WebACL_IPSetReference_forwardedIP (615.88s)
--- PASS: TestAccWAFV2WebACL_RateBased_customKeys (1336.91s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/wafv2      1337.451s
$ 
```