### PR TITLE
r/aws_apigateway_domain_name: support update of `ownership_verification_certificate_arn`

### DIFF
--- a/internal/service/apigateway/domain_name.go
+++ b/internal/service/apigateway/domain_name.go
@@ -352,6 +352,14 @@ func resourceDomainNameUpdate(ctx context.Context, d *schema.ResourceData, meta 
 			}
 		}
 
+		if d.HasChange("ownership_verification_certificate_arn") {
+			operations = append(operations, &apigateway.PatchOperation{
+				Op:    aws.String(apigateway.OpReplace),
+				Path:  aws.String("/ownershipVerificationCertificateArn"),
+				Value: aws.String(d.Get("ownership_verification_certificate_arn").(string)),
+			})
+		}
+
 		if d.HasChange("regional_certificate_arn") {
 			operations = append(operations, &apigateway.PatchOperation{
 				Op:    aws.String(apigateway.OpReplace),


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Previously the update operation did not handle modifications to this argument.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #35741

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/apigateway/latest/api/API_UpdateDomainName.html
- https://docs.aws.amazon.com/apigateway/latest/api/patch-operations.html#UpdateDomainName-Patch

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=apigateway TESTS=TestAccAPIGatewayDomainName_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/apigateway/... -v -count 1 -parallel 20 -run='TestAccAPIGatewayDomainName_'  -timeout 360m
=== RUN   TestAccAPIGatewayDomainName_certificateARN
    acctest.go:1814: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccAPIGatewayDomainName_certificateARN (0.00s)

=== RUN   TestAccAPIGatewayDomainName_certificateName
    domain_name_test.go:63: Environment variable AWS_API_GATEWAY_DOMAIN_NAME_CERTIFICATE_BODY is not set. This environment variable must be set to any non-empty value with a publicly trusted certificate body to enable the test.
--- SKIP: TestAccAPIGatewayDomainName_certificateName (0.00s)

=== RUN   TestAccAPIGatewayDomainName_regionalCertificateName
    domain_name_test.go:159: Environment variable AWS_API_GATEWAY_DOMAIN_NAME_REGIONAL_CERTIFICATE_NAME_ENABLED is not set. This environment variable must be set to any non-empty value in a region where uploading REGIONAL certificates is allowed to enable the test.
--- SKIP: TestAccAPIGatewayDomainName_regionalCertificateName (0.00s)

=== RUN   TestAccAPIGatewayDomainName_MutualTLSAuthentication_basic
    acctest.go:1814: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccAPIGatewayDomainName_MutualTLSAuthentication_basic (0.00s)

=== RUN   TestAccAPIGatewayDomainName_MutualTLSAuthentication_ownership
    acctest.go:1814: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccAPIGatewayDomainName_MutualTLSAuthentication_ownership (0.00s)

--- PASS: TestAccAPIGatewayDomainName_disappears (42.26s)
--- PASS: TestAccAPIGatewayDomainName_securityPolicy (130.87s)
--- PASS: TestAccAPIGatewayDomainName_regionalCertificateARN (165.97s)
--- PASS: TestAccAPIGatewayDomainName_tags (181.97s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/apigateway 189.369s
```
