### PR TITLE
[Enhancement]: Geoproximity Routing Policy in Route 53 resource.

### DIFF
--- a/internal/service/route53/record.go
+++ b/internal/service/route53/record.go
@@ -117,6 +117,7 @@ func ResourceRecord() *schema.Resource {
 				ConflictsWith: []string{
 					"failover_routing_policy",
 					"geolocation_routing_policy",
+					"geoproximity_routing_policy",
 					"latency_routing_policy",
 					"multivalue_answer_routing_policy",
 					"weighted_routing_policy",
@@ -139,6 +140,7 @@ func ResourceRecord() *schema.Resource {
 				ConflictsWith: []string{
 					"cidr_routing_policy",
 					"geolocation_routing_policy",
+					"geoproximity_routing_policy",
 					"latency_routing_policy",
 					"multivalue_answer_routing_policy",
 					"weighted_routing_policy",
@@ -172,6 +174,54 @@ func ResourceRecord() *schema.Resource {
 				ConflictsWith: []string{
 					"cidr_routing_policy",
 					"failover_routing_policy",
+					"geoproximity_routing_policy",
+					"latency_routing_policy",
+					"multivalue_answer_routing_policy",
+					"weighted_routing_policy",
+				},
+				RequiredWith: []string{"set_identifier"},
+			},
+			"geoproximity_routing_policy": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"awsregion": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"bias": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(-99, 99),
+						},
+						"coordinates": {
+							Type: schema.TypeSet,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"latitude": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"longitude": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+							Optional: true,
+						},
+						"localzonegroup": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+				ConflictsWith: []string{
+					"cidr_routing_policy",
+					"failover_routing_policy",
+					"geolocation_routing_policy",
 					"latency_routing_policy",
 					"multivalue_answer_routing_policy",
 					"weighted_routing_policy",
@@ -198,6 +248,7 @@ func ResourceRecord() *schema.Resource {
 					"cidr_routing_policy",
 					"failover_routing_policy",
 					"geolocation_routing_policy",
+					"geoproximity_routing_policy",
 					"multivalue_answer_routing_policy",
 					"weighted_routing_policy",
 				},
@@ -210,6 +261,7 @@ func ResourceRecord() *schema.Resource {
 					"cidr_routing_policy",
 					"failover_routing_policy",
 					"geolocation_routing_policy",
+					"geoproximity_routing_policy",
 					"latency_routing_policy",
 					"weighted_routing_policy",
 				},
@@ -264,6 +316,7 @@ func ResourceRecord() *schema.Resource {
 					"cidr_routing_policy",
 					"failover_routing_policy",
 					"geolocation_routing_policy",
+					"geoproximity_routing_policy",
 					"latency_routing_policy",
 					"multivalue_answer_routing_policy",
 				},
@@ -411,6 +464,18 @@ func resourceRecordRead(ctx context.Context, d *schema.ResourceData, meta interf
 		}
 	}
 
+	if record.GeoProximityLocation != nil {
+		v := []map[string]interface{}{{
+			"awsregion":      aws.StringValue(record.GeoProximityLocation.AWSRegion),
+			"bias":           aws.Int64Value((record.GeoProximityLocation.Bias)),
+			"coordinates":    flattenCoordinate(record.GeoProximityLocation.Coordinates),
+			"localzonegroup": aws.StringValue(record.GeoProximityLocation.LocalZoneGroup),
+		}}
+		if err := d.Set("geoproximity_routing_policy", v); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting geoproximity_routing_policy: %s", err)
+		}
+	}
+
 	if record.Region != nil {
 		v := []map[string]interface{}{{
 			"region": aws.StringValue(record.Region),
@@ -512,6 +577,21 @@ func resourceRecordUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 						ContinentCode:   nilString(v["continent"].(string)),
 						CountryCode:     nilString(v["country"].(string)),
 						SubdivisionCode: nilString(v["subdivision"].(string)),
+					}
+				}
+			}
+		}
+	}
+
+	if v, _ := d.GetChange("geoproximity_routing_policy"); v != nil {
+		if o, ok := v.([]interface{}); ok {
+			if len(o) == 1 {
+				if v, ok := o[0].(map[string]interface{}); ok {
+					oldRec.GeoProximityLocation = &route53.GeoProximityLocation{
+						AWSRegion:      nilString(v["awsregion"].(string)),
+						Bias:           aws.Int64(int64(v["bias"].(int))),
+						Coordinates:    expandCoordinatesValue(v["coordinates"].(*schema.Set).List()),
+						LocalZoneGroup: nilString(v["localzonegroup"].(string)),
 					}
 				}
 			}
@@ -852,6 +932,23 @@ func expandResourceRecordSet(d *schema.ResourceData, zoneName string) *route53.R
 		}
 	}
 
