### PR TITLE
Tech debt: Migrate `cloudsearch` resources to AWS SDK for Go v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/chimesdkvoice v1.12.6
 	github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.8.6
 	github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.15.7
+	github.com/aws/aws-sdk-go-v2/service/cloudsearch v1.20.6
 	github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.36.0
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.32.2
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.32.0

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,8 @@ github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.8.6 h1:ype6mmLnDjOX8d4pkbj7SX
 github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.8.6/go.mod h1:ibuCTolZ5/w65nBDKpsXhzZUeQluX/m0hnXAiwFPvP8=
 github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.15.7 h1:8sBfx7QkDZ6dgfUNXWHWRc6Eax7WOI3Slgj6OKDHKTI=
 github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.15.7/go.mod h1:P1EMD13hrBE2KUw030w482Eyk2NmOFIvGqmgNi4XRDc=
+github.com/aws/aws-sdk-go-v2/service/cloudsearch v1.20.6 h1:JnPMJhFeFICqHCS5eRMB3ZwdD53ytQ1CzJIXaiJ7rW0=
+github.com/aws/aws-sdk-go-v2/service/cloudsearch v1.20.6/go.mod h1:AxaZoqWLbXOy30l+IpFv5ryhIGDjhhap9+MQg5Xqndo=
 github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.36.0 h1:tRzTDe5E/dgGwJRR1cltjV9NPG9J5L7HK01+p2B4gCM=
 github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.36.0/go.mod h1:ZyywmYcQbdJcIh8YMwqkw18mkA6nuQ+Uj1ouT2rXTYQ=
 github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.32.2 h1:vQfCIHSDouEvbE4EuDrlCGKcrtABEqF3cMt61nGEV4g=

--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -21,6 +21,7 @@ import (
 	chimesdkvoice_sdkv2 "github.com/aws/aws-sdk-go-v2/service/chimesdkvoice"
 	cleanrooms_sdkv2 "github.com/aws/aws-sdk-go-v2/service/cleanrooms"
 	cloudcontrol_sdkv2 "github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
+	cloudsearch_sdkv2 "github.com/aws/aws-sdk-go-v2/service/cloudsearch"
 	cloudtrail_sdkv2 "github.com/aws/aws-sdk-go-v2/service/cloudtrail"
 	cloudwatch_sdkv2 "github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	cloudwatchlogs_sdkv2 "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
@@ -145,7 +146,6 @@ import (
 	cloudformation_sdkv1 "github.com/aws/aws-sdk-go/service/cloudformation"
 	cloudfront_sdkv1 "github.com/aws/aws-sdk-go/service/cloudfront"
 	cloudhsmv2_sdkv1 "github.com/aws/aws-sdk-go/service/cloudhsmv2"
-	cloudsearch_sdkv1 "github.com/aws/aws-sdk-go/service/cloudsearch"
 	cloudwatchrum_sdkv1 "github.com/aws/aws-sdk-go/service/cloudwatchrum"
 	cognitoidentity_sdkv1 "github.com/aws/aws-sdk-go/service/cognitoidentity"
 	cognitoidentityprovider_sdkv1 "github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
@@ -401,8 +401,8 @@ func (c *AWSClient) CloudHSMV2Conn(ctx context.Context) *cloudhsmv2_sdkv1.CloudH
 	return errs.Must(conn[*cloudhsmv2_sdkv1.CloudHSMV2](ctx, c, names.CloudHSMV2, make(map[string]any)))
 }
 
-func (c *AWSClient) CloudSearchConn(ctx context.Context) *cloudsearch_sdkv1.CloudSearch {
-	return errs.Must(conn[*cloudsearch_sdkv1.CloudSearch](ctx, c, names.CloudSearch, make(map[string]any)))
+func (c *AWSClient) CloudSearchClient(ctx context.Context) *cloudsearch_sdkv2.Client {
+	return errs.Must(client[*cloudsearch_sdkv2.Client](ctx, c, names.CloudSearch, make(map[string]any)))
 }
 
 func (c *AWSClient) CloudTrailClient(ctx context.Context) *cloudtrail_sdkv2.Client {

--- a/internal/flex/flex.go
+++ b/internal/flex/flex.go
@@ -307,6 +307,11 @@ func FlattenResourceId(idParts []string, partCount int, allowEmptyPart bool) (st
 	return strings.Join(idParts, ResourceIdSeparator), nil
 }
 
+// BoolToStringValue converts a bool point to a Go string.
+func BoolToStringValue(v *bool) string {
+	return strconv.FormatBool(aws.BoolValue(v))
+}
+
 // BoolValueToString converts a Go bool value to a string pointer.
 func BoolValueToString(v bool) *string {
 	return aws.String(strconv.FormatBool(v))

--- a/internal/flex/flex.go
+++ b/internal/flex/flex.go
@@ -307,7 +307,7 @@ func FlattenResourceId(idParts []string, partCount int, allowEmptyPart bool) (st
 	return strings.Join(idParts, ResourceIdSeparator), nil
 }
 
-// BoolToStringValue converts a bool point to a Go string.
+// BoolToStringValue converts a bool pointer to a Go string value.
 func BoolToStringValue(v *bool) string {
 	return strconv.FormatBool(aws.BoolValue(v))
 }
@@ -323,9 +323,19 @@ func StringToBoolValue(v *string) bool {
 	return aws.StringValue(v) == strconv.FormatBool(true)
 }
 
+// Float64ToStringValue converts a float64 pointer to a Go string value.
+func Float64ToStringValue(v *float64) string {
+	return strconv.FormatFloat(aws.Float64Value(v), 'f', -1, 64)
+}
+
 // IntValueToString converts a Go int value to a string pointer.
 func IntValueToString(v int) *string {
 	return aws.String(strconv.Itoa(v))
+}
+
+// Int64ToStringValue converts an int64 pointer to a Go string value.
+func Int64ToStringValue(v *int64) string {
+	return strconv.FormatInt(aws.Int64Value(v), 10)
 }
 
 // Int64ValueToString converts a Go int64 value to a string pointer.

--- a/internal/service/cloudsearch/domain.go
+++ b/internal/service/cloudsearch/domain.go
@@ -11,25 +11,30 @@ import (
 	"time"
 
 	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/cloudsearch"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudsearch"
+	"github.com/aws/aws-sdk-go-v2/service/cloudsearch/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-// @SDKResource("aws_cloudsearch_domain")
-func ResourceDomain() *schema.Resource {
+// @SDKResource("aws_cloudsearch_domain", name="Domain")
+func resourceDomain() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceDomainCreate,
 		ReadWithoutTimeout:   resourceDomainRead,
 		UpdateWithoutTimeout: resourceDomainUpdate,
 		DeleteWithoutTimeout: resourceDomainDelete,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -66,10 +71,10 @@ func ResourceDomain() *schema.Resource {
 							Computed: true,
 						},
 						"tls_security_policy": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Computed:     true,
-							ValidateFunc: validation.StringInSlice(cloudsearch.TLSSecurityPolicy_Values(), false),
+							Type:             schema.TypeString,
+							Optional:         true,
+							Computed:         true,
+							ValidateDiagFunc: enum.Validate[types.TLSSecurityPolicy](),
 						},
 					},
 				},
@@ -124,9 +129,9 @@ func ResourceDomain() *schema.Resource {
 							ValidateFunc: validation.StringDoesNotMatch(regexache.MustCompile(`score`), "Cannot be set to reserved field score"),
 						},
 						"type": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringInSlice(cloudsearch.IndexFieldType_Values(), false),
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateDiagFunc: enum.Validate[types.IndexFieldType](),
 						},
 					},
 				},
