### PR TITLE
docs: Fix EKS Access Argument: Update principal_arn Parameter Descrip…

### DIFF
--- a/website/docs/d/eks_access_entry.html.markdown
+++ b/website/docs/d/eks_access_entry.html.markdown
@@ -26,7 +26,7 @@ output "eks_access_entry_outputs" {
 ## Argument Reference
 
 * `cluster_name` – (Required) Name of the EKS Cluster. Must be between 1-100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (`^[0-9A-Za-z][A-Za-z0-9\-_]+$`).
-* `principal_arn` – (Required) The IAM Princial ARN which requires Authentication access to the EKS cluster.
+* `principal_arn` – (Required) The IAM Principal ARN which requires Authentication access to the EKS cluster.
 
 ## Attribute Reference
 

--- a/website/docs/r/eks_access_entry.html.markdown
+++ b/website/docs/r/eks_access_entry.html.markdown
@@ -26,7 +26,7 @@ resource "aws_eks_access_entry" "example" {
 The following arguments are required:
 
 * `cluster_name` – (Required) Name of the EKS Cluster. Must be between 1-100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (`^[0-9A-Za-z][A-Za-z0-9\-_]+$`).
-* `principal_arn` – (Required) The IAM Princial ARN which requires Authentication access to the EKS cluster.
+* `principal_arn` – (Required) The IAM Principal ARN which requires Authentication access to the EKS cluster.
 
 The following arguments are optional:
 

--- a/website/docs/r/eks_access_policy_association.html.markdown
+++ b/website/docs/r/eks_access_policy_association.html.markdown
@@ -31,7 +31,7 @@ The following arguments are required:
 
 * `cluster_name` – (Required) Name of the EKS Cluster. Must be between 1-100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (`^[0-9A-Za-z][A-Za-z0-9\-_]+$`).
 * `policy_arn` – (Required) The ARN of the access policy that you're associating.
-* `principal_arn` – (Required) The IAM Princial ARN which requires Authentication access to the EKS cluster.
+* `principal_arn` – (Required) The IAM Principal ARN which requires Authentication access to the EKS cluster.
 * `access_scope` – (Required) The configuration block to determine the scope of the access. See [`access_scope` Block](#access_scope-block) below.
 
 ### `access_scope` Block


### PR DESCRIPTION
### Description
This PR corrects the description of the principal_arn in the argument reference for eks_access_entry and eks_access_policy_association, changing `princial` to `principal`.


### Relations
n/a

### References
n/a

### Output from Acceptance Testing
n/a
