### PR TITLE
Fix bug in `aws_datasync_task`

### DIFF
--- a/.changelog/35778.txt
+++ b/.changelog/35778.txt
@@ -1,0 +1,6 @@
+```release-note:bug
+resource/aws_datasync_task: Prevent ValidationErrors when empty values are sent with `report_override` arguments
+```
+```release-note:bug
+resource/aws_datasync_task: Fix crash when reading empty `report_override` values
+```

--- a/internal/service/datasync/task.go
+++ b/internal/service/datasync/task.go
@@ -697,7 +697,6 @@ func expandTaskReportDestination(l []interface{}) *datasync.ReportDestination {
 }
 
 func expandTaskReportOverrides(l []interface{}) *datasync.ReportOverrides {
-
 	var overrides = &datasync.ReportOverrides{}
 
 	if len(l) == 0 || l[0] == nil {

--- a/website/docs/r/datasync_task.html.markdown
+++ b/website/docs/r/datasync_task.html.markdown
@@ -122,6 +122,8 @@ The following arguments are supported inside the `report_overrides` configuratio
 * `transferred_override` - (Optional) Specifies the level of reporting for the files, objects, and directories that DataSync attempted to transfer. Valid values: `ERRORS_ONLY` and `SUCCESSES_AND_ERRORS`.
 * `verified_override` - (Optional) Specifies the level of reporting for the files, objects, and directories that DataSync attempted to verify at the end of your transfer. Valid values: `ERRORS_ONLY` and `SUCCESSES_AND_ERRORS`.
 
+~> **NOTE:** If any `report_overrides` are set to the same value as `task_report_config.report_level`, they will always be flagged as changed. Only set overrides to a value that differs from `task_report_config.report_level`.
+
 ### Schedule
 
 * `schedule_expression` - (Required) Specifies the schedule you want your task to use for repeated executions. For more information, see [Schedule Expressions for Rules](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).


### PR DESCRIPTION
### Description
This fixes 2 bugs:
- One could cause a complete plugin crash due to accessing an uninitialized object in the AWS read response
  - This would occur in the `flattenTaskReportConfigReportOverrides` method
- Leaving a `report_override` property blank could cause empty quotes to be sent in certain circumstances
  - This would cause validation failures on the AWS side, preventing the resource from being created.
  - This would occur in the `expandTaskReportOverrides` method

A third change was made in the docs to highlight how setting `report_override` to the same value as the report default would cause changes to always be detected.