+	if v, ok := d.GetOk("geoproximity_routing_policy"); ok {
+		geoproximityvalues := v.([]interface{})
+		geoproximity := geoproximityvalues[0].(map[string]interface{})
+
+		rec.GeoProximityLocation = &route53.GeoProximityLocation{
+			AWSRegion:      nilString(geoproximity["awsregion"].(string)),
+			Bias:           aws.Int64(int64(geoproximity["bias"].(int))),
+			Coordinates:    expandCoordinatesValue(geoproximity["coordinates"].(*schema.Set).List()),
+			LocalZoneGroup: nilString(geoproximity["localzonegroup"].(string)),
+		}
+		// if len(geoproximity["coordinates"].(*schema.Set).List()) > 0 {
+		// 	coordinatesvalue := geoproximity["coordinates"].(*schema.Set).List()
+		// 	coordinates := expandCoordinatesValue(coordinatesvalue)
+		// 	rec.GeoProximityLocation.Coordinates = coordinates
+		// }
+	}
+
 	if v, ok := d.GetOk("health_check_id"); ok {
 		rec.HealthCheckId = aws.String(v.(string))
 	}
@@ -918,6 +1015,22 @@ func ExpandRecordName(name, zone string) string {
 	return rn
 }
 
+func expandCoordinatesValue(tfList []interface{}) *route53.Coordinates {
+	if len(tfList) == 0 {
+		return nil
+	}
+	coordinatesvalue := &route53.Coordinates{}
+	for _, tfMapRaw := range tfList {
+		tfMap, ok := tfMapRaw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		coordinatesvalue.Latitude = aws.String(tfMap["latitude"].(string))
+		coordinatesvalue.Longitude = aws.String(tfMap["longitude"].(string))
+	}
+	return coordinatesvalue
+}
+
 // nilString takes a string as an argument and returns a string
 // pointer. The returned pointer is nil if the string argument is
 // empty. Otherwise, it is a pointer to a copy of the string.
@@ -955,6 +1068,26 @@ func ParseRecordID(id string) [4]string {
 		}
 	}
 	return [4]string{recZone, recName, recType, recSet}
+}
+
+func flattenCoordinate(coordinates *route53.Coordinates) []interface{} {
+	if coordinates == nil {
+		return nil
+	}
+	var tfList []interface{}
+	tfMap := map[string]interface{}{}
+
+	if v := coordinates.Latitude; v != nil {
+		tfMap["latitude"] = aws.StringValue(v)
+	}
+
+	if v := coordinates.Longitude; v != nil {
+		tfMap["longitude"] = aws.StringValue(v)
+	}
+
+	tfList = append(tfList, tfMap)
+
+	return tfList
 }
 
 func validRecordType(s string) bool {

--- a/internal/service/route53/record.go
+++ b/internal/service/route53/record.go
@@ -942,11 +942,6 @@ func expandResourceRecordSet(d *schema.ResourceData, zoneName string) *route53.R
 			Coordinates:    ExpandCoordinatesValue(geoproximity["coordinates"].(*schema.Set).List()),
 			LocalZoneGroup: nilString(geoproximity["localzonegroup"].(string)),
 		}
-		// if len(geoproximity["coordinates"].(*schema.Set).List()) > 0 {
-		// 	coordinatesvalue := geoproximity["coordinates"].(*schema.Set).List()
-		// 	coordinates := expandCoordinatesValue(coordinatesvalue)
-		// 	rec.GeoProximityLocation.Coordinates = coordinates
-		// }
 	}
 
 	if v, ok := d.GetOk("health_check_id"); ok {

--- a/internal/service/route53/record.go
+++ b/internal/service/route53/record.go
@@ -590,7 +590,7 @@ func resourceRecordUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 					oldRec.GeoProximityLocation = &route53.GeoProximityLocation{
 						AWSRegion:      nilString(v["awsregion"].(string)),
 						Bias:           aws.Int64(int64(v["bias"].(int))),
-						Coordinates:    expandCoordinatesValue(v["coordinates"].(*schema.Set).List()),
+						Coordinates:    ExpandCoordinatesValue(v["coordinates"].(*schema.Set).List()),
 						LocalZoneGroup: nilString(v["localzonegroup"].(string)),
 					}
 				}
@@ -939,7 +939,7 @@ func expandResourceRecordSet(d *schema.ResourceData, zoneName string) *route53.R
 		rec.GeoProximityLocation = &route53.GeoProximityLocation{
 			AWSRegion:      nilString(geoproximity["awsregion"].(string)),
 			Bias:           aws.Int64(int64(geoproximity["bias"].(int))),
-			Coordinates:    expandCoordinatesValue(geoproximity["coordinates"].(*schema.Set).List()),
+			Coordinates:    ExpandCoordinatesValue(geoproximity["coordinates"].(*schema.Set).List()),
 			LocalZoneGroup: nilString(geoproximity["localzonegroup"].(string)),
 		}
 		// if len(geoproximity["coordinates"].(*schema.Set).List()) > 0 {
@@ -1015,7 +1015,7 @@ func ExpandRecordName(name, zone string) string {
 	return rn
 }
 
