### PR TITLE
Tech debt: Migrate `codegurureviewer` resources to AWS SDK for Go v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/codecommit v1.20.1
 	github.com/aws/aws-sdk-go-v2/service/codedeploy v1.22.3
 	github.com/aws/aws-sdk-go-v2/service/codeguruprofiler v1.18.6
+	github.com/aws/aws-sdk-go-v2/service/codegurureviewer v1.22.6
 	github.com/aws/aws-sdk-go-v2/service/codepipeline v1.22.6
 	github.com/aws/aws-sdk-go-v2/service/codestarconnections v1.22.1
 	github.com/aws/aws-sdk-go-v2/service/codestarnotifications v1.20.6

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ github.com/aws/aws-sdk-go-v2/service/codedeploy v1.22.3 h1:KUQmoqL05L+fftMgWLVlk
 github.com/aws/aws-sdk-go-v2/service/codedeploy v1.22.3/go.mod h1:NqMyFU67rmETeGllV83ilhMC7r+7KnjeEvux4PYakPk=
 github.com/aws/aws-sdk-go-v2/service/codeguruprofiler v1.18.6 h1:x5j98Y39PwTePUmTdY5XG7OX9+76sKnA9D88xeCtXcc=
 github.com/aws/aws-sdk-go-v2/service/codeguruprofiler v1.18.6/go.mod h1:iDwHJEm4R1uHugNE19aiKPQ/hYNIPOgLSbbnI6YsPP4=
+github.com/aws/aws-sdk-go-v2/service/codegurureviewer v1.22.6 h1:WFFgT8UwGwweIMUgDJZ1RfU1XESBQWNkOo0ohTtlJFE=
+github.com/aws/aws-sdk-go-v2/service/codegurureviewer v1.22.6/go.mod h1:70WSgelOSLynj945kxLDv7J10zf0JN0s9HUOl49UdS4=
 github.com/aws/aws-sdk-go-v2/service/codepipeline v1.22.6 h1:I1sVOeBvwB0k6urXzQNeyHmK4tsqhBI4bZrxPmDRwK8=
 github.com/aws/aws-sdk-go-v2/service/codepipeline v1.22.6/go.mod h1:Kv4J83SNr492WbgfOKsEkcwqF8Xy10aAaGOh6mYgC8w=
 github.com/aws/aws-sdk-go-v2/service/codestarconnections v1.22.1 h1:BDHWW50nyoLyg/J+Tkwsh/SdTd1uUOkW9LISJH82JCA=

