### PR TITLE
Tech Debt: `synthetics` service to AWS Go SDKv2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -115,6 +115,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.23.7
 	github.com/aws/aws-sdk-go-v2/service/sts v1.26.7
 	github.com/aws/aws-sdk-go-v2/service/swf v1.20.7
+	github.com/aws/aws-sdk-go-v2/service/synthetics v1.22.7
 	github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.23.7
 	github.com/aws/aws-sdk-go-v2/service/transcribe v1.34.6
 	github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -266,6 +266,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.26.7 h1:NzO4Vrau795RkUdSHKEwiR01FaGz
 github.com/aws/aws-sdk-go-v2/service/sts v1.26.7/go.mod h1:6h2YuIoxaMSCFf5fi1EgZAwdfkGMgDY+DVfa61uLe4U=
 github.com/aws/aws-sdk-go-v2/service/swf v1.20.7 h1:Tq3SyI52JByer7RDjBV/D2sJ0Wl1FXK5Fu2atTlHl9g=
 github.com/aws/aws-sdk-go-v2/service/swf v1.20.7/go.mod h1:RaUPSwU6VmfmhBX33lTvcwmlPZXEX5KOjyj1rgmuP1Q=
+github.com/aws/aws-sdk-go-v2/service/synthetics v1.22.7 h1:YhRDOSThHu2MwhYfByxY1q9iIRW7LR49U4zaJrkh3WQ=
+github.com/aws/aws-sdk-go-v2/service/synthetics v1.22.7/go.mod h1:IiywQMsyhXIQhzYHoFG0YnF78ZN6OuSWRCzc4vYCZyc=
 github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.23.7 h1:5aeaLIUYE0PJKajl9E4ZMEx8+IKWIR5znEscda7t9kc=
 github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.23.7/go.mod h1:v1cLeowZxJZe0yv6lEqj3nUZ8FVoBu2sLLhb8gcdcQ0=
 github.com/aws/aws-sdk-go-v2/service/transcribe v1.34.6 h1:2i4Fk0oOHFZYuzE1edTySCj/iPpV1TUvBsMQlcBjXRc=