-func expandCoordinatesValue(tfList []interface{}) *route53.Coordinates {
+func ExpandCoordinatesValue(tfList []interface{}) *route53.Coordinates {
 	if len(tfList) == 0 {
 		return nil
 	}

--- a/internal/service/route53/record_test.go
+++ b/internal/service/route53/record_test.go
@@ -160,6 +160,7 @@ func TestAccRoute53Record_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "failover_routing_policy.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "fqdn", recordName.String()),
 					resource.TestCheckResourceAttr(resourceName, "geolocation_routing_policy.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "geoproximity_routing_policy.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "health_check_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "latency_routing_policy.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "multivalue_answer_routing_policy", "false"),
@@ -777,6 +778,7 @@ func TestAccRoute53Record_cidr(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "failover_routing_policy.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "fqdn", recordName.String()),
 					resource.TestCheckResourceAttr(resourceName, "geolocation_routing_policy.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "geoproximity_routing_policy.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "health_check_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "latency_routing_policy.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "multivalue_answer_routing_policy", "false"),
@@ -838,6 +840,35 @@ func TestAccRoute53Record_Geolocation_basic(t *testing.T) {
 					testAccCheckRecordExists(ctx, "aws_route53_record.california", &record2),
 					testAccCheckRecordExists(ctx, "aws_route53_record.oceania", &record3),
 					testAccCheckRecordExists(ctx, "aws_route53_record.denmark", &record4),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "weight"},
+			},
+		},
+	})
+}
+
+func TestAccRoute53Record_Geoproximity_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	var record1, record2, record3 route53.ResourceRecordSet
+	resourceName := "aws_route53_record.awsregion"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, route53.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRecordDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRecordConfig_geoproximityCNAME,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRecordExists(ctx, "aws_route53_record.awsregion", &record1),
+					testAccCheckRecordExists(ctx, "aws_route53_record.localzonegroup", &record2),
+					testAccCheckRecordExists(ctx, "aws_route53_record.coordinates", &record3),
 				),
 			},
 			{
@@ -1175,6 +1206,105 @@ func TestAccRoute53Record_SetIdentifierRename_geolocationCountrySubdivision(t *t
 			},
 			{
 				Config: testAccRecordConfig_setIdentifierRenameGeolocationCountrySubdivision("US", "CA", "after"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRecordExists(ctx, resourceName, &record2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRoute53Record_SetIdentifierRename_geoproximityAwsRegion(t *testing.T) {
+	ctx := acctest.Context(t)
+	var record1, record2 route53.ResourceRecordSet
+	resourceName := "aws_route53_record.set_identifier_rename_geoproximity"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, route53.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRecordDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRecordConfig_setIdentifierRenameGeoproximityAwsRegion("us-east-1", "before"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRecordExists(ctx, resourceName, &record1),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+			},
+			{
+				Config: testAccRecordConfig_setIdentifierRenameGeoproximityAwsRegion("us-east-1", "after"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRecordExists(ctx, resourceName, &record2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRoute53Record_SetIdentifierRename_geoproximityLocalZoneGroup(t *testing.T) {
+	ctx := acctest.Context(t)
+	var record1, record2 route53.ResourceRecordSet
+	resourceName := "aws_route53_record.set_identifier_rename_geoproximity"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, route53.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRecordDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRecordConfig_setIdentifierRenameGeoproximityLocalZoneGroup("us-east-1-atl-1", "before"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRecordExists(ctx, resourceName, &record1),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+			},
+			{
+				Config: testAccRecordConfig_setIdentifierRenameGeoproximityLocalZoneGroup("us-east-1-atl-1", "after"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRecordExists(ctx, resourceName, &record2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRoute53Record_SetIdentifierRename_geoproximityCoordinates(t *testing.T) {
+	ctx := acctest.Context(t)
+	var record1, record2 route53.ResourceRecordSet
+	resourceName := "aws_route53_record.set_identifier_rename_geoproximity"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, route53.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRecordDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRecordConfig_setIdentifierRenameGeoproximityCoordinates("49.22", "-74.01", "before"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRecordExists(ctx, resourceName, &record1),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+			},
+			{
+				Config: testAccRecordConfig_setIdentifierRenameGeoproximityCoordinates("49.22", "-74.01", "after"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(ctx, resourceName, &record2),
 				),
@@ -2093,6 +2223,55 @@ resource "aws_route53_record" "denmark" {
 }
 `
 
+const testAccRecordConfig_geoproximityCNAME = `
+resource "aws_route53_zone" "main" {
+	name = "domain.test"
+  }
+
+resource "aws_route53_record" "awsregion" {
+	name           = "www"
+	zone_id        = aws_route53_zone.main.zone_id
+	type           = "CNAME"
+	ttl            = "5"
+
+	geoproximity_routing_policy {
+		awsregion = "us-east-1"
+		bias = 40
+	}
+	records        = ["dev.domain.test"]
+	set_identifier = "awsregion"
+}
+
+resource "aws_route53_record" "localzonegroup" {
+	name           = "www"
+	zone_id        = aws_route53_zone.main.zone_id
+	type           = "CNAME"
+	ttl            = "5"
+
+	geoproximity_routing_policy {
+		localzonegroup = "us-east-1-atl-1"
+	}
+	records        = ["dev.domain.test"]
+	set_identifier = "localzonegroup"
+}
+
+resource "aws_route53_record" "coordinates" {
+	name           = "www"
+	zone_id        = aws_route53_zone.main.zone_id
+	type           = "CNAME"
+	ttl            = "5"
+
+	geoproximity_routing_policy {
+		coordinates {
+			latitude = "49.22"
+			longitude = "-74.01"
+		  }
+	}
+	records        = ["dev.domain.test"]
+	set_identifier = "coordinates"
+}
+`
+
 func testAccRecordConfig_latencyCNAME(firstRegion, secondRegion, thirdRegion string) string {
 	return fmt.Sprintf(`
 resource "aws_route53_zone" "main" {
@@ -2753,6 +2932,72 @@ resource "aws_route53_record" "set_identifier_rename_geolocation" {
   records        = ["primary.domain.test"]
 }
 `, country, subdivision, set_identifier)
+}
+
+func testAccRecordConfig_setIdentifierRenameGeoproximityAwsRegion(region, set_identifier string) string {
+	return fmt.Sprintf(`
+resource "aws_route53_zone" "main" {
+	name = "domain.test"
+	}
+
+resource "aws_route53_record" "set_identifier_rename_geoproximity" {
+	name           = "www"
+	zone_id        = aws_route53_zone.main.zone_id
+	type           = "CNAME"
+	ttl            = "5"
+
+	geoproximity_routing_policy {
+		awsregion = %[1]q
+	}
+
+	records        = ["dev.example.com"]
+	set_identifier = %[2]q
+	}`, region, set_identifier)
+}
+
+func testAccRecordConfig_setIdentifierRenameGeoproximityLocalZoneGroup(zonegroup, set_identifier string) string {
+	return fmt.Sprintf(`
+resource "aws_route53_zone" "main" {
+	name = "domain.test"
+	}
+
+resource "aws_route53_record" "set_identifier_rename_geoproximity" {
+	name           = "www"
+	zone_id        = aws_route53_zone.main.zone_id
+	type           = "CNAME"
+	ttl            = "5"
+	
+	geoproximity_routing_policy {
+		localzonegroup = %[1]q
+	}
+
+	records        = ["dev.example.com"]
+	set_identifier = %[2]q
+	}`, zonegroup, set_identifier)
+}
+
+func testAccRecordConfig_setIdentifierRenameGeoproximityCoordinates(latitude, longitude, set_identifier string) string {
+	return fmt.Sprintf(`
+resource "aws_route53_zone" "main" {
+	name = "domain.test"
+	}
+
+resource "aws_route53_record" "set_identifier_rename_geoproximity" {
+	name           = "www"
+	zone_id        = aws_route53_zone.main.zone_id
+	type           = "CNAME"
+	ttl            = "5"
+	
+	geoproximity_routing_policy {
+		coordinates {
+			latitude = %[1]q
+			longitude = %[2]q
+		  }
+	}
+
+	records        = ["dev.example.com"]
+	set_identifier = %[3]q
+	}`, latitude, longitude, set_identifier)
 }
 
 func testAccRecordConfig_setIdentifierRenameLatency(region, set_identifier string) string {

--- a/internal/service/route53/record_test.go
+++ b/internal/service/route53/record_test.go
@@ -2227,49 +2227,50 @@ const testAccRecordConfig_geoproximityCNAME = `
 resource "aws_route53_zone" "main" {
 	name = "domain.test"
   }
-
-resource "aws_route53_record" "awsregion" {
-	name           = "www"
-	zone_id        = aws_route53_zone.main.zone_id
-	type           = "CNAME"
-	ttl            = "5"
-
+  
+  resource "aws_route53_record" "awsregion" {
+	name    = "www"
+	zone_id = aws_route53_zone.main.zone_id
+	type    = "CNAME"
+	ttl     = "5"
+  
 	geoproximity_routing_policy {
-		awsregion = "us-east-1"
-		bias = 40
+	  awsregion = "us-east-1"
+	  bias      = 40
 	}
 	records        = ["dev.domain.test"]
 	set_identifier = "awsregion"
-}
-
-resource "aws_route53_record" "localzonegroup" {
-	name           = "www"
-	zone_id        = aws_route53_zone.main.zone_id
-	type           = "CNAME"
-	ttl            = "5"
-
+  }
+  
+  resource "aws_route53_record" "localzonegroup" {
+	name    = "www"
+	zone_id = aws_route53_zone.main.zone_id
+	type    = "CNAME"
+	ttl     = "5"
+  
 	geoproximity_routing_policy {
-		localzonegroup = "us-east-1-atl-1"
+	  localzonegroup = "us-east-1-atl-1"
 	}
 	records        = ["dev.domain.test"]
 	set_identifier = "localzonegroup"
-}
-
-resource "aws_route53_record" "coordinates" {
-	name           = "www"
-	zone_id        = aws_route53_zone.main.zone_id
-	type           = "CNAME"
-	ttl            = "5"
-
+  }
+  
+  resource "aws_route53_record" "coordinates" {
+	name    = "www"
+	zone_id = aws_route53_zone.main.zone_id
+	type    = "CNAME"
+	ttl     = "5"
+  
 	geoproximity_routing_policy {
-		coordinates {
-			latitude = "49.22"
-			longitude = "-74.01"
-		  }
+	  coordinates {
+		latitude  = "49.22"
+		longitude = "-74.01"
+	  }
 	}
 	records        = ["dev.domain.test"]
 	set_identifier = "coordinates"
-}
+  }
+  
 `
 
 func testAccRecordConfig_latencyCNAME(firstRegion, secondRegion, thirdRegion string) string {
@@ -2937,67 +2938,70 @@ resource "aws_route53_record" "set_identifier_rename_geolocation" {
 func testAccRecordConfig_setIdentifierRenameGeoproximityAwsRegion(region, set_identifier string) string {
 	return fmt.Sprintf(`
 resource "aws_route53_zone" "main" {
-	name = "domain.test"
-	}
+  name = "domain.test"
+}
 
 resource "aws_route53_record" "set_identifier_rename_geoproximity" {
-	name           = "www"
-	zone_id        = aws_route53_zone.main.zone_id
-	type           = "CNAME"
-	ttl            = "5"
+  name    = "www"
+  zone_id = aws_route53_zone.main.zone_id
+  type    = "CNAME"
+  ttl     = "5"
 
-	geoproximity_routing_policy {
-		awsregion = %[1]q
-	}
+  geoproximity_routing_policy {
+    awsregion = %[1]q
+  }
 
-	records        = ["dev.example.com"]
-	set_identifier = %[2]q
-	}`, region, set_identifier)
+  records        = ["dev.example.com"]
+  set_identifier = %[2]q
+}
+`, region, set_identifier)
 }
 
 func testAccRecordConfig_setIdentifierRenameGeoproximityLocalZoneGroup(zonegroup, set_identifier string) string {
 	return fmt.Sprintf(`
 resource "aws_route53_zone" "main" {
-	name = "domain.test"
-	}
+  name = "domain.test"
+}
 
 resource "aws_route53_record" "set_identifier_rename_geoproximity" {
-	name           = "www"
-	zone_id        = aws_route53_zone.main.zone_id
-	type           = "CNAME"
-	ttl            = "5"
-	
-	geoproximity_routing_policy {
-		localzonegroup = %[1]q
-	}
+  name    = "www"
+  zone_id = aws_route53_zone.main.zone_id
+  type    = "CNAME"
+  ttl     = "5"
 
-	records        = ["dev.example.com"]
-	set_identifier = %[2]q
-	}`, zonegroup, set_identifier)
+  geoproximity_routing_policy {
+    localzonegroup = %[1]q
+  }
+
+  records        = ["dev.example.com"]
+  set_identifier = %[2]q
+}
+`, zonegroup, set_identifier)
 }
 
 func testAccRecordConfig_setIdentifierRenameGeoproximityCoordinates(latitude, longitude, set_identifier string) string {
 	return fmt.Sprintf(`
 resource "aws_route53_zone" "main" {
-	name = "domain.test"
-	}
+  name = "domain.test"
+}
 
 resource "aws_route53_record" "set_identifier_rename_geoproximity" {
-	name           = "www"
-	zone_id        = aws_route53_zone.main.zone_id
-	type           = "CNAME"
-	ttl            = "5"
-	
-	geoproximity_routing_policy {
-		coordinates {
-			latitude = %[1]q
-			longitude = %[2]q
-		  }
-	}
+  name    = "www"
+  zone_id = aws_route53_zone.main.zone_id
+  type    = "CNAME"
+  ttl     = "5"
 
-	records        = ["dev.example.com"]
-	set_identifier = %[3]q
-	}`, latitude, longitude, set_identifier)
+  geoproximity_routing_policy {
+    coordinates {
+      latitude  = %[1]q
+      longitude = %[2]q
+    }
+  }
+
+  records        = ["dev.example.com"]
+  set_identifier = %[3]q
+}
+`, latitude, longitude, set_identifier)
 }
 
 func testAccRecordConfig_setIdentifierRenameLatency(region, set_identifier string) string {

--- a/internal/service/route53/record_test.go
+++ b/internal/service/route53/record_test.go
@@ -2225,52 +2225,51 @@ resource "aws_route53_record" "denmark" {
 
 const testAccRecordConfig_geoproximityCNAME = `
 resource "aws_route53_zone" "main" {
-	name = "domain.test"
+  name = "domain.test"
+}
+
+resource "aws_route53_record" "awsregion" {
+  name    = "www"
+  zone_id = aws_route53_zone.main.zone_id
+  type    = "CNAME"
+  ttl     = "5"
+
+  geoproximity_routing_policy {
+    awsregion = "us-east-1"
+    bias      = 40
   }
-  
-  resource "aws_route53_record" "awsregion" {
-	name    = "www"
-	zone_id = aws_route53_zone.main.zone_id
-	type    = "CNAME"
-	ttl     = "5"
-  
-	geoproximity_routing_policy {
-	  awsregion = "us-east-1"
-	  bias      = 40
-	}
-	records        = ["dev.domain.test"]
-	set_identifier = "awsregion"
+  records        = ["dev.domain.test"]
+  set_identifier = "awsregion"
+}
+
+resource "aws_route53_record" "localzonegroup" {
+  name    = "www"
+  zone_id = aws_route53_zone.main.zone_id
+  type    = "CNAME"
+  ttl     = "5"
+
+  geoproximity_routing_policy {
+    localzonegroup = "us-east-1-atl-1"
   }
-  
-  resource "aws_route53_record" "localzonegroup" {
-	name    = "www"
-	zone_id = aws_route53_zone.main.zone_id
-	type    = "CNAME"
-	ttl     = "5"
-  
-	geoproximity_routing_policy {
-	  localzonegroup = "us-east-1-atl-1"
-	}
-	records        = ["dev.domain.test"]
-	set_identifier = "localzonegroup"
+  records        = ["dev.domain.test"]
+  set_identifier = "localzonegroup"
+}
+
+resource "aws_route53_record" "coordinates" {
+  name    = "www"
+  zone_id = aws_route53_zone.main.zone_id
+  type    = "CNAME"
+  ttl     = "5"
+
+  geoproximity_routing_policy {
+    coordinates {
+      latitude  = "49.22"
+      longitude = "-74.01"
+    }
   }
-  
-  resource "aws_route53_record" "coordinates" {
-	name    = "www"
-	zone_id = aws_route53_zone.main.zone_id
-	type    = "CNAME"
-	ttl     = "5"
-  
-	geoproximity_routing_policy {
-	  coordinates {
-		latitude  = "49.22"
-		longitude = "-74.01"
-	  }
-	}
-	records        = ["dev.domain.test"]
-	set_identifier = "coordinates"
-  }
-  
+  records        = ["dev.domain.test"]
+  set_identifier = "coordinates"
+}
 `
 
 func testAccRecordConfig_latencyCNAME(firstRegion, secondRegion, thirdRegion string) string {

--- a/internal/service/route53/record_test.go
+++ b/internal/service/route53/record_test.go
@@ -864,7 +864,7 @@ func TestAccRoute53Record_Geoproximity_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckRecordDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRecordConfig_geoproximityCNAME,
+				Config: testAccRecordConfig_geoproximityCNAME(endpoints.UsEast1RegionID, fmt.Sprintf("%s-atl-1", endpoints.UsEast1RegionID)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(ctx, "aws_route53_record.awsregion", &record1),
 					testAccCheckRecordExists(ctx, "aws_route53_record.localzonegroup", &record2),
@@ -1214,7 +1214,7 @@ func TestAccRoute53Record_SetIdentifierRename_geolocationCountrySubdivision(t *t
 	})
 }
 
-func TestAccRoute53Record_SetIdentifierRename_geoproximityAwsRegion(t *testing.T) {
+func TestAccRoute53Record_SetIdentifierRename_geoproximityRegion(t *testing.T) {
 	ctx := acctest.Context(t)
 	var record1, record2 route53.ResourceRecordSet
 	resourceName := "aws_route53_record.set_identifier_rename_geoproximity"
@@ -1226,7 +1226,7 @@ func TestAccRoute53Record_SetIdentifierRename_geoproximityAwsRegion(t *testing.T
 		CheckDestroy:             testAccCheckRecordDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRecordConfig_setIdentifierRenameGeoproximityAwsRegion("us-east-1", "before"),
+				Config: testAccRecordConfig_setIdentifierRenameGeoproximityRegion(endpoints.UsEast1RegionID, "before"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(ctx, resourceName, &record1),
 				),
@@ -1238,7 +1238,7 @@ func TestAccRoute53Record_SetIdentifierRename_geoproximityAwsRegion(t *testing.T
 				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 			{
-				Config: testAccRecordConfig_setIdentifierRenameGeoproximityAwsRegion("us-east-1", "after"),
+				Config: testAccRecordConfig_setIdentifierRenameGeoproximityRegion(endpoints.UsEast1RegionID, "after"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(ctx, resourceName, &record2),
 				),
@@ -1259,7 +1259,7 @@ func TestAccRoute53Record_SetIdentifierRename_geoproximityLocalZoneGroup(t *test
 		CheckDestroy:             testAccCheckRecordDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRecordConfig_setIdentifierRenameGeoproximityLocalZoneGroup("us-east-1-atl-1", "before"),
+				Config: testAccRecordConfig_setIdentifierRenameGeoproximityLocalZoneGroup(fmt.Sprintf("%s-atl-1", endpoints.UsEast1RegionID), "before"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(ctx, resourceName, &record1),
 				),
@@ -1271,7 +1271,7 @@ func TestAccRoute53Record_SetIdentifierRename_geoproximityLocalZoneGroup(t *test
 				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 			{
-				Config: testAccRecordConfig_setIdentifierRenameGeoproximityLocalZoneGroup("us-east-1-atl-1", "after"),
+				Config: testAccRecordConfig_setIdentifierRenameGeoproximityLocalZoneGroup(fmt.Sprintf("%s-atl-1", endpoints.UsEast1RegionID), "after"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists(ctx, resourceName, &record2),
 				),
@@ -2223,7 +2223,8 @@ resource "aws_route53_record" "denmark" {
 }
 `
 
-const testAccRecordConfig_geoproximityCNAME = `
+func testAccRecordConfig_geoproximityCNAME(region string, localzonegroup string) string {
+	return fmt.Sprintf(`
 resource "aws_route53_zone" "main" {
   name = "domain.test"
 }
@@ -2235,7 +2236,7 @@ resource "aws_route53_record" "awsregion" {
   ttl     = "5"
 
   geoproximity_routing_policy {
-    awsregion = "us-east-1"
+    awsregion = %[1]q
     bias      = 40
   }
   records        = ["dev.domain.test"]
@@ -2249,7 +2250,7 @@ resource "aws_route53_record" "localzonegroup" {
   ttl     = "5"
 
   geoproximity_routing_policy {
-    localzonegroup = "us-east-1-atl-1"
+    localzonegroup = %[2]q
   }
   records        = ["dev.domain.test"]
   set_identifier = "localzonegroup"
@@ -2270,7 +2271,8 @@ resource "aws_route53_record" "coordinates" {
   records        = ["dev.domain.test"]
   set_identifier = "coordinates"
 }
-`
+`, region, localzonegroup)
+}
 
 func testAccRecordConfig_latencyCNAME(firstRegion, secondRegion, thirdRegion string) string {
 	return fmt.Sprintf(`
@@ -2934,7 +2936,7 @@ resource "aws_route53_record" "set_identifier_rename_geolocation" {
 `, country, subdivision, set_identifier)
 }
 
-func testAccRecordConfig_setIdentifierRenameGeoproximityAwsRegion(region, set_identifier string) string {
+func testAccRecordConfig_setIdentifierRenameGeoproximityRegion(region, set_identifier string) string {
 	return fmt.Sprintf(`
 resource "aws_route53_zone" "main" {
   name = "domain.test"

--- a/website/docs/r/route53_record.html.markdown
+++ b/website/docs/r/route53_record.html.markdown
@@ -68,12 +68,12 @@ resource "aws_route53_record" "www" {
   ttl     = 300
   geoproximity_routing_policy {
     coordinates {
-			latitude = "49.22"
-			longitude = "-74.01"
-		}
-  } 
+      latitude  = "49.22"
+      longitude = "-74.01"
+    }
+  }
   set_identifier = "dev"
-  records = ["dev.example.com"]
+  records        = ["dev.example.com"]
 }
 ```
 
@@ -194,7 +194,7 @@ Geolocation routing policies support the following:
 Geoproximity routing policies support the following:
 
 * `awsregion` - A AWS region where the resource is present.
-* `bias` - Route more traffic or less traffic to the resource by specifing a value ranges between -90 to 90. See https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-policy-geoproximity.html for bias details.
+* `bias` - Route more traffic or less traffic to the resource by specifying a value ranges between -90 to 90. See https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-policy-geoproximity.html for bias details.
 * `coordinates` - Specify `latitude` and `longitude` for routing traffic to non-AWS resources.
 * `localzonegroup` - A AWS local zone group where the resource is present. See https://docs.aws.amazon.com/local-zones/latest/ug/available-local-zones.html for local zone group list.
 

--- a/website/docs/r/route53_record.html.markdown
+++ b/website/docs/r/route53_record.html.markdown
@@ -145,7 +145,7 @@ This resource supports the following arguments:
 * `type` - (Required) The record type. Valid values are `A`, `AAAA`, `CAA`, `CNAME`, `DS`, `MX`, `NAPTR`, `NS`, `PTR`, `SOA`, `SPF`, `SRV` and `TXT`.
 * `ttl` - (Required for non-alias records) The TTL of the record.
 * `records` - (Required for non-alias records) A string list of records. To specify a single record value longer than 255 characters such as a TXT record for DKIM, add `\"\"` inside the Terraform configuration string (e.g., `"first255characters\"\"morecharacters"`).
-* `set_identifier` - (Optional) Unique identifier to differentiate records with routing policies from one another. Required if using `cidr_routing_policy`, `failover_routing_policy`, `geolocation_routing_policy`,`geolocation_routing_policy`, `latency_routing_policy`, `multivalue_answer_routing_policy`, or `weighted_routing_policy`.
+* `set_identifier` - (Optional) Unique identifier to differentiate records with routing policies from one another. Required if using `cidr_routing_policy`, `failover_routing_policy`, `geolocation_routing_policy`,`geoproximity_routing_policy`, `latency_routing_policy`, `multivalue_answer_routing_policy`, or `weighted_routing_policy`.
 * `health_check_id` - (Optional) The health check the record should be associated with.
 * `alias` - (Optional) An alias block. Conflicts with `ttl` & `records`.
   [Documented below](#alias).

--- a/website/docs/r/route53_record.html.markdown
+++ b/website/docs/r/route53_record.html.markdown
@@ -58,6 +58,25 @@ resource "aws_route53_record" "www-live" {
 }
 ```
 
+### Geoproximity routing policy
+
+```terraform
+resource "aws_route53_record" "www" {
+  zone_id = aws_route53_zone.primary.zone_id
+  name    = "www.example.com"
+  type    = "CNAME"
+  ttl     = 300
+  geoproximity_routing_policy {
+    coordinates {
+			latitude = "49.22"
+			longitude = "-74.01"
+		}
+  } 
+  set_identifier = "dev"
+  records = ["dev.example.com"]
+}
+```
+
 ### Alias record
 
 See [related part of Amazon Route 53 Developer Guide](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-choosing-alias-non-alias.html)

--- a/website/docs/r/route53_record.html.markdown
+++ b/website/docs/r/route53_record.html.markdown
@@ -126,13 +126,14 @@ This resource supports the following arguments:
 * `type` - (Required) The record type. Valid values are `A`, `AAAA`, `CAA`, `CNAME`, `DS`, `MX`, `NAPTR`, `NS`, `PTR`, `SOA`, `SPF`, `SRV` and `TXT`.
 * `ttl` - (Required for non-alias records) The TTL of the record.
 * `records` - (Required for non-alias records) A string list of records. To specify a single record value longer than 255 characters such as a TXT record for DKIM, add `\"\"` inside the Terraform configuration string (e.g., `"first255characters\"\"morecharacters"`).
-* `set_identifier` - (Optional) Unique identifier to differentiate records with routing policies from one another. Required if using `cidr_routing_policy`, `failover_routing_policy`, `geolocation_routing_policy`, `latency_routing_policy`, `multivalue_answer_routing_policy`, or `weighted_routing_policy`.
+* `set_identifier` - (Optional) Unique identifier to differentiate records with routing policies from one another. Required if using `cidr_routing_policy`, `failover_routing_policy`, `geolocation_routing_policy`,`geolocation_routing_policy`, `latency_routing_policy`, `multivalue_answer_routing_policy`, or `weighted_routing_policy`.
 * `health_check_id` - (Optional) The health check the record should be associated with.
 * `alias` - (Optional) An alias block. Conflicts with `ttl` & `records`.
   [Documented below](#alias).
 * `cidr_routing_policy` - (Optional) A block indicating a routing policy based on the IP network ranges of requestors. Conflicts with any other routing policy. [Documented below](#cidr-routing-policy).
 * `failover_routing_policy` - (Optional) A block indicating the routing behavior when associated health check fails. Conflicts with any other routing policy. [Documented below](#failover-routing-policy).
 * `geolocation_routing_policy` - (Optional) A block indicating a routing policy based on the geolocation of the requestor. Conflicts with any other routing policy. [Documented below](#geolocation-routing-policy).
+* `geoproximity_routing_policy` - (Optional) A block indicating a routing policy based on the geoproximity of the requestor. Conflicts with any other routing policy. [Documented below](#geoproximity-routing-policy).
 * `latency_routing_policy` - (Optional) A block indicating a routing policy based on the latency between the requestor and an AWS region. Conflicts with any other routing policy. [Documented below](#latency-routing-policy).
 * `multivalue_answer_routing_policy` - (Optional) Set to `true` to indicate a multivalue answer routing policy. Conflicts with any other routing policy.
 * `weighted_routing_policy` - (Optional) A block indicating a weighted routing policy. Conflicts with any other routing policy. [Documented below](#weighted-routing-policy).
@@ -168,6 +169,15 @@ Geolocation routing policies support the following:
 * `continent` - A two-letter continent code. See http://docs.aws.amazon.com/Route53/latest/APIReference/API_GetGeoLocation.html for code details. Either `continent` or `country` must be specified.
 * `country` - A two-character country code or `*` to indicate a default resource record set.
 * `subdivision` - (Optional) A subdivision code for a country.
+
+### GeoproximityRouting Policy
+
+Geoproximity routing policies support the following:
+
+* `awsregion` - A AWS region where the resource is present.
+* `bias` - Route more traffic or less traffic to the resource by specifing a value ranges between -90 to 90. See https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-policy-geoproximity.html for bias details.
+* `coordinates` - Specify `latitude` and `longitude` for routing traffic to non-AWS resources.
+* `localzonegroup` - A AWS local zone group where the resource is present. See https://docs.aws.amazon.com/local-zones/latest/ug/available-local-zones.html for local zone group list.
 
 ### Latency Routing Policy
 


### PR DESCRIPTION
Enabling the geoproximity feature in Route 53 service

https://aws.amazon.com/about-aws/whats-new/2024/01/amazon-route-53-expands-geoproximity-routing/

Closes https://github.com/hashicorp/terraform-provider-aws/issues/35277.