### PR TITLE
Adds warnings for conflicting service endpoints

### DIFF
--- a/internal/generate/serviceendpointtests/file.tmpl
+++ b/internal/generate/serviceendpointtests/file.tmpl
@@ -38,6 +38,9 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	{{- if gt (len .Aliases) 0 }}
+    "github.com/hashicorp/go-cty/cty"
+	{{- end }}
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -129,7 +132,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName{{ $i }}EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 {{ end }}
 
@@ -205,7 +208,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withAliasName{{ $i }}EndpointInConfig,
 				withAliasName{{ $j }}EndpointInConfig,
 		},
-			expected: expectAliasName{{ $i }}ConfigEndpoint(),
+			expected: conflictsWith(expectAliasName{{ $i }}ConfigEndpoint()),
 		},
 {{ end }}
 
@@ -589,6 +592,19 @@ func withAliasName{{ $i }}EndpointInConfig(setup *caseSetup) {
 	}
 	endpoints := setup.config["endpoints"].([]any)[0].(map[string]any)
 	endpoints[aliasName{{ $i }}] = aliasName{{ $i }}ConfigEndpoint
+}
+{{ end }}
+
+{{ if gt (len .Aliases) 0 }}
+func conflictsWith(e caseExpectations) caseExpectations {
+	e.diags = append(e.diags, provider.ConflictingEndpointsWarningDiag(
+		cty.GetAttrPath("endpoints").IndexInt(0),
+		packageName,
+		{{ range $i, $alias := .Aliases -}}
+		aliasName{{ $i }},
+		{{ end }}
+	))
+	return e
 }
 {{ end }}
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -8,12 +8,14 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	awsbase "github.com/hashicorp/aws-sdk-go-base/v2"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -865,17 +867,49 @@ func expandIgnoreTags(ctx context.Context, tfMap map[string]interface{}) *tftags
 func expandEndpoints(_ context.Context, tfList []interface{}) (map[string]string, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	endpointsPath := cty.GetAttrPath("endpoints")
+
+	if l := len(tfList); l > 1 {
+		diags = append(diags, errs.NewAttributeWarningDiagnostic(
+			endpointsPath,
+			"Invalid Attribute Value",
+			fmt.Sprintf("Attribute %q should have at most 1 element, got %d."+
+				"\n\nThis will be an error in a future release.",
+				errs.PathString(endpointsPath), l),
+		))
+	}
+
 	endpoints := make(map[string]string)
 
-	for _, tfMapRaw := range tfList {
+	for i, tfMapRaw := range tfList {
 		tfMap, ok := tfMapRaw.(map[string]interface{})
 
 		if !ok {
 			continue
 		}
 
+		elementPath := endpointsPath.IndexInt(i)
+
 		for _, endpoint := range names.Endpoints() {
 			pkg := endpoint.ProviderPackage
+
+			if len(endpoint.Aliases) > 0 {
+				count := 0
+				attrs := []string{pkg}
+				if tfMap[pkg] != "" {
+					count++
+				}
+				for _, alias := range endpoint.Aliases {
+					attrs = append(attrs, alias)
+					if tfMap[alias] != "" {
+						count++
+					}
+				}
+
+				if count > 1 {
+					diags = append(diags, ConflictingEndpointsWarningDiag(elementPath, attrs...))
+				}
+			}
 
 			if endpoints[pkg] == "" {
 				if v := tfMap[pkg].(string); v != "" {
@@ -939,5 +973,20 @@ func DeprecatedEnvVarDiag(envvar, replacement string) diag.Diagnostic {
 	return errs.NewWarningDiagnostic(
 		"Deprecated Environment Variable",
 		fmt.Sprintf(`The environment variable "%s" is deprecated. Use environment variable "%s" instead.`, envvar, replacement),
+	)
+}
+
+func ConflictingEndpointsWarningDiag(elementPath cty.Path, attrs ...string) diag.Diagnostic {
+	attrPaths := make([]string, len(attrs))
+	for i, attr := range attrs {
+		path := elementPath.GetAttr(attr)
+		attrPaths[i] = `"` + errs.PathString(path) + `"`
+	}
+	return errs.NewAttributeWarningDiagnostic(
+		elementPath,
+		"Invalid Attribute Combination",
+		fmt.Sprintf("Only one of the following attributes should be set: %s"+
+			"\n\nThis will be an error in a future release.",
+			strings.Join(attrPaths, ", ")),
 	)
 }

--- a/internal/service/amp/service_endpoints_gen_test.go
+++ b/internal/service/amp/service_endpoints_gen_test.go
@@ -18,6 +18,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -96,7 +97,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName0EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides alias name 1 config": {
@@ -104,7 +105,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName1EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides aws service envvar": {
@@ -153,7 +154,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withAliasName0EndpointInConfig,
 				withAliasName1EndpointInConfig,
 			},
-			expected: expectAliasName0ConfigEndpoint(),
+			expected: conflictsWith(expectAliasName0ConfigEndpoint()),
 		},
 
 		"alias name 0 endpoint config overrides aws service envvar": {
@@ -396,6 +397,16 @@ func withAliasName1EndpointInConfig(setup *caseSetup) {
 	}
 	endpoints := setup.config["endpoints"].([]any)[0].(map[string]any)
 	endpoints[aliasName1] = aliasName1ConfigEndpoint
+}
+
+func conflictsWith(e caseExpectations) caseExpectations {
+	e.diags = append(e.diags, provider.ConflictingEndpointsWarningDiag(
+		cty.GetAttrPath("endpoints").IndexInt(0),
+		packageName,
+		aliasName0,
+		aliasName1,
+	))
+	return e
 }
 
 func withAwsEnvVar(setup *caseSetup) {

--- a/internal/service/appautoscaling/service_endpoints_gen_test.go
+++ b/internal/service/appautoscaling/service_endpoints_gen_test.go
@@ -18,6 +18,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -94,7 +95,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName0EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides aws service envvar": {
@@ -317,6 +318,15 @@ func withAliasName0EndpointInConfig(setup *caseSetup) {
 	}
 	endpoints := setup.config["endpoints"].([]any)[0].(map[string]any)
 	endpoints[aliasName0] = aliasName0ConfigEndpoint
+}
+
+func conflictsWith(e caseExpectations) caseExpectations {
+	e.diags = append(e.diags, provider.ConflictingEndpointsWarningDiag(
+		cty.GetAttrPath("endpoints").IndexInt(0),
+		packageName,
+		aliasName0,
+	))
+	return e
 }
 
 func withAwsEnvVar(setup *caseSetup) {

--- a/internal/service/appintegrations/service_endpoints_gen_test.go
+++ b/internal/service/appintegrations/service_endpoints_gen_test.go
@@ -18,6 +18,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -94,7 +95,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName0EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides aws service envvar": {
@@ -317,6 +318,15 @@ func withAliasName0EndpointInConfig(setup *caseSetup) {
 	}
 	endpoints := setup.config["endpoints"].([]any)[0].(map[string]any)
 	endpoints[aliasName0] = aliasName0ConfigEndpoint
+}
+
+func conflictsWith(e caseExpectations) caseExpectations {
+	e.diags = append(e.diags, provider.ConflictingEndpointsWarningDiag(
+		cty.GetAttrPath("endpoints").IndexInt(0),
+		packageName,
+		aliasName0,
+	))
+	return e
 }
 
 func withAwsEnvVar(setup *caseSetup) {

--- a/internal/service/ce/service_endpoints_gen_test.go
+++ b/internal/service/ce/service_endpoints_gen_test.go
@@ -18,6 +18,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -94,7 +95,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName0EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides aws service envvar": {
@@ -317,6 +318,15 @@ func withAliasName0EndpointInConfig(setup *caseSetup) {
 	}
 	endpoints := setup.config["endpoints"].([]any)[0].(map[string]any)
 	endpoints[aliasName0] = aliasName0ConfigEndpoint
+}
+
+func conflictsWith(e caseExpectations) caseExpectations {
+	e.diags = append(e.diags, provider.ConflictingEndpointsWarningDiag(
+		cty.GetAttrPath("endpoints").IndexInt(0),
+		packageName,
+		aliasName0,
+	))
+	return e
 }
 
 func withAwsEnvVar(setup *caseSetup) {

--- a/internal/service/cloudcontrol/service_endpoints_gen_test.go
+++ b/internal/service/cloudcontrol/service_endpoints_gen_test.go
@@ -18,6 +18,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -94,7 +95,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName0EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides aws service envvar": {
@@ -327,6 +328,15 @@ func withAliasName0EndpointInConfig(setup *caseSetup) {
 	}
 	endpoints := setup.config["endpoints"].([]any)[0].(map[string]any)
 	endpoints[aliasName0] = aliasName0ConfigEndpoint
+}
+
+func conflictsWith(e caseExpectations) caseExpectations {
+	e.diags = append(e.diags, provider.ConflictingEndpointsWarningDiag(
+		cty.GetAttrPath("endpoints").IndexInt(0),
+		packageName,
+		aliasName0,
+	))
+	return e
 }
 
 func withAwsEnvVar(setup *caseSetup) {

--- a/internal/service/cloudhsmv2/service_endpoints_gen_test.go
+++ b/internal/service/cloudhsmv2/service_endpoints_gen_test.go
@@ -18,6 +18,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -94,7 +95,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName0EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides aws service envvar": {
@@ -317,6 +318,15 @@ func withAliasName0EndpointInConfig(setup *caseSetup) {
 	}
 	endpoints := setup.config["endpoints"].([]any)[0].(map[string]any)
 	endpoints[aliasName0] = aliasName0ConfigEndpoint
+}
+
+func conflictsWith(e caseExpectations) caseExpectations {
+	e.diags = append(e.diags, provider.ConflictingEndpointsWarningDiag(
+		cty.GetAttrPath("endpoints").IndexInt(0),
+		packageName,
+		aliasName0,
+	))
+	return e
 }
 
 func withAwsEnvVar(setup *caseSetup) {

--- a/internal/service/cognitoidp/service_endpoints_gen_test.go
+++ b/internal/service/cognitoidp/service_endpoints_gen_test.go
@@ -18,6 +18,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -94,7 +95,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName0EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides aws service envvar": {
@@ -317,6 +318,15 @@ func withAliasName0EndpointInConfig(setup *caseSetup) {
 	}
 	endpoints := setup.config["endpoints"].([]any)[0].(map[string]any)
 	endpoints[aliasName0] = aliasName0ConfigEndpoint
+}
+
+func conflictsWith(e caseExpectations) caseExpectations {
+	e.diags = append(e.diags, provider.ConflictingEndpointsWarningDiag(
+		cty.GetAttrPath("endpoints").IndexInt(0),
+		packageName,
+		aliasName0,
+	))
+	return e
 }
 
 func withAwsEnvVar(setup *caseSetup) {

--- a/internal/service/configservice/service_endpoints_gen_test.go
+++ b/internal/service/configservice/service_endpoints_gen_test.go
@@ -18,6 +18,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -94,7 +95,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName0EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides aws service envvar": {
@@ -317,6 +318,15 @@ func withAliasName0EndpointInConfig(setup *caseSetup) {
 	}
 	endpoints := setup.config["endpoints"].([]any)[0].(map[string]any)
 	endpoints[aliasName0] = aliasName0ConfigEndpoint
+}
+
+func conflictsWith(e caseExpectations) caseExpectations {
+	e.diags = append(e.diags, provider.ConflictingEndpointsWarningDiag(
+		cty.GetAttrPath("endpoints").IndexInt(0),
+		packageName,
+		aliasName0,
+	))
+	return e
 }
 
 func withAwsEnvVar(setup *caseSetup) {

--- a/internal/service/cur/service_endpoints_gen_test.go
+++ b/internal/service/cur/service_endpoints_gen_test.go
@@ -18,6 +18,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -94,7 +95,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName0EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides aws service envvar": {
@@ -317,6 +318,15 @@ func withAliasName0EndpointInConfig(setup *caseSetup) {
 	}
 	endpoints := setup.config["endpoints"].([]any)[0].(map[string]any)
 	endpoints[aliasName0] = aliasName0ConfigEndpoint
+}
+
+func conflictsWith(e caseExpectations) caseExpectations {
+	e.diags = append(e.diags, provider.ConflictingEndpointsWarningDiag(
+		cty.GetAttrPath("endpoints").IndexInt(0),
+		packageName,
+		aliasName0,
+	))
+	return e
 }
 
 func withAwsEnvVar(setup *caseSetup) {

--- a/internal/service/deploy/service_endpoints_gen_test.go
+++ b/internal/service/deploy/service_endpoints_gen_test.go
@@ -18,6 +18,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -94,7 +95,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName0EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides aws service envvar": {
@@ -327,6 +328,15 @@ func withAliasName0EndpointInConfig(setup *caseSetup) {
 	}
 	endpoints := setup.config["endpoints"].([]any)[0].(map[string]any)
 	endpoints[aliasName0] = aliasName0ConfigEndpoint
+}
+
+func conflictsWith(e caseExpectations) caseExpectations {
+	e.diags = append(e.diags, provider.ConflictingEndpointsWarningDiag(
+		cty.GetAttrPath("endpoints").IndexInt(0),
+		packageName,
+		aliasName0,
+	))
+	return e
 }
 
 func withAwsEnvVar(setup *caseSetup) {

--- a/internal/service/dms/service_endpoints_gen_test.go
+++ b/internal/service/dms/service_endpoints_gen_test.go
@@ -18,6 +18,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -96,7 +97,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName0EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides alias name 1 config": {
@@ -104,7 +105,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName1EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides aws service envvar": {
@@ -153,7 +154,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withAliasName0EndpointInConfig,
 				withAliasName1EndpointInConfig,
 			},
-			expected: expectAliasName0ConfigEndpoint(),
+			expected: conflictsWith(expectAliasName0ConfigEndpoint()),
 		},
 
 		"alias name 0 endpoint config overrides aws service envvar": {
@@ -386,6 +387,16 @@ func withAliasName1EndpointInConfig(setup *caseSetup) {
 	}
 	endpoints := setup.config["endpoints"].([]any)[0].(map[string]any)
 	endpoints[aliasName1] = aliasName1ConfigEndpoint
+}
+
+func conflictsWith(e caseExpectations) caseExpectations {
+	e.diags = append(e.diags, provider.ConflictingEndpointsWarningDiag(
+		cty.GetAttrPath("endpoints").IndexInt(0),
+		packageName,
+		aliasName0,
+		aliasName1,
+	))
+	return e
 }
 
 func withAwsEnvVar(setup *caseSetup) {

--- a/internal/service/ds/service_endpoints_gen_test.go
+++ b/internal/service/ds/service_endpoints_gen_test.go
@@ -19,6 +19,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -95,7 +96,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName0EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides aws service envvar": {
@@ -354,6 +355,15 @@ func withAliasName0EndpointInConfig(setup *caseSetup) {
 	}
 	endpoints := setup.config["endpoints"].([]any)[0].(map[string]any)
 	endpoints[aliasName0] = aliasName0ConfigEndpoint
+}
+
+func conflictsWith(e caseExpectations) caseExpectations {
+	e.diags = append(e.diags, provider.ConflictingEndpointsWarningDiag(
+		cty.GetAttrPath("endpoints").IndexInt(0),
+		packageName,
+		aliasName0,
+	))
+	return e
 }
 
 func withAwsEnvVar(setup *caseSetup) {

--- a/internal/service/elasticbeanstalk/service_endpoints_gen_test.go
+++ b/internal/service/elasticbeanstalk/service_endpoints_gen_test.go
@@ -18,6 +18,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -94,7 +95,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName0EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides aws service envvar": {
@@ -317,6 +318,15 @@ func withAliasName0EndpointInConfig(setup *caseSetup) {
 	}
 	endpoints := setup.config["endpoints"].([]any)[0].(map[string]any)
 	endpoints[aliasName0] = aliasName0ConfigEndpoint
+}
+
+func conflictsWith(e caseExpectations) caseExpectations {
+	e.diags = append(e.diags, provider.ConflictingEndpointsWarningDiag(
+		cty.GetAttrPath("endpoints").IndexInt(0),
+		packageName,
+		aliasName0,
+	))
+	return e
 }
 
 func withAwsEnvVar(setup *caseSetup) {

--- a/internal/service/elasticsearch/service_endpoints_gen_test.go
+++ b/internal/service/elasticsearch/service_endpoints_gen_test.go
@@ -18,6 +18,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -96,7 +97,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName0EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides alias name 1 config": {
@@ -104,7 +105,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName1EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides aws service envvar": {
@@ -153,7 +154,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withAliasName0EndpointInConfig,
 				withAliasName1EndpointInConfig,
 			},
-			expected: expectAliasName0ConfigEndpoint(),
+			expected: conflictsWith(expectAliasName0ConfigEndpoint()),
 		},
 
 		"alias name 0 endpoint config overrides aws service envvar": {
@@ -386,6 +387,16 @@ func withAliasName1EndpointInConfig(setup *caseSetup) {
 	}
 	endpoints := setup.config["endpoints"].([]any)[0].(map[string]any)
 	endpoints[aliasName1] = aliasName1ConfigEndpoint
+}
+
+func conflictsWith(e caseExpectations) caseExpectations {
+	e.diags = append(e.diags, provider.ConflictingEndpointsWarningDiag(
+		cty.GetAttrPath("endpoints").IndexInt(0),
+		packageName,
+		aliasName0,
+		aliasName1,
+	))
+	return e
 }
 
 func withAwsEnvVar(setup *caseSetup) {

--- a/internal/service/elb/service_endpoints_gen_test.go
+++ b/internal/service/elb/service_endpoints_gen_test.go
@@ -18,6 +18,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -94,7 +95,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName0EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides aws service envvar": {
@@ -317,6 +318,15 @@ func withAliasName0EndpointInConfig(setup *caseSetup) {
 	}
 	endpoints := setup.config["endpoints"].([]any)[0].(map[string]any)
 	endpoints[aliasName0] = aliasName0ConfigEndpoint
+}
+
+func conflictsWith(e caseExpectations) caseExpectations {
+	e.diags = append(e.diags, provider.ConflictingEndpointsWarningDiag(
+		cty.GetAttrPath("endpoints").IndexInt(0),
+		packageName,
+		aliasName0,
+	))
+	return e
 }
 
 func withAwsEnvVar(setup *caseSetup) {

--- a/internal/service/elbv2/service_endpoints_gen_test.go
+++ b/internal/service/elbv2/service_endpoints_gen_test.go
@@ -19,6 +19,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -95,7 +96,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName0EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides aws service envvar": {
@@ -354,6 +355,15 @@ func withAliasName0EndpointInConfig(setup *caseSetup) {
 	}
 	endpoints := setup.config["endpoints"].([]any)[0].(map[string]any)
 	endpoints[aliasName0] = aliasName0ConfigEndpoint
+}
+
+func conflictsWith(e caseExpectations) caseExpectations {
+	e.diags = append(e.diags, provider.ConflictingEndpointsWarningDiag(
+		cty.GetAttrPath("endpoints").IndexInt(0),
+		packageName,
+		aliasName0,
+	))
+	return e
 }
 
 func withAwsEnvVar(setup *caseSetup) {

--- a/internal/service/events/service_endpoints_gen_test.go
+++ b/internal/service/events/service_endpoints_gen_test.go
@@ -18,6 +18,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -96,7 +97,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName0EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides alias name 1 config": {
@@ -104,7 +105,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName1EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides aws service envvar": {
@@ -153,7 +154,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withAliasName0EndpointInConfig,
 				withAliasName1EndpointInConfig,
 			},
-			expected: expectAliasName0ConfigEndpoint(),
+			expected: conflictsWith(expectAliasName0ConfigEndpoint()),
 		},
 
 		"alias name 0 endpoint config overrides aws service envvar": {
@@ -386,6 +387,16 @@ func withAliasName1EndpointInConfig(setup *caseSetup) {
 	}
 	endpoints := setup.config["endpoints"].([]any)[0].(map[string]any)
 	endpoints[aliasName1] = aliasName1ConfigEndpoint
+}
+
+func conflictsWith(e caseExpectations) caseExpectations {
+	e.diags = append(e.diags, provider.ConflictingEndpointsWarningDiag(
+		cty.GetAttrPath("endpoints").IndexInt(0),
+		packageName,
+		aliasName0,
+		aliasName1,
+	))
+	return e
 }
 
 func withAwsEnvVar(setup *caseSetup) {

--- a/internal/service/evidently/service_endpoints_gen_test.go
+++ b/internal/service/evidently/service_endpoints_gen_test.go
@@ -18,6 +18,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -94,7 +95,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName0EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides aws service envvar": {
@@ -327,6 +328,15 @@ func withAliasName0EndpointInConfig(setup *caseSetup) {
 	}
 	endpoints := setup.config["endpoints"].([]any)[0].(map[string]any)
 	endpoints[aliasName0] = aliasName0ConfigEndpoint
+}
+
+func conflictsWith(e caseExpectations) caseExpectations {
+	e.diags = append(e.diags, provider.ConflictingEndpointsWarningDiag(
+		cty.GetAttrPath("endpoints").IndexInt(0),
+		packageName,
+		aliasName0,
+	))
+	return e
 }
 
 func withAwsEnvVar(setup *caseSetup) {

--- a/internal/service/grafana/service_endpoints_gen_test.go
+++ b/internal/service/grafana/service_endpoints_gen_test.go
@@ -18,6 +18,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -96,7 +97,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName0EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides alias name 1 config": {
@@ -104,7 +105,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName1EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides aws service envvar": {
@@ -153,7 +154,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withAliasName0EndpointInConfig,
 				withAliasName1EndpointInConfig,
 			},
-			expected: expectAliasName0ConfigEndpoint(),
+			expected: conflictsWith(expectAliasName0ConfigEndpoint()),
 		},
 
 		"alias name 0 endpoint config overrides aws service envvar": {
@@ -386,6 +387,16 @@ func withAliasName1EndpointInConfig(setup *caseSetup) {
 	}
 	endpoints := setup.config["endpoints"].([]any)[0].(map[string]any)
 	endpoints[aliasName1] = aliasName1ConfigEndpoint
+}
+
+func conflictsWith(e caseExpectations) caseExpectations {
+	e.diags = append(e.diags, provider.ConflictingEndpointsWarningDiag(
+		cty.GetAttrPath("endpoints").IndexInt(0),
+		packageName,
+		aliasName0,
+		aliasName1,
+	))
+	return e
 }
 
 func withAwsEnvVar(setup *caseSetup) {

--- a/internal/service/inspector2/service_endpoints_gen_test.go
+++ b/internal/service/inspector2/service_endpoints_gen_test.go
@@ -18,6 +18,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -94,7 +95,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName0EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides aws service envvar": {
@@ -327,6 +328,15 @@ func withAliasName0EndpointInConfig(setup *caseSetup) {
 	}
 	endpoints := setup.config["endpoints"].([]any)[0].(map[string]any)
 	endpoints[aliasName0] = aliasName0ConfigEndpoint
+}
+
+func conflictsWith(e caseExpectations) caseExpectations {
+	e.diags = append(e.diags, provider.ConflictingEndpointsWarningDiag(
+		cty.GetAttrPath("endpoints").IndexInt(0),
+		packageName,
+		aliasName0,
+	))
+	return e
 }
 
 func withAwsEnvVar(setup *caseSetup) {

--- a/internal/service/kafka/service_endpoints_gen_test.go
+++ b/internal/service/kafka/service_endpoints_gen_test.go
@@ -18,6 +18,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -94,7 +95,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName0EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides aws service envvar": {
@@ -327,6 +328,15 @@ func withAliasName0EndpointInConfig(setup *caseSetup) {
 	}
 	endpoints := setup.config["endpoints"].([]any)[0].(map[string]any)
 	endpoints[aliasName0] = aliasName0ConfigEndpoint
+}
+
+func conflictsWith(e caseExpectations) caseExpectations {
+	e.diags = append(e.diags, provider.ConflictingEndpointsWarningDiag(
+		cty.GetAttrPath("endpoints").IndexInt(0),
+		packageName,
+		aliasName0,
+	))
+	return e
 }
 
 func withAwsEnvVar(setup *caseSetup) {

--- a/internal/service/lexv2models/service_endpoints_gen_test.go
+++ b/internal/service/lexv2models/service_endpoints_gen_test.go
@@ -18,6 +18,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -94,7 +95,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName0EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides aws service envvar": {
@@ -327,6 +328,15 @@ func withAliasName0EndpointInConfig(setup *caseSetup) {
 	}
 	endpoints := setup.config["endpoints"].([]any)[0].(map[string]any)
 	endpoints[aliasName0] = aliasName0ConfigEndpoint
+}
+
+func conflictsWith(e caseExpectations) caseExpectations {
+	e.diags = append(e.diags, provider.ConflictingEndpointsWarningDiag(
+		cty.GetAttrPath("endpoints").IndexInt(0),
+		packageName,
+		aliasName0,
+	))
+	return e
 }
 
 func withAwsEnvVar(setup *caseSetup) {

--- a/internal/service/location/service_endpoints_gen_test.go
+++ b/internal/service/location/service_endpoints_gen_test.go
@@ -18,6 +18,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -94,7 +95,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName0EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides aws service envvar": {
@@ -317,6 +318,15 @@ func withAliasName0EndpointInConfig(setup *caseSetup) {
 	}
 	endpoints := setup.config["endpoints"].([]any)[0].(map[string]any)
 	endpoints[aliasName0] = aliasName0ConfigEndpoint
+}
+
+func conflictsWith(e caseExpectations) caseExpectations {
+	e.diags = append(e.diags, provider.ConflictingEndpointsWarningDiag(
+		cty.GetAttrPath("endpoints").IndexInt(0),
+		packageName,
+		aliasName0,
+	))
+	return e
 }
 
 func withAwsEnvVar(setup *caseSetup) {

--- a/internal/service/logs/service_endpoints_gen_test.go
+++ b/internal/service/logs/service_endpoints_gen_test.go
@@ -18,6 +18,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -96,7 +97,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName0EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides alias name 1 config": {
@@ -104,7 +105,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName1EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides aws service envvar": {
@@ -153,7 +154,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withAliasName0EndpointInConfig,
 				withAliasName1EndpointInConfig,
 			},
