### PR TITLE
r/aws_ram_resource_share_accepter: handle out-of-band resource deletion

### DIFF
--- a/.changelog/35800.txt
+++ b/.changelog/35800.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ram_resource_share_accepter: Fix handling of out-of-band resource share deletion
+```

--- a/internal/service/ram/resource_share_accepter.go
+++ b/internal/service/ram/resource_share_accepter.go
@@ -211,6 +211,9 @@ func resourceResourceShareAccepterDelete(ctx context.Context, d *schema.Resource
 	}
 
 	if err != nil && !tfawserr.ErrCodeEquals(err, ram.ErrCodeOperationNotPermittedException) {
+		if tfawserr.ErrCodeEquals(err, ram.ErrCodeUnknownResourceException) {
+			return diags
+		}
 		return sdkdiag.AppendErrorf(diags, "leaving RAM resource share: %s", err)
 	}
 


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Previously, resource shares left out-of-band would result in the terraform destroy operation failing with an UnknownResourceException indicating the share could not be found. Nowthis error will be appropriately ignored allowing destroy to exit cleanly.

Before:

```console
% AWS_ALTERNATE_PROFILE=foo make testacc TESTS=TestAccRAMResourceShareAccepter_disappears PKG=ram
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ram/... -v -count 1 -parallel 20 -run='TestAccRAMResourceShareAccepter_disappears'  -timeout 360m
=== RUN   TestAccRAMResourceShareAccepter_disappears
=== PAUSE TestAccRAMResourceShareAccepter_disappears
=== CONT  TestAccRAMResourceShareAccepter_disappears
    testing_new.go:91: Error running post-test destroy, there may be dangling resources: exit status 1

        Error: leaving RAM resource share: UnknownResourceException: ResourceShare arn:aws:ram:us-west-2:927163995318:resource-share/1db3b09a-9c52-49e2-be80-97bc94fbe03a could not be found.

--- FAIL: TestAccRAMResourceShareAccepter_disappears (141.26s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/ram        148.194s
```




### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% AWS_ALTERNATE_PROFILE=foo make testacc TESTS=TestAccRAMResourceShareAccepter_disappears PKG=ram
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ram/... -v -count 1 -parallel 20 -run='TestAccRAMResourceShareAccepter_disappears'  -timeout 360m
=== RUN   TestAccRAMResourceShareAccepter_disappears
=== PAUSE TestAccRAMResourceShareAccepter_disappears
=== CONT  TestAccRAMResourceShareAccepter_disappears
--- PASS: TestAccRAMResourceShareAccepter_disappears (149.78s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ram        158.022s
```
