### PR TITLE
r/medialive_channel: add `client_cache` to HLS group settings

### DIFF
--- a/.changelog/33798.txt
+++ b/.changelog/33798.txt
@@ -1,4 +1,0 @@
-
-```release-note:bug
-resource/aws_medialive_channel: Added `client_cache` to `expandHLSGroupSettings`.
-```

--- a/.changelog/35738.txt
+++ b/.changelog/35738.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_medialive_channel: Added `client_cache` to `hls_group_settings`.
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Relates #33798

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccMediaLiveChannel_' PKG=medialive

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/medialive/... -v -count 1 -parallel 20  -run=TestAccMediaLiveChannel_ -timeout 360m
--- PASS: TestAccMediaLiveChannel_MsSmooth_outputSettings (71.97s)
--- PASS: TestAccMediaLiveChannel_captionDescriptions (88.18s)
--- PASS: TestAccMediaLiveChannel_VideoDescriptions_CodecSettings_h265Settings (107.84s)
--- PASS: TestAccMediaLiveChannel_basic (143.69s)
--- PASS: TestAccMediaLiveChannel_UDP_outputSettings (172.74s)
--- PASS: TestAccMediaLiveChannel_M2TS_settings (213.53s)
--- PASS: TestAccMediaLiveChannel_hls (247.95s)
--- PASS: TestAccMediaLiveChannel_status (266.42s)
--- PASS: TestAccMediaLiveChannel_AudioDescriptions_codecSettings (296.39s)
--- PASS: TestAccMediaLiveChannel_VideoDescriptions_CodecSettings_h264Settings (321.22s)
--- PASS: TestAccMediaLiveChannel_update (350.62s)
--- PASS: TestAccMediaLiveChannel_disappears (397.24s)
--- PASS: TestAccMediaLiveChannel_updateTags (399.25s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/medialive	406.406s
```