-			expected: expectAliasName0ConfigEndpoint(),
+			expected: conflictsWith(expectAliasName0ConfigEndpoint()),
 		},
 
 		"alias name 0 endpoint config overrides aws service envvar": {
@@ -396,6 +397,16 @@ func withAliasName1EndpointInConfig(setup *caseSetup) {
 	}
 	endpoints := setup.config["endpoints"].([]any)[0].(map[string]any)
 	endpoints[aliasName1] = aliasName1ConfigEndpoint
+}
+
+func conflictsWith(e caseExpectations) caseExpectations {
+	e.diags = append(e.diags, provider.ConflictingEndpointsWarningDiag(
+		cty.GetAttrPath("endpoints").IndexInt(0),
+		packageName,
+		aliasName0,
+		aliasName1,
+	))
+	return e
 }
 
 func withAwsEnvVar(setup *caseSetup) {

--- a/internal/service/oam/service_endpoints_gen_test.go
+++ b/internal/service/oam/service_endpoints_gen_test.go
@@ -18,6 +18,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -94,7 +95,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName0EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides aws service envvar": {
@@ -327,6 +328,15 @@ func withAliasName0EndpointInConfig(setup *caseSetup) {
 	}
 	endpoints := setup.config["endpoints"].([]any)[0].(map[string]any)
 	endpoints[aliasName0] = aliasName0ConfigEndpoint
+}
+
+func conflictsWith(e caseExpectations) caseExpectations {
+	e.diags = append(e.diags, provider.ConflictingEndpointsWarningDiag(
+		cty.GetAttrPath("endpoints").IndexInt(0),
+		packageName,
+		aliasName0,
+	))
+	return e
 }
 
 func withAwsEnvVar(setup *caseSetup) {

--- a/internal/service/opensearch/service_endpoints_gen_test.go
+++ b/internal/service/opensearch/service_endpoints_gen_test.go
@@ -18,6 +18,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -94,7 +95,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName0EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides aws service envvar": {
@@ -317,6 +318,15 @@ func withAliasName0EndpointInConfig(setup *caseSetup) {
 	}
 	endpoints := setup.config["endpoints"].([]any)[0].(map[string]any)
 	endpoints[aliasName0] = aliasName0ConfigEndpoint
+}
+
+func conflictsWith(e caseExpectations) caseExpectations {
+	e.diags = append(e.diags, provider.ConflictingEndpointsWarningDiag(
+		cty.GetAttrPath("endpoints").IndexInt(0),
+		packageName,
+		aliasName0,
+	))
+	return e
 }
 
 func withAwsEnvVar(setup *caseSetup) {

--- a/internal/service/osis/service_endpoints_gen_test.go
+++ b/internal/service/osis/service_endpoints_gen_test.go
@@ -18,6 +18,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -94,7 +95,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName0EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides aws service envvar": {
@@ -327,6 +328,15 @@ func withAliasName0EndpointInConfig(setup *caseSetup) {
 	}
 	endpoints := setup.config["endpoints"].([]any)[0].(map[string]any)
 	endpoints[aliasName0] = aliasName0ConfigEndpoint
+}
+
+func conflictsWith(e caseExpectations) caseExpectations {
+	e.diags = append(e.diags, provider.ConflictingEndpointsWarningDiag(
+		cty.GetAttrPath("endpoints").IndexInt(0),
+		packageName,
+		aliasName0,
+	))
+	return e
 }
 
 func withAwsEnvVar(setup *caseSetup) {

--- a/internal/service/redshiftdata/service_endpoints_gen_test.go
+++ b/internal/service/redshiftdata/service_endpoints_gen_test.go
@@ -18,6 +18,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -94,7 +95,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName0EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides aws service envvar": {
@@ -329,6 +330,15 @@ func withAliasName0EndpointInConfig(setup *caseSetup) {
 	}
 	endpoints := setup.config["endpoints"].([]any)[0].(map[string]any)
 	endpoints[aliasName0] = aliasName0ConfigEndpoint
+}
+
+func conflictsWith(e caseExpectations) caseExpectations {
+	e.diags = append(e.diags, provider.ConflictingEndpointsWarningDiag(
+		cty.GetAttrPath("endpoints").IndexInt(0),
+		packageName,
+		aliasName0,
+	))
+	return e
 }
 
 func withAwsEnvVar(setup *caseSetup) {

--- a/internal/service/resourcegroupstaggingapi/service_endpoints_gen_test.go
+++ b/internal/service/resourcegroupstaggingapi/service_endpoints_gen_test.go
@@ -18,6 +18,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -94,7 +95,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName0EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides aws service envvar": {
@@ -327,6 +328,15 @@ func withAliasName0EndpointInConfig(setup *caseSetup) {
 	}
 	endpoints := setup.config["endpoints"].([]any)[0].(map[string]any)
 	endpoints[aliasName0] = aliasName0ConfigEndpoint
+}
+
+func conflictsWith(e caseExpectations) caseExpectations {
+	e.diags = append(e.diags, provider.ConflictingEndpointsWarningDiag(
+		cty.GetAttrPath("endpoints").IndexInt(0),
+		packageName,
+		aliasName0,
+	))
+	return e
 }
 
 func withAwsEnvVar(setup *caseSetup) {

--- a/internal/service/rum/service_endpoints_gen_test.go
+++ b/internal/service/rum/service_endpoints_gen_test.go
@@ -18,6 +18,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -94,7 +95,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName0EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides aws service envvar": {
@@ -317,6 +318,15 @@ func withAliasName0EndpointInConfig(setup *caseSetup) {
 	}
 	endpoints := setup.config["endpoints"].([]any)[0].(map[string]any)
 	endpoints[aliasName0] = aliasName0ConfigEndpoint
+}
+
+func conflictsWith(e caseExpectations) caseExpectations {
+	e.diags = append(e.diags, provider.ConflictingEndpointsWarningDiag(
+		cty.GetAttrPath("endpoints").IndexInt(0),
+		packageName,
+		aliasName0,
+	))
+	return e
 }
 
 func withAwsEnvVar(setup *caseSetup) {

--- a/internal/service/s3/service_endpoints_gen_test.go
+++ b/internal/service/s3/service_endpoints_gen_test.go
@@ -18,6 +18,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -96,7 +97,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName0EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides aws service envvar": {
@@ -451,6 +452,15 @@ func withAliasName0EndpointInConfig(setup *caseSetup) {
 	}
 	endpoints := setup.config["endpoints"].([]any)[0].(map[string]any)
 	endpoints[aliasName0] = aliasName0ConfigEndpoint
+}
+
+func conflictsWith(e caseExpectations) caseExpectations {
+	e.diags = append(e.diags, provider.ConflictingEndpointsWarningDiag(
+		cty.GetAttrPath("endpoints").IndexInt(0),
+		packageName,
+		aliasName0,
+	))
+	return e
 }
 
 func withAwsEnvVar(setup *caseSetup) {

--- a/internal/service/serverlessrepo/service_endpoints_gen_test.go
+++ b/internal/service/serverlessrepo/service_endpoints_gen_test.go
@@ -18,6 +18,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -96,7 +97,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName0EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides alias name 1 config": {
@@ -104,7 +105,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName1EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides aws service envvar": {
@@ -153,7 +154,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withAliasName0EndpointInConfig,
 				withAliasName1EndpointInConfig,
 			},
