### PR TITLE
Enhancing Documentation for aws_cognito_resource_server with Required Field - user_pool_id

### DIFF
--- a/website/docs/r/cognito_resource_server.html.markdown
+++ b/website/docs/r/cognito_resource_server.html.markdown
@@ -54,6 +54,7 @@ This resource supports the following arguments:
 
 * `identifier` - (Required) An identifier for the resource server.
 * `name` - (Required) A name for the resource server.
+* `user_pool_id` - (Required) User pool the client belongs to.
 * `scope` - (Optional) A list of [Authorization Scope](#authorization-scope).
 
 ### Authorization Scope


### PR DESCRIPTION
# Overview

This PR adds the required field `user_pool_id` to the `aws_cognito_resource_server` resource docs for enhanced clarity and alignment.

## Reasons for the Change

- **Clarity Improvement:**
  The inclusion of `user_pool_id` offers explicit configuration guidance, reducing implementation confusion.

- **Alignment:**
  Requiring `user_pool_id` aligns with standard AWS resource practices.

Closes #0000

# References

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cognito-idp/client/create_resource_server.html