### PR TITLE
Fixes unexpected diff for `aws_lb_listener` and `aws_lb_listener_rule`

### DIFF
--- a/.changelog/35678.txt
+++ b/.changelog/35678.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_lb_listener: Fixes unexpected diff when using `default_action` parameters which don't match the `type`.
+```
+
+```release-note:bug
+resource/aws_lb_listener_rule: Fixes unexpected diff when using `action` parameters which don't match the `type`.
+```

--- a/internal/service/elbv2/listener.go
+++ b/internal/service/elbv2/listener.go
@@ -217,11 +217,6 @@ func ResourceListener() *schema.Resource {
 							},
 						},
 						"forward": {
-							// Type:                  schema.TypeList,
-							// Optional:              true,
-							// DiffSuppressOnRefresh: true,
-							// DiffSuppressFunc:      diffSuppressMissingForward("default_action"),
-							// MaxItems:              1,
 							Type:             schema.TypeList,
 							Optional:         true,
 							DiffSuppressFunc: suppressIfDefaultActionTypeNot(awstypes.ActionTypeEnumForward),

--- a/internal/service/elbv2/listener_rule.go
+++ b/internal/service/elbv2/listener_rule.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/YakDriver/regexache"
@@ -92,12 +93,17 @@ func ResourceListenerRule() *schema.Resource {
 						},
 
 						"target_group_arn": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: verify.ValidARN,
+							Type:             schema.TypeString,
+							Optional:         true,
+							DiffSuppressFunc: suppressIfActionTypeNot(awstypes.ActionTypeEnumForward),
+							ValidateFunc:     verify.ValidARN,
 						},
 
 						"forward": {
+							// Type:             schema.TypeList,
+							// Optional:         true,
+							// DiffSuppressFunc: suppressIfActionTypeNot(awstypes.ActionTypeEnumForward),
+							// MaxItems:         1,
 							Type:                  schema.TypeList,
 							Optional:              true,
 							DiffSuppressOnRefresh: true,
@@ -151,9 +157,10 @@ func ResourceListenerRule() *schema.Resource {
 						},
 
 						"redirect": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
+							Type:             schema.TypeList,
+							Optional:         true,
+							DiffSuppressFunc: suppressIfActionTypeNot(awstypes.ActionTypeEnumRedirect),
+							MaxItems:         1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"host": {
@@ -204,9 +211,10 @@ func ResourceListenerRule() *schema.Resource {
 						},
 
 						"fixed_response": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
+							Type:             schema.TypeList,
+							Optional:         true,
+							DiffSuppressFunc: suppressIfActionTypeNot(awstypes.ActionTypeEnumFixedResponse),
+							MaxItems:         1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"content_type": {
@@ -238,9 +246,10 @@ func ResourceListenerRule() *schema.Resource {
 						},
 
 						"authenticate_cognito": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
+							Type:             schema.TypeList,
+							Optional:         true,
+							DiffSuppressFunc: suppressIfActionTypeNot(awstypes.ActionTypeEnumAuthenticateCognito),
+							MaxItems:         1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"authentication_request_extra_params": {
@@ -287,9 +296,10 @@ func ResourceListenerRule() *schema.Resource {
 						},
 
 						"authenticate_oidc": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
+							Type:             schema.TypeList,
+							Optional:         true,
+							DiffSuppressFunc: suppressIfActionTypeNot(awstypes.ActionTypeEnumAuthenticateOidc),
+							MaxItems:         1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"authentication_request_extra_params": {
@@ -478,6 +488,21 @@ func ResourceListenerRule() *schema.Resource {
 			verify.SetTagsDiff,
 			validateListenerActionsCustomDiff("action"),
 		),
+	}
+}
+
+func suppressIfActionTypeNot(t awstypes.ActionTypeEnum) schema.SchemaDiffSuppressFunc {
+	return func(k, old, new string, d *schema.ResourceData) bool {
+		take := 2
+		i := strings.IndexFunc(k, func(r rune) bool {
+			if r == '.' {
+				take -= 1
+				return take == 0
+			}
+			return false
+		})
+		at := k[:i+1] + "type"
+		return awstypes.ActionTypeEnum(d.Get(at).(string)) != t
 	}
 }
 

--- a/internal/service/elbv2/listener_rule.go
+++ b/internal/service/elbv2/listener_rule.go
@@ -100,10 +100,6 @@ func ResourceListenerRule() *schema.Resource {
 						},
 
 						"forward": {
-							// Type:             schema.TypeList,
-							// Optional:         true,
-							// DiffSuppressFunc: suppressIfActionTypeNot(awstypes.ActionTypeEnumForward),
-							// MaxItems:         1,
 							Type:                  schema.TypeList,
 							Optional:              true,
 							DiffSuppressOnRefresh: true,

--- a/internal/service/elbv2/listener_rule_test.go
+++ b/internal/service/elbv2/listener_rule_test.go
@@ -1512,7 +1512,7 @@ func TestAccELBV2ListenerRule_EmptyAction(t *testing.T) {
 
 func TestAccELBV2ListenerRule_redirectWithTargetGroupARN(t *testing.T) {
 	ctx := acctest.Context(t)
-	var conf elbv2.Rule
+	var conf awstypes.Rule
 	lbName := fmt.Sprintf("testrule-redirect-%s", sdkacctest.RandString(14))
 
 	resourceName := "aws_lb_listener_rule.static"

--- a/internal/service/elbv2/listener_rule_test.go
+++ b/internal/service/elbv2/listener_rule_test.go
@@ -1510,6 +1510,48 @@ func TestAccELBV2ListenerRule_EmptyAction(t *testing.T) {
 	}
 }
 
+func TestAccELBV2ListenerRule_redirectWithTargetGroupARN(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf elbv2.Rule
+	lbName := fmt.Sprintf("testrule-redirect-%s", sdkacctest.RandString(14))
+
+	resourceName := "aws_lb_listener_rule.static"
+	frontEndListenerResourceName := "aws_lb_listener.front_end"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, tfelbv2.AwsSdkId),
+		CheckDestroy: testAccCheckListenerRuleDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "5.34.0",
+					},
+				},
+				Config: testAccListenerRuleConfig_redirectWithTargetGroupARN(lbName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckListenerRuleExists(ctx, resourceName, &conf),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexache.MustCompile(fmt.Sprintf(`listener-rule/app/%s/.+$`, lbName))),
+					resource.TestCheckResourceAttrPair(resourceName, "listener_arn", frontEndListenerResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "action.0.type", "redirect"),
+					resource.TestCheckResourceAttr(resourceName, "action.0.redirect.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "action.0.forward.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "action.0.target_group_arn", ""),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				Config:                   testAccListenerRuleConfig_redirectWithTargetGroupARN(lbName),
+				PlanOnly:                 true,
+				ExpectNonEmptyPlan:       false,
+			},
+		},
+	})
+}
+
 func TestAccELBV2ListenerRule_conditionAttributesCount(t *testing.T) {
 	ctx := acctest.Context(t)
 	err_many := regexache.MustCompile("Only one of host_header, http_header, http_request_method, path_pattern, query_string or source_ip can be set in a condition block")
@@ -4316,6 +4358,119 @@ resource "aws_security_group" "test" {
   }
 }
 `, rName, action)