-			expected: expectAliasName0ConfigEndpoint(),
+			expected: conflictsWith(expectAliasName0ConfigEndpoint()),
 		},
 
 		"alias name 0 endpoint config overrides aws service envvar": {
@@ -386,6 +387,16 @@ func withAliasName1EndpointInConfig(setup *caseSetup) {
 	}
 	endpoints := setup.config["endpoints"].([]any)[0].(map[string]any)
 	endpoints[aliasName1] = aliasName1ConfigEndpoint
+}
+
+func conflictsWith(e caseExpectations) caseExpectations {
+	e.diags = append(e.diags, provider.ConflictingEndpointsWarningDiag(
+		cty.GetAttrPath("endpoints").IndexInt(0),
+		packageName,
+		aliasName0,
+		aliasName1,
+	))
+	return e
 }
 
 func withAwsEnvVar(setup *caseSetup) {

--- a/internal/service/servicecatalogappregistry/service_endpoints_gen_test.go
+++ b/internal/service/servicecatalogappregistry/service_endpoints_gen_test.go
@@ -18,6 +18,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -94,7 +95,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName0EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides aws service envvar": {
@@ -327,6 +328,15 @@ func withAliasName0EndpointInConfig(setup *caseSetup) {
 	}
 	endpoints := setup.config["endpoints"].([]any)[0].(map[string]any)
 	endpoints[aliasName0] = aliasName0ConfigEndpoint
+}
+
+func conflictsWith(e caseExpectations) caseExpectations {
+	e.diags = append(e.diags, provider.ConflictingEndpointsWarningDiag(
+		cty.GetAttrPath("endpoints").IndexInt(0),
+		packageName,
+		aliasName0,
+	))
+	return e
 }
 
 func withAwsEnvVar(setup *caseSetup) {

--- a/internal/service/sfn/service_endpoints_gen_test.go
+++ b/internal/service/sfn/service_endpoints_gen_test.go
@@ -18,6 +18,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -94,7 +95,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName0EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides aws service envvar": {
@@ -317,6 +318,15 @@ func withAliasName0EndpointInConfig(setup *caseSetup) {
 	}
 	endpoints := setup.config["endpoints"].([]any)[0].(map[string]any)
 	endpoints[aliasName0] = aliasName0ConfigEndpoint
+}
+
+func conflictsWith(e caseExpectations) caseExpectations {
+	e.diags = append(e.diags, provider.ConflictingEndpointsWarningDiag(
+		cty.GetAttrPath("endpoints").IndexInt(0),
+		packageName,
+		aliasName0,
+	))
+	return e
 }
 
 func withAwsEnvVar(setup *caseSetup) {

--- a/internal/service/simpledb/service_endpoints_gen_test.go
+++ b/internal/service/simpledb/service_endpoints_gen_test.go
@@ -18,6 +18,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -94,7 +95,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName0EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides aws service envvar": {
@@ -317,6 +318,15 @@ func withAliasName0EndpointInConfig(setup *caseSetup) {
 	}
 	endpoints := setup.config["endpoints"].([]any)[0].(map[string]any)
 	endpoints[aliasName0] = aliasName0ConfigEndpoint
+}
+
+func conflictsWith(e caseExpectations) caseExpectations {
+	e.diags = append(e.diags, provider.ConflictingEndpointsWarningDiag(
+		cty.GetAttrPath("endpoints").IndexInt(0),
+		packageName,
+		aliasName0,
+	))
+	return e
 }
 
 func withAwsEnvVar(setup *caseSetup) {

--- a/internal/service/transcribe/service_endpoints_gen_test.go
+++ b/internal/service/transcribe/service_endpoints_gen_test.go
@@ -18,6 +18,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	terraformsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -94,7 +95,7 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 				withPackageNameEndpointInConfig,
 				withAliasName0EndpointInConfig,
 			},
