### PR TITLE
Update go.mod for better module version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hashicorp/terraform-provider-aws
+module github.com/hashicorp/terraform-provider-aws/v5
 
 go 1.20
 


### PR DESCRIPTION
Update go.mod for valid version path

### Description

For now, go require version matches SCM version in module name  while version > 1.0

### References
https://go.dev/ref/mod#version
