### PR TITLE
Correct issue with unlabel-on-milestone-closed

### DIFF
--- a/.ci/scripts/unlabel-on-milestone-closed.sh
+++ b/.ci/scripts/unlabel-on-milestone-closed.sh
@@ -44,11 +44,11 @@ main () {
     }' --jq '.data.organization.repository.milestone.pullRequests.edges[].node' | jq --raw-output --slurp '.[] | .url')
 
   # gh issues allows passing multiple URLs at once
-  gh issue edit $ISSUES --remove-label bug
+  gh issue edit $ISSUES --remove-label prioritized
 
   # gh pr does not allow passing multiple URLs at once
   for item in $PULLS; do
-    gh pr edit "$item" --remove-label bug
+    gh pr edit "$item" --remove-label prioritized
   done
 }
 


### PR DESCRIPTION
### Description

When migrating to a separate script in [this commit](https://github.com/hashicorp/terraform-provider-aws/pull/32605/commits/f7fccf41592e76923f204fb3d638095f4a844a29), a typo was introduced that caused the script to remove the `bug` label from all issues/PRs in a milestone (rather than the `prioritized` label) when a milestone was closed. This PR corrects that typo. Separate remediation efforts have already happened to fix the removed labels.

### Relations

Relates #32605

### Output from Acceptance Testing

N/a, workflow/script