### PR TITLE
Set Optional flag for selected resource attributes

### DIFF
--- a/.changelog/35695.txt
+++ b/.changelog/35695.txt
@@ -1,0 +1,6 @@
+```release-note:bug
+resource/resource_aws_lambda_function: Add `Optional` flag for `last_modified` attribute to allow it to be ignored from Plans
+resource/aws_lakeformation_resource: Add `Optional` flag for `last_modified` attribute to allow it to be ignored from Plans
+resource/aws_synthetics_canary: Add `Optional` flag for `last_modified` attribute to allow it to be ignored from Plans
+resource/aws_schemas_schema: Add `Optional` flag for `last_modified` attribute to allow it to be ignored from Plans
+```

--- a/internal/service/lakeformation/resource.go
+++ b/internal/service/lakeformation/resource.go
@@ -43,6 +43,7 @@ func ResourceResource() *schema.Resource {
 			"last_modified": {
 				Type:     schema.TypeString,
 				Computed: true,
+				Optional: true,
 			},
 			"role_arn": {
 				Type:         schema.TypeString,

--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -222,6 +222,7 @@ func ResourceFunction() *schema.Resource {
 			"last_modified": {
 				Type:     schema.TypeString,
 				Computed: true,
+				Optional: true,
 			},
 			"layers": {
 				Type:     schema.TypeList,

--- a/internal/service/lambda/function_data_source.go
+++ b/internal/service/lambda/function_data_source.go
@@ -118,6 +118,7 @@ func DataSourceFunction() *schema.Resource {
 			"last_modified": {
 				Type:     schema.TypeString,
 				Computed: true,
+				Optional: true,
 			},
 			"layers": {
 				Type:     schema.TypeList,

--- a/internal/service/lambda/function_data_source.go
+++ b/internal/service/lambda/function_data_source.go
@@ -118,7 +118,6 @@ func DataSourceFunction() *schema.Resource {
 			"last_modified": {
 				Type:     schema.TypeString,
 				Computed: true,
-				Optional: true,
 			},
 			"layers": {
 				Type:     schema.TypeList,

--- a/internal/service/schemas/schema.go
+++ b/internal/service/schemas/schema.go
@@ -57,6 +57,7 @@ func ResourceSchema() *schema.Resource {
 			"last_modified": {
 				Type:     schema.TypeString,
 				Computed: true,
+				Optional: true,
 			},
 
 			"name": {

--- a/internal/service/synthetics/canary.go
+++ b/internal/service/synthetics/canary.go
@@ -226,6 +226,7 @@ func ResourceCanary() *schema.Resource {
 						"last_modified": {
 							Type:     schema.TypeString,
 							Computed: true,
+							Optional: true,
 						},
 						"last_started": {
 							Type:     schema.TypeString,


### PR DESCRIPTION
### Update selected `last_modified` attributes to be optional

As per [Issue 29085](https://github.com/hashicorp/terraform-provider-aws/issues/29085), updates to the Terraform Source now include a warning if a computed attribute that is not specifically set as 'optional' is added to the `ignore_changes` lifecycle. 

The `last_modified` attribute associated with several resource types will always show up as changed on a `Terraform Plan`. This is noisy, and some administrators would prefer to ignore them, with the above issue causing further disruption as this generates a warning - which can obscure more serious issues that they would need to resolve.

### Relations
Relates #29085

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