@@ -150,10 +155,10 @@ func ResourceDomain() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"desired_instance_type": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Computed:     true,
-							ValidateFunc: validation.StringInSlice(cloudsearch.PartitionInstanceType_Values(), false),
+							Type:             schema.TypeString,
+							Optional:         true,
+							Computed:         true,
+							ValidateDiagFunc: enum.Validate[types.PartitionInstanceType](),
 						},
 						"desired_partition_count": {
 							Type:     schema.TypeInt,
@@ -178,15 +183,13 @@ func ResourceDomain() *schema.Resource {
 
 func resourceDomainCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).CloudSearchConn(ctx)
+	conn := meta.(*conns.AWSClient).CloudSearchClient(ctx)
 
 	name := d.Get("name").(string)
-	input := cloudsearch.CreateDomainInput{
+	input := &cloudsearch.CreateDomainInput{
 		DomainName: aws.String(name),
 	}
-
-	log.Printf("[DEBUG] Creating CloudSearch Domain: %s", input)
-	_, err := conn.CreateDomainWithContext(ctx, &input)
+	_, err := conn.CreateDomain(ctx, input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating CloudSearch Domain (%s): %s", name, err)
@@ -200,8 +203,7 @@ func resourceDomainCreate(ctx context.Context, d *schema.ResourceData, meta inte
 			ScalingParameters: expandScalingParameters(v.([]interface{})[0].(map[string]interface{})),
 		}
 
-		log.Printf("[DEBUG] Updating CloudSearch Domain scaling parameters: %s", input)
-		_, err := conn.UpdateScalingParametersWithContext(ctx, input)
+		_, err := conn.UpdateScalingParameters(ctx, input)
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating CloudSearch Domain (%s) scaling parameters: %s", d.Id(), err)
@@ -214,8 +216,7 @@ func resourceDomainCreate(ctx context.Context, d *schema.ResourceData, meta inte
 			MultiAZ:    aws.Bool(v.(bool)),
 		}
 
-		log.Printf("[DEBUG] Updating CloudSearch Domain availability options: %s", input)
-		_, err := conn.UpdateAvailabilityOptionsWithContext(ctx, input)
+		_, err := conn.UpdateAvailabilityOptions(ctx, input)
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating CloudSearch Domain (%s) availability options: %s", d.Id(), err)
@@ -228,8 +229,7 @@ func resourceDomainCreate(ctx context.Context, d *schema.ResourceData, meta inte
 			DomainName:            aws.String(d.Id()),
 		}
 
-		log.Printf("[DEBUG] Updating CloudSearch Domain endpoint options: %s", input)
-		_, err := conn.UpdateDomainEndpointOptionsWithContext(ctx, input)
+		_, err := conn.UpdateDomainEndpointOptions(ctx, input)
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating CloudSearch Domain (%s) endpoint options: %s", d.Id(), err)
@@ -243,10 +243,11 @@ func resourceDomainCreate(ctx context.Context, d *schema.ResourceData, meta inte
 			return sdkdiag.AppendErrorf(diags, "creating CloudSearch Domain (%s): %s", name, err)
 		}
 
-		log.Printf("[DEBUG] Indexing CloudSearch Domain documents: %s", d.Id())
-		_, err = conn.IndexDocumentsWithContext(ctx, &cloudsearch.IndexDocumentsInput{
+		input := &cloudsearch.IndexDocumentsInput{
 			DomainName: aws.String(d.Id()),
-		})
+		}
+
+		_, err = conn.IndexDocuments(ctx, input)
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "indexing CloudSearch Domain (%s) documents: %s", d.Id(), err)
@@ -255,9 +256,7 @@ func resourceDomainCreate(ctx context.Context, d *schema.ResourceData, meta inte
 
 	// TODO: Status.RequiresIndexDocuments = true?
 
-	_, err = waitDomainActive(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate))
-
-	if err != nil {
+	if _, err := waitDomainActive(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for CloudSearch Domain (%s) create: %s", d.Id(), err)
 	}
 
@@ -266,9 +265,9 @@ func resourceDomainCreate(ctx context.Context, d *schema.ResourceData, meta inte
 
 func resourceDomainRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).CloudSearchConn(ctx)
+	conn := meta.(*conns.AWSClient).CloudSearchClient(ctx)
 
-	domainStatus, err := FindDomainStatusByName(ctx, conn, d.Id())
+	domain, err := findDomainByName(ctx, conn, d.Id())
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] CloudSearch Domain (%s) not found, removing from state", d.Id())
@@ -280,17 +279,16 @@ func resourceDomainRead(ctx context.Context, d *schema.ResourceData, meta interf
 		return sdkdiag.AppendErrorf(diags, "reading CloudSearch Domain (%s): %s", d.Id(), err)
 	}
 
-	d.Set("arn", domainStatus.ARN)
-	d.Set("domain_id", domainStatus.DomainId)
-	d.Set("name", domainStatus.DomainName)
-
-	if domainStatus.DocService != nil {
-		d.Set("document_service_endpoint", domainStatus.DocService.Endpoint)
+	d.Set("arn", domain.ARN)
+	if domain.DocService != nil {
+		d.Set("document_service_endpoint", domain.DocService.Endpoint)
 	} else {
 		d.Set("document_service_endpoint", nil)
 	}
-	if domainStatus.SearchService != nil {
-		d.Set("search_service_endpoint", domainStatus.SearchService.Endpoint)
+	d.Set("domain_id", domain.DomainId)
+	d.Set("name", domain.DomainName)
+	if domain.SearchService != nil {
+		d.Set("search_service_endpoint", domain.SearchService.Endpoint)
 	} else {
 		d.Set("search_service_endpoint", nil)
 	}
@@ -323,7 +321,7 @@ func resourceDomainRead(ctx context.Context, d *schema.ResourceData, meta interf
 		return sdkdiag.AppendErrorf(diags, "setting scaling_parameters: %s", err)
 	}
 
-	indexResults, err := conn.DescribeIndexFieldsWithContext(ctx, &cloudsearch.DescribeIndexFieldsInput{
+	indexResults, err := conn.DescribeIndexFields(ctx, &cloudsearch.DescribeIndexFieldsInput{
 		DomainName: aws.String(d.Get("name").(string)),
 	})
 
@@ -342,9 +340,9 @@ func resourceDomainRead(ctx context.Context, d *schema.ResourceData, meta interf
 
 func resourceDomainUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).CloudSearchConn(ctx)
-	requiresIndexDocuments := false
+	conn := meta.(*conns.AWSClient).CloudSearchClient(ctx)
 
+	requiresIndexDocuments := false
 	if d.HasChange("scaling_parameters") {
 		input := &cloudsearch.UpdateScalingParametersInput{
 			DomainName: aws.String(d.Id()),
@@ -353,17 +351,16 @@ func resourceDomainUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		if v, ok := d.GetOk("scaling_parameters"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 			input.ScalingParameters = expandScalingParameters(v.([]interface{})[0].(map[string]interface{}))
 		} else {
-			input.ScalingParameters = &cloudsearch.ScalingParameters{}
+			input.ScalingParameters = &types.ScalingParameters{}
 		}
 
-		log.Printf("[DEBUG] Updating CloudSearch Domain scaling parameters: %s", input)
-		output, err := conn.UpdateScalingParametersWithContext(ctx, input)
+		output, err := conn.UpdateScalingParameters(ctx, input)
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating CloudSearch Domain (%s) scaling parameters: %s", d.Id(), err)
 		}
 
-		if output != nil && output.ScalingParameters != nil && output.ScalingParameters.Status != nil && aws.StringValue(output.ScalingParameters.Status.State) == cloudsearch.OptionStateRequiresIndexDocuments {
+		if output != nil && output.ScalingParameters != nil && output.ScalingParameters.Status != nil && output.ScalingParameters.Status.State == types.OptionStateRequiresIndexDocuments {
 			requiresIndexDocuments = true
 		}
 	}
@@ -374,14 +371,13 @@ func resourceDomainUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			MultiAZ:    aws.Bool(d.Get("multi_az").(bool)),
 		}
 
-		log.Printf("[DEBUG] Updating CloudSearch Domain availability options: %s", input)
-		output, err := conn.UpdateAvailabilityOptionsWithContext(ctx, input)
+		output, err := conn.UpdateAvailabilityOptions(ctx, input)
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating CloudSearch Domain (%s) availability options: %s", d.Id(), err)
 		}
 
-		if output != nil && output.AvailabilityOptions != nil && output.AvailabilityOptions.Status != nil && aws.StringValue(output.AvailabilityOptions.Status.State) == cloudsearch.OptionStateRequiresIndexDocuments {
+		if output != nil && output.AvailabilityOptions != nil && output.AvailabilityOptions.Status != nil && output.AvailabilityOptions.Status.State == types.OptionStateRequiresIndexDocuments {
 			requiresIndexDocuments = true
 		}
 	}
@@ -394,29 +390,26 @@ func resourceDomainUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		if v, ok := d.GetOk("endpoint_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 			input.DomainEndpointOptions = expandDomainEndpointOptions(v.([]interface{})[0].(map[string]interface{}))
 		} else {
-			input.DomainEndpointOptions = &cloudsearch.DomainEndpointOptions{}
+			input.DomainEndpointOptions = &types.DomainEndpointOptions{}
 		}
 
-		log.Printf("[DEBUG] Updating CloudSearch Domain endpoint options: %s", input)
-		output, err := conn.UpdateDomainEndpointOptionsWithContext(ctx, input)
+		output, err := conn.UpdateDomainEndpointOptions(ctx, input)
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating CloudSearch Domain (%s) endpoint options: %s", d.Id(), err)
 		}
 
-		if output != nil && output.DomainEndpointOptions != nil && output.DomainEndpointOptions.Status != nil && aws.StringValue(output.DomainEndpointOptions.Status.State) == cloudsearch.OptionStateRequiresIndexDocuments {
+		if output != nil && output.DomainEndpointOptions != nil && output.DomainEndpointOptions.Status != nil && output.DomainEndpointOptions.Status.State == types.OptionStateRequiresIndexDocuments {
 			requiresIndexDocuments = true
 		}
 	}
 
 	if d.HasChange("index_field") {
 		o, n := d.GetChange("index_field")
-		old := o.(*schema.Set)
-		new := n.(*schema.Set)
+		os, ns := o.(*schema.Set), n.(*schema.Set)
 
-		for _, tfMapRaw := range old.Difference(new).List() {
+		for _, tfMapRaw := range os.Difference(ns).List() {
 			tfMap, ok := tfMapRaw.(map[string]interface{})
-
 			if !ok {
 				continue
 			}
@@ -432,8 +425,7 @@ func resourceDomainUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 				IndexFieldName: aws.String(fieldName),
 			}
 
-			log.Printf("[DEBUG] Deleting CloudSearch Domain index field: %s", input)
-			_, err := conn.DeleteIndexFieldWithContext(ctx, input)
+			_, err := conn.DeleteIndexField(ctx, input)
 
 			if err != nil {
 				return sdkdiag.AppendErrorf(diags, "deleting CloudSearch Domain (%s) index field (%s): %s", d.Id(), fieldName, err)
@@ -442,7 +434,7 @@ func resourceDomainUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			requiresIndexDocuments = true
 		}
 
-		if v := new.Difference(old); v.Len() > 0 {
+		if v := ns.Difference(os); v.Len() > 0 {
 			if err := defineIndexFields(ctx, conn, d.Id(), v.List()); err != nil {
 				return sdkdiag.AppendErrorf(diags, "updating CloudSearch Domain (%s): %s", d.Id(), err)
 			}
@@ -452,19 +444,18 @@ func resourceDomainUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if requiresIndexDocuments {
-		log.Printf("[DEBUG] Indexing CloudSearch Domain documents: %s", d.Id())
-		_, err := conn.IndexDocumentsWithContext(ctx, &cloudsearch.IndexDocumentsInput{
+		input := &cloudsearch.IndexDocumentsInput{
 			DomainName: aws.String(d.Id()),
-		})
+		}
+
+		_, err := conn.IndexDocuments(ctx, input)
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "indexing CloudSearch Domain (%s) documents: %s", d.Id(), err)
 		}
 	}
 
-	_, err := waitDomainActive(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
-
-	if err != nil {
+	if _, err := waitDomainActive(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for CloudSearch Domain (%s) update: %s", d.Id(), err)
 	}
 
@@ -473,10 +464,10 @@ func resourceDomainUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 
 func resourceDomainDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).CloudSearchConn(ctx)
+	conn := meta.(*conns.AWSClient).CloudSearchClient(ctx)
 
 	log.Printf("[DEBUG] Deleting CloudSearch Domain: %s", d.Id())
-	_, err := conn.DeleteDomainWithContext(ctx, &cloudsearch.DeleteDomainInput{
+	_, err := conn.DeleteDomain(ctx, &cloudsearch.DeleteDomainInput{
 		DomainName: aws.String(d.Id()),
 	})
 
@@ -484,9 +475,7 @@ func resourceDomainDelete(ctx context.Context, d *schema.ResourceData, meta inte
 		return sdkdiag.AppendErrorf(diags, "deleting CloudSearch Domain (%s): %s", d.Id(), err)
 	}
 
-	_, err = waitDomainDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete))
-
-	if err != nil {
+	if _, err := waitDomainDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for CloudSearch Domain (%s) delete: %s", d.Id(), err)
 	}
 
@@ -508,7 +497,7 @@ func validateIndexName(v interface{}, k string) (ws []string, es []error) {
 	return
 }
 
-func defineIndexFields(ctx context.Context, conn *cloudsearch.CloudSearch, domainName string, tfList []interface{}) error {
+func defineIndexFields(ctx context.Context, conn *cloudsearch.Client, domainName string, tfList []interface{}) error {
 	// Define index fields with source fields after those without.
 	for _, defineWhenSourceFieldsConfigured := range []bool{false, true} {
 		for _, tfMapRaw := range tfList {
@@ -541,11 +530,10 @@ func defineIndexFields(ctx context.Context, conn *cloudsearch.CloudSearch, domai
 				IndexField: apiObject,
 			}
 
-			log.Printf("[DEBUG] Defining CloudSearch Domain index field: %s", input)
-			_, err = conn.DefineIndexFieldWithContext(ctx, input)
+			_, err = conn.DefineIndexField(ctx, input)
 
 			if err != nil {
-				return fmt.Errorf("defining CloudSearch Domain (%s) index field (%s): %w", domainName, aws.StringValue(apiObject.IndexFieldName), err)
+				return fmt.Errorf("defining CloudSearch Domain (%s) index field (%s): %w", domainName, aws.ToString(apiObject.IndexFieldName), err)
 			}
 		}
 	}
@@ -553,36 +541,32 @@ func defineIndexFields(ctx context.Context, conn *cloudsearch.CloudSearch, domai
 	return nil
 }
 
-func FindDomainStatusByName(ctx context.Context, conn *cloudsearch.CloudSearch, name string) (*cloudsearch.DomainStatus, error) {
+func findDomainByName(ctx context.Context, conn *cloudsearch.Client, name string) (*types.DomainStatus, error) {
 	input := &cloudsearch.DescribeDomainsInput{
-		DomainNames: aws.StringSlice([]string{name}),
+		DomainNames: tfslices.Of(name),
 	}
 
-	output, err := conn.DescribeDomainsWithContext(ctx, input)
+	output, err := conn.DescribeDomains(ctx, input)
 
 	if err != nil {
 		return nil, err
 	}
 
-	if output == nil || len(output.DomainStatusList) == 0 || output.DomainStatusList[0] == nil {
+	if output == nil {
 		return nil, tfresource.NewEmptyResultError(input)
 	}
 
-	if count := len(output.DomainStatusList); count > 1 {
-		return nil, tfresource.NewTooManyResultsError(count, input)
-	}
-
-	return output.DomainStatusList[0], nil
+	return tfresource.AssertSingleValueResult(output.DomainStatusList)
 }
 
-func findAvailabilityOptionsStatusByName(ctx context.Context, conn *cloudsearch.CloudSearch, name string) (*cloudsearch.AvailabilityOptionsStatus, error) {
+func findAvailabilityOptionsStatusByName(ctx context.Context, conn *cloudsearch.Client, name string) (*types.AvailabilityOptionsStatus, error) {
 	input := &cloudsearch.DescribeAvailabilityOptionsInput{
 		DomainName: aws.String(name),
 	}
 
-	output, err := conn.DescribeAvailabilityOptionsWithContext(ctx, input)
+	output, err := conn.DescribeAvailabilityOptions(ctx, input)
 
-	if tfawserr.ErrCodeEquals(err, cloudsearch.ErrCodeResourceNotFoundException) {
+	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return nil, &retry.NotFoundError{
 			LastError:   err,
 			LastRequest: input,
@@ -600,7 +584,7 @@ func findAvailabilityOptionsStatusByName(ctx context.Context, conn *cloudsearch.
 	return output.AvailabilityOptions, nil
 }
 
-func findDomainEndpointOptionsByName(ctx context.Context, conn *cloudsearch.CloudSearch, name string) (*cloudsearch.DomainEndpointOptions, error) {
+func findDomainEndpointOptionsByName(ctx context.Context, conn *cloudsearch.Client, name string) (*types.DomainEndpointOptions, error) {
 	output, err := findDomainEndpointOptionsStatusByName(ctx, conn, name)
 
 	if err != nil {
@@ -614,14 +598,14 @@ func findDomainEndpointOptionsByName(ctx context.Context, conn *cloudsearch.Clou
 	return output.Options, nil
 }
 
-func findDomainEndpointOptionsStatusByName(ctx context.Context, conn *cloudsearch.CloudSearch, name string) (*cloudsearch.DomainEndpointOptionsStatus, error) {
+func findDomainEndpointOptionsStatusByName(ctx context.Context, conn *cloudsearch.Client, name string) (*types.DomainEndpointOptionsStatus, error) {
 	input := &cloudsearch.DescribeDomainEndpointOptionsInput{
 		DomainName: aws.String(name),
 	}
 
-	output, err := conn.DescribeDomainEndpointOptionsWithContext(ctx, input)
+	output, err := conn.DescribeDomainEndpointOptions(ctx, input)
 
-	if tfawserr.ErrCodeEquals(err, cloudsearch.ErrCodeResourceNotFoundException) {
+	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return nil, &retry.NotFoundError{
 			LastError:   err,
 			LastRequest: input,
@@ -639,7 +623,7 @@ func findDomainEndpointOptionsStatusByName(ctx context.Context, conn *cloudsearc
 	return output.DomainEndpointOptions, nil
 }
 
-func findScalingParametersByName(ctx context.Context, conn *cloudsearch.CloudSearch, name string) (*cloudsearch.ScalingParameters, error) {
+func findScalingParametersByName(ctx context.Context, conn *cloudsearch.Client, name string) (*types.ScalingParameters, error) {
 	output, err := findScalingParametersStatusByName(ctx, conn, name)
 
 	if err != nil {
@@ -653,14 +637,14 @@ func findScalingParametersByName(ctx context.Context, conn *cloudsearch.CloudSea
 	return output.Options, nil
 }
 
-func findScalingParametersStatusByName(ctx context.Context, conn *cloudsearch.CloudSearch, name string) (*cloudsearch.ScalingParametersStatus, error) {
+func findScalingParametersStatusByName(ctx context.Context, conn *cloudsearch.Client, name string) (*types.ScalingParametersStatus, error) {
 	input := &cloudsearch.DescribeScalingParametersInput{
 		DomainName: aws.String(name),
 	}
 
-	output, err := conn.DescribeScalingParametersWithContext(ctx, input)
+	output, err := conn.DescribeScalingParameters(ctx, input)
 
-	if tfawserr.ErrCodeEquals(err, cloudsearch.ErrCodeResourceNotFoundException) {
+	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return nil, &retry.NotFoundError{
 			LastError:   err,
 			LastRequest: input,
@@ -678,9 +662,9 @@ func findScalingParametersStatusByName(ctx context.Context, conn *cloudsearch.Cl
 	return output.ScalingParameters, nil
 }
 
-func statusDomainDeleting(ctx context.Context, conn *cloudsearch.CloudSearch, name string) retry.StateRefreshFunc {
+func statusDomainDeleting(ctx context.Context, conn *cloudsearch.Client, name string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		output, err := FindDomainStatusByName(ctx, conn, name)
+		output, err := findDomainByName(ctx, conn, name)
 
 		if tfresource.NotFound(err) {
 			return nil, "", nil
@@ -690,13 +674,13 @@ func statusDomainDeleting(ctx context.Context, conn *cloudsearch.CloudSearch, na
 			return nil, "", err
 		}
 
-		return output, strconv.FormatBool(aws.BoolValue(output.Deleted)), nil
+		return output, flex.BoolToStringValue(output.Deleted), nil
 	}
 }
 
-func statusDomainProcessing(ctx context.Context, conn *cloudsearch.CloudSearch, name string) retry.StateRefreshFunc {
+func statusDomainProcessing(ctx context.Context, conn *cloudsearch.Client, name string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		output, err := FindDomainStatusByName(ctx, conn, name)
+		output, err := findDomainByName(ctx, conn, name)
 
 		if tfresource.NotFound(err) {
 			return nil, "", nil
@@ -706,11 +690,11 @@ func statusDomainProcessing(ctx context.Context, conn *cloudsearch.CloudSearch, 
 			return nil, "", err
 		}
 
-		return output, strconv.FormatBool(aws.BoolValue(output.Processing)), nil
+		return output, flex.BoolToStringValue(output.Processing), nil
 	}
 }
 
-func waitDomainActive(ctx context.Context, conn *cloudsearch.CloudSearch, name string, timeout time.Duration) (*cloudsearch.DomainStatus, error) { //nolint:unparam
+func waitDomainActive(ctx context.Context, conn *cloudsearch.Client, name string, timeout time.Duration) (*types.DomainStatus, error) { //nolint:unparam
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{"true"},
 		Target:  []string{"false"},
@@ -720,14 +704,14 @@ func waitDomainActive(ctx context.Context, conn *cloudsearch.CloudSearch, name s
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
-	if output, ok := outputRaw.(*cloudsearch.DomainStatus); ok {
+	if output, ok := outputRaw.(*types.DomainStatus); ok {
 		return output, err
 	}
 
 	return nil, err
 }
 
-func waitDomainDeleted(ctx context.Context, conn *cloudsearch.CloudSearch, name string, timeout time.Duration) (*cloudsearch.DomainStatus, error) {
+func waitDomainDeleted(ctx context.Context, conn *cloudsearch.Client, name string, timeout time.Duration) (*types.DomainStatus, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{"true"},
 		Target:  []string{},
@@ -737,63 +721,60 @@ func waitDomainDeleted(ctx context.Context, conn *cloudsearch.CloudSearch, name 
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
-	if output, ok := outputRaw.(*cloudsearch.DomainStatus); ok {
+	if output, ok := outputRaw.(*types.DomainStatus); ok {
 		return output, err
 	}
 
 	return nil, err
 }
 
-func expandDomainEndpointOptions(tfMap map[string]interface{}) *cloudsearch.DomainEndpointOptions {
+func expandDomainEndpointOptions(tfMap map[string]interface{}) *types.DomainEndpointOptions {
 	if tfMap == nil {
 		return nil
 	}
 
-	apiObject := &cloudsearch.DomainEndpointOptions{}
+	apiObject := &types.DomainEndpointOptions{}
 
 	if v, ok := tfMap["enforce_https"].(bool); ok {
 		apiObject.EnforceHTTPS = aws.Bool(v)
 	}
 
 	if v, ok := tfMap["tls_security_policy"].(string); ok && v != "" {
-		apiObject.TLSSecurityPolicy = aws.String(v)
+		apiObject.TLSSecurityPolicy = types.TLSSecurityPolicy(v)
 	}
 
 	return apiObject
 }
 
-func flattenDomainEndpointOptions(apiObject *cloudsearch.DomainEndpointOptions) map[string]interface{} {
+func flattenDomainEndpointOptions(apiObject *types.DomainEndpointOptions) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
-
-	if v := apiObject.EnforceHTTPS; v != nil {
-		tfMap["enforce_https"] = aws.BoolValue(v)
+	tfMap := map[string]interface{}{
+		"tls_security_policy": apiObject.TLSSecurityPolicy,
 	}
 
-	if v := apiObject.TLSSecurityPolicy; v != nil {
-		tfMap["tls_security_policy"] = aws.StringValue(v)
+	if v := apiObject.EnforceHTTPS; v != nil {
+		tfMap["enforce_https"] = aws.ToBool(v)
 	}
 
 	return tfMap
 }
 
-func expandIndexField(tfMap map[string]interface{}) (*cloudsearch.IndexField, bool, error) {
+func expandIndexField(tfMap map[string]interface{}) (*types.IndexField, bool, error) {
 	if tfMap == nil {
 		return nil, false, nil
 	}
 
-	apiObject := &cloudsearch.IndexField{}
+	apiObject := &types.IndexField{}
 
 	if v, ok := tfMap["name"].(string); ok && v != "" {
 		apiObject.IndexFieldName = aws.String(v)
 	}
 
-	fieldType, ok := tfMap["type"].(string)
-	if ok && fieldType != "" {
-		apiObject.IndexFieldType = aws.String(fieldType)
+	if v, ok := tfMap["type"].(string); ok && v != "" {
+		apiObject.IndexFieldType = types.IndexFieldType(v)
 	}
 
 	analysisScheme, _ := tfMap["analysis_scheme"].(string)
@@ -804,9 +785,9 @@ func expandIndexField(tfMap map[string]interface{}) (*cloudsearch.IndexField, bo
 	sortEnabled, _ := tfMap["sort"].(bool)
 	var sourceFieldsConfigured bool
 
-	switch fieldType {
-	case cloudsearch.IndexFieldTypeDate:
-		options := &cloudsearch.DateOptions{
+	switch fieldType := apiObject.IndexFieldType; fieldType {
+	case types.IndexFieldTypeDate:
+		options := &types.DateOptions{
 			FacetEnabled:  aws.Bool(facetEnabled),
 			ReturnEnabled: aws.Bool(returnEnabled),
 			SearchEnabled: aws.Bool(searchEnabled),
@@ -824,8 +805,8 @@ func expandIndexField(tfMap map[string]interface{}) (*cloudsearch.IndexField, bo
 
 		apiObject.DateOptions = options
 
-	case cloudsearch.IndexFieldTypeDateArray:
-		options := &cloudsearch.DateArrayOptions{
+	case types.IndexFieldTypeDateArray:
+		options := &types.DateArrayOptions{
 			FacetEnabled:  aws.Bool(facetEnabled),
 			ReturnEnabled: aws.Bool(returnEnabled),
 			SearchEnabled: aws.Bool(searchEnabled),
@@ -842,8 +823,8 @@ func expandIndexField(tfMap map[string]interface{}) (*cloudsearch.IndexField, bo
 
 		apiObject.DateArrayOptions = options
 
-	case cloudsearch.IndexFieldTypeDouble:
-		options := &cloudsearch.DoubleOptions{
+	case types.IndexFieldTypeDouble:
+		options := &types.DoubleOptions{
 			FacetEnabled:  aws.Bool(facetEnabled),
 			ReturnEnabled: aws.Bool(returnEnabled),
 			SearchEnabled: aws.Bool(searchEnabled),
@@ -867,8 +848,8 @@ func expandIndexField(tfMap map[string]interface{}) (*cloudsearch.IndexField, bo
 
 		apiObject.DoubleOptions = options
 
-	case cloudsearch.IndexFieldTypeDoubleArray:
-		options := &cloudsearch.DoubleArrayOptions{
+	case types.IndexFieldTypeDoubleArray:
+		options := &types.DoubleArrayOptions{
 			FacetEnabled:  aws.Bool(facetEnabled),
 			ReturnEnabled: aws.Bool(returnEnabled),
 			SearchEnabled: aws.Bool(searchEnabled),
@@ -891,8 +872,8 @@ func expandIndexField(tfMap map[string]interface{}) (*cloudsearch.IndexField, bo
 
 		apiObject.DoubleArrayOptions = options
 
-	case cloudsearch.IndexFieldTypeInt:
-		options := &cloudsearch.IntOptions{
+	case types.IndexFieldTypeInt:
+		options := &types.IntOptions{
 			FacetEnabled:  aws.Bool(facetEnabled),
 			ReturnEnabled: aws.Bool(returnEnabled),
 			SearchEnabled: aws.Bool(searchEnabled),
@@ -916,8 +897,8 @@ func expandIndexField(tfMap map[string]interface{}) (*cloudsearch.IndexField, bo
 
 		apiObject.IntOptions = options
 
-	case cloudsearch.IndexFieldTypeIntArray:
-		options := &cloudsearch.IntArrayOptions{
+	case types.IndexFieldTypeIntArray:
+		options := &types.IntArrayOptions{
 			FacetEnabled:  aws.Bool(facetEnabled),
 			ReturnEnabled: aws.Bool(returnEnabled),
 			SearchEnabled: aws.Bool(searchEnabled),
@@ -940,8 +921,8 @@ func expandIndexField(tfMap map[string]interface{}) (*cloudsearch.IndexField, bo
 
 		apiObject.IntArrayOptions = options
 
-	case cloudsearch.IndexFieldTypeLatlon:
-		options := &cloudsearch.LatLonOptions{
+	case types.IndexFieldTypeLatlon:
+		options := &types.LatLonOptions{
 			FacetEnabled:  aws.Bool(facetEnabled),
 			ReturnEnabled: aws.Bool(returnEnabled),
 			SearchEnabled: aws.Bool(searchEnabled),
@@ -959,8 +940,8 @@ func expandIndexField(tfMap map[string]interface{}) (*cloudsearch.IndexField, bo
 
 		apiObject.LatLonOptions = options
 
-	case cloudsearch.IndexFieldTypeLiteral:
-		options := &cloudsearch.LiteralOptions{
+	case types.IndexFieldTypeLiteral:
+		options := &types.LiteralOptions{
 			FacetEnabled:  aws.Bool(facetEnabled),
 			ReturnEnabled: aws.Bool(returnEnabled),
 			SearchEnabled: aws.Bool(searchEnabled),
@@ -978,8 +959,8 @@ func expandIndexField(tfMap map[string]interface{}) (*cloudsearch.IndexField, bo
 
 		apiObject.LiteralOptions = options
 
-	case cloudsearch.IndexFieldTypeLiteralArray:
-		options := &cloudsearch.LiteralArrayOptions{
+	case types.IndexFieldTypeLiteralArray:
+		options := &types.LiteralArrayOptions{
 			FacetEnabled:  aws.Bool(facetEnabled),
 			ReturnEnabled: aws.Bool(returnEnabled),
 			SearchEnabled: aws.Bool(searchEnabled),
@@ -996,8 +977,8 @@ func expandIndexField(tfMap map[string]interface{}) (*cloudsearch.IndexField, bo
 
 		apiObject.LiteralArrayOptions = options
 
-	case cloudsearch.IndexFieldTypeText:
-		options := &cloudsearch.TextOptions{
+	case types.IndexFieldTypeText:
+		options := &types.TextOptions{
 			HighlightEnabled: aws.Bool(highlightEnabled),
 			ReturnEnabled:    aws.Bool(returnEnabled),
 			SortEnabled:      aws.Bool(sortEnabled),
@@ -1018,8 +999,8 @@ func expandIndexField(tfMap map[string]interface{}) (*cloudsearch.IndexField, bo
 
 		apiObject.TextOptions = options
 
-	case cloudsearch.IndexFieldTypeTextArray:
-		options := &cloudsearch.TextArrayOptions{
+	case types.IndexFieldTypeTextArray:
+		options := &types.TextArrayOptions{
 			HighlightEnabled: aws.Bool(highlightEnabled),
 			ReturnEnabled:    aws.Bool(returnEnabled),
 		}
@@ -1046,13 +1027,13 @@ func expandIndexField(tfMap map[string]interface{}) (*cloudsearch.IndexField, bo
 	return apiObject, sourceFieldsConfigured, nil
 }
 
-func flattenIndexFieldStatus(apiObject *cloudsearch.IndexFieldStatus) (map[string]interface{}, error) {
-	if apiObject == nil || apiObject.Options == nil || apiObject.Status == nil {
+func flattenIndexFieldStatus(apiObject types.IndexFieldStatus) (map[string]interface{}, error) {
+	if apiObject.Options == nil || apiObject.Status == nil {
 		return nil, nil
 	}
 
 	// Don't read in any fields that are pending deletion.
-	if aws.BoolValue(apiObject.Status.PendingDeletion) {
+	if aws.ToBool(apiObject.Status.PendingDeletion) {
 		return nil, nil
 	}
 
@@ -1060,67 +1041,65 @@ func flattenIndexFieldStatus(apiObject *cloudsearch.IndexFieldStatus) (map[strin
 	tfMap := map[string]interface{}{}
 
 	if v := field.IndexFieldName; v != nil {
-		tfMap["name"] = aws.StringValue(v)
+		tfMap["name"] = aws.ToString(v)
 	}
 
 	fieldType := field.IndexFieldType
-	if fieldType != nil {
-		tfMap["type"] = aws.StringValue(fieldType)
-	}
+	tfMap["type"] = fieldType
 
-	switch fieldType := aws.StringValue(fieldType); fieldType {
-	case cloudsearch.IndexFieldTypeDate:
+	switch fieldType {
+	case types.IndexFieldTypeDate:
 		options := field.DateOptions
 
 		if v := options.DefaultValue; v != nil {
-			tfMap["default_value"] = aws.StringValue(v)
+			tfMap["default_value"] = aws.ToString(v)
 		}
 
 		if v := options.FacetEnabled; v != nil {
-			tfMap["facet"] = aws.BoolValue(v)
+			tfMap["facet"] = aws.ToBool(v)
 		}
 
 		if v := options.ReturnEnabled; v != nil {
-			tfMap["return"] = aws.BoolValue(v)
+			tfMap["return"] = aws.ToBool(v)
 		}
 
 		if v := options.SearchEnabled; v != nil {
-			tfMap["search"] = aws.BoolValue(v)
+			tfMap["search"] = aws.ToBool(v)
 		}
 
 		if v := options.SortEnabled; v != nil {
-			tfMap["sort"] = aws.BoolValue(v)
+			tfMap["sort"] = aws.ToBool(v)
 		}
 
 		if v := options.SourceField; v != nil {
-			tfMap["source_fields"] = aws.StringValue(v)
+			tfMap["source_fields"] = aws.ToString(v)
 		}
 
 		// Defaults not returned via the API.
 		tfMap["analysis_scheme"] = ""
 		tfMap["highlight"] = false
 
-	case cloudsearch.IndexFieldTypeDateArray:
+	case types.IndexFieldTypeDateArray:
 		options := field.DateArrayOptions
 
 		if v := options.DefaultValue; v != nil {
-			tfMap["default_value"] = aws.StringValue(v)
+			tfMap["default_value"] = aws.ToString(v)
 		}
 
 		if v := options.FacetEnabled; v != nil {
-			tfMap["facet"] = aws.BoolValue(v)
+			tfMap["facet"] = aws.ToBool(v)
 		}
 
 		if v := options.ReturnEnabled; v != nil {
-			tfMap["return"] = aws.BoolValue(v)
+			tfMap["return"] = aws.ToBool(v)
 		}
 
 		if v := options.SearchEnabled; v != nil {
-			tfMap["search"] = aws.BoolValue(v)
+			tfMap["search"] = aws.ToBool(v)
 		}
 
 		if v := options.SourceFields; v != nil {
-			tfMap["source_fields"] = aws.StringValue(v)
+			tfMap["source_fields"] = aws.ToString(v)
 		}
 
 		// Defaults not returned via the API.
@@ -1128,58 +1107,58 @@ func flattenIndexFieldStatus(apiObject *cloudsearch.IndexFieldStatus) (map[strin
 		tfMap["highlight"] = false
 		tfMap["sort"] = false
 
-	case cloudsearch.IndexFieldTypeDouble:
+	case types.IndexFieldTypeDouble:
 		options := field.DoubleOptions
 
 		if v := options.DefaultValue; v != nil {
-			tfMap["default_value"] = strconv.FormatFloat(aws.Float64Value(v), 'f', -1, 64)
+			tfMap["default_value"] = flex.Float64ToStringValue(v)
 		}
 
 		if v := options.FacetEnabled; v != nil {
-			tfMap["facet"] = aws.BoolValue(v)
+			tfMap["facet"] = aws.ToBool(v)
 		}
 
 		if v := options.ReturnEnabled; v != nil {
-			tfMap["return"] = aws.BoolValue(v)
+			tfMap["return"] = aws.ToBool(v)
 		}
 
 		if v := options.SearchEnabled; v != nil {
-			tfMap["search"] = aws.BoolValue(v)
+			tfMap["search"] = aws.ToBool(v)
 		}
 
 		if v := options.SortEnabled; v != nil {
-			tfMap["sort"] = aws.BoolValue(v)
+			tfMap["sort"] = aws.ToBool(v)
 		}
 
 		if v := options.SourceField; v != nil {
-			tfMap["source_fields"] = aws.StringValue(v)
+			tfMap["source_fields"] = aws.ToString(v)
 		}
 
 		// Defaults not returned via the API.
 		tfMap["analysis_scheme"] = ""
 		tfMap["highlight"] = false
 
-	case cloudsearch.IndexFieldTypeDoubleArray:
+	case types.IndexFieldTypeDoubleArray:
 		options := field.DoubleArrayOptions
 
 		if v := options.DefaultValue; v != nil {
-			tfMap["default_value"] = strconv.FormatFloat(aws.Float64Value(v), 'f', -1, 64)
+			tfMap["default_value"] = flex.Float64ToStringValue(v)
 		}
 
 		if v := options.FacetEnabled; v != nil {
-			tfMap["facet"] = aws.BoolValue(v)
+			tfMap["facet"] = aws.ToBool(v)
 		}
 
 		if v := options.ReturnEnabled; v != nil {
-			tfMap["return"] = aws.BoolValue(v)
+			tfMap["return"] = aws.ToBool(v)
 		}
 
 		if v := options.SearchEnabled; v != nil {
-			tfMap["search"] = aws.BoolValue(v)
+			tfMap["search"] = aws.ToBool(v)
 		}
 
 		if v := options.SourceFields; v != nil {
-			tfMap["source_fields"] = aws.StringValue(v)
+			tfMap["source_fields"] = aws.ToString(v)
 		}
 
 		// Defaults not returned via the API.
@@ -1187,58 +1166,58 @@ func flattenIndexFieldStatus(apiObject *cloudsearch.IndexFieldStatus) (map[strin
 		tfMap["highlight"] = false
 		tfMap["sort"] = false
 
-	case cloudsearch.IndexFieldTypeInt:
+	case types.IndexFieldTypeInt:
 		options := field.IntOptions
 
 		if v := options.DefaultValue; v != nil {
-			tfMap["default_value"] = strconv.FormatInt(aws.Int64Value(v), 10)
+			tfMap["default_value"] = flex.Int64ToStringValue(v)
 		}
 
 		if v := options.FacetEnabled; v != nil {
-			tfMap["facet"] = aws.BoolValue(v)
+			tfMap["facet"] = aws.ToBool(v)
 		}
 
 		if v := options.ReturnEnabled; v != nil {
-			tfMap["return"] = aws.BoolValue(v)
+			tfMap["return"] = aws.ToBool(v)
 		}
 
 		if v := options.SearchEnabled; v != nil {
-			tfMap["search"] = aws.BoolValue(v)
+			tfMap["search"] = aws.ToBool(v)
 		}
 
 		if v := options.SortEnabled; v != nil {
-			tfMap["sort"] = aws.BoolValue(v)
+			tfMap["sort"] = aws.ToBool(v)
 		}
 
 		if v := options.SourceField; v != nil {
-			tfMap["source_fields"] = aws.StringValue(v)
+			tfMap["source_fields"] = aws.ToString(v)
 		}
 
 		// Defaults not returned via the API.
 		tfMap["analysis_scheme"] = ""
 		tfMap["highlight"] = false
 
-	case cloudsearch.IndexFieldTypeIntArray:
+	case types.IndexFieldTypeIntArray:
 		options := field.IntArrayOptions
 
 		if v := options.DefaultValue; v != nil {
-			tfMap["default_value"] = strconv.FormatInt(aws.Int64Value(v), 10)
+			tfMap["default_value"] = flex.Int64ToStringValue(v)
 		}
 
 		if v := options.FacetEnabled; v != nil {
-			tfMap["facet"] = aws.BoolValue(v)
+			tfMap["facet"] = aws.ToBool(v)
 		}
 
 		if v := options.ReturnEnabled; v != nil {
-			tfMap["return"] = aws.BoolValue(v)
+			tfMap["return"] = aws.ToBool(v)
 		}
 
 		if v := options.SearchEnabled; v != nil {
-			tfMap["search"] = aws.BoolValue(v)
+			tfMap["search"] = aws.ToBool(v)
 		}
 
 		if v := options.SourceFields; v != nil {
-			tfMap["source_fields"] = aws.StringValue(v)
+			tfMap["source_fields"] = aws.ToString(v)
 		}
 
 		// Defaults not returned via the API.
@@ -1246,89 +1225,89 @@ func flattenIndexFieldStatus(apiObject *cloudsearch.IndexFieldStatus) (map[strin
 		tfMap["highlight"] = false
 		tfMap["sort"] = false
 
-	case cloudsearch.IndexFieldTypeLatlon:
+	case types.IndexFieldTypeLatlon:
 		options := field.LatLonOptions
 
 		if v := options.DefaultValue; v != nil {
-			tfMap["default_value"] = aws.StringValue(v)
+			tfMap["default_value"] = aws.ToString(v)
 		}
 
 		if v := options.FacetEnabled; v != nil {
-			tfMap["facet"] = aws.BoolValue(v)
+			tfMap["facet"] = aws.ToBool(v)
 		}
 
 		if v := options.ReturnEnabled; v != nil {
-			tfMap["return"] = aws.BoolValue(v)
+			tfMap["return"] = aws.ToBool(v)
 		}
 
 		if v := options.SearchEnabled; v != nil {
-			tfMap["search"] = aws.BoolValue(v)
+			tfMap["search"] = aws.ToBool(v)
 		}
 
 		if v := options.SortEnabled; v != nil {
-			tfMap["sort"] = aws.BoolValue(v)
+			tfMap["sort"] = aws.ToBool(v)
 		}
 
 		if v := options.SourceField; v != nil {
-			tfMap["source_fields"] = aws.StringValue(v)
+			tfMap["source_fields"] = aws.ToString(v)
 		}
 
 		// Defaults not returned via the API.
 		tfMap["analysis_scheme"] = ""
 		tfMap["highlight"] = false
 
-	case cloudsearch.IndexFieldTypeLiteral:
+	case types.IndexFieldTypeLiteral:
 		options := field.LiteralOptions
 
 		if v := options.DefaultValue; v != nil {
-			tfMap["default_value"] = aws.StringValue(v)
+			tfMap["default_value"] = aws.ToString(v)
 		}
 
 		if v := options.FacetEnabled; v != nil {
-			tfMap["facet"] = aws.BoolValue(v)
+			tfMap["facet"] = aws.ToBool(v)
 		}
 
 		if v := options.ReturnEnabled; v != nil {
-			tfMap["return"] = aws.BoolValue(v)
+			tfMap["return"] = aws.ToBool(v)
 		}
 
 		if v := options.SearchEnabled; v != nil {
-			tfMap["search"] = aws.BoolValue(v)
+			tfMap["search"] = aws.ToBool(v)
 		}
 
 		if v := options.SortEnabled; v != nil {
-			tfMap["sort"] = aws.BoolValue(v)
+			tfMap["sort"] = aws.ToBool(v)
 		}
 
 		if v := options.SourceField; v != nil {
-			tfMap["source_fields"] = aws.StringValue(v)
+			tfMap["source_fields"] = aws.ToString(v)
 		}
 
 		// Defaults not returned via the API.
 		tfMap["analysis_scheme"] = ""
 		tfMap["highlight"] = false
 
-	case cloudsearch.IndexFieldTypeLiteralArray:
+	case types.IndexFieldTypeLiteralArray:
 		options := field.LiteralArrayOptions
 
 		if v := options.DefaultValue; v != nil {
-			tfMap["default_value"] = aws.StringValue(v)
+			tfMap["default_value"] = aws.ToString(v)
 		}
 
 		if v := options.FacetEnabled; v != nil {
-			tfMap["facet"] = aws.BoolValue(v)
+			tfMap["facet"] = aws.ToBool(v)
 		}
 
 		if v := options.ReturnEnabled; v != nil {
-			tfMap["return"] = aws.BoolValue(v)
+			tfMap["return"] = aws.ToBool(v)
 		}
 
 		if v := options.SearchEnabled; v != nil {
-			tfMap["search"] = aws.BoolValue(v)
+			tfMap["search"] = aws.ToBool(v)
 		}
 
 		if v := options.SourceFields; v != nil {
-			tfMap["source_fields"] = aws.StringValue(v)
+			tfMap["source_fields"] = aws.ToString(v)
 		}
 
 		// Defaults not returned via the API.
@@ -1336,58 +1315,58 @@ func flattenIndexFieldStatus(apiObject *cloudsearch.IndexFieldStatus) (map[strin
 		tfMap["highlight"] = false
 		tfMap["sort"] = false
 
-	case cloudsearch.IndexFieldTypeText:
+	case types.IndexFieldTypeText:
 		options := field.TextOptions
 
 		if v := options.AnalysisScheme; v != nil {
-			tfMap["analysis_scheme"] = aws.StringValue(v)
+			tfMap["analysis_scheme"] = aws.ToString(v)
 		}
 
 		if v := options.DefaultValue; v != nil {
-			tfMap["default_value"] = aws.StringValue(v)
+			tfMap["default_value"] = aws.ToString(v)
 		}
 
 		if v := options.HighlightEnabled; v != nil {
-			tfMap["highlight"] = aws.BoolValue(v)
+			tfMap["highlight"] = aws.ToBool(v)
 		}
 
 		if v := options.ReturnEnabled; v != nil {
-			tfMap["return"] = aws.BoolValue(v)
+			tfMap["return"] = aws.ToBool(v)
 		}
 
 		if v := options.SortEnabled; v != nil {
-			tfMap["sort"] = aws.BoolValue(v)
+			tfMap["sort"] = aws.ToBool(v)
 		}
 
 		if v := options.SourceField; v != nil {
-			tfMap["source_fields"] = aws.StringValue(v)
+			tfMap["source_fields"] = aws.ToString(v)
 		}
 
 		// Defaults not returned via the API.
 		tfMap["facet"] = false
 		tfMap["search"] = true
 
-	case cloudsearch.IndexFieldTypeTextArray:
+	case types.IndexFieldTypeTextArray:
 		options := field.TextArrayOptions
 
 		if v := options.AnalysisScheme; v != nil {
-			tfMap["analysis_scheme"] = aws.StringValue(v)
+			tfMap["analysis_scheme"] = aws.ToString(v)
 		}
 
 		if v := options.DefaultValue; v != nil {
-			tfMap["default_value"] = aws.StringValue(v)
+			tfMap["default_value"] = aws.ToString(v)
 		}
 
 		if v := options.HighlightEnabled; v != nil {
-			tfMap["highlight"] = aws.BoolValue(v)
+			tfMap["highlight"] = aws.ToBool(v)
 		}
 
 		if v := options.ReturnEnabled; v != nil {
-			tfMap["return"] = aws.BoolValue(v)
+			tfMap["return"] = aws.ToBool(v)
 		}
 
 		if v := options.SourceFields; v != nil {
-			tfMap["source_fields"] = aws.StringValue(v)
+			tfMap["source_fields"] = aws.ToString(v)
 		}
 
 		// Defaults not returned via the API.
@@ -1402,7 +1381,7 @@ func flattenIndexFieldStatus(apiObject *cloudsearch.IndexFieldStatus) (map[strin
 	return tfMap, nil
 }
 
-func flattenIndexFieldStatuses(apiObjects []*cloudsearch.IndexFieldStatus) ([]interface{}, error) {
+func flattenIndexFieldStatuses(apiObjects []types.IndexFieldStatus) ([]interface{}, error) {
 	if len(apiObjects) == 0 {
 		return nil, nil
 	}
@@ -1410,10 +1389,6 @@ func flattenIndexFieldStatuses(apiObjects []*cloudsearch.IndexFieldStatus) ([]in
 	var tfList []interface{}
 
 	for _, apiObject := range apiObjects {
-		if apiObject == nil {
-			continue
-		}
-
 		tfMap, err := flattenIndexFieldStatus(apiObject)
 
 		if err != nil {
@@ -1426,45 +1401,37 @@ func flattenIndexFieldStatuses(apiObjects []*cloudsearch.IndexFieldStatus) ([]in
 	return tfList, nil
 }
 
-func expandScalingParameters(tfMap map[string]interface{}) *cloudsearch.ScalingParameters {
+func expandScalingParameters(tfMap map[string]interface{}) *types.ScalingParameters {
 	if tfMap == nil {
 		return nil
 	}
 
-	apiObject := &cloudsearch.ScalingParameters{}
+	apiObject := &types.ScalingParameters{}
 
 	if v, ok := tfMap["desired_instance_type"].(string); ok && v != "" {
-		apiObject.DesiredInstanceType = aws.String(v)
+		apiObject.DesiredInstanceType = types.PartitionInstanceType(v)
 	}
 
 	if v, ok := tfMap["desired_partition_count"].(int); ok && v != 0 {
-		apiObject.DesiredPartitionCount = aws.Int64(int64(v))
+		apiObject.DesiredPartitionCount = int32(v)
 	}
 
 	if v, ok := tfMap["desired_replication_count"].(int); ok && v != 0 {
-		apiObject.DesiredReplicationCount = aws.Int64(int64(v))
+		apiObject.DesiredReplicationCount = int32(v)
 	}
 
 	return apiObject
 }
 
-func flattenScalingParameters(apiObject *cloudsearch.ScalingParameters) map[string]interface{} {
+func flattenScalingParameters(apiObject *types.ScalingParameters) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
-
-	if v := apiObject.DesiredInstanceType; v != nil {
-		tfMap["desired_instance_type"] = aws.StringValue(v)
-	}
-
-	if v := apiObject.DesiredPartitionCount; v != nil {
-		tfMap["desired_partition_count"] = aws.Int64Value(v)
-	}
-
-	if v := apiObject.DesiredReplicationCount; v != nil {
-		tfMap["desired_replication_count"] = aws.Int64Value(v)
+	tfMap := map[string]interface{}{
+		"desired_instance_type":     apiObject.DesiredInstanceType,
+		"desired_partition_count":   apiObject.DesiredPartitionCount,
+		"desired_replication_count": apiObject.DesiredReplicationCount,
 	}
 
 	return tfMap

--- a/internal/service/cloudsearch/domain_service_access_policy.go
+++ b/internal/service/cloudsearch/domain_service_access_policy.go
@@ -8,27 +8,30 @@ import (
 	"log"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/cloudsearch"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudsearch"
+	"github.com/aws/aws-sdk-go-v2/service/cloudsearch/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-// @SDKResource("aws_cloudsearch_domain_service_access_policy")
-func ResourceDomainServiceAccessPolicy() *schema.Resource {
+// @SDKResource("aws_cloudsearch_domain_service_access_policy", name="Domain Service Access Policy")
+func resourceDomainServiceAccessPolicy() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceDomainServiceAccessPolicyPut,
 		ReadWithoutTimeout:   resourceDomainServiceAccessPolicyRead,
 		UpdateWithoutTimeout: resourceDomainServiceAccessPolicyPut,
 		DeleteWithoutTimeout: resourceDomainServiceAccessPolicyDelete,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -60,35 +63,32 @@ func ResourceDomainServiceAccessPolicy() *schema.Resource {
 
 func resourceDomainServiceAccessPolicyPut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).CloudSearchConn(ctx)
-
-	domainName := d.Get("domain_name").(string)
-	input := &cloudsearch.UpdateServiceAccessPoliciesInput{
-		DomainName: aws.String(domainName),
-	}
+	conn := meta.(*conns.AWSClient).CloudSearchClient(ctx)
 
 	accessPolicy := d.Get("access_policy").(string)
 	policy, err := structure.NormalizeJsonString(accessPolicy)
-
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "policy (%s) is invalid JSON: %s", accessPolicy, err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	input.AccessPolicies = aws.String(policy)
+	domainName := d.Get("domain_name").(string)
+	input := &cloudsearch.UpdateServiceAccessPoliciesInput{
+		AccessPolicies: aws.String(policy),
+		DomainName:     aws.String(domainName),
+	}
 
-	log.Printf("[DEBUG] Updating CloudSearch Domain access policies: %s", input)
-	_, err = conn.UpdateServiceAccessPoliciesWithContext(ctx, input)
+	_, err = conn.UpdateServiceAccessPolicies(ctx, input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "updating CloudSearch Domain Service Access Policy (%s): %s", domainName, err)
 	}
 
-	d.SetId(domainName)
+	if d.IsNewResource() {
+		d.SetId(domainName)
+	}
 
-	_, err = waitAccessPolicyActive(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "waiting for CloudSearch Domain Service Access Policy (%s) to become active: %s", d.Id(), err)
+	if _, err := waitAccessPolicyActive(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "waiting for CloudSearch Domain Service Access Policy (%s) update: %s", d.Id(), err)
 	}
 
 	return append(diags, resourceDomainServiceAccessPolicyRead(ctx, d, meta)...)
@@ -96,9 +96,9 @@ func resourceDomainServiceAccessPolicyPut(ctx context.Context, d *schema.Resourc
 
 func resourceDomainServiceAccessPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).CloudSearchConn(ctx)
+	conn := meta.(*conns.AWSClient).CloudSearchClient(ctx)
 
-	accessPolicy, err := FindAccessPolicyByName(ctx, conn, d.Id())
+	accessPolicy, err := findAccessPolicyByName(ctx, conn, d.Id())
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] CloudSearch Domain Service Access Policy (%s) not found, removing from state", d.Id())
@@ -124,17 +124,15 @@ func resourceDomainServiceAccessPolicyRead(ctx context.Context, d *schema.Resour
 
 func resourceDomainServiceAccessPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).CloudSearchConn(ctx)
-
-	input := &cloudsearch.UpdateServiceAccessPoliciesInput{
-		AccessPolicies: aws.String(""),
-		DomainName:     aws.String(d.Id()),
-	}
+	conn := meta.(*conns.AWSClient).CloudSearchClient(ctx)
 
 	log.Printf("[DEBUG] Deleting CloudSearch Domain Service Access Policy: %s", d.Id())
-	_, err := conn.UpdateServiceAccessPoliciesWithContext(ctx, input)
+	_, err := conn.UpdateServiceAccessPolicies(ctx, &cloudsearch.UpdateServiceAccessPoliciesInput{
+		AccessPolicies: aws.String(""),
+		DomainName:     aws.String(d.Id()),
+	})
 
-	if tfawserr.ErrCodeEquals(err, cloudsearch.ErrCodeResourceNotFoundException) {
+	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return diags
 	}
 
@@ -142,23 +140,21 @@ func resourceDomainServiceAccessPolicyDelete(ctx context.Context, d *schema.Reso
 		return sdkdiag.AppendErrorf(diags, "deleting CloudSearch Domain Service Access Policy (%s): %s", d.Id(), err)
 	}
 
-	_, err = waitAccessPolicyActive(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete))
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "waiting for CloudSearch Domain Service Access Policy (%s) to delete: %s", d.Id(), err)
+	if _, err := waitAccessPolicyActive(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "waiting for CloudSearch Domain Service Access Policy (%s) delete: %s", d.Id(), err)
 	}
 
 	return diags
 }
 
-func FindAccessPolicyByName(ctx context.Context, conn *cloudsearch.CloudSearch, name string) (string, error) {
+func findAccessPolicyByName(ctx context.Context, conn *cloudsearch.Client, name string) (string, error) {
 	output, err := findAccessPoliciesStatusByName(ctx, conn, name)
 
 	if err != nil {
 		return "", err
 	}
 
-	accessPolicy := aws.StringValue(output.Options)
+	accessPolicy := aws.ToString(output.Options)
 
 	if accessPolicy == "" {
 		return "", tfresource.NewEmptyResultError(name)
@@ -167,14 +163,14 @@ func FindAccessPolicyByName(ctx context.Context, conn *cloudsearch.CloudSearch, 
 	return accessPolicy, nil
 }
 
-func findAccessPoliciesStatusByName(ctx context.Context, conn *cloudsearch.CloudSearch, name string) (*cloudsearch.AccessPoliciesStatus, error) {
+func findAccessPoliciesStatusByName(ctx context.Context, conn *cloudsearch.Client, name string) (*types.AccessPoliciesStatus, error) {
 	input := &cloudsearch.DescribeServiceAccessPoliciesInput{
 		DomainName: aws.String(name),
 	}
 
-	output, err := conn.DescribeServiceAccessPoliciesWithContext(ctx, input)
+	output, err := conn.DescribeServiceAccessPolicies(ctx, input)
 
-	if tfawserr.ErrCodeEquals(err, cloudsearch.ErrCodeResourceNotFoundException) {
+	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return nil, &retry.NotFoundError{
 			LastError:   err,
 			LastRequest: input,
@@ -192,7 +188,7 @@ func findAccessPoliciesStatusByName(ctx context.Context, conn *cloudsearch.Cloud
 	return output.AccessPolicies, nil
 }
 
-func statusAccessPolicyState(ctx context.Context, conn *cloudsearch.CloudSearch, name string) retry.StateRefreshFunc {
+func statusAccessPolicyState(ctx context.Context, conn *cloudsearch.Client, name string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		output, err := findAccessPoliciesStatusByName(ctx, conn, name)
 
@@ -204,21 +200,21 @@ func statusAccessPolicyState(ctx context.Context, conn *cloudsearch.CloudSearch,
 			return nil, "", err
 		}
 
-		return output, aws.StringValue(output.Status.State), nil
+		return output, string(output.Status.State), nil
 	}
 }
 
-func waitAccessPolicyActive(ctx context.Context, conn *cloudsearch.CloudSearch, name string, timeout time.Duration) (*cloudsearch.AccessPoliciesStatus, error) { //nolint:unparam
+func waitAccessPolicyActive(ctx context.Context, conn *cloudsearch.Client, name string, timeout time.Duration) (*types.AccessPoliciesStatus, error) { //nolint:unparam
 	stateConf := &retry.StateChangeConf{
-		Pending: []string{cloudsearch.OptionStateProcessing},
-		Target:  []string{cloudsearch.OptionStateActive},
+		Pending: enum.Slice(types.OptionStateProcessing),
+		Target:  enum.Slice(types.OptionStateActive),
 		Refresh: statusAccessPolicyState(ctx, conn, name),
 		Timeout: timeout,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
-	if output, ok := outputRaw.(*cloudsearch.AccessPoliciesStatus); ok {
+	if output, ok := outputRaw.(*types.AccessPoliciesStatus); ok {
 		return output, err
 	}
 

--- a/internal/service/cloudsearch/domain_service_access_policy_test.go
+++ b/internal/service/cloudsearch/domain_service_access_policy_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/cloudsearch"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -16,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfcloudsearch "github.com/hashicorp/terraform-provider-aws/internal/service/cloudsearch"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccCloudSearchDomainServiceAccessPolicy_basic(t *testing.T) {
@@ -24,8 +24,8 @@ func TestAccCloudSearchDomainServiceAccessPolicy_basic(t *testing.T) {
 	rName := acctest.ResourcePrefix + "-" + sdkacctest.RandString(28-(len(acctest.ResourcePrefix)+1))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, cloudsearch.EndpointsID) },
-		ErrorCheck:               acctest.ErrorCheck(t, cloudsearch.EndpointsID),
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudSearchEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudSearchEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDomainServiceAccessPolicyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -51,8 +51,8 @@ func TestAccCloudSearchDomainServiceAccessPolicy_update(t *testing.T) {
 	rName := acctest.ResourcePrefix + "-" + sdkacctest.RandString(28-(len(acctest.ResourcePrefix)+1))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, cloudsearch.EndpointsID) },
-		ErrorCheck:               acctest.ErrorCheck(t, cloudsearch.EndpointsID),
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudSearchEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudSearchEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDomainServiceAccessPolicyDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -86,11 +86,7 @@ func testAccDomainServiceAccessPolicyExists(ctx context.Context, n string) resou
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No CloudSearch Domain Service Access Policy ID is set")
-		}
-
-		conn := acctest.Provider.Meta().(*conns.AWSClient).CloudSearchConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).CloudSearchClient(ctx)
 
 		_, err := tfcloudsearch.FindAccessPolicyByName(ctx, conn, rs.Primary.ID)
 
@@ -105,7 +101,7 @@ func testAccCheckDomainServiceAccessPolicyDestroy(ctx context.Context) resource.
 				continue
 			}
 
-			conn := acctest.Provider.Meta().(*conns.AWSClient).CloudSearchConn(ctx)
+			conn := acctest.Provider.Meta().(*conns.AWSClient).CloudSearchClient(ctx)
 
 			_, err := tfcloudsearch.FindAccessPolicyByName(ctx, conn, rs.Primary.ID)
 

--- a/internal/service/cloudsearch/domain_test.go
+++ b/internal/service/cloudsearch/domain_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/cloudsearch"
+	"github.com/aws/aws-sdk-go-v2/service/cloudsearch/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -16,17 +16,18 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfcloudsearch "github.com/hashicorp/terraform-provider-aws/internal/service/cloudsearch"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccCloudSearchDomain_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	var v cloudsearch.DomainStatus
+	var v types.DomainStatus
 	resourceName := "aws_cloudsearch_domain.test"
 	rName := testAccDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, cloudsearch.EndpointsID) },
-		ErrorCheck:               acctest.ErrorCheck(t, cloudsearch.EndpointsID),
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudSearchEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudSearchEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDomainDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -59,13 +60,13 @@ func TestAccCloudSearchDomain_basic(t *testing.T) {
 
 func TestAccCloudSearchDomain_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	var v cloudsearch.DomainStatus
+	var v types.DomainStatus
 	resourceName := "aws_cloudsearch_domain.test"
 	rName := testAccDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, cloudsearch.EndpointsID) },
-		ErrorCheck:               acctest.ErrorCheck(t, cloudsearch.EndpointsID),
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudSearchEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudSearchEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDomainDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -83,13 +84,13 @@ func TestAccCloudSearchDomain_disappears(t *testing.T) {
 
 func TestAccCloudSearchDomain_indexFields(t *testing.T) {
 	ctx := acctest.Context(t)
-	var v cloudsearch.DomainStatus
+	var v types.DomainStatus
 	resourceName := "aws_cloudsearch_domain.test"
 	rName := testAccDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, cloudsearch.EndpointsID) },
-		ErrorCheck:               acctest.ErrorCheck(t, cloudsearch.EndpointsID),
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudSearchEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudSearchEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDomainDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -148,13 +149,13 @@ func TestAccCloudSearchDomain_indexFields(t *testing.T) {
 
 func TestAccCloudSearchDomain_sourceFields(t *testing.T) {
 	ctx := acctest.Context(t)
-	var v cloudsearch.DomainStatus
+	var v types.DomainStatus
 	resourceName := "aws_cloudsearch_domain.test"
 	rName := testAccDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, cloudsearch.EndpointsID) },
-		ErrorCheck:               acctest.ErrorCheck(t, cloudsearch.EndpointsID),
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudSearchEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudSearchEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDomainDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -223,13 +224,13 @@ func TestAccCloudSearchDomain_sourceFields(t *testing.T) {
 
 func TestAccCloudSearchDomain_update(t *testing.T) {
 	ctx := acctest.Context(t)
-	var v cloudsearch.DomainStatus
+	var v types.DomainStatus
 	resourceName := "aws_cloudsearch_domain.test"
 	rName := testAccDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, cloudsearch.EndpointsID) },
-		ErrorCheck:               acctest.ErrorCheck(t, cloudsearch.EndpointsID),
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudSearchEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudSearchEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDomainDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -292,18 +293,14 @@ func testAccDomainName() string {
 	return acctest.ResourcePrefix + "-" + sdkacctest.RandString(28-(len(acctest.ResourcePrefix)+1))
 }
 
-func testAccDomainExists(ctx context.Context, n string, v *cloudsearch.DomainStatus) resource.TestCheckFunc {
+func testAccDomainExists(ctx context.Context, n string, v *types.DomainStatus) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No CloudSearch Domain ID is set")
-		}
-
-		conn := acctest.Provider.Meta().(*conns.AWSClient).CloudSearchConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).CloudSearchClient(ctx)
 
 		output, err := tfcloudsearch.FindDomainByName(ctx, conn, rs.Primary.ID)
 
@@ -324,7 +321,7 @@ func testAccCheckDomainDestroy(ctx context.Context) resource.TestCheckFunc {
 				continue
 			}
 
-			conn := acctest.Provider.Meta().(*conns.AWSClient).CloudSearchConn(ctx)
+			conn := acctest.Provider.Meta().(*conns.AWSClient).CloudSearchClient(ctx)
 
 			_, err := tfcloudsearch.FindDomainByName(ctx, conn, rs.Primary.ID)
 

--- a/internal/service/cloudsearch/domain_test.go
+++ b/internal/service/cloudsearch/domain_test.go
@@ -305,7 +305,7 @@ func testAccDomainExists(ctx context.Context, n string, v *cloudsearch.DomainSta
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).CloudSearchConn(ctx)
 
-		output, err := tfcloudsearch.FindDomainStatusByName(ctx, conn, rs.Primary.ID)
+		output, err := tfcloudsearch.FindDomainByName(ctx, conn, rs.Primary.ID)
 
 		if err != nil {
 			return err
@@ -326,7 +326,7 @@ func testAccCheckDomainDestroy(ctx context.Context) resource.TestCheckFunc {
 
 			conn := acctest.Provider.Meta().(*conns.AWSClient).CloudSearchConn(ctx)
 
-			_, err := tfcloudsearch.FindDomainStatusByName(ctx, conn, rs.Primary.ID)
+			_, err := tfcloudsearch.FindDomainByName(ctx, conn, rs.Primary.ID)
 
 			if tfresource.NotFound(err) {
 				continue

--- a/internal/service/cloudsearch/exports_test.go
+++ b/internal/service/cloudsearch/exports_test.go
@@ -1,0 +1,11 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cloudsearch
+
+// Exports for use in tests only.
+var (
+	ResourceDomainServiceAccessPolicy = resourceDomainServiceAccessPolicy
+
+	FindAccessPolicyByName = findAccessPolicyByName
+)

--- a/internal/service/cloudsearch/exports_test.go
+++ b/internal/service/cloudsearch/exports_test.go
@@ -5,7 +5,9 @@ package cloudsearch
 
 // Exports for use in tests only.
 var (
+	ResourceDomain                    = resourceDomain
 	ResourceDomainServiceAccessPolicy = resourceDomainServiceAccessPolicy
 
 	FindAccessPolicyByName = findAccessPolicyByName
+	FindDomainByName       = findDomainByName
 )

--- a/internal/service/cloudsearch/service_endpoints_gen_test.go
+++ b/internal/service/cloudsearch/service_endpoints_gen_test.go
@@ -4,16 +4,16 @@ package cloudsearch_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
-	cloudsearch_sdkv1 "github.com/aws/aws-sdk-go/service/cloudsearch"
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	cloudsearch_sdkv2 "github.com/aws/aws-sdk-go-v2/service/cloudsearch"
 	"github.com/aws/smithy-go/middleware"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
@@ -212,32 +212,42 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 }
 
 func defaultEndpoint(region string) string {
-	r := endpoints.DefaultResolver()
+	r := cloudsearch_sdkv2.NewDefaultEndpointResolverV2()
 
-	ep, err := r.EndpointFor(cloudsearch_sdkv1.EndpointsID, region)
+	ep, err := r.ResolveEndpoint(context.Background(), cloudsearch_sdkv2.EndpointParameters{
+		Region: aws_sdkv2.String(region),
+	})
 	if err != nil {
 		return err.Error()
 	}
 
-	url, _ := url.Parse(ep.URL)
-
-	if url.Path == "" {
-		url.Path = "/"
+	if ep.URI.Path == "" {
+		ep.URI.Path = "/"
 	}
 
-	return url.String()
+	return ep.URI.String()
 }
 
 func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) string {
 	t.Helper()
 
-	client := meta.CloudSearchConn(ctx)
+	var endpoint string
 
-	req, _ := client.ListDomainNamesRequest(&cloudsearch_sdkv1.ListDomainNamesInput{})
+	client := meta.CloudSearchClient(ctx)
 
-	req.HTTPRequest.URL.Path = "/"
-
-	endpoint := req.HTTPRequest.URL.String()
+	_, err := client.ListDomainNames(ctx, &cloudsearch_sdkv2.ListDomainNamesInput{},
+		func(opts *cloudsearch_sdkv2.Options) {
+			opts.APIOptions = append(opts.APIOptions,
+				addRetrieveEndpointURLMiddleware(t, &endpoint),
+				addCancelRequestMiddleware(),
+			)
+		},
+	)
+	if err == nil {
+		t.Fatal("Expected an error, got none")
+	} else if !errors.Is(err, errCancelOperation) {
+		t.Fatalf("Unexpected error: %s", err)
+	}
 
 	return endpoint
 }

--- a/internal/service/cloudsearch/service_package_gen.go
+++ b/internal/service/cloudsearch/service_package_gen.go
@@ -5,9 +5,8 @@ package cloudsearch
 import (
 	"context"
 
-	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
-	session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
-	cloudsearch_sdkv1 "github.com/aws/aws-sdk-go/service/cloudsearch"
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	cloudsearch_sdkv2 "github.com/aws/aws-sdk-go-v2/service/cloudsearch"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -44,11 +43,15 @@ func (p *servicePackage) ServicePackageName() string {
 	return names.CloudSearch
 }
 
-// NewConn returns a new AWS SDK for Go v1 client for this service package's AWS API.
-func (p *servicePackage) NewConn(ctx context.Context, config map[string]any) (*cloudsearch_sdkv1.CloudSearch, error) {
-	sess := config["session"].(*session_sdkv1.Session)
+// NewClient returns a new AWS SDK for Go v2 client for this service package's AWS API.
+func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (*cloudsearch_sdkv2.Client, error) {
+	cfg := *(config["aws_sdkv2_config"].(*aws_sdkv2.Config))
 
-	return cloudsearch_sdkv1.New(sess.Copy(&aws_sdkv1.Config{Endpoint: aws_sdkv1.String(config["endpoint"].(string))})), nil
+	return cloudsearch_sdkv2.NewFromConfig(cfg, func(o *cloudsearch_sdkv2.Options) {
+		if endpoint := config["endpoint"].(string); endpoint != "" {
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
+		}
+	}), nil
 }
 
 func ServicePackage(ctx context.Context) conns.ServicePackage {

--- a/internal/service/cloudsearch/service_package_gen.go
+++ b/internal/service/cloudsearch/service_package_gen.go
@@ -33,8 +33,9 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			TypeName: "aws_cloudsearch_domain",
 		},
 		{
-			Factory:  ResourceDomainServiceAccessPolicy,
+			Factory:  resourceDomainServiceAccessPolicy,
 			TypeName: "aws_cloudsearch_domain_service_access_policy",
+			Name:     "Domain Service Access Policy",
 		},
 	}
 }

--- a/internal/service/cloudsearch/service_package_gen.go
+++ b/internal/service/cloudsearch/service_package_gen.go
@@ -29,8 +29,9 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePackageSDKResource {
 	return []*types.ServicePackageSDKResource{
 		{
-			Factory:  ResourceDomain,
+			Factory:  resourceDomain,
 			TypeName: "aws_cloudsearch_domain",
+			Name:     "Domain",
 		},
 		{
 			Factory:  resourceDomainServiceAccessPolicy,

--- a/internal/service/cloudsearch/sweep.go
+++ b/internal/service/cloudsearch/sweep.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/cloudsearch"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudsearch"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
-	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv1"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
 )
 
 func RegisterSweepers() {
@@ -27,25 +27,28 @@ func sweepDomains(region string) error {
 	if err != nil {
 		return fmt.Errorf("error getting client: %s", err)
 	}
-	conn := client.CloudSearchConn(ctx)
+	conn := client.CloudSearchClient(ctx)
 	input := &cloudsearch.DescribeDomainsInput{}
 	sweepResources := make([]sweep.Sweepable, 0)
 
-	domains, err := conn.DescribeDomainsWithContext(ctx, input)
+	domains, err := conn.DescribeDomains(ctx, input)
 
-	for _, domain := range domains.DomainStatusList {
-		if aws.BoolValue(domain.Deleted) {
+	for _, v := range domains.DomainStatusList {
+		name := aws.ToString(v.DomainName)
+
+		if deleted := aws.ToBool(v.Deleted); deleted {
+			log.Printf("[INFO] Skipping CloudSearch Domain %s: Deleted=%s", name, deleted)
 			continue
 		}
 
-		r := ResourceDomain()
+		r := resourceDomain()
 		d := r.Data(nil)
-		d.SetId(aws.StringValue(domain.DomainName))
+		d.SetId(name)
 
 		sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 	}
 
-	if awsv1.SkipSweepError(err) {
+	if awsv2.SkipSweepError(err) {
 		log.Printf("[WARN] Skipping CloudSearch Domain sweep for %s: %s", region, err)
 		return nil
 	}

--- a/internal/service/cloudsearch/sweep.go
+++ b/internal/service/cloudsearch/sweep.go
@@ -37,7 +37,7 @@ func sweepDomains(region string) error {
 		name := aws.ToString(v.DomainName)
 
 		if deleted := aws.ToBool(v.Deleted); deleted {
-			log.Printf("[INFO] Skipping CloudSearch Domain %s: Deleted=%s", name, deleted)
+			log.Printf("[INFO] Skipping CloudSearch Domain %s: Deleted=%t", name, deleted)
 			continue
 		}
 

--- a/names/data/names_data.csv
+++ b/names/data/names_data.csv
@@ -64,7 +64,7 @@ cloudformation,cloudformation,cloudformation,cloudformation,,cloudformation,,,Cl
 cloudfront,cloudfront,cloudfront,cloudfront,,cloudfront,,,CloudFront,CloudFront,,1,,,aws_cloudfront_,,cloudfront_,CloudFront,Amazon,,,,,,,CloudFront,ListDistributions,,
 cloudhsm,cloudhsm,cloudhsm,cloudhsm,,,,,,,,,,,,,,CloudHSM,AWS,x,,,,,,,,,Legacy
 cloudhsmv2,cloudhsmv2,cloudhsmv2,cloudhsmv2,,cloudhsmv2,,cloudhsm,CloudHSMV2,CloudHSMV2,,1,,aws_cloudhsm_v2_,aws_cloudhsmv2_,,cloudhsm,CloudHSM,AWS,,,,,,,CloudHSM V2,DescribeClusters,,
-cloudsearch,cloudsearch,cloudsearch,cloudsearch,,cloudsearch,,,CloudSearch,CloudSearch,,1,,,aws_cloudsearch_,,cloudsearch_,CloudSearch,Amazon,,,,,,,CloudSearch,ListDomainNames,,
+cloudsearch,cloudsearch,cloudsearch,cloudsearch,,cloudsearch,,,CloudSearch,CloudSearch,,,2,,aws_cloudsearch_,,cloudsearch_,CloudSearch,Amazon,,,,,,,CloudSearch,ListDomainNames,,
 cloudsearchdomain,cloudsearchdomain,cloudsearchdomain,cloudsearchdomain,,cloudsearchdomain,,,CloudSearchDomain,CloudSearchDomain,,1,,,aws_cloudsearchdomain_,,cloudsearchdomain_,CloudSearch Domain,Amazon,,x,,,,,CloudSearch Domain,,,
 ,,,,,,,,,,,,,,,,,CloudShell,AWS,x,,,,,,,,,No SDK support
 cloudtrail,cloudtrail,cloudtrail,cloudtrail,,cloudtrail,,,CloudTrail,CloudTrail,,,2,aws_cloudtrail,aws_cloudtrail_,,cloudtrail,CloudTrail,AWS,,,,,,,CloudTrail,ListChannels,,

--- a/names/names.go
+++ b/names/names.go
@@ -38,6 +38,7 @@ const (
 	ChimeSDKVoiceEndpointID              = "voice-chime"
 	ChimeSDKMediaPipelinesEndpointID     = "media-pipelines-chime"
 	CleanRoomsEndpointID                 = "cleanrooms"
+	CloudSearchEndpointID                = "cloudsearch"
 	CloudTrailEndpointID                 = "cloudtrail"
 	CloudWatchEndpointID                 = "monitoring"
 	CloudWatchLogsEndpointID             = "logs"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Ibid.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/32976.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccCloudSearch' PKG=cloudsearch ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudsearch/... -v -count 1 -parallel 2  -run=TestAccCloudSearch -timeout 360m
=== RUN   TestAccCloudSearchDomainServiceAccessPolicy_basic
=== PAUSE TestAccCloudSearchDomainServiceAccessPolicy_basic
=== RUN   TestAccCloudSearchDomainServiceAccessPolicy_update
=== PAUSE TestAccCloudSearchDomainServiceAccessPolicy_update
=== RUN   TestAccCloudSearchDomain_basic
=== PAUSE TestAccCloudSearchDomain_basic
=== RUN   TestAccCloudSearchDomain_disappears
=== PAUSE TestAccCloudSearchDomain_disappears
=== RUN   TestAccCloudSearchDomain_indexFields
=== PAUSE TestAccCloudSearchDomain_indexFields
=== RUN   TestAccCloudSearchDomain_sourceFields
=== PAUSE TestAccCloudSearchDomain_sourceFields
=== RUN   TestAccCloudSearchDomain_update
=== PAUSE TestAccCloudSearchDomain_update
=== CONT  TestAccCloudSearchDomainServiceAccessPolicy_basic
=== CONT  TestAccCloudSearchDomain_indexFields
--- PASS: TestAccCloudSearchDomainServiceAccessPolicy_basic (1809.10s)
=== CONT  TestAccCloudSearchDomain_update
--- PASS: TestAccCloudSearchDomain_indexFields (2594.00s)
=== CONT  TestAccCloudSearchDomain_sourceFields
--- PASS: TestAccCloudSearchDomain_update (2058.34s)
=== CONT  TestAccCloudSearchDomain_basic
--- PASS: TestAccCloudSearchDomain_sourceFields (1633.14s)
=== CONT  TestAccCloudSearchDomain_disappears
--- PASS: TestAccCloudSearchDomain_basic (704.65s)
=== CONT  TestAccCloudSearchDomainServiceAccessPolicy_update
--- PASS: TestAccCloudSearchDomain_disappears (824.51s)
--- PASS: TestAccCloudSearchDomainServiceAccessPolicy_update (2462.50s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudsearch	7045.461s
```
