### PR TITLE
Modified the cloudfront origin access identity doc

### DIFF
--- a/website/docs/d/cloudfront_origin_access_identity.html.markdown
+++ b/website/docs/d/cloudfront_origin_access_identity.html.markdown
@@ -22,7 +22,7 @@ data "aws_cloudfront_origin_access_identity" "example" {
 
 ## Argument Reference
 
-* `id` (Required) -  The identifier for the distribution. For example: `EDFDVBD632BHDS5`.
+* `id` (Required) -  The identifier for the origin of distribution. For example: `EDFDVBD632BHDS5`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
Description

Updated description for the id attribute of aws_cloudfront_origin_access_identity since it is misleading users with Cloudfront distribution.

Relations
Closes https://github.com/hashicorp/terraform-provider-aws/issues/34416

References

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudfront_origin_access_identity