### PR TITLE
Support for GuardDuty Member Detector Features

### DIFF
--- a/internal/service/guardduty/guardduty_test.go
+++ b/internal/service/guardduty/guardduty_test.go
@@ -64,6 +64,11 @@ func TestAccGuardDuty_serial(t *testing.T) {
 			"additional_configuration": testAccOrganizationConfigurationFeature_additionalConfiguration,
 			"multiple":                 testAccOrganizationConfigurationFeature_multiple,
 		},
+		"MemberDetectorFeature": {
+			"basic":                    testAccMemberDetectorFeature_basic,
+			"additional_configuration": testAccMemberDetectorFeature_additionalConfiguration,
+			"multiple":                 testAccMemberDetectorFeature_multiple,
+		},
 		"ThreatIntelSet": {
 			"basic": testAccThreatIntelSet_basic,
 			"tags":  testAccThreatIntelSet_tags,
@@ -99,6 +104,17 @@ func testAccMemberFromEnv(t *testing.T) (string, string) {
 				"a valid email associated with the AWS_GUARDDUTY_MEMBER_ACCOUNT_ID must be provided.")
 	}
 	return accountID, email
+}
+
+func testAccMemberAccountFromEnv(t *testing.T) string {
+	accountID := os.Getenv("AWS_GUARDDUTY_MEMBER_ACCOUNT_ID")
+	if accountID == "" {
+		t.Skip(
+			"Environment variable AWS_GUARDDUTY_MEMBER_ACCOUNT_ID is not set. " +
+				"To properly test GuardDuty member accounts, " +
+				"a valid AWS account ID must be provided.")
+	}
+	return accountID
 }
 
 // testAccPreCheckDetectorExists verifies the current account has a single active GuardDuty detector configured.

