### PR TITLE
d/aws_ec2_instance_type maximum_network_cards

### DIFF
--- a/.changelog/35840.txt
+++ b/.changelog/35840.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_ec2_instance_type: Add `maximum_network_cards` attribute
+```

--- a/internal/service/ec2/ec2_instance_type_data_source.go
+++ b/internal/service/ec2/ec2_instance_type_data_source.go
@@ -225,6 +225,10 @@ func DataSourceInstanceType() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+			"maximum_network_cards": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 			"maximum_network_interfaces": {
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -388,6 +392,7 @@ func dataSourceInstanceTypeRead(ctx context.Context, d *schema.ResourceData, met
 	d.Set("ipv6_supported", v.NetworkInfo.Ipv6Supported)
 	d.Set("maximum_ipv4_addresses_per_interface", v.NetworkInfo.Ipv4AddressesPerInterface)
 	d.Set("maximum_ipv6_addresses_per_interface", v.NetworkInfo.Ipv6AddressesPerInterface)
+	d.Set("maximum_network_cards", v.NetworkInfo.MaximumNetworkCards)
 	d.Set("maximum_network_interfaces", v.NetworkInfo.MaximumNetworkInterfaces)
 	d.Set("memory_size", v.MemoryInfo.SizeInMiB)
 	d.Set("network_performance", v.NetworkInfo.NetworkPerformance)

--- a/internal/service/ec2/ec2_instance_type_data_source_test.go
+++ b/internal/service/ec2/ec2_instance_type_data_source_test.go
@@ -45,6 +45,7 @@ func TestAccEC2InstanceTypeDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "ipv6_supported", "true"),
 					resource.TestCheckResourceAttr(dataSourceName, "maximum_ipv4_addresses_per_interface", "10"),
 					resource.TestCheckResourceAttr(dataSourceName, "maximum_ipv6_addresses_per_interface", "10"),
+					resource.TestCheckResourceAttr(dataSourceName, "maximum_network_cards", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "maximum_network_interfaces", "3"),
 					resource.TestCheckResourceAttr(dataSourceName, "memory_size", "8192"),
 					resource.TestCheckResourceAttr(dataSourceName, "network_performance", "Up to 10 Gigabit"),
@@ -115,10 +116,12 @@ func TestAccEC2InstanceTypeDataSource_gpu(t *testing.T) {
 				Config: testAccInstanceTypeDataSourceConfig_gpu,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "gpus.#", "1"),
-					resource.TestCheckResourceAttr(dataSourceName, "gpus.0.count", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "gpus.0.count", "8"),
 					resource.TestCheckResourceAttr(dataSourceName, "gpus.0.manufacturer", "NVIDIA"),
-					resource.TestCheckResourceAttr(dataSourceName, "gpus.0.memory_size", "8192"),
-					resource.TestCheckResourceAttr(dataSourceName, "gpus.0.name", "M60"),
+					resource.TestCheckResourceAttr(dataSourceName, "gpus.0.memory_size", "81920"),
+					resource.TestCheckResourceAttr(dataSourceName, "gpus.0.name", "H100"),
+					resource.TestCheckResourceAttr(dataSourceName, "maximum_network_cards", "32"),
+					resource.TestCheckResourceAttr(dataSourceName, "maximum_network_interfaces", "64"),
 				),
 			},
 		},
@@ -163,7 +166,7 @@ data "aws_ec2_instance_type" "test" {
 
 const testAccInstanceTypeDataSourceConfig_gpu = `
 data "aws_ec2_instance_type" "test" {
-  instance_type = "g3.4xlarge"
+  instance_type = "p5.48xlarge"
 }
 `
 

--- a/website/docs/d/ec2_instance_type.html.markdown
+++ b/website/docs/d/ec2_instance_type.html.markdown
@@ -77,6 +77,7 @@ This data source exports the following attributes in addition to the arguments a
 * `ipv6_supported` - `true` if IPv6 is supported.
 * `maximum_ipv4_addresses_per_interface` - The maximum number of IPv4 addresses per network interface.
 * `maximum_ipv6_addresses_per_interface` - The maximum number of IPv6 addresses per network interface.
+* `maximum_network_cards` - The maximum number of physical network cards that can be allocated to the instance.
 * `maximum_network_interfaces` - The maximum number of network interfaces for the instance type.
 * `memory_size` - Size of the instance memory, in MiB.
 * `network_performance` - Describes the network performance.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
- Add attribute for `maximum_network_cards` to the `aws_ec2_instance_type` data source. This is used to show the max number of EFA devices that can be exposed on EFA supported instance types

### Relations


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
make testacc TESTS="TestAccEC2InstanceTypeDataSource_" PKG=ec2                 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2InstanceTypeDataSource_'  -timeout 360m
=== RUN   TestAccEC2InstanceTypeDataSource_basic
=== PAUSE TestAccEC2InstanceTypeDataSource_basic
=== RUN   TestAccEC2InstanceTypeDataSource_metal
=== PAUSE TestAccEC2InstanceTypeDataSource_metal
=== RUN   TestAccEC2InstanceTypeDataSource_gpu
=== PAUSE TestAccEC2InstanceTypeDataSource_gpu
=== RUN   TestAccEC2InstanceTypeDataSource_fpga
=== PAUSE TestAccEC2InstanceTypeDataSource_fpga
=== CONT  TestAccEC2InstanceTypeDataSource_basic
=== CONT  TestAccEC2InstanceTypeDataSource_gpu
=== CONT  TestAccEC2InstanceTypeDataSource_fpga
=== CONT  TestAccEC2InstanceTypeDataSource_metal
--- PASS: TestAccEC2InstanceTypeDataSource_gpu (21.63s)
--- PASS: TestAccEC2InstanceTypeDataSource_fpga (21.76s)
--- PASS: TestAccEC2InstanceTypeDataSource_metal (21.79s)
--- PASS: TestAccEC2InstanceTypeDataSource_basic (21.80s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        22.127s
```
