### PR TITLE
Verified Access: Limit acceptance test concurrency

### DIFF
--- a/docs/acc-test-environment-variables.md
+++ b/docs/acc-test-environment-variables.md
@@ -53,6 +53,7 @@ Environment variables (beyond standard AWS Go SDK ones) used by acceptance testi
 | `AWS_DETECTIVE_MEMBER_EMAIL` | Email address for Detective Member testing. A valid email address associated with an AWS root account is required for tests to pass. |
 | `AWS_EC2_CLIENT_VPN_LIMIT` | Concurrency limit for Client VPN acceptance tests. [Default is 5](https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/limits.html) if not specified. |
 | `AWS_EC2_EIP_PUBLIC_IPV4_POOL` | Identifier for EC2 Public IPv4 Pool for EC2 EIP testing. |
+| `AWS_EC2_VERIFIED_ACCESS_INSTANCE_LIMIT` | Concurrency limit for Verified Access acceptance tests. [Default is 5](https://docs.aws.amazon.com/verified-access/latest/ug/verified-access-quotas.html) if not specified. |
 | `AWS_GUARDDUTY_MEMBER_ACCOUNT_ID` | Identifier of AWS Account for GuardDuty Member testing. **DEPRECATED:** Should be replaced with standard alternate account handling for tests. |
 | `AWS_GUARDDUTY_MEMBER_EMAIL` | Email address for GuardDuty Member testing. **DEPRECATED:** It may be possible to use a placeholder email address instead. |
 | `AWS_LAMBDA_IMAGE_LATEST_ID` | ECR repository image URI (tagged as `latest`) for Lambda container image acceptance tests.

--- a/internal/envvar/envvar.go
+++ b/internal/envvar/envvar.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/mitchellh/go-testing-interface"
+	testing "github.com/mitchellh/go-testing-interface"
 )
 
 // Standard AWS environment variables used in the Terraform AWS Provider testing.

--- a/internal/experimental/sync/sync.go
+++ b/internal/experimental/sync/sync.go
@@ -4,29 +4,46 @@
 package sync
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"strconv"
-	"testing"
+	"sync"
+
+	testing "github.com/mitchellh/go-testing-interface"
 )
 
-// Semaphore can be used to limit concurrent executions. This can be used to work with resources with low quotas
+// Semaphore can be used to limit concurrent executions.
+// This can be used to work with resources with low quotas.
 type Semaphore chan struct{}
 
-// InitializeSemaphore initializes a semaphore with a default capacity or overrides it using an environment variable
+var semaphoreKV = &struct {
+	lock  sync.Locker
+	store map[string]Semaphore
+}{
+	lock:  &sync.Mutex{},
+	store: make(map[string]Semaphore),
+}
+
+// GetSemaphore returns a named semaphore with a default capacity or overrides it using an environment variable
 // NOTE: this is currently an experimental feature and is likely to change. DO NOT USE.
-func InitializeSemaphore(envvar string, defaultLimit int) Semaphore {
-	limit := defaultLimit
-	x := os.Getenv(envvar)
-	if x != "" {
-		var err error
-		limit, err = strconv.Atoi(x)
-		if err != nil {
-			panic(fmt.Errorf("could not parse %q: expected integer, got %q", envvar, x))
+func GetSemaphore(key, envvar string, defaultLimit int) Semaphore {
+	semaphoreKV.lock.Lock()
+	defer semaphoreKV.lock.Unlock()
+
+	semaphore, ok := semaphoreKV.store[key]
+	if !ok {
+		limit := defaultLimit
+		if v := os.Getenv(envvar); v != "" {
+			if v, err := strconv.Atoi(v); err == nil {
+				limit = v
+			}
 		}
+
+		semaphore = make(Semaphore, limit)
+		semaphoreKV.store[key] = semaphore
 	}
-	return make(Semaphore, limit)
+
+	return semaphore
 }
 
 // Wait waits for a semaphore before continuing
@@ -48,7 +65,7 @@ func (s Semaphore) Notify() {
 
 // TestAccPreCheckSyncronized waits for a semaphore and skips the test if there is no capacity
 // NOTE: this is currently an experimental feature and is likely to change. DO NOT USE.
-func TestAccPreCheckSyncronize(t *testing.T, semaphore Semaphore, resource string) {
+func TestAccPreCheckSyncronize(t testing.T, semaphore Semaphore, resource string) {
 	if cap(semaphore) == 0 {
 		t.Skipf("concurrency for %s testing set to 0", resource)
 	}

--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -7246,7 +7246,7 @@ func FindVerifiedAccessInstanceTrustProviderAttachmentExists(ctx context.Context
 	}
 
 	return &retry.NotFoundError{
-		LastError: fmt.Errorf("Verified Access Instance (%s) Trust Provider (%s) Association not found", vaiID, vatpID),
+		LastError: fmt.Errorf("Verified Access Instance (%s) Trust Provider (%s) Attachment not found", vaiID, vatpID),
 	}
 }
 

--- a/internal/service/ec2/sweep.go
+++ b/internal/service/ec2/sweep.go
@@ -418,6 +418,11 @@ func RegisterSweepers() {
 		Name: "aws_verifiedaccess_trust_provider",
 		F:    sweepVerifiedAccessTrustProviders,
 	})
+
+	resource.AddTestSweepers("aws_verifiedaccess_instance", &resource.Sweeper{
+		Name: "aws_verifiedaccess_instance",
+		F:    sweepVerifiedAccessInstances,
+	})
 }
 
 func sweepCapacityReservations(region string) error {
@@ -2875,6 +2880,50 @@ func sweepInstanceConnectEndpoints(region string) error {
 
 	if err != nil {
 		return fmt.Errorf("error sweeping EC2 Instance Connect Endpoints (%s): %w", region, err)
+	}
+
+	return nil
+}
+
+func sweepVerifiedAccessInstances(region string) error {
+	ctx := sweep.Context(region)
+	client, err := sweep.SharedRegionalSweepClient(ctx, region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.EC2Conn(ctx)
+	input := &ec2.DescribeVerifiedAccessInstancesInput{}
+	sweepResources := make([]sweep.Sweepable, 0)
+
+	err = conn.DescribeVerifiedAccessInstancesPagesWithContext(ctx, input, func(page *ec2.DescribeVerifiedAccessInstancesOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, v := range page.VerifiedAccessInstances {
+			r := ResourceVerifiedAccessInstance()
+			d := r.Data(nil)
+			d.SetId(aws.StringValue(v.VerifiedAccessInstanceId))
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+
+		return !lastPage
+	})
+
+	if awsv1.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping Verified Access Instance sweep for %s: %s", region, err)
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error listing Verified Access Instances (%s): %w", region, err)
+	}
+
+	err = sweep.SweepOrchestrator(ctx, sweepResources)
+
+	if err != nil {
+		return fmt.Errorf("error sweeping Verified Access Instances (%s): %w", region, err)
 	}
 
 	return nil

--- a/internal/service/ec2/sweep.go
+++ b/internal/service/ec2/sweep.go
@@ -433,6 +433,14 @@ func RegisterSweepers() {
 	resource.AddTestSweepers("aws_verifiedaccess_group", &resource.Sweeper{
 		Name: "aws_verifiedaccess_group",
 		F:    sweepVerifiedAccessGroups,
+		Dependencies: []string{
+			"aws_verifiedaccess_endpoint",
+		},
+	})
+
+	resource.AddTestSweepers("aws_verifiedaccess_endpoint", &resource.Sweeper{
+		Name: "aws_verifiedaccess_endpoint",
+		F:    sweepVerifiedAccessEndpoints,
 	})
 
 	resource.AddTestSweepers("aws_verifiedaccess_instance", &resource.Sweeper{
@@ -2899,6 +2907,50 @@ func sweepInstanceConnectEndpoints(region string) error {
 
 	if err != nil {
 		return fmt.Errorf("error sweeping EC2 Instance Connect Endpoints (%s): %w", region, err)
+	}
+
+	return nil
+}
+
+func sweepVerifiedAccessEndpoints(region string) error {
+	ctx := sweep.Context(region)
+	client, err := sweep.SharedRegionalSweepClient(ctx, region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.EC2Conn(ctx)
+	input := &ec2.DescribeVerifiedAccessEndpointsInput{}
+	sweepResources := make([]sweep.Sweepable, 0)
+
+	err = conn.DescribeVerifiedAccessEndpointsPagesWithContext(ctx, input, func(page *ec2.DescribeVerifiedAccessEndpointsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, v := range page.VerifiedAccessEndpoints {
+			r := ResourceVerifiedAccessEndpoint()
+			d := r.Data(nil)
+			d.SetId(aws.StringValue(v.VerifiedAccessEndpointId))
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+
+		return !lastPage
+	})
+
+	if awsv1.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping Verified Access Endpoint sweep for %s: %s", region, err)
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error listing Verified Access Endpoints (%s): %w", region, err)
+	}
+
+	err = sweep.SweepOrchestrator(ctx, sweepResources)
+
+	if err != nil {
+		return fmt.Errorf("error sweeping Verified Access Endpoints (%s): %w", region, err)
 	}
 
 	return nil

--- a/internal/service/ec2/verifiedaccess_endpoint_test.go
+++ b/internal/service/ec2/verifiedaccess_endpoint_test.go
@@ -14,12 +14,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfsync "github.com/hashicorp/terraform-provider-aws/internal/experimental/sync"
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccVerifiedAccessEndpoint_basic(t *testing.T) {
+func testAccVerifiedAccessEndpoint_basic(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v types.VerifiedAccessEndpoint
 	resourceName := "aws_verifiedaccess_endpoint.test"
@@ -29,6 +30,7 @@ func TestAccVerifiedAccessEndpoint_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
+			testAccPreCheckVerifiedAccessSynchronize(t, semaphore)
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckVerifiedAccess(ctx, t)
 		},
@@ -68,7 +70,7 @@ func TestAccVerifiedAccessEndpoint_basic(t *testing.T) {
 	})
 }
 
-func TestAccVerifiedAccessEndpoint_networkInterface(t *testing.T) {
+func testAccVerifiedAccessEndpoint_networkInterface(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v types.VerifiedAccessEndpoint
 	resourceName := "aws_verifiedaccess_endpoint.test"
@@ -78,6 +80,7 @@ func TestAccVerifiedAccessEndpoint_networkInterface(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
+			testAccPreCheckVerifiedAccessSynchronize(t, semaphore)
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckVerifiedAccess(ctx, t)
 		},
@@ -114,7 +117,7 @@ func TestAccVerifiedAccessEndpoint_networkInterface(t *testing.T) {
 	})
 }
 
-func TestAccVerifiedAccessEndpoint_tags(t *testing.T) {
+func testAccVerifiedAccessEndpoint_tags(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v types.VerifiedAccessEndpoint
 	resourceName := "aws_verifiedaccess_endpoint.test"
@@ -124,6 +127,7 @@ func TestAccVerifiedAccessEndpoint_tags(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
+			testAccPreCheckVerifiedAccessSynchronize(t, semaphore)
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckVerifiedAccess(ctx, t)
 		},
@@ -168,7 +172,7 @@ func TestAccVerifiedAccessEndpoint_tags(t *testing.T) {
 	})
 }
 
-func TestAccVerifiedAccessEndpoint_disappears(t *testing.T) {
+func testAccVerifiedAccessEndpoint_disappears(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v types.VerifiedAccessEndpoint
 	resourceName := "aws_verifiedaccess_endpoint.test"
@@ -178,6 +182,7 @@ func TestAccVerifiedAccessEndpoint_disappears(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
+			testAccPreCheckVerifiedAccessSynchronize(t, semaphore)
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckVerifiedAccess(ctx, t)
 		},
@@ -197,7 +202,7 @@ func TestAccVerifiedAccessEndpoint_disappears(t *testing.T) {
 	})
 }
 
-func TestAccVerifiedAccessEndpoint_policyDocument(t *testing.T) {
+func testAccVerifiedAccessEndpoint_policyDocument(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v types.VerifiedAccessEndpoint
 	resourceName := "aws_verifiedaccess_endpoint.test"
@@ -208,6 +213,7 @@ func TestAccVerifiedAccessEndpoint_policyDocument(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
+			testAccPreCheckVerifiedAccessSynchronize(t, semaphore)
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckVerifiedAccess(ctx, t)
 		},

--- a/internal/service/ec2/verifiedaccess_group_test.go
+++ b/internal/service/ec2/verifiedaccess_group_test.go
@@ -14,12 +14,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfsync "github.com/hashicorp/terraform-provider-aws/internal/experimental/sync"
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccVerifiedAccessGroup_basic(t *testing.T) {
+func testAccVerifiedAccessGroup_basic(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v types.VerifiedAccessGroup
 	resourceName := "aws_verifiedaccess_group.test"
@@ -27,6 +28,7 @@ func TestAccVerifiedAccessGroup_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
+			testAccPreCheckVerifiedAccessSynchronize(t, semaphore)
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckVerifiedAccess(ctx, t)
 		},
@@ -61,7 +63,7 @@ func TestAccVerifiedAccessGroup_basic(t *testing.T) {
 	})
 }
 
-func TestAccVerifiedAccessGroup_kms(t *testing.T) {
+func testAccVerifiedAccessGroup_kms(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v types.VerifiedAccessGroup
 	resourceName := "aws_verifiedaccess_group.test"
@@ -70,6 +72,7 @@ func TestAccVerifiedAccessGroup_kms(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
+			testAccPreCheckVerifiedAccessSynchronize(t, semaphore)
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckVerifiedAccess(ctx, t)
 		},
@@ -96,7 +99,7 @@ func TestAccVerifiedAccessGroup_kms(t *testing.T) {
 	})
 }
 
-func TestAccVerifiedAccessGroup_updateKMS(t *testing.T) {
+func testAccVerifiedAccessGroup_updateKMS(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v types.VerifiedAccessGroup
 	resourceName := "aws_verifiedaccess_group.test"
@@ -106,6 +109,7 @@ func TestAccVerifiedAccessGroup_updateKMS(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
+			testAccPreCheckVerifiedAccessSynchronize(t, semaphore)
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckVerifiedAccess(ctx, t)
 		},
@@ -155,7 +159,7 @@ func TestAccVerifiedAccessGroup_updateKMS(t *testing.T) {
 	})
 }
 
-func TestAccVerifiedAccessGroup_disappears(t *testing.T) {
+func testAccVerifiedAccessGroup_disappears(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v types.VerifiedAccessGroup
 	resourceName := "aws_verifiedaccess_group.test"
@@ -163,6 +167,7 @@ func TestAccVerifiedAccessGroup_disappears(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
+			testAccPreCheckVerifiedAccessSynchronize(t, semaphore)
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckVerifiedAccess(ctx, t)
 		},
@@ -182,7 +187,7 @@ func TestAccVerifiedAccessGroup_disappears(t *testing.T) {
 	})
 }
 
-func TestAccVerifiedAccessGroup_tags(t *testing.T) {
+func testAccVerifiedAccessGroup_tags(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v types.VerifiedAccessGroup
 	resourceName := "aws_verifiedaccess_group.test"
@@ -190,6 +195,7 @@ func TestAccVerifiedAccessGroup_tags(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
+			testAccPreCheckVerifiedAccessSynchronize(t, semaphore)
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckVerifiedAccess(ctx, t)
 		},
@@ -232,7 +238,7 @@ func TestAccVerifiedAccessGroup_tags(t *testing.T) {
 	})
 }
 
-func TestAccVerifiedAccessGroup_policy(t *testing.T) {
+func testAccVerifiedAccessGroup_policy(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v types.VerifiedAccessGroup
 	resourceName := "aws_verifiedaccess_group.test"
@@ -242,6 +248,7 @@ func TestAccVerifiedAccessGroup_policy(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
+			testAccPreCheckVerifiedAccessSynchronize(t, semaphore)
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckVerifiedAccess(ctx, t)
 		},
@@ -267,7 +274,7 @@ func TestAccVerifiedAccessGroup_policy(t *testing.T) {
 	})
 }
 
-func TestAccVerifiedAccessGroup_updatePolicy(t *testing.T) {
+func testAccVerifiedAccessGroup_updatePolicy(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v types.VerifiedAccessGroup
 	resourceName := "aws_verifiedaccess_group.test"
@@ -278,6 +285,7 @@ func TestAccVerifiedAccessGroup_updatePolicy(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
+			testAccPreCheckVerifiedAccessSynchronize(t, semaphore)
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckVerifiedAccess(ctx, t)
 		},
@@ -316,7 +324,7 @@ func TestAccVerifiedAccessGroup_updatePolicy(t *testing.T) {
 		},
 	})
 }
-func TestAccVerifiedAccessGroup_setPolicy(t *testing.T) {
+func testAccVerifiedAccessGroup_setPolicy(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v types.VerifiedAccessGroup
 	resourceName := "aws_verifiedaccess_group.test"
@@ -326,6 +334,7 @@ func TestAccVerifiedAccessGroup_setPolicy(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
+			testAccPreCheckVerifiedAccessSynchronize(t, semaphore)
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckVerifiedAccess(ctx, t)
 		},

--- a/internal/service/ec2/verifiedaccess_instance.go
+++ b/internal/service/ec2/verifiedaccess_instance.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/service/ec2/verifiedaccess_instance_logging_configuration.go
+++ b/internal/service/ec2/verifiedaccess_instance_logging_configuration.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/service/ec2/verifiedaccess_instance_logging_configuration_test.go
+++ b/internal/service/ec2/verifiedaccess_instance_logging_configuration_test.go
@@ -16,23 +16,23 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfsync "github.com/hashicorp/terraform-provider-aws/internal/experimental/sync"
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsIncludeTrustContext(t *testing.T) {
+func testAccVerifiedAccessInstanceLoggingConfiguration_accessLogsIncludeTrustContext(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
-
 	var v types.VerifiedAccessInstanceLoggingConfiguration
 	resourceName := "aws_verifiedaccess_instance_logging_configuration.test"
 	instanceResourceName := "aws_verifiedaccess_instance.test"
-
 	include_trust_context_original := true
 	include_trust_context_updated := false
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
+			testAccPreCheckVerifiedAccessSynchronize(t, semaphore)
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckVerifiedAccessInstanceLoggingConfiguration(ctx, t)
 		},
@@ -68,18 +68,17 @@ func TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsIncludeTrustCon
 	})
 }
 
-func TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsLogVersion(t *testing.T) {
+func testAccVerifiedAccessInstanceLoggingConfiguration_accessLogsLogVersion(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
-
 	var v types.VerifiedAccessInstanceLoggingConfiguration
 	resourceName := "aws_verifiedaccess_instance_logging_configuration.test"
 	instanceResourceName := "aws_verifiedaccess_instance.test"
-
 	log_version_original := "ocsf-0.1"
 	log_version_updated := "ocsf-1.0.0-rc.2"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
+			testAccPreCheckVerifiedAccessSynchronize(t, semaphore)
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckVerifiedAccessInstanceLoggingConfiguration(ctx, t)
 		},
@@ -115,9 +114,8 @@ func TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsLogVersion(t *t
 	})
 }
 
-func TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsCloudWatchLogs(t *testing.T) {
+func testAccVerifiedAccessInstanceLoggingConfiguration_accessLogsCloudWatchLogs(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
-
 	var v types.VerifiedAccessInstanceLoggingConfiguration
 	resourceName := "aws_verifiedaccess_instance_logging_configuration.test"
 	instanceResourceName := "aws_verifiedaccess_instance.test"
@@ -126,6 +124,7 @@ func TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsCloudWatchLogs(
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
+			testAccPreCheckVerifiedAccessSynchronize(t, semaphore)
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckVerifiedAccessInstanceLoggingConfiguration(ctx, t)
 		},
@@ -165,21 +164,20 @@ func TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsCloudWatchLogs(
 	})
 }
 
-func TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsKinesisDataFirehose(t *testing.T) {
+func testAccVerifiedAccessInstanceLoggingConfiguration_accessLogsKinesisDataFirehose(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
-
 	var v types.VerifiedAccessInstanceLoggingConfiguration
 	resourceName := "aws_verifiedaccess_instance_logging_configuration.test"
 	instanceResourceName := "aws_verifiedaccess_instance.test"
 	kinesisStreamName := "aws_kinesis_firehose_delivery_stream.test"
 	kinesisStreamName2 := "aws_kinesis_firehose_delivery_stream.test2"
-
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName3 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
+			testAccPreCheckVerifiedAccessSynchronize(t, semaphore)
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckVerifiedAccessInstanceLoggingConfiguration(ctx, t)
 		},
@@ -188,7 +186,7 @@ func TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsKinesisDataFire
 		CheckDestroy:             testAccCheckVerifiedAccessInstanceLoggingConfigurationDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLoggingConfigurationConfig_basic_accessLogsKinesisDataFirehose(rName, rName2, rName3, "first"),
+				Config: testAccLoggingConfigurationConfig_basic_accessLogsKinesisDataFirehose(rName1, rName2, rName3, "first"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVerifiedAccessInstanceLoggingConfigurationExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.#", "1"),
@@ -205,7 +203,7 @@ func TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsKinesisDataFire
 				ImportStateVerifyIgnore: []string{},
 			},
 			{
-				Config: testAccLoggingConfigurationConfig_basic_accessLogsKinesisDataFirehose(rName, rName2, rName3, "second"),
+				Config: testAccLoggingConfigurationConfig_basic_accessLogsKinesisDataFirehose(rName1, rName2, rName3, "second"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVerifiedAccessInstanceLoggingConfigurationExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.#", "1"),
@@ -219,22 +217,21 @@ func TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsKinesisDataFire
 	})
 }
 
-func TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsS3(t *testing.T) {
+func testAccVerifiedAccessInstanceLoggingConfiguration_accessLogsS3(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
-
 	var v types.VerifiedAccessInstanceLoggingConfiguration
 	resourceName := "aws_verifiedaccess_instance_logging_configuration.test"
 	instanceResourceName := "aws_verifiedaccess_instance.test"
 	bucketName := "aws_s3_bucket.test"
 	bucketName2 := "aws_s3_bucket.test2"
-
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	prefix_original := "prefix-original"
 	prefix_updated := "prefix-updated"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
+			testAccPreCheckVerifiedAccessSynchronize(t, semaphore)
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckVerifiedAccessInstanceLoggingConfiguration(ctx, t)
 		},
@@ -243,7 +240,7 @@ func TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsS3(t *testing.T
 		CheckDestroy:             testAccCheckVerifiedAccessInstanceLoggingConfigurationDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLoggingConfigurationConfig_basic_accessLogsS3(rName, rName2, "first", prefix_original),
+				Config: testAccLoggingConfigurationConfig_basic_accessLogsS3(rName1, rName2, "first", prefix_original),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVerifiedAccessInstanceLoggingConfigurationExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.#", "1"),
@@ -262,7 +259,7 @@ func TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsS3(t *testing.T
 				ImportStateVerifyIgnore: []string{},
 			},
 			{
-				Config: testAccLoggingConfigurationConfig_basic_accessLogsS3(rName, rName2, "second", prefix_updated),
+				Config: testAccLoggingConfigurationConfig_basic_accessLogsS3(rName1, rName2, "second", prefix_updated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVerifiedAccessInstanceLoggingConfigurationExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.#", "1"),
@@ -278,22 +275,21 @@ func TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsS3(t *testing.T
 	})
 }
 
-func TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsCloudWatchLogsKinesisDataFirehoseS3(t *testing.T) {
+func testAccVerifiedAccessInstanceLoggingConfiguration_accessLogsCloudWatchLogsKinesisDataFirehoseS3(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
-
 	var v types.VerifiedAccessInstanceLoggingConfiguration
 	resourceName := "aws_verifiedaccess_instance_logging_configuration.test"
 	instanceResourceName := "aws_verifiedaccess_instance.test"
 	logGroupName := "aws_cloudwatch_log_group.test"
 	kinesisStreamName := "aws_kinesis_firehose_delivery_stream.test"
 	bucketName := "aws_s3_bucket.test"
-
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName3 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
+			testAccPreCheckVerifiedAccessSynchronize(t, semaphore)
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckVerifiedAccessInstanceLoggingConfiguration(ctx, t)
 		},
@@ -303,7 +299,7 @@ func TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsCloudWatchLogsK
 		Steps: []resource.TestStep{
 			{
 				// Test all 3 logging configurations together - CloudWatch, Kinesis Data Firehose, S3
-				Config: testAccLoggingConfigurationConfig_basic_accessLogsCloudWatchLogsKinesisDataFirehoseS3(rName, rName2, rName3),
+				Config: testAccLoggingConfigurationConfig_basic_accessLogsCloudWatchLogsKinesisDataFirehoseS3(rName1, rName2, rName3),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVerifiedAccessInstanceLoggingConfigurationExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.#", "1"),
@@ -327,7 +323,7 @@ func TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsCloudWatchLogsK
 			},
 			{
 				// Test 2 logging configurations together - CloudWatch, Kinesis Data Firehose
-				Config: testAccLoggingConfigurationConfig_basic_accessLogsCloudWatchLogsKinesisDataFirehose(rName, rName2, rName3),
+				Config: testAccLoggingConfigurationConfig_basic_accessLogsCloudWatchLogsKinesisDataFirehose(rName1, rName2, rName3),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVerifiedAccessInstanceLoggingConfigurationExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.#", "1"),
@@ -344,7 +340,7 @@ func TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsCloudWatchLogsK
 			},
 			{
 				// Test 2 logging configurations together - CloudWatch, S3
-				Config: testAccLoggingConfigurationConfig_basic_accessLogsCloudWatchLogsS3(rName, rName2, rName3),
+				Config: testAccLoggingConfigurationConfig_basic_accessLogsCloudWatchLogsS3(rName1, rName2, rName3),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVerifiedAccessInstanceLoggingConfigurationExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.#", "1"),
@@ -361,7 +357,7 @@ func TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsCloudWatchLogsK
 			},
 			{
 				// Test 2 logging configurations together - Kinesis Data Firehose, S3
-				Config: testAccLoggingConfigurationConfig_basic_accessLogsKinesisDataFirehoseS3(rName, rName2, rName3),
+				Config: testAccLoggingConfigurationConfig_basic_accessLogsKinesisDataFirehoseS3(rName1, rName2, rName3),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVerifiedAccessInstanceLoggingConfigurationExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "access_logs.#", "1"),
@@ -380,16 +376,16 @@ func TestAccVerifiedAccessInstanceLoggingConfiguration_accessLogsCloudWatchLogsK
 	})
 }
 
-func TestAccVerifiedAccessInstanceLoggingConfiguration_disappears(t *testing.T) {
+func testAccVerifiedAccessInstanceLoggingConfiguration_disappears(t *testing.T, semaphore tfsync.Semaphore) {
 	// note: disappears test does not test the logging configuration since the instance is deleted
 	// the logging configuration cannot be deleted, rather, the boolean flags and logging version are reset to the default values
 	ctx := acctest.Context(t)
-
 	var v types.VerifiedAccessInstanceLoggingConfiguration
 	resourceName := "aws_verifiedaccess_instance.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
+			testAccPreCheckVerifiedAccessSynchronize(t, semaphore)
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckVerifiedAccessInstanceLoggingConfiguration(ctx, t)
 		},

--- a/internal/service/ec2/verifiedaccess_instance_test.go
+++ b/internal/service/ec2/verifiedaccess_instance_test.go
@@ -16,18 +16,20 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfsync "github.com/hashicorp/terraform-provider-aws/internal/experimental/sync"
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccVerifiedAccessInstance_basic(t *testing.T) {
+func testAccVerifiedAccessInstance_basic(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v types.VerifiedAccessInstance
 	resourceName := "aws_verifiedaccess_instance.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
+			testAccPreCheckVerifiedAccessSynchronize(t, semaphore)
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckVerifiedAccessInstance(ctx, t)
 		},
@@ -54,16 +56,16 @@ func TestAccVerifiedAccessInstance_basic(t *testing.T) {
 	})
 }
 
-func TestAccVerifiedAccessInstance_description(t *testing.T) {
+func testAccVerifiedAccessInstance_description(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v1, v2 types.VerifiedAccessInstance
 	resourceName := "aws_verifiedaccess_instance.test"
-
 	originalDescription := "original description"
 	updatedDescription := "updated description"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
+			testAccPreCheckVerifiedAccessSynchronize(t, semaphore)
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckVerifiedAccessInstance(ctx, t)
 		},
@@ -96,16 +98,16 @@ func TestAccVerifiedAccessInstance_description(t *testing.T) {
 	})
 }
 
-func TestAccVerifiedAccessInstance_fipsEnabled(t *testing.T) {
+func testAccVerifiedAccessInstance_fipsEnabled(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v1, v2 types.VerifiedAccessInstance
 	resourceName := "aws_verifiedaccess_instance.test"
-
 	originalFipsEnabled := true
 	updatedFipsEnabled := false
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
+			testAccPreCheckVerifiedAccessSynchronize(t, semaphore)
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckVerifiedAccessInstance(ctx, t)
 		},
@@ -138,13 +140,14 @@ func TestAccVerifiedAccessInstance_fipsEnabled(t *testing.T) {
 	})
 }
 
-func TestAccVerifiedAccessInstance_disappears(t *testing.T) {
+func testAccVerifiedAccessInstance_disappears(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v types.VerifiedAccessInstance
 	resourceName := "aws_verifiedaccess_instance.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
+			testAccPreCheckVerifiedAccessSynchronize(t, semaphore)
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckVerifiedAccessInstance(ctx, t)
 		},
@@ -164,13 +167,14 @@ func TestAccVerifiedAccessInstance_disappears(t *testing.T) {
 	})
 }
 
-func TestAccVerifiedAccessInstance_tags(t *testing.T) {
+func testAccVerifiedAccessInstance_tags(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v1, v2, v3 types.VerifiedAccessInstance
 	resourceName := "aws_verifiedaccess_instance.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
+			testAccPreCheckVerifiedAccessSynchronize(t, semaphore)
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckVerifiedAccessInstance(ctx, t)
 		},

--- a/internal/service/ec2/verifiedaccess_instance_trust_provider_attachment.go
+++ b/internal/service/ec2/verifiedaccess_instance_trust_provider_attachment.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/service/ec2/verifiedaccess_instance_trust_provider_attachment.go
+++ b/internal/service/ec2/verifiedaccess_instance_trust_provider_attachment.go
@@ -113,7 +113,8 @@ func resourceVerifiedAccessInstanceTrustProviderAttachmentDelete(ctx context.Con
 		VerifiedAccessTrustProviderId: aws.String(vatpID),
 	})
 
-	if tfawserr.ErrCodeEquals(err, errCodeInvalidVerifiedAccessTrustProviderIdNotFound) {
+	if tfawserr.ErrCodeEquals(err, errCodeInvalidVerifiedAccessTrustProviderIdNotFound) ||
+		tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, "is not attached to instance") {
 		return diags
 	}
 

--- a/internal/service/ec2/verifiedaccess_instance_trust_provider_attachment_test.go
+++ b/internal/service/ec2/verifiedaccess_instance_trust_provider_attachment_test.go
@@ -12,12 +12,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfsync "github.com/hashicorp/terraform-provider-aws/internal/experimental/sync"
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccVerifiedAccessInstanceTrustProviderAttachment_basic(t *testing.T) {
+func testAccVerifiedAccessInstanceTrustProviderAttachment_basic(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_verifiedaccess_instance_trust_provider_attachment.test"
 	instanceResourceName := "aws_verifiedaccess_instance.test"
@@ -25,6 +26,7 @@ func TestAccVerifiedAccessInstanceTrustProviderAttachment_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
+			testAccPreCheckVerifiedAccessSynchronize(t, semaphore)
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckVerifiedAccessInstance(ctx, t)
 		},
@@ -49,12 +51,13 @@ func TestAccVerifiedAccessInstanceTrustProviderAttachment_basic(t *testing.T) {
 	})
 }
 
-func TestAccVerifiedAccessInstanceTrustProviderAttachment_disappears(t *testing.T) {
+func testAccVerifiedAccessInstanceTrustProviderAttachment_disappears(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_verifiedaccess_instance_trust_provider_attachment.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
+			testAccPreCheckVerifiedAccessSynchronize(t, semaphore)
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckVerifiedAccessInstance(ctx, t)
 		},

--- a/internal/service/ec2/verifiedaccess_test.go
+++ b/internal/service/ec2/verifiedaccess_test.go
@@ -1,0 +1,62 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ec2_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfsync "github.com/hashicorp/terraform-provider-aws/internal/experimental/sync"
+)
+
+func TestAccVerifiedAccess_serial(t *testing.T) {
+	t.Parallel()
+
+	semaphore := tfsync.InitializeSemaphore("AWS_VERIFIED_ACCESS_INSTANCE_LIMIT", 5)
+	testCases := map[string]map[string]func(*testing.T, tfsync.Semaphore){
+		"Endpoint": {
+			"basic":            testAccVerifiedAccessEndpoint_basic,
+			"networkInterface": testAccVerifiedAccessEndpoint_networkInterface,
+			"tags":             testAccVerifiedAccessEndpoint_tags,
+			"disappears":       testAccVerifiedAccessEndpoint_disappears,
+			"policyDocument":   testAccVerifiedAccessEndpoint_policyDocument,
+		},
+		"Group": {
+			"basic":        testAccVerifiedAccessGroup_basic,
+			"kms":          testAccVerifiedAccessGroup_kms,
+			"updateKMS":    testAccVerifiedAccessGroup_updateKMS,
+			"disappears":   testAccVerifiedAccessGroup_disappears,
+			"tags":         testAccVerifiedAccessGroup_tags,
+			"policy":       testAccVerifiedAccessGroup_policy,
+			"updatePolicy": testAccVerifiedAccessGroup_updatePolicy,
+			"setPolicy":    testAccVerifiedAccessGroup_setPolicy,
+		},
+		"Instance": {
+			"basic":       testAccVerifiedAccessInstance_basic,
+			"description": testAccVerifiedAccessInstance_description,
+			"fipsEnabled": testAccVerifiedAccessInstance_fipsEnabled,
+			"disappears":  testAccVerifiedAccessInstance_disappears,
+			"tags":        testAccVerifiedAccessInstance_tags,
+		},
+		"InstanceLoggingConfiguration": {
+			"accessLogsIncludeTrustContext":                 testAccVerifiedAccessInstanceLoggingConfiguration_accessLogsIncludeTrustContext,
+			"accessLogsLogVersion":                          testAccVerifiedAccessInstanceLoggingConfiguration_accessLogsLogVersion,
+			"accessLogsCloudWatchLogs":                      testAccVerifiedAccessInstanceLoggingConfiguration_accessLogsCloudWatchLogs,
+			"accessLogsKinesisDataFirehose":                 testAccVerifiedAccessInstanceLoggingConfiguration_accessLogsKinesisDataFirehose,
+			"accessLogsS3":                                  testAccVerifiedAccessInstanceLoggingConfiguration_accessLogsS3,
+			"accessLogsCloudWatchLogsKinesisDataFirehoseS3": testAccVerifiedAccessInstanceLoggingConfiguration_accessLogsCloudWatchLogsKinesisDataFirehoseS3,
+			"disappears":                                    testAccVerifiedAccessInstanceLoggingConfiguration_disappears,
+		},
+		"InstanceTrustProviderAttachment": {
+			"basic":      testAccVerifiedAccessInstanceTrustProviderAttachment_basic,
+			"disappears": testAccVerifiedAccessInstanceTrustProviderAttachment_disappears,
+		},
+	}
+
+	acctest.RunLimitedConcurrencyTests2Levels(t, semaphore, testCases)
+}
+
+func testAccPreCheckVerifiedAccessSynchronize(t *testing.T, semaphore tfsync.Semaphore) {
+	tfsync.TestAccPreCheckSyncronize(t, semaphore, "Verified Access")
+}

--- a/internal/service/ec2/verifiedaccess_test.go
+++ b/internal/service/ec2/verifiedaccess_test.go
@@ -13,7 +13,7 @@ import (
 func TestAccVerifiedAccess_serial(t *testing.T) {
 	t.Parallel()
 
-	semaphore := tfsync.GetSemaphore("VerifiedAccess", "AWS_VERIFIED_ACCESS_INSTANCE_LIMIT", 5)
+	semaphore := tfsync.GetSemaphore("VerifiedAccess", "AWS_EC2_VERIFIED_ACCESS_INSTANCE_LIMIT", 5)
 	testCases := map[string]map[string]func(*testing.T, tfsync.Semaphore){
 		"Endpoint": {
 			"basic":            testAccVerifiedAccessEndpoint_basic,

--- a/internal/service/ec2/verifiedaccess_test.go
+++ b/internal/service/ec2/verifiedaccess_test.go
@@ -13,7 +13,7 @@ import (
 func TestAccVerifiedAccess_serial(t *testing.T) {
 	t.Parallel()
 
-	semaphore := tfsync.InitializeSemaphore("AWS_VERIFIED_ACCESS_INSTANCE_LIMIT", 5)
+	semaphore := tfsync.GetSemaphore("VerifiedAccess", "AWS_VERIFIED_ACCESS_INSTANCE_LIMIT", 5)
 	testCases := map[string]map[string]func(*testing.T, tfsync.Semaphore){
 		"Endpoint": {
 			"basic":            testAccVerifiedAccessEndpoint_basic,

--- a/internal/service/ec2/verifiedaccess_trust_provider.go
+++ b/internal/service/ec2/verifiedaccess_trust_provider.go
@@ -11,7 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/service/ec2/vpnclient_authorization_rule_test.go
+++ b/internal/service/ec2/vpnclient_authorization_rule_test.go
@@ -15,11 +15,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfsync "github.com/hashicorp/terraform-provider-aws/internal/experimental/sync"
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func testAccClientVPNAuthorizationRule_basic(t *testing.T) {
+func testAccClientVPNAuthorizationRule_basic(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v ec2.AuthorizationRule
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -27,7 +28,10 @@ func testAccClientVPNAuthorizationRule_basic(t *testing.T) {
 	subnetResourceName := "aws_subnet.test.0"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheckClientVPNSyncronize(t); acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			testAccPreCheckClientVPNSyncronize(t, semaphore)
+			acctest.PreCheck(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckClientVPNAuthorizationRuleDestroy(ctx),
@@ -50,14 +54,17 @@ func testAccClientVPNAuthorizationRule_basic(t *testing.T) {
 	})
 }
 
-func testAccClientVPNAuthorizationRule_disappears(t *testing.T) {
+func testAccClientVPNAuthorizationRule_disappears(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v ec2.AuthorizationRule
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ec2_client_vpn_authorization_rule.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheckClientVPNSyncronize(t); acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			testAccPreCheckClientVPNSyncronize(t, semaphore)
+			acctest.PreCheck(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckClientVPNAuthorizationRuleDestroy(ctx),
@@ -74,14 +81,17 @@ func testAccClientVPNAuthorizationRule_disappears(t *testing.T) {
 	})
 }
 
-func testAccClientVPNAuthorizationRule_Disappears_endpoint(t *testing.T) {
+func testAccClientVPNAuthorizationRule_Disappears_endpoint(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v ec2.AuthorizationRule
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ec2_client_vpn_authorization_rule.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheckClientVPNSyncronize(t); acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			testAccPreCheckClientVPNSyncronize(t, semaphore)
+			acctest.PreCheck(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckClientVPNAuthorizationRuleDestroy(ctx),
@@ -98,17 +108,15 @@ func testAccClientVPNAuthorizationRule_Disappears_endpoint(t *testing.T) {
 	})
 }
 
-func testAccClientVPNAuthorizationRule_groups(t *testing.T) {
+func testAccClientVPNAuthorizationRule_groups(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v ec2.AuthorizationRule
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resource1Name := "aws_ec2_client_vpn_authorization_rule.test1"
 	resource2Name := "aws_ec2_client_vpn_authorization_rule.test2"
 	subnetResourceName := "aws_subnet.test.0"
-
 	group1Name := "group_one"
 	group2Name := "group_two"
-
 	groups1 := map[string]string{
 		"test1": group1Name,
 	}
@@ -121,7 +129,10 @@ func testAccClientVPNAuthorizationRule_groups(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheckClientVPNSyncronize(t); acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			testAccPreCheckClientVPNSyncronize(t, semaphore)
+			acctest.PreCheck(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckClientVPNAuthorizationRuleDestroy(ctx),
@@ -172,18 +183,15 @@ func testAccClientVPNAuthorizationRule_groups(t *testing.T) {
 	})
 }
 
-func testAccClientVPNAuthorizationRule_subnets(t *testing.T) {
+func testAccClientVPNAuthorizationRule_subnets(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v ec2.AuthorizationRule
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resource1Name := "aws_ec2_client_vpn_authorization_rule.test1"
 	resource2Name := "aws_ec2_client_vpn_authorization_rule.test2"
-
 	subnetCount := 2
-
 	subnetIndex1 := 0
 	subnetIndex2 := 1
-
 	case1 := map[string]int{
 		"test1": subnetIndex1,
 		"test2": subnetIndex2,
@@ -193,7 +201,10 @@ func testAccClientVPNAuthorizationRule_subnets(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheckClientVPNSyncronize(t); acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			testAccPreCheckClientVPNSyncronize(t, semaphore)
+			acctest.PreCheck(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckClientVPNAuthorizationRuleDestroy(ctx),
@@ -240,7 +251,6 @@ func testAccCheckClientVPNAuthorizationRuleDestroy(ctx context.Context) resource
 			}
 
 			endpointID, targetNetworkCIDR, accessGroupID, err := tfec2.ClientVPNAuthorizationRuleParseResourceID(rs.Primary.ID)
-
 			if err != nil {
 				return err
 			}
@@ -269,12 +279,7 @@ func testAccCheckClientVPNAuthorizationRuleExists(ctx context.Context, name stri
 			return fmt.Errorf("Not found: %s", name)
 		}
 
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No EC2 Client VPN Authorization Rule ID is set")
-		}
-
 		endpointID, targetNetworkCIDR, accessGroupID, err := tfec2.ClientVPNAuthorizationRuleParseResourceID(rs.Primary.ID)
-
 		if err != nil {
 			return err
 		}

--- a/internal/service/ec2/vpnclient_endpoint_data_source_test.go
+++ b/internal/service/ec2/vpnclient_endpoint_data_source_test.go
@@ -10,9 +10,10 @@ import (
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfsync "github.com/hashicorp/terraform-provider-aws/internal/experimental/sync"
 )
 
-func testAccClientVPNEndpointDataSource_basic(t *testing.T) {
+func testAccClientVPNEndpointDataSource_basic(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ec2_client_vpn_endpoint.test"
@@ -21,7 +22,10 @@ func testAccClientVPNEndpointDataSource_basic(t *testing.T) {
 	datasource3Name := "data.aws_ec2_client_vpn_endpoint.by_tags"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheckClientVPNSyncronize(t); acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			testAccPreCheckClientVPNSyncronize(t, semaphore)
+			acctest.PreCheck(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckClientVPNEndpointDestroy(ctx),

--- a/internal/service/ec2/vpnclient_endpoint_test.go
+++ b/internal/service/ec2/vpnclient_endpoint_test.go
@@ -26,7 +26,7 @@ const clientVPNEndpointDefaultLimit = 5
 var testAccEc2ClientVpnEndpointSemaphore sync.Semaphore
 
 func init() {
-	testAccEc2ClientVpnEndpointSemaphore = sync.InitializeSemaphore("AWS_EC2_CLIENT_VPN_LIMIT", clientVPNEndpointDefaultLimit)
+	testAccEc2ClientVpnEndpointSemaphore = sync.GetSemaphore("ClientVPN", "AWS_EC2_CLIENT_VPN_LIMIT", clientVPNEndpointDefaultLimit)
 }
 
 // This is part of an experimental feature, do not use this as a starting point for tests

--- a/internal/service/ec2/vpnclient_endpoint_test.go
+++ b/internal/service/ec2/vpnclient_endpoint_test.go
@@ -6,7 +6,6 @@ package ec2_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/YakDriver/regexache"
@@ -16,89 +15,22 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/experimental/sync"
+	tfsync "github.com/hashicorp/terraform-provider-aws/internal/experimental/sync"
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-const clientVPNEndpointDefaultLimit = 5
-
-var testAccEc2ClientVpnEndpointSemaphore sync.Semaphore
-
-func init() {
-	testAccEc2ClientVpnEndpointSemaphore = sync.GetSemaphore("ClientVPN", "AWS_EC2_CLIENT_VPN_LIMIT", clientVPNEndpointDefaultLimit)
-}
-
-// This is part of an experimental feature, do not use this as a starting point for tests
-//
-//	"This place is not a place of honor... no highly esteemed deed is commemorated here... nothing valued is here.
-//	What is here was dangerous and repulsive to us. This message is a warning about danger."
-//	--  https://hyperallergic.com/312318/a-nuclear-warning-designed-to-last-10000-years/
-func TestAccClientVPNEndpoint_serial(t *testing.T) {
-	t.Parallel()
-
-	testCases := map[string]map[string]func(t *testing.T){
-		"Endpoint": {
-			"basic":                        testAccClientVPNEndpoint_basic,
-			"disappears":                   testAccClientVPNEndpoint_disappears,
-			"msADAuth":                     testAccClientVPNEndpoint_msADAuth,
-			"msADAuthAndMutualAuth":        testAccClientVPNEndpoint_msADAuthAndMutualAuth,
-			"federatedAuth":                testAccClientVPNEndpoint_federatedAuth,
-			"federatedAuthWithSelfService": testAccClientVPNEndpoint_federatedAuthWithSelfServiceProvider,
-			"withClientConnect":            testAccClientVPNEndpoint_withClientConnectOptions,
-			"withClientLoginBanner":        testAccClientVPNEndpoint_withClientLoginBannerOptions,
-			"withLogGroup":                 testAccClientVPNEndpoint_withConnectionLogOptions,
-			"withDNSServers":               testAccClientVPNEndpoint_withDNSServers,
-			"tags":                         testAccClientVPNEndpoint_tags,
-			"simpleAttributesUpdate":       testAccClientVPNEndpoint_simpleAttributesUpdate,
-			"selfServicePortal":            testAccClientVPNEndpoint_selfServicePortal,
-			"vpcNoSecurityGroups":          testAccClientVPNEndpoint_vpcNoSecurityGroups,
-			"vpcSecurityGroups":            testAccClientVPNEndpoint_vpcSecurityGroups,
-			"basicDataSource":              testAccClientVPNEndpointDataSource_basic,
-		},
-		"AuthorizationRule": {
-			"basic":              testAccClientVPNAuthorizationRule_basic,
-			"groups":             testAccClientVPNAuthorizationRule_groups,
-			"subnets":            testAccClientVPNAuthorizationRule_subnets,
-			"disappears":         testAccClientVPNAuthorizationRule_disappears,
-			"disappearsEndpoint": testAccClientVPNAuthorizationRule_Disappears_endpoint,
-		},
-		"NetworkAssociation": {
-			"basic":           testAccClientVPNNetworkAssociation_basic,
-			"multipleSubnets": testAccClientVPNNetworkAssociation_multipleSubnets,
-			"disappears":      testAccClientVPNNetworkAssociation_disappears,
-		},
-		"Route": {
-			"basic":       testAccClientVPNRoute_basic,
-			"description": testAccClientVPNRoute_description,
-			"disappears":  testAccClientVPNRoute_disappears,
-		},
-	}
-
-	for group, m := range testCases { //nolint:paralleltest
-		m := m
-		for name, tc := range m {
-			tc := tc
-			t.Run(fmt.Sprintf("%s_%s", group, name), func(t *testing.T) {
-				t.Cleanup(func() {
-					if os.Getenv(resource.EnvTfAcc) != "" {
-						testAccEc2ClientVpnEndpointSemaphore.Notify()
-					}
-				})
-				tc(t)
-			})
-		}
-	}
-}
-
-func testAccClientVPNEndpoint_basic(t *testing.T) {
+func testAccClientVPNEndpoint_basic(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v ec2.ClientVpnEndpoint
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ec2_client_vpn_endpoint.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheckClientVPNSyncronize(t); acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			testAccPreCheckClientVPNSyncronize(t, semaphore)
+			acctest.PreCheck(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckClientVPNEndpointDestroy(ctx),
@@ -147,14 +79,17 @@ func testAccClientVPNEndpoint_basic(t *testing.T) {
 	})
 }
 
-func testAccClientVPNEndpoint_disappears(t *testing.T) {
+func testAccClientVPNEndpoint_disappears(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v ec2.ClientVpnEndpoint
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ec2_client_vpn_endpoint.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheckClientVPNSyncronize(t); acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			testAccPreCheckClientVPNSyncronize(t, semaphore)
+			acctest.PreCheck(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckClientVPNEndpointDestroy(ctx),
@@ -171,13 +106,16 @@ func testAccClientVPNEndpoint_disappears(t *testing.T) {
 	})
 }
 
-func testAccClientVPNEndpoint_tags(t *testing.T) {
+func testAccClientVPNEndpoint_tags(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v ec2.ClientVpnEndpoint
 	resourceName := "aws_ec2_client_vpn_endpoint.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheckClientVPNSyncronize(t); acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			testAccPreCheckClientVPNSyncronize(t, semaphore)
+			acctest.PreCheck(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckClientVPNEndpointDestroy(ctx),
@@ -216,7 +154,7 @@ func testAccClientVPNEndpoint_tags(t *testing.T) {
 	})
 }
 
-func testAccClientVPNEndpoint_msADAuth(t *testing.T) {
+func testAccClientVPNEndpoint_msADAuth(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v ec2.ClientVpnEndpoint
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -228,7 +166,10 @@ func testAccClientVPNEndpoint_msADAuth(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheckClientVPNSyncronize(t); acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			testAccPreCheckClientVPNSyncronize(t, semaphore)
+			acctest.PreCheck(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckClientVPNEndpointDestroy(ctx),
@@ -252,7 +193,7 @@ func testAccClientVPNEndpoint_msADAuth(t *testing.T) {
 	})
 }
 
-func testAccClientVPNEndpoint_msADAuthAndMutualAuth(t *testing.T) {
+func testAccClientVPNEndpoint_msADAuthAndMutualAuth(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v ec2.ClientVpnEndpoint
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -264,7 +205,10 @@ func testAccClientVPNEndpoint_msADAuthAndMutualAuth(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheckClientVPNSyncronize(t); acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			testAccPreCheckClientVPNSyncronize(t, semaphore)
+			acctest.PreCheck(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckClientVPNEndpointDestroy(ctx),
@@ -291,7 +235,7 @@ func testAccClientVPNEndpoint_msADAuthAndMutualAuth(t *testing.T) {
 	})
 }
 
-func testAccClientVPNEndpoint_federatedAuth(t *testing.T) {
+func testAccClientVPNEndpoint_federatedAuth(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v ec2.ClientVpnEndpoint
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -299,7 +243,10 @@ func testAccClientVPNEndpoint_federatedAuth(t *testing.T) {
 	resourceName := "aws_ec2_client_vpn_endpoint.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckClientVPNSyncronize(t) },
+		PreCheck: func() {
+			testAccPreCheckClientVPNSyncronize(t, semaphore)
+			acctest.PreCheck(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckClientVPNEndpointDestroy(ctx),
@@ -323,7 +270,7 @@ func testAccClientVPNEndpoint_federatedAuth(t *testing.T) {
 	})
 }
 
-func testAccClientVPNEndpoint_federatedAuthWithSelfServiceProvider(t *testing.T) {
+func testAccClientVPNEndpoint_federatedAuthWithSelfServiceProvider(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v ec2.ClientVpnEndpoint
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -331,7 +278,10 @@ func testAccClientVPNEndpoint_federatedAuthWithSelfServiceProvider(t *testing.T)
 	resourceName := "aws_ec2_client_vpn_endpoint.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckClientVPNSyncronize(t) },
+		PreCheck: func() {
+			testAccPreCheckClientVPNSyncronize(t, semaphore)
+			acctest.PreCheck(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckClientVPNEndpointDestroy(ctx),
@@ -355,7 +305,7 @@ func testAccClientVPNEndpoint_federatedAuthWithSelfServiceProvider(t *testing.T)
 	})
 }
 
-func testAccClientVPNEndpoint_withClientConnectOptions(t *testing.T) {
+func testAccClientVPNEndpoint_withClientConnectOptions(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v ec2.ClientVpnEndpoint
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -364,7 +314,10 @@ func testAccClientVPNEndpoint_withClientConnectOptions(t *testing.T) {
 	lambdaFunction2ResourceName := "aws_lambda_function.test2"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheckClientVPNSyncronize(t); acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			testAccPreCheckClientVPNSyncronize(t, semaphore)
+			acctest.PreCheck(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckClientVPNEndpointDestroy(ctx),
@@ -405,14 +358,17 @@ func testAccClientVPNEndpoint_withClientConnectOptions(t *testing.T) {
 	})
 }
 
-func testAccClientVPNEndpoint_withClientLoginBannerOptions(t *testing.T) {
+func testAccClientVPNEndpoint_withClientLoginBannerOptions(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v ec2.ClientVpnEndpoint
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ec2_client_vpn_endpoint.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheckClientVPNSyncronize(t); acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			testAccPreCheckClientVPNSyncronize(t, semaphore)
+			acctest.PreCheck(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckClientVPNEndpointDestroy(ctx),
@@ -453,7 +409,7 @@ func testAccClientVPNEndpoint_withClientLoginBannerOptions(t *testing.T) {
 	})
 }
 
-func testAccClientVPNEndpoint_withConnectionLogOptions(t *testing.T) {
+func testAccClientVPNEndpoint_withConnectionLogOptions(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v ec2.ClientVpnEndpoint
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -463,7 +419,10 @@ func testAccClientVPNEndpoint_withConnectionLogOptions(t *testing.T) {
 	logStream2ResourceName := "aws_cloudwatch_log_stream.test2"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheckClientVPNSyncronize(t); acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			testAccPreCheckClientVPNSyncronize(t, semaphore)
+			acctest.PreCheck(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckClientVPNEndpointDestroy(ctx),
@@ -517,14 +476,17 @@ func testAccClientVPNEndpoint_withConnectionLogOptions(t *testing.T) {
 	})
 }
 
-func testAccClientVPNEndpoint_withDNSServers(t *testing.T) {
+func testAccClientVPNEndpoint_withDNSServers(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v ec2.ClientVpnEndpoint
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ec2_client_vpn_endpoint.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheckClientVPNSyncronize(t); acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			testAccPreCheckClientVPNSyncronize(t, semaphore)
+			acctest.PreCheck(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckClientVPNEndpointDestroy(ctx),
@@ -562,7 +524,7 @@ func testAccClientVPNEndpoint_withDNSServers(t *testing.T) {
 	})
 }
 
-func testAccClientVPNEndpoint_simpleAttributesUpdate(t *testing.T) {
+func testAccClientVPNEndpoint_simpleAttributesUpdate(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v ec2.ClientVpnEndpoint
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -571,7 +533,10 @@ func testAccClientVPNEndpoint_simpleAttributesUpdate(t *testing.T) {
 	serverCertificate2ResourceName := "aws_acm_certificate.test2"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheckClientVPNSyncronize(t); acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			testAccPreCheckClientVPNSyncronize(t, semaphore)
+			acctest.PreCheck(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckClientVPNEndpointDestroy(ctx),
@@ -609,7 +574,7 @@ func testAccClientVPNEndpoint_simpleAttributesUpdate(t *testing.T) {
 	})
 }
 
-func testAccClientVPNEndpoint_selfServicePortal(t *testing.T) {
+func testAccClientVPNEndpoint_selfServicePortal(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v ec2.ClientVpnEndpoint
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -617,7 +582,10 @@ func testAccClientVPNEndpoint_selfServicePortal(t *testing.T) {
 	resourceName := "aws_ec2_client_vpn_endpoint.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheckClientVPNSyncronize(t); acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			testAccPreCheckClientVPNSyncronize(t, semaphore)
+			acctest.PreCheck(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckClientVPNEndpointDestroy(ctx),
@@ -647,7 +615,7 @@ func testAccClientVPNEndpoint_selfServicePortal(t *testing.T) {
 	})
 }
 
-func testAccClientVPNEndpoint_vpcNoSecurityGroups(t *testing.T) {
+func testAccClientVPNEndpoint_vpcNoSecurityGroups(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v ec2.ClientVpnEndpoint
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -656,7 +624,10 @@ func testAccClientVPNEndpoint_vpcNoSecurityGroups(t *testing.T) {
 	vpcResourceName := "aws_vpc.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheckClientVPNSyncronize(t); acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			testAccPreCheckClientVPNSyncronize(t, semaphore)
+			acctest.PreCheck(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckClientVPNEndpointDestroy(ctx),
@@ -679,7 +650,7 @@ func testAccClientVPNEndpoint_vpcNoSecurityGroups(t *testing.T) {
 	})
 }
 
-func testAccClientVPNEndpoint_vpcSecurityGroups(t *testing.T) {
+func testAccClientVPNEndpoint_vpcSecurityGroups(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v ec2.ClientVpnEndpoint
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -689,7 +660,10 @@ func testAccClientVPNEndpoint_vpcSecurityGroups(t *testing.T) {
 	vpcResourceName := "aws_vpc.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheckClientVPNSyncronize(t); acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			testAccPreCheckClientVPNSyncronize(t, semaphore)
+			acctest.PreCheck(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckClientVPNEndpointDestroy(ctx),
@@ -722,10 +696,6 @@ func testAccClientVPNEndpoint_vpcSecurityGroups(t *testing.T) {
 	})
 }
 
-func testAccPreCheckClientVPNSyncronize(t *testing.T) {
-	sync.TestAccPreCheckSyncronize(t, testAccEc2ClientVpnEndpointSemaphore, "Client VPN")
-}
-
 func testAccCheckClientVPNEndpointDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Conn(ctx)
@@ -756,10 +726,6 @@ func testAccCheckClientVPNEndpointExists(ctx context.Context, name string, v *ec
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
 			return fmt.Errorf("Not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No EC2 Client VPN Endpoint ID is set")
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Conn(ctx)

--- a/internal/service/ec2/vpnclient_network_association_test.go
+++ b/internal/service/ec2/vpnclient_network_association_test.go
@@ -15,11 +15,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfsync "github.com/hashicorp/terraform-provider-aws/internal/experimental/sync"
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func testAccClientVPNNetworkAssociation_basic(t *testing.T) {
+func testAccClientVPNNetworkAssociation_basic(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var assoc ec2.TargetNetwork
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -29,7 +30,10 @@ func testAccClientVPNNetworkAssociation_basic(t *testing.T) {
 	vpcResourceName := "aws_vpc.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheckClientVPNSyncronize(t); acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			testAccPreCheckClientVPNSyncronize(t, semaphore)
+			acctest.PreCheck(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckClientVPNNetworkAssociationDestroy(ctx),
@@ -55,7 +59,7 @@ func testAccClientVPNNetworkAssociation_basic(t *testing.T) {
 	})
 }
 
-func testAccClientVPNNetworkAssociation_multipleSubnets(t *testing.T) {
+func testAccClientVPNNetworkAssociation_multipleSubnets(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var assoc ec2.TargetNetwork
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -65,7 +69,10 @@ func testAccClientVPNNetworkAssociation_multipleSubnets(t *testing.T) {
 	vpcResourceName := "aws_vpc.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheckClientVPNSyncronize(t); acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			testAccPreCheckClientVPNSyncronize(t, semaphore)
+			acctest.PreCheck(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckClientVPNNetworkAssociationDestroy(ctx),
@@ -87,14 +94,17 @@ func testAccClientVPNNetworkAssociation_multipleSubnets(t *testing.T) {
 	})
 }
 
-func testAccClientVPNNetworkAssociation_disappears(t *testing.T) {
+func testAccClientVPNNetworkAssociation_disappears(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var assoc ec2.TargetNetwork
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ec2_client_vpn_network_association.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheckClientVPNSyncronize(t); acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			testAccPreCheckClientVPNSyncronize(t, semaphore)
+			acctest.PreCheck(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckClientVPNNetworkAssociationDestroy(ctx),
@@ -142,10 +152,6 @@ func testAccCheckClientVPNNetworkAssociationExists(ctx context.Context, name str
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
 			return fmt.Errorf("Not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No EC2 Client VPN Network Association ID is set")
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Conn(ctx)

--- a/internal/service/ec2/vpnclient_route_test.go
+++ b/internal/service/ec2/vpnclient_route_test.go
@@ -14,11 +14,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfsync "github.com/hashicorp/terraform-provider-aws/internal/experimental/sync"
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func testAccClientVPNRoute_basic(t *testing.T) {
+func testAccClientVPNRoute_basic(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v ec2.ClientVpnRoute
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -27,7 +28,10 @@ func testAccClientVPNRoute_basic(t *testing.T) {
 	subnetResourceName := "aws_subnet.test.0"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheckClientVPNSyncronize(t); acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			testAccPreCheckClientVPNSyncronize(t, semaphore)
+			acctest.PreCheck(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckClientVPNRouteDestroy(ctx),
@@ -53,14 +57,17 @@ func testAccClientVPNRoute_basic(t *testing.T) {
 	})
 }
 
-func testAccClientVPNRoute_disappears(t *testing.T) {
+func testAccClientVPNRoute_disappears(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v ec2.ClientVpnRoute
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ec2_client_vpn_route.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheckClientVPNSyncronize(t); acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			testAccPreCheckClientVPNSyncronize(t, semaphore)
+			acctest.PreCheck(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckClientVPNRouteDestroy(ctx),
@@ -77,14 +84,17 @@ func testAccClientVPNRoute_disappears(t *testing.T) {
 	})
 }
 
-func testAccClientVPNRoute_description(t *testing.T) {
+func testAccClientVPNRoute_description(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var v ec2.ClientVpnRoute
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ec2_client_vpn_route.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheckClientVPNSyncronize(t); acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			testAccPreCheckClientVPNSyncronize(t, semaphore)
+			acctest.PreCheck(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckClientVPNRouteDestroy(ctx),
@@ -115,7 +125,6 @@ func testAccCheckClientVPNRouteDestroy(ctx context.Context) resource.TestCheckFu
 			}
 
 			endpointID, targetSubnetID, destinationCIDR, err := tfec2.ClientVPNRouteParseResourceID(rs.Primary.ID)
-
 			if err != nil {
 				return err
 			}
@@ -144,12 +153,7 @@ func testAccCheckClientVPNRouteExists(ctx context.Context, name string, v *ec2.C
 			return fmt.Errorf("Not found: %s", name)
 		}
 
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No EC2 Client VPN Route ID is set")
-		}
-
 		endpointID, targetSubnetID, destinationCIDR, err := tfec2.ClientVPNRouteParseResourceID(rs.Primary.ID)
-
 		if err != nil {
 			return err
 		}

--- a/internal/service/ec2/vpnclient_test.go
+++ b/internal/service/ec2/vpnclient_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ec2_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfsync "github.com/hashicorp/terraform-provider-aws/internal/experimental/sync"
+)
+
+// This is part of an experimental feature, do not use this as a starting point for tests
+//
+//	"This place is not a place of honor... no highly esteemed deed is commemorated here... nothing valued is here.
+//	What is here was dangerous and repulsive to us. This message is a warning about danger."
+//	--  https://hyperallergic.com/312318/a-nuclear-warning-designed-to-last-10000-years/
+func TestAccClientVPNEndpoint_serial(t *testing.T) {
+	t.Parallel()
+
+	semaphore := tfsync.GetSemaphore("ClientVPN", "AWS_EC2_CLIENT_VPN_LIMIT", 5)
+	testCases := map[string]map[string]func(*testing.T, tfsync.Semaphore){
+		"Endpoint": {
+			"basic":                        testAccClientVPNEndpoint_basic,
+			"disappears":                   testAccClientVPNEndpoint_disappears,
+			"msADAuth":                     testAccClientVPNEndpoint_msADAuth,
+			"msADAuthAndMutualAuth":        testAccClientVPNEndpoint_msADAuthAndMutualAuth,
+			"federatedAuth":                testAccClientVPNEndpoint_federatedAuth,
+			"federatedAuthWithSelfService": testAccClientVPNEndpoint_federatedAuthWithSelfServiceProvider,
+			"withClientConnect":            testAccClientVPNEndpoint_withClientConnectOptions,
+			"withClientLoginBanner":        testAccClientVPNEndpoint_withClientLoginBannerOptions,
+			"withLogGroup":                 testAccClientVPNEndpoint_withConnectionLogOptions,
+			"withDNSServers":               testAccClientVPNEndpoint_withDNSServers,
+			"tags":                         testAccClientVPNEndpoint_tags,
+			"simpleAttributesUpdate":       testAccClientVPNEndpoint_simpleAttributesUpdate,
+			"selfServicePortal":            testAccClientVPNEndpoint_selfServicePortal,
+			"vpcNoSecurityGroups":          testAccClientVPNEndpoint_vpcNoSecurityGroups,
+			"vpcSecurityGroups":            testAccClientVPNEndpoint_vpcSecurityGroups,
+			"basicDataSource":              testAccClientVPNEndpointDataSource_basic,
+		},
+		"AuthorizationRule": {
+			"basic":              testAccClientVPNAuthorizationRule_basic,
+			"groups":             testAccClientVPNAuthorizationRule_groups,
+			"subnets":            testAccClientVPNAuthorizationRule_subnets,
+			"disappears":         testAccClientVPNAuthorizationRule_disappears,
+			"disappearsEndpoint": testAccClientVPNAuthorizationRule_Disappears_endpoint,
+		},
+		"NetworkAssociation": {
+			"basic":           testAccClientVPNNetworkAssociation_basic,
+			"multipleSubnets": testAccClientVPNNetworkAssociation_multipleSubnets,
+			"disappears":      testAccClientVPNNetworkAssociation_disappears,
+		},
+		"Route": {
+			"basic":       testAccClientVPNRoute_basic,
+			"description": testAccClientVPNRoute_description,
+			"disappears":  testAccClientVPNRoute_disappears,
+		},
+	}
+
+	acctest.RunLimitedConcurrencyTests2Levels(t, semaphore, testCases)
+}
+
+func testAccPreCheckClientVPNSyncronize(t *testing.T, semaphore tfsync.Semaphore) {
+	tfsync.TestAccPreCheckSyncronize(t, semaphore, "Client VPN")
+}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Limits `aws_verifiedaccess_*` acceptance test concurrency using the same mechanism as Client VPN.
Fixes:

```
Error: creating Verified Access Instance: operation error EC2: CreateVerifiedAccessInstance, https response error StatusCode: 400, RequestID: ..., api error VerifiedAccessInstanceLimitExceeded: The number of instances you have are exceeding your current defined limit
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/33768.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/35747.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccVerifiedAccess_serial' PKG=ec2                 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccVerifiedAccess_serial -timeout 360m
=== RUN   TestAccVerifiedAccess_serial
=== PAUSE TestAccVerifiedAccess_serial
=== CONT  TestAccVerifiedAccess_serial
=== RUN   TestAccVerifiedAccess_serial/Group_tags
=== PAUSE TestAccVerifiedAccess_serial/Group_tags
=== RUN   TestAccVerifiedAccess_serial/Group_policy
=== PAUSE TestAccVerifiedAccess_serial/Group_policy
=== RUN   TestAccVerifiedAccess_serial/Group_updatePolicy
=== PAUSE TestAccVerifiedAccess_serial/Group_updatePolicy
=== RUN   TestAccVerifiedAccess_serial/Group_setPolicy
=== PAUSE TestAccVerifiedAccess_serial/Group_setPolicy
=== RUN   TestAccVerifiedAccess_serial/Group_basic
=== PAUSE TestAccVerifiedAccess_serial/Group_basic
=== RUN   TestAccVerifiedAccess_serial/Group_kms
=== PAUSE TestAccVerifiedAccess_serial/Group_kms
=== RUN   TestAccVerifiedAccess_serial/Group_updateKMS
=== PAUSE TestAccVerifiedAccess_serial/Group_updateKMS
=== RUN   TestAccVerifiedAccess_serial/Group_disappears
=== PAUSE TestAccVerifiedAccess_serial/Group_disappears
=== RUN   TestAccVerifiedAccess_serial/Instance_description
=== PAUSE TestAccVerifiedAccess_serial/Instance_description
=== RUN   TestAccVerifiedAccess_serial/Instance_fipsEnabled
=== PAUSE TestAccVerifiedAccess_serial/Instance_fipsEnabled
=== RUN   TestAccVerifiedAccess_serial/Instance_disappears
=== PAUSE TestAccVerifiedAccess_serial/Instance_disappears
=== RUN   TestAccVerifiedAccess_serial/Instance_tags
=== PAUSE TestAccVerifiedAccess_serial/Instance_tags
=== RUN   TestAccVerifiedAccess_serial/Instance_basic
=== PAUSE TestAccVerifiedAccess_serial/Instance_basic
=== RUN   TestAccVerifiedAccess_serial/InstanceLoggingConfiguration_accessLogsIncludeTrustContext
=== PAUSE TestAccVerifiedAccess_serial/InstanceLoggingConfiguration_accessLogsIncludeTrustContext
=== RUN   TestAccVerifiedAccess_serial/InstanceLoggingConfiguration_accessLogsLogVersion
=== PAUSE TestAccVerifiedAccess_serial/InstanceLoggingConfiguration_accessLogsLogVersion
=== RUN   TestAccVerifiedAccess_serial/InstanceLoggingConfiguration_accessLogsCloudWatchLogs
=== PAUSE TestAccVerifiedAccess_serial/InstanceLoggingConfiguration_accessLogsCloudWatchLogs
=== RUN   TestAccVerifiedAccess_serial/InstanceLoggingConfiguration_accessLogsKinesisDataFirehose
=== PAUSE TestAccVerifiedAccess_serial/InstanceLoggingConfiguration_accessLogsKinesisDataFirehose
=== RUN   TestAccVerifiedAccess_serial/InstanceLoggingConfiguration_accessLogsS3
=== PAUSE TestAccVerifiedAccess_serial/InstanceLoggingConfiguration_accessLogsS3
=== RUN   TestAccVerifiedAccess_serial/InstanceLoggingConfiguration_accessLogsCloudWatchLogsKinesisDataFirehoseS3
=== PAUSE TestAccVerifiedAccess_serial/InstanceLoggingConfiguration_accessLogsCloudWatchLogsKinesisDataFirehoseS3
=== RUN   TestAccVerifiedAccess_serial/InstanceLoggingConfiguration_disappears
=== PAUSE TestAccVerifiedAccess_serial/InstanceLoggingConfiguration_disappears
=== RUN   TestAccVerifiedAccess_serial/InstanceTrustProviderAttachment_basic
=== PAUSE TestAccVerifiedAccess_serial/InstanceTrustProviderAttachment_basic
=== RUN   TestAccVerifiedAccess_serial/InstanceTrustProviderAttachment_disappears
=== PAUSE TestAccVerifiedAccess_serial/InstanceTrustProviderAttachment_disappears
=== RUN   TestAccVerifiedAccess_serial/Endpoint_basic
=== PAUSE TestAccVerifiedAccess_serial/Endpoint_basic
=== RUN   TestAccVerifiedAccess_serial/Endpoint_networkInterface
=== PAUSE TestAccVerifiedAccess_serial/Endpoint_networkInterface
=== RUN   TestAccVerifiedAccess_serial/Endpoint_tags
=== PAUSE TestAccVerifiedAccess_serial/Endpoint_tags
=== RUN   TestAccVerifiedAccess_serial/Endpoint_disappears
=== PAUSE TestAccVerifiedAccess_serial/Endpoint_disappears
=== RUN   TestAccVerifiedAccess_serial/Endpoint_policyDocument
=== PAUSE TestAccVerifiedAccess_serial/Endpoint_policyDocument
=== CONT  TestAccVerifiedAccess_serial/Group_tags
=== CONT  TestAccVerifiedAccess_serial/InstanceLoggingConfiguration_accessLogsLogVersion
=== CONT  TestAccVerifiedAccess_serial/Instance_description
=== CONT  TestAccVerifiedAccess_serial/Group_basic
=== CONT  TestAccVerifiedAccess_serial/InstanceTrustProviderAttachment_disappears
=== CONT  TestAccVerifiedAccess_serial/Endpoint_policyDocument
=== CONT  TestAccVerifiedAccess_serial/Endpoint_tags
=== CONT  TestAccVerifiedAccess_serial/Endpoint_disappears
=== CONT  TestAccVerifiedAccess_serial/InstanceLoggingConfiguration_accessLogsIncludeTrustContext
=== CONT  TestAccVerifiedAccess_serial/Group_disappears
=== CONT  TestAccVerifiedAccess_serial/Instance_tags
=== CONT  TestAccVerifiedAccess_serial/Instance_disappears
=== CONT  TestAccVerifiedAccess_serial/Instance_fipsEnabled
=== CONT  TestAccVerifiedAccess_serial/InstanceTrustProviderAttachment_basic
=== CONT  TestAccVerifiedAccess_serial/InstanceLoggingConfiguration_disappears
=== CONT  TestAccVerifiedAccess_serial/InstanceLoggingConfiguration_accessLogsCloudWatchLogsKinesisDataFirehoseS3
=== CONT  TestAccVerifiedAccess_serial/InstanceLoggingConfiguration_accessLogsS3
=== CONT  TestAccVerifiedAccess_serial/InstanceLoggingConfiguration_accessLogsKinesisDataFirehose
=== CONT  TestAccVerifiedAccess_serial/InstanceLoggingConfiguration_accessLogsCloudWatchLogs
=== CONT  TestAccVerifiedAccess_serial/Instance_basic
=== CONT  TestAccVerifiedAccess_serial/Group_updateKMS
=== CONT  TestAccVerifiedAccess_serial/Endpoint_networkInterface
=== CONT  TestAccVerifiedAccess_serial/Endpoint_basic
=== CONT  TestAccVerifiedAccess_serial/Group_kms
=== CONT  TestAccVerifiedAccess_serial/Group_updatePolicy
=== CONT  TestAccVerifiedAccess_serial/Group_setPolicy
=== CONT  TestAccVerifiedAccess_serial/Group_policy
--- PASS: TestAccVerifiedAccess_serial (0.76s)
    --- PASS: TestAccVerifiedAccess_serial/Group_disappears (31.80s)
    --- PASS: TestAccVerifiedAccess_serial/Group_basic (37.97s)
    --- PASS: TestAccVerifiedAccess_serial/Instance_description (56.86s)
    --- PASS: TestAccVerifiedAccess_serial/InstanceLoggingConfiguration_accessLogsLogVersion (59.91s)
    --- PASS: TestAccVerifiedAccess_serial/InstanceTrustProviderAttachment_disappears (64.85s)
    --- PASS: TestAccVerifiedAccess_serial/Group_tags (80.78s)
    --- PASS: TestAccVerifiedAccess_serial/Instance_disappears (84.45s)
    --- PASS: TestAccVerifiedAccess_serial/Instance_tags (107.91s)
    --- PASS: TestAccVerifiedAccess_serial/Instance_fipsEnabled (116.52s)
    --- PASS: TestAccVerifiedAccess_serial/InstanceLoggingConfiguration_accessLogsIncludeTrustContext (123.69s)
    --- PASS: TestAccVerifiedAccess_serial/InstanceTrustProviderAttachment_basic (132.36s)
    --- PASS: TestAccVerifiedAccess_serial/InstanceLoggingConfiguration_disappears (138.26s)
    --- PASS: TestAccVerifiedAccess_serial/InstanceLoggingConfiguration_accessLogsS3 (183.30s)
    --- PASS: TestAccVerifiedAccess_serial/InstanceLoggingConfiguration_accessLogsCloudWatchLogsKinesisDataFirehoseS3 (278.50s)
    --- PASS: TestAccVerifiedAccess_serial/InstanceLoggingConfiguration_accessLogsKinesisDataFirehose (293.48s)
    --- PASS: TestAccVerifiedAccess_serial/Instance_basic (324.79s)
    --- PASS: TestAccVerifiedAccess_serial/InstanceLoggingConfiguration_accessLogsCloudWatchLogs (325.67s)
    --- PASS: TestAccVerifiedAccess_serial/Group_updateKMS (343.68s)
    --- PASS: TestAccVerifiedAccess_serial/Endpoint_tags (1137.16s)
    --- PASS: TestAccVerifiedAccess_serial/Group_kms (1101.10s)
    --- PASS: TestAccVerifiedAccess_serial/Endpoint_policyDocument (1175.56s)
    --- PASS: TestAccVerifiedAccess_serial/Group_updatePolicy (1139.90s)
    --- PASS: TestAccVerifiedAccess_serial/Group_setPolicy (1141.71s)
    --- PASS: TestAccVerifiedAccess_serial/Group_policy (1146.42s)
    --- PASS: TestAccVerifiedAccess_serial/Endpoint_networkInterface (1454.74s)
    --- PASS: TestAccVerifiedAccess_serial/Endpoint_disappears (1518.37s)
    --- PASS: TestAccVerifiedAccess_serial/Endpoint_basic (1665.17s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	1737.803s
```
```console
% make testacc TESTARGS='-run=TestAccClientVPNEndpoint_serial/basic\|TestAccClientVPNEndpoint_serial/disappears' PKG=ec2 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccClientVPNEndpoint_serial/basic\|TestAccClientVPNEndpoint_serial/disappears -timeout 360m
=== RUN   TestAccClientVPNEndpoint_serial
=== PAUSE TestAccClientVPNEndpoint_serial
=== CONT  TestAccClientVPNEndpoint_serial
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_disappears
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_disappears
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_basicDataSource
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_basicDataSource
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_basic
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_basic
=== RUN   TestAccClientVPNEndpoint_serial/AuthorizationRule_disappears
=== PAUSE TestAccClientVPNEndpoint_serial/AuthorizationRule_disappears
=== RUN   TestAccClientVPNEndpoint_serial/AuthorizationRule_disappearsEndpoint
=== PAUSE TestAccClientVPNEndpoint_serial/AuthorizationRule_disappearsEndpoint
=== RUN   TestAccClientVPNEndpoint_serial/AuthorizationRule_basic
=== PAUSE TestAccClientVPNEndpoint_serial/AuthorizationRule_basic
=== RUN   TestAccClientVPNEndpoint_serial/NetworkAssociation_basic
=== PAUSE TestAccClientVPNEndpoint_serial/NetworkAssociation_basic
=== RUN   TestAccClientVPNEndpoint_serial/NetworkAssociation_disappears
=== PAUSE TestAccClientVPNEndpoint_serial/NetworkAssociation_disappears
=== RUN   TestAccClientVPNEndpoint_serial/Route_basic
=== PAUSE TestAccClientVPNEndpoint_serial/Route_basic
=== RUN   TestAccClientVPNEndpoint_serial/Route_disappears
=== PAUSE TestAccClientVPNEndpoint_serial/Route_disappears
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_disappears
=== CONT  TestAccClientVPNEndpoint_serial/AuthorizationRule_basic
=== CONT  TestAccClientVPNEndpoint_serial/AuthorizationRule_disappears
=== CONT  TestAccClientVPNEndpoint_serial/NetworkAssociation_disappears
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_basicDataSource
=== CONT  TestAccClientVPNEndpoint_serial/AuthorizationRule_disappearsEndpoint
=== CONT  TestAccClientVPNEndpoint_serial/Route_basic
=== CONT  TestAccClientVPNEndpoint_serial/Route_disappears
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_basic
=== CONT  TestAccClientVPNEndpoint_serial/NetworkAssociation_basic
--- PASS: TestAccClientVPNEndpoint_serial (1.13s)
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_disappears (26.50s)
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_basicDataSource (27.07s)
    --- PASS: TestAccClientVPNEndpoint_serial/AuthorizationRule_disappears (60.47s)
    --- PASS: TestAccClientVPNEndpoint_serial/AuthorizationRule_basic (62.77s)
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_basic (84.77s)
    --- PASS: TestAccClientVPNEndpoint_serial/AuthorizationRule_disappearsEndpoint (111.29s)
    --- PASS: TestAccClientVPNEndpoint_serial/NetworkAssociation_disappears (712.44s)
    --- PASS: TestAccClientVPNEndpoint_serial/Route_disappears (797.96s)
    --- PASS: TestAccClientVPNEndpoint_serial/Route_basic (863.54s)
    --- PASS: TestAccClientVPNEndpoint_serial/NetworkAssociation_basic (880.54s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	892.576s
```
