### PR TITLE
r/aws_redshiftserverless_workgroup: Add max_capacity argument

### DIFF
--- a/.changelog/35720.txt
+++ b/.changelog/35720.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_redshiftserverless_workgroup: Add `max_capacity` argument
+```

--- a/internal/service/redshiftserverless/workgroup_test.go
+++ b/internal/service/redshiftserverless/workgroup_test.go
@@ -50,7 +50,7 @@ func TestAccRedshiftServerlessWorkgroup_basic(t *testing.T) {
 	})
 }
 
-func TestAccRedshiftServerlessWorkgroup_baseCapacityAndPubliclyAccessible(t *testing.T) {
+func TestAccRedshiftServerlessWorkgroup_baseAndMaxCapacityAndPubliclyAccessible(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_redshiftserverless_workgroup.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -62,10 +62,11 @@ func TestAccRedshiftServerlessWorkgroup_baseCapacityAndPubliclyAccessible(t *tes
 		CheckDestroy:             testAccCheckWorkgroupDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkgroupConfig_baseCapacityAndPubliclyAccessible(rName, 64, true),
+				Config: testAccWorkgroupConfig_baseAndMaxCapacityAndPubliclyAccessible(rName, 64, 128, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkgroupExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "base_capacity", "64"),
+					resource.TestCheckResourceAttr(resourceName, "max_capacity", "128"),
 					resource.TestCheckResourceAttr(resourceName, "publicly_accessible", "true"),
 				),
 			},
@@ -75,10 +76,11 @@ func TestAccRedshiftServerlessWorkgroup_baseCapacityAndPubliclyAccessible(t *tes
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccWorkgroupConfig_baseCapacityAndPubliclyAccessible(rName, 128, false),
+				Config: testAccWorkgroupConfig_baseAndMaxCapacityAndPubliclyAccessible(rName, 128, 5632, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWorkgroupExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "base_capacity", "128"),
+					resource.TestCheckResourceAttr(resourceName, "max_capacity", "5632"),
 					resource.TestCheckResourceAttr(resourceName, "publicly_accessible", "false"),
 				),
 			},
@@ -343,7 +345,7 @@ resource "aws_redshiftserverless_workgroup" "test" {
 `, rName)
 }
 
-func testAccWorkgroupConfig_baseCapacityAndPubliclyAccessible(rName string, baseCapacity int, publiclyAccessible bool) string {
+func testAccWorkgroupConfig_baseAndMaxCapacityAndPubliclyAccessible(rName string, baseCapacity int, maxCapacity int, publiclyAccessible bool) string {
 	return fmt.Sprintf(`
 resource "aws_redshiftserverless_namespace" "test" {
   namespace_name = %[1]q
@@ -353,9 +355,10 @@ resource "aws_redshiftserverless_workgroup" "test" {
   namespace_name      = aws_redshiftserverless_namespace.test.namespace_name
   workgroup_name      = %[1]q
   base_capacity       = %[2]d
-  publicly_accessible = %[3]t
+  max_capacity        = %[3]d
+  publicly_accessible = %[4]t
 }
-`, rName, baseCapacity, publiclyAccessible)
+`, rName, baseCapacity, maxCapacity, publiclyAccessible)
 }
 
 func testAccWorkgroupConfig_configParameters(rName, maxQueryExecutionTime string) string {

--- a/website/docs/r/redshiftserverless_workgroup.html.markdown
+++ b/website/docs/r/redshiftserverless_workgroup.html.markdown
@@ -31,6 +31,7 @@ The following arguments are optional:
 * `base_capacity` - (Optional) The base data warehouse capacity of the workgroup in Redshift Processing Units (RPUs).
 * `config_parameter` - (Optional) An array of parameters to set for more control over a serverless database. See `Config Parameter` below.
 * `enhanced_vpc_routing` - (Optional) The value that specifies whether to turn on enhanced virtual private cloud (VPC) routing, which forces Amazon Redshift Serverless to route traffic through your VPC instead of over the internet.
+* `max_capacity` - (Optional) The maximum data-warehouse capacity Amazon Redshift Serverless uses to serve queries, specified in Redshift Processing Units (RPUs).
 * `port` - (Optional) The port number on which the cluster accepts incoming connections.
 * `publicly_accessible` - (Optional) A value that specifies whether the workgroup can be accessed from a public network.
 * `security_group_ids` - (Optional) An array of security group IDs to associate with the workgroup.


### PR DESCRIPTION
### Description
Adds max_capacity argument to aws_redshiftserverless_workgroup resource allowing for better control of workgroup scale-out hence costs.

### Relations

Closes #35719
Closes #34440

### References
Maximum capacity setting is described in [AWS docs here](https://docs.aws.amazon.com/redshift/latest/mgmt/serverless-billing.html)


### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccRedshiftServerlessWorkgroup_baseAndMaxCapacityAndPubliclyAccessible PKG=redshiftserverless
```
