### PR TITLE
fix: Remove MaxItems limitation for `aws_networkmanager_core_network_policy_document` edge_locations

### DIFF
--- a/.changelog/35585.txt
+++ b/.changelog/35585.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/core_network_policy_document_data_source: Remove MaxItems limitation for edge_locations
+data-source/aws_networkmanager_core_network_policy_document: Remove `core_network_configuration.edge_locations` maximum item limit
 ```

--- a/.changelog/35585.txt
+++ b/.changelog/35585.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/core_network_policy_document_data_source: Remove MaxItems limitation for edge_locations
+```

--- a/internal/service/networkmanager/core_network_policy_document_data_source.go
+++ b/internal/service/networkmanager/core_network_policy_document_data_source.go
@@ -157,7 +157,6 @@ func DataSourceCoreNetworkPolicyDocument() *schema.Resource {
 							Type:     schema.TypeList,
 							Required: true,
 							MinItems: 1,
-							MaxItems: 17,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"location": {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Removing the `MaxItems` limit for `edge_locations` under the `aws_networkmanager_core_network_policy_document` data source. There are more than 17 regions supported today by AWS Cloud WAN, so this limit prevents users from defining all supported regions.

I did not find any public documentation or discussion pointing to why this limit was initially added.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #35404

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic PKG=networkmanager
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/networkmanager/... -v -count 1 -parallel 20 -run='TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic'  -timeout 360m
=== RUN   TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic
=== PAUSE TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic
=== CONT  TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic
--- PASS: TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic (12.70s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/networkmanager     12.781s
```
