### PR TITLE
Specify default value for event bridge rule state

### DIFF
--- a/internal/service/events/rule.go
+++ b/internal/service/events/rule.go
@@ -129,11 +129,11 @@ func ResourceRule() *schema.Resource {
 					eventbridge.RuleState_Values(),
 					false,
 				),
+				Default: "ENABLED",
 				DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
-					if oldValue != "" && newValue == "" {
-						return true
-					}
-					return false
+					rawConfig := d.GetRawConfig()
+					rawIsEnabled := rawConfig.GetAttr("is_enabled")
+					return rawIsEnabled.IsKnown() && !rawIsEnabled.IsNull()
 				},
 				ConflictsWith: []string{
 					"is_enabled",

--- a/internal/service/events/rule_test.go
+++ b/internal/service/events/rule_test.go
@@ -511,7 +511,7 @@ func TestAccEventsRule_isEnabled(t *testing.T) {
 
 func TestAccEventsRule_state(t *testing.T) {
 	ctx := acctest.Context(t)
-	var v1, v2, v3 eventbridge.DescribeRuleOutput
+	var v1, v2, v3, v4 eventbridge.DescribeRuleOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_cloudwatch_event_rule.test"
 
@@ -522,23 +522,9 @@ func TestAccEventsRule_state(t *testing.T) {
 		CheckDestroy:             testAccCheckRuleDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRuleConfig_state(rName, eventbridge.RuleStateDisabled),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRuleExists(ctx, resourceName, &v1),
-					resource.TestCheckResourceAttr(resourceName, "is_enabled", "false"),
-					resource.TestCheckResourceAttr(resourceName, "state", eventbridge.RuleStateDisabled),
-					testAccCheckRuleEnabled(ctx, resourceName, eventbridge.RuleStateDisabled),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
 				Config: testAccRuleConfig_state(rName, eventbridge.RuleStateEnabled),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRuleExists(ctx, resourceName, &v2),
+					testAccCheckRuleExists(ctx, resourceName, &v1),
 					resource.TestCheckResourceAttr(resourceName, "is_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "state", eventbridge.RuleStateEnabled),
 					testAccCheckRuleEnabled(ctx, resourceName, eventbridge.RuleStateEnabled),
@@ -550,9 +536,37 @@ func TestAccEventsRule_state(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccRuleConfig_state(rName, eventbridge.RuleStateEnabledWithAllCloudtrailManagementEvents),
+				Config: testAccRuleConfig_state(rName, eventbridge.RuleStateDisabled),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRuleExists(ctx, resourceName, &v2),
+					resource.TestCheckResourceAttr(resourceName, "is_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "state", eventbridge.RuleStateDisabled),
+					testAccCheckRuleEnabled(ctx, resourceName, eventbridge.RuleStateDisabled),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccRuleConfig_state_default(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRuleExists(ctx, resourceName, &v3),
+					resource.TestCheckResourceAttr(resourceName, "is_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "state", eventbridge.RuleStateEnabled),
+					testAccCheckRuleEnabled(ctx, resourceName, eventbridge.RuleStateEnabled),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccRuleConfig_state_cloudTrail(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRuleExists(ctx, resourceName, &v4),
 					resource.TestCheckResourceAttr(resourceName, "is_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "state", eventbridge.RuleStateEnabledWithAllCloudtrailManagementEvents),
 					testAccCheckRuleEnabled(ctx, resourceName, eventbridge.RuleStateEnabledWithAllCloudtrailManagementEvents),
@@ -1017,6 +1031,25 @@ resource "aws_cloudwatch_event_rule" "test" {
   state               = %[2]q
 }
 `, rName, state)
+}
+
+func testAccRuleConfig_state_cloudTrail(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_event_rule" "test" {
+  name          = %[1]q
+  event_pattern = jsonencode({ "detail" : { "count" : [1] } })
+  state         = %[2]q
+}
+`, rName, eventbridge.RuleStateEnabledWithAllCloudtrailManagementEvents)
+}
+
+func testAccRuleConfig_state_default(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_event_rule" "test" {
+  name                = %[1]q
+  schedule_expression = "rate(1 hour)"
+}
+`, rName)
 }
 
 func testAccRuleConfig_namePrefix(namePrefix string) string {


### PR DESCRIPTION
### Description
Addresses bug raised in https://github.com/hashicorp/terraform-provider-aws/issues/35616 where a manually disabled event bridge rule would not be enabled during an apply. This only occurs when no value is set for the state in the config, even thought state has a default of ENABLED.
### Relations
Closes #35616
### Output from Acceptance Testing
```console
% make testacc TESTS=TestAccEventsRule PKG=events ACCTEST_PARALLELISM=20

--- PASS: TestAccEventsRule_patternJSONEncoder (19.20s)
--- PASS: TestAccEventsRule_eventBusARN (26.78s)
--- PASS: TestAccEventsRule_scheduleAndPattern (28.41s)
--- PASS: TestAccEventsRule_namePrefix (28.77s)
--- PASS: TestAccEventsRule_partnerEventBus (29.12s)
--- PASS: TestAccEventsRule_Name_generated (29.21s)
=== NAME  TestAccEventsRule_migrateV0/disabled
    rule_test.go:701: Step 1/2 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # aws_cloudwatch_event_rule.test will be updated in-place
          ~ resource "aws_cloudwatch_event_rule" "test" {
                id                  = "tf-acc-test-1899204285147128855"
                name                = "tf-acc-test-1899204285147128855"
              ~ state               = "DISABLED" -> "ENABLED"
                # (5 unchanged attributes hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- PASS: TestAccEventsRule_role (40.93s)
--- PASS: TestAccEventsRule_description (41.73s)
--- PASS: TestAccEventsRule_pattern (42.44s)
=== NAME  TestAccEventsRule_migrateV0_Equivalent/disabled
    rule_test.go:774: Step 1/2 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # aws_cloudwatch_event_rule.test will be updated in-place
          ~ resource "aws_cloudwatch_event_rule" "test" {
                id                  = "tf-acc-test-361675241127195179"
                name                = "tf-acc-test-361675241127195179"
              ~ state               = "DISABLED" -> "ENABLED"
                # (5 unchanged attributes hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccEventsRule_migrateV0_Equivalent (0.00s)
    --- FAIL: TestAccEventsRule_migrateV0_Equivalent/disabled (46.31s)
    --- PASS: TestAccEventsRule_migrateV0_Equivalent/enabled (52.70s)
--- PASS: TestAccEventsRule_basic (53.03s)
--- PASS: TestAccEventsRule_tags (53.19s)
--- PASS: TestAccEventsRule_eventBusName (53.57s)
--- FAIL: TestAccEventsRule_migrateV0 (0.00s)
    --- FAIL: TestAccEventsRule_migrateV0/disabled (42.21s)
    --- PASS: TestAccEventsRule_migrateV0/basic (53.18s)
    --- PASS: TestAccEventsRule_migrateV0/enabled (54.03s)
--- PASS: TestAccEventsRule_isEnabled (55.18s)
--- PASS: TestAccEventsRule_state (64.34s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/events     64.415s
FAIL
make: *** [GNUmakefile:348: testacc] Error 1
...
```