--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -232,7 +232,6 @@ import (
 	simpledb_sdkv1 "github.com/aws/aws-sdk-go/service/simpledb"
 	ssm_sdkv1 "github.com/aws/aws-sdk-go/service/ssm"
 	storagegateway_sdkv1 "github.com/aws/aws-sdk-go/service/storagegateway"
-	synthetics_sdkv1 "github.com/aws/aws-sdk-go/service/synthetics"
 	transfer_sdkv1 "github.com/aws/aws-sdk-go/service/transfer"
 	waf_sdkv1 "github.com/aws/aws-sdk-go/service/waf"
 	wafregional_sdkv1 "github.com/aws/aws-sdk-go/service/wafregional"
@@ -1120,10 +1119,6 @@ func (c *AWSClient) SimpleDBConn(ctx context.Context) *simpledb_sdkv1.SimpleDB {
 
 func (c *AWSClient) StorageGatewayConn(ctx context.Context) *storagegateway_sdkv1.StorageGateway {
 	return errs.Must(conn[*storagegateway_sdkv1.StorageGateway](ctx, c, names.StorageGateway, make(map[string]any)))
-}
-
-func (c *AWSClient) SyntheticsConn(ctx context.Context) *synthetics_sdkv1.Synthetics {
-	return errs.Must(conn[*synthetics_sdkv1.Synthetics](ctx, c, names.Synthetics, make(map[string]any)))
 }
 
 func (c *AWSClient) SyntheticsClient(ctx context.Context) *synthetics_sdkv2.Client {

--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -109,6 +109,7 @@ import (
 	ssoadmin_sdkv2 "github.com/aws/aws-sdk-go-v2/service/ssoadmin"
 	sts_sdkv2 "github.com/aws/aws-sdk-go-v2/service/sts"
 	swf_sdkv2 "github.com/aws/aws-sdk-go-v2/service/swf"
+	synthetics_sdkv2 "github.com/aws/aws-sdk-go-v2/service/synthetics"
 	timestreamwrite_sdkv2 "github.com/aws/aws-sdk-go-v2/service/timestreamwrite"
 	transcribe_sdkv2 "github.com/aws/aws-sdk-go-v2/service/transcribe"
 	verifiedpermissions_sdkv2 "github.com/aws/aws-sdk-go-v2/service/verifiedpermissions"
@@ -1123,6 +1124,10 @@ func (c *AWSClient) StorageGatewayConn(ctx context.Context) *storagegateway_sdkv
 
 func (c *AWSClient) SyntheticsConn(ctx context.Context) *synthetics_sdkv1.Synthetics {
 	return errs.Must(conn[*synthetics_sdkv1.Synthetics](ctx, c, names.Synthetics, make(map[string]any)))
+}
+
+func (c *AWSClient) SyntheticsClient(ctx context.Context) *synthetics_sdkv2.Client {
+	return errs.Must(client[*synthetics_sdkv2.Client](ctx, c, names.Synthetics, make(map[string]any)))
 }
 
 func (c *AWSClient) TimestreamWriteClient(ctx context.Context) *timestreamwrite_sdkv2.Client {

--- a/internal/service/lexv2models/generate.go
+++ b/internal/service/lexv2models/generate.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-//go:generate go run ../../generate/tags/main.go -AWSSDKVersion=2 -ServiceTagsMap -KVTValues -SkipTypesImp -ListTags -UpdateTags
+//go:generate go run ../../generate/tags/main.go -AWSSDKVersion=2 -ServiceTagsMap -KVTValues -SkipTypesImp -TagInIDElem=ResourceARN -ListTagsInIDElem=ResourceARN -ListTags -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/lexv2models/generate.go
+++ b/internal/service/lexv2models/generate.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-//go:generate go run ../../generate/tags/main.go -AWSSDKVersion=2 -ServiceTagsMap -KVTValues -SkipTypesImp -TagInIDElem=ResourceARN -ListTagsInIDElem=ResourceARN -ListTags -UpdateTags
+//go:generate go run ../../generate/tags/main.go -AWSSDKVersion=2 -ServiceTagsMap -KVTValues -SkipTypesImp -ListTags -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/lexv2models/tags_gen.go
+++ b/internal/service/lexv2models/tags_gen.go
@@ -20,7 +20,7 @@ import (
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *lexmodelsv2.Client, identifier string, optFns ...func(*lexmodelsv2.Options)) (tftags.KeyValueTags, error) {
 	input := &lexmodelsv2.ListTagsForResourceInput{
-		ResourceArn: aws.String(identifier),
+		ResourceARN: aws.String(identifier),
 	}
 
 	output, err := conn.ListTagsForResource(ctx, input, optFns...)
@@ -92,7 +92,7 @@ func updateTags(ctx context.Context, conn *lexmodelsv2.Client, identifier string
 	removedTags = removedTags.IgnoreSystem(names.LexV2Models)
 	if len(removedTags) > 0 {
 		input := &lexmodelsv2.UntagResourceInput{
-			ResourceArn: aws.String(identifier),
+			ResourceARN: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
@@ -107,7 +107,7 @@ func updateTags(ctx context.Context, conn *lexmodelsv2.Client, identifier string
 	updatedTags = updatedTags.IgnoreSystem(names.LexV2Models)
 	if len(updatedTags) > 0 {
 		input := &lexmodelsv2.TagResourceInput{
-			ResourceArn: aws.String(identifier),
+			ResourceARN: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 

--- a/internal/service/lexv2models/tags_gen.go
+++ b/internal/service/lexv2models/tags_gen.go
@@ -20,7 +20,7 @@ import (
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *lexmodelsv2.Client, identifier string, optFns ...func(*lexmodelsv2.Options)) (tftags.KeyValueTags, error) {
 	input := &lexmodelsv2.ListTagsForResourceInput{
-		ResourceARN: aws.String(identifier),
+		ResourceArn: aws.String(identifier),
 	}
 
 	output, err := conn.ListTagsForResource(ctx, input, optFns...)
@@ -92,7 +92,7 @@ func updateTags(ctx context.Context, conn *lexmodelsv2.Client, identifier string
 	removedTags = removedTags.IgnoreSystem(names.LexV2Models)
 	if len(removedTags) > 0 {
 		input := &lexmodelsv2.UntagResourceInput{
-			ResourceARN: aws.String(identifier),
+			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
@@ -107,7 +107,7 @@ func updateTags(ctx context.Context, conn *lexmodelsv2.Client, identifier string
 	updatedTags = updatedTags.IgnoreSystem(names.LexV2Models)
 	if len(updatedTags) > 0 {
 		input := &lexmodelsv2.TagResourceInput{
-			ResourceARN: aws.String(identifier),
+			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 

--- a/internal/service/synthetics/canary.go
+++ b/internal/service/synthetics/canary.go
@@ -12,14 +12,16 @@ import (
 	"time"
 
 	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/aws/aws-sdk-go/service/synthetics"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/service/synthetics"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/synthetics/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
@@ -61,9 +63,9 @@ func ResourceCanary() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"encryption_mode": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ValidateFunc: validation.StringInSlice(synthetics.EncryptionMode_Values(), false),
+										Type:             schema.TypeString,
+										Optional:         true,
+										ValidateDiagFunc: enum.Validate[awstypes.EncryptionMode](),
 									},
 									"kms_key_arn": {
 										Type:         schema.TypeString,
@@ -272,7 +274,7 @@ func ResourceCanary() *schema.Resource {
 
 func resourceCanaryCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).SyntheticsConn(ctx)
+	conn := meta.(*conns.AWSClient).SyntheticsClient(ctx)
 
 	name := d.Get("name").(string)
 	input := &synthetics.CreateCanaryInput{
@@ -306,20 +308,20 @@ func resourceCanaryCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if v, ok := d.GetOk("failure_retention_period"); ok {
-		input.FailureRetentionPeriodInDays = aws.Int64(int64(v.(int)))
+		input.FailureRetentionPeriodInDays = aws.Int32(int32(v.(int)))
 	}
 
 	if v, ok := d.GetOk("success_retention_period"); ok {
-		input.SuccessRetentionPeriodInDays = aws.Int64(int64(v.(int)))
+		input.SuccessRetentionPeriodInDays = aws.Int32(int32(v.(int)))
 	}
 
-	output, err := conn.CreateCanaryWithContext(ctx, input)
+	output, err := conn.CreateCanary(ctx, input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating Synthetics Canary (%s): %s", name, err)
 	}
 
-	d.SetId(aws.StringValue(output.Canary.Name))
+	d.SetId(aws.ToString(output.Canary.Name))
 
 	// Underlying IAM eventual consistency errors can occur after the creation
 	// operation. The goal is only retry these types of errors up to the IAM
@@ -359,7 +361,7 @@ func resourceCanaryCreate(ctx context.Context, d *schema.ResourceData, meta inte
 
 func resourceCanaryRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).SyntheticsConn(ctx)
+	conn := meta.(*conns.AWSClient).SyntheticsClient(ctx)
 
 	canary, err := FindCanaryByName(ctx, conn, d.Id())
 
@@ -375,10 +377,10 @@ func resourceCanaryRead(ctx context.Context, d *schema.ResourceData, meta interf
 
 	canaryArn := arn.ARN{
 		Partition: meta.(*conns.AWSClient).Partition,
-		Service:   synthetics.ServiceName,
+		Service:   "synthetics",
 		Region:    meta.(*conns.AWSClient).Region,
 		AccountID: meta.(*conns.AWSClient).AccountID,
-		Resource:  fmt.Sprintf("canary:%s", aws.StringValue(canary.Name)),
+		Resource:  fmt.Sprintf("canary:%s", aws.ToString(canary.Name)),
 	}.String()
 	d.Set("arn", canaryArn)
 	d.Set("artifact_s3_location", canary.ArtifactS3Location)
@@ -396,7 +398,7 @@ func resourceCanaryRead(ctx context.Context, d *schema.ResourceData, meta interf
 		return sdkdiag.AppendErrorf(diags, "setting vpc config: %s", err)
 	}
 
-	runConfig := &synthetics.CanaryRunConfigInput{}
+	runConfig := &awstypes.CanaryRunConfigInput{}
 	if v, ok := d.GetOk("run_config"); ok {
 		runConfig = expandCanaryRunConfig(v.([]interface{}))
 	}
@@ -424,7 +426,7 @@ func resourceCanaryRead(ctx context.Context, d *schema.ResourceData, meta interf
 
 func resourceCanaryUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).SyntheticsConn(ctx)
+	conn := meta.(*conns.AWSClient).SyntheticsClient(ctx)
 
 	if d.HasChangesExcept("tags", "tags_all", "start_canary") {
 		input := &synthetics.UpdateCanaryInput{
@@ -465,12 +467,12 @@ func resourceCanaryUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 
 		if d.HasChange("success_retention_period") {
 			_, n := d.GetChange("success_retention_period")
-			input.SuccessRetentionPeriodInDays = aws.Int64(int64(n.(int)))
+			input.SuccessRetentionPeriodInDays = aws.Int32(int32(n.(int)))
 		}
 
 		if d.HasChange("failure_retention_period") {
 			_, n := d.GetChange("failure_retention_period")
-			input.FailureRetentionPeriodInDays = aws.Int64(int64(n.(int)))
+			input.FailureRetentionPeriodInDays = aws.Int32(int32(n.(int)))
 		}
 
 		if d.HasChange("execution_role_arn") {
@@ -479,19 +481,19 @@ func resourceCanaryUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		}
 
 		status := d.Get("status").(string)
-		if status == synthetics.CanaryStateRunning {
+		if status == string(awstypes.CanaryStateRunning) {
 			if err := stopCanary(ctx, d.Id(), conn); err != nil {
 				return sdkdiag.AppendErrorf(diags, "updating Synthetics Canary (%s): %s", d.Id(), err)
 			}
 		}
 
-		_, err := conn.UpdateCanaryWithContext(ctx, input)
+		_, err := conn.UpdateCanary(ctx, input)
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating Synthetics Canary (%s): %s", d.Id(), err)
 		}
 
-		if status != synthetics.CanaryStateReady {
+		if status != string(awstypes.CanaryStateReady) {
 			if _, err := waitCanaryStopped(ctx, conn, d.Id()); err != nil {
 				return sdkdiag.AppendErrorf(diags, "updating Synthetics Canary (%s): waiting for Canary to stop: %s", d.Id(), err)
 			}
@@ -511,13 +513,13 @@ func resourceCanaryUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	if d.HasChange("start_canary") {
 		status := d.Get("status").(string)
 		if d.Get("start_canary").(bool) {
-			if status != synthetics.CanaryStateRunning {
+			if status != string(awstypes.CanaryStateRunning) {
 				if err := startCanary(ctx, d.Id(), conn); err != nil {
 					return sdkdiag.AppendErrorf(diags, "updating Synthetics Canary (%s): %s", d.Id(), err)
 				}
 			}
 		} else {
-			if status == synthetics.CanaryStateRunning {
+			if status == string(awstypes.CanaryStateRunning) {
 				if err := stopCanary(ctx, d.Id(), conn); err != nil {
 					return sdkdiag.AppendErrorf(diags, "updating Synthetics Canary (%s): %s", d.Id(), err)
 				}
@@ -530,21 +532,21 @@ func resourceCanaryUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 
 func resourceCanaryDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).SyntheticsConn(ctx)
+	conn := meta.(*conns.AWSClient).SyntheticsClient(ctx)
 
-	if status := d.Get("status").(string); status == synthetics.CanaryStateRunning {
+	if status := d.Get("status").(string); status == string(awstypes.CanaryStateRunning) {
 		if err := stopCanary(ctx, d.Id(), conn); err != nil {
 			return sdkdiag.AppendErrorf(diags, "deleting Synthetics Canary (%s): %s", d.Id(), err)
 		}
 	}
 
 	log.Printf("[DEBUG] Deleting Synthetics Canary: (%s)", d.Id())
-	_, err := conn.DeleteCanaryWithContext(ctx, &synthetics.DeleteCanaryInput{
+	_, err := conn.DeleteCanary(ctx, &synthetics.DeleteCanaryInput{
 		Name:         aws.String(d.Id()),
-		DeleteLambda: aws.Bool(d.Get("delete_lambda").(bool)),
+		DeleteLambda: d.Get("delete_lambda").(bool),
 	})
 
-	if tfawserr.ErrCodeEquals(err, synthetics.ErrCodeResourceNotFoundException) {
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return diags
 	}
 
@@ -561,8 +563,8 @@ func resourceCanaryDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	return diags
 }
 
-func expandCanaryCode(d *schema.ResourceData) (*synthetics.CanaryCodeInput, error) {
-	codeConfig := &synthetics.CanaryCodeInput{
+func expandCanaryCode(d *schema.ResourceData) (*awstypes.CanaryCodeInput, error) {
+	codeConfig := &awstypes.CanaryCodeInput{
 		Handler: aws.String(d.Get("handler").(string)),
 	}
 
@@ -586,14 +588,14 @@ func expandCanaryCode(d *schema.ResourceData) (*synthetics.CanaryCodeInput, erro
 	return codeConfig, nil
 }
 
-func expandCanaryArtifactConfig(l []interface{}) *synthetics.ArtifactConfigInput_ {
+func expandCanaryArtifactConfig(l []interface{}) *awstypes.ArtifactConfigInput {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
 	m := l[0].(map[string]interface{})
 
-	config := &synthetics.ArtifactConfigInput_{}
+	config := &awstypes.ArtifactConfigInput{}
 
 	if v, ok := m["s3_encryption"].([]interface{}); ok && len(v) > 0 {
 		config.S3Encryption = expandCanaryS3EncryptionConfig(v)
@@ -602,7 +604,7 @@ func expandCanaryArtifactConfig(l []interface{}) *synthetics.ArtifactConfigInput
 	return config
 }
 
-func flattenCanaryArtifactConfig(config *synthetics.ArtifactConfigOutput_) []interface{} {
+func flattenCanaryArtifactConfig(config *awstypes.ArtifactConfigOutput) []interface{} {
 	if config == nil {
 		return []interface{}{}
 	}
@@ -616,17 +618,17 @@ func flattenCanaryArtifactConfig(config *synthetics.ArtifactConfigOutput_) []int
 	return []interface{}{m}
 }
 
-func expandCanaryS3EncryptionConfig(l []interface{}) *synthetics.S3EncryptionConfig {
+func expandCanaryS3EncryptionConfig(l []interface{}) *awstypes.S3EncryptionConfig {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
 	m := l[0].(map[string]interface{})
 
-	config := &synthetics.S3EncryptionConfig{}
+	config := &awstypes.S3EncryptionConfig{}
 
 	if v, ok := m["encryption_mode"].(string); ok && v != "" {
-		config.EncryptionMode = aws.String(v)
+		config.EncryptionMode = awstypes.EncryptionMode(v)
 	}
 
 	if v, ok := m["kms_key_arn"].(string); ok && v != "" {
@@ -636,32 +638,32 @@ func expandCanaryS3EncryptionConfig(l []interface{}) *synthetics.S3EncryptionCon
 	return config
 }
 
-func flattenCanaryS3EncryptionConfig(config *synthetics.S3EncryptionConfig) []interface{} {
+func flattenCanaryS3EncryptionConfig(config *awstypes.S3EncryptionConfig) []interface{} {
 	if config == nil {
 		return []interface{}{}
 	}
 
 	m := map[string]interface{}{}
 
-	if config.EncryptionMode != nil {
-		m["encryption_mode"] = aws.StringValue(config.EncryptionMode)
+	if config.EncryptionMode != "" {
+		m["encryption_mode"] = string(config.EncryptionMode)
 	}
 
 	if config.KmsKeyArn != nil {
-		m["kms_key_arn"] = aws.StringValue(config.KmsKeyArn)
+		m["kms_key_arn"] = aws.ToString(config.KmsKeyArn)
 	}
 
 	return []interface{}{m}
 }
 
-func expandCanarySchedule(l []interface{}) *synthetics.CanaryScheduleInput {
+func expandCanarySchedule(l []interface{}) *awstypes.CanaryScheduleInput {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
 	m := l[0].(map[string]interface{})
 
-	codeConfig := &synthetics.CanaryScheduleInput{
+	codeConfig := &awstypes.CanaryScheduleInput{
 		Expression: aws.String(m["expression"].(string)),
 	}
 
@@ -672,32 +674,32 @@ func expandCanarySchedule(l []interface{}) *synthetics.CanaryScheduleInput {
 	return codeConfig
 }
 
-func flattenCanarySchedule(canarySchedule *synthetics.CanaryScheduleOutput) []interface{} {
+func flattenCanarySchedule(canarySchedule *awstypes.CanaryScheduleOutput) []interface{} {
 	if canarySchedule == nil {
 		return []interface{}{}
 	}
 
 	m := map[string]interface{}{
-		"expression":          aws.StringValue(canarySchedule.Expression),
-		"duration_in_seconds": aws.Int64Value(canarySchedule.DurationInSeconds),
+		"expression":          aws.ToString(canarySchedule.Expression),
+		"duration_in_seconds": aws.ToInt64(canarySchedule.DurationInSeconds),
 	}
 
 	return []interface{}{m}
 }
 
-func expandCanaryRunConfig(l []interface{}) *synthetics.CanaryRunConfigInput {
+func expandCanaryRunConfig(l []interface{}) *awstypes.CanaryRunConfigInput {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
 	m := l[0].(map[string]interface{})
 
-	codeConfig := &synthetics.CanaryRunConfigInput{
-		TimeoutInSeconds: aws.Int64(int64(m["timeout_in_seconds"].(int))),
+	codeConfig := &awstypes.CanaryRunConfigInput{
+		TimeoutInSeconds: aws.Int32(int32(m["timeout_in_seconds"].(int))),
 	}
 
 	if v, ok := m["memory_in_mb"].(int); ok && v > 0 {
-		codeConfig.MemoryInMB = aws.Int64(int64(v))
+		codeConfig.MemoryInMB = aws.Int32(int32(v))
 	}
 
 	if v, ok := m["active_tracing"].(bool); ok {
@@ -705,86 +707,86 @@ func expandCanaryRunConfig(l []interface{}) *synthetics.CanaryRunConfigInput {
 	}
 
 	if vars, ok := m["environment_variables"].(map[string]interface{}); ok && len(vars) > 0 {
-		codeConfig.EnvironmentVariables = flex.ExpandStringMap(vars)
+		codeConfig.EnvironmentVariables = flex.ExpandStringValueMap(vars)
 	}
 
 	return codeConfig
 }
 
-func flattenCanaryRunConfig(canaryCodeOut *synthetics.CanaryRunConfigOutput, envVars map[string]*string) []interface{} {
+func flattenCanaryRunConfig(canaryCodeOut *awstypes.CanaryRunConfigOutput, envVars map[string]string) []interface{} {
 	if canaryCodeOut == nil {
 		return []interface{}{}
 	}
 
 	m := map[string]interface{}{
-		"timeout_in_seconds": aws.Int64Value(canaryCodeOut.TimeoutInSeconds),
-		"memory_in_mb":       aws.Int64Value(canaryCodeOut.MemoryInMB),
-		"active_tracing":     aws.BoolValue(canaryCodeOut.ActiveTracing),
+		"timeout_in_seconds": aws.ToInt32(canaryCodeOut.TimeoutInSeconds),
+		"memory_in_mb":       aws.ToInt32(canaryCodeOut.MemoryInMB),
+		"active_tracing":     aws.ToBool(canaryCodeOut.ActiveTracing),
 	}
 
 	if envVars != nil {
-		m["environment_variables"] = aws.StringValueMap(envVars)
+		m["environment_variables"] = envVars
 	}
 
 	return []interface{}{m}
 }
 
-func flattenCanaryVPCConfig(canaryVpcOutput *synthetics.VpcConfigOutput) []interface{} {
+func flattenCanaryVPCConfig(canaryVpcOutput *awstypes.VpcConfigOutput) []interface{} {
 	if canaryVpcOutput == nil {
 		return []interface{}{}
 	}
 
 	m := map[string]interface{}{
-		"subnet_ids":         flex.FlattenStringSet(canaryVpcOutput.SubnetIds),
-		"security_group_ids": flex.FlattenStringSet(canaryVpcOutput.SecurityGroupIds),
-		"vpc_id":             aws.StringValue(canaryVpcOutput.VpcId),
+		"subnet_ids":         flex.FlattenStringValueSet(canaryVpcOutput.SubnetIds),
+		"security_group_ids": flex.FlattenStringValueSet(canaryVpcOutput.SecurityGroupIds),
+		"vpc_id":             aws.ToString(canaryVpcOutput.VpcId),
 	}
 
 	return []interface{}{m}
 }
 
-func expandCanaryVPCConfig(l []interface{}) *synthetics.VpcConfigInput {
+func expandCanaryVPCConfig(l []interface{}) *awstypes.VpcConfigInput {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
 	m := l[0].(map[string]interface{})
 
-	codeConfig := &synthetics.VpcConfigInput{
-		SubnetIds:        flex.ExpandStringSet(m["subnet_ids"].(*schema.Set)),
-		SecurityGroupIds: flex.ExpandStringSet(m["security_group_ids"].(*schema.Set)),
+	codeConfig := &awstypes.VpcConfigInput{
+		SubnetIds:        flex.ExpandStringValueSet(m["subnet_ids"].(*schema.Set)),
+		SecurityGroupIds: flex.ExpandStringValueSet(m["security_group_ids"].(*schema.Set)),
 	}
 
 	return codeConfig
 }
 
-func flattenCanaryTimeline(timeline *synthetics.CanaryTimeline) []interface{} {
+func flattenCanaryTimeline(timeline *awstypes.CanaryTimeline) []interface{} {
 	if timeline == nil {
 		return []interface{}{}
 	}
 
 	m := map[string]interface{}{
-		"created": aws.TimeValue(timeline.Created).Format(time.RFC3339),
+		"created": aws.ToTime(timeline.Created).Format(time.RFC3339),
 	}
 
 	if timeline.LastModified != nil {
-		m["last_modified"] = aws.TimeValue(timeline.LastModified).Format(time.RFC3339)
+		m["last_modified"] = aws.ToTime(timeline.LastModified).Format(time.RFC3339)
 	}
 
 	if timeline.LastStarted != nil {
-		m["last_started"] = aws.TimeValue(timeline.LastStarted).Format(time.RFC3339)
+		m["last_started"] = aws.ToTime(timeline.LastStarted).Format(time.RFC3339)
 	}
 
 	if timeline.LastStopped != nil {
-		m["last_stopped"] = aws.TimeValue(timeline.LastStopped).Format(time.RFC3339)
+		m["last_stopped"] = aws.ToTime(timeline.LastStopped).Format(time.RFC3339)
 	}
 
 	return []interface{}{m}
 }
 
-func startCanary(ctx context.Context, name string, conn *synthetics.Synthetics) error {
+func startCanary(ctx context.Context, name string, conn *synthetics.Client) error {
 	log.Printf("[DEBUG] Starting Synthetics Canary: (%s)", name)
-	_, err := conn.StartCanaryWithContext(ctx, &synthetics.StartCanaryInput{
+	_, err := conn.StartCanary(ctx, &synthetics.StartCanaryInput{
 		Name: aws.String(name),
 	})
 
@@ -801,13 +803,13 @@ func startCanary(ctx context.Context, name string, conn *synthetics.Synthetics) 
 	return nil
 }
 
-func stopCanary(ctx context.Context, name string, conn *synthetics.Synthetics) error {
+func stopCanary(ctx context.Context, name string, conn *synthetics.Client) error {
 	log.Printf("[DEBUG] Stopping Synthetics Canary: (%s)", name)
-	_, err := conn.StopCanaryWithContext(ctx, &synthetics.StopCanaryInput{
+	_, err := conn.StopCanary(ctx, &synthetics.StopCanaryInput{
 		Name: aws.String(name),
 	})
 
-	if tfawserr.ErrCodeEquals(err, synthetics.ErrCodeConflictException) {
+	if errs.IsA[*awstypes.ConflictException](err) {
 		return nil
 	}
 

--- a/internal/service/synthetics/canary_test.go
+++ b/internal/service/synthetics/canary_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go/service/synthetics"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/synthetics/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -17,17 +17,18 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfsynthetics "github.com/hashicorp/terraform-provider-aws/internal/service/synthetics"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccSyntheticsCanary_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	var conf1, conf2 synthetics.Canary
+	var conf1, conf2 awstypes.Canary
 	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(8))
 	resourceName := "aws_synthetics_canary.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, synthetics.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.SyntheticsEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckCanaryDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -35,7 +36,7 @@ func TestAccSyntheticsCanary_basic(t *testing.T) {
 				Config: testAccCanaryConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCanaryExists(ctx, resourceName, &conf1),
-					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", synthetics.ServiceName, regexache.MustCompile(`canary:.+`)),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "synthetics", regexache.MustCompile(`canary:.+`)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "runtime_version", "syn-nodejs-puppeteer-6.1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -67,7 +68,7 @@ func TestAccSyntheticsCanary_basic(t *testing.T) {
 				Config: testAccCanaryConfig_zipUpdated(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCanaryExists(ctx, resourceName, &conf2),
-					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", synthetics.ServiceName, regexache.MustCompile(`canary:.+`)),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "synthetics", regexache.MustCompile(`canary:.+`)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "runtime_version", "syn-nodejs-puppeteer-6.1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -96,13 +97,13 @@ func TestAccSyntheticsCanary_basic(t *testing.T) {
 
 func TestAccSyntheticsCanary_artifactEncryption(t *testing.T) {
 	ctx := acctest.Context(t)
-	var conf synthetics.Canary
+	var conf awstypes.Canary
 	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(8))
 	resourceName := "aws_synthetics_canary.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, synthetics.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.SyntheticsEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckCanaryDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -137,13 +138,13 @@ func TestAccSyntheticsCanary_artifactEncryption(t *testing.T) {
 
 func TestAccSyntheticsCanary_runtimeVersion(t *testing.T) {
 	ctx := acctest.Context(t)
-	var conf1 synthetics.Canary
+	var conf1 awstypes.Canary
 	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(8))
 	resourceName := "aws_synthetics_canary.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, synthetics.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.SyntheticsEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckCanaryDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -173,13 +174,13 @@ func TestAccSyntheticsCanary_runtimeVersion(t *testing.T) {
 
 func TestAccSyntheticsCanary_startCanary(t *testing.T) {
 	ctx := acctest.Context(t)
-	var conf1, conf2, conf3 synthetics.Canary
+	var conf1, conf2, conf3 awstypes.Canary
 	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(8))
 	resourceName := "aws_synthetics_canary.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, synthetics.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.SyntheticsEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckCanaryDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -222,13 +223,13 @@ func TestAccSyntheticsCanary_startCanary(t *testing.T) {
 
 func TestAccSyntheticsCanary_StartCanary_codeChanges(t *testing.T) {
 	ctx := acctest.Context(t)
-	var conf1, conf2 synthetics.Canary
+	var conf1, conf2 awstypes.Canary
 	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(8))
 	resourceName := "aws_synthetics_canary.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, synthetics.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.SyntheticsEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckCanaryDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -264,13 +265,13 @@ func TestAccSyntheticsCanary_StartCanary_codeChanges(t *testing.T) {
 
 func TestAccSyntheticsCanary_s3(t *testing.T) {
 	ctx := acctest.Context(t)
-	var conf synthetics.Canary
+	var conf awstypes.Canary
 	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(8))
 	resourceName := "aws_synthetics_canary.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, synthetics.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.SyntheticsEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckCanaryDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -278,7 +279,7 @@ func TestAccSyntheticsCanary_s3(t *testing.T) {
 				Config: testAccCanaryConfig_basicS3Code(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCanaryExists(ctx, resourceName, &conf),
-					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", synthetics.ServiceName, regexache.MustCompile(`canary:.+`)),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "synthetics", regexache.MustCompile(`canary:.+`)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "runtime_version", "syn-nodejs-puppeteer-6.1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -309,13 +310,13 @@ func TestAccSyntheticsCanary_s3(t *testing.T) {
 
 func TestAccSyntheticsCanary_run(t *testing.T) {
 	ctx := acctest.Context(t)
-	var conf synthetics.Canary
+	var conf awstypes.Canary
 	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(8))
 	resourceName := "aws_synthetics_canary.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, synthetics.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.SyntheticsEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckCanaryDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -356,13 +357,13 @@ func TestAccSyntheticsCanary_run(t *testing.T) {
 
 func TestAccSyntheticsCanary_runTracing(t *testing.T) {
 	ctx := acctest.Context(t)
-	var conf synthetics.Canary
+	var conf awstypes.Canary
 	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(8))
 	resourceName := "aws_synthetics_canary.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, synthetics.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.SyntheticsEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckCanaryDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -399,13 +400,13 @@ func TestAccSyntheticsCanary_runTracing(t *testing.T) {
 
 func TestAccSyntheticsCanary_runEnvironmentVariables(t *testing.T) {
 	ctx := acctest.Context(t)
-	var conf synthetics.Canary
+	var conf awstypes.Canary
 	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(8))
 	resourceName := "aws_synthetics_canary.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, synthetics.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.SyntheticsEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckCanaryDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -442,13 +443,13 @@ func TestAccSyntheticsCanary_vpc(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	var conf synthetics.Canary
+	var conf awstypes.Canary
 	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(8))
 	resourceName := "aws_synthetics_canary.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, synthetics.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.SyntheticsEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckCanaryDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -491,13 +492,13 @@ func TestAccSyntheticsCanary_vpc(t *testing.T) {
 
 func TestAccSyntheticsCanary_tags(t *testing.T) {
 	ctx := acctest.Context(t)
-	var conf synthetics.Canary
+	var conf awstypes.Canary
 	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(8))
 	resourceName := "aws_synthetics_canary.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, synthetics.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.SyntheticsEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckCanaryDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -538,13 +539,13 @@ func TestAccSyntheticsCanary_tags(t *testing.T) {
 
 func TestAccSyntheticsCanary_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	var conf synthetics.Canary
+	var conf awstypes.Canary
 	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(8))
 	resourceName := "aws_synthetics_canary.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, synthetics.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.SyntheticsEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckCanaryDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -563,7 +564,7 @@ func TestAccSyntheticsCanary_disappears(t *testing.T) {
 
 func testAccCheckCanaryDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).SyntheticsConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).SyntheticsClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_synthetics_canary" {
@@ -587,7 +588,7 @@ func testAccCheckCanaryDestroy(ctx context.Context) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckCanaryExists(ctx context.Context, n string, canary *synthetics.Canary) resource.TestCheckFunc {
+func testAccCheckCanaryExists(ctx context.Context, n string, canary *awstypes.Canary) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -598,7 +599,7 @@ func testAccCheckCanaryExists(ctx context.Context, n string, canary *synthetics.
 			return fmt.Errorf("No Synthetics Canary ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).SyntheticsConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).SyntheticsClient(ctx)
 
 		output, err := tfsynthetics.FindCanaryByName(ctx, conn, rs.Primary.ID)
 
@@ -612,7 +613,7 @@ func testAccCheckCanaryExists(ctx context.Context, n string, canary *synthetics.
 	}
 }
 
-func testAccCheckCanaryIsUpdated(first, second *synthetics.Canary) resource.TestCheckFunc {
+func testAccCheckCanaryIsUpdated(first, second *awstypes.Canary) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if !second.Timeline.LastModified.After(*first.Timeline.LastModified) {
 			return fmt.Errorf("synthetics Canary not updated")
@@ -622,7 +623,7 @@ func testAccCheckCanaryIsUpdated(first, second *synthetics.Canary) resource.Test
 	}
 }
 
-func testAccCheckCanaryIsStartedAfter(first, second *synthetics.Canary) resource.TestCheckFunc {
+func testAccCheckCanaryIsStartedAfter(first, second *awstypes.Canary) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if !second.Timeline.LastStarted.After(*first.Timeline.LastStarted) {
 			return fmt.Errorf("synthetics Canary not updated")

--- a/internal/service/synthetics/find.go
+++ b/internal/service/synthetics/find.go
@@ -25,6 +25,8 @@ func FindCanaryByName(ctx context.Context, conn *synthetics.Client, name string)
 	output, err := conn.GetCanary(ctx, input)
 
 	if err != nil {
+		// error is not being asserted into type *awstypes.ResourceNotFoundException but has all the properties
+		// of the error.
 		if strings.Contains(err.Error(), errResourceNotFound.ErrorCode()) {
 			return nil, &retry.NotFoundError{
 				LastError:   err,
@@ -34,7 +36,7 @@ func FindCanaryByName(ctx context.Context, conn *synthetics.Client, name string)
 
 		return nil, err
 	}
-	
+
 	if output == nil || output.Canary == nil || output.Canary.Status == nil {
 		return nil, tfresource.NewEmptyResultError(input)
 	}

--- a/internal/service/synthetics/find.go
+++ b/internal/service/synthetics/find.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-var errResourceNotFound = &awstypes.ResourceNotFoundException{}
+var errResourceNotFoundException = &awstypes.ResourceNotFoundException{}
 
 func FindCanaryByName(ctx context.Context, conn *synthetics.Client, name string) (*awstypes.Canary, error) {
 	input := &synthetics.GetCanaryInput{
@@ -27,7 +27,7 @@ func FindCanaryByName(ctx context.Context, conn *synthetics.Client, name string)
 	if err != nil {
 		// error is not being asserted into type *awstypes.ResourceNotFoundException but has all the properties
 		// of the error.
-		if strings.Contains(err.Error(), errResourceNotFound.ErrorCode()) {
+		if strings.Contains(err.Error(), errResourceNotFoundException.ErrorCode()) {
 			return nil, &retry.NotFoundError{
 				LastError:   err,
 				LastRequest: input,

--- a/internal/service/synthetics/generate.go
+++ b/internal/service/synthetics/generate.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-//go:generate go run ../../generate/tags/main.go -ServiceTagsMap -UpdateTags
+//go:generate go run ../../generate/tags/main.go -AWSSDKVersion=2 -ServiceTagsMap -KVTValues -SkipTypesImp -ListTags -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/synthetics/group_association.go
+++ b/internal/service/synthetics/group_association.go
@@ -9,12 +9,13 @@ import (
 	"log"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/synthetics"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/synthetics"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/synthetics/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
@@ -55,7 +56,7 @@ func ResourceGroupAssociation() *schema.Resource {
 
 func resourceGroupAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).SyntheticsConn(ctx)
+	conn := meta.(*conns.AWSClient).SyntheticsClient(ctx)
 
 	canaryArn := d.Get("canary_arn").(string)
 	groupName := d.Get("group_name").(string)
@@ -65,7 +66,7 @@ func resourceGroupAssociationCreate(ctx context.Context, d *schema.ResourceData,
 		GroupIdentifier: aws.String(groupName),
 	}
 
-	out, err := conn.AssociateResourceWithContext(ctx, in)
+	out, err := conn.AssociateResource(ctx, in)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "associating canary (%s) with group (%s): %s", canaryArn, groupName, err)
@@ -82,7 +83,7 @@ func resourceGroupAssociationCreate(ctx context.Context, d *schema.ResourceData,
 
 func resourceGroupAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).SyntheticsConn(ctx)
+	conn := meta.(*conns.AWSClient).SyntheticsClient(ctx)
 
 	canaryArn, groupName, err := GroupAssociationParseResourceID(d.Id())
 
@@ -112,7 +113,7 @@ func resourceGroupAssociationRead(ctx context.Context, d *schema.ResourceData, m
 
 func resourceGroupAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).SyntheticsConn(ctx)
+	conn := meta.(*conns.AWSClient).SyntheticsClient(ctx)
 
 	log.Printf("[DEBUG] Deleting Synthetics Group Association %s", d.Id())
 
@@ -127,13 +128,13 @@ func resourceGroupAssociationDelete(ctx context.Context, d *schema.ResourceData,
 		GroupIdentifier: aws.String(groupName),
 	}
 
-	_, err = conn.DisassociateResourceWithContext(ctx, in)
+	_, err = conn.DisassociateResource(ctx, in)
 
-	if tfawserr.ErrCodeEquals(err, synthetics.ErrCodeResourceNotFoundException) {
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return diags
 	}
 
-	if tfawserr.ErrMessageContains(err, synthetics.ErrCodeValidationException, "does not exist in group") {
+	if errs.IsAErrorMessageContains[*awstypes.ValidationException](err, "does not exist in group") {
 		return diags
 	}
 

--- a/internal/service/synthetics/group_association_test.go
+++ b/internal/service/synthetics/group_association_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go/service/synthetics"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/synthetics/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -17,17 +17,18 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfsynthetics "github.com/hashicorp/terraform-provider-aws/internal/service/synthetics"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccSyntheticsGroupAssociation_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(8))
 	resourceName := "aws_synthetics_group_association.test"
-	var groupSummary synthetics.GroupSummary
+	var groupSummary awstypes.GroupSummary
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, synthetics.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.SyntheticsEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckGroupAssociationDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -35,8 +36,8 @@ func TestAccSyntheticsGroupAssociation_basic(t *testing.T) {
 				Config: testAccGroupAssociationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGroupAssociationExists(ctx, resourceName, &groupSummary),
-					acctest.MatchResourceAttrRegionalARN(resourceName, "canary_arn", synthetics.ServiceName, regexache.MustCompile(`canary:.+`)),
-					acctest.MatchResourceAttrRegionalARN(resourceName, "group_arn", synthetics.ServiceName, regexache.MustCompile(`group:.+`)),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "canary_arn", "synthetics", regexache.MustCompile(`canary:.+`)),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "group_arn", "synthetics", regexache.MustCompile(`group:.+`)),
 					resource.TestCheckResourceAttr(resourceName, "group_name", rName),
 					resource.TestCheckResourceAttrSet(resourceName, "group_id"),
 				),
@@ -54,11 +55,11 @@ func TestAccSyntheticsGroupAssociation_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(8))
 	resourceName := "aws_synthetics_group_association.test"
-	var groupSummary synthetics.GroupSummary
+	var groupSummary awstypes.GroupSummary
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, synthetics.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.SyntheticsEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckGroupAssociationDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -74,7 +75,7 @@ func TestAccSyntheticsGroupAssociation_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckGroupAssociationExists(ctx context.Context, name string, v *synthetics.GroupSummary) resource.TestCheckFunc {
+func testAccCheckGroupAssociationExists(ctx context.Context, name string, v *awstypes.GroupSummary) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -91,7 +92,7 @@ func testAccCheckGroupAssociationExists(ctx context.Context, name string, v *syn
 			return err
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).SyntheticsConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).SyntheticsClient(ctx)
 		output, err := tfsynthetics.FindAssociatedGroup(ctx, conn, canaryArn, groupName)
 
 		if err != nil {
@@ -106,7 +107,7 @@ func testAccCheckGroupAssociationExists(ctx context.Context, name string, v *syn
 
 func testAccCheckGroupAssociationDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).SyntheticsConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).SyntheticsClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_synthetics_group_association" {

--- a/internal/service/synthetics/group_test.go
+++ b/internal/service/synthetics/group_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go/service/synthetics"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/synthetics/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -17,17 +17,18 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfsynthetics "github.com/hashicorp/terraform-provider-aws/internal/service/synthetics"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccSyntheticsGroup_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	var group synthetics.Group
+	var group awstypes.Group
 	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(8))
 	resourceName := "aws_synthetics_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, synthetics.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.SyntheticsEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckGroupDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -35,7 +36,7 @@ func TestAccSyntheticsGroup_basic(t *testing.T) {
 				Config: testAccGroupConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGroupExists(ctx, resourceName, &group),
-					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", synthetics.ServiceName, regexache.MustCompile(`group:.+`)),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "synthetics", regexache.MustCompile(`group:.+`)),
 					resource.TestCheckResourceAttrSet(resourceName, "group_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 				),
@@ -51,13 +52,13 @@ func TestAccSyntheticsGroup_basic(t *testing.T) {
 
 func TestAccSyntheticsGroup_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	var group synthetics.Group
+	var group awstypes.Group
 	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(8))
 	resourceName := "aws_synthetics_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, synthetics.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.SyntheticsEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckGroupDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -75,13 +76,13 @@ func TestAccSyntheticsGroup_disappears(t *testing.T) {
 
 func TestAccSyntheticsGroup_tags(t *testing.T) {
 	ctx := acctest.Context(t)
-	var group synthetics.Group
+	var group awstypes.Group
 	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(8))
 	resourceName := "aws_synthetics_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, synthetics.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.SyntheticsEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckGroupDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -119,7 +120,7 @@ func TestAccSyntheticsGroup_tags(t *testing.T) {
 	})
 }
 
-func testAccCheckGroupExists(ctx context.Context, name string, group *synthetics.Group) resource.TestCheckFunc {
+func testAccCheckGroupExists(ctx context.Context, name string, group *awstypes.Group) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -130,7 +131,7 @@ func testAccCheckGroupExists(ctx context.Context, name string, group *synthetics
 			return fmt.Errorf("no Synthetics Group ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).SyntheticsConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).SyntheticsClient(ctx)
 		output, err := tfsynthetics.FindGroupByName(ctx, conn, rs.Primary.ID)
 
 		if err != nil {
@@ -145,7 +146,7 @@ func testAccCheckGroupExists(ctx context.Context, name string, group *synthetics
 
 func testAccCheckGroupDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).SyntheticsConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).SyntheticsClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_synthetics_group" {

--- a/internal/service/synthetics/retry.go
+++ b/internal/service/synthetics/retry.go
@@ -7,35 +7,33 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/synthetics"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/synthetics"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/synthetics/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 )
 
-const (
-	canaryCreateFail = "CREATE_FAILED"
-)
-
-func retryCreateCanary(ctx context.Context, conn *synthetics.Synthetics, d *schema.ResourceData, input *synthetics.CreateCanaryInput) (*synthetics.Canary, error) {
+func retryCreateCanary(ctx context.Context, conn *synthetics.Client, d *schema.ResourceData, input *synthetics.CreateCanaryInput) (*awstypes.Canary, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending: []string{synthetics.CanaryStateCreating, synthetics.CanaryStateUpdating},
-		Target:  []string{synthetics.CanaryStateReady},
+		Pending: enum.Slice(awstypes.CanaryStateCreating, awstypes.CanaryStateUpdating),
+		Target:  enum.Slice(awstypes.CanaryStateReady),
 		Refresh: statusCanaryState(ctx, conn, d.Id()),
 		Timeout: canaryCreatedTimeout,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
-	if output, ok := outputRaw.(*synthetics.Canary); ok {
-		if status := output.Status; aws.StringValue(status.State) == synthetics.CanaryStateError && aws.StringValue(status.StateReasonCode) == canaryCreateFail {
+	if output, ok := outputRaw.(*awstypes.Canary); ok {
+		if status := output.Status; status.State == awstypes.CanaryStateError && status.StateReasonCode == awstypes.CanaryStateReasonCodeCreateFailed {
 			// delete canary because it is the only way to reprovision if in an error state
 			err = deleteCanary(ctx, conn, d.Id())
 			if err != nil {
 				return output, fmt.Errorf("deleting Synthetics Canary on retry (%s): %w", d.Id(), err)
 			}
 
-			_, err = conn.CreateCanaryWithContext(ctx, input)
+			_, err = conn.CreateCanary(ctx, input)
 			if err != nil {
 				return output, fmt.Errorf("creating Synthetics Canary on retry (%s): %w", d.Id(), err)
 			}
@@ -50,12 +48,12 @@ func retryCreateCanary(ctx context.Context, conn *synthetics.Synthetics, d *sche
 	return nil, err
 }
 
-func deleteCanary(ctx context.Context, conn *synthetics.Synthetics, name string) error {
-	_, err := conn.DeleteCanaryWithContext(ctx, &synthetics.DeleteCanaryInput{
+func deleteCanary(ctx context.Context, conn *synthetics.Client, name string) error {
+	_, err := conn.DeleteCanary(ctx, &synthetics.DeleteCanaryInput{
 		Name: aws.String(name),
 	})
 
-	if tfawserr.ErrCodeEquals(err, synthetics.ErrCodeResourceNotFoundException) {
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return nil
 	}
 

--- a/internal/service/synthetics/service_endpoints_gen_test.go
+++ b/internal/service/synthetics/service_endpoints_gen_test.go
@@ -14,7 +14,6 @@ import (
 
 	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
 	synthetics_sdkv2 "github.com/aws/aws-sdk-go-v2/service/synthetics"
-	synthetics_sdkv1 "github.com/aws/aws-sdk-go/service/synthetics"
 	"github.com/aws/smithy-go/middleware"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
@@ -203,25 +202,13 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 		},
 	}
 
-	t.Run("v1", func(t *testing.T) {
-		for name, testcase := range testcases { //nolint:paralleltest // uses t.Setenv
-			testcase := testcase
+	for name, testcase := range testcases { //nolint:paralleltest // uses t.Setenv
+		testcase := testcase
 
-			t.Run(name, func(t *testing.T) {
-				testEndpointCase(t, region, testcase, callServiceV1)
-			})
-		}
-	})
-
-	t.Run("v2", func(t *testing.T) {
-		for name, testcase := range testcases { //nolint:paralleltest // uses t.Setenv
-			testcase := testcase
-
-			t.Run(name, func(t *testing.T) {
-				testEndpointCase(t, region, testcase, callServiceV2)
-			})
-		}
-	})
+		t.Run(name, func(t *testing.T) {
+			testEndpointCase(t, region, testcase, callService)
+		})
+	}
 }
 
 func defaultEndpoint(region string) string {
@@ -241,7 +228,7 @@ func defaultEndpoint(region string) string {
 	return ep.URI.String()
 }
 
-func callServiceV2(ctx context.Context, t *testing.T, meta *conns.AWSClient) string {
+func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) string {
 	t.Helper()
 
 	var endpoint string
@@ -261,20 +248,6 @@ func callServiceV2(ctx context.Context, t *testing.T, meta *conns.AWSClient) str
 	} else if !errors.Is(err, errCancelOperation) {
 		t.Fatalf("Unexpected error: %s", err)
 	}
-
-	return endpoint
-}
-
-func callServiceV1(ctx context.Context, t *testing.T, meta *conns.AWSClient) string {
-	t.Helper()
-
-	client := meta.SyntheticsConn(ctx)
-
-	req, _ := client.ListGroupsRequest(&synthetics_sdkv1.ListGroupsInput{})
-
-	req.HTTPRequest.URL.Path = "/"
-
-	endpoint := req.HTTPRequest.URL.String()
 
 	return endpoint
 }

--- a/internal/service/synthetics/service_endpoints_gen_test.go
+++ b/internal/service/synthetics/service_endpoints_gen_test.go
@@ -4,15 +4,16 @@ package synthetics_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	synthetics_sdkv2 "github.com/aws/aws-sdk-go-v2/service/synthetics"
 	synthetics_sdkv1 "github.com/aws/aws-sdk-go/service/synthetics"
 	"github.com/aws/smithy-go/middleware"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
@@ -202,33 +203,69 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 		},
 	}
 
-	for name, testcase := range testcases { //nolint:paralleltest // uses t.Setenv
-		testcase := testcase
+	t.Run("v1", func(t *testing.T) {
+		for name, testcase := range testcases { //nolint:paralleltest // uses t.Setenv
+			testcase := testcase
 
-		t.Run(name, func(t *testing.T) {
-			testEndpointCase(t, region, testcase, callService)
-		})
-	}
+			t.Run(name, func(t *testing.T) {
+				testEndpointCase(t, region, testcase, callServiceV1)
+			})
+		}
+	})
+
+	t.Run("v2", func(t *testing.T) {
+		for name, testcase := range testcases { //nolint:paralleltest // uses t.Setenv
+			testcase := testcase
+
+			t.Run(name, func(t *testing.T) {
+				testEndpointCase(t, region, testcase, callServiceV2)
+			})
+		}
+	})
 }
 
 func defaultEndpoint(region string) string {
-	r := endpoints.DefaultResolver()
+	r := synthetics_sdkv2.NewDefaultEndpointResolverV2()
 
-	ep, err := r.EndpointFor(synthetics_sdkv1.EndpointsID, region)
+	ep, err := r.ResolveEndpoint(context.Background(), synthetics_sdkv2.EndpointParameters{
+		Region: aws_sdkv2.String(region),
+	})
 	if err != nil {
 		return err.Error()
 	}
 
-	url, _ := url.Parse(ep.URL)
-
-	if url.Path == "" {
-		url.Path = "/"
+	if ep.URI.Path == "" {
+		ep.URI.Path = "/"
 	}
 
-	return url.String()
+	return ep.URI.String()
 }
 
-func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) string {
+func callServiceV2(ctx context.Context, t *testing.T, meta *conns.AWSClient) string {
+	t.Helper()
+
+	var endpoint string
+
+	client := meta.SyntheticsClient(ctx)
+
+	_, err := client.ListGroups(ctx, &synthetics_sdkv2.ListGroupsInput{},
+		func(opts *synthetics_sdkv2.Options) {
+			opts.APIOptions = append(opts.APIOptions,
+				addRetrieveEndpointURLMiddleware(t, &endpoint),
+				addCancelRequestMiddleware(),
+			)
+		},
+	)
+	if err == nil {
+		t.Fatal("Expected an error, got none")
+	} else if !errors.Is(err, errCancelOperation) {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+
+	return endpoint
+}
+
+func callServiceV1(ctx context.Context, t *testing.T, meta *conns.AWSClient) string {
 	t.Helper()
 
 	client := meta.SyntheticsConn(ctx)

--- a/internal/service/synthetics/service_package_gen.go
+++ b/internal/service/synthetics/service_package_gen.go
@@ -5,6 +5,8 @@ package synthetics
 import (
 	"context"
 
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	synthetics_sdkv2 "github.com/aws/aws-sdk-go-v2/service/synthetics"
 	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
 	session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
 	synthetics_sdkv1 "github.com/aws/aws-sdk-go/service/synthetics"
@@ -62,6 +64,17 @@ func (p *servicePackage) NewConn(ctx context.Context, config map[string]any) (*s
 	sess := config["session"].(*session_sdkv1.Session)
 
 	return synthetics_sdkv1.New(sess.Copy(&aws_sdkv1.Config{Endpoint: aws_sdkv1.String(config["endpoint"].(string))})), nil
+}
+
+// NewClient returns a new AWS SDK for Go v2 client for this service package's AWS API.
+func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (*synthetics_sdkv2.Client, error) {
+	cfg := *(config["aws_sdkv2_config"].(*aws_sdkv2.Config))
+
+	return synthetics_sdkv2.NewFromConfig(cfg, func(o *synthetics_sdkv2.Options) {
+		if endpoint := config["endpoint"].(string); endpoint != "" {
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
+		}
+	}), nil
 }
 
 func ServicePackage(ctx context.Context) conns.ServicePackage {

--- a/internal/service/synthetics/service_package_gen.go
+++ b/internal/service/synthetics/service_package_gen.go
@@ -7,9 +7,6 @@ import (
 
 	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
 	synthetics_sdkv2 "github.com/aws/aws-sdk-go-v2/service/synthetics"
-	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
-	session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
-	synthetics_sdkv1 "github.com/aws/aws-sdk-go/service/synthetics"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -57,13 +54,6 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 
 func (p *servicePackage) ServicePackageName() string {
 	return names.Synthetics
-}
-
-// NewConn returns a new AWS SDK for Go v1 client for this service package's AWS API.
-func (p *servicePackage) NewConn(ctx context.Context, config map[string]any) (*synthetics_sdkv1.Synthetics, error) {
-	sess := config["session"].(*session_sdkv1.Session)
-
-	return synthetics_sdkv1.New(sess.Copy(&aws_sdkv1.Config{Endpoint: aws_sdkv1.String(config["endpoint"].(string))})), nil
 }
 
 // NewClient returns a new AWS SDK for Go v2 client for this service package's AWS API.

--- a/internal/service/synthetics/status.go
+++ b/internal/service/synthetics/status.go
@@ -6,13 +6,12 @@ package synthetics
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/synthetics"
+	"github.com/aws/aws-sdk-go-v2/service/synthetics"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func statusCanaryState(ctx context.Context, conn *synthetics.Synthetics, name string) retry.StateRefreshFunc {
+func statusCanaryState(ctx context.Context, conn *synthetics.Client, name string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		output, err := FindCanaryByName(ctx, conn, name)
 
@@ -24,6 +23,6 @@ func statusCanaryState(ctx context.Context, conn *synthetics.Synthetics, name st
 			return nil, "", err
 		}
 
-		return output, aws.StringValue(output.Status.State), nil
+		return output, string(output.Status.State), nil
 	}
 }

--- a/internal/service/synthetics/tags_gen.go
+++ b/internal/service/synthetics/tags_gen.go
@@ -5,9 +5,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/synthetics"
-	"github.com/aws/aws-sdk-go/service/synthetics/syntheticsiface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/synthetics"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/logging"
@@ -16,21 +15,54 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// map[string]*string handling
+// listTags lists synthetics service tags.
+// The identifier is typically the Amazon Resource Name (ARN), although
+// it may also be a different identifier depending on the service.
+func listTags(ctx context.Context, conn *synthetics.Client, identifier string, optFns ...func(*synthetics.Options)) (tftags.KeyValueTags, error) {
+	input := &synthetics.ListTagsForResourceInput{
+		ResourceArn: aws.String(identifier),
+	}
+
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+
+	if err != nil {
+		return tftags.New(ctx, nil), err
+	}
+
+	return KeyValueTags(ctx, output.Tags), nil
+}
+
+// ListTags lists synthetics service tags and set them in Context.
+// It is called from outside this package.
+func (p *servicePackage) ListTags(ctx context.Context, meta any, identifier string) error {
+	tags, err := listTags(ctx, meta.(*conns.AWSClient).SyntheticsClient(ctx), identifier)
+
+	if err != nil {
+		return err
+	}
+
+	if inContext, ok := tftags.FromContext(ctx); ok {
+		inContext.TagsOut = option.Some(tags)
+	}
+
+	return nil
+}
+
+// map[string]string handling
 
 // Tags returns synthetics service tags.
-func Tags(tags tftags.KeyValueTags) map[string]*string {
-	return aws.StringMap(tags.Map())
+func Tags(tags tftags.KeyValueTags) map[string]string {
+	return tags.Map()
 }
 
 // KeyValueTags creates tftags.KeyValueTags from synthetics service tags.
-func KeyValueTags(ctx context.Context, tags map[string]*string) tftags.KeyValueTags {
+func KeyValueTags(ctx context.Context, tags map[string]string) tftags.KeyValueTags {
 	return tftags.New(ctx, tags)
 }
 
 // getTagsIn returns synthetics service tags from Context.
 // nil is returned if there are no input tags.
-func getTagsIn(ctx context.Context) map[string]*string {
+func getTagsIn(ctx context.Context) map[string]string {
 	if inContext, ok := tftags.FromContext(ctx); ok {
 		if tags := Tags(inContext.TagsIn.UnwrapOrDefault()); len(tags) > 0 {
 			return tags
@@ -41,7 +73,7 @@ func getTagsIn(ctx context.Context) map[string]*string {
 }
 
 // setTagsOut sets synthetics service tags in Context.
-func setTagsOut(ctx context.Context, tags map[string]*string) {
+func setTagsOut(ctx context.Context, tags map[string]string) {
 	if inContext, ok := tftags.FromContext(ctx); ok {
 		inContext.TagsOut = option.Some(KeyValueTags(ctx, tags))
 	}
@@ -50,7 +82,7 @@ func setTagsOut(ctx context.Context, tags map[string]*string) {
 // updateTags updates synthetics service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn syntheticsiface.SyntheticsAPI, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *synthetics.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*synthetics.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -61,10 +93,10 @@ func updateTags(ctx context.Context, conn syntheticsiface.SyntheticsAPI, identif
 	if len(removedTags) > 0 {
 		input := &synthetics.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.Keys()),
+			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResourceWithContext(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -79,7 +111,7 @@ func updateTags(ctx context.Context, conn syntheticsiface.SyntheticsAPI, identif
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResourceWithContext(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)
@@ -92,5 +124,5 @@ func updateTags(ctx context.Context, conn syntheticsiface.SyntheticsAPI, identif
 // UpdateTags updates synthetics service tags.
 // It is called from outside this package.
 func (p *servicePackage) UpdateTags(ctx context.Context, meta any, identifier string, oldTags, newTags any) error {
-	return updateTags(ctx, meta.(*conns.AWSClient).SyntheticsConn(ctx), identifier, oldTags, newTags)
+	return updateTags(ctx, meta.(*conns.AWSClient).SyntheticsClient(ctx), identifier, oldTags, newTags)
 }

--- a/names/data/names_data.csv
+++ b/names/data/names_data.csv
@@ -73,7 +73,7 @@ evidently,evidently,cloudwatchevidently,evidently,,evidently,,cloudwatchevidentl
 internetmonitor,internetmonitor,internetmonitor,internetmonitor,,internetmonitor,,,InternetMonitor,InternetMonitor,,,2,,aws_internetmonitor_,,internetmonitor_,CloudWatch Internet Monitor,Amazon,,,,,,,InternetMonitor,ListMonitors,,
 logs,logs,cloudwatchlogs,cloudwatchlogs,,logs,,cloudwatchlog;cloudwatchlogs,Logs,CloudWatchLogs,,,2,aws_cloudwatch_(log_|query_),aws_logs_,,cloudwatch_log_;cloudwatch_query_,CloudWatch Logs,Amazon,,,,,,,CloudWatch Logs,ListAnomalies,,
 rum,rum,cloudwatchrum,rum,,rum,,cloudwatchrum,RUM,CloudWatchRUM,,1,,,aws_rum_,,rum_,CloudWatch RUM,Amazon,,,,,,,RUM,ListAppMonitors,,
-synthetics,synthetics,synthetics,synthetics,,synthetics,,,Synthetics,Synthetics,,1,,,aws_synthetics_,,synthetics_,CloudWatch Synthetics,Amazon,,,,,,,synthetics,ListGroups,,
+synthetics,synthetics,synthetics,synthetics,,synthetics,,,Synthetics,Synthetics,,1,2,,aws_synthetics_,,synthetics_,CloudWatch Synthetics,Amazon,,,,,,,synthetics,ListGroups,,
 codeartifact,codeartifact,codeartifact,codeartifact,,codeartifact,,,CodeArtifact,CodeArtifact,,,2,,aws_codeartifact_,,codeartifact_,CodeArtifact,AWS,,,,,,,codeartifact,ListDomains,,
 codebuild,codebuild,codebuild,codebuild,,codebuild,,,CodeBuild,CodeBuild,,,2,,aws_codebuild_,,codebuild_,CodeBuild,AWS,,,,,,,CodeBuild,ListBuildBatches,,
 codecommit,codecommit,codecommit,codecommit,,codecommit,,,CodeCommit,CodeCommit,,,2,,aws_codecommit_,,codecommit_,CodeCommit,AWS,,,,,,,CodeCommit,ListRepositories,,

--- a/names/data/names_data.csv
+++ b/names/data/names_data.csv
@@ -73,7 +73,7 @@ evidently,evidently,cloudwatchevidently,evidently,,evidently,,cloudwatchevidentl
 internetmonitor,internetmonitor,internetmonitor,internetmonitor,,internetmonitor,,,InternetMonitor,InternetMonitor,,,2,,aws_internetmonitor_,,internetmonitor_,CloudWatch Internet Monitor,Amazon,,,,,,,InternetMonitor,ListMonitors,,
 logs,logs,cloudwatchlogs,cloudwatchlogs,,logs,,cloudwatchlog;cloudwatchlogs,Logs,CloudWatchLogs,,,2,aws_cloudwatch_(log_|query_),aws_logs_,,cloudwatch_log_;cloudwatch_query_,CloudWatch Logs,Amazon,,,,,,,CloudWatch Logs,ListAnomalies,,
 rum,rum,cloudwatchrum,rum,,rum,,cloudwatchrum,RUM,CloudWatchRUM,,1,,,aws_rum_,,rum_,CloudWatch RUM,Amazon,,,,,,,RUM,ListAppMonitors,,
-synthetics,synthetics,synthetics,synthetics,,synthetics,,,Synthetics,Synthetics,,1,2,,aws_synthetics_,,synthetics_,CloudWatch Synthetics,Amazon,,,,,,,synthetics,ListGroups,,
+synthetics,synthetics,synthetics,synthetics,,synthetics,,,Synthetics,Synthetics,,,2,,aws_synthetics_,,synthetics_,CloudWatch Synthetics,Amazon,,,,,,,synthetics,ListGroups,,
 codeartifact,codeartifact,codeartifact,codeartifact,,codeartifact,,,CodeArtifact,CodeArtifact,,,2,,aws_codeartifact_,,codeartifact_,CodeArtifact,AWS,,,,,,,codeartifact,ListDomains,,
 codebuild,codebuild,codebuild,codebuild,,codebuild,,,CodeBuild,CodeBuild,,,2,,aws_codebuild_,,codebuild_,CodeBuild,AWS,,,,,,,CodeBuild,ListBuildBatches,,
 codecommit,codecommit,codecommit,codecommit,,codecommit,,,CodeCommit,CodeCommit,,,2,,aws_codecommit_,,codecommit_,CodeCommit,AWS,,,,,,,CodeCommit,ListRepositories,,

--- a/names/names.go
+++ b/names/names.go
@@ -102,6 +102,7 @@ const (
 	SSOAdminEndpointID                   = "sso"
 	STSEndpointID                        = "sts"
 	SWFEndpointID                        = "swf"
+	SyntheticsEndpointID                 = "synthetics"
 	TimestreamWriteEndpointID            = "ingest.timestream"
 	TranscribeEndpointID                 = "transcribe"
 	VerifiedPermissionsEndpointID        = "verifiedpermissions"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:


--->

Relates #32976

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS="-run=TestAccSynthetics" PKG=synthetics

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/synthetics/... -v -count 1 -parallel 20  -run=TestAccSynthetics -timeout 360m
--- PASS: TestAccSyntheticsGroup_disappears (15.82s)
--- PASS: TestAccSyntheticsGroup_basic (17.69s)
--- PASS: TestAccSyntheticsGroup_tags (31.50s)
--- PASS: TestAccSyntheticsGroupAssociation_disappears (59.94s)
--- PASS: TestAccSyntheticsCanary_s3 (62.23s)
--- PASS: TestAccSyntheticsCanary_artifactEncryption (65.36s)
--- PASS: TestAccSyntheticsCanary_disappears (65.90s)
--- PASS: TestAccSyntheticsCanary_runTracing (66.15s)
--- PASS: TestAccSyntheticsGroupAssociation_basic (68.31s)
--- PASS: TestAccSyntheticsCanary_runEnvironmentVariables (70.80s)
--- PASS: TestAccSyntheticsCanary_tags (75.68s)
--- PASS: TestAccSyntheticsCanary_startCanary (81.70s)
--- PASS: TestAccSyntheticsCanary_basic (88.25s)
--- PASS: TestAccSyntheticsCanary_run (89.31s)
--- PASS: TestAccSyntheticsCanary_runtimeVersion (97.08s)
--- PASS: TestAccSyntheticsCanary_StartCanary_codeChanges (98.67s)
--- PASS: TestAccSyntheticsCanary_vpc (1939.52s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/synthetics	1946.647s
```
