### PR TITLE
DOCS: Change aws_iam_user_login_profile's encrypted_password text.

### DIFF
--- a/website/docs/r/iam_user_login_profile.html.markdown
+++ b/website/docs/r/iam_user_login_profile.html.markdown
@@ -38,7 +38,17 @@ This resource supports the following arguments:
 * `user` - (Required) The IAM user's name.
 * `pgp_key` - (Optional) Either a base-64 encoded PGP public key, or a keybase username in the form `keybase:username`. Only applies on resource creation. Drift detection is not possible with this argument.
 * `password_length` - (Optional) The length of the generated password on resource creation. Only applies on resource creation. Drift detection is not possible with this argument. Default value is `20`.
-* `password_reset_required` - (Optional) Whether the user should be forced to reset the generated password on resource creation. Only applies on resource creation.
+* `password_reset_required` - (Optional) Whether the user should be forced to reset the generated password. This is applied all the time! If you want to avoid the situation where you set up a new user, they change their password as required, then the next `terraform apply` causes that user to be destroyed and then created with a new initial password, then, you need to use:
+
+  ```
+  lifecycle {
+    ignore_changes = [
+      password_reset_required,
+    ]
+  }
+  ```
+
+  Currently waiting on issue [#23567](https://github.com/hashicorp/terraform-provider-aws/issues/23567) to be prioritized which would hope to restore the default behaviour of applying this only on resource creation.
 
 ## Attribute Reference
 


### PR DESCRIPTION
### Description

There is a descrepency between the docs and observed behaviour for `aws_iam_user_login_profile`'s `encrypted_password`. Unfortunatly I don't know any golang so can't have a crack at changing the implementation but I can change the docs to save others time with this in the future.

This is to make the docs align with observed behaviour of not "_only applies on resource creation_" but on all `terraform apply`s. 

This also provides documentation of an interim work around. I read this as maybe a not good practise in the Contributing Guide so I'm willing to modify this, but we should at least provide a hint for how to use this without it trying to be re-applied every time a user has changed their password from the initial one. 

I'm open to any wording or formatting changes and happy for a maintainer to make changes as they see fit to this PR, the only thing that is needed is for the docs to align with the resources behaviour.

### Relations

Relates #23567

### References

Steps to reproduce the reasoning for this documentation change. 

1. Use terraform config:
```
variable "developers" {
  description = "A list of objects of developers usernames and their public PGP key to setup."
  type        = set(object({ user-name : string, their-public-pgp-key : string }))
}

resource "aws_iam_user" "iam-users-developers" {
  for_each = { for obj in var.developers : obj.user-name => obj }

  name = each.value.user-name
}

resource "aws_iam_user_login_profile" "iam-login-developers" {
  depends_on = [aws_iam_user.iam-users-developers]
  for_each   = { for obj in var.developers : obj.user-name => obj }

  user                    = each.value.user-name
  pgp_key                 = each.value.their-public-pgp-key
  password_reset_required = true
}
```
2. `terraform apply` it.
3. Log into the AWS console as this new user.
4. Change the password as required.
5. Perform a `terraform plan` and see that it's showing destroy and create on the user.
6. (Optionally) `terraform apply` and see that you need to use the new pgp encrypted password to log into the user.


### Output from Acceptance Testing

Documentation change so doesn't require tests?
