### PR TITLE
B fix ssm patching manager to set computed value as new

### DIFF
--- a/.changelog/35606.txt
+++ b/.changelog/35606.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ssm_patch_baseline: Mark `json` as Computed if there are content changes
+```

--- a/internal/service/ssm/default_patch_baseline.go
+++ b/internal/service/ssm/default_patch_baseline.go
@@ -33,8 +33,8 @@ const (
 	patchBaselineIDRegexPattern = `pb-[0-9a-f]{17}`
 )
 
-// @SDKResource("aws_ssm_default_patch_baseline")
-func ResourceDefaultPatchBaseline() *schema.Resource {
+// @SDKResource("aws_ssm_default_patch_baseline", name="Default Patch Baseline")
+func resourceDefaultPatchBaseline() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceDefaultPatchBaselineCreate,
 		ReadWithoutTimeout:   resourceDefaultPatchBaselineRead,
@@ -47,7 +47,7 @@ func ResourceDefaultPatchBaseline() *schema.Resource {
 				if isPatchBaselineID(id) || isPatchBaselineARN(id) {
 					conn := meta.(*conns.AWSClient).SSMClient(ctx)
 
-					patchbaseline, err := findPatchBaselineByID(ctx, conn, id)
+					patchbaseline, err := findPatchBaselineByIDV2(ctx, conn, id)
 					if err != nil {
 						return nil, fmt.Errorf("reading SSM Patch Baseline (%s): %w", id, err)
 					}
@@ -171,17 +171,16 @@ const (
 
 func resourceDefaultPatchBaselineCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
-
 	conn := meta.(*conns.AWSClient).SSMClient(ctx)
 
 	baselineID := d.Get("baseline_id").(string)
 
-	patchBaseline, err := findPatchBaselineByID(ctx, conn, baselineID)
+	patchBaseline, err := findPatchBaselineByIDV2(ctx, conn, baselineID)
+
 	if err != nil {
-		return create.AppendDiagErrorMessage(diags, names.SSM, "registering", ResNameDefaultPatchBaseline, baselineID,
-			create.ProblemStandardMessage(names.SSM, create.ErrActionReading, resNamePatchBaseline, baselineID, err),
-		)
+		return sdkdiag.AppendErrorf(diags, "reading SSM Patch Baseline (%s): %s", baselineID, err)
 	}
+
 	if pbOS, cOS := string(patchBaseline.OperatingSystem), d.Get("operating_system"); pbOS != cOS {
 		return create.AppendDiagErrorMessage(diags, names.SSM, "registering", ResNameDefaultPatchBaseline, baselineID,
 			fmt.Sprintf("Patch Baseline Operating System (%s) does not match %s", pbOS, cOS),
@@ -304,16 +303,17 @@ func FindDefaultPatchBaseline(ctx context.Context, conn *ssm.Client, os types.Op
 	return out, nil
 }
 
-func findPatchBaselineByID(ctx context.Context, conn *ssm.Client, id string) (*ssm.GetPatchBaselineOutput, error) {
-	in := &ssm.GetPatchBaselineInput{
+func findPatchBaselineByIDV2(ctx context.Context, conn *ssm.Client, id string) (*ssm.GetPatchBaselineOutput, error) {
+	input := &ssm.GetPatchBaselineInput{
 		BaselineId: aws.String(id),
 	}
-	out, err := conn.GetPatchBaseline(ctx, in)
+
+	output, err := conn.GetPatchBaseline(ctx, input)
 
 	if errs.IsA[*types.DoesNotExistException](err) {
 		return nil, &retry.NotFoundError{
 			LastError:   err,
-			LastRequest: in,
+			LastRequest: input,
 		}
 	}
 
@@ -321,11 +321,11 @@ func findPatchBaselineByID(ctx context.Context, conn *ssm.Client, id string) (*s
 		return nil, err
 	}
 
-	if out == nil {
-		return nil, tfresource.NewEmptyResultError(in)
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError(input)
 	}
 
-	return out, nil
+	return output, nil
 }
 
 func patchBaselinesPaginator(conn *ssm.Client, filters ...types.PatchOrchestratorFilter) *ssm.DescribePatchBaselinesPaginator {

--- a/internal/service/ssm/exports_test.go
+++ b/internal/service/ssm/exports_test.go
@@ -1,0 +1,9 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ssm
+
+// Exports for use in tests only.
+var (
+	ResourcePatchBaseline = resourcePatchBaseline
+)

--- a/internal/service/ssm/exports_test.go
+++ b/internal/service/ssm/exports_test.go
@@ -5,5 +5,8 @@ package ssm
 
 // Exports for use in tests only.
 var (
-	ResourcePatchBaseline = resourcePatchBaseline
+	ResourceDefaultPatchBaseline = resourceDefaultPatchBaseline
+	ResourcePatchBaseline        = resourcePatchBaseline
+
+	FindPatchBaselineByID = findPatchBaselineByID
 )

--- a/internal/service/ssm/patch_baseline.go
+++ b/internal/service/ssm/patch_baseline.go
@@ -284,7 +284,7 @@ func resourcePatchBaselineRead(ctx context.Context, d *schema.ResourceData, meta
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SSMConn(ctx)
 
-	output, err := FindPatchBaselineByID(ctx, conn, d.Id())
+	output, err := findPatchBaselineByID(ctx, conn, d.Id())
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] SSM Patch Baseline (%s) not found, removing from state", d.Id())
@@ -419,7 +419,7 @@ func resourcePatchBaselineDelete(ctx context.Context, d *schema.ResourceData, me
 	return
 }
 
-func FindPatchBaselineByID(ctx context.Context, conn *ssm.SSM, id string) (*ssm.GetPatchBaselineOutput, error) {
+func findPatchBaselineByID(ctx context.Context, conn *ssm.SSM, id string) (*ssm.GetPatchBaselineOutput, error) {
 	input := &ssm.GetPatchBaselineInput{
 		BaselineId: aws.String(id),
 	}

--- a/internal/service/ssm/patch_baseline.go
+++ b/internal/service/ssm/patch_baseline.go
@@ -42,50 +42,6 @@ func ResourcePatchBaseline() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(3, 128),
-					validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]{3,128}$`), "must contain only alphanumeric, underscore, hyphen, or period characters"),
-				),
-			},
-
-			"description": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(0, 1024),
-			},
-
-			"global_filter": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 4,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"key": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringInSlice(ssm.PatchFilterKey_Values(), false),
-						},
-						"values": {
-							Type:     schema.TypeList,
-							Required: true,
-							MaxItems: 20,
-							MinItems: 1,
-							Elem: &schema.Schema{
-								Type:         schema.TypeString,
-								ValidateFunc: validation.StringLenBetween(1, 64),
-							},
-						},
-					},
-				},
-			},
-
 			"approval_rule": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -96,26 +52,22 @@ func ResourcePatchBaseline() *schema.Resource {
 							Optional:     true,
 							ValidateFunc: validation.IntBetween(0, 100),
 						},
