### PR TITLE
r/aws_rekognition_collection: retry on create

### DIFF
--- a/website/docs/r/rekognition_collection.html.markdown
+++ b/website/docs/r/rekognition_collection.html.markdown
@@ -40,6 +40,12 @@ This resource exports the following attributes in addition to the arguments abov
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 * `face_model_version` - The Face Model Version that the collection was initialized with
 
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+- `create` - (Default `2m`)
+
 ## Import
 
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Rekognition Collection using the `example_id_arg`. For example:


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Add retry during create when resource is not found.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Relates #35407

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS="-run=TestAccRekognitionCollection_" PKG=rekognition

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rekognition/... -v -count 1 -parallel 20  -run=TestAccRekognitionCollection_ -timeout 360m
--- PASS: TestAccRekognitionCollection_disappears (11.65s)
--- PASS: TestAccRekognitionCollection_basic (12.64s)
--- PASS: TestAccRekognitionCollection_tags (23.40s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rekognition	30.406s
```