-			expected: expectPackageNameConfigEndpoint(),
+			expected: conflictsWith(expectPackageNameConfigEndpoint()),
 		},
 
 		"package name endpoint config overrides aws service envvar": {
@@ -327,6 +328,15 @@ func withAliasName0EndpointInConfig(setup *caseSetup) {
 	}
 	endpoints := setup.config["endpoints"].([]any)[0].(map[string]any)
 	endpoints[aliasName0] = aliasName0ConfigEndpoint
+}
+
+func conflictsWith(e caseExpectations) caseExpectations {
+	e.diags = append(e.diags, provider.ConflictingEndpointsWarningDiag(
+		cty.GetAttrPath("endpoints").IndexInt(0),
+		packageName,
+		aliasName0,
+	))
+	return e
 }
 
 func withAwsEnvVar(setup *caseSetup) {


### PR DESCRIPTION
### Description

Adds warnings for conflicting service endpoint attributes in provider configuration.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% go test ./internal/service/... -run=TestEndpointConfiguration
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/accessanalyzer	9.357s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/account	12.284s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/acm	16.997s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/acmpca	30.744s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/amp	(cached)
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/amplify	23.854s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/apigateway	36.407s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/apigatewayv2	42.707s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/appautoscaling	49.189s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/appconfig	54.076s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/appfabric	50.125s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/appflow	51.703s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/appintegrations	55.238s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/applicationinsights	58.570s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/appmesh	57.159s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/apprunner	51.934s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/appstream	53.143s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/appsync	57.781s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/athena	51.032s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/auditmanager	38.998s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/autoscaling	37.512s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/autoscalingplans	36.729s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/backup	32.105s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/batch	27.547s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/bedrock	40.425s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagent	34.046s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/budgets	44.513s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ce	50.346s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/chime	47.190s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/chimesdkmediapipelines	50.861s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/chimesdkvoice	50.350s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cleanrooms	52.648s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloud9	57.272s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudcontrol	58.631s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudformation	57.300s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront	48.149s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudhsmv2	54.008s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudsearch	58.065s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudtrail	51.409s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudwatch	47.316s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codeartifact	45.948s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codebuild	44.044s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codecatalyst	48.469s [no tests to run]
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codecommit	52.647s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codeguruprofiler	48.587s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codegurureviewer	48.920s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codepipeline	43.870s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codestarconnections	48.080s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codestarnotifications	27.305s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidentity	32.336s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp	33.068s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/comprehend	33.918s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/computeoptimizer	15.600s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/configservice	38.683s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/connect	24.446s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/connectcases	15.401s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/controltower	46.106s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cur	34.510s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/customerprofiles	37.374s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dataexchange	15.898s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/datapipeline	10.664s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/datasync	18.238s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dax	11.883s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/deploy	19.529s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/detective	28.216s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/devicefarm	10.056s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/directconnect	28.660s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dlm	14.684s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dms	23.351s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/docdb	37.547s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/docdbelastic	27.302s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ds	40.153s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb	31.933s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	38.733s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecr	9.995s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecrpublic	29.946s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	16.727s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/efs	44.840s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/eks	22.971s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticache	53.345s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticbeanstalk	45.865s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticsearch	67.196s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elastictranscoder	59.536s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elb	50.727s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	34.092s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/emr	40.133s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/emrcontainers	44.906s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/emrserverless	46.281s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/events	48.198s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/evidently	41.220s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/finspace	50.818s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/firehose	48.119s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/fis	50.710s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/fms	50.284s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/fsx	49.283s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/gamelift	54.951s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/glacier	50.570s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/globalaccelerator	51.215s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/glue	53.296s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/grafana	54.005s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/greengrass	55.318s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/groundstation	56.522s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/guardduty	56.129s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/healthlake	56.317s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	39.681s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/identitystore	46.207s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder	52.964s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/inspector	55.553s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/inspector2	47.700s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/internetmonitor	48.664s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iot	53.221s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iotanalytics	58.735s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iotevents	57.758s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ivs	56.798s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ivschat	55.939s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kafka	35.934s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kafkaconnect	42.062s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kendra	48.341s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/keyspaces	42.673s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kinesis	44.583s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kinesisanalytics	37.234s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kinesisanalyticsv2	48.005s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kinesisvideo	53.211s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kms	25.722s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lakeformation	32.497s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lambda	40.157s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/launchwizard	32.355s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lexmodels	44.224s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lexv2models	41.089s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/licensemanager	33.849s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lightsail	47.311s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/location	53.844s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/logs	49.334s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lookoutmetrics	52.331s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/m2	56.686s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/macie2	56.936s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/mediaconnect	56.167s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/mediaconvert	48.476s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/medialive	43.718s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/mediapackage	46.335s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/mediapackagev2	48.076s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/mediastore	47.068s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/memorydb	48.881s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/meta	54.116s [no tests to run]
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/mq	50.525s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/mwaa	52.168s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/neptune	50.285s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/networkfirewall	52.946s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/networkmanager	56.915s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/oam	58.594s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/opensearch	50.512s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/opensearchserverless	41.949s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/opsworks	48.618s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/organizations	42.365s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/osis	49.302s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/outposts	42.322s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/pcaconnectorad	52.660s
?   	github.com/hashicorp/terraform-provider-aws/internal/service/quicksight/schema	[no test files]
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/pinpoint	56.331s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/pipes	51.080s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/polly	52.229s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/pricing	57.012s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/qbusiness	57.536s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/qldb	52.114s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/quicksight	44.837s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ram	42.174s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rbin	42.709s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	46.545s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/redshift	32.186s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/redshiftdata	39.403s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/redshiftserverless	47.660s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rekognition	47.251s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/resourceexplorer2	44.343s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/resourcegroups	47.719s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/resourcegroupstaggingapi	51.889s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rolesanywhere	56.548s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53	48.088s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53domains	44.966s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53recoverycontrolconfig	51.983s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53recoveryreadiness	56.532s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53resolver	50.473s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rum	52.470s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	38.229s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3control	41.636s [no tests to run]
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3outposts	35.534s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker	38.084s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/scheduler	45.311s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/schemas	48.846s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager	43.266s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/securityhub	46.370s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/securitylake	44.084s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/serverlessrepo	37.784s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/servicecatalog	42.558s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/servicecatalogappregistry	49.524s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/servicediscovery	43.388s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/servicequotas	42.502s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ses	49.965s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sesv2	51.626s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sfn	57.089s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/shield	52.440s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/signer	46.599s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/simpledb	42.897s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sns	44.852s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sqs	20.156s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ssm	27.501s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ssmcontacts	37.337s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ssmincidents	23.830s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ssmsap	30.693s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sso	41.977s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ssoadmin	39.449s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/storagegateway	44.674s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sts	50.488s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/swf	40.530s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/synthetics	47.272s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/timestreamwrite	36.164s [no tests to run]
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/transcribe	30.595s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/transfer	23.740s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/verifiedpermissions	29.704s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/vpclattice	29.860s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/waf	29.577s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/wafregional	35.703s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/wafv2	32.658s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/wellarchitected	39.561s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/worklink	44.447s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/workspaces	46.094s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/xray	38.136s
```
