### PR TITLE
`r/aws_route53_resolver_rule`: add `protocols`

### DIFF
--- a/.changelog/35744.txt
+++ b/.changelog/35744.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_route53_resolver_rule: Add `target_ip.protocol` argument
+```

--- a/internal/service/route53resolver/rule.go
+++ b/internal/service/route53resolver/rule.go
@@ -98,6 +98,12 @@ func ResourceRule() *schema.Resource {
 							Default:      53,
 							ValidateFunc: validation.IntBetween(1, 65535),
 						},
+						"protocol": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      route53resolver.ProtocolDo53,
+							ValidateFunc: validation.StringInSlice(route53resolver.Protocol_Values(), false),
+						},
 					},
 				},
 			},
@@ -368,6 +374,9 @@ func expandRuleTargetIPs(vTargetIps *schema.Set) []*route53resolver.TargetAddres
 		if vPort, ok := mTargetIp["port"].(int); ok {
 			targetAddress.Port = aws.Int64(int64(vPort))
 		}
+		if vProtocol, ok := mTargetIp["protocol"].(string); ok && vProtocol != "" {
+			targetAddress.Protocol = aws.String(vProtocol)
+		}
 
 		targetAddresses = append(targetAddresses, targetAddress)
 	}
@@ -384,8 +393,9 @@ func flattenRuleTargetIPs(targetAddresses []*route53resolver.TargetAddress) []in
 
 	for _, targetAddress := range targetAddresses {
 		mTargetIp := map[string]interface{}{
-			"ip":   aws.StringValue(targetAddress.Ip),
-			"port": int(aws.Int64Value(targetAddress.Port)),
+			"ip":       aws.StringValue(targetAddress.Ip),
+			"port":     int(aws.Int64Value(targetAddress.Port)),
+			"protocol": aws.StringValue(targetAddress.Protocol),
 		}
 
 		vTargetIps = append(vTargetIps, mTargetIp)


### PR DESCRIPTION
### Description
`target_ip.protocol` parameter added to select a `protocol` for multiprotocol endpoints.

### Relations
Closes #35733

### References
#35098

### Output from Acceptance Testing


```console
% make testacc TESTS=TestAccRoute53ResolverRule_forward PKG=route53resolver
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/route53resolver/... -v -count 1 -parallel 20 -run='TestAccRoute53ResolverRule_forwardMultiProtocol'  -timeout 360m
=== RUN   TestAccRoute53ResolverRule_forward
=== PAUSE TestAccRoute53ResolverRule_forward
=== RUN   TestAccRoute53ResolverRule_forwardMultiProtocol
=== PAUSE TestAccRoute53ResolverRule_forwardMultiProtocol
=== RUN   TestAccRoute53ResolverRule_forwardEndpointRecreate
=== PAUSE TestAccRoute53ResolverRule_forwardEndpointRecreate
=== CONT  TestAccRoute53ResolverRule_forward
=== CONT  TestAccRoute53ResolverRule_forwardEndpointRecreate
=== CONT  TestAccRoute53ResolverRule_forwardMultiProtocol
--- PASS: TestAccRoute53ResolverRule_forward (305.13s)
--- PASS: TestAccRoute53ResolverRule_forwardMultiProtocol (320.71s)
--- PASS: TestAccRoute53ResolverRule_forwardEndpointRecreate (495.80s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53resolver    500.604s
```
