### PR TITLE
aws_lexv2models_slot - Correct locale_id example to aws_lexv2models_bot_locale

### DIFF
--- a/website/docs/r/lexv2models_slot.html.markdown
+++ b/website/docs/r/lexv2models_slot.html.markdown
@@ -19,7 +19,7 @@ resource "aws_lexv2models_slot" "example" {
   bot_id      = aws_lexv2models_bot.example.id
   bot_version = aws_lexv2models_bot_version.example.bot_version
   intent_id   = aws_lexv2models_intent.example.id
-  locale_id   = aws_lexv2models_locale.example.locale_id
+  locale_id   = aws_lexv2models_bot_locale.example.locale_id
   name        = "example"
 }
 ```


### PR DESCRIPTION

### Description

Currently there is a broken example in the new Lex v2 `aws_lexv2models_slot` example, this corrects that type.


