### PR TITLE
New Resource slot_type

### DIFF
--- a/.changelog/35555.txt
+++ b/.changelog/35555.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_lexv2models_slot_type
+```

--- a/internal/framework/flex/autoflex.go
+++ b/internal/framework/flex/autoflex.go
@@ -160,6 +160,7 @@ func findFieldFuzzy(ctx context.Context, fieldNameFrom string, valTo, valFrom re
 
 	// fourth precedence is using resource prefix
 	if v, ok := ctx.Value(ResourcePrefix).(string); ok && v != "" {
+		v = strings.ReplaceAll(v, " ", "")
 		if ctx.Value(ResourcePrefixRecurse) == nil {
 			// so it will only recurse once
 			ctx = context.WithValue(ctx, ResourcePrefixRecurse, true)

--- a/internal/service/lexv2models/exports_test.go
+++ b/internal/service/lexv2models/exports_test.go
@@ -10,6 +10,7 @@ var (
 	ResourceBotVersion = newResourceBotVersion
 	ResourceIntent     = newResourceIntent
 	ResourceSlot       = newResourceSlot
+	ResourceSlotType   = newResourceSlotType
 
 	FindSlotByID = findSlotByID
 )

--- a/internal/service/lexv2models/service_package_gen.go
+++ b/internal/service/lexv2models/service_package_gen.go
@@ -43,6 +43,10 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 			Factory: newResourceSlot,
 			Name:    "Slot",
 		},
+		{
+			Factory: newResourceSlotType,
+			Name:    "Slot Type",
+		},
 	}
 }
 

--- a/internal/service/lexv2models/slot_type.go
+++ b/internal/service/lexv2models/slot_type.go
@@ -550,7 +550,7 @@ type GrammarSlotTypeSetting struct {
 }
 
 type ExternalSourceSetting struct {
-	GrammarSlotTypeSetting fwtypes.ListNestedObjectValueOf[GrammarSlotTypeSetting] `tfsdk: "grammar_slot_type_setting"`
+	GrammarSlotTypeSetting fwtypes.ListNestedObjectValueOf[GrammarSlotTypeSetting] `tfsdk:"grammar_slot_type_setting"`
 }
 
 type SlotTypeValue struct {
@@ -563,7 +563,7 @@ type SlotTypeValues struct {
 }
 
 type AdvancedRecognitionSetting struct {
-	AudioRecognitionSetting fwtypes.ListNestedObjectValueOf[awstypes.AudioRecognitionStrategy] `tfsdk:"audio_recognition_setting"`
+	AudioRecognitionSetting types.String `tfsdk:"audio_recognition_setting"`
 }
 
 type RegexFilter struct {
@@ -571,9 +571,9 @@ type RegexFilter struct {
 }
 
 type ValueSelectionSetting struct {
-	ResolutionStrategy         fwtypes.StringEnum[awstypes.SlotValueResolutionStrategy]    `tfsdk: "resolution_strategy"`
-	AdvancedRecognitionSetting fwtypes.ListNestedObjectValueOf[AdvancedRecognitionSetting] `tfsdk: "advanced_recognition_setting"`
-	RegexFilter                fwtypes.ListNestedObjectValueOf[RegexFilter]                `tfsdk: "regex_filter"`
+	ResolutionStrategy         fwtypes.StringEnum[awstypes.SlotValueResolutionStrategy]    `tfsdk:"resolution_strategy"`
+	AdvancedRecognitionSetting fwtypes.ListNestedObjectValueOf[AdvancedRecognitionSetting] `tfsdk:"advanced_recognition_setting"`
+	RegexFilter                fwtypes.ListNestedObjectValueOf[RegexFilter]                `tfsdk:"regex_filter"`
 }
 
 func slotTypeHasChanges(_ context.Context, plan, state resourceSlotTypeData) bool {

--- a/internal/service/lexv2models/slot_type.go
+++ b/internal/service/lexv2models/slot_type.go
@@ -1,0 +1,586 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package lexv2models
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lexmodelsv2"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/lexmodelsv2/types"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	intflex "github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource(name="Slot Type")
+func newResourceSlotType(_ context.Context) (resource.ResourceWithConfigure, error) {
+	r := &resourceSlotType{}
+
+	r.SetDefaultCreateTimeout(30 * time.Minute)
+	r.SetDefaultUpdateTimeout(30 * time.Minute)
+	r.SetDefaultDeleteTimeout(30 * time.Minute)
+
+	return r, nil
+}
+
+const (
+	ResNameSlotType = "Slot Type"
+
+	slotTypeIDPartCount = 4
+)
+
+type resourceSlotType struct {
+	framework.ResourceWithConfigure
+	framework.WithTimeouts
+}
+
+func (r *resourceSlotType) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "aws_lexv2models_slot_type"
+}
+
+func (r *resourceSlotType) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+
+	subSlotTypeCompositionLNB := schema.ListNestedBlock{
+		CustomType: fwtypes.NewListNestedObjectTypeOf[SubSlotTypeComposition](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"name": schema.StringAttribute{
+					Required: true,
+				},
+				"slot_type_id": schema.StringAttribute{
+					Required: true,
+				},
+			},
+		},
+	}
+
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"bot_id": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"bot_version": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"description": schema.StringAttribute{
+				Optional: true,
+			},
+			"id": framework.IDAttribute(),
+			"locale_id": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"slot_type_id": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Required: true,
+			},
+			"parent_slot_type_signature": schema.StringAttribute{
+				Optional: true,
+			},
+			"type": schema.StringAttribute{
+				Required: true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"composite_slot_type_setting": schema.ListNestedBlock{
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				CustomType: fwtypes.NewListNestedObjectTypeOf[CompositeSlotTypeSetting](ctx),
+				NestedObject: schema.NestedBlockObject{
+					Blocks: map[string]schema.Block{
+						"subslots": subSlotTypeCompositionLNB,
+					},
+				},
+			},
+			"external_source_setting": schema.ListNestedBlock{
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				CustomType: fwtypes.NewListNestedObjectTypeOf[ExternalSourceSetting](ctx),
+				NestedObject: schema.NestedBlockObject{
+					Blocks: map[string]schema.Block{
+						"grammar_slot_type_setting": schema.ListNestedBlock{
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							CustomType: fwtypes.NewListNestedObjectTypeOf[GrammarSlotTypeSetting](ctx),
+							NestedObject: schema.NestedBlockObject{
+								Blocks: map[string]schema.Block{
+									"source": schema.ListNestedBlock{
+										Validators: []validator.List{
+											listvalidator.SizeAtMost(1),
+										},
+										CustomType: fwtypes.NewListNestedObjectTypeOf[Source](ctx),
+										NestedObject: schema.NestedBlockObject{
+											Attributes: map[string]schema.Attribute{
+												"s3_bucket_name": schema.StringAttribute{
+													Required: true,
+												},
+												"s3_object_key": schema.StringAttribute{
+													Required: true,
+												},
+												"kms_key_arn": schema.StringAttribute{
+													Required: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+
+			//not sure https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/lexmodelsv2@v1.38.6/types#SlotTypeValue
+			"slot_type_values": schema.ListNestedBlock{
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				CustomType: fwtypes.NewListNestedObjectTypeOf[SlotTypeValues](ctx),
+				NestedObject: schema.NestedBlockObject{
+					Blocks: map[string]schema.Block{
+						"slot_type_value": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[SlotTypeValue](ctx),
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"value": schema.StringAttribute{
+										Required: true,
+									},
+								},
+							},
+						},
+						"synonyms": schema.ListNestedBlock{
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"value": schema.StringAttribute{
+										Required: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"value_selection_setting": schema.ListNestedBlock{
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				CustomType: fwtypes.NewListNestedObjectTypeOf[ValueSelectionSetting](ctx),
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"resolution_strategy": schema.StringAttribute{
+							Required: true,
+							Validators: []validator.String{
+								enum.FrameworkValidate[awstypes.SlotValueResolutionStrategy](),
+							},
+						},
+					},
+					Blocks: map[string]schema.Block{
+						"advanced_recognition_settings": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[AdvancedRecognitionSetting](ctx),
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"audio_recognition_setting": schema.StringAttribute{
+										Optional: true,
+										Validators: []validator.String{
+											enum.FrameworkValidate[awstypes.AudioRecognitionStrategy](),
+										},
+									},
+								},
+							},
+						},
+						"regex_filter": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[RegexFilter](ctx),
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"pattern": schema.StringAttribute{
+										Required: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+
+			"timeouts": timeouts.Block(ctx, timeouts.Opts{
+				Create: true,
+				Update: true,
+				Delete: true,
+			}),
+		},
+	}
+}
+
+func (r *resourceSlotType) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().LexV2ModelsClient(ctx)
+
+	var plan resourceSlotTypeData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := &lexmodelsv2.CreateSlotTypeInput{
+		SlotTypeName: aws.String(plan.Name.ValueString()),
+	}
+	resp.Diagnostics.Append(flex.Expand(context.WithValue(ctx, flex.ResourcePrefix, ResNameSlotType), &plan, in)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := conn.CreateSlotType(ctx, in)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.LexV2Models, create.ErrActionCreating, ResNameSlotType, plan.Name.String(), err),
+			err.Error(),
+		)
+		return
+	}
+	if out == nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.LexV2Models, create.ErrActionCreating, ResNameSlotType, plan.Name.String(), nil),
+			errors.New("empty output").Error(),
+		)
+		return
+	}
+
+	idParts := []string{
+		aws.ToString(out.BotId),
+		aws.ToString(out.BotVersion),
+		aws.ToString(out.LocaleId),
+		aws.ToString(out.SlotTypeId),
+	}
+	id, err := intflex.FlattenResourceId(idParts, slotTypeIDPartCount, false)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.LexV2Models, create.ErrActionCreating, ResNameSlotType, plan.Name.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	plan.ID = types.StringValue(id)
+
+	resp.Diagnostics.Append(flex.Flatten(context.WithValue(ctx, flex.ResourcePrefix, ResNameSlotType), out, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *resourceSlotType) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().LexV2ModelsClient(ctx)
+
+	var state resourceSlotTypeData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := FindSlotTypeByID(ctx, conn, state.ID.ValueString())
+	if tfresource.NotFound(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.LexV2Models, create.ErrActionSetting, ResNameSlotType, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(flex.Flatten(context.WithValue(ctx, flex.ResourcePrefix, ResNameSlotType), out, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *resourceSlotType) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	conn := r.Meta().LexV2ModelsClient(ctx)
+
+	var plan, state resourceSlotTypeData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if slotTypeHasChanges(ctx, plan, state) {
+		input := &lexmodelsv2.UpdateSlotTypeInput{}
+
+		resp.Diagnostics.Append(flex.Expand(context.WithValue(ctx, flex.ResourcePrefix, ResNameSlotType), plan, input)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		out, err := conn.UpdateSlotType(ctx, input)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.LexV2Models, create.ErrActionUpdating, ResNameSlotType, plan.ID.String(), err),
+				err.Error(),
+			)
+			return
+		}
+		if out == nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.LexV2Models, create.ErrActionUpdating, ResNameSlotType, plan.ID.String(), nil),
+				errors.New("empty output").Error(),
+			)
+			return
+		}
+
+		resp.Diagnostics.Append(flex.Flatten(context.WithValue(ctx, flex.ResourcePrefix, ResNameSlotType), input, &plan)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *resourceSlotType) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	conn := r.Meta().LexV2ModelsClient(ctx)
+
+	var state resourceSlotTypeData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// TIP: -- 3. Populate a delete input structure
+	in := &lexmodelsv2.DeleteSlotTypeInput{
+		BotId:      aws.String(state.BotID.ValueString()),
+		BotVersion: aws.String(state.BotVersion.ValueString()),
+		LocaleId:   aws.String(state.LocaleID.ValueString()),
+		SlotTypeId: aws.String(state.SlotTypeID.ValueString()),
+	}
+
+	_, err := conn.DeleteSlotType(ctx, in)
+
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return
+	}
+
+	if errs.IsAErrorMessageContains[*awstypes.PreconditionFailedException](err, "does not exist") {
+		return
+	}
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.LexV2Models, create.ErrActionDeleting, ResNameSlotType, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+}
+
+// func waitSlotTypeCreated(ctx context.Context, conn *lexmodelsv2.Client, id string, timeout time.Duration) (*lexmodelsv2.DescribeSlotTypeOutput, error) {
+// 	stateConf := &retry.StateChangeConf{
+// 		Pending:                   []string{},
+// 		Target:                    []string{statusNormal},
+// 		Refresh:                   statusSlotType(ctx, conn, id),
+// 		Timeout:                   timeout,
+// 		NotFoundChecks:            20,
+// 		ContinuousTargetOccurence: 2,
+// 	}
+
+// 	outputRaw, err := stateConf.WaitForStateContext(ctx)
+// 	if out, ok := outputRaw.(*lexmodelsv2.DescribeSlotTypeOutput); ok {
+// 		return out, err
+// 	}
+
+// 	return nil, err
+// }
+
+// func waitSlotTypeUpdated(ctx context.Context, conn *lexmodelsv2.Client, id string, timeout time.Duration) (*lexmodelsv2.DescribeSlotTypeOutput, error) {
+// 	stateConf := &retry.StateChangeConf{
+// 		Pending:                   []string{statusChangePending},
+// 		Target:                    []string{statusUpdated},
+// 		Refresh:                   statusSlotType(ctx, conn, id),
+// 		Timeout:                   timeout,
+// 		NotFoundChecks:            20,
+// 		ContinuousTargetOccurence: 2,
+// 	}
+
+// 	outputRaw, err := stateConf.WaitForStateContext(ctx)
+// 	if out, ok := outputRaw.(*lexv2models.SlotType); ok {
+// 		return out, err
+// 	}
+
+// 	return nil, err
+// }
+
+// func waitSlotTypeDeleted(ctx context.Context, conn *lexmodelsv2.Client, id string, timeout time.Duration) (*lexmodelsv2.DescribeSlotTypeOutput, error) {
+// 	stateConf := &retry.StateChangeConf{
+// 		Pending: []string{statusDeleting, statusNormal},
+// 		Target:  []string{},
+// 		Refresh: statusSlotType(ctx, conn, id),
+// 		Timeout: timeout,
+// 	}
+
+// 	outputRaw, err := stateConf.WaitForStateContext(ctx)
+// 	if out, ok := outputRaw.(*lexmodelsv2.DescribeSlotTypeOutput); ok {
+// 		return out, err
+// 	}
+
+// 	return nil, err
+// }
+
+// func statusSlotType(ctx context.Context, conn *lexmodelsv2.Client, id string) retry.StateRefreshFunc {
+// 	return func() (interface{}, string, error) {
+// 		out, err := findSlotTypeByID(ctx, conn, id)
+// 		if tfresource.NotFound(err) {
+// 			return nil, "", nil
+// 		}
+
+// 		if err != nil {
+// 			return nil, "", err
+// 		}
+
+// 		return out, aws.ToString(out.Status), nil
+// 	}
+// }
+
+func FindSlotTypeByID(ctx context.Context, conn *lexmodelsv2.Client, id string) (*lexmodelsv2.DescribeSlotTypeOutput, error) {
+	parts, err := intflex.ExpandResourceId(id, slotIDPartCount, false)
+	if err != nil {
+		return nil, err
+	}
+
+	in := &lexmodelsv2.DescribeSlotTypeInput{
+		BotId:      aws.String(parts[0]),
+		BotVersion: aws.String(parts[1]),
+		LocaleId:   aws.String(parts[2]),
+		SlotTypeId: aws.String(parts[3]),
+	}
+
+	out, err := conn.DescribeSlotType(ctx, in)
+
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: in,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if out == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return out, nil
+}
+
+type resourceSlotTypeData struct {
+	BotID                    types.String                                              `tfsdk:"bot_id"`
+	BotVersion               types.String                                              `tfsdk:"bot_version"`
+	LocaleID                 types.String                                              `tfsdk:"locale_id"`
+	Description              types.String                                              `tfsdk:"description"`
+	ID                       types.String                                              `tfsdk:"id"`
+	SlotTypeID               types.String                                              `tfsdk:"slot_type_id"`
+	Name                     types.String                                              `tfsdk:"name"`
+	CompositeSlotTypeSetting fwtypes.ListNestedObjectValueOf[CompositeSlotTypeSetting] `tfsdk:"composite_slot_type_setting"`
+	ExternalSourceSetting    fwtypes.ListNestedObjectValueOf[ExternalSourceSetting]    `tfsdk:"external_source_setting"`
+	SlotTypeValues           fwtypes.ListNestedObjectValueOf[SlotTypeValues]           `tfsdk:"slot_type_values"`
+	ValueSelectionSetting    fwtypes.ListNestedObjectValueOf[ValueSelectionSetting]    `tfsdk:"value_selection_setting"`
+	ParentSlotTypeSignature  types.String                                              `tfsdk:"parent_slot_type_signature"`
+	Timeouts                 timeouts.Value                                            `tfsdk:"timeouts"`
+}
+
+type SubSlotTypeComposition struct {
+	Name      types.String `tfsdk:"name"`
+	SubSlotID types.String `tfsdk:"sub_slot_id"`
+}
+
+type CompositeSlotTypeSetting struct {
+	SubSlots fwtypes.ListNestedObjectValueOf[SubSlotTypeComposition] `tfsdk:"sub_slots"`
+}
+
+type Source struct {
+	S3BucketName types.String `tfsdk:"s3_bucket_name"`
+	S3ObjectKey  types.String `tfsdk:"s3_object_key"`
+	KmsKeyARN    types.String `tfsdk:"kms_key_arn"`
+}
+
+type GrammarSlotTypeSetting struct {
+	Source fwtypes.ListNestedObjectValueOf[Source] `tfsdk:"source"`
+}
+
+type ExternalSourceSetting struct {
+	GrammarSlotTypeSetting fwtypes.ListNestedObjectValueOf[GrammarSlotTypeSetting] `tfsdk: "grammar_slot_type_setting"`
+}
+
+type SlotTypeValue struct {
+	Value types.String `tfsdk:"value"`
+}
+
+type SlotTypeValues struct {
+	SlotTypeValues fwtypes.ListNestedObjectValueOf[SlotTypeValue] `tfsdk:"slot_type_values"`
+	Synonyms       fwtypes.ListNestedObjectValueOf[SlotTypeValue] `tfsdk:"synonyms"`
+}
+
+type AdvancedRecognitionSetting struct {
+	AudioRecognitionSetting fwtypes.ListNestedObjectValueOf[awstypes.AudioRecognitionStrategy] `tfsdk:"audio_recognition_setting"`
+}
+
+type RegexFilter struct {
+	Pattern types.String `tfsdk:"pattern"`
+}
+
+type ValueSelectionSetting struct {
+	ResolutionStrategy         fwtypes.StringEnum[awstypes.SlotValueResolutionStrategy]    `tfsdk: "resolution_strategy"`
+	AdvancedRecognitionSetting fwtypes.ListNestedObjectValueOf[AdvancedRecognitionSetting] `tfsdk: "advanced_recognition_setting"`
+	RegexFilter                fwtypes.ListNestedObjectValueOf[RegexFilter]                `tfsdk: "regex_filter"`
+}
+
+func slotTypeHasChanges(_ context.Context, plan, state resourceSlotTypeData) bool {
+	return !plan.Description.Equal(state.Description) ||
+		!plan.ValueSelectionSetting.Equal(state.ValueSelectionSetting) ||
+		!plan.ExternalSourceSetting.Equal(state.ExternalSourceSetting) ||
+		!plan.CompositeSlotTypeSetting.Equal(state.CompositeSlotTypeSetting) ||
+		!plan.SlotTypeValues.Equal(state.SlotTypeValues) ||
+		!plan.ParentSlotTypeSignature.Equal(state.ParentSlotTypeSignature)
+}

--- a/internal/service/lexv2models/slot_type.go
+++ b/internal/service/lexv2models/slot_type.go
@@ -59,7 +59,6 @@ func (r *resourceSlotType) Metadata(_ context.Context, req resource.MetadataRequ
 }
 
 func (r *resourceSlotType) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
-
 	subSlotTypeCompositionLNB := schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[SubSlotTypeComposition](ctx),
 		NestedObject: schema.NestedBlockObject{
@@ -164,8 +163,6 @@ func (r *resourceSlotType) Schema(ctx context.Context, req resource.SchemaReques
 					},
 				},
 			},
-
-			//not sure https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/lexmodelsv2@v1.38.6/types#SlotTypeValue
 			"slot_type_values": schema.ListNestedBlock{
 				Validators: []validator.List{
 					listvalidator.SizeAtMost(1),

--- a/internal/service/lexv2models/slot_type.go
+++ b/internal/service/lexv2models/slot_type.go
@@ -384,7 +384,6 @@ func (r *resourceSlotType) Delete(ctx context.Context, req resource.DeleteReques
 		return
 	}
 
-	// TIP: -- 3. Populate a delete input structure
 	in := &lexmodelsv2.DeleteSlotTypeInput{
 		BotId:      aws.String(state.BotID.ValueString()),
 		BotVersion: aws.String(state.BotVersion.ValueString()),

--- a/internal/service/lexv2models/slot_type.go
+++ b/internal/service/lexv2models/slot_type.go
@@ -236,7 +236,6 @@ func (r *resourceSlotType) Schema(ctx context.Context, req resource.SchemaReques
 					},
 				},
 			},
-
 			"timeouts": timeouts.Block(ctx, timeouts.Opts{
 				Create: true,
 				Update: true,

--- a/internal/service/lexv2models/slot_type.go
+++ b/internal/service/lexv2models/slot_type.go
@@ -111,9 +111,6 @@ func (r *resourceSlotType) Schema(ctx context.Context, req resource.SchemaReques
 			"parent_slot_type_signature": schema.StringAttribute{
 				Optional: true,
 			},
-			"type": schema.StringAttribute{
-				Required: true,
-			},
 		},
 		Blocks: map[string]schema.Block{
 			"composite_slot_type_setting": schema.ListNestedBlock{

--- a/internal/service/lexv2models/slot_type.go
+++ b/internal/service/lexv2models/slot_type.go
@@ -50,6 +50,7 @@ const (
 
 type resourceSlotType struct {
 	framework.ResourceWithConfigure
+	framework.WithImportByID
 	framework.WithTimeouts
 }
 
@@ -209,7 +210,7 @@ func (r *resourceSlotType) Schema(ctx context.Context, req resource.SchemaReques
 						},
 					},
 					Blocks: map[string]schema.Block{
-						"advanced_recognition_settings": schema.ListNestedBlock{
+						"advanced_recognition_setting": schema.ListNestedBlock{
 							CustomType: fwtypes.NewListNestedObjectTypeOf[AdvancedRecognitionSetting](ctx),
 							NestedObject: schema.NestedBlockObject{
 								Attributes: map[string]schema.Attribute{
@@ -410,75 +411,8 @@ func (r *resourceSlotType) Delete(ctx context.Context, req resource.DeleteReques
 	}
 }
 
-// func waitSlotTypeCreated(ctx context.Context, conn *lexmodelsv2.Client, id string, timeout time.Duration) (*lexmodelsv2.DescribeSlotTypeOutput, error) {
-// 	stateConf := &retry.StateChangeConf{
-// 		Pending:                   []string{},
-// 		Target:                    []string{statusNormal},
-// 		Refresh:                   statusSlotType(ctx, conn, id),
-// 		Timeout:                   timeout,
-// 		NotFoundChecks:            20,
-// 		ContinuousTargetOccurence: 2,
-// 	}
-
-// 	outputRaw, err := stateConf.WaitForStateContext(ctx)
-// 	if out, ok := outputRaw.(*lexmodelsv2.DescribeSlotTypeOutput); ok {
-// 		return out, err
-// 	}
-
-// 	return nil, err
-// }
-
-// func waitSlotTypeUpdated(ctx context.Context, conn *lexmodelsv2.Client, id string, timeout time.Duration) (*lexmodelsv2.DescribeSlotTypeOutput, error) {
-// 	stateConf := &retry.StateChangeConf{
-// 		Pending:                   []string{statusChangePending},
-// 		Target:                    []string{statusUpdated},
-// 		Refresh:                   statusSlotType(ctx, conn, id),
-// 		Timeout:                   timeout,
-// 		NotFoundChecks:            20,
-// 		ContinuousTargetOccurence: 2,
-// 	}
-
-// 	outputRaw, err := stateConf.WaitForStateContext(ctx)
-// 	if out, ok := outputRaw.(*lexv2models.SlotType); ok {
-// 		return out, err
-// 	}
-
-// 	return nil, err
-// }
-
-// func waitSlotTypeDeleted(ctx context.Context, conn *lexmodelsv2.Client, id string, timeout time.Duration) (*lexmodelsv2.DescribeSlotTypeOutput, error) {
-// 	stateConf := &retry.StateChangeConf{
-// 		Pending: []string{statusDeleting, statusNormal},
-// 		Target:  []string{},
-// 		Refresh: statusSlotType(ctx, conn, id),
-// 		Timeout: timeout,
-// 	}
-
-// 	outputRaw, err := stateConf.WaitForStateContext(ctx)
-// 	if out, ok := outputRaw.(*lexmodelsv2.DescribeSlotTypeOutput); ok {
-// 		return out, err
-// 	}
-
-// 	return nil, err
-// }
-
-// func statusSlotType(ctx context.Context, conn *lexmodelsv2.Client, id string) retry.StateRefreshFunc {
-// 	return func() (interface{}, string, error) {
-// 		out, err := findSlotTypeByID(ctx, conn, id)
-// 		if tfresource.NotFound(err) {
-// 			return nil, "", nil
-// 		}
-
-// 		if err != nil {
-// 			return nil, "", err
-// 		}
-
-// 		return out, aws.ToString(out.Status), nil
-// 	}
-// }
-
 func FindSlotTypeByID(ctx context.Context, conn *lexmodelsv2.Client, id string) (*lexmodelsv2.DescribeSlotTypeOutput, error) {
-	parts, err := intflex.ExpandResourceId(id, slotIDPartCount, false)
+	parts, err := intflex.ExpandResourceId(id, slotTypeIDPartCount, false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/lexv2models/slot_type_test.go
+++ b/internal/service/lexv2models/slot_type_test.go
@@ -126,10 +126,8 @@ func testAccCheckSlotTypeExists(ctx context.Context, name string, slottype *lexm
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).LexV2ModelsClient(ctx)
+
 		out, err := tflexv2models.FindSlotTypeByID(ctx, conn, rs.Primary.ID)
-		if err != nil {
-			return create.Error(names.LexV2Models, create.ErrActionCheckingExistence, tflexv2models.ResNameSlotType, rs.Primary.ID, err)
-		}
 		if err != nil {
 			return create.Error(names.LexV2Models, create.ErrActionCheckingExistence, tflexv2models.ResNameSlotType, rs.Primary.ID, err)
 		}

--- a/internal/service/lexv2models/slot_type_test.go
+++ b/internal/service/lexv2models/slot_type_test.go
@@ -51,9 +51,9 @@ func TestAccLexV2ModelsSlotType_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName: resourceName,
-				ImportState:  true,
-				// ImportStateVerify: true,
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/internal/service/lexv2models/slot_type_test.go
+++ b/internal/service/lexv2models/slot_type_test.go
@@ -1,0 +1,208 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package lexv2models_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/lexmodelsv2"
+	"github.com/aws/aws-sdk-go-v2/service/lexmodelsv2/types"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	tflexv2models "github.com/hashicorp/terraform-provider-aws/internal/service/lexv2models"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccLexV2ModelsSlotType_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var slottype lexmodelsv2.DescribeSlotTypeOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lexv2models_slot_type.test"
+	botLocaleName := "aws_lexv2models_bot_locale.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.LexV2ModelsEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.LexV2ModelsEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSlotTypeDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSlotTypeConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSlotTypeExists(ctx, resourceName, &slottype),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrPair(resourceName, "bot_id", botLocaleName, "bot_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "bot_version", botLocaleName, "bot_version"),
+					resource.TestCheckResourceAttrPair(resourceName, "locale_id", botLocaleName, "locale_id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccLexV2ModelsSlotType_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var slottype lexmodelsv2.DescribeSlotTypeOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lexv2models_slot_type.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.LexV2ModelsEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.LexV2ModelsEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSlotTypeDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSlotTypeConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSlotTypeExists(ctx, resourceName, &slottype),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tflexv2models.ResourceSlotType, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckSlotTypeDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).LexV2ModelsClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_lexv2models_slot" {
+				continue
+			}
+
+			_, err := tflexv2models.FindSlotTypeByID(ctx, conn, rs.Primary.ID)
+			if errs.IsA[*types.ResourceNotFoundException](err) {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+
+			return create.Error(names.LexV2Models, create.ErrActionCheckingDestroyed, tflexv2models.ResNameSlotType, rs.Primary.ID, errors.New("not destroyed"))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckSlotTypeExists(ctx context.Context, name string, slottype *lexmodelsv2.DescribeSlotTypeOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.LexV2Models, create.ErrActionCheckingExistence, tflexv2models.ResNameSlotType, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.LexV2Models, create.ErrActionCheckingExistence, tflexv2models.ResNameSlotType, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).LexV2ModelsClient(ctx)
+		out, err := tflexv2models.FindSlotTypeByID(ctx, conn, rs.Primary.ID)
+		if err != nil {
+			return create.Error(names.LexV2Models, create.ErrActionCheckingExistence, tflexv2models.ResNameSlotType, rs.Primary.ID, err)
+		}
+		if err != nil {
+			return create.Error(names.LexV2Models, create.ErrActionCheckingExistence, tflexv2models.ResNameSlotType, rs.Primary.ID, err)
+		}
+
+		*slottype = *out
+
+		return nil
+	}
+}
+
+func testAccSlotTypeConfig_base(rName string, ttl int, dp bool) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "lexv2.amazonaws.com"
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "test" {
+  role       = aws_iam_role.test.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonLexFullAccess"
+}
+
+resource "aws_lexv2models_bot" "test" {
+  name                        = %[1]q
+  idle_session_ttl_in_seconds = %[2]d
+  role_arn                    = aws_iam_role.test.arn
+
+  data_privacy {
+    child_directed = %[3]t
+  }
+}
+
+resource "aws_lexv2models_bot_locale" "test" {
+  locale_id                        = "en_US"
+  bot_id                           = aws_lexv2models_bot.test.id
+  bot_version                      = "DRAFT"
+  n_lu_intent_confidence_threshold = 0.7
+}
+
+resource "aws_lexv2models_bot_version" "test" {
+  bot_id = aws_lexv2models_bot.test.id
+  locale_specification = {
+    (aws_lexv2models_bot_locale.test.locale_id) = {
+      source_bot_version = "DRAFT"
+    }
+  }
+}
+`, rName, ttl, dp)
+}
+
+func testAccSlotTypeConfig_basic(rName string) string {
+	return acctest.ConfigCompose(
+		testAccSlotConfig_base(rName, 60, true),
+		fmt.Sprintf(`
+resource "aws_lexv2models_slot_type" "test" {
+  bot_id      = aws_lexv2models_bot.test.id
+  bot_version = aws_lexv2models_bot_locale.test.bot_version
+  name        = %[1]q
+  locale_id   = aws_lexv2models_bot_locale.test.locale_id
+}
+`, rName))
+}