+}
+
+func testAccListenerRuleConfig_redirectWithTargetGroupARN(lbName string) string {
+	return fmt.Sprintf(`
+resource "aws_lb_listener_rule" "static" {
+  listener_arn = aws_lb_listener.front_end.arn
+  priority     = 100
+
+  action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+
+  condition {
+    path_pattern {
+      values = ["/static/*"]
+    }
+  }
+}
+
+resource "aws_lb_listener" "front_end" {
+  load_balancer_arn = aws_lb.alb_test.id
+  protocol          = "HTTP"
+  port              = "80"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_lb" "alb_test" {
+  name            = %[1]q
+  internal        = true
+  security_groups = [aws_security_group.alb_test.id]
+  subnets         = aws_subnet.alb_test[*].id
+
+  idle_timeout               = 30
+  enable_deletion_protection = false
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+variable "subnets" {
+  default = ["10.0.1.0/24", "10.0.2.0/24"]
+  type    = list(string)
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_vpc" "alb_test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = "terraform-testacc-lb-listener-rule-redirect"
+  }
+}
+
+resource "aws_subnet" "alb_test" {
+  count                   = 2
+  vpc_id                  = aws_vpc.alb_test.id
+  cidr_block              = element(var.subnets, count.index)
+  map_public_ip_on_launch = true
+  availability_zone       = element(data.aws_availability_zones.available.names, count.index)
+
+  tags = {
+    Name = "tf-acc-lb-listener-rule-redirect-${count.index}"
+  }
+}
+
+resource "aws_security_group" "alb_test" {
+  name        = "allow_all_alb_test"
+  description = "Used for ALB Testing"
+  vpc_id      = aws_vpc.alb_test.id
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, lbName)
 }
 
 func testAccListenerRuleConfig_condition_error(condition string) string {

--- a/internal/service/elbv2/listener_test.go
+++ b/internal/service/elbv2/listener_test.go
@@ -3757,8 +3757,8 @@ resource "aws_lb_listener" "test" {
   port              = "80"
 
   default_action {
-	target_group_arn = aws_lb_target_group.test.arn
-	type = "redirect"
+    target_group_arn = aws_lb_target_group.test.arn
+    type             = "redirect"
 
     redirect {
       port        = "443"

--- a/internal/service/elbv2/listener_test.go
+++ b/internal/service/elbv2/listener_test.go
@@ -1636,6 +1636,48 @@ func TestAccELBV2Listener_EmptyDefaultAction(t *testing.T) {
 	}
 }
 
+func TestAccELBV2Listener_redirectWithTargetGroupARN(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf awstypes.Listener
+	resourceName := "aws_lb_listener.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, tfelbv2.AwsSdkId),
+		CheckDestroy: testAccCheckListenerDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "5.34.0",
+					},
+				},
+				Config: testAccListenerConfig_redirectWithTargetGroupARN(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckListenerExists(ctx, resourceName, &conf),
+					resource.TestCheckResourceAttrPair(resourceName, "load_balancer_arn", "aws_lb.test", "arn"),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexache.MustCompile("listener/.+$")),
+					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "port", "80"),
+					resource.TestCheckResourceAttr(resourceName, "default_action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "redirect"),
+					resource.TestCheckResourceAttr(resourceName, "default_action.0.redirect.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "default_action.0.target_group_arn", ""),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				Config:                   testAccListenerConfig_redirectWithTargetGroupARN(rName),
+				PlanOnly:                 true,
+				ExpectNonEmptyPlan:       false,
+			},
+		},
+	})
+}
+
 func testAccCheckListenerDefaultActionOrderDisappears(ctx context.Context, listener *awstypes.Listener, actionOrderToDelete int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		var newDefaultActions []awstypes.Action
@@ -3705,4 +3747,61 @@ resource "aws_lb_target_group" "test" {
   }
 }
 `, rName, action))