--- a/internal/service/guardduty/member_detector_feature.go
+++ b/internal/service/guardduty/member_detector_feature.go
@@ -1,0 +1,287 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package guardduty
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/guardduty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+// @SDKResource("aws_guardduty_member_detector_feature", name="Member Detector Feature")
+func ResourceMemberDetectorFeature() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceMemberDetectorFeaturePut,
+		ReadWithoutTimeout:   resourceMemberDetectorFeatureRead,
+		UpdateWithoutTimeout: resourceMemberDetectorFeaturePut,
+		DeleteWithoutTimeout: schema.NoopContext,
+
+		Schema: map[string]*schema.Schema{
+			"account_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidAccountID,
+			},
+			"additional_configuration": {
+				Optional: true,
+				ForceNew: true,
+				Type:     schema.TypeList,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringInSlice(guardduty.FeatureAdditionalConfiguration_Values(), false),
+						},
+						"status": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(guardduty.FeatureStatus_Values(), false),
+						},
+					},
+				},
+			},
+			"detector_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(guardduty.DetectorFeature_Values(), false),
+			},
+			"status": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(guardduty.FeatureStatus_Values(), false),
+			},
+		},
+	}
+}
+
+func resourceMemberDetectorFeaturePut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).GuardDutyConn(ctx)
+
+	detectorID, accountID, name := d.Get("detector_id").(string), d.Get("account_id").(string), d.Get("name").(string)
+
+	// Use a mutex to ensure that multiple features being updated concurrently don't trample on each other.
+	conns.GlobalMutexKV.Lock(detectorID)
+	defer conns.GlobalMutexKV.Unlock(detectorID)
+
+	feature := &guardduty.MemberFeaturesConfiguration{
+		Name:   aws.String(name),
+		Status: aws.String(d.Get("status").(string)),
+	}
+
+	if v, ok := d.GetOk("additional_configuration"); ok && len(v.([]interface{})) > 0 {
+		feature.AdditionalConfiguration = expandMemberDetectorAdditionalConfigurations(v.([]interface{}))
+	}
+
+	input := &guardduty.UpdateMemberDetectorsInput{
+		DetectorId: aws.String(detectorID),
+		AccountIds: []*string{aws.String(accountID)},
+		Features:   []*guardduty.MemberFeaturesConfiguration{feature},
+	}
+
+	output, err := conn.UpdateMemberDetectorsWithContext(ctx, input)
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "updating GuardDuty Member Detector (%s) Feature (%s): %s", detectorID, name, err)
+	}
+
+	// {"unprocessedAccounts":[{"result":"The request is rejected because the given account ID is not an associated member of account the current account.","accountId":"123456789012"}]}
+	if len(output.UnprocessedAccounts) > 0 {
+		return sdkdiag.AppendErrorf(diags, "updating GuardDuty Member Detector (%s) Feature (%s): %s", detectorID, name, aws.StringValue(output.UnprocessedAccounts[0].Result))
+	}
+
+	if d.IsNewResource() {
+		d.SetId(memberDetectorFeatureCreateResourceID(detectorID, accountID, name))
+	}
+
+	return append(diags, resourceMemberDetectorFeatureRead(ctx, d, meta)...)
+}
+
+func resourceMemberDetectorFeatureRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).GuardDutyConn(ctx)
+
+	detectorID, accountID, name, err := memberDetectorFeatureParseResourceID(d.Id())
+	if err != nil {
+		return sdkdiag.AppendFromErr(diags, err)
+	}
+
+	feature, err := FindMemberDetectorFeatureByThreePartKey(ctx, conn, detectorID, accountID, name)
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] GuardDuty Member Detector Feature (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return diags
+	}
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading GuardDuty Member Detector Feature (%s): %s", d.Id(), err)
+	}
+
+	if err := d.Set("additional_configuration", flattenMemberDetectorAdditionalConfigurationResults(feature.AdditionalConfiguration)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting additional_configuration: %s", err)
+	}
+
+	d.Set("detector_id", detectorID)
+	d.Set("account_id", accountID)
+	d.Set("name", feature.Name)
+	d.Set("status", feature.Status)
+
+	return diags
+}
+
+const memberDetectorFeatureResourceIDSeparator = "/"
+
+func memberDetectorFeatureCreateResourceID(detectorID, accountID, name string) string {
+	parts := []string{detectorID, accountID, name}
+	id := strings.Join(parts, memberDetectorFeatureResourceIDSeparator)
+
+	return id
+}
+
+func memberDetectorFeatureParseResourceID(id string) (string, string, string, error) {
+	parts := strings.Split(id, memberDetectorFeatureResourceIDSeparator)
+
+	if len(parts) == 3 && parts[0] != "" && parts[1] != "" && parts[2] != "" {
+		return parts[0], parts[1], parts[2], nil
+	}
+
+	return "", "", "", fmt.Errorf("unexpected format for ID (%[1]s), expected DETECTORID%[2]sACCOUNTID%[2]sFEATURENAME", id, memberDetectorFeatureResourceIDSeparator)
+}
+
+func FindMemberDetectorFeatureByThreePartKey(ctx context.Context, conn *guardduty.GuardDuty, detectorID, accountID, name string) (*guardduty.MemberFeaturesConfigurationResult, error) {
+	output, err := findMemberConfigurationByDetectorAndAccountID(ctx, conn, detectorID, accountID)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfresource.AssertSinglePtrResult(tfslices.Filter(output.Features, func(v *guardduty.MemberFeaturesConfigurationResult) bool {
+		return aws.StringValue(v.Name) == name
+	}))
+}
+
+func expandMemberDetectorAdditionalConfiguration(tfMap map[string]interface{}) *guardduty.MemberAdditionalConfiguration {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &guardduty.MemberAdditionalConfiguration{}
+
+	if v, ok := tfMap["name"].(string); ok && v != "" {
+		apiObject.Name = aws.String(v)
+	}
+
+	if v, ok := tfMap["status"].(string); ok && v != "" {
+		apiObject.Status = aws.String(v)
+	}
+
+	return apiObject
+}
+
+func expandMemberDetectorAdditionalConfigurations(tfList []interface{}) []*guardduty.MemberAdditionalConfiguration {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	var apiObjects []*guardduty.MemberAdditionalConfiguration
+
+	for _, tfMapRaw := range tfList {
+		tfMap, ok := tfMapRaw.(map[string]interface{})
+
+		if !ok {
+			continue
+		}
+
+		apiObject := expandMemberDetectorAdditionalConfiguration(tfMap)
+
+		if apiObject == nil {
+			continue
+		}
+
+		apiObjects = append(apiObjects, apiObject)
+	}
+
+	return apiObjects
+}
+
+func flattenMemberDetectorAdditionalConfigurationResult(apiObject *guardduty.MemberAdditionalConfigurationResult) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.Name; v != nil {
+		tfMap["name"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.Status; v != nil {
+		tfMap["status"] = aws.StringValue(v)
+	}
+
+	return tfMap
+}
+
+func flattenMemberDetectorAdditionalConfigurationResults(apiObjects []*guardduty.MemberAdditionalConfigurationResult) []interface{} {
+	if len(apiObjects) == 0 {
+		return nil
+	}
+
+	var tfList []interface{}
+
+	for _, apiObject := range apiObjects {
+		if apiObject == nil {
+			continue
+		}
+
+		tfList = append(tfList, flattenMemberDetectorAdditionalConfigurationResult(apiObject))
+	}
+
+	return tfList
+}
+
+func findMemberConfigurationByDetectorAndAccountID(ctx context.Context, conn *guardduty.GuardDuty, detectorID string, accountID string) (*guardduty.MemberDataSourceConfiguration, error) {
+	input := &guardduty.GetMemberDetectorsInput{
+		DetectorId: aws.String(detectorID),
+		AccountIds: []*string{aws.String(accountID)},
+	}
+
+	output, err := conn.GetMemberDetectorsWithContext(ctx, input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	if output.MemberDataSourceConfigurations == nil || len(output.MemberDataSourceConfigurations) == 0 {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.MemberDataSourceConfigurations[0], nil
+}

--- a/internal/service/guardduty/member_detector_feature_test.go
+++ b/internal/service/guardduty/member_detector_feature_test.go
@@ -1,0 +1,206 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package guardduty_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/guardduty"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfguardduty "github.com/hashicorp/terraform-provider-aws/internal/service/guardduty"
+)
+
+func testAccMemberDetectorFeature_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_guardduty_member_detector_feature.test"
+	accountID := testAccMemberAccountFromEnv(t)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckOrganizationManagementAccount(ctx, t)
+			testAccPreCheckDetectorExists(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, guardduty.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMemberDetectorFeatureConfig_basic("RDS_LOGIN_EVENTS", "ENABLED", accountID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccMemberDetectorFeatureExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "additional_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "status", "ENABLED"),
+					resource.TestCheckResourceAttrSet(resourceName, "detector_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", "RDS_LOGIN_EVENTS"),
+					resource.TestCheckResourceAttr(resourceName, "account_id", accountID),
+				),
+			},
+		},
+	})
+}
+
+func testAccMemberDetectorFeature_additionalConfiguration(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_guardduty_member_detector_feature.test"
+	accountID := testAccMemberAccountFromEnv(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckOrganizationManagementAccount(ctx, t)
+			testAccPreCheckDetectorExists(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, guardduty.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMemberDetectorFeatureConfig_additionalConfiguration(accountID, "ENABLED", "DISABLED"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccMemberDetectorFeatureExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "status", "ENABLED"),
+					resource.TestCheckResourceAttr(resourceName, "additional_configuration.#", "2"),
+					// TODO: member_detector_feature_test.go:53: Step 1/1 error: After applying this test step, the plan was not empty.
+					//resource.TestCheckResourceAttr(resourceName, "additional_configuration.0.status", "ENABLED"),
+					//resource.TestCheckResourceAttr(resourceName, "additional_configuration.0.name", "ECS_FARGATE_AGENT_MANAGEMENT"),
+					//resource.TestCheckResourceAttr(resourceName, "additional_configuration.1.status", "DISABLED"),
+					//resource.TestCheckResourceAttr(resourceName, "additional_configuration.1.name", "EKS_ADDON_MANAGEMENT"),
+					resource.TestCheckResourceAttr(resourceName, "name", "RUNTIME_MONITORING"),
+					resource.TestCheckResourceAttr(resourceName, "account_id", accountID),
+				),
+			},
+		},
+	})
+}
+
+func testAccMemberDetectorFeature_multiple(t *testing.T) {
+	ctx := acctest.Context(t)
+	resource1Name := "aws_guardduty_member_detector_feature.test1"
+	resource2Name := "aws_guardduty_member_detector_feature.test2"
+	resource3Name := "aws_guardduty_member_detector_feature.test3"
+	accountID := testAccMemberAccountFromEnv(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckOrganizationManagementAccount(ctx, t)
+			testAccPreCheckDetectorExists(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, guardduty.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMemberDetectorFeatureConfig_multiple(accountID, "ENABLED", "DISABLED", "ENABLED"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccMemberDetectorFeatureExists(ctx, resource1Name),
+					testAccMemberDetectorFeatureExists(ctx, resource2Name),
+					testAccMemberDetectorFeatureExists(ctx, resource3Name),
+					resource.TestCheckResourceAttr(resource1Name, "additional_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resource1Name, "additional_configuration.0.status", "ENABLED"),
+					resource.TestCheckResourceAttr(resource1Name, "additional_configuration.0.name", "EKS_ADDON_MANAGEMENT"),
+					resource.TestCheckResourceAttr(resource1Name, "status", "ENABLED"),
+					resource.TestCheckResourceAttr(resource1Name, "name", "EKS_RUNTIME_MONITORING"),
+					resource.TestCheckResourceAttr(resource1Name, "account_id", accountID),
+					resource.TestCheckResourceAttr(resource2Name, "additional_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resource2Name, "status", "DISABLED"),
+					resource.TestCheckResourceAttr(resource2Name, "name", "S3_DATA_EVENTS"),
+					resource.TestCheckResourceAttr(resource2Name, "account_id", accountID),
+					resource.TestCheckResourceAttr(resource3Name, "additional_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resource3Name, "status", "ENABLED"),
+					resource.TestCheckResourceAttr(resource3Name, "name", "LAMBDA_NETWORK_LOGS"),
+					resource.TestCheckResourceAttr(resource3Name, "account_id", accountID),
+				),
+			},
+		},
+	})
+}
+
+func testAccMemberDetectorFeatureExists(ctx context.Context, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).GuardDutyConn(ctx)
+
+		_, err := tfguardduty.FindMemberDetectorFeatureByThreePartKey(ctx, conn, rs.Primary.Attributes["detector_id"], rs.Primary.Attributes["account_id"], rs.Primary.Attributes["name"])
+
+		return err
+	}
+}
+
+func testAccMemberDetectorFeatureConfig_basic(name, status, accountID string) string {
+	return acctest.ConfigCompose(testAccMemberDetectorFeatureConfig_base, fmt.Sprintf(`
+resource "aws_guardduty_member_detector_feature" "test" {
+  detector_id = data.aws_guardduty_detector.test.id
+  name        = "%[1]s"
+  status      = "%[2]s"
+  account_id  = "%[3]s"
+}
+`, name, status, accountID))
+}
+
+func testAccMemberDetectorFeatureConfig_additionalConfiguration(accountID, eksStatus, ecsStatus string) string {
+	return acctest.ConfigCompose(testAccMemberDetectorFeatureConfig_base, fmt.Sprintf(`
+resource "aws_guardduty_member_detector_feature" "test" {
+	detector_id = data.aws_guardduty_detector.test.id
+	name        = "RUNTIME_MONITORING"
+	status      = "ENABLED"
+	account_id  = "%[1]s"
+
+	additional_configuration {
+		name        = "EKS_ADDON_MANAGEMENT"
+		status      = "%[3]s"
+	}
+	additional_configuration {
+		name        = "ECS_FARGATE_AGENT_MANAGEMENT"
+		status      = "%[2]s"
+	}
+}
+`, accountID, ecsStatus, eksStatus))
+}
+
+func testAccMemberDetectorFeatureConfig_multiple(accountID, status1, status2, status3 string) string {
+	return acctest.ConfigCompose(testAccMemberDetectorFeatureConfig_base, fmt.Sprintf(`
+resource "aws_guardduty_member_detector_feature" "test1" {
+	detector_id = data.aws_guardduty_detector.test.id
+	name        = "EKS_RUNTIME_MONITORING"
+	status      = "%[2]s"
+	account_id  = "%[1]s"
+
+	additional_configuration {
+		name        = "EKS_ADDON_MANAGEMENT"
+		status      = "%[2]s"
+	}
+}
+
+resource "aws_guardduty_member_detector_feature" "test2" {
+	detector_id = data.aws_guardduty_detector.test.id
+	name        = "S3_DATA_EVENTS"
+	status      = "%[3]s"
+	account_id  = "%[1]s"
+}
+
+resource "aws_guardduty_member_detector_feature" "test3" {
+	detector_id = data.aws_guardduty_detector.test.id
+	name        = "LAMBDA_NETWORK_LOGS"
+	status      = "%[4]s"
+	account_id  = "%[1]s"
+}
+
+`, accountID, status1, status2, status3))
+}
+
+const testAccMemberDetectorFeatureConfig_base = `
+
+data "aws_guardduty_detector" "test" {}
+
+`

