### PR TITLE
docs: update vpclattice docs

### DIFF
--- a/website/docs/r/vpclattice_listener.html.markdown
+++ b/website/docs/r/vpclattice_listener.html.markdown
@@ -15,14 +15,14 @@ Terraform resource for managing an AWS VPC Lattice Listener.
 ### Fixed response action
 
 ```terraform
-resource "aws_vpclattice_service" "test" {
-  name = %[1]q
+resource "aws_vpclattice_service" "example" {
+  name = "example"
 }
 
-resource "aws_vpclattice_listener" "test" {
-  name               = %[1]q
+resource "aws_vpclattice_listener" "example" {
+  name               = "example"
   protocol           = "HTTPS"
-  service_identifier = aws_vpclattice_service.test.id
+  service_identifier = aws_vpclattice_service.example.id
   default_action {
     fixed_response {
       status_code = 404
@@ -34,7 +34,7 @@ resource "aws_vpclattice_listener" "test" {
 ### Forward action
 
 ```terraform
-resource "aws_vpclattice_service" "test" {
+resource "aws_vpclattice_service" "example" {
   name = "example"
 }
 
@@ -45,7 +45,7 @@ resource "aws_vpclattice_target_group" "example" {
   config {
     port           = 80
     protocol       = "HTTP"
-    vpc_identifier = aws_vpc.test.id
+    vpc_identifier = aws_vpc.example.id
   }
 }
 
@@ -66,7 +66,7 @@ resource "aws_vpclattice_listener" "example" {
 ### Forward action with weighted target groups
 
 ```terraform
-resource "aws_vpclattice_service" "test" {
+resource "aws_vpclattice_service" "example" {
   name = "example"
 }
 
@@ -77,7 +77,7 @@ resource "aws_vpclattice_target_group" "example1" {
   config {
     port           = 80
     protocol       = "HTTP"
-    vpc_identifier = aws_vpc.test.id
+    vpc_identifier = aws_vpc.example.id
   }
 }
 
@@ -88,7 +88,7 @@ resource "aws_vpclattice_target_group" "example2" {
   config {
     port           = 8080
     protocol       = "HTTP"
-    vpc_identifier = aws_vpc.test.id
+    vpc_identifier = aws_vpc.example.id
   }
 }
 

--- a/website/docs/r/vpclattice_listener.html.markdown
+++ b/website/docs/r/vpclattice_listener.html.markdown
@@ -14,7 +14,7 @@ Terraform resource for managing an AWS VPC Lattice Listener.
 
 ### Fixed response action
 
-```
+```terraform
 resource "aws_vpclattice_service" "test" {
   name = %[1]q
 }
@@ -33,7 +33,7 @@ resource "aws_vpclattice_listener" "test" {
 
 ### Forward action
 
-```
+```terraform
 resource "aws_vpclattice_service" "test" {
   name = "example"
 }
@@ -65,7 +65,7 @@ resource "aws_vpclattice_listener" "example" {
 
 ### Forward action with weighted target groups
 
-```
+```terraform
 resource "aws_vpclattice_service" "test" {
   name = "example"
 }

--- a/website/docs/r/vpclattice_service.html.markdown
+++ b/website/docs/r/vpclattice_service.html.markdown
@@ -39,8 +39,8 @@ The following arguments are optional:
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `arn` - ARN of the service. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
-* `dns_entry` - Concise description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+* `arn` - ARN of the service.
+* `dns_entry` - DNS name of the service.
 * `id` - Unique identifier for the service.
 * `status` - Status of the service.
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Some vpc lattice resources were missing `terraform` syntax highlighting
Some vpc lattice attribute descriptions were using template text for descriptions


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.
--->

Closes #35706

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpclattice_listener https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpclattice_service

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

N/A -- just updating docs
