### PR TITLE
aws_dx_connection: add unknown encryption mode

### DIFF
--- a/internal/service/directconnect/connection.go
+++ b/internal/service/directconnect/connection.go
@@ -49,7 +49,7 @@ func ResourceConnection() *schema.Resource {
 				Type:         schema.TypeString,
 				Computed:     true,
 				Optional:     true,
-				ValidateFunc: validation.StringInSlice([]string{"no_encrypt", "should_encrypt", "must_encrypt"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"no_encrypt", "should_encrypt", "must_encrypt", "unknown"}, false),
 			},
 			"has_logical_redundancy": {
 				Type:     schema.TypeString,
@@ -169,7 +169,7 @@ func ResourceConnection() *schema.Resource {
 				Type:         schema.TypeString,
 				Computed:     true,
 				Optional:     true,
-				ValidateFunc: validation.StringInSlice([]string{"no_encrypt", "should_encrypt", "must_encrypt"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"no_encrypt", "should_encrypt", "must_encrypt", "unknown"}, false),
 			},
 			"has_logical_redundancy": {
 				Type:     schema.TypeString,

--- a/internal/service/directconnect/connection_test.go
+++ b/internal/service/directconnect/connection_test.go
@@ -136,6 +136,17 @@ func TestAccDirectConnectConnection_encryptionMode(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "skip_destroy", "true"),
 				),
 			},
+			{
+				Config: testAccConnectionConfig_encryptionModeUnknown(connectionName, ckn, cak),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConnectionExists(ctx, resourceName, &connection),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "directconnect", regexache.MustCompile(`dxcon/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "encryption_mode", "unknown"),
+					resource.TestCheckResourceAttrSet(resourceName, "location"),
+					resource.TestCheckResourceAttr(resourceName, "name", connectionName),
+					resource.TestCheckResourceAttr(resourceName, "skip_destroy", "true"),
+				),
+			},
 		},
 	})
 }
@@ -463,6 +474,24 @@ resource "aws_dx_connection" "test" {
   location        = "CSOW"
   bandwidth       = "100Gbps"
   encryption_mode = "should_encrypt"
+  skip_destroy    = true
+}
+
+resource "aws_dx_macsec_key_association" "test" {
+  connection_id = aws_dx_connection.test.id
+  ckn           = %[2]q
+  cak           = %[3]q
+}
+`, rName, ckn, cak)
+}
+
+func testAccConnectionConfig_encryptionModeUnknown(rName, ckn, cak string) string {
+	return fmt.Sprintf(`
+resource "aws_dx_connection" "test" {
+  name            = %[1]q
+  location        = "CSOW"
+  bandwidth       = "100Gbps"
+  encryption_mode = "unknown"
   skip_destroy    = true
 }
 

--- a/website/docs/cdktf/python/r/dx_connection.html.markdown
+++ b/website/docs/cdktf/python/r/dx_connection.html.markdown
@@ -87,7 +87,7 @@ class MyConvertedCode(TerraformStack):
 This resource supports the following arguments:
 
 * `bandwidth` - (Required) The bandwidth of the connection. Valid values for dedicated connections: 1Gbps, 10Gbps. Valid values for hosted connections: 50Mbps, 100Mbps, 200Mbps, 300Mbps, 400Mbps, 500Mbps, 1Gbps, 2Gbps, 5Gbps, 10Gbps and 100Gbps. Case sensitive.
-* `encryption_mode` - (Optional) The connection MAC Security (MACsec) encryption mode. MAC Security (MACsec) is only available on dedicated connections. Valid values are `no_encrypt`, `should_encrypt`, and `must_encrypt`.
+* `encryption_mode` - (Optional) The connection MAC Security (MACsec) encryption mode. MAC Security (MACsec) is only available on dedicated connections. Valid values are `no_encrypt`, `should_encrypt`, `must_encrypt` and `unknown`.
 * `location` - (Required) The AWS Direct Connect location where the connection is located. See [DescribeLocations](https://docs.aws.amazon.com/directconnect/latest/APIReference/API_DescribeLocations.html) for the list of AWS Direct Connect locations. Use `locationCode`.
 * `name` - (Required) The name of the connection.
 * `provider_name` - (Optional) The name of the service provider associated with the connection.

--- a/website/docs/cdktf/typescript/r/dx_connection.html.markdown
+++ b/website/docs/cdktf/typescript/r/dx_connection.html.markdown
@@ -96,7 +96,7 @@ class MyConvertedCode extends TerraformStack {
 This resource supports the following arguments:
 
 * `bandwidth` - (Required) The bandwidth of the connection. Valid values for dedicated connections: 1Gbps, 10Gbps. Valid values for hosted connections: 50Mbps, 100Mbps, 200Mbps, 300Mbps, 400Mbps, 500Mbps, 1Gbps, 2Gbps, 5Gbps, 10Gbps and 100Gbps. Case sensitive.
-* `encryptionMode` - (Optional) The connection MAC Security (MACsec) encryption mode. MAC Security (MACsec) is only available on dedicated connections. Valid values are `no_encrypt`, `should_encrypt`, and `must_encrypt`.
+* `encryptionMode` - (Optional) The connection MAC Security (MACsec) encryption mode. MAC Security (MACsec) is only available on dedicated connections. Valid values are `no_encrypt`, `should_encrypt`, `must_encrypt` and `unknown`.
 * `location` - (Required) The AWS Direct Connect location where the connection is located. See [DescribeLocations](https://docs.aws.amazon.com/directconnect/latest/APIReference/API_DescribeLocations.html) for the list of AWS Direct Connect locations. Use `locationCode`.
 * `name` - (Required) The name of the connection.
 * `providerName` - (Optional) The name of the service provider associated with the connection.

--- a/website/docs/r/dx_connection.html.markdown
+++ b/website/docs/r/dx_connection.html.markdown
@@ -52,7 +52,7 @@ resource "aws_dx_connection" "example" {
 This resource supports the following arguments:
 
 * `bandwidth` - (Required) The bandwidth of the connection. Valid values for dedicated connections: 1Gbps, 10Gbps. Valid values for hosted connections: 50Mbps, 100Mbps, 200Mbps, 300Mbps, 400Mbps, 500Mbps, 1Gbps, 2Gbps, 5Gbps, 10Gbps and 100Gbps. Case sensitive.
-* `encryption_mode` - (Optional) The connection MAC Security (MACsec) encryption mode. MAC Security (MACsec) is only available on dedicated connections. Valid values are `no_encrypt`, `should_encrypt`, and `must_encrypt`.
+* `encryption_mode` - (Optional) The connection MAC Security (MACsec) encryption mode. MAC Security (MACsec) is only available on dedicated connections. Valid values are `no_encrypt`, `should_encrypt`, `must_encrypt` and `unknown`.
 * `location` - (Required) The AWS Direct Connect location where the connection is located. See [DescribeLocations](https://docs.aws.amazon.com/directconnect/latest/APIReference/API_DescribeLocations.html) for the list of AWS Direct Connect locations. Use `locationCode`.
 * `name` - (Required) The name of the connection.
 * `provider_name` - (Optional) The name of the service provider associated with the connection.


### PR DESCRIPTION
### Description

Add `unknown` encryption mode on direct connect connection.

### Relations

Closes #29789

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