--- a/internal/service/lexv2models/slot_type_test.go
+++ b/internal/service/lexv2models/slot_type_test.go
@@ -51,9 +51,9 @@ func TestAccLexV2ModelsSlotType_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName: resourceName,
+				ImportState:  true,
+				// ImportStateVerify: true,
 			},
 		},
 	})
@@ -194,13 +194,17 @@ resource "aws_lexv2models_bot_version" "test" {
 
 func testAccSlotTypeConfig_basic(rName string) string {
 	return acctest.ConfigCompose(
-		testAccSlotConfig_base(rName, 60, true),
+		testAccSlotTypeConfig_base(rName, 60, true),
 		fmt.Sprintf(`
 resource "aws_lexv2models_slot_type" "test" {
   bot_id      = aws_lexv2models_bot.test.id
   bot_version = aws_lexv2models_bot_locale.test.bot_version
   name        = %[1]q
   locale_id   = aws_lexv2models_bot_locale.test.locale_id
+
+  value_selection_setting {
+    resolution_strategy = "OriginalValue"
+  }
 }
 `, rName))
 }

--- a/website/docs/r/lexv2models_slot_type.html.markdown
+++ b/website/docs/r/lexv2models_slot_type.html.markdown
@@ -74,8 +74,6 @@ The following arguments are optional:
  - TOP_RESOLUTION - If there is a resolution list for the slot, return the first value in the resolution list. If there is no resolution list, return null.
 If you don't specify the valueSelectionSetting parameter, the default is ORIGINAL_VALUE. See [`value_selection_setting` argument reference](#value_selection_setting) below.
 
-
-
 ### `slot_type_values` Argument Reference
 * `sample_value` - Value of the slot type entry.  See [`sample_value` argument reference](#sample_value) below.
 * `synonyms` - Additional values related to the slot type entry. See [`sample_value` argument reference](#sample_value) below.

--- a/website/docs/r/lexv2models_slot_type.html.markdown
+++ b/website/docs/r/lexv2models_slot_type.html.markdown
@@ -1,0 +1,154 @@
+---
+subcategory: "Lex V2 Models"
+layout: "aws"
+page_title: "AWS: aws_lexv2models_slot_type"
+description: |-
+  Terraform resource for managing an AWS Lex V2 Models Slot Type.
+---
+
+# Resource: aws_lexv2models_slot_type
+
+Terraform resource for managing an AWS Lex V2 Models Slot Type.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_iam_role_policy_attachment" "test" {
+  role       = aws_iam_role.test.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonLexFullAccess"
+}
+
+resource "aws_lexv2models_bot" "test" {
+  name                        = "testbot"
+  idle_session_ttl_in_seconds = 60
+  role_arn                    = aws_iam_role.test.arn
+
+  data_privacy {
+    child_directed = %[3]t
+  }
+}
+
+resource "aws_lexv2models_bot_locale" "test" {
+  locale_id                        = "en_US"
+  bot_id                           = aws_lexv2models_bot.test.id
+  bot_version                      = "DRAFT"
+  n_lu_intent_confidence_threshold = 0.7
+}
+
+resource "aws_lexv2models_bot_version" "test" {
+  bot_id = aws_lexv2models_bot.test.id
+  locale_specification = {
+    (aws_lexv2models_bot_locale.test.locale_id) = {
+      source_bot_version = "DRAFT"
+    }
+  }
+}
+resource "aws_lexv2models_slot_type" "test" {
+  bot_id      = aws_lexv2models_bot.test.id
+  bot_version = aws_lexv2models_bot_locale.test.bot_version
+  name        = "test"
+  locale_id   = aws_lexv2models_bot_locale.test.locale_id
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `bot_id` - Identifier of the bot associated with this slot type.
+* `bot_version` - Version of the bot associated with this slot type.
+* `locale_id` - Identifier of the language and locale where this slot type is used. All of the bots, slot types, and slots used by the intent must have the same locale.
+* `name` - Name of the slot type
+
+The following arguments are optional:
+
+* `description` - (Optional) Description of the slot type.
+* `composite_slot_type_setting` - Specifications for a composite slot type. See [`composite_slot_tyype_setting` argument reference](#composite_slot_type_reference) below.
+* `external_source_setting` - Type of external information used to create the slot type. See [`external_source_setting` argument reference](#external_source_setting) below.
+* `parent_slot_type_signature` - Built-in slot type used as a parent of this slot type. When you define a parent slot type, the new slot type has the configuration of the parent slot type. Only AMAZON.AlphaNumeric is supported.
+* `slot_type_values` - List of SlotTypeValue objects that defines the values that the slot type can take. Each value can have a list of synonyms, additional values that help train the machine learning model about the values that it resolves for a slot. See [`slot_type_values` argument reference](#slot_type_values) below.
+* `value_selection_setting` - Determines the strategy that Amazon Lex uses to select a value from the list of possible values. The field can be set to one of the following values:
+ - ORIGINAL_VALUE - Returns the value entered by the user, if the user value is similar to the slot value.
+ - TOP_RESOLUTION - If there is a resolution list for the slot, return the first value in the resolution list. If there is no resolution list, return null.
+If you don't specify the valueSelectionSetting parameter, the default is ORIGINAL_VALUE. See [`value_selection_setting` argument reference](#value_selection_setting) below.
+
+
+
+### `slot_type_values` Argument Reference
+* `sample_value` - Value of the slot type entry.  See [`sample_value` argument reference](#sample_value) below.
+* `synonyms` - Additional values related to the slot type entry. See [`sample_value` argument reference](#sample_value) below.
+
+### `sample_value` Argument Reference
+* `value` - (Required) Value that can be used for a slot type.
+
+### `external_source_setting` Argument Reference
+*`grammar_slot_type_setting` - Settings required for a slot type based on a grammar that you provide. See [`grammar_slot_type_setting` argument reference](#grammar_slot_type_setting) below.
+
+### `grammar_slot_type_setting` Argument Reference
+* `source` - Source of the grammar used to create the slot type. See [`grammar_slot_type_source` argument reference](#grammar_slot_type_reference) below.
+
+### `grammar_slot_type_source` Argument Reference
+* `s3_bucket_name` - (Required) Name of the Amazon S3 bucket that contains the grammar source.
+* `s3_object_key` - (Required) Path to the grammar in the Amazon S3 bucket.
+* `kms_key_arn` - KMS key required to decrypt the contents of the grammar, if any.
+
+### `composite_slot_type_setting` Argument Reference
+* `sub_slots` - Subslots in the composite slot. Contains filtered or unexported fields. See [`sub_slot_type_composition` argument reference] below.
+
+### `sub_slot_type_composition` Arugment Reference
+* `name` - Name of a constituent sub slot inside a composite slot.
+* `slot_type_id` - (Required) Unique identifier assigned to a slot type. This refers to either a built-in slot type or the unique slotTypeId of a custom slot type.
+
+### `value_selection_setting` Argument Reference
+* `resolution_strategy` - (Required) Determines the slot resolution strategy that Amazon Lex uses to return slot type values. The field can be set to one of the following values:
+ - ORIGINAL_VALUE - Returns the value entered by the user, if the user value is similar to the slot value.
+ - TOP_RESOLUTION - If there is a resolution list for the slot, return the first value in the resolution list as the slot type value. If there is no resolution list, null is returned.
+If you don't specify the valueSelectionStrategy , the default is ORIGINAL_VALUE. Valid values are `OriginalValue`, `TopResolution`, and `Concatenation`.
+* `advanced_recognition_setting` - Provides settings that enable advanced recognition settings for slot values. You can use this to enable using slot values as a custom vocabulary for recognizing user utterances. See [`advanced_recognition_setting` argument reference] below.
+* `regex_filter` - Used to validate the value of the slot. See [`regex_filter` argument reference] below.
+
+### `advanced_recognition_setting` Argument Reference
+* `pattern` - (Required) Used to validate the value of a slot. Use a standard regular expression. Amazon Lex supports the following characters in the regular expression:
+ - A-Z, a-z
+ - 0-9
+ - Unicode characters ("\⁠u")
+Represent Unicode characters with four digits, for example "\⁠u0041" or "\⁠u005A". The following regular expression operators are not supported:
+ - Infinite repeaters: *, +, or {x,} with no upper bound.
+ - Wild card (.)
+
+### `advanced_recognition_setting` Argument Reference
+* `audio_recognition_strategy` - Enables using the slot values as a custom vocabulary for recognizing user utterances. Valid value is `UseSlotValuesAsCustomVocabulary`.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `id` - Comma-delimited string concatenating `bot_id`, `bot_version`, `locale_id`, and `slot_type_id`.
+* `slot_id` - Unique identifier for the intent.
+
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+* `create` - (Default `60m`)
+* `update` - (Default `180m`)
+* `delete` - (Default `90m`)
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Lex V2 Models Slot Type using the `example_id_arg`. For example:
+
+```terraform
+import {
+  to = aws_lexv2models_slot_type.example
+  id = "slot_type-id-12345678"
+}
+```
+
+Using `terraform import`, import Lex V2 Models Slot Type using the `example_id_arg`. For example:
+
+```console
+% terraform import aws_lexv2models_slot_type.example bot-1234,DRAFT,en_US,slot_type-id-12345678
+```

--- a/website/docs/r/lexv2models_slot_type.html.markdown
+++ b/website/docs/r/lexv2models_slot_type.html.markdown
@@ -69,10 +69,7 @@ The following arguments are optional:
 * `external_source_setting` - Type of external information used to create the slot type. See [`external_source_setting` argument reference](#external_source_setting) below.
 * `parent_slot_type_signature` - Built-in slot type used as a parent of this slot type. When you define a parent slot type, the new slot type has the configuration of the parent slot type. Only AMAZON.AlphaNumeric is supported.
 * `slot_type_values` - List of SlotTypeValue objects that defines the values that the slot type can take. Each value can have a list of synonyms, additional values that help train the machine learning model about the values that it resolves for a slot. See [`slot_type_values` argument reference](#slot_type_values) below.
-* `value_selection_setting` - Determines the strategy that Amazon Lex uses to select a value from the list of possible values. The field can be set to one of the following values:
- - ORIGINAL_VALUE - Returns the value entered by the user, if the user value is similar to the slot value.
- - TOP_RESOLUTION - If there is a resolution list for the slot, return the first value in the resolution list. If there is no resolution list, return null.
-If you don't specify the valueSelectionSetting parameter, the default is ORIGINAL_VALUE. See [`value_selection_setting` argument reference](#value_selection_setting) below.
+* `value_selection_setting` - Determines the strategy that Amazon Lex uses to select a value from the list of possible values. The field can be set to one of the following values: `ORIGINAL_VALUE` returns the value entered by the user, if the user value is similar to the slot value. `TOP_RESOLUTION` if there is a resolution list for the slot, return the first value in the resolution list. If there is no resolution list, return null. If you don't specify the valueSelectionSetting parameter, the default is ORIGINAL_VALUE. See [`value_selection_setting` argument reference](#value_selection_setting) below.
 
 ### `slot_type_values` Argument Reference
 * `sample_value` - Value of the slot type entry.  See [`sample_value` argument reference](#sample_value) below.
@@ -95,7 +92,7 @@ If you don't specify the valueSelectionSetting parameter, the default is ORIGINA
 ### `composite_slot_type_setting` Argument Reference
 * `sub_slots` - Subslots in the composite slot. Contains filtered or unexported fields. See [`sub_slot_type_composition` argument reference] below.
 
-### `sub_slot_type_composition` Arugment Reference
+### `sub_slot_type_composition` Argument Reference
 * `name` - Name of a constituent sub slot inside a composite slot.
 * `slot_type_id` - (Required) Unique identifier assigned to a slot type. This refers to either a built-in slot type or the unique slotTypeId of a custom slot type.
 

--- a/website/docs/r/lexv2models_slot_type.html.markdown
+++ b/website/docs/r/lexv2models_slot_type.html.markdown
@@ -65,55 +65,57 @@ The following arguments are required:
 The following arguments are optional:
 
 * `description` - (Optional) Description of the slot type.
-* `composite_slot_type_setting` - Specifications for a composite slot type. See [`composite_slot_tyype_setting` argument reference](#composite_slot_type_reference) below.
-* `external_source_setting` - Type of external information used to create the slot type. See [`external_source_setting` argument reference](#external_source_setting) below.
+* `composite_slot_type_setting` - Specifications for a composite slot type. See [`composite_slot_type_setting` argument reference](#composite_slot_type_setting-argument-reference) below.
+* `external_source_setting` - Type of external information used to create the slot type. See [`external_source_setting` argument reference](#external_source_setting-argument-reference) below.
 * `parent_slot_type_signature` - Built-in slot type used as a parent of this slot type. When you define a parent slot type, the new slot type has the configuration of the parent slot type. Only AMAZON.AlphaNumeric is supported.
-* `slot_type_values` - List of SlotTypeValue objects that defines the values that the slot type can take. Each value can have a list of synonyms, additional values that help train the machine learning model about the values that it resolves for a slot. See [`slot_type_values` argument reference](#slot_type_values) below.
-* `value_selection_setting` - Determines the strategy that Amazon Lex uses to select a value from the list of possible values. The field can be set to one of the following values: `ORIGINAL_VALUE` returns the value entered by the user, if the user value is similar to the slot value. `TOP_RESOLUTION` if there is a resolution list for the slot, return the first value in the resolution list. If there is no resolution list, return null. If you don't specify the valueSelectionSetting parameter, the default is ORIGINAL_VALUE. See [`value_selection_setting` argument reference](#value_selection_setting) below.
+* `slot_type_values` - List of SlotTypeValue objects that defines the values that the slot type can take. Each value can have a list of synonyms, additional values that help train the machine learning model about the values that it resolves for a slot. See [`slot_type_values` argument reference](#slot_type_values-argument-reference) below.
+* `value_selection_setting` - Determines the strategy that Amazon Lex uses to select a value from the list of possible values. The field can be set to one of the following values: `ORIGINAL_VALUE` returns the value entered by the user, if the user value is similar to the slot value. `TOP_RESOLUTION` if there is a resolution list for the slot, return the first value in the resolution list. If there is no resolution list, return null. If you don't specify the valueSelectionSetting parameter, the default is ORIGINAL_VALUE. See [`value_selection_setting` argument reference](#value_selection_setting-argument-reference) below.
 
 ### `slot_type_values` Argument Reference
-* `sample_value` - Value of the slot type entry.  See [`sample_value` argument reference](#sample_value) below.
-* `synonyms` - Additional values related to the slot type entry. See [`sample_value` argument reference](#sample_value) below.
+
+* `sample_value` - Value of the slot type entry.  See [`sample_value` argument reference](#sample_value-argument-reference) below.
+* `synonyms` - Additional values related to the slot type entry. See [`sample_value` argument reference](#sample_value-argument-reference) below.
 
 ### `sample_value` Argument Reference
+
 * `value` - (Required) Value that can be used for a slot type.
 
 ### `external_source_setting` Argument Reference
-*`grammar_slot_type_setting` - Settings required for a slot type based on a grammar that you provide. See [`grammar_slot_type_setting` argument reference](#grammar_slot_type_setting) below.
+
+*`grammar_slot_type_setting` - Settings required for a slot type based on a grammar that you provide. See [`grammar_slot_type_setting` argument reference](#grammar_slot_type_setting-argument-reference) below.
 
 ### `grammar_slot_type_setting` Argument Reference
-* `source` - Source of the grammar used to create the slot type. See [`grammar_slot_type_source` argument reference](#grammar_slot_type_reference) below.
+
+* `source` - Source of the grammar used to create the slot type. See [`grammar_slot_type_source` argument reference](#grammar_slot_type_source-argument-reference) below.
 
 ### `grammar_slot_type_source` Argument Reference
+
 * `s3_bucket_name` - (Required) Name of the Amazon S3 bucket that contains the grammar source.
 * `s3_object_key` - (Required) Path to the grammar in the Amazon S3 bucket.
 * `kms_key_arn` - KMS key required to decrypt the contents of the grammar, if any.
 
 ### `composite_slot_type_setting` Argument Reference
+
 * `sub_slots` - Subslots in the composite slot. Contains filtered or unexported fields. See [`sub_slot_type_composition` argument reference] below.
 
 ### `sub_slot_type_composition` Argument Reference
+
 * `name` - Name of a constituent sub slot inside a composite slot.
 * `slot_type_id` - (Required) Unique identifier assigned to a slot type. This refers to either a built-in slot type or the unique slotTypeId of a custom slot type.
 
 ### `value_selection_setting` Argument Reference
-* `resolution_strategy` - (Required) Determines the slot resolution strategy that Amazon Lex uses to return slot type values. The field can be set to one of the following values:
- - ORIGINAL_VALUE - Returns the value entered by the user, if the user value is similar to the slot value.
- - TOP_RESOLUTION - If there is a resolution list for the slot, return the first value in the resolution list as the slot type value. If there is no resolution list, null is returned.
-If you don't specify the valueSelectionStrategy , the default is ORIGINAL_VALUE. Valid values are `OriginalValue`, `TopResolution`, and `Concatenation`.
+
+* `resolution_strategy` - (Required) Determines the slot resolution strategy that Amazon Lex uses to return slot type values. The field can be set to one of the following values: `ORIGINAL_VALUE` - Returns the value entered by the user, if the user value is similar to the slot value. `TOP_RESOLUTION` If there is a resolution list for the slot, return the first value in the resolution list as the slot type value. If there is no resolution list, null is returned. If you don't specify the valueSelectionStrategy , the default is `ORIGINAL_VALUE`. Valid values are `OriginalValue`, `TopResolution`, and `Concatenation`.
 * `advanced_recognition_setting` - Provides settings that enable advanced recognition settings for slot values. You can use this to enable using slot values as a custom vocabulary for recognizing user utterances. See [`advanced_recognition_setting` argument reference] below.
 * `regex_filter` - Used to validate the value of the slot. See [`regex_filter` argument reference] below.
 
 ### `advanced_recognition_setting` Argument Reference
-* `pattern` - (Required) Used to validate the value of a slot. Use a standard regular expression. Amazon Lex supports the following characters in the regular expression:
- - A-Z, a-z
- - 0-9
- - Unicode characters ("\⁠u")
-Represent Unicode characters with four digits, for example "\⁠u0041" or "\⁠u005A". The following regular expression operators are not supported:
- - Infinite repeaters: *, +, or {x,} with no upper bound.
- - Wild card (.)
+
+* `pattern` - (Required) Used to validate the value of a slot. Use a standard regular expression. Amazon Lex supports the following characters in the regular expression: A-Z, a-z, 0-9, Unicode characters ("\⁠u").
+Represent Unicode characters with four digits, for example "\⁠u0041" or "\⁠u005A". The following regular expression operators are not supported: Infinite repeaters: *, +, or {x,} with no upper bound, wild card (.)
 
 ### `advanced_recognition_setting` Argument Reference
+
 * `audio_recognition_strategy` - Enables using the slot values as a custom vocabulary for recognizing user utterances. Valid value is `UseSlotValuesAsCustomVocabulary`.
 
 ## Attribute Reference

--- a/website/docs/r/lexv2models_slot_type.html.markdown
+++ b/website/docs/r/lexv2models_slot_type.html.markdown
@@ -57,24 +57,24 @@ resource "aws_lexv2models_slot_type" "test" {
 
 The following arguments are required:
 
-* `bot_id` - Identifier of the bot associated with this slot type.
-* `bot_version` - Version of the bot associated with this slot type.
-* `locale_id` - Identifier of the language and locale where this slot type is used. All of the bots, slot types, and slots used by the intent must have the same locale.
-* `name` - Name of the slot type
+* `bot_id` - (Required) Identifier of the bot associated with this slot type.
+* `bot_version` - (Required) Version of the bot associated with this slot type.
+* `locale_id` - (Required) Identifier of the language and locale where this slot type is used. All of the bots, slot types, and slots used by the intent must have the same locale.
+* `name` - (Required) Name of the slot type
 
 The following arguments are optional:
 
 * `description` - (Optional) Description of the slot type.
-* `composite_slot_type_setting` - Specifications for a composite slot type. See [`composite_slot_type_setting` argument reference](#composite_slot_type_setting-argument-reference) below.
-* `external_source_setting` - Type of external information used to create the slot type. See [`external_source_setting` argument reference](#external_source_setting-argument-reference) below.
-* `parent_slot_type_signature` - Built-in slot type used as a parent of this slot type. When you define a parent slot type, the new slot type has the configuration of the parent slot type. Only AMAZON.AlphaNumeric is supported.
-* `slot_type_values` - List of SlotTypeValue objects that defines the values that the slot type can take. Each value can have a list of synonyms, additional values that help train the machine learning model about the values that it resolves for a slot. See [`slot_type_values` argument reference](#slot_type_values-argument-reference) below.
-* `value_selection_setting` - Determines the strategy that Amazon Lex uses to select a value from the list of possible values. The field can be set to one of the following values: `ORIGINAL_VALUE` returns the value entered by the user, if the user value is similar to the slot value. `TOP_RESOLUTION` if there is a resolution list for the slot, return the first value in the resolution list. If there is no resolution list, return null. If you don't specify the valueSelectionSetting parameter, the default is ORIGINAL_VALUE. See [`value_selection_setting` argument reference](#value_selection_setting-argument-reference) below.
+* `composite_slot_type_setting` - (Optional) Specifications for a composite slot type. See [`composite_slot_type_setting` argument reference](#composite_slot_type_setting-argument-reference) below.
+* `external_source_setting` - (Optional) Type of external information used to create the slot type. See [`external_source_setting` argument reference](#external_source_setting-argument-reference) below.
+* `parent_slot_type_signature` - (Optional) Built-in slot type used as a parent of this slot type. When you define a parent slot type, the new slot type has the configuration of the parent slot type. Only AMAZON.AlphaNumeric is supported.
+* `slot_type_values` - (Optional) List of SlotTypeValue objects that defines the values that the slot type can take. Each value can have a list of synonyms, additional values that help train the machine learning model about the values that it resolves for a slot. See [`slot_type_values` argument reference](#slot_type_values-argument-reference) below.
+* `value_selection_setting` - (Optional) Determines the strategy that Amazon Lex uses to select a value from the list of possible values. The field can be set to one of the following values: `ORIGINAL_VALUE` returns the value entered by the user, if the user value is similar to the slot value. `TOP_RESOLUTION` if there is a resolution list for the slot, return the first value in the resolution list. If there is no resolution list, return null. If you don't specify the valueSelectionSetting parameter, the default is ORIGINAL_VALUE. See [`value_selection_setting` argument reference](#value_selection_setting-argument-reference) below.
 
 ### `slot_type_values` Argument Reference
 
-* `sample_value` - Value of the slot type entry.  See [`sample_value` argument reference](#sample_value-argument-reference) below.
-* `synonyms` - Additional values related to the slot type entry. See [`sample_value` argument reference](#sample_value-argument-reference) below.
+* `sample_value` - (Optional) Value of the slot type entry.  See [`sample_value` argument reference](#sample_value-argument-reference) below.
+* `synonyms` - (Optional) Additional values related to the slot type entry. See [`sample_value` argument reference](#sample_value-argument-reference) below.
 
 ### `sample_value` Argument Reference
 
@@ -82,32 +82,32 @@ The following arguments are optional:
 
 ### `external_source_setting` Argument Reference
 
-*`grammar_slot_type_setting` - Settings required for a slot type based on a grammar that you provide. See [`grammar_slot_type_setting` argument reference](#grammar_slot_type_setting-argument-reference) below.
+*`grammar_slot_type_setting` - (Optional) Settings required for a slot type based on a grammar that you provide. See [`grammar_slot_type_setting` argument reference](#grammar_slot_type_setting-argument-reference) below.
 
 ### `grammar_slot_type_setting` Argument Reference
 
-* `source` - Source of the grammar used to create the slot type. See [`grammar_slot_type_source` argument reference](#grammar_slot_type_source-argument-reference) below.
+* `source` - (Optional) Source of the grammar used to create the slot type. See [`grammar_slot_type_source` argument reference](#grammar_slot_type_source-argument-reference) below.
 
 ### `grammar_slot_type_source` Argument Reference
 
 * `s3_bucket_name` - (Required) Name of the Amazon S3 bucket that contains the grammar source.
 * `s3_object_key` - (Required) Path to the grammar in the Amazon S3 bucket.
-* `kms_key_arn` - KMS key required to decrypt the contents of the grammar, if any.
+* `kms_key_arn` - (Optional) KMS key required to decrypt the contents of the grammar, if any.
 
 ### `composite_slot_type_setting` Argument Reference
 
-* `sub_slots` - Subslots in the composite slot. Contains filtered or unexported fields. See [`sub_slot_type_composition` argument reference] below.
+* `sub_slots` - (Optional) Subslots in the composite slot. Contains filtered or unexported fields. See [`sub_slot_type_composition` argument reference] below.
 
 ### `sub_slot_type_composition` Argument Reference
 
-* `name` - Name of a constituent sub slot inside a composite slot.
+* `name` - (Required) Name of a constituent sub slot inside a composite slot.
 * `slot_type_id` - (Required) Unique identifier assigned to a slot type. This refers to either a built-in slot type or the unique slotTypeId of a custom slot type.
 
 ### `value_selection_setting` Argument Reference
 
 * `resolution_strategy` - (Required) Determines the slot resolution strategy that Amazon Lex uses to return slot type values. The field can be set to one of the following values: `ORIGINAL_VALUE` - Returns the value entered by the user, if the user value is similar to the slot value. `TOP_RESOLUTION` If there is a resolution list for the slot, return the first value in the resolution list as the slot type value. If there is no resolution list, null is returned. If you don't specify the valueSelectionStrategy , the default is `ORIGINAL_VALUE`. Valid values are `OriginalValue`, `TopResolution`, and `Concatenation`.
-* `advanced_recognition_setting` - Provides settings that enable advanced recognition settings for slot values. You can use this to enable using slot values as a custom vocabulary for recognizing user utterances. See [`advanced_recognition_setting` argument reference] below.
-* `regex_filter` - Used to validate the value of the slot. See [`regex_filter` argument reference] below.
+* `advanced_recognition_setting` - (Optional) Provides settings that enable advanced recognition settings for slot values. You can use this to enable using slot values as a custom vocabulary for recognizing user utterances. See [`advanced_recognition_setting` argument reference] below.
+* `regex_filter` - (Optional) Used to validate the value of the slot. See [`regex_filter` argument reference] below.
 
 ### `advanced_recognition_setting` Argument Reference
 
@@ -116,7 +116,7 @@ Represent Unicode characters with four digits, for example "\⁠u0041" or "\⁠u
 
 ### `advanced_recognition_setting` Argument Reference
 
-* `audio_recognition_strategy` - Enables using the slot values as a custom vocabulary for recognizing user utterances. Valid value is `UseSlotValuesAsCustomVocabulary`.
+* `audio_recognition_strategy` - (Optional) Enables using the slot values as a custom vocabulary for recognizing user utterances. Valid value is `UseSlotValuesAsCustomVocabulary`.
 
 ## Attribute Reference
 

--- a/website/docs/r/lexv2models_slot_type.html.markdown
+++ b/website/docs/r/lexv2models_slot_type.html.markdown
@@ -26,7 +26,7 @@ resource "aws_lexv2models_bot" "test" {
   role_arn                    = aws_iam_role.test.arn
 
   data_privacy {
-    child_directed = %[3]t
+    child_directed = true
   }
 }
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
New resource LexV2Models `slot_type` 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
> make testacc TESTS=TestAccLexV2ModelsSlotType_ PKG=lexv2models
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lexv2models/... -v -count 1 -parallel 20 -run='TestAccLexV2ModelsSlotType_'  -timeout 360m
=== RUN   TestAccLexV2ModelsSlotType_basic
=== PAUSE TestAccLexV2ModelsSlotType_basic
=== RUN   TestAccLexV2ModelsSlotType_disappears
=== PAUSE TestAccLexV2ModelsSlotType_disappears
=== CONT  TestAccLexV2ModelsSlotType_basic
=== CONT  TestAccLexV2ModelsSlotType_disappears
--- PASS: TestAccLexV2ModelsSlotType_disappears (37.69s)
--- PASS: TestAccLexV2ModelsSlotType_basic (56.21s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lexv2models        62.650s

...
```