-
 						"approve_until_date": {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ValidateFunc: validation.StringMatch(regexache.MustCompile(`([12]\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))`), "must be formatted YYYY-MM-DD"),
 						},
-
 						"compliance_level": {
 							Type:         schema.TypeString,
 							Optional:     true,
 							Default:      ssm.PatchComplianceLevelUnspecified,
 							ValidateFunc: validation.StringInSlice(ssm.PatchComplianceLevel_Values(), false),
 						},
-
 						"enable_non_security": {
 							Type:     schema.TypeBool,
 							Optional: true,
 							Default:  false,
 						},
-
 						"patch_filter": {
 							Type:     schema.TypeList,
 							Required: true,
@@ -143,7 +95,6 @@ func ResourcePatchBaseline() *schema.Resource {
 					},
 				},
 			},
-
 			"approved_patches": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -153,7 +104,68 @@ func ResourcePatchBaseline() *schema.Resource {
 					ValidateFunc: validation.StringLenBetween(1, 100),
 				},
 			},
-
+			"approved_patches_compliance_level": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      ssm.PatchComplianceLevelUnspecified,
+				ValidateFunc: validation.StringInSlice(ssm.PatchComplianceLevel_Values(), false),
+			},
+			"approved_patches_enable_non_security": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 1024),
+			},
+			"global_filter": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 4,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(ssm.PatchFilterKey_Values(), false),
+						},
+						"values": {
+							Type:     schema.TypeList,
+							Required: true,
+							MaxItems: 20,
+							MinItems: 1,
+							Elem: &schema.Schema{
+								Type:         schema.TypeString,
+								ValidateFunc: validation.StringLenBetween(1, 64),
+							},
+						},
+					},
+				},
+			},
+			"json": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(3, 128),
+					validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]{3,128}$`), "must contain only alphanumeric, underscore, hyphen, or period characters"),
+				),
+			},
+			"operating_system": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      ssm.OperatingSystemWindows,
+				ValidateFunc: validation.StringInSlice(ssm.OperatingSystem_Values(), false),
+			},
 			"rejected_patches": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -163,38 +175,23 @@ func ResourcePatchBaseline() *schema.Resource {
 					ValidateFunc: validation.StringLenBetween(1, 100),
 				},
 			},
-
-			"operating_system": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				Default:      ssm.OperatingSystemWindows,
-				ValidateFunc: validation.StringInSlice(ssm.OperatingSystem_Values(), false),
-			},
-
-			"approved_patches_compliance_level": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Default:      ssm.PatchComplianceLevelUnspecified,
-				ValidateFunc: validation.StringInSlice(ssm.PatchComplianceLevel_Values(), false),
-			},
 			"rejected_patches_action": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
 				ValidateFunc: validation.StringInSlice(ssm.PatchAction_Values(), false),
 			},
-			"approved_patches_enable_non_security": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-
 			"source": {
 				Type:     schema.TypeList,
 				Optional: true,
 				MaxItems: 20,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"configuration": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringLenBetween(1, 1024),
+						},
 						"name": {
 							Type:     schema.TypeString,
 							Required: true,
@@ -203,13 +200,6 @@ func ResourcePatchBaseline() *schema.Resource {
 								validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]{3,50}$`), "must contain only alphanumeric, underscore, hyphen, or period characters"),
 							),
 						},
-
-						"configuration": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringLenBetween(1, 1024),
-						},
-
 						"products": {
 							Type:     schema.TypeList,
 							Required: true,
@@ -222,11 +212,6 @@ func ResourcePatchBaseline() *schema.Resource {
 					},
 				},
 			},
-			"json": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},

--- a/internal/service/ssm/patch_baseline.go
+++ b/internal/service/ssm/patch_baseline.go
@@ -350,44 +350,44 @@ func resourcePatchBaselineUpdate(ctx context.Context, d *schema.ResourceData, me
 			BaselineId: aws.String(d.Id()),
 		}
 
-		if d.HasChange("name") {
-			input.Name = aws.String(d.Get("name").(string))
-		}
-
-		if d.HasChange("description") {
-			input.Description = aws.String(d.Get("description").(string))
+		if d.HasChange("approval_rule") {
+			input.ApprovalRules = expandPatchRuleGroup(d)
 		}
 
 		if d.HasChange("approved_patches") {
 			input.ApprovedPatches = flex.ExpandStringSet(d.Get("approved_patches").(*schema.Set))
 		}
 
-		if d.HasChange("rejected_patches") {
-			input.RejectedPatches = flex.ExpandStringSet(d.Get("rejected_patches").(*schema.Set))
-		}
-
 		if d.HasChange("approved_patches_compliance_level") {
 			input.ApprovedPatchesComplianceLevel = aws.String(d.Get("approved_patches_compliance_level").(string))
-		}
-
-		if d.HasChange("approval_rule") {
-			input.ApprovalRules = expandPatchRuleGroup(d)
-		}
-
-		if d.HasChange("global_filter") {
-			input.GlobalFilters = expandPatchFilterGroup(d)
-		}
-
-		if d.HasChange("source") {
-			input.Sources = expandPatchSource(d)
 		}
 
 		if d.HasChange("approved_patches_enable_non_security") {
 			input.ApprovedPatchesEnableNonSecurity = aws.Bool(d.Get("approved_patches_enable_non_security").(bool))
 		}
 
+		if d.HasChange("description") {
+			input.Description = aws.String(d.Get("description").(string))
+		}
+
+		if d.HasChange("global_filter") {
+			input.GlobalFilters = expandPatchFilterGroup(d)
+		}
+
+		if d.HasChange("name") {
+			input.Name = aws.String(d.Get("name").(string))
+		}
+
+		if d.HasChange("rejected_patches") {
+			input.RejectedPatches = flex.ExpandStringSet(d.Get("rejected_patches").(*schema.Set))
+		}
+
 		if d.HasChange("rejected_patches_action") {
 			input.RejectedPatchesAction = aws.String(d.Get("rejected_patches_action").(string))
+		}
+
+		if d.HasChange("source") {
+			input.Sources = expandPatchSource(d)
 		}
 
 		_, err := conn.UpdatePatchBaselineWithContext(ctx, input)

--- a/internal/service/ssm/patch_baseline.go
+++ b/internal/service/ssm/patch_baseline.go
@@ -239,36 +239,36 @@ func resourcePatchBaselineCreate(ctx context.Context, d *schema.ResourceData, me
 		Tags:                           getTagsIn(ctx),
 	}
 
-	if v, ok := d.GetOk("description"); ok {
-		input.Description = aws.String(v.(string))
+	if _, ok := d.GetOk("approval_rule"); ok {
+		input.ApprovalRules = expandPatchRuleGroup(d)
 	}
 
 	if v, ok := d.GetOk("approved_patches"); ok && v.(*schema.Set).Len() > 0 {
 		input.ApprovedPatches = flex.ExpandStringSet(v.(*schema.Set))
 	}
 
-	if v, ok := d.GetOk("rejected_patches"); ok && v.(*schema.Set).Len() > 0 {
-		input.RejectedPatches = flex.ExpandStringSet(v.(*schema.Set))
+	if v, ok := d.GetOk("approved_patches_enable_non_security"); ok {
+		input.ApprovedPatchesEnableNonSecurity = aws.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		input.Description = aws.String(v.(string))
 	}
 
 	if _, ok := d.GetOk("global_filter"); ok {
 		input.GlobalFilters = expandPatchFilterGroup(d)
 	}
 
-	if _, ok := d.GetOk("approval_rule"); ok {
-		input.ApprovalRules = expandPatchRuleGroup(d)
-	}
-
-	if _, ok := d.GetOk("source"); ok {
-		input.Sources = expandPatchSource(d)
-	}
-
-	if v, ok := d.GetOk("approved_patches_enable_non_security"); ok {
-		input.ApprovedPatchesEnableNonSecurity = aws.Bool(v.(bool))
+	if v, ok := d.GetOk("rejected_patches"); ok && v.(*schema.Set).Len() > 0 {
+		input.RejectedPatches = flex.ExpandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("rejected_patches_action"); ok {
 		input.RejectedPatchesAction = aws.String(v.(string))
+	}
+
+	if _, ok := d.GetOk("source"); ok {
+		input.Sources = expandPatchSource(d)
 	}
 
 	output, err := conn.CreatePatchBaselineWithContext(ctx, input)

--- a/internal/service/ssm/patch_baseline.go
+++ b/internal/service/ssm/patch_baseline.go
@@ -32,7 +32,7 @@ import (
 
 // @SDKResource("aws_ssm_patch_baseline", name="Patch Baseline")
 // @Tags(identifierAttribute="id", resourceType="PatchBaseline")
-func ResourcePatchBaseline() *schema.Resource {
+func resourcePatchBaseline() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourcePatchBaselineCreate,
 		ReadWithoutTimeout:   resourcePatchBaselineRead,
@@ -224,10 +224,6 @@ func ResourcePatchBaseline() *schema.Resource {
 		),
 	}
 }
-
-const (
-	resNamePatchBaseline = "Patch Baseline"
-)
 
 func resourcePatchBaselineCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics

--- a/internal/service/ssm/patch_baseline_test.go
+++ b/internal/service/ssm/patch_baseline_test.go
@@ -13,7 +13,9 @@ import (
 	"github.com/aws/aws-sdk-go/service/ssm"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfssm "github.com/hashicorp/terraform-provider-aws/internal/service/ssm"
@@ -32,6 +34,11 @@ func TestAccSSMPatchBaseline_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccPatchBaselineConfig_basic(name),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("json")),
+					},
+				},
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPatchBaselineExists(ctx, resourceName, &before),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ssm", regexache.MustCompile(`patchbaseline/pb-.+`)),
@@ -58,6 +65,11 @@ func TestAccSSMPatchBaseline_basic(t *testing.T) {
 			},
 			{
 				Config: testAccPatchBaselineConfig_basicUpdated(name),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("json")),
+					},
+				},
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPatchBaselineExists(ctx, resourceName, &after),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ssm", regexache.MustCompile(`patchbaseline/pb-.+`)),

--- a/internal/service/ssm/service_package_gen.go
+++ b/internal/service/ssm/service_package_gen.go
@@ -67,8 +67,9 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			TypeName: "aws_ssm_association",
 		},
 		{
-			Factory:  ResourceDefaultPatchBaseline,
+			Factory:  resourceDefaultPatchBaseline,
 			TypeName: "aws_ssm_default_patch_baseline",
+			Name:     "Default Patch Baseline",
 		},
 		{
 			Factory:  ResourceDocument,

--- a/internal/service/ssm/service_package_gen.go
+++ b/internal/service/ssm/service_package_gen.go
@@ -106,7 +106,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			},
 		},
 		{
-			Factory:  ResourcePatchBaseline,
+			Factory:  resourcePatchBaseline,
 			TypeName: "aws_ssm_patch_baseline",
 			Name:     "Patch Baseline",
 			Tags: &types.ServicePackageResourceTags{

--- a/internal/service/ssm/sweep.go
+++ b/internal/service/ssm/sweep.go
@@ -84,7 +84,7 @@ func sweepDefaultPatchBaselines(region string) error {
 			return b.DefaultBaseline
 		}) {
 			baselineID := aws.ToString(identity.BaselineId)
-			pb, err := findPatchBaselineByID(ctx, conn, baselineID)
+			pb, err := findPatchBaselineByIDV2(ctx, conn, baselineID)
 			if err != nil {
 				errs = multierror.Append(errs, fmt.Errorf("reading Patch Baseline (%s): %w", baselineID, err))
 				continue

--- a/internal/service/ssm/sweep.go
+++ b/internal/service/ssm/sweep.go
@@ -202,7 +202,7 @@ func sweepPatchBaselines(region string) error {
 
 		for _, identity := range page.BaselineIdentities {
 			baselineID := aws.ToString(identity.BaselineId)
-			r := ResourcePatchBaseline()
+			r := resourcePatchBaseline()
 			d := r.Data(nil)
 			d.SetId(baselineID)
 			d.Set("operating_system", identity.OperatingSystem)


### PR DESCRIPTION

### Description
https://github.com/hashicorp/terraform-provider-aws/issues/33565 introduced a bug where the json value was not recalculated when the configuration changed. This PR address this. And adds a test to prevent a regression next time


### Relations
Relates #33565 



### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% ❯ make testacc TESTS=TestAccSSMPatchBaseline_basic PKG=ssm
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ssm/... -v -count 1 -parallel 20 -run='TestAccSSMPatchBaseline_basic'  -timeout 360m
=== RUN   TestAccSSMPatchBaseline_basic
=== PAUSE TestAccSSMPatchBaseline_basic
=== CONT  TestAccSSMPatchBaseline_basic
--- PASS: TestAccSSMPatchBaseline_basic (18.35s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssm        18.456s
...
```
