### PR TITLE
r/aws_lakeformation_resource: add hybrid_access_enabled argument

### DIFF
--- a/internal/service/lakeformation/resource.go
+++ b/internal/service/lakeformation/resource.go
@@ -48,6 +48,11 @@ func ResourceResource() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"hybrid_access_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -69,6 +74,10 @@ func resourceResourceCreate(ctx context.Context, d *schema.ResourceData, meta in
 
 	if v, ok := d.GetOk("use_service_linked_role"); ok {
 		input.UseServiceLinkedRole = aws.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOk("hybrid_access_enabled"); ok {
+		input.HybridAccessEnabled = aws.Bool(v.(bool))
 	}
 
 	_, err := conn.RegisterResourceWithContext(ctx, input)

--- a/website/docs/r/lakeformation_resource.html.markdown
+++ b/website/docs/r/lakeformation_resource.html.markdown
@@ -37,6 +37,7 @@ The following arguments are optional:
 
 * `role_arn` – (Optional) Role that has read/write access to the resource.
 * `use_service_linked_role` - (Optional) Designates an AWS Identity and Access Management (IAM) service-linked role by registering this role with the Data Catalog.
+* `hybrid_access_enabled` - (Optional) Flag to enable AWS LakeFormation hybrid access permission mode.
 
 ~> **NOTE:** AWS does not support registering an S3 location with an IAM role and subsequently updating the S3 location registration to a service-linked role.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
This argument will allow users to configure whether the value of `HybridAccessEnabled` parameter boolean in the underlying AWS RegisterResource API. Users can then register S3 data location in Hybrid access mode.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/35548

### References
https://docs.aws.amazon.com/lake-formation/latest/APIReference/API_RegisterResource.html


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=lakeformation TESTS=TestAccLakeFormationResource_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lakeformation/... -v -count 1 -parallel 20 -run='TestAccLakeFormationResource_'  -timeout 360m
=== RUN   TestAccLakeFormationResource_basic
=== PAUSE TestAccLakeFormationResource_basic
=== RUN   TestAccLakeFormationResource_disappears
=== PAUSE TestAccLakeFormationResource_disappears
=== RUN   TestAccLakeFormationResource_serviceLinkedRole
=== PAUSE TestAccLakeFormationResource_serviceLinkedRole
=== RUN   TestAccLakeFormationResource_updateRoleToRole
=== PAUSE TestAccLakeFormationResource_updateRoleToRole
=== RUN   TestAccLakeFormationResource_updateSLRToRole
=== PAUSE TestAccLakeFormationResource_updateSLRToRole
=== RUN   TestAccLakeFormationResource_hybridAccessEnabled
=== PAUSE TestAccLakeFormationResource_hybridAccessEnabled
=== CONT  TestAccLakeFormationResource_basic
=== CONT  TestAccLakeFormationResource_updateRoleToRole
=== CONT  TestAccLakeFormationResource_serviceLinkedRole
=== CONT  TestAccLakeFormationResource_disappears
=== CONT  TestAccLakeFormationResource_updateSLRToRole
=== CONT  TestAccLakeFormationResource_hybridAccessEnabled
--- PASS: TestAccLakeFormationResource_basic (31.81s)
--- PASS: TestAccLakeFormationResource_hybridAccessEnabled (32.86s)
--- PASS: TestAccLakeFormationResource_serviceLinkedRole (33.00s)
--- PASS: TestAccLakeFormationResource_disappears (33.28s)
--- PASS: TestAccLakeFormationResource_updateRoleToRole (49.31s)
--- PASS: TestAccLakeFormationResource_updateSLRToRole (50.01s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lakeformation	58.692s


...
```
