### PR TITLE
Fixes ECS Example

### DIFF
--- a/examples/ecs-alb/terraform.template.tfvars
+++ b/examples/ecs-alb/terraform.template.tfvars
@@ -2,4 +2,3 @@
 # SPDX-License-Identifier: MPL-2.0
 
 admin_cidr_ingress = "1.2.3.4/32"
-key_name           = "terraform-aws-provider-example"

--- a/examples/ecs-alb/variables.tf
+++ b/examples/ecs-alb/variables.tf
@@ -1,23 +1,14 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-variable "aws_region" {
-  description = "The AWS region to create things in."
-  default     = "us-west-2"
-}
-
 variable "az_count" {
   description = "Number of AZs to cover in a given AWS region"
   type        = number
   default     = "2"
 }
 
-variable "key_name" {
-  description = "Name of AWS key pair"
-}
-
 variable "instance_type" {
-  default     = "t2.small"
+  default     = "t3.small"
   description = "AWS instance type"
 }
 


### PR DESCRIPTION
### Description

The ECS example at `example/ecs-alb` references an AMI that no longer exists. Now retrieve the AMI ID from SSM Parameter Store (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/retrieve-ecs-optimized_AMI.html)
