### PR TITLE
Resolve logging_config consecutive diff issue

### DIFF
--- a/.changelog/35694.txt
+++ b/.changelog/35694.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lambda_function: Resolve consecutive diff issue in `logging_config` when values for `application_log_level` or `system_log_level` are not specified
+```

--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -244,6 +244,7 @@ func ResourceFunction() *schema.Resource {
 							Optional:         true,
 							Default:          "",
 							ValidateDiagFunc: enum.Validate[types.ApplicationLogLevel](),
+							DiffSuppressFunc: suppressLoggingConfigUnspecifiedLogLevels,
 						},
 						"log_format": {
 							Type:             schema.TypeString,
@@ -261,6 +262,7 @@ func ResourceFunction() *schema.Resource {
 							Optional:         true,
 							Default:          "",
 							ValidateDiagFunc: enum.Validate[types.SystemLogLevel](),
+							DiffSuppressFunc: suppressLoggingConfigUnspecifiedLogLevels,
 						},
 					},
 				},
@@ -1466,6 +1468,17 @@ func flattenLoggingConfig(apiObject *types.LoggingConfig) []map[string]interface
 	}
 
 	return []map[string]interface{}{m}
+}
+
+// Suppress diff if log levels have not been specified, unless log_format has changed
+func suppressLoggingConfigUnspecifiedLogLevels(k, old, new string, d *schema.ResourceData) bool {
+	if d.HasChanges("logging_config.0.log_format") {
+		return false
+	}
+	if old != "" && new == "" {
+		return true
+	}
+	return false
 }
 
 func flattenEphemeralStorage(response *types.EphemeralStorage) []map[string]interface{} {

--- a/internal/service/lambda/function_test.go
+++ b/internal/service/lambda/function_test.go
@@ -1280,6 +1280,25 @@ func TestAccLambdaFunction_loggingConfig(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "logging_config.0.system_log_level", "DEBUG"),
 				),
 			},
+			{
+				Config: testAccFunctionConfig_updateLoggingConfigLevelsUnspecified(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFunctionExists(ctx, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "logging_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logging_config.0.application_log_level", "TRACE"),
+					resource.TestCheckResourceAttr(resourceName, "logging_config.0.system_log_level", "DEBUG"),
+				),
+			},
+			{
+				Config: testAccFunctionConfig_loggingConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFunctionExists(ctx, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "logging_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logging_config.0.application_log_level", ""),
+					resource.TestCheckResourceAttr(resourceName, "logging_config.0.log_format", "Text"),
+					resource.TestCheckResourceAttr(resourceName, "logging_config.0.system_log_level", ""),
+				),
+			},
 		},
 	})
 }
@@ -3434,6 +3453,24 @@ resource "aws_lambda_function" "test" {
     application_log_level = "TRACE"
     log_format            = "JSON"
     system_log_level      = "DEBUG"
+  }
+}
+`, rName))
+}
+
+func testAccFunctionConfig_updateLoggingConfigLevelsUnspecified(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigLambdaBase(rName, rName, rName),
+		fmt.Sprintf(`
+resource "aws_lambda_function" "test" {
+  filename      = "test-fixtures/lambdatest.zip"
+  function_name = %[1]q
+  role          = aws_iam_role.iam_for_lambda.arn
+  handler       = "exports.example"
+  runtime       = "nodejs16.x"
+
+  logging_config {
+    log_format = "JSON"
   }
 }
 `, rName))


### PR DESCRIPTION
### Description

Suppresses incorrect diff on consecutive apply, and maintains existing log levels, when `logging_config.application_log_level` or `logging_config.system_log_level` have not been specified in configuration.

### Relations

Closes #35301

### Output from Acceptance Testing

```console
make testacc 'TESTS=TestAccLambdaFunction(DataSource)?_(basic|loggingConfig)'  PKG=lambda
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaFunction(DataSource)?_(basic|loggingConfig)'  -timeout 360m
=== RUN   TestAccLambdaFunctionDataSource_basic
=== PAUSE TestAccLambdaFunctionDataSource_basic
=== RUN   TestAccLambdaFunctionDataSource_loggingConfig
=== PAUSE TestAccLambdaFunctionDataSource_loggingConfig
=== RUN   TestAccLambdaFunction_basic
=== PAUSE TestAccLambdaFunction_basic
=== RUN   TestAccLambdaFunction_loggingConfig
=== PAUSE TestAccLambdaFunction_loggingConfig
=== CONT  TestAccLambdaFunctionDataSource_basic
=== CONT  TestAccLambdaFunction_basic
=== CONT  TestAccLambdaFunction_loggingConfig
=== CONT  TestAccLambdaFunctionDataSource_loggingConfig
--- PASS: TestAccLambdaFunctionDataSource_basic (54.18s)
--- PASS: TestAccLambdaFunction_basic (67.51s)
--- PASS: TestAccLambdaFunctionDataSource_loggingConfig (75.29s)
--- PASS: TestAccLambdaFunction_loggingConfig (144.38s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lambda	152.545s
```
