### PR TITLE
Quick fix: Loosen restriction on command line argument length

### DIFF
--- a/internal/service/finspace/kx_cluster.go
+++ b/internal/service/finspace/kx_cluster.go
@@ -181,8 +181,8 @@ func ResourceKxCluster() *schema.Resource {
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				ValidateDiagFunc: validation.AllDiag(
-					validation.MapKeyLenBetween(1, 50),
-					validation.MapValueLenBetween(1, 50),
+					validation.MapKeyLenBetween(1, 1024),
+					validation.MapValueLenBetween(1, 1024),
 				),
 			},
 			"created_timestamp": {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This minor change increases the upper limit on command line argument key/value length from 50 to 1024, in accordance with a model change on our side. We perform validation on both of these on our side as well.