### PR TITLE
td/shield: fix various tests

### DIFF
--- a/internal/service/shield/drt_access_log_bucket_association_test.go
+++ b/internal/service/shield/drt_access_log_bucket_association_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccShieldDRTAccessLogBucketAssociation_basic(t *testing.T) {
+func testDRTAccessLogBucketAssociation_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	if testing.Short() {
@@ -48,7 +48,7 @@ func TestAccShieldDRTAccessLogBucketAssociation_basic(t *testing.T) {
 	})
 }
 
-func TestAccShieldDRTAccessLogBucketAssociation_multibucket(t *testing.T) {
+func testDRTAccessLogBucketAssociation_multibucket(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	if testing.Short() {
@@ -82,7 +82,7 @@ func TestAccShieldDRTAccessLogBucketAssociation_multibucket(t *testing.T) {
 	})
 }
 
-func TestAccShieldDRTAccessLogBucketAssociation_disappears(t *testing.T) {
+func testDRTAccessLogBucketAssociation_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")

--- a/internal/service/shield/drt_access_role_arn_association.go
+++ b/internal/service/shield/drt_access_role_arn_association.go
@@ -105,6 +105,14 @@ func (r *resourceDRTAccessRoleARNAssociation) Create(ctx context.Context, req re
 		return conn.AssociateDRTRoleWithContext(ctx, in)
 	}, "InvalidParameterException", "role does not have a valid DRT managed policy")
 
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.Shield, create.ErrActionCreating, ResNameDRTAccessRoleARNAssociation, plan.RoleARN.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
 	out := outputRaw.(*shield.AssociateDRTRoleOutput)
 
 	if out == nil {

--- a/internal/service/shield/drt_access_role_arn_association_test.go
+++ b/internal/service/shield/drt_access_role_arn_association_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Acceptance test access AWS and cost money to run.
-func TestAccShieldDRTAccessRoleARNAssociation_basic(t *testing.T) {
+func testDRTAccessRoleARNAssociation_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	if testing.Short() {
@@ -51,7 +51,7 @@ func TestAccShieldDRTAccessRoleARNAssociation_basic(t *testing.T) {
 	})
 }
 
-func TestAccShieldDRTAccessRoleARNAssociation_disappears(t *testing.T) {
+func testDRTAccessRoleARNAssociation_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")

--- a/internal/service/shield/protection_group_test.go
+++ b/internal/service/shield/protection_group_test.go
@@ -42,7 +42,6 @@ func TestAccShieldProtectionGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "aggregation", shield.ProtectionGroupAggregationMax),
 					resource.TestCheckNoResourceAttr(resourceName, "members"),
 					resource.TestCheckResourceAttr(resourceName, "pattern", shield.ProtectionGroupPatternAll),
-					resource.TestCheckNoResourceAttr(resourceName, "resource_type"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "0"),
 				),

--- a/internal/service/shield/shield_test.go
+++ b/internal/service/shield/shield_test.go
@@ -1,0 +1,28 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package shield_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccShield_serial(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]map[string]func(t *testing.T){
+		"DRTAccessLogBucketAssociation": {
+			"basic":       testDRTAccessLogBucketAssociation_basic,
+			"multibucket": testDRTAccessLogBucketAssociation_multibucket,
+			"disappears":  testDRTAccessLogBucketAssociation_disappears,
+		},
+		"DRTAccessRoleARNAssociation": {
+			"basic":      testDRTAccessRoleARNAssociation_basic,
+			"disappears": testDRTAccessRoleARNAssociation_disappears,
+		},
+	}
+
+	acctest.RunSerialTests2Levels(t, testCases, 0)
+}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

```
------- Stdout: -------
=== RUN   TestAccShieldDRTAccessLogBucketAssociation_basic
    drt_access_log_bucket_association_test.go:35: Step 1/1 error: Error running apply: exit status 1
        Error: creating AWS Shield DRT Access Log Bucket Association ("tf-acc-test-1909124837205883387"): OptimisticLockException: Resource has been modified by another client. Please retry
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% AWS_DEFAULT_REGION=us-east-1 make testacc TESTARGS='-run=TestAccShield' PKG=shield

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/shield/... -v -count 1 -parallel 20  -run=TestAccShield -timeout 360m
--- PASS: TestAccShieldProtectionGroup_disappears (20.64s)
--- PASS: TestAccShieldProtection_disappears (22.74s)
--- PASS: TestAccShieldProtectionHealthCheckAssociation_basic (24.70s)
--- PASS: TestAccShieldProtectionHealthCheckAssociation_disappears (26.04s)
--- PASS: TestAccShieldProtection_elasticIPAddress (43.88s)
--- PASS: TestAccShieldProtectionGroup_tags (50.43s)
--- PASS: TestAccShieldProtectionGroup_protectionGroupID (57.61s)
--- PASS: TestAccShieldProtectionGroup_basic (61.33s)
--- PASS: TestAccShieldProtection_globalAccelerator (70.58s)
--- PASS: TestAccShieldProtection_route53 (71.40s)
--- PASS: TestAccShield_serial (75.75s)
    --- PASS: TestAccShield_serial/DRTAccessLogBucketAssociation (54.25s)
        --- PASS: TestAccShield_serial/DRTAccessLogBucketAssociation/basic (30.36s)
        --- PASS: TestAccShield_serial/DRTAccessLogBucketAssociation/multibucket (11.88s)
        --- PASS: TestAccShield_serial/DRTAccessLogBucketAssociation/disappears (12.01s)
    --- PASS: TestAccShield_serial/DRTAccessRoleARNAssociation (21.50s)
        --- PASS: TestAccShield_serial/DRTAccessRoleARNAssociation/basic (11.14s)
        --- PASS: TestAccShield_serial/DRTAccessRoleARNAssociation/disappears (10.36s)
--- PASS: TestAccShieldProtectionGroup_resourceType (81.31s)
--- PASS: TestAccShieldProtection_elb (87.51s)
--- PASS: TestAccShieldProtectionGroup_aggregation (97.39s)
--- PASS: TestAccShieldProtectionGroup_members (107.02s)
--- PASS: TestAccShieldProtection_alb (238.35s)
--- PASS: TestAccShieldProtection_CloudFront_tags (259.71s)
--- PASS: TestAccShieldApplicationLayerAutomaticResponse_disappears (265.67s)
--- PASS: TestAccShieldProtection_cloudFront (267.25s)
--- PASS: TestAccShieldApplicationLayerAutomaticResponse_basic (268.92s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/shield	276.153s

```