--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -26,6 +26,7 @@ import (
 	codecommit_sdkv2 "github.com/aws/aws-sdk-go-v2/service/codecommit"
 	codedeploy_sdkv2 "github.com/aws/aws-sdk-go-v2/service/codedeploy"
 	codeguruprofiler_sdkv2 "github.com/aws/aws-sdk-go-v2/service/codeguruprofiler"
+	codegurureviewer_sdkv2 "github.com/aws/aws-sdk-go-v2/service/codegurureviewer"
 	codepipeline_sdkv2 "github.com/aws/aws-sdk-go-v2/service/codepipeline"
 	codestarconnections_sdkv2 "github.com/aws/aws-sdk-go-v2/service/codestarconnections"
 	codestarnotifications_sdkv2 "github.com/aws/aws-sdk-go-v2/service/codestarnotifications"
@@ -138,7 +139,6 @@ import (
 	cloudwatch_sdkv1 "github.com/aws/aws-sdk-go/service/cloudwatch"
 	cloudwatchrum_sdkv1 "github.com/aws/aws-sdk-go/service/cloudwatchrum"
 	codeartifact_sdkv1 "github.com/aws/aws-sdk-go/service/codeartifact"
-	codegurureviewer_sdkv1 "github.com/aws/aws-sdk-go/service/codegurureviewer"
 	cognitoidentity_sdkv1 "github.com/aws/aws-sdk-go/service/cognitoidentity"
 	cognitoidentityprovider_sdkv1 "github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
 	configservice_sdkv1 "github.com/aws/aws-sdk-go/service/configservice"
@@ -424,8 +424,8 @@ func (c *AWSClient) CodeGuruProfilerClient(ctx context.Context) *codeguruprofile
 	return errs.Must(client[*codeguruprofiler_sdkv2.Client](ctx, c, names.CodeGuruProfiler, make(map[string]any)))
 }
 
-func (c *AWSClient) CodeGuruReviewerConn(ctx context.Context) *codegurureviewer_sdkv1.CodeGuruReviewer {
-	return errs.Must(conn[*codegurureviewer_sdkv1.CodeGuruReviewer](ctx, c, names.CodeGuruReviewer, make(map[string]any)))
+func (c *AWSClient) CodeGuruReviewerClient(ctx context.Context) *codegurureviewer_sdkv2.Client {
+	return errs.Must(client[*codegurureviewer_sdkv2.Client](ctx, c, names.CodeGuruReviewer, make(map[string]any)))
 }
 
 func (c *AWSClient) CodePipelineClient(ctx context.Context) *codepipeline_sdkv2.Client {

--- a/internal/service/codegurureviewer/exports_test.go
+++ b/internal/service/codegurureviewer/exports_test.go
@@ -6,4 +6,6 @@ package codegurureviewer
 // Exports for use in tests only.
 var (
 	ResourceRepositoryAssociation = resourceRepositoryAssociation
+
+	FindRepositoryAssociationByID = findRepositoryAssociationByID
 )

--- a/internal/service/codegurureviewer/exports_test.go
+++ b/internal/service/codegurureviewer/exports_test.go
@@ -1,0 +1,9 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package codegurureviewer
+
+// Exports for use in tests only.
+var (
+	ResourceRepositoryAssociation = resourceRepositoryAssociation
+)

--- a/internal/service/codegurureviewer/generate.go
+++ b/internal/service/codegurureviewer/generate.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-//go:generate go run ../../generate/tags/main.go -ListTags -ServiceTagsMap -UpdateTags
+//go:generate go run ../../generate/tags/main.go -AWSSDKVersion=2 -KVTValues -SkipTypesImp -ServiceTagsMap -ListTags -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/codegurureviewer/list_pages.go
+++ b/internal/service/codegurureviewer/list_pages.go
@@ -1,0 +1,30 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package codegurureviewer
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/codegurureviewer"
+)
+
+// Custom CodeGuruReviewer service lister functions using the same format as generated code.
+
+func listRepositoryAssociationsPages(ctx context.Context, conn *codegurureviewer.Client, input *codegurureviewer.ListRepositoryAssociationsInput, fn func(*codegurureviewer.ListRepositoryAssociationsOutput, bool) bool) error {
+	for {
+		output, err := conn.ListRepositoryAssociations(ctx, input)
+		if err != nil {
+			return err
+		}
+
+		lastPage := aws.ToString(output.NextToken) == ""
+		if !fn(output, lastPage) || lastPage {
+			break
+		}
+
+		input.NextToken = output.NextToken
+	}
+	return nil
+}

--- a/internal/service/codegurureviewer/repository_association.go
+++ b/internal/service/codegurureviewer/repository_association.go
@@ -10,16 +10,17 @@ import (
 	"time"
 
 	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/codegurureviewer"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/codegurureviewer"
+	"github.com/aws/aws-sdk-go-v2/service/codegurureviewer/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -28,7 +29,7 @@ import (
 
 // @SDKResource("aws_codegurureviewer_repository_association", name="Repository Association")
 // @Tags(identifierAttribute="id")
-func ResourceRepositoryAssociation() *schema.Resource {
+func resourceRepositoryAssociation() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceRepositoryAssociationCreate,
 		ReadWithoutTimeout:   resourceRepositoryAssociationRead,
@@ -66,18 +67,18 @@ func ResourceRepositoryAssociation() *schema.Resource {
 					}
 					// Show difference if existing state reflects different default type
 					_, defaultEncryptionOption := d.GetChange("kms_key_details.0.encryption_option")
-					if defaultEncryptionOption.(string) != codegurureviewer.EncryptionOptionAwsOwnedCmk {
-						return defaultEncryptionOption.(string) == codegurureviewer.EncryptionOptionAwsOwnedCmk
+					if defaultEncryptionOption := types.EncryptionOption(defaultEncryptionOption.(string)); defaultEncryptionOption != types.EncryptionOptionAoCmk {
+						return defaultEncryptionOption == types.EncryptionOptionAoCmk
 					}
 					return true
 				},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"encryption_option": {
-							Type:         schema.TypeString,
-							ForceNew:     true,
-							Optional:     true,
-							ValidateFunc: validation.StringInSlice(codegurureviewer.EncryptionOption_Values(), false),
+							Type:             schema.TypeString,
+							ForceNew:         true,
+							Optional:         true,
+							ValidateDiagFunc: enum.Validate[types.EncryptionOption](),
 						},
 						"kms_key_id": {
 							Type:     schema.TypeString,
@@ -258,45 +259,35 @@ func ResourceRepositoryAssociation() *schema.Resource {
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
-		CustomizeDiff: customdiff.Sequence(
-			verify.SetTagsDiff,
-		),
+
+		CustomizeDiff: verify.SetTagsDiff,
 	}
 }
 
-const (
-	ResNameRepositoryAssociation = "RepositoryAssociation"
-)
-
 func resourceRepositoryAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).CodeGuruReviewerClient(ctx)
 
-	conn := meta.(*conns.AWSClient).CodeGuruReviewerConn(ctx)
-
-	in := &codegurureviewer.AssociateRepositoryInput{
+	input := &codegurureviewer.AssociateRepositoryInput{
 		Tags: getTagsIn(ctx),
 	}
 
-	in.KMSKeyDetails = expandKMSKeyDetails(d.Get("kms_key_details").([]interface{}))
+	input.KMSKeyDetails = expandKMSKeyDetails(d.Get("kms_key_details").([]interface{}))
 
 	if v, ok := d.GetOk("repository"); ok {
-		in.Repository = expandRepository(v.([]interface{}))
+		input.Repository = expandRepository(v.([]interface{}))
 	}
 
-	out, err := conn.AssociateRepositoryWithContext(ctx, in)
+	output, err := conn.AssociateRepository(ctx, input)
 
 	if err != nil {
-		return create.AppendDiagError(diags, names.CodeGuruReviewer, create.ErrActionCreating, ResNameRepositoryAssociation, d.Get("name").(string), err)
+		return sdkdiag.AppendErrorf(diags, "creating CodeGuru Repository Association: %s", err)
 	}
 
-	if out == nil || out.RepositoryAssociation == nil {
-		return create.AppendDiagError(diags, names.CodeGuruReviewer, create.ErrActionCreating, ResNameRepositoryAssociation, d.Get("name").(string), errors.New("empty output"))
-	}
-
-	d.SetId(aws.StringValue(out.RepositoryAssociation.AssociationArn))
+	d.SetId(aws.ToString(output.RepositoryAssociation.AssociationArn))
 
 	if _, err := waitRepositoryAssociationCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return create.AppendDiagError(diags, names.CodeGuruReviewer, create.ErrActionWaitingForCreation, ResNameRepositoryAssociation, d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for CodeGuru Repository Association (%s) create: %s", d.Id(), err)
 	}
 
 	return append(diags, resourceRepositoryAssociationRead(ctx, d, meta)...)
@@ -304,36 +295,32 @@ func resourceRepositoryAssociationCreate(ctx context.Context, d *schema.Resource
 
 func resourceRepositoryAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-
-	conn := meta.(*conns.AWSClient).CodeGuruReviewerConn(ctx)
+	conn := meta.(*conns.AWSClient).CodeGuruReviewerClient(ctx)
 
 	out, err := findRepositoryAssociationByID(ctx, conn, d.Id())
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
-		log.Printf("[WARN] CodeGuruReviewer RepositoryAssociation (%s) not found, removing from state", d.Id())
+		log.Printf("[WARN] CodeGuru Reviewer Repository Association (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
 	}
+
 	if err != nil {
-		return create.AppendDiagError(diags, names.CodeGuruReviewer, create.ErrActionReading, ResNameRepositoryAssociation, d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading CodeGuru Repository Association (%s): %s", d.Id(), err)
 	}
 
 	d.Set("arn", out.AssociationArn)
 	d.Set("association_id", out.AssociationId)
 	d.Set("connection_arn", out.ConnectionArn)
-
 	if err := d.Set("kms_key_details", flattenKMSKeyDetails(out.KMSKeyDetails)); err != nil {
-		return create.AppendDiagError(diags, names.CodeGuruReviewer, create.ErrActionSetting, ResNameRepositoryAssociation, d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "setting kms_key_details: %s", err)
 	}
-
 	d.Set("name", out.Name)
 	d.Set("owner", out.Owner)
 	d.Set("provider_type", out.ProviderType)
-
 	if err := d.Set("s3_repository_details", flattenS3RepositoryDetails(out.S3RepositoryDetails)); err != nil {
-		return create.AppendDiagError(diags, names.CodeGuruReviewer, create.ErrActionSetting, ResNameRepositoryAssociation, d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "setting s3_repository_details: %s", err)
 	}
-
 	d.Set("state", out.State)
 	d.Set("state_reason", out.StateReason)
 
@@ -350,67 +337,57 @@ func resourceRepositoryAssociationUpdate(ctx context.Context, d *schema.Resource
 
 func resourceRepositoryAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).CodeGuruReviewerClient(ctx)
 
-	conn := meta.(*conns.AWSClient).CodeGuruReviewerConn(ctx)
-
-	log.Printf("[INFO] Deleting CodeGuruReviewer RepositoryAssociation %s", d.Id())
-
-	_, err := conn.DisassociateRepositoryWithContext(ctx, &codegurureviewer.DisassociateRepositoryInput{
+	log.Printf("[INFO] Deleting CodeGuru Repository Association %s", d.Id())
+	_, err := conn.DisassociateRepository(ctx, &codegurureviewer.DisassociateRepositoryInput{
 		AssociationArn: aws.String(d.Id()),
 	})
 
-	if tfawserr.ErrCodeEquals(err, codegurureviewer.ErrCodeNotFoundException) {
+	if errs.IsA[*types.NotFoundException](err) {
 		return diags
 	}
 
 	if err != nil {
-		return create.AppendDiagError(diags, names.CodeGuruReviewer, create.ErrActionDeleting, ResNameRepositoryAssociation, d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting CodeGuru Repository Association (%s): %s", d.Id(), err)
 	}
 
 	if _, err := waitRepositoryAssociationDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return create.AppendDiagError(diags, names.CodeGuruReviewer, create.ErrActionWaitingForDeletion, ResNameRepositoryAssociation, d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for CodeGuru Repository Association (%s) delete: %s", d.Id(), err)
 	}
 
 	return diags
 }
 
-func waitRepositoryAssociationCreated(ctx context.Context, conn *codegurureviewer.CodeGuruReviewer, id string, timeout time.Duration) (*codegurureviewer.RepositoryAssociation, error) {
-	stateConf := &retry.StateChangeConf{
-		Pending:                   []string{codegurureviewer.RepositoryAssociationStateAssociating},
-		Target:                    []string{codegurureviewer.RepositoryAssociationStateAssociated},
-		Refresh:                   statusRepositoryAssociation(ctx, conn, id),
-		Timeout:                   timeout,
-		NotFoundChecks:            20,
-		ContinuousTargetOccurence: 2,
+func findRepositoryAssociationByID(ctx context.Context, conn *codegurureviewer.Client, id string) (*types.RepositoryAssociation, error) {
+	input := &codegurureviewer.DescribeRepositoryAssociationInput{
+		AssociationArn: aws.String(id),
 	}
 
-	outputRaw, err := stateConf.WaitForStateContext(ctx)
-	if out, ok := outputRaw.(*codegurureviewer.RepositoryAssociation); ok {
-		return out, err
+	output, err := conn.DescribeRepositoryAssociation(ctx, input)
+
+	if errs.IsA[*types.NotFoundException](err) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
 	}
 
-	return nil, err
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.RepositoryAssociation == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.RepositoryAssociation, nil
 }
 
-func waitRepositoryAssociationDeleted(ctx context.Context, conn *codegurureviewer.CodeGuruReviewer, id string, timeout time.Duration) (*codegurureviewer.RepositoryAssociation, error) {
-	stateConf := &retry.StateChangeConf{
-		Pending: []string{codegurureviewer.RepositoryAssociationStateDisassociating, codegurureviewer.RepositoryAssociationStateAssociated},
-		Target:  []string{},
-		Refresh: statusRepositoryAssociation(ctx, conn, id),
-		Timeout: timeout,
-	}
-
-	outputRaw, err := stateConf.WaitForStateContext(ctx)
-	if out, ok := outputRaw.(*codegurureviewer.RepositoryAssociation); ok {
-		return out, err
-	}
-
-	return nil, err
-}
-
-func statusRepositoryAssociation(ctx context.Context, conn *codegurureviewer.CodeGuruReviewer, id string) retry.StateRefreshFunc {
+func statusRepositoryAssociation(ctx context.Context, conn *codegurureviewer.Client, id string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		out, err := findRepositoryAssociationByID(ctx, conn, id)
+		output, err := findRepositoryAssociationByID(ctx, conn, id)
+
 		if tfresource.NotFound(err) {
 			return nil, "", nil
 		}
@@ -419,52 +396,67 @@ func statusRepositoryAssociation(ctx context.Context, conn *codegurureviewer.Cod
 			return nil, "", err
 		}
 
-		return out, aws.StringValue(out.State), nil
+		return output, string(output.State), nil
 	}
 }
 
-func findRepositoryAssociationByID(ctx context.Context, conn *codegurureviewer.CodeGuruReviewer, id string) (*codegurureviewer.RepositoryAssociation, error) {
-	in := &codegurureviewer.DescribeRepositoryAssociationInput{
-		AssociationArn: aws.String(id),
-	}
-	out, err := conn.DescribeRepositoryAssociationWithContext(ctx, in)
-	if tfawserr.ErrCodeEquals(err, codegurureviewer.ErrCodeNotFoundException) {
-		return nil, &retry.NotFoundError{
-			LastError:   err,
-			LastRequest: in,
-		}
+func waitRepositoryAssociationCreated(ctx context.Context, conn *codegurureviewer.Client, id string, timeout time.Duration) (*types.RepositoryAssociation, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending:                   enum.Slice(types.RepositoryAssociationStateAssociating),
+		Target:                    enum.Slice(types.RepositoryAssociationStateAssociated),
+		Refresh:                   statusRepositoryAssociation(ctx, conn, id),
+		Timeout:                   timeout,
+		NotFoundChecks:            20,
+		ContinuousTargetOccurence: 2,
 	}
 
-	if err != nil {
-		return nil, err
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*types.RepositoryAssociation); ok {
+		tfresource.SetLastError(err, errors.New(aws.ToString(output.StateReason)))
+
+		return output, err
 	}
 
-	if out == nil || out.RepositoryAssociation == nil {
-		return nil, tfresource.NewEmptyResultError(in)
-	}
-
-	return out.RepositoryAssociation, nil
+	return nil, err
 }
 
-func flattenKMSKeyDetails(kmsKeyDetails *codegurureviewer.KMSKeyDetails) []interface{} {
+func waitRepositoryAssociationDeleted(ctx context.Context, conn *codegurureviewer.Client, id string, timeout time.Duration) (*types.RepositoryAssociation, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: enum.Slice(types.RepositoryAssociationStateDisassociating, types.RepositoryAssociationStateAssociated),
+		Target:  []string{},
+		Refresh: statusRepositoryAssociation(ctx, conn, id),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*types.RepositoryAssociation); ok {
+		tfresource.SetLastError(err, errors.New(aws.ToString(output.StateReason)))
+
+		return output, err
+	}
+
+	return nil, err
+}
+
+func flattenKMSKeyDetails(kmsKeyDetails *types.KMSKeyDetails) []interface{} {
 	if kmsKeyDetails == nil {
 		return nil
 	}
 
-	values := map[string]interface{}{}
-
-	if v := kmsKeyDetails.EncryptionOption; v != nil {
-		values["encryption_option"] = aws.StringValue(v)
+	values := map[string]interface{}{
+		"encryption_option": kmsKeyDetails.EncryptionOption,
 	}
 
 	if v := kmsKeyDetails.KMSKeyId; v != nil {
-		values["kms_key_id"] = aws.StringValue(v)
+		values["kms_key_id"] = aws.ToString(v)
 	}
 
 	return []interface{}{values}
 }
 
-func flattenS3RepositoryDetails(s3RepositoryDetails *codegurureviewer.S3RepositoryDetails) []interface{} {
+func flattenS3RepositoryDetails(s3RepositoryDetails *types.S3RepositoryDetails) []interface{} {
 	if s3RepositoryDetails == nil {
 		return nil
 	}
@@ -472,7 +464,7 @@ func flattenS3RepositoryDetails(s3RepositoryDetails *codegurureviewer.S3Reposito
 	values := map[string]interface{}{}
 
 	if v := s3RepositoryDetails.BucketName; v != nil {
-		values["bucket_name"] = aws.StringValue(v)
+		values["bucket_name"] = aws.ToString(v)
 	}
 
 	if v := s3RepositoryDetails.CodeArtifacts; v != nil {
@@ -482,7 +474,7 @@ func flattenS3RepositoryDetails(s3RepositoryDetails *codegurureviewer.S3Reposito
 	return []interface{}{values}
 }
 
-func flattenCodeArtifacts(apiObject *codegurureviewer.CodeArtifacts) map[string]interface{} {
+func flattenCodeArtifacts(apiObject *types.CodeArtifacts) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}
@@ -490,17 +482,17 @@ func flattenCodeArtifacts(apiObject *codegurureviewer.CodeArtifacts) map[string]
 	m := map[string]interface{}{}
 
 	if v := apiObject.BuildArtifactsObjectKey; v != nil {
-		m["build_artifacts_object_key"] = aws.StringValue(v)
+		m["build_artifacts_object_key"] = aws.ToString(v)
 	}
 
 	if v := apiObject.SourceCodeArtifactsObjectKey; v != nil {
-		m["source_code_artifacts_object_key"] = aws.StringValue(v)
+		m["source_code_artifacts_object_key"] = aws.ToString(v)
 	}
 
 	return m
 }
 
-func expandKMSKeyDetails(kmsKeyDetails []interface{}) *codegurureviewer.KMSKeyDetails {
+func expandKMSKeyDetails(kmsKeyDetails []interface{}) *types.KMSKeyDetails {
 	if len(kmsKeyDetails) == 0 || kmsKeyDetails[0] == nil {
 		return nil
 	}
@@ -510,10 +502,10 @@ func expandKMSKeyDetails(kmsKeyDetails []interface{}) *codegurureviewer.KMSKeyDe
 		return nil
 	}
 
-	result := &codegurureviewer.KMSKeyDetails{}
+	result := &types.KMSKeyDetails{}
 
 	if v, ok := tfMap["encryption_option"].(string); ok && v != "" {
-		result.EncryptionOption = aws.String(v)
+		result.EncryptionOption = types.EncryptionOption(v)
 	}
 
 	if v, ok := tfMap["kms_key_id"].(string); ok && v != "" {
@@ -523,7 +515,7 @@ func expandKMSKeyDetails(kmsKeyDetails []interface{}) *codegurureviewer.KMSKeyDe
 	return result
 }
 
-func expandCodeCommitRepository(repository []interface{}) *codegurureviewer.CodeCommitRepository {
+func expandCodeCommitRepository(repository []interface{}) *types.CodeCommitRepository {
 	if len(repository) == 0 || repository[0] == nil {
 		return nil
 	}
@@ -533,7 +525,7 @@ func expandCodeCommitRepository(repository []interface{}) *codegurureviewer.Code
 		return nil
 	}
 
-	result := &codegurureviewer.CodeCommitRepository{}
+	result := &types.CodeCommitRepository{}
 
 	if v, ok := tfMap["name"].(string); ok && v != "" {
 		result.Name = aws.String(v)
@@ -542,7 +534,7 @@ func expandCodeCommitRepository(repository []interface{}) *codegurureviewer.Code
 	return result
 }
 
-func expandRepository(repository []interface{}) *codegurureviewer.Repository {
+func expandRepository(repository []interface{}) *types.Repository {
 	if len(repository) == 0 || repository[0] == nil {
 		return nil
 	}
@@ -552,7 +544,7 @@ func expandRepository(repository []interface{}) *codegurureviewer.Repository {
 		return nil
 	}
 
-	result := &codegurureviewer.Repository{}
+	result := &types.Repository{}
 
 	if v, ok := tfMap["bitbucket"]; ok {
 		result.Bitbucket = expandThirdPartySourceRepository(v.([]interface{}))
@@ -570,7 +562,7 @@ func expandRepository(repository []interface{}) *codegurureviewer.Repository {
 	return result
 }
 
-func expandS3Repository(repository []interface{}) *codegurureviewer.S3Repository {
+func expandS3Repository(repository []interface{}) *types.S3Repository {
 	if len(repository) == 0 || repository[0] == nil {
 		return nil
 	}
@@ -580,7 +572,7 @@ func expandS3Repository(repository []interface{}) *codegurureviewer.S3Repository
 		return nil
 	}
 
-	result := &codegurureviewer.S3Repository{}
+	result := &types.S3Repository{}
 
 	if v, ok := tfMap["bucket_name"].(string); ok && v != "" {
 		result.BucketName = aws.String(v)
@@ -593,7 +585,7 @@ func expandS3Repository(repository []interface{}) *codegurureviewer.S3Repository
 	return result
 }
 
-func expandThirdPartySourceRepository(repository []interface{}) *codegurureviewer.ThirdPartySourceRepository {
+func expandThirdPartySourceRepository(repository []interface{}) *types.ThirdPartySourceRepository {
 	if len(repository) == 0 || repository[0] == nil {
 		return nil
 	}
@@ -603,7 +595,7 @@ func expandThirdPartySourceRepository(repository []interface{}) *codegurureviewe
 		return nil
 	}
 
-	result := &codegurureviewer.ThirdPartySourceRepository{}
+	result := &types.ThirdPartySourceRepository{}
 
 	if v, ok := tfMap["connection_arn"].(string); ok && v != "" {
 		result.ConnectionArn = aws.String(v)

--- a/internal/service/codegurureviewer/repository_association_test.go
+++ b/internal/service/codegurureviewer/repository_association_test.go
@@ -5,21 +5,19 @@ package codegurureviewer_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/codegurureviewer"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/service/codegurureviewer"
+	"github.com/aws/aws-sdk-go-v2/service/codegurureviewer/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	tfcodegurureviewer "github.com/hashicorp/terraform-provider-aws/internal/service/codegurureviewer"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -27,17 +25,17 @@ import (
 // However, this has been manually tested successfully
 func TestAccCodeGuruReviewerRepositoryAssociation_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	var repositoryassociation codegurureviewer.DescribeRepositoryAssociationOutput
+	var repositoryassociation types.RepositoryAssociation
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_codegurureviewer_repository_association.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, codegurureviewer.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.CodeGuruReviewerEndpointID)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, codegurureviewer.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.CodeGuruReviewerEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckRepositoryAssociationDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -62,17 +60,17 @@ func TestAccCodeGuruReviewerRepositoryAssociation_basic(t *testing.T) {
 
 func TestAccCodeGuruReviewerRepositoryAssociation_KMSKey(t *testing.T) {
 	ctx := acctest.Context(t)
-	var repositoryassociation codegurureviewer.DescribeRepositoryAssociationOutput
+	var repositoryassociation types.RepositoryAssociation
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_codegurureviewer_repository_association.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, codegurureviewer.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.CodeGuruReviewerEndpointID)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, codegurureviewer.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.CodeGuruReviewerEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckRepositoryAssociationDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -97,17 +95,17 @@ func TestAccCodeGuruReviewerRepositoryAssociation_KMSKey(t *testing.T) {
 
 func TestAccCodeGuruReviewerRepositoryAssociation_S3Repository(t *testing.T) {
 	ctx := acctest.Context(t)
-	var repositoryassociation codegurureviewer.DescribeRepositoryAssociationOutput
-	rName := "codeguru-reviewer-" + sdkacctest.RandString(10)
+	var repositoryassociation types.RepositoryAssociation
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_codegurureviewer_repository_association.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, codegurureviewer.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.CodeGuruReviewerEndpointID)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, codegurureviewer.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.CodeGuruReviewerEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckRepositoryAssociationDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -133,17 +131,17 @@ func TestAccCodeGuruReviewerRepositoryAssociation_S3Repository(t *testing.T) {
 
 func TestAccCodeGuruReviewerRepositoryAssociation_tags(t *testing.T) {
 	ctx := acctest.Context(t)
-	var repositoryassociation codegurureviewer.DescribeRepositoryAssociationOutput
+	var repositoryassociation types.RepositoryAssociation
 	resourceName := "aws_codegurureviewer_repository_association.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, codegurureviewer.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.CodeGuruReviewerEndpointID)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, codegurureviewer.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.CodeGuruReviewerEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckRepositoryAssociationDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -178,16 +176,16 @@ func TestAccCodeGuruReviewerRepositoryAssociation_tags(t *testing.T) {
 
 func TestAccCodeGuruReviewerRepositoryAssociation_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	var repositoryassociation codegurureviewer.DescribeRepositoryAssociationOutput
+	var repositoryassociation types.RepositoryAssociation
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_codegurureviewer_repository_association.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, codegurureviewer.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.CodeGuruReviewerEndpointID)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, codegurureviewer.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.CodeGuruReviewerEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckRepositoryAssociationDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -205,62 +203,56 @@ func TestAccCodeGuruReviewerRepositoryAssociation_disappears(t *testing.T) {
 
 func testAccCheckRepositoryAssociationDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).CodeGuruReviewerConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).CodeGuruReviewerClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_codegurureviewer_repository_association" {
 				continue
 			}
 
-			input := &codegurureviewer.DescribeRepositoryAssociationInput{
-				AssociationArn: aws.String(rs.Primary.ID),
+			_, err := tfcodegurureviewer.FindRepositoryAssociationByID(ctx, conn, rs.Primary.ID)
+
+			if tfresource.NotFound(err) {
+				continue
 			}
-			_, err := conn.DescribeRepositoryAssociationWithContext(ctx, input)
+
 			if err != nil {
-				if tfawserr.ErrCodeEquals(err, codegurureviewer.ErrCodeNotFoundException) {
-					return nil
-				}
 				return err
 			}
 
-			return fmt.Errorf("CodeGuru Reviewer Association Connection %s still exists", rs.Primary.ID)
+			return fmt.Errorf("CodeGuru Reviewer Repository Association (%s) still exists", rs.Primary.ID)
 		}
 
 		return nil
 	}
 }
 
-func testAccCheckRepositoryAssociationExists(ctx context.Context, name string, repositoryassociation *codegurureviewer.DescribeRepositoryAssociationOutput) resource.TestCheckFunc {
+func testAccCheckRepositoryAssociationExists(ctx context.Context, n string, v *types.RepositoryAssociation) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return create.Error(names.CodeGuruReviewer, create.ErrActionCheckingExistence, tfcodegurureviewer.ResNameRepositoryAssociation, name, errors.New("not found"))
+			return fmt.Errorf("Not found: %s", n)
 		}
 
-		if rs.Primary.ID == "" {
-			return create.Error(names.CodeGuruReviewer, create.ErrActionCheckingExistence, tfcodegurureviewer.ResNameRepositoryAssociation, name, errors.New("not set"))
-		}
+		conn := acctest.Provider.Meta().(*conns.AWSClient).CodeGuruReviewerClient(ctx)
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).CodeGuruReviewerConn(ctx)
-		resp, err := conn.DescribeRepositoryAssociationWithContext(ctx, &codegurureviewer.DescribeRepositoryAssociationInput{
-			AssociationArn: aws.String(rs.Primary.ID),
-		})
+		output, err := tfcodegurureviewer.FindRepositoryAssociationByID(ctx, conn, rs.Primary.ID)
 
 		if err != nil {
-			return create.Error(names.CodeGuruReviewer, create.ErrActionCheckingExistence, tfcodegurureviewer.ResNameRepositoryAssociation, rs.Primary.ID, err)
+			return err
 		}
 
-		*repositoryassociation = *resp
+		*v = *output
 
 		return nil
 	}
 }
 
 func testAccPreCheck(ctx context.Context, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).CodeGuruReviewerConn(ctx)
+	conn := acctest.Provider.Meta().(*conns.AWSClient).CodeGuruReviewerClient(ctx)
 
 	input := &codegurureviewer.ListRepositoryAssociationsInput{}
-	_, err := conn.ListRepositoryAssociationsWithContext(ctx, input)
+	_, err := conn.ListRepositoryAssociations(ctx, input)
 
 	if acctest.PreCheckSkipError(err) {
 		t.Skipf("skipping acceptance testing: %s", err)

--- a/internal/service/codegurureviewer/repository_association_test.go
+++ b/internal/service/codegurureviewer/repository_association_test.go
@@ -119,7 +119,7 @@ func TestAccCodeGuruReviewerRepositoryAssociation_S3Repository(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "repository.0.codecommit.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "repository.0.github_enterprise_server.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "repository.0.s3_bucket.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "repository.0.s3_bucket.0.bucket_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "repository.0.s3_bucket.0.bucket_name", "codeguru-reviewer-"+rName),
 					resource.TestCheckResourceAttr(resourceName, "repository.0.s3_bucket.0.name", "test"),
 					resource.TestCheckResourceAttr(resourceName, "kms_key_details.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "kms_key_details.0.encryption_option", "AWS_OWNED_CMK"),
@@ -326,7 +326,7 @@ resource "aws_codegurureviewer_repository_association" "test" {
 func testAccRepositoryAssociationConfig_s3_repository(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
-  bucket = %[1]q
+  bucket = "codeguru-reviewer-%[1]s"
 }
 
 resource "aws_codegurureviewer_repository_association" "test" {

--- a/internal/service/codegurureviewer/service_package_gen.go
+++ b/internal/service/codegurureviewer/service_package_gen.go
@@ -5,9 +5,8 @@ package codegurureviewer
 import (
 	"context"
 
-	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
-	session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
-	codegurureviewer_sdkv1 "github.com/aws/aws-sdk-go/service/codegurureviewer"
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	codegurureviewer_sdkv2 "github.com/aws/aws-sdk-go-v2/service/codegurureviewer"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -44,11 +43,15 @@ func (p *servicePackage) ServicePackageName() string {
 	return names.CodeGuruReviewer
 }
 
-// NewConn returns a new AWS SDK for Go v1 client for this service package's AWS API.
-func (p *servicePackage) NewConn(ctx context.Context, config map[string]any) (*codegurureviewer_sdkv1.CodeGuruReviewer, error) {
-	sess := config["session"].(*session_sdkv1.Session)
+// NewClient returns a new AWS SDK for Go v2 client for this service package's AWS API.
+func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (*codegurureviewer_sdkv2.Client, error) {
+	cfg := *(config["aws_sdkv2_config"].(*aws_sdkv2.Config))
 
-	return codegurureviewer_sdkv1.New(sess.Copy(&aws_sdkv1.Config{Endpoint: aws_sdkv1.String(config["endpoint"].(string))})), nil
+	return codegurureviewer_sdkv2.NewFromConfig(cfg, func(o *codegurureviewer_sdkv2.Options) {
+		if endpoint := config["endpoint"].(string); endpoint != "" {
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
+		}
+	}), nil
 }
 
 func ServicePackage(ctx context.Context) conns.ServicePackage {

--- a/internal/service/codegurureviewer/service_package_gen.go
+++ b/internal/service/codegurureviewer/service_package_gen.go
@@ -29,7 +29,7 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePackageSDKResource {
 	return []*types.ServicePackageSDKResource{
 		{
-			Factory:  ResourceRepositoryAssociation,
+			Factory:  resourceRepositoryAssociation,
 			TypeName: "aws_codegurureviewer_repository_association",
 			Name:     "Repository Association",
 			Tags: &types.ServicePackageResourceTags{

--- a/internal/service/codegurureviewer/sweep.go
+++ b/internal/service/codegurureviewer/sweep.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/codegurureviewer"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/codegurureviewer"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
-	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv1"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
 )
 
 func RegisterSweepers() {
@@ -28,20 +28,18 @@ func sweepAssociations(region string) error {
 		return fmt.Errorf("error getting client: %w", err)
 	}
 	input := &codegurureviewer.ListRepositoryAssociationsInput{}
-	conn := client.CodeGuruReviewerConn(ctx)
-
+	conn := client.CodeGuruReviewerClient(ctx)
 	sweepResources := make([]sweep.Sweepable, 0)
 
-	err = conn.ListRepositoryAssociationsPagesWithContext(ctx, input, func(page *codegurureviewer.ListRepositoryAssociationsOutput, lastPage bool) bool {
+	err = listRepositoryAssociationsPages(ctx, conn, input, func(page *codegurureviewer.ListRepositoryAssociationsOutput, lastPage bool) bool {
 		if page == nil {
 			return !lastPage
 		}
 
 		for _, v := range page.RepositoryAssociationSummaries {
-			r := ResourceRepositoryAssociation()
+			r := resourceRepositoryAssociation()
 			d := r.Data(nil)
-
-			d.SetId(aws.StringValue(v.Name))
+			d.SetId(aws.ToString(v.Name))
 
 			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 		}
@@ -49,19 +47,19 @@ func sweepAssociations(region string) error {
 		return !lastPage
 	})
 
-	if awsv1.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping CodeGuruReviewer Association sweep for %s: %s", region, err)
+	if awsv2.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping CodeGuru Reviewer Repository Association sweep for %s: %s", region, err)
 		return nil
 	}
 
 	if err != nil {
-		return fmt.Errorf("error listing CodeGuruReviewer Associations (%s): %w", region, err)
+		return fmt.Errorf("error listing CodeGuru Reviewer Repository Associations (%s): %w", region, err)
 	}
 
 	err = sweep.SweepOrchestrator(ctx, sweepResources)
 
 	if err != nil {
-		return fmt.Errorf("error sweeping CodeGuruReviewer Associations (%s): %w", region, err)
+		return fmt.Errorf("error sweeping CodeGuru Reviewer Repository Associations (%s): %w", region, err)
 	}
 
 	return nil

--- a/internal/service/codegurureviewer/tags_gen.go
+++ b/internal/service/codegurureviewer/tags_gen.go
@@ -5,9 +5,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/codegurureviewer"
-	"github.com/aws/aws-sdk-go/service/codegurureviewer/codegururevieweriface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/codegurureviewer"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/logging"
@@ -19,12 +18,12 @@ import (
 // listTags lists codegurureviewer service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn codegururevieweriface.CodeGuruReviewerAPI, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *codegurureviewer.Client, identifier string, optFns ...func(*codegurureviewer.Options)) (tftags.KeyValueTags, error) {
 	input := &codegurureviewer.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResourceWithContext(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -36,7 +35,7 @@ func listTags(ctx context.Context, conn codegururevieweriface.CodeGuruReviewerAP
 // ListTags lists codegurureviewer service tags and set them in Context.
 // It is called from outside this package.
 func (p *servicePackage) ListTags(ctx context.Context, meta any, identifier string) error {
-	tags, err := listTags(ctx, meta.(*conns.AWSClient).CodeGuruReviewerConn(ctx), identifier)
+	tags, err := listTags(ctx, meta.(*conns.AWSClient).CodeGuruReviewerClient(ctx), identifier)
 
 	if err != nil {
 		return err
@@ -49,21 +48,21 @@ func (p *servicePackage) ListTags(ctx context.Context, meta any, identifier stri
 	return nil
 }
 
-// map[string]*string handling
+// map[string]string handling
 
 // Tags returns codegurureviewer service tags.
-func Tags(tags tftags.KeyValueTags) map[string]*string {
-	return aws.StringMap(tags.Map())
+func Tags(tags tftags.KeyValueTags) map[string]string {
+	return tags.Map()
 }
 
 // KeyValueTags creates tftags.KeyValueTags from codegurureviewer service tags.
-func KeyValueTags(ctx context.Context, tags map[string]*string) tftags.KeyValueTags {
+func KeyValueTags(ctx context.Context, tags map[string]string) tftags.KeyValueTags {
 	return tftags.New(ctx, tags)
 }
 
 // getTagsIn returns codegurureviewer service tags from Context.
 // nil is returned if there are no input tags.
-func getTagsIn(ctx context.Context) map[string]*string {
+func getTagsIn(ctx context.Context) map[string]string {
 	if inContext, ok := tftags.FromContext(ctx); ok {
 		if tags := Tags(inContext.TagsIn.UnwrapOrDefault()); len(tags) > 0 {
 			return tags
@@ -74,7 +73,7 @@ func getTagsIn(ctx context.Context) map[string]*string {
 }
 
 // setTagsOut sets codegurureviewer service tags in Context.
-func setTagsOut(ctx context.Context, tags map[string]*string) {
+func setTagsOut(ctx context.Context, tags map[string]string) {
 	if inContext, ok := tftags.FromContext(ctx); ok {
 		inContext.TagsOut = option.Some(KeyValueTags(ctx, tags))
 	}
@@ -83,7 +82,7 @@ func setTagsOut(ctx context.Context, tags map[string]*string) {
 // updateTags updates codegurureviewer service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn codegururevieweriface.CodeGuruReviewerAPI, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *codegurureviewer.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*codegurureviewer.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -94,10 +93,10 @@ func updateTags(ctx context.Context, conn codegururevieweriface.CodeGuruReviewer
 	if len(removedTags) > 0 {
 		input := &codegurureviewer.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.Keys()),
+			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResourceWithContext(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -112,7 +111,7 @@ func updateTags(ctx context.Context, conn codegururevieweriface.CodeGuruReviewer
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResourceWithContext(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)
@@ -125,5 +124,5 @@ func updateTags(ctx context.Context, conn codegururevieweriface.CodeGuruReviewer
 // UpdateTags updates codegurureviewer service tags.
 // It is called from outside this package.
 func (p *servicePackage) UpdateTags(ctx context.Context, meta any, identifier string, oldTags, newTags any) error {
-	return updateTags(ctx, meta.(*conns.AWSClient).CodeGuruReviewerConn(ctx), identifier, oldTags, newTags)
+	return updateTags(ctx, meta.(*conns.AWSClient).CodeGuruReviewerClient(ctx), identifier, oldTags, newTags)
 }

--- a/names/data/names_data.csv
+++ b/names/data/names_data.csv
@@ -79,7 +79,7 @@ codebuild,codebuild,codebuild,codebuild,,codebuild,,,CodeBuild,CodeBuild,,,2,,aw
 codecommit,codecommit,codecommit,codecommit,,codecommit,,,CodeCommit,CodeCommit,,,2,,aws_codecommit_,,codecommit_,CodeCommit,AWS,,,,,,,CodeCommit,,,
 deploy,deploy,codedeploy,codedeploy,,deploy,,codedeploy,Deploy,CodeDeploy,,,2,aws_codedeploy_,aws_deploy_,,codedeploy_,CodeDeploy,AWS,,,,,,,CodeDeploy,,,
 codeguruprofiler,codeguruprofiler,codeguruprofiler,codeguruprofiler,,codeguruprofiler,,,CodeGuruProfiler,CodeGuruProfiler,,,2,,aws_codeguruprofiler_,,codeguruprofiler_,CodeGuru Profiler,Amazon,,,,,,,CodeGuruProfiler,ListProfilingGroups,,
-codeguru-reviewer,codegurureviewer,codegurureviewer,codegurureviewer,,codegurureviewer,,,CodeGuruReviewer,CodeGuruReviewer,,1,,,aws_codegurureviewer_,,codegurureviewer_,CodeGuru Reviewer,Amazon,,,,,,,CodeGuru Reviewer,,,
+codeguru-reviewer,codegurureviewer,codegurureviewer,codegurureviewer,,codegurureviewer,,,CodeGuruReviewer,CodeGuruReviewer,,,2,,aws_codegurureviewer_,,codegurureviewer_,CodeGuru Reviewer,Amazon,,,,,,,CodeGuru Reviewer,,,
 codepipeline,codepipeline,codepipeline,codepipeline,,codepipeline,,,CodePipeline,CodePipeline,,,2,aws_codepipeline,aws_codepipeline_,,codepipeline,CodePipeline,AWS,,,,,,,CodePipeline,ListPipelines,,
 codestar,codestar,codestar,codestar,,codestar,,,CodeStar,CodeStar,,1,,,aws_codestar_,,codestar_,CodeStar,AWS,,x,,,,,CodeStar,,,
 codestar-connections,codestarconnections,codestarconnections,codestarconnections,,codestarconnections,,,CodeStarConnections,CodeStarConnections,,,2,,aws_codestarconnections_,,codestarconnections_,CodeStar Connections,AWS,,,,,,,CodeStar connections,ListConnections,,

--- a/names/names.go
+++ b/names/names.go
@@ -44,6 +44,7 @@ const (
 	CodeCommitEndpointID                 = "codecommit"
 	CodeDeployEndpointID                 = "codedeploy"
 	CodeGuruProfilerEndpointID           = "codeguru-profiler"
+	CodeGuruReviewerEndpointID           = "codeguru-reviewer"
 	CodePipelineEndpointID               = "codepipeline"
 	CodeStarConnectionsEndpointID        = "codestar-connections"
 	CodeStarNotificationsEndpointID      = "codestar-notifications"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Ibid.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/32976.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccCodeGuruReviewerRepositoryAssociation_' PKG=codegurureviewer ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/codegurureviewer/... -v -count 1 -parallel 2  -run=TestAccCodeGuruReviewerRepositoryAssociation_ -timeout 360m
=== RUN   TestAccCodeGuruReviewerRepositoryAssociation_basic
=== PAUSE TestAccCodeGuruReviewerRepositoryAssociation_basic
=== RUN   TestAccCodeGuruReviewerRepositoryAssociation_KMSKey
=== PAUSE TestAccCodeGuruReviewerRepositoryAssociation_KMSKey
=== RUN   TestAccCodeGuruReviewerRepositoryAssociation_S3Repository
=== PAUSE TestAccCodeGuruReviewerRepositoryAssociation_S3Repository
=== RUN   TestAccCodeGuruReviewerRepositoryAssociation_tags
=== PAUSE TestAccCodeGuruReviewerRepositoryAssociation_tags
=== RUN   TestAccCodeGuruReviewerRepositoryAssociation_disappears
=== PAUSE TestAccCodeGuruReviewerRepositoryAssociation_disappears
=== CONT  TestAccCodeGuruReviewerRepositoryAssociation_basic
=== CONT  TestAccCodeGuruReviewerRepositoryAssociation_tags
--- PASS: TestAccCodeGuruReviewerRepositoryAssociation_basic (75.49s)
=== CONT  TestAccCodeGuruReviewerRepositoryAssociation_disappears
--- PASS: TestAccCodeGuruReviewerRepositoryAssociation_tags (120.12s)
=== CONT  TestAccCodeGuruReviewerRepositoryAssociation_S3Repository
--- PASS: TestAccCodeGuruReviewerRepositoryAssociation_disappears (84.71s)
=== CONT  TestAccCodeGuruReviewerRepositoryAssociation_KMSKey
--- PASS: TestAccCodeGuruReviewerRepositoryAssociation_S3Repository (76.59s)
--- PASS: TestAccCodeGuruReviewerRepositoryAssociation_KMSKey (73.97s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codegurureviewer	244.340s
```
