### PR TITLE
docs: update codestarconnections_connection supported provider_type values

### DIFF
--- a/website/docs/d/codestarconnections_connection.html.markdown
+++ b/website/docs/d/codestarconnections_connection.html.markdown
@@ -45,5 +45,5 @@ This data source exports the following attributes in addition to the arguments a
 * `id` - CodeStar Connection ARN.
 * `host_arn` - ARN of the host associated with the connection.
 * `name` - Name of the CodeStar Connection. The name is unique in the calling AWS account.
-* `provider_type` - Name of the external provider where your third-party code repository is configured. Possible values are `Bitbucket`, `GitHub` or `GitLab`. For connections to GitHub Enterprise Server or GitLab Self-Managed instances, you must create an [aws_codestarconnections_host](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codestarconnections_host) resource and use `host_arn` instead.
+* `provider_type` - Name of the external provider where your third-party code repository is configured. Possible values are `Bitbucket`, `GitHub` and `GitLab`. For connections to GitHub Enterprise Server or GitLab Self-Managed instances, you must create an [aws_codestarconnections_host](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codestarconnections_host) resource and use `host_arn` instead.
 * `tags` - Map of key-value resource tags to associate with the resource.

--- a/website/docs/d/codestarconnections_connection.html.markdown
+++ b/website/docs/d/codestarconnections_connection.html.markdown
@@ -45,5 +45,5 @@ This data source exports the following attributes in addition to the arguments a
 * `id` - CodeStar Connection ARN.
 * `host_arn` - ARN of the host associated with the connection.
 * `name` - Name of the CodeStar Connection. The name is unique in the calling AWS account.
-* `provider_type` - Name of the external provider where your third-party code repository is configured. Possible values are `Bitbucket` and `GitHub`. For connections to a GitHub Enterprise Server instance, you must create an [aws_codestarconnections_host](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codestarconnections_host) resource and use `host_arn` instead.
+* `provider_type` - Name of the external provider where your third-party code repository is configured. Possible values are `Bitbucket`, `GitHub` or `GitLab`. For connections to GitHub Enterprise Server or GitLab Self-Managed instances, you must create an [aws_codestarconnections_host](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codestarconnections_host) resource and use `host_arn` instead.
 * `tags` - Map of key-value resource tags to associate with the resource.

--- a/website/docs/r/codestarconnections_connection.html.markdown
+++ b/website/docs/r/codestarconnections_connection.html.markdown
@@ -66,7 +66,7 @@ resource "aws_codepipeline" "example" {
 This resource supports the following arguments:
 
 * `name` - (Required) The name of the connection to be created. The name must be unique in the calling AWS account. Changing `name` will create a new resource.
-* `provider_type` - (Optional) The name of the external provider where your third-party code repository is configured. Valid values are `Bitbucket`, `GitHub` or `GitHubEnterpriseServer`. Changing `provider_type` will create a new resource. Conflicts with `host_arn`
+* `provider_type` - (Optional) The name of the external provider where your third-party code repository is configured. Valid values are `Bitbucket`, `GitHub`, `GitHubEnterpriseServer`, `GitLab` or `GitLabSelfManaged`. Changing `provider_type` will create a new resource. Conflicts with `host_arn`
 * `host_arn` - (Optional) The Amazon Resource Name (ARN) of the host associated with the connection. Conflicts with `provider_type`
 * `tags` - (Optional) Map of key-value resource tags to associate with the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Adding `Gitlab` and `GitLabSelfManaged` as they are now supported in the SDK https://docs.aws.amazon.com/sdk-for-go/api/service/codestarconnections/#pkg-constants

Just confirmed using `hashicorp/aws v5.34.0` with an invalid `provider_type` (to check the SDK complaining and showing the available types):

```terraform
resource "aws_codestarconnections_connection" "example" {
  name          = "example-connection"
  provider_type = "LabGit"
}
```

```shell
nicosingh@nicomac test-codestar % terraform plan
╷
│ Error: expected provider_type to be one of ["Bitbucket" "GitHub" "GitHubEnterpriseServer" "GitLab" "GitLabSelfManaged"], got LabGit
│
│   with aws_codestarconnections_connection.example,
│   on main.tf line 3, in resource "aws_codestarconnections_connection" "example":
│    3:   provider_type = "LabGit"
│
╵
```