### PR TITLE
[New Resource]: `aws_redshift_data_share_consumer_association`

### DIFF
--- a/.changelog/35771.txt
+++ b/.changelog/35771.txt
@@ -1,0 +1,6 @@
+```release-note:new-resource
+aws_redshift_data_share_consumer_association
+```
+```release-note:bug
+resource/aws_redshift_data_share_authorization: Fix read operation to properly handle shares in `ACTIVE` status
+```

--- a/internal/service/redshift/data_share_authorization.go
+++ b/internal/service/redshift/data_share_authorization.go
@@ -250,12 +250,12 @@ func findDataShareAuthorizationByID(ctx context.Context, conn *redshift.Redshift
 	}
 
 	// Verify a share with the expected consumer identifier is present and the
-	// status is "AUTHORIZED" or "PENDING_AUTHORIZATION"
+	// status is one of "AUTHORIZED" or "ACTIVE".
 	share := out.DataShares[0]
 	for _, assoc := range share.DataShareAssociations {
 		if aws.StringValue(assoc.ConsumerIdentifier) == parts[1] {
 			switch aws.StringValue(assoc.Status) {
-			case redshift.DataShareStatusAuthorized, redshift.DataShareStatusPendingAuthorization:
+			case redshift.DataShareStatusAuthorized, redshift.DataShareStatusActive:
 				return share, nil
 			}
 		}

--- a/internal/service/redshift/data_share_consumer_association.go
+++ b/internal/service/redshift/data_share_consumer_association.go
@@ -1,0 +1,356 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package redshift
+
+import (
+	"context"
+	"errors"
+	"strconv"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/redshift"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	intflex "github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource(name="Data Share Consumer Association")
+func newResourceDataShareConsumerAssociation(_ context.Context) (resource.ResourceWithConfigure, error) {
+	return &resourceDataShareConsumerAssociation{}, nil
+}
+
+const (
+	ResNameDataShareConsumerAssociation = "Data Share Consumer Association"
+)
+
+type resourceDataShareConsumerAssociation struct {
+	framework.ResourceWithConfigure
+}
+
+func (r *resourceDataShareConsumerAssociation) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "aws_redshift_data_share_consumer_association"
+}
+
+func (r *resourceDataShareConsumerAssociation) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"allow_writes": schema.BoolAttribute{
+				Optional: true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.RequiresReplace(),
+				},
+			},
+			"associate_entire_account": schema.BoolAttribute{
+				Optional: true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.RequiresReplace(),
+				},
+			},
+			"consumer_arn": schema.StringAttribute{
+				CustomType: fwtypes.ARNType,
+				Optional:   true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"consumer_region": schema.StringAttribute{
+				Optional: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"data_share_arn": schema.StringAttribute{
+				CustomType: fwtypes.ARNType,
+				Required:   true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"id": framework.IDAttribute(),
+			"managed_by": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"producer_arn": schema.StringAttribute{
+				CustomType: fwtypes.ARNType,
+				Computed:   true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+const dataShareConsumerAssociationIDPartCount = 4
+
+func (r *resourceDataShareConsumerAssociation) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().RedshiftConn(ctx)
+
+	var plan resourceDataShareConsumerAssociationData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	dataShareARN := plan.DataShareARN.ValueString()
+	associateEntireAccountString := ""
+	if plan.AssociateEntireAccount.ValueBool() {
+		associateEntireAccountString = strconv.FormatBool(plan.AssociateEntireAccount.ValueBool())
+	}
+	consumerARN := plan.ConsumerARN.ValueString()
+	consumerRegion := plan.ConsumerRegion.ValueString()
+	parts := []string{
+		dataShareARN,
+		associateEntireAccountString,
+		consumerARN,
+		consumerRegion,
+	}
+	id, err := intflex.FlattenResourceId(parts, dataShareConsumerAssociationIDPartCount, true)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.Redshift, create.ErrActionFlatteningResourceId, ResNameDataShareConsumerAssociation, dataShareARN, err),
+			err.Error(),
+		)
+		return
+	}
+	plan.ID = types.StringValue(id)
+
+	in := &redshift.AssociateDataShareConsumerInput{
+		DataShareArn: aws.String(dataShareARN),
+	}
+
+	if !plan.AllowWrites.IsNull() {
+		in.AllowWrites = aws.Bool(plan.AllowWrites.ValueBool())
+	}
+	if !plan.AssociateEntireAccount.IsNull() {
+		in.AssociateEntireAccount = aws.Bool(plan.AssociateEntireAccount.ValueBool())
+	}
+	if !plan.ConsumerARN.IsNull() {
+		in.ConsumerArn = aws.String(consumerARN)
+	}
+	if !plan.ConsumerRegion.IsNull() {
+		in.ConsumerRegion = aws.String(consumerRegion)
+	}
+
+	out, err := conn.AssociateDataShareConsumerWithContext(ctx, in)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.Redshift, create.ErrActionCreating, ResNameDataShareConsumerAssociation, id, err),
+			err.Error(),
+		)
+		return
+	}
+	if out == nil || len(out.DataShareAssociations) == 0 {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.Redshift, create.ErrActionCreating, ResNameDataShareConsumerAssociation, id, nil),
+			errors.New("empty output").Error(),
+		)
+		return
+	}
+
+	plan.ProducerARN = flex.StringToFrameworkARN(ctx, out.ProducerArn)
+	plan.ManagedBy = flex.StringToFramework(ctx, out.ManagedBy)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *resourceDataShareConsumerAssociation) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().RedshiftConn(ctx)
+
+	var state resourceDataShareConsumerAssociationData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	parts, err := intflex.ExpandResourceId(state.ID.ValueString(), dataShareConsumerAssociationIDPartCount, true)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.Redshift, create.ErrActionExpandingResourceId, ResNameDataShareAuthorization, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+	// split ID and write constituent parts to state to support import
+	state.DataShareARN = fwtypes.ARNValue(parts[0])
+	if parts[1] != "" {
+		state.AssociateEntireAccount = types.BoolValue(parts[1] == "true")
+	}
+	if parts[2] != "" {
+		state.ConsumerARN = fwtypes.ARNValue(parts[2])
+	}
+	if parts[3] != "" {
+		state.ConsumerRegion = types.StringValue(parts[3])
+	}
+
+	out, err := findDataShareConsumerAssociationByID(ctx, conn, state.ID.ValueString())
+	if tfresource.NotFound(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.Redshift, create.ErrActionSetting, ResNameDataShareConsumerAssociation, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	state.ProducerARN = flex.StringToFrameworkARN(ctx, out.ProducerArn)
+	state.ManagedBy = flex.StringToFramework(ctx, out.ManagedBy)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *resourceDataShareConsumerAssociation) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// Update is a no-op
+}
+
+func (r *resourceDataShareConsumerAssociation) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	conn := r.Meta().RedshiftConn(ctx)
+
+	var state resourceDataShareConsumerAssociationData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := &redshift.DisassociateDataShareConsumerInput{
+		DataShareArn: aws.String(state.DataShareARN.ValueString()),
+	}
+	if !state.AssociateEntireAccount.IsNull() && state.AssociateEntireAccount.ValueBool() {
+		in.DisassociateEntireAccount = aws.Bool(true)
+	}
+	if !state.ConsumerARN.IsNull() {
+		in.ConsumerArn = aws.String(state.ConsumerARN.ValueString())
+	}
+	if !state.ConsumerRegion.IsNull() {
+		in.ConsumerRegion = aws.String(state.ConsumerRegion.ValueString())
+	}
+
+	_, err := conn.DisassociateDataShareConsumerWithContext(ctx, in)
+	if err != nil {
+		if tfawserr.ErrMessageContains(err, redshift.ErrCodeInvalidDataShareFault, "because the ARN doesn't exist.") ||
+			tfawserr.ErrMessageContains(err, redshift.ErrCodeInvalidDataShareFault, "either doesn't exist or isn't associated with this data consumer") {
+			return
+		}
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.Redshift, create.ErrActionDeleting, ResNameDataShareConsumerAssociation, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+}
+
+func (r *resourceDataShareConsumerAssociation) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+func (r *resourceDataShareConsumerAssociation) ConfigValidators(_ context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		resourcevalidator.ExactlyOneOf(
+			path.MatchRoot("associate_entire_account"),
+			path.MatchRoot("consumer_arn"),
+			path.MatchRoot("consumer_region"),
+		),
+	}
+}
+
+func findDataShareConsumerAssociationByID(ctx context.Context, conn *redshift.Redshift, id string) (*redshift.DataShare, error) {
+	parts, err := intflex.ExpandResourceId(id, dataShareConsumerAssociationIDPartCount, true)
+	if err != nil {
+		return nil, err
+	}
+	dataShareARN := parts[0]
+	associateEntireAccount := parts[1]
+	consumerARN := parts[2]
+	consumerRegion := parts[3]
+
+	in := &redshift.DescribeDataSharesInput{
+		DataShareArn: aws.String(dataShareARN),
+	}
+
+	out, err := conn.DescribeDataSharesWithContext(ctx, in)
+	if tfawserr.ErrMessageContains(err, redshift.ErrCodeInvalidDataShareFault, "because the ARN doesn't exist.") ||
+		tfawserr.ErrMessageContains(err, redshift.ErrCodeInvalidDataShareFault, "either doesn't exist or isn't associated with this data consumer") {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: in,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if out == nil || len(out.DataShares) == 0 {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+	if len(out.DataShares) != 1 {
+		return nil, tfresource.NewTooManyResultsError(len(out.DataShares), in)
+	}
+
+	share := out.DataShares[0]
+
+	// The data share should include an association in an "ACTIVE" status where
+	// one of the following is true:
+	// - `associate_entire_account` is `true` and `ConsumerIdentifier` matches the
+	//   account number of the data share ARN.
+	// - `consumer_arn` is set and `ConsumerIdentifier` matches its value.
+	// - `consumer_region` is set and `ConsumerRegion` matches its value.
+	for _, assoc := range share.DataShareAssociations {
+		if aws.StringValue(assoc.Status) == redshift.DataShareStatusActive {
+			if associateEntireAccount == "true" && accountIDFromARN(dataShareARN) == aws.StringValue(assoc.ConsumerIdentifier) ||
+				consumerARN != "" && consumerARN == aws.StringValue(assoc.ConsumerIdentifier) ||
+				consumerRegion != "" && consumerRegion == aws.StringValue(assoc.ConsumerRegion) {
+				return share, nil
+			}
+		}
+	}
+
+	return nil, &retry.NotFoundError{
+		LastError:   err,
+		LastRequest: in,
+	}
+}
+
+type resourceDataShareConsumerAssociationData struct {
+	AllowWrites            types.Bool   `tfsdk:"allow_writes"`
+	AssociateEntireAccount types.Bool   `tfsdk:"associate_entire_account"`
+	ConsumerARN            fwtypes.ARN  `tfsdk:"consumer_arn"`
+	ConsumerRegion         types.String `tfsdk:"consumer_region"`
+	DataShareARN           fwtypes.ARN  `tfsdk:"data_share_arn"`
+	ID                     types.String `tfsdk:"id"`
+	ManagedBy              types.String `tfsdk:"managed_by"`
+	ProducerARN            fwtypes.ARN  `tfsdk:"producer_arn"`
+}
+
+// accountIDFromARN returns the account ID from the provided ARN string
+//
+// If the string is not a valid ARN, an empty string is returned, making
+// this function safe for use in comparison operators.
+func accountIDFromARN(s string) string {
+	parsed, err := arn.Parse(s)
+	if err != nil {
+		return ""
+	}
+	return parsed.AccountID
+}

--- a/internal/service/redshift/data_share_consumer_association_test.go
+++ b/internal/service/redshift/data_share_consumer_association_test.go
@@ -1,0 +1,241 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package redshift_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/YakDriver/regexache"
+	"github.com/aws/aws-sdk-go/service/redshift"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tfredshift "github.com/hashicorp/terraform-provider-aws/internal/service/redshift"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccRedshiftDataShareConsumerAssociation_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_redshift_data_share_consumer_association.test"
+	regionDataSourceName := "data.aws_region.current"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, redshift.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, redshift.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDataShareConsumerAssociationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataShareConsumerAssociationConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataShareConsumerAssociationExists(ctx, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "consumer_region", regionDataSourceName, "name"),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "data_share_arn", "redshift", regexache.MustCompile(`datashare:+.`)),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "producer_arn", "redshift-serverless", regexache.MustCompile(`namespace/+.`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccRedshiftDataShareConsumerAssociation_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_redshift_data_share_consumer_association.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, redshift.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, redshift.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDataShareConsumerAssociationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataShareConsumerAssociationConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataShareConsumerAssociationExists(ctx, resourceName),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfredshift.ResourceDataShareConsumerAssociation, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccRedshiftDataShareConsumerAssociation_associateEntireAccount(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_redshift_data_share_consumer_association.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, redshift.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, redshift.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDataShareConsumerAssociationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataShareConsumerAssociationConfig_associateEntireAccount(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataShareConsumerAssociationExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "associate_entire_account", "true"),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "data_share_arn", "redshift", regexache.MustCompile(`datashare:+.`)),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "producer_arn", "redshift-serverless", regexache.MustCompile(`namespace/+.`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckDataShareConsumerAssociationDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).RedshiftConn(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_redshift_data_share_consumer_association" {
+				continue
+			}
+
+			_, err := tfredshift.FindDataShareConsumerAssociationByID(ctx, conn, rs.Primary.ID)
+			if tfawserr.ErrMessageContains(err, redshift.ErrCodeInvalidDataShareFault, "because the ARN doesn't exist.") ||
+				tfawserr.ErrMessageContains(err, redshift.ErrCodeInvalidDataShareFault, "either doesn't exist or isn't associated with this data consumer") {
+				return nil
+			}
+			if err != nil {
+				return create.Error(names.Redshift, create.ErrActionCheckingDestroyed, tfredshift.ResNameDataShareConsumerAssociation, rs.Primary.ID, err)
+			}
+
+			return create.Error(names.Redshift, create.ErrActionCheckingDestroyed, tfredshift.ResNameDataShareConsumerAssociation, rs.Primary.ID, errors.New("not destroyed"))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckDataShareConsumerAssociationExists(ctx context.Context, name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.Redshift, create.ErrActionCheckingExistence, tfredshift.ResNameDataShareConsumerAssociation, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.Redshift, create.ErrActionCheckingExistence, tfredshift.ResNameDataShareConsumerAssociation, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).RedshiftConn(ctx)
+		_, err := tfredshift.FindDataShareConsumerAssociationByID(ctx, conn, rs.Primary.ID)
+		if err != nil {
+			return create.Error(names.Redshift, create.ErrActionCheckingExistence, tfredshift.ResNameDataShareConsumerAssociation, rs.Primary.ID, err)
+		}
+
+		return nil
+	}
+}
+
+func testAccDataShareConsumerAssociationConfigBase(rName string) string {
+	return acctest.ConfigCompose(
+		fmt.Sprintf(`
+data "aws_region" "current" {}
+data "aws_partition" "current" {}
+data "aws_caller_identity" "current" {}
+
+resource "aws_redshiftserverless_namespace" "test" {
+  namespace_name = %[1]q
+  db_name        = "test"
+}
+
+resource "aws_redshiftserverless_workgroup" "test" {
+  namespace_name = aws_redshiftserverless_namespace.test.namespace_name
+  workgroup_name = %[1]q
+}
+
+resource "aws_redshiftdata_statement" "test_create" {
+  workgroup_name = aws_redshiftserverless_workgroup.test.workgroup_name
+  database       = aws_redshiftserverless_namespace.test.db_name
+  sql            = "CREATE DATASHARE tfacctest;"
+}
+`, rName),
+		// Split this resource into a string literal so the terraform `format` function
+		// interpolates properly
+		`
+resource "aws_redshiftdata_statement" "test_grant_usage" {
+  depends_on     = [aws_redshiftdata_statement.test_create]
+  workgroup_name = aws_redshiftserverless_workgroup.test.workgroup_name
+  database       = aws_redshiftserverless_namespace.test.db_name
+  sql            = format("GRANT USAGE ON DATASHARE tfacctest TO ACCOUNT '%s';", data.aws_caller_identity.current.account_id)
+}
+
+locals {
+  # Data share ARN is not returned from the GRANT USAGE statement, so must be
+  # composed manually.
+  # Ref: https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonredshift.html#amazonredshift-resources-for-iam-policies
+  data_share_arn = format("arn:%s:redshift:%s:%s:datashare:%s/%s",
+    data.aws_partition.current.id,
+    data.aws_region.current.name,
+    data.aws_caller_identity.current.account_id,
+    aws_redshiftserverless_namespace.test.namespace_id,
+    "tfacctest",
+  )
+}
+
+resource "aws_redshift_data_share_authorization" "test" {
+  depends_on = [aws_redshiftdata_statement.test_grant_usage]
+
+  data_share_arn      = local.data_share_arn
+  consumer_identifier = data.aws_caller_identity.current.account_id
+}
+`)
+}
+
+func testAccDataShareConsumerAssociationConfig_basic(rName string) string {
+	return acctest.ConfigCompose(
+		testAccDataShareConsumerAssociationConfigBase(rName),
+		`
+resource "aws_redshift_data_share_consumer_association" "test" {
+  depends_on = [aws_redshift_data_share_authorization.test]
+
+  data_share_arn  = local.data_share_arn
+  consumer_region = data.aws_region.current.name
+}
+`)
+}
+
+func testAccDataShareConsumerAssociationConfig_associateEntireAccount(rName string) string {
+	return acctest.ConfigCompose(
+		testAccDataShareConsumerAssociationConfigBase(rName),
+		`
+resource "aws_redshift_data_share_consumer_association" "test" {
+  depends_on = [aws_redshift_data_share_authorization.test]
+
+  data_share_arn           = local.data_share_arn
+  associate_entire_account = true
+}
+`)
+}

--- a/internal/service/redshift/exports_test.go
+++ b/internal/service/redshift/exports_test.go
@@ -5,7 +5,9 @@ package redshift
 
 // Exports for use in tests only.
 var (
-	ResourceDataShareAuthorization = newResourceDataShareAuthorization
+	ResourceDataShareAuthorization       = newResourceDataShareAuthorization
+	ResourceDataShareConsumerAssociation = newResourceDataShareConsumerAssociation
 
-	FindDataShareAuthorizationByID = findDataShareAuthorizationByID
+	FindDataShareAuthorizationByID       = findDataShareAuthorizationByID
+	FindDataShareConsumerAssociationByID = findDataShareConsumerAssociationByID
 )

--- a/internal/service/redshift/service_package_gen.go
+++ b/internal/service/redshift/service_package_gen.go
@@ -25,6 +25,10 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 			Factory: newResourceDataShareAuthorization,
 			Name:    "Data Share Authorization",
 		},
+		{
+			Factory: newResourceDataShareConsumerAssociation,
+			Name:    "Data Share Consumer Association",
+		},
 	}
 }
 

--- a/website/docs/r/redshift_data_share_consumer_association.html.markdown
+++ b/website/docs/r/redshift_data_share_consumer_association.html.markdown
@@ -1,0 +1,68 @@
+---
+subcategory: "Redshift"
+layout: "aws"
+page_title: "AWS: aws_redshift_data_share_consumer_association"
+description: |-
+  Terraform resource for managing an AWS Redshift Data Share Consumer Association.
+---
+# Resource: aws_redshift_data_share_consumer_association
+
+Terraform resource for managing an AWS Redshift Data Share Consumer Association.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_redshift_data_share_consumer_association" "example" {
+  data_share_arn           = "arn:aws:redshift:us-west-2:012345678901:datashare:b3bfde75-73fd-408b-9086-d6fccfd6d588/example"
+  associate_entire_account = true
+}
+```
+
+### Consumer Region
+
+```terraform
+resource "aws_redshift_data_share_consumer_association" "example" {
+  data_share_arn  = "arn:aws:redshift:us-west-2:012345678901:datashare:b3bfde75-73fd-408b-9086-d6fccfd6d588/example"
+  consumer_region = "us-west-2"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `data_share_arn` - (Required) Amazon Resource Name (ARN) of the datashare that the consumer is to use with the account or the namespace.
+
+The following arguments are optional:
+
+* `allow_writes` - (Optional) Whether to allow write operations for a datashare.
+* `associate_entire_account` - (Optional) Whether the datashare is associated with the entire account. Conflicts with `consumer_arn` and `consumer_region`.
+* `consumer_arn` - (Optional) Amazon Resource Name (ARN) of the consumer that is associated with the datashare. Conflicts with `associate_entire_account` and `consumer_region`.
+* `consumer_region` - (Optional) From a datashare consumer account, associates a datashare with all existing and future namespaces in the specified AWS Region. Conflicts with `associate_entire_account` and `consumer_arn`.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `id` - A comma-delimited string concatenating `data_share_arn` and `associate_entire_account`, `consumer_arn`, and `consumer_region`. As only one of the final three arguments can be specified, the other two will always be empty.
+* `managed_by` - Identifier of a datashare to show its managing entity.
+* `producer_arn` - Amazon Resource Name (ARN) of the producer.
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Redshift Data Share Consumer Association using the `id`. For example:
+
+```terraform
+import {
+  to = aws_redshift_data_share_consumer_association.example
+  id = "arn:aws:redshift:us-west-2:012345678901:datashare:b3bfde75-73fd-408b-9086-d6fccfd6d588/example,,,us-west-2"
+}
+```
+
+Using `terraform import`, import Redshift Data Share Consumer Association using the `id`. For example:
+
+```console
+% terraform import aws_redshift_data_share_consumer_association.example arn:aws:redshift:us-west-2:012345678901:datashare:b3bfde75-73fd-408b-9086-d6fccfd6d588/example,,,us-west-2
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This resource will allow practitioners to manage Redshift data share consumer associations via Terraform.

Also fixes a bug in the `aws_redshift_data_share_authorization` data source that incorrectly handled an `ACTIVE` data share status, causing persistent differences and forced re-creation of the resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #33454
Relates #35703 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/redshift/latest/APIReference/API_AssociateDataShareConsumer.html
- https://docs.aws.amazon.com/redshift/latest/APIReference/API_DisassociateDataShareConsumer.html
- https://docs.aws.amazon.com/redshift/latest/APIReference/API_DescribeDataShares.html


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=redshift TESTS=TestAccRedshiftDataShareConsumerAssociation_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/redshift/... -v -count 1 -parallel 20 -run='TestAccRedshiftDataShareConsumerAssociation_'  -timeout 360m

--- PASS: TestAccRedshiftDataShareConsumerAssociation_associateEntireAccount (294.14s)
--- PASS: TestAccRedshiftDataShareConsumerAssociation_disappears (312.61s)
--- PASS: TestAccRedshiftDataShareConsumerAssociation_basic (355.38s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/redshift   362.372s
```
