### PR TITLE
fix: add iam retry to eks access entry

### DIFF
--- a/.changelog/35535.txt
+++ b/.changelog/35535.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_eks_access_entry: Fix IAM eventual consistency preventing creation
+resource/aws_eks_access_entry: Retry IAM eventual consistency errors on create
 ```

--- a/.changelog/35535.txt
+++ b/.changelog/35535.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_eks_access_entry: Fix IAM eventual consistency preventing creation
+```

--- a/internal/service/eks/access_entry.go
+++ b/internal/service/eks/access_entry.go
@@ -120,7 +120,9 @@ func resourceAccessEntryCreate(ctx context.Context, d *schema.ResourceData, meta
 		input.Username = aws.String(v.(string))
 	}
 
-	_, err := conn.CreateAccessEntry(ctx, input)
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[*types.InvalidParameterException](ctx, propagationTimeout, func() (interface{}, error) {
+		return conn.CreateAccessEntry(ctx, input)
+	}, "The specified principalArn is invalid: invalid principal")
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating EKS Access Entry (%s): %s", id, err)

--- a/internal/service/eks/access_entry_test.go
+++ b/internal/service/eks/access_entry_test.go
@@ -487,7 +487,7 @@ resource "aws_eks_access_entry" "test" {
 }
 
 func testAccAccessEntryConfig_eventualConsistency(rName string) string {
-	return acctest.ConfigCompose(testAccAccessEntryConfig_base(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccAccessEntryConfig_base(rName), `
 resource "aws_iam_role" "test2" {
   name = "${aws_eks_cluster.test.name}-2"
 
@@ -513,7 +513,7 @@ resource "aws_eks_access_entry" "test" {
 
   type = "EC2_LINUX"
 }
-`))
+`)
 }
 
 func testAccAccessEntryConfig_username(rName, username string) string {

--- a/internal/service/eks/access_entry_test.go
+++ b/internal/service/eks/access_entry_test.go
@@ -257,6 +257,43 @@ func TestAccEKSAccessEntry_username(t *testing.T) {
 	})
 }
 
+func TestAccEKSAccessEntry_eventualConsistency(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var accessentry types.AccessEntry
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_eks_access_entry.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.EKSEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAccessEntryDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAccessEntryConfig_eventualConsistency(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccessEntryExists(ctx, resourceName, &accessentry),
+					acctest.CheckResourceAttrGreaterThanOrEqualValue(resourceName, "kubernetes_groups.#", 1),
+					resource.TestCheckResourceAttr(resourceName, "type", "EC2_LINUX"),
+					resource.TestCheckResourceAttrSet(resourceName, "user_name"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAccessEntryDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).EKSClient(ctx)
@@ -423,6 +460,36 @@ func testAccAccessEntryConfig_type(rName string) string {
 	return acctest.ConfigCompose(testAccAccessEntryConfig_base(rName), fmt.Sprintf(`
 resource "aws_iam_role" "test2" {
   name = "%[1]s-2"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "eks.${data.aws_partition.current.dns_suffix}"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_eks_access_entry" "test" {
+  cluster_name  = aws_eks_cluster.test.name
+  principal_arn = aws_iam_role.test2.arn
+
+  type = "EC2_LINUX"
+}
+`, rName))
+}
+
+func testAccAccessEntryConfig_eventualConsistency(rName string) string {
+	return acctest.ConfigCompose(testAccAccessEntryConfig_base(rName), fmt.Sprintf(`
+resource "aws_iam_role" "test2" {
+  name = "${aws_eks_cluster.test.name}-2"
 
   assume_role_policy = <<POLICY
 {

--- a/internal/service/eks/access_entry_test.go
+++ b/internal/service/eks/access_entry_test.go
@@ -513,7 +513,7 @@ resource "aws_eks_access_entry" "test" {
 
   type = "EC2_LINUX"
 }
-`, rName))
+`))
 }
 
 func testAccAccessEntryConfig_username(rName, username string) string {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
If an EKS Access Entry is made in the same Terraform apply as the IAM role associated with it, it may fail due to eventual consistency with IAM. This PR adds a retry to handle this case.

The existing tests would not have triggered this as the IAM role resource did not depend on the cluster resource, so the role would have been made early, with plenty of time for consistency to catch up by the time the cluster was ready to accept access entry resources.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

N/A

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

N/A

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccEKSAccessEntry_eventualConsistency PKG=eks
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/eks/... -v -count 1 -parallel 20 -run='TestAccEKSAccessEntry_eventualConsistency'  -timeout 360m
=== RUN   TestAccEKSAccessEntry_eventualConsistency
=== PAUSE TestAccEKSAccessEntry_eventualConsistency
=== CONT  TestAccEKSAccessEntry_eventualConsistency
--- PASS: TestAccEKSAccessEntry_eventualConsistency (734.30s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/eks        734.859s
...
```