+}
+
+func testAccListenerConfig_redirectWithTargetGroupARN(rName string) string {
+	return acctest.ConfigCompose(testAccListenerConfig_base(rName), fmt.Sprintf(`
+resource "aws_lb_listener" "test" {
+  load_balancer_arn = aws_lb.test.id
+  protocol          = "HTTP"
+  port              = "80"
+
+  default_action {
+	target_group_arn = aws_lb_target_group.test.arn
+	type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_lb" "test" {
+  name            = %[1]q
+  internal        = true
+  security_groups = [aws_security_group.test.id]
+  subnets         = aws_subnet.test[*].id
+
+  idle_timeout               = 30
+  enable_deletion_protection = false
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_lb_target_group" "test" {
+  name     = %[1]q
+  port     = 8080
+  protocol = "HTTP"
+  vpc_id   = aws_vpc.test.id
+
+  health_check {
+    path                = "/health"
+    interval            = 60
+    port                = 8081
+    protocol            = "HTTP"
+    timeout             = 3
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    matcher             = "200-299"
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName))
 }


### PR DESCRIPTION
### Description

Prior to v5.35.0, invalid parameters for the action `type` were ignored. In order to provide warnings to users in advance of returning errors in v6.0, the invalid configurations were no longer ignored. However, this caused unexpected diffs to be reported for existing `aws_lb_listener` and `aws_lb_listener_rule` resources.

Ignores the invalid configuration again. This means that there will be no warnings about the invalid configuration for users.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #35668

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=elbv2 TESTS=TestAccELBV2Listener_

--- PASS: TestAccELBV2Listener_forwardTargetARNAndBlock (4.80s)
--- PASS: TestAccELBV2Listener_LoadBalancerARN_gatewayLoadBalancer (167.17s)
--- PASS: TestAccELBV2Listener_Gateway_basic (187.15s)
--- PASS: TestAccELBV2Listener_EmptyDefaultAction (0.00s)
    --- PASS: TestAccELBV2Listener_EmptyDefaultAction/authenticate-oidc (1.39s)
    --- PASS: TestAccELBV2Listener_EmptyDefaultAction/fixed-response (1.53s)
    --- PASS: TestAccELBV2Listener_EmptyDefaultAction/forward (1.43s)
    --- PASS: TestAccELBV2Listener_EmptyDefaultAction/redirect (1.61s)
    --- PASS: TestAccELBV2Listener_EmptyDefaultAction/authenticate-cognito (1.91s)
--- PASS: TestAccELBV2Listener_fixedResponse (203.64s)
--- PASS: TestAccELBV2Listener_Protocol_tls (212.16s)
--- PASS: TestAccELBV2Listener_oidc (224.74s)
--- PASS: TestAccELBV2Listener_DefaultAction_defaultOrder (225.49s)
--- PASS: TestAccELBV2Listener_DefaultAction_actionDisappears (226.60s)
--- PASS: TestAccELBV2Listener_mutualAuthentication (228.68s)
--- PASS: TestAccELBV2Listener_disappears (230.89s)
--- PASS: TestAccELBV2Listener_cognito (234.95s)
--- PASS: TestAccELBV2Listener_DefaultAction_specifyOrder (236.55s)
--- PASS: TestAccELBV2Listener_Application_basic (237.40s)
--- PASS: TestAccELBV2Listener_tags (251.23s)
--- PASS: TestAccELBV2Listener_redirect (255.89s)
--- PASS: TestAccELBV2Listener_forwardWeighted (257.19s)
--- PASS: TestAccELBV2Listener_mutualAuthenticationPassthrough (257.39s)
--- PASS: TestAccELBV2Listener_redirectWithTargetGroupARN (260.94s)
--- PASS: TestAccELBV2Listener_Protocol_https (273.93s)
--- PASS: TestAccELBV2Listener_backwardsCompatibility (274.42s)
--- PASS: TestAccELBV2Listener_Protocol_upd (283.94s)
--- PASS: TestAccELBV2Listener_Network_basic (196.09s)
```

```console
% make testacc PKG=elbv2 TESTS=TestAccELBV2ListenerRule_

--- PASS: TestAccELBV2ListenerRule_ConditionHTTPHeader_invalid (3.96s)
--- PASS: TestAccELBV2ListenerRule_forwardTargetARNAndBlock (5.22s)
--- PASS: TestAccELBV2ListenerRule_conditionAttributesCount (21.88s)
--- PASS: TestAccELBV2ListenerRule_basic (199.00s)
--- PASS: TestAccELBV2ListenerRule_cognito (205.27s)
--- PASS: TestAccELBV2ListenerRule_conditionHTTPHeader (215.73s)
--- PASS: TestAccELBV2ListenerRule_updateRulePriority (225.82s)
--- PASS: TestAccELBV2ListenerRule_conditionHTTPRequestMethod (228.47s)
--- PASS: TestAccELBV2ListenerRule_conditionUpdateMultiple (230.99s)
--- PASS: TestAccELBV2ListenerRule_conditionMultiple (234.38s)
--- PASS: TestAccELBV2ListenerRule_Action_defaultOrder (237.08s)
--- PASS: TestAccELBV2ListenerRule_conditionSourceIP (237.53s)
--- PASS: TestAccELBV2ListenerRule_Action_specifyOrder (237.65s)
--- PASS: TestAccELBV2ListenerRule_conditionHostHeader (238.93s)
--- PASS: TestAccELBV2ListenerRule_EmptyAction (0.00s)
    --- PASS: TestAccELBV2ListenerRule_EmptyAction/forward (1.42s)
    --- PASS: TestAccELBV2ListenerRule_EmptyAction/redirect (1.53s)
    --- PASS: TestAccELBV2ListenerRule_EmptyAction/fixed-response (1.76s)
    --- PASS: TestAccELBV2ListenerRule_EmptyAction/authenticate-cognito (1.74s)
    --- PASS: TestAccELBV2ListenerRule_EmptyAction/authenticate-oidc (1.70s)
--- PASS: TestAccELBV2ListenerRule_conditionQueryString (242.39s)
--- FAIL: TestAccELBV2ListenerRule_priority (246.14s)
--- PASS: TestAccELBV2ListenerRule_changeListenerRuleARNForcesNew (253.08s)
--- PASS: TestAccELBV2ListenerRule_fixedResponse (248.93s)
--- PASS: TestAccELBV2ListenerRule_updateFixedResponse (258.86s)
--- PASS: TestAccELBV2ListenerRule_oidc (263.31s)
--- PASS: TestAccELBV2ListenerRule_redirectWithTargetGroupARN (269.66s)
--- PASS: TestAccELBV2ListenerRule_conditionUpdateMixed (280.04s)
--- PASS: TestAccELBV2ListenerRule_redirect (260.90s)
--- PASS: TestAccELBV2ListenerRule_backwardsCompatibility (197.27s)
--- PASS: TestAccELBV2ListenerRule_Action_actionDisappears (193.72s)
--- PASS: TestAccELBV2ListenerRule_disappears (195.89s)
--- PASS: TestAccELBV2ListenerRule_tags (215.25s)
--- PASS: TestAccELBV2ListenerRule_conditionPathPattern (207.06s)
--- PASS: TestAccELBV2ListenerRule_forwardWeighted (215.71s)
--- PASS: TestAccELBV2ListenerRule_priority (299.62s)
```