--- a/internal/service/guardduty/service_package_gen.go
+++ b/internal/service/guardduty/service_package_gen.go
@@ -77,6 +77,11 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			TypeName: "aws_guardduty_member",
 		},
 		{
+			Factory:  ResourceMemberDetectorFeature,
+			TypeName: "aws_guardduty_member_detector_feature",
+			Name:     "Member Detector Feature",
+		},
+		{
 			Factory:  ResourceOrganizationAdminAccount,
 			TypeName: "aws_guardduty_organization_admin_account",
 		},

--- a/website/docs/r/guardduty_member_detector_feature.html.markdown
+++ b/website/docs/r/guardduty_member_detector_feature.html.markdown
@@ -1,0 +1,59 @@
+---
+subcategory: "GuardDuty"
+layout: "aws"
+page_title: "AWS: aws_guardduty_member_detector_feature"
+description: |-
+  Provides a resource to manage an Amazon GuardDuty member account detector feature
+---
+
+# Resource: aws_guardduty_member_detector_feature
+
+Provides a resource to manage a single Amazon GuardDuty [detector feature](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty-features-activation-model.html#guardduty-features) for a member account.
+
+~> **NOTE:** Deleting this resource does not disable the detector feature in the member account, the resource in simply removed from state instead.
+
+## Example Usage
+
+```terraform
+resource "aws_guardduty_detector" "example" {
+  enable = true
+}
+
+resource "aws_guardduty_member_detector_feature" "runtime_monitoring" {
+  detector_id = aws_guardduty_detector.example.id
+  account_id  = "123456789012"
+  name        = "RUNTIME_MONITORING"
+  status      = "ENABLED"
+
+  additional_configuration {
+    name   = "EKS_ADDON_MANAGEMENT"
+    status = "ENABLED"
+  }
+
+  additional_configuration {
+    name   = "ECS_FARGATE_AGENT_MANAGEMENT"
+    status = "ENABLED"
+  }
+}
+```
+
+## Argument Reference
+
+This resource supports the following arguments:
+
+* `detector_id` - (Required) Amazon GuardDuty detector ID.
+* `account_id` - (Required) Member account ID to be updated.
+* `name` - (Required) The name of the detector feature. Valid values: `S3_DATA_EVENTS`, `EKS_AUDIT_LOGS`, `EBS_MALWARE_PROTECTION`, `RDS_LOGIN_EVENTS`, `EKS_RUNTIME_MONITORING`,`RUNTIME_MONITORING`, `LAMBDA_NETWORK_LOGS`.
+* `status` - (Required) The status of the detector feature. Valid values: `ENABLED`, `DISABLED`.
+* `additional_configuration` - (Optional) Additional feature configuration block. See [below](#additional-configuration).
+
+### Additional Configuration
+
+The `additional_configuration` block supports the following:
+
+* `name` - (Required) The name of the additional configuration. Valid values: `EKS_ADDON_MANAGEMENT`, `ECS_FARGATE_AGENT_MANAGEMENT`.
+* `status` - (Required) The status of the additional configuration. Valid values: `ENABLED`, `DISABLED`.
+
+## Attribute Reference
+
+This resource exports no additional attributes.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR adds support for configuring AWS GuardDuty Member Detector Features, e.g.

```terraform
resource "aws_guardduty_detector" "example" {
  enable = true
}

resource "aws_guardduty_member_detector_feature" "runtime_monitoring" {
  detector_id = aws_guardduty_detector.example.id
  account_id  = "123456789012"
  name        = "RUNTIME_MONITORING"
  status      = "ENABLED"

  additional_configuration {
    name   = "EKS_ADDON_MANAGEMENT"
    status = "ENABLED"
  }

  additional_configuration {
    name   = "ECS_FARGATE_AGENT_MANAGEMENT"
    status = "ENABLED"
  }
}
```
### Gotchas

**Deleting the resource**
When deleted (as many other existing GuarDuty Org features, such as [guardduty_organization_configuration_feature](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_organization_configuration_feature)), just removes the resource from state without disabling the resource. 

**Eventual consistency**
When you use [`aws_guardduty_organization_configuration`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_organization_configuration) and set `auto_enable_organization_members = "ALL"` and try to use the resource for configuring member features, you keep hitting this:
```
{"unprocessedAccounts":[{"result":"The request is rejected because the given account ID is not an associated member of account the current account.","accountId":"123456789012"}]}
```
This is likely due to eventual consistency with the member accounts. My original test strategy was exactly this, but I just gave up. This definitely has serious implications on the usability as you most likely would use these resources together. Ended up testing with a prepared env where you already have an existing member account.

**Random order of additional configuration**

I keep hitting an issue where the API returns the additional configuration in random order and you get a perpetual diff - causing test failures and general annoyance 😅 . This is why the tests have some checks disabled atm. This behaviour was reported in [this issue](https://github.com/hashicorp/terraform-provider-aws/issues/26168), as well.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #26168

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
https://docs.aws.amazon.com/guardduty/latest/APIReference/API_UpdateMemberDetectors.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
❯ make testacc TESTS=TestAccGuardDuty_serial/MemberDetectorFeature PKG=guardduty
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/guardduty/... -v -count 1 -parallel 20 -run='TestAccGuardDuty_serial/MemberDetectorFeature'  -timeout 360m
=== RUN   TestAccGuardDuty_serial
=== PAUSE TestAccGuardDuty_serial
=== CONT  TestAccGuardDuty_serial
=== RUN   TestAccGuardDuty_serial/MemberDetectorFeature
=== RUN   TestAccGuardDuty_serial/MemberDetectorFeature/basic
=== RUN   TestAccGuardDuty_serial/MemberDetectorFeature/additional_configuration
=== RUN   TestAccGuardDuty_serial/MemberDetectorFeature/multiple
--- PASS: TestAccGuardDuty_serial (46.67s)
    --- PASS: TestAccGuardDuty_serial/MemberDetectorFeature (46.67s)
        --- PASS: TestAccGuardDuty_serial/MemberDetectorFeature/basic (18.96s)
        --- PASS: TestAccGuardDuty_serial/MemberDetectorFeature/additional_configuration (12.75s)
        --- PASS: TestAccGuardDuty_serial/MemberDetectorFeature/multiple (14.96s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/guardduty	52.627s
```
