### PR TITLE
Tech Debt: migrate `shield` resources to AWS SDK for Go v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -116,6 +116,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.25.0
 	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.20.0
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.25.0
+	github.com/aws/aws-sdk-go-v2/service/shield v1.24.0
 	github.com/aws/aws-sdk-go-v2/service/signer v1.20.0
 	github.com/aws/aws-sdk-go-v2/service/sns v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.30.0

--- a/go.sum
+++ b/go.sum
@@ -266,6 +266,8 @@ github.com/aws/aws-sdk-go-v2/service/servicequotas v1.20.0 h1:kLSBfjG97Vx/pMaOz8
 github.com/aws/aws-sdk-go-v2/service/servicequotas v1.20.0/go.mod h1:qyFFLkY1mrTC8HV/GMtO5InUd6xGLtGoZulZVRl3o+o=
 github.com/aws/aws-sdk-go-v2/service/sesv2 v1.25.0 h1:g83UKhVWJjUBebWg8HpvDGDAtLgAcSGT0it2Tqf4CSU=
 github.com/aws/aws-sdk-go-v2/service/sesv2 v1.25.0/go.mod h1:XB8oFCr7ZjacT1xw6A6Z7FsgX4gW8thwHw7L0ilmGQo=
+github.com/aws/aws-sdk-go-v2/service/shield v1.24.0 h1:DasZw37v6ciRecoPkslCl8rHmoPfzfwpnR48pxWJaGg=
+github.com/aws/aws-sdk-go-v2/service/shield v1.24.0/go.mod h1:sq11Jfbf0XW0SoJ4esedM4kCsBPmjzakxfpvG1Z+pgs=
 github.com/aws/aws-sdk-go-v2/service/signer v1.20.0 h1:qF7oMpwsttmjJ4GPrRmidn+heJr373qp2DP6tU+x/PY=
 github.com/aws/aws-sdk-go-v2/service/signer v1.20.0/go.mod h1:4OCqIXgppd45tQiOCT5kQdYL1hBT8cwQ6pSXPM+04rU=
 github.com/aws/aws-sdk-go-v2/service/sns v1.27.0 h1:Qa8B9/cgLWNt5zNogF81CuT+Nh+XkzW+hkfO784u1bs=

--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -109,6 +109,7 @@ import (
 	servicecatalogappregistry_sdkv2 "github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry"
 	servicequotas_sdkv2 "github.com/aws/aws-sdk-go-v2/service/servicequotas"
 	sesv2_sdkv2 "github.com/aws/aws-sdk-go-v2/service/sesv2"
+	shield_sdkv2 "github.com/aws/aws-sdk-go-v2/service/shield"
 	signer_sdkv2 "github.com/aws/aws-sdk-go-v2/service/signer"
 	sns_sdkv2 "github.com/aws/aws-sdk-go-v2/service/sns"
 	sqs_sdkv2 "github.com/aws/aws-sdk-go-v2/service/sqs"
@@ -1138,6 +1139,10 @@ func (c *AWSClient) ServiceQuotasClient(ctx context.Context) *servicequotas_sdkv
 
 func (c *AWSClient) ShieldConn(ctx context.Context) *shield_sdkv1.Shield {
 	return errs.Must(conn[*shield_sdkv1.Shield](ctx, c, names.Shield, make(map[string]any)))
+}
+
+func (c *AWSClient) ShieldClient(ctx context.Context) *shield_sdkv2.Client {
+	return errs.Must(client[*shield_sdkv2.Client](ctx, c, names.Shield, make(map[string]any)))
 }
 
 func (c *AWSClient) SignerClient(ctx context.Context) *signer_sdkv2.Client {

--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -236,7 +236,6 @@ import (
 	servicediscovery_sdkv1 "github.com/aws/aws-sdk-go/service/servicediscovery"
 	ses_sdkv1 "github.com/aws/aws-sdk-go/service/ses"
 	sfn_sdkv1 "github.com/aws/aws-sdk-go/service/sfn"
-	shield_sdkv1 "github.com/aws/aws-sdk-go/service/shield"
 	simpledb_sdkv1 "github.com/aws/aws-sdk-go/service/simpledb"
 	ssm_sdkv1 "github.com/aws/aws-sdk-go/service/ssm"
 	storagegateway_sdkv1 "github.com/aws/aws-sdk-go/service/storagegateway"
@@ -1135,10 +1134,6 @@ func (c *AWSClient) ServiceDiscoveryConn(ctx context.Context) *servicediscovery_
 
 func (c *AWSClient) ServiceQuotasClient(ctx context.Context) *servicequotas_sdkv2.Client {
 	return errs.Must(client[*servicequotas_sdkv2.Client](ctx, c, names.ServiceQuotas, make(map[string]any)))
-}
-
-func (c *AWSClient) ShieldConn(ctx context.Context) *shield_sdkv1.Shield {
-	return errs.Must(conn[*shield_sdkv1.Shield](ctx, c, names.Shield, make(map[string]any)))
 }
 
 func (c *AWSClient) ShieldClient(ctx context.Context) *shield_sdkv2.Client {

--- a/internal/service/shield/drt_access_log_bucket_association.go
+++ b/internal/service/shield/drt_access_log_bucket_association.go
@@ -15,8 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -55,14 +53,7 @@ func (r *resourceDRTAccessLogBucketAssociation) Metadata(_ context.Context, req 
 func (r *resourceDRTAccessLogBucketAssociation) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
-				DeprecationMessage:  "id is only for framework compatibility and not used by the provider",
-				MarkdownDescription: "The ID of the directory.",
-				Computed:            true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
+			"id": framework.IDAttribute(),
 			"log_bucket": schema.StringAttribute{
 				Required: true,
 				Validators: []validator.String{

--- a/internal/service/shield/drt_access_log_bucket_association.go
+++ b/internal/service/shield/drt_access_log_bucket_association.go
@@ -8,8 +8,9 @@ import (
 	"errors"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/shield"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/shield"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/shield/types"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -20,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -83,7 +85,7 @@ func (r *resourceDRTAccessLogBucketAssociation) Schema(ctx context.Context, req 
 }
 
 func (r *resourceDRTAccessLogBucketAssociation) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	conn := r.Meta().ShieldConn(ctx)
+	conn := r.Meta().ShieldClient(ctx)
 
 	var plan resourceDRTAccessLogBucketAssociationData
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -92,9 +94,9 @@ func (r *resourceDRTAccessLogBucketAssociation) Create(ctx context.Context, req 
 	}
 
 	in := &shield.AssociateDRTLogBucketInput{
-		LogBucket: aws.String(plan.LogBucket.ValueString()),
+		LogBucket: flex.StringFromFramework(ctx, plan.LogBucket),
 	}
-	out, err := conn.AssociateDRTLogBucketWithContext(ctx, in)
+	out, err := conn.AssociateDRTLogBucket(ctx, in)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			create.ProblemStandardMessage(names.Shield, create.ErrActionCreating, ResNameDRTAccessLogBucketAssociation, plan.LogBucket.String(), err),
@@ -119,13 +121,13 @@ func (r *resourceDRTAccessLogBucketAssociation) Create(ctx context.Context, req 
 		)
 		return
 	}
-	plan.ID = types.StringValue(plan.LogBucket.ValueString())
+	plan.ID = plan.LogBucket
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
 
 func (r *resourceDRTAccessLogBucketAssociation) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	conn := r.Meta().ShieldConn(ctx)
+	conn := r.Meta().ShieldClient(ctx)
 
 	var state resourceDRTAccessLogBucketAssociationData
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -134,7 +136,7 @@ func (r *resourceDRTAccessLogBucketAssociation) Read(ctx context.Context, req re
 	}
 	in := &shield.DescribeDRTAccessInput{}
 
-	out, err := conn.DescribeDRTAccessWithContext(ctx, in)
+	out, err := conn.DescribeDRTAccess(ctx, in)
 	if tfresource.NotFound(err) {
 		resp.State.RemoveResource(ctx)
 		return
@@ -153,31 +155,22 @@ func (r *resourceDRTAccessLogBucketAssociation) Read(ctx context.Context, req re
 		if len(out.LogBucketList) > 0 && associatedLogBucket == nil {
 			resp.Diagnostics.AddError(
 				create.ProblemStandardMessage(names.Shield, create.ErrActionSetting, ResNameDRTAccessLogBucketAssociation, state.LogBucket.String(), nil),
-				errors.New("Log Bucket not in list").Error(),
+				errors.New("log Bucket not in list").Error(),
 			)
 		}
 	}
 
 	if state.ID.IsNull() || state.ID.IsUnknown() {
 		// Setting ID of state - required by hashicorps terraform plugin testing framework for Import. See issue https://github.com/hashicorp/terraform-plugin-testing/issues/84
-		state.ID = types.StringValue(state.LogBucket.ValueString())
+		state.ID = state.LogBucket
 	}
 	state.LogBucket = flex.StringToFramework(ctx, associatedLogBucket)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func getAssociatedLogBucket(bucket string, bucketList []*string) *string {
-	for _, bkt := range bucketList {
-		if aws.StringValue(bkt) == bucket {
-			return bkt
-		}
-	}
-	return nil
-}
-
 func (r *resourceDRTAccessLogBucketAssociation) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	conn := r.Meta().ShieldConn(ctx)
+	conn := r.Meta().ShieldClient(ctx)
 
 	var plan, state resourceDRTAccessLogBucketAssociationData
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -188,9 +181,9 @@ func (r *resourceDRTAccessLogBucketAssociation) Update(ctx context.Context, req 
 
 	if !plan.LogBucket.Equal(state.LogBucket) {
 		in := &shield.AssociateDRTLogBucketInput{
-			LogBucket: aws.String(plan.LogBucket.ValueString()),
+			LogBucket: flex.StringFromFramework(ctx, plan.LogBucket),
 		}
-		out, err := conn.AssociateDRTLogBucketWithContext(ctx, in)
+		out, err := conn.AssociateDRTLogBucket(ctx, in)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				create.ProblemStandardMessage(names.Shield, create.ErrActionUpdating, ResNameDRTAccessLogBucketAssociation, plan.LogBucket.String(), err),
@@ -221,7 +214,7 @@ func (r *resourceDRTAccessLogBucketAssociation) Update(ctx context.Context, req 
 }
 
 func (r *resourceDRTAccessLogBucketAssociation) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	conn := r.Meta().ShieldConn(ctx)
+	conn := r.Meta().ShieldClient(ctx)
 
 	var state resourceDRTAccessLogBucketAssociationData
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -236,18 +229,20 @@ func (r *resourceDRTAccessLogBucketAssociation) Delete(ctx context.Context, req 
 		LogBucket: aws.String(state.LogBucket.ValueString()),
 	}
 
-	_, err := conn.DisassociateDRTLogBucketWithContext(ctx, in)
+	_, err := conn.DisassociateDRTLogBucket(ctx, in)
+
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return
+	}
+
 	if err != nil {
-		var nfe *shield.ResourceNotFoundException
-		if errors.As(err, &nfe) {
-			return
-		}
 		resp.Diagnostics.AddError(
 			create.ProblemStandardMessage(names.Shield, create.ErrActionDeleting, ResNameDRTAccessLogBucketAssociation, state.LogBucket.String(), err),
 			err.Error(),
 		)
 		return
 	}
+
 	deleteTimeout := r.DeleteTimeout(ctx, state.Timeouts)
 	_, err = waitDRTAccessLogBucketAssociationDeleted(ctx, conn, state.LogBucket.ValueString(), deleteTimeout)
 	if err != nil {
@@ -266,7 +261,7 @@ const (
 	statusUpdated       = "Updated"
 )
 
-func waitDRTAccessLogBucketAssociationCreated(ctx context.Context, conn *shield.Shield, bucket string, timeout time.Duration) (*shield.DescribeDRTAccessOutput, error) {
+func waitDRTAccessLogBucketAssociationCreated(ctx context.Context, conn *shield.Client, bucket string, timeout time.Duration) (*shield.DescribeDRTAccessOutput, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending:                   []string{},
 		Target:                    []string{statusNormal},
@@ -284,7 +279,7 @@ func waitDRTAccessLogBucketAssociationCreated(ctx context.Context, conn *shield.
 	return nil, err
 }
 
-func waitDRTAccessLogBucketAssociationUpdated(ctx context.Context, conn *shield.Shield, bucket string, timeout time.Duration) (*shield.DescribeDRTAccessOutput, error) {
+func waitDRTAccessLogBucketAssociationUpdated(ctx context.Context, conn *shield.Client, bucket string, timeout time.Duration) (*shield.DescribeDRTAccessOutput, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending:                   []string{statusChangePending},
 		Target:                    []string{statusUpdated},
@@ -302,7 +297,7 @@ func waitDRTAccessLogBucketAssociationUpdated(ctx context.Context, conn *shield.
 	return nil, err
 }
 
-func waitDRTAccessLogBucketAssociationDeleted(ctx context.Context, conn *shield.Shield, bucket string, timeout time.Duration) (*shield.DescribeDRTAccessOutput, error) {
+func waitDRTAccessLogBucketAssociationDeleted(ctx context.Context, conn *shield.Client, bucket string, timeout time.Duration) (*shield.DescribeDRTAccessOutput, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{statusDeleting, statusNormal},
 		Target:  []string{},
@@ -318,9 +313,10 @@ func waitDRTAccessLogBucketAssociationDeleted(ctx context.Context, conn *shield.
 	return nil, err
 }
 
-func statusDRTAccessLogBucketAssociation(ctx context.Context, conn *shield.Shield, bucket string) retry.StateRefreshFunc {
+func statusDRTAccessLogBucketAssociation(ctx context.Context, conn *shield.Client, bucket string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		out, err := describeDRTAccessLogBucketAssociation(ctx, conn, bucket)
+
 		if tfresource.NotFound(err) {
 			return nil, "", nil
 		}
@@ -328,13 +324,14 @@ func statusDRTAccessLogBucketAssociation(ctx context.Context, conn *shield.Shiel
 		if err != nil {
 			return nil, "", err
 		}
+
 		if out == nil || out.LogBucketList == nil || len(out.LogBucketList) == 0 {
 			return nil, "", nil
 		}
 
 		if out != nil && len(out.LogBucketList) > 0 {
 			for _, bkt := range out.LogBucketList {
-				if aws.StringValue(bkt) == bucket {
+				if bkt == bucket {
 					return out, statusNormal, nil
 				}
 			}
@@ -345,18 +342,20 @@ func statusDRTAccessLogBucketAssociation(ctx context.Context, conn *shield.Shiel
 	}
 }
 
-func describeDRTAccessLogBucketAssociation(ctx context.Context, conn *shield.Shield, bucketName string) (*shield.DescribeDRTAccessOutput, error) {
+func describeDRTAccessLogBucketAssociation(ctx context.Context, conn *shield.Client, bucketName string) (*shield.DescribeDRTAccessOutput, error) {
 	in := &shield.DescribeDRTAccessInput{}
 
-	out, err := conn.DescribeDRTAccessWithContext(ctx, in)
-	if err != nil {
-		var nfe *shield.ResourceNotFoundException
-		if errors.As(err, &nfe) {
-			return nil, &retry.NotFoundError{
-				LastError:   err,
-				LastRequest: in,
-			}
+	out, err := conn.DescribeDRTAccess(ctx, in)
+
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: in,
 		}
+	}
+
+	if err != nil {
+		return nil, err
 	}
 
 	if out == nil || out.LogBucketList == nil || len(out.LogBucketList) == 0 {
@@ -364,11 +363,20 @@ func describeDRTAccessLogBucketAssociation(ctx context.Context, conn *shield.Shi
 	}
 
 	for _, bucket := range out.LogBucketList {
-		if aws.StringValue(bucket) == bucketName {
+		if bucket == bucketName {
 			return out, nil
 		}
 	}
 	return nil, err
+}
+
+func getAssociatedLogBucket(bucket string, bucketList []string) *string {
+	for _, bkt := range bucketList {
+		if bkt == bucket {
+			return &bkt
+		}
+	}
+	return nil
 }
 
 type resourceDRTAccessLogBucketAssociationData struct {

--- a/internal/service/shield/drt_access_log_bucket_association_test.go
+++ b/internal/service/shield/drt_access_log_bucket_association_test.go
@@ -9,7 +9,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/shield"
+	"github.com/aws/aws-sdk-go-v2/service/shield"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/shield/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -114,7 +115,7 @@ func testDRTAccessLogBucketAssociation_disappears(t *testing.T) {
 
 func testAccCheckDRTAccessLogBucketAssociationDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ShieldConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ShieldClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_shield_drt_access_log_bucket_association" {
@@ -122,18 +123,20 @@ func testAccCheckDRTAccessLogBucketAssociationDestroy(ctx context.Context) resou
 			}
 
 			input := &shield.DescribeDRTAccessInput{}
-			resp, err := conn.DescribeDRTAccessWithContext(ctx, input)
+			resp, err := conn.DescribeDRTAccess(ctx, input)
 
-			if errs.IsA[*shield.ResourceNotFoundException](err) {
+			if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 				return nil
 			}
+
 			if err != nil {
 				return err
 			}
+
 			if resp != nil {
 				if resp.LogBucketList != nil && len(resp.LogBucketList) > 0 {
 					for _, bucket := range resp.LogBucketList {
-						if *bucket == rs.Primary.Attributes["log_bucket"] {
+						if bucket == rs.Primary.Attributes["log_bucket"] {
 							return create.Error(names.Shield, create.ErrActionCheckingDestroyed, tfshield.ResNameDRTAccessLogBucketAssociation, rs.Primary.ID, errors.New("bucket association not destroyed"))
 						}
 					}
@@ -160,8 +163,8 @@ func testAccCheckDRTAccessLogBucketAssociationExists(ctx context.Context, name s
 			return create.Error(names.Shield, create.ErrActionCheckingExistence, tfshield.ResNameDRTAccessLogBucketAssociation, name, errors.New("not set"))
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ShieldConn(ctx)
-		resp, err := conn.DescribeDRTAccessWithContext(ctx, &shield.DescribeDRTAccessInput{})
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ShieldClient(ctx)
+		resp, err := conn.DescribeDRTAccess(ctx, &shield.DescribeDRTAccessInput{})
 		if err != nil {
 			return create.Error(names.Shield, create.ErrActionCheckingExistence, tfshield.ResNameDRTAccessLogBucketAssociation, rs.Primary.ID, err)
 		}
@@ -173,10 +176,10 @@ func testAccCheckDRTAccessLogBucketAssociationExists(ctx context.Context, name s
 }
 
 func testAccPreCheckLogBucket(ctx context.Context, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).ShieldConn(ctx)
+	conn := acctest.Provider.Meta().(*conns.AWSClient).ShieldClient(ctx)
 
 	input := &shield.DescribeDRTAccessInput{}
-	_, err := conn.DescribeDRTAccessWithContext(ctx, input)
+	_, err := conn.DescribeDRTAccess(ctx, input)
 
 	if acctest.PreCheckSkipError(err) {
 		t.Skipf("skipping acceptance testing: %s", err)

--- a/internal/service/shield/drt_access_role_arn_association.go
+++ b/internal/service/shield/drt_access_role_arn_association.go
@@ -8,21 +8,19 @@ import (
 	"errors"
 	"time"
 
-	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/shield"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/shield"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/shield/types"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -59,23 +57,10 @@ func (r *resourceDRTAccessRoleARNAssociation) Metadata(_ context.Context, req re
 func (r *resourceDRTAccessRoleARNAssociation) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
-				DeprecationMessage:  "id is only for framework compatibility and not used by the provider",
-				MarkdownDescription: "The ID of the directory.",
-				Computed:            true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
+			"id": framework.IDAttribute(),
 			"role_arn": schema.StringAttribute{
-				Required: true,
-				Validators: []validator.String{
-					stringvalidator.LengthBetween(1, 2048),
-					stringvalidator.RegexMatches(
-						regexache.MustCompile(`^arn:?[A-Za-z-]+:iam::\d{12}:role/?[0-9A-Za-z_+,./=@-]+`),
-						"must match arn pattern",
-					),
-				},
+				CustomType: fwtypes.ARNType,
+				Required:   true,
 			},
 		},
 		Blocks: map[string]schema.Block{
@@ -89,7 +74,7 @@ func (r *resourceDRTAccessRoleARNAssociation) Schema(ctx context.Context, req re
 }
 
 func (r *resourceDRTAccessRoleARNAssociation) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	conn := r.Meta().ShieldConn(ctx)
+	conn := r.Meta().ShieldClient(ctx)
 
 	var plan resourceDRTAccessRoleARNAssociationData
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -98,11 +83,11 @@ func (r *resourceDRTAccessRoleARNAssociation) Create(ctx context.Context, req re
 	}
 
 	in := &shield.AssociateDRTRoleInput{
-		RoleArn: aws.String(plan.RoleARN.ValueString()),
+		RoleArn: flex.StringFromFramework(ctx, plan.RoleARN),
 	}
 
 	outputRaw, err := tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout, func() (interface{}, error) {
-		return conn.AssociateDRTRoleWithContext(ctx, in)
+		return conn.AssociateDRTRole(ctx, in)
 	}, "InvalidParameterException", "role does not have a valid DRT managed policy")
 
 	if err != nil {
@@ -125,6 +110,7 @@ func (r *resourceDRTAccessRoleARNAssociation) Create(ctx context.Context, req re
 
 	createTimeout := r.CreateTimeout(ctx, plan.Timeouts)
 	_, err = waitDRTAccessRoleARNAssociationCreated(ctx, conn, plan.RoleARN.ValueString(), createTimeout)
+
 	if err != nil {
 		resp.Diagnostics.AddError(
 			create.ProblemStandardMessage(names.Shield, create.ErrActionWaitingForCreation, ResNameDRTAccessRoleARNAssociation, plan.RoleARN.String(), err),
@@ -133,13 +119,13 @@ func (r *resourceDRTAccessRoleARNAssociation) Create(ctx context.Context, req re
 		return
 	}
 
-	plan.ID = types.StringValue(plan.RoleARN.ValueString())
+	plan.ID = flex.StringValueToFramework(ctx, plan.RoleARN.ValueString())
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
 
 func (r *resourceDRTAccessRoleARNAssociation) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	conn := r.Meta().ShieldConn(ctx)
+	conn := r.Meta().ShieldClient(ctx)
 
 	var state resourceDRTAccessRoleARNAssociationData
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -148,7 +134,7 @@ func (r *resourceDRTAccessRoleARNAssociation) Read(ctx context.Context, req reso
 	}
 
 	in := &shield.DescribeDRTAccessInput{}
-	out, err := conn.DescribeDRTAccessWithContext(ctx, in)
+	out, err := conn.DescribeDRTAccess(ctx, in)
 
 	if tfresource.NotFound(err) {
 		resp.State.RemoveResource(ctx)
@@ -163,17 +149,16 @@ func (r *resourceDRTAccessRoleARNAssociation) Read(ctx context.Context, req reso
 	}
 	if state.ID.IsNull() || state.ID.IsUnknown() {
 		// Setting ID of state - required by hashicorps terraform plugin testing framework for Import. See issue https://github.com/hashicorp/terraform-plugin-testing/issues/84
-		state.ID = types.StringValue(state.RoleARN.ValueString())
+		state.ID = flex.StringValueToFramework(ctx, state.RoleARN.ValueString())
 	}
 
-	state.RoleARN = flex.StringToFramework(ctx, out.RoleArn)
+	state.RoleARN = flex.StringToFrameworkARN(ctx, out.RoleArn)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
 func (r *resourceDRTAccessRoleARNAssociation) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	conn := r.Meta().ShieldConn(ctx)
+	conn := r.Meta().ShieldClient(ctx)
 
-	// TIP: -- 2. Fetch the plan
 	var plan, state resourceDRTAccessRoleARNAssociationData
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -183,10 +168,10 @@ func (r *resourceDRTAccessRoleARNAssociation) Update(ctx context.Context, req re
 
 	if !plan.RoleARN.Equal(state.RoleARN) {
 		in := &shield.AssociateDRTRoleInput{
-			RoleArn: aws.String(plan.RoleARN.ValueString()),
+			RoleArn: flex.StringFromFramework(ctx, plan.RoleARN),
 		}
 
-		out, err := conn.AssociateDRTRoleWithContext(ctx, in)
+		out, err := conn.AssociateDRTRole(ctx, in)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				create.ProblemStandardMessage(names.Shield, create.ErrActionUpdating, ResNameDRTAccessRoleARNAssociation, plan.RoleARN.String(), err),
@@ -217,7 +202,7 @@ func (r *resourceDRTAccessRoleARNAssociation) Update(ctx context.Context, req re
 }
 
 func (r *resourceDRTAccessRoleARNAssociation) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	conn := r.Meta().ShieldConn(ctx)
+	conn := r.Meta().ShieldClient(ctx)
 
 	var state resourceDRTAccessRoleARNAssociationData
 
@@ -227,13 +212,13 @@ func (r *resourceDRTAccessRoleARNAssociation) Delete(ctx context.Context, req re
 	}
 	in := &shield.DisassociateDRTRoleInput{}
 
-	_, err := conn.DisassociateDRTRoleWithContext(ctx, in)
-	if err != nil {
-		var nfe *shield.ResourceNotFoundException
-		if errors.As(err, &nfe) {
-			return
-		}
+	_, err := conn.DisassociateDRTRole(ctx, in)
 
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return
+	}
+
+	if err != nil {
 		resp.Diagnostics.AddError(
 			create.ProblemStandardMessage(names.Shield, create.ErrActionDeleting, ResNameDRTAccessRoleARNAssociation, state.RoleARN.String(), err),
 			err.Error(),
@@ -253,7 +238,7 @@ func (r *resourceDRTAccessRoleARNAssociation) Delete(ctx context.Context, req re
 	}
 }
 
-func waitDRTAccessRoleARNAssociationCreated(ctx context.Context, conn *shield.Shield, roleARN string, timeout time.Duration) (*shield.DescribeDRTAccessOutput, error) {
+func waitDRTAccessRoleARNAssociationCreated(ctx context.Context, conn *shield.Client, roleARN string, timeout time.Duration) (*shield.DescribeDRTAccessOutput, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending:                   []string{},
 		Target:                    []string{statusNormal},
@@ -271,7 +256,7 @@ func waitDRTAccessRoleARNAssociationCreated(ctx context.Context, conn *shield.Sh
 	return nil, err
 }
 
-func waitDRTAccessRoleARNAssociationUpdated(ctx context.Context, conn *shield.Shield, roleARN string, timeout time.Duration) (*shield.DescribeDRTAccessOutput, error) {
+func waitDRTAccessRoleARNAssociationUpdated(ctx context.Context, conn *shield.Client, roleARN string, timeout time.Duration) (*shield.DescribeDRTAccessOutput, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending:                   []string{statusChangePending},
 		Target:                    []string{statusUpdated},
@@ -289,7 +274,7 @@ func waitDRTAccessRoleARNAssociationUpdated(ctx context.Context, conn *shield.Sh
 	return nil, err
 }
 
-func waitDRTAccessRoleARNAssociationDeleted(ctx context.Context, conn *shield.Shield, roleARN string, timeout time.Duration) (*shield.DescribeDRTAccessOutput, error) {
+func waitDRTAccessRoleARNAssociationDeleted(ctx context.Context, conn *shield.Client, roleARN string, timeout time.Duration) (*shield.DescribeDRTAccessOutput, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{statusDeleting, statusNormal},
 		Target:  []string{},
@@ -306,7 +291,7 @@ func waitDRTAccessRoleARNAssociationDeleted(ctx context.Context, conn *shield.Sh
 	return nil, err
 }
 
-func statusDRTAccessRoleARNAssociation(ctx context.Context, conn *shield.Shield, roleARN string) retry.StateRefreshFunc {
+func statusDRTAccessRoleARNAssociation(ctx context.Context, conn *shield.Client, roleARN string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		out, err := describeDRTAccessRoleARNAssociation(ctx, conn, roleARN)
 		if tfresource.NotFound(err) {
@@ -321,7 +306,7 @@ func statusDRTAccessRoleARNAssociation(ctx context.Context, conn *shield.Shield,
 	}
 }
 
-func statusDRTAccessRoleARNAssociationDeleted(ctx context.Context, conn *shield.Shield, roleARN string) retry.StateRefreshFunc {
+func statusDRTAccessRoleARNAssociationDeleted(ctx context.Context, conn *shield.Client, roleARN string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		out, err := describeDRTAccessRoleARNAssociation(ctx, conn, roleARN)
 
@@ -333,7 +318,7 @@ func statusDRTAccessRoleARNAssociationDeleted(ctx context.Context, conn *shield.
 			return nil, "", err
 		}
 
-		if out.RoleArn != nil && aws.StringValue(out.RoleArn) == roleARN {
+		if out.RoleArn != nil && aws.ToString(out.RoleArn) == roleARN {
 			return out, statusDeleting, nil
 		}
 
@@ -341,21 +326,23 @@ func statusDRTAccessRoleARNAssociationDeleted(ctx context.Context, conn *shield.
 	}
 }
 
-func describeDRTAccessRoleARNAssociation(ctx context.Context, conn *shield.Shield, roleARN string) (*shield.DescribeDRTAccessOutput, error) {
+func describeDRTAccessRoleARNAssociation(ctx context.Context, conn *shield.Client, roleARN string) (*shield.DescribeDRTAccessOutput, error) {
 	in := &shield.DescribeDRTAccessInput{}
 
-	out, err := conn.DescribeDRTAccessWithContext(ctx, in)
-	if err != nil {
-		var nfe *shield.ResourceNotFoundException
-		if errors.As(err, &nfe) {
-			return nil, &retry.NotFoundError{
-				LastError:   err,
-				LastRequest: in,
-			}
+	out, err := conn.DescribeDRTAccess(ctx, in)
+
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: in,
 		}
 	}
 
-	if out == nil || out.RoleArn == nil || aws.StringValue(out.RoleArn) != roleARN {
+	if err != nil {
+		return nil, err
+	}
+
+	if out == nil || out.RoleArn == nil || aws.ToString(out.RoleArn) != roleARN {
 		return nil, tfresource.NewEmptyResultError(in)
 	}
 
@@ -364,6 +351,6 @@ func describeDRTAccessRoleARNAssociation(ctx context.Context, conn *shield.Shiel
 
 type resourceDRTAccessRoleARNAssociationData struct {
 	ID       types.String   `tfsdk:"id"`
-	RoleARN  types.String   `tfsdk:"role_arn"`
+	RoleARN  fwtypes.ARN    `tfsdk:"role_arn"`
 	Timeouts timeouts.Value `tfsdk:"timeouts"`
 }

--- a/internal/service/shield/drt_access_role_arn_association_test.go
+++ b/internal/service/shield/drt_access_role_arn_association_test.go
@@ -9,7 +9,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/shield"
+	"github.com/aws/aws-sdk-go-v2/service/shield"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/shield/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -83,16 +84,16 @@ func testDRTAccessRoleARNAssociation_disappears(t *testing.T) {
 
 func testAccCheckDRTAccessRoleARNAssociationDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ShieldConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ShieldClient(ctx)
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_shield_drt_access_role_arn_association" {
 				continue
 			}
 
 			input := &shield.DescribeDRTAccessInput{}
-			resp, err := conn.DescribeDRTAccessWithContext(ctx, input)
+			resp, err := conn.DescribeDRTAccess(ctx, input)
 
-			if errs.IsA[*shield.ResourceNotFoundException](err) {
+			if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 				return nil
 			}
 
@@ -116,8 +117,8 @@ func testAccCheckDRTAccessRoleARNAssociationExists(ctx context.Context, name str
 		if rs.Primary.ID == "" {
 			return create.Error(names.Shield, create.ErrActionCheckingExistence, tfshield.ResNameDRTAccessLogBucketAssociation, name, errors.New("not set"))
 		}
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ShieldConn(ctx)
-		resp, err := conn.DescribeDRTAccessWithContext(ctx, &shield.DescribeDRTAccessInput{})
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ShieldClient(ctx)
+		resp, err := conn.DescribeDRTAccess(ctx, &shield.DescribeDRTAccessInput{})
 		if err != nil {
 			return create.Error(names.Shield, create.ErrActionCheckingExistence, tfshield.ResNameDRTAccessRoleARNAssociation, "testing", err)
 		}
@@ -128,10 +129,10 @@ func testAccCheckDRTAccessRoleARNAssociationExists(ctx context.Context, name str
 }
 
 func testAccPreCheckRoleARN(ctx context.Context, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).ShieldConn(ctx)
+	conn := acctest.Provider.Meta().(*conns.AWSClient).ShieldClient(ctx)
 
 	input := &shield.DescribeDRTAccessInput{}
-	_, err := conn.DescribeDRTAccessWithContext(ctx, input)
+	_, err := conn.DescribeDRTAccess(ctx, input)
 	if acctest.PreCheckSkipError(err) {
 		t.Skipf("skipping acceptance testing: %s", err)
 	}

--- a/internal/service/shield/generate.go
+++ b/internal/service/shield/generate.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-//go:generate go run ../../generate/tags/main.go -ListTags -ListTagsInIDElem=ResourceARN -ServiceTagsSlice -TagInIDElem=ResourceARN -UpdateTags
+//go:generate go run ../../generate/tags/main.go -AWSSDKVersion=2 -ListTags -ListTagsInIDElem=ResourceARN -ServiceTagsSlice -TagInIDElem=ResourceARN -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/shield/protection_group.go
+++ b/internal/service/shield/protection_group.go
@@ -7,16 +7,20 @@ import (
 	"context"
 	"log"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/shield"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/shield"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/shield/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -35,9 +39,9 @@ func ResourceProtectionGroup() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"aggregation": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringInSlice(shield.ProtectionGroupAggregation_Values(), false),
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateDiagFunc: enum.Validate[awstypes.ProtectionGroupAggregation](),
 			},
 			"members": {
 				Type:          schema.TypeList,
@@ -53,9 +57,9 @@ func ResourceProtectionGroup() *schema.Resource {
 				},
 			},
 			"pattern": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringInSlice(shield.ProtectionGroupPattern_Values(), false),
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateDiagFunc: enum.Validate[awstypes.ProtectionGroupPattern](),
 			},
 			"protection_group_id": {
 				Type:         schema.TypeString,
@@ -68,10 +72,10 @@ func ResourceProtectionGroup() *schema.Resource {
 				Computed: true,
 			},
 			"resource_type": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ConflictsWith: []string{"members"},
-				ValidateFunc:  validation.StringInSlice(shield.ProtectedResourceType_Values(), false),
+				Type:             schema.TypeString,
+				Optional:         true,
+				ConflictsWith:    []string{"members"},
+				ValidateDiagFunc: enum.Validate[awstypes.ProtectedResourceType](),
 			},
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
@@ -82,26 +86,25 @@ func ResourceProtectionGroup() *schema.Resource {
 
 func resourceProtectionGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).ShieldConn(ctx)
+	conn := meta.(*conns.AWSClient).ShieldClient(ctx)
 
 	protectionGroupID := d.Get("protection_group_id").(string)
 	input := &shield.CreateProtectionGroupInput{
-		Aggregation:       aws.String(d.Get("aggregation").(string)),
-		Pattern:           aws.String(d.Get("pattern").(string)),
+		Aggregation:       awstypes.ProtectionGroupAggregation(d.Get("aggregation").(string)),
+		Pattern:           awstypes.ProtectionGroupPattern(d.Get("pattern").(string)),
 		ProtectionGroupId: aws.String(protectionGroupID),
 		Tags:              getTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("members"); ok {
-		input.Members = flex.ExpandStringList(v.([]interface{}))
+		input.Members = flex.ExpandStringValueList(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("resource_type"); ok {
-		input.ResourceType = aws.String(v.(string))
+		input.ResourceType = awstypes.ProtectedResourceType(v.(string))
 	}
 
-	log.Printf("[DEBUG] Creating Shield Protection Group: %s", input)
-	_, err := conn.CreateProtectionGroupWithContext(ctx, input)
+	_, err := conn.CreateProtectionGroup(ctx, input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating Shield Protection Group (%s): %s", protectionGroupID, err)
@@ -114,15 +117,11 @@ func resourceProtectionGroupCreate(ctx context.Context, d *schema.ResourceData, 
 
 func resourceProtectionGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).ShieldConn(ctx)
+	conn := meta.(*conns.AWSClient).ShieldClient(ctx)
 
-	input := &shield.DescribeProtectionGroupInput{
-		ProtectionGroupId: aws.String(d.Id()),
-	}
+	resp, err := findProtectionGroupByID(ctx, conn, d.Id())
 
-	resp, err := conn.DescribeProtectionGroupWithContext(ctx, input)
-
-	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, shield.ErrCodeResourceNotFoundException) {
+	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Shield Protection Group (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
@@ -132,38 +131,37 @@ func resourceProtectionGroupRead(ctx context.Context, d *schema.ResourceData, me
 		return sdkdiag.AppendErrorf(diags, "reading Shield Protection Group (%s): %s", d.Id(), err)
 	}
 
-	arn := aws.StringValue(resp.ProtectionGroup.ProtectionGroupArn)
+	arn := aws.ToString(resp.ProtectionGroupArn)
 	d.Set("protection_group_arn", arn)
-	d.Set("aggregation", resp.ProtectionGroup.Aggregation)
-	d.Set("protection_group_id", resp.ProtectionGroup.ProtectionGroupId)
-	d.Set("pattern", resp.ProtectionGroup.Pattern)
-	d.Set("members", resp.ProtectionGroup.Members)
-	d.Set("resource_type", resp.ProtectionGroup.ResourceType)
+	d.Set("aggregation", resp.Aggregation)
+	d.Set("protection_group_id", resp.ProtectionGroupId)
+	d.Set("pattern", resp.Pattern)
+	d.Set("members", resp.Members)
+	d.Set("resource_type", resp.ResourceType)
 
 	return diags
 }
 
 func resourceProtectionGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).ShieldConn(ctx)
+	conn := meta.(*conns.AWSClient).ShieldClient(ctx)
 
 	if d.HasChangesExcept("tags", "tags_all") {
 		input := &shield.UpdateProtectionGroupInput{
-			Aggregation:       aws.String(d.Get("aggregation").(string)),
-			Pattern:           aws.String(d.Get("pattern").(string)),
+			Aggregation:       awstypes.ProtectionGroupAggregation(d.Get("aggregation").(string)),
+			Pattern:           awstypes.ProtectionGroupPattern(d.Get("pattern").(string)),
 			ProtectionGroupId: aws.String(d.Id()),
 		}
 
 		if v, ok := d.GetOk("members"); ok {
-			input.Members = flex.ExpandStringList(v.([]interface{}))
+			input.Members = flex.ExpandStringValueList(v.([]interface{}))
 		}
 
 		if v, ok := d.GetOk("resource_type"); ok {
-			input.ResourceType = aws.String(v.(string))
+			input.ResourceType = awstypes.ProtectedResourceType(v.(string))
 		}
 
-		log.Printf("[DEBUG] Updating Shield Protection Group: %s", input)
-		_, err := conn.UpdateProtectionGroupWithContext(ctx, input)
+		_, err := conn.UpdateProtectionGroup(ctx, input)
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating Shield Protection Group (%s): %s", d.Id(), err)
@@ -175,14 +173,14 @@ func resourceProtectionGroupUpdate(ctx context.Context, d *schema.ResourceData, 
 
 func resourceProtectionGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).ShieldConn(ctx)
+	conn := meta.(*conns.AWSClient).ShieldClient(ctx)
 
 	log.Printf("[DEBUG] Deletinh Shield Protection Group: %s", d.Id())
-	_, err := conn.DeleteProtectionGroupWithContext(ctx, &shield.DeleteProtectionGroupInput{
+	_, err := conn.DeleteProtectionGroup(ctx, &shield.DeleteProtectionGroupInput{
 		ProtectionGroupId: aws.String(d.Id()),
 	})
 
-	if tfawserr.ErrCodeEquals(err, shield.ErrCodeResourceNotFoundException) {
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return diags
 	}
 
@@ -191,4 +189,29 @@ func resourceProtectionGroupDelete(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	return diags
+}
+
+func findProtectionGroupByID(ctx context.Context, conn *shield.Client, id string) (*awstypes.ProtectionGroup, error) {
+	input := &shield.DescribeProtectionGroupInput{
+		ProtectionGroupId: aws.String(id),
+	}
+
+	resp, err := conn.DescribeProtectionGroup(ctx, input)
+
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.ProtectionGroup == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return resp.ProtectionGroup, nil
 }

--- a/internal/service/shield/protection_group_test.go
+++ b/internal/service/shield/protection_group_test.go
@@ -9,15 +9,17 @@ import (
 	"testing"
 
 	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/shield"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/shield"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/shield/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	tfshield "github.com/hashicorp/terraform-provider-aws/internal/service/shield"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccShieldProtectionGroup_basic(t *testing.T) {
@@ -28,10 +30,10 @@ func TestAccShieldProtectionGroup_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, shield.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.ShieldEndpointID)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, shield.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ShieldEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckProtectionGroupDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -39,9 +41,9 @@ func TestAccShieldProtectionGroup_basic(t *testing.T) {
 				Config: testAccProtectionGroupConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProtectionGroupExists(ctx, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "aggregation", shield.ProtectionGroupAggregationMax),
+					resource.TestCheckResourceAttr(resourceName, "aggregation", string(awstypes.ProtectionGroupAggregationMax)),
 					resource.TestCheckNoResourceAttr(resourceName, "members"),
-					resource.TestCheckResourceAttr(resourceName, "pattern", shield.ProtectionGroupPatternAll),
+					resource.TestCheckResourceAttr(resourceName, "pattern", string(awstypes.ProtectionGroupPatternAll)),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "0"),
 				),
@@ -63,10 +65,10 @@ func TestAccShieldProtectionGroup_disappears(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, shield.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.ShieldEndpointID)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, shield.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ShieldEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckProtectionGroupDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -90,18 +92,18 @@ func TestAccShieldProtectionGroup_aggregation(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, shield.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.ShieldEndpointID)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, shield.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ShieldEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckProtectionGroupDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProtectionGroupConfig_aggregation(rName, shield.ProtectionGroupAggregationMean),
+				Config: testAccProtectionGroupConfig_aggregation(rName, string(awstypes.ProtectionGroupAggregationMean)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProtectionGroupExists(ctx, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "aggregation", shield.ProtectionGroupAggregationMean),
+					resource.TestCheckResourceAttr(resourceName, "aggregation", string(awstypes.ProtectionGroupAggregationMean)),
 				),
 			},
 			{
@@ -110,10 +112,10 @@ func TestAccShieldProtectionGroup_aggregation(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProtectionGroupConfig_aggregation(rName, shield.ProtectionGroupAggregationSum),
+				Config: testAccProtectionGroupConfig_aggregation(rName, string(awstypes.ProtectionGroupAggregationSum)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProtectionGroupExists(ctx, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "aggregation", shield.ProtectionGroupAggregationSum),
+					resource.TestCheckResourceAttr(resourceName, "aggregation", string(awstypes.ProtectionGroupAggregationSum)),
 				),
 			},
 			{
@@ -133,10 +135,10 @@ func TestAccShieldProtectionGroup_members(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, shield.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.ShieldEndpointID)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, shield.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ShieldEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckProtectionGroupDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -144,7 +146,7 @@ func TestAccShieldProtectionGroup_members(t *testing.T) {
 				Config: testAccProtectionGroupConfig_members(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProtectionGroupExists(ctx, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "pattern", shield.ProtectionGroupPatternArbitrary),
+					resource.TestCheckResourceAttr(resourceName, "pattern", string(awstypes.ProtectionGroupPatternArbitrary)),
 					resource.TestCheckResourceAttr(resourceName, "members.#", "1"),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "members.0", "ec2", regexache.MustCompile(`eip-allocation/eipalloc-.+`)),
 				),
@@ -167,10 +169,10 @@ func TestAccShieldProtectionGroup_protectionGroupID(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, shield.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.ShieldEndpointID)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, shield.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ShieldEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckProtectionGroupDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -210,19 +212,19 @@ func TestAccShieldProtectionGroup_resourceType(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, shield.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.ShieldEndpointID)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, shield.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ShieldEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckProtectionGroupDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProtectionGroupConfig_resourceType(rName, shield.ProtectedResourceTypeElasticIpAllocation),
+				Config: testAccProtectionGroupConfig_resourceType(rName, string(awstypes.ProtectedResourceTypeElasticIpAllocation)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProtectionGroupExists(ctx, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "pattern", shield.ProtectionGroupPatternByResourceType),
-					resource.TestCheckResourceAttr(resourceName, "resource_type", shield.ProtectedResourceTypeElasticIpAllocation),
+					resource.TestCheckResourceAttr(resourceName, "pattern", string(awstypes.ProtectionGroupPatternByResourceType)),
+					resource.TestCheckResourceAttr(resourceName, "resource_type", string(awstypes.ProtectedResourceTypeElasticIpAllocation)),
 				),
 			},
 			{
@@ -231,11 +233,11 @@ func TestAccShieldProtectionGroup_resourceType(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProtectionGroupConfig_resourceType(rName, shield.ProtectedResourceTypeApplicationLoadBalancer),
+				Config: testAccProtectionGroupConfig_resourceType(rName, string(awstypes.ProtectedResourceTypeApplicationLoadBalancer)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProtectionGroupExists(ctx, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "pattern", shield.ProtectionGroupPatternByResourceType),
-					resource.TestCheckResourceAttr(resourceName, "resource_type", shield.ProtectedResourceTypeApplicationLoadBalancer),
+					resource.TestCheckResourceAttr(resourceName, "pattern", string(awstypes.ProtectionGroupPatternByResourceType)),
+					resource.TestCheckResourceAttr(resourceName, "resource_type", string(awstypes.ProtectedResourceTypeApplicationLoadBalancer)),
 				),
 			},
 			{
@@ -255,10 +257,10 @@ func TestAccShieldProtectionGroup_tags(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, shield.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.ShieldEndpointID)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, shield.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ShieldEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckProtectionGroupDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -298,7 +300,7 @@ func TestAccShieldProtectionGroup_tags(t *testing.T) {
 
 func testAccCheckProtectionGroupDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ShieldConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ShieldClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_shield_protection_group" {
@@ -309,9 +311,9 @@ func testAccCheckProtectionGroupDestroy(ctx context.Context) resource.TestCheckF
 				ProtectionGroupId: aws.String(rs.Primary.ID),
 			}
 
-			resp, err := conn.DescribeProtectionGroupWithContext(ctx, input)
+			resp, err := conn.DescribeProtectionGroup(ctx, input)
 
-			if tfawserr.ErrCodeEquals(err, shield.ErrCodeResourceNotFoundException) {
+			if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 				continue
 			}
 
@@ -319,7 +321,7 @@ func testAccCheckProtectionGroupDestroy(ctx context.Context) resource.TestCheckF
 				return err
 			}
 
-			if resp != nil && resp.ProtectionGroup != nil && aws.StringValue(resp.ProtectionGroup.ProtectionGroupId) == rs.Primary.ID {
+			if resp != nil && resp.ProtectionGroup != nil && aws.ToString(resp.ProtectionGroup.ProtectionGroupId) == rs.Primary.ID {
 				return fmt.Errorf("The Shield protection group with ID %v still exists", rs.Primary.ID)
 			}
 		}
@@ -335,13 +337,13 @@ func testAccCheckProtectionGroupExists(ctx context.Context, name string) resourc
 			return fmt.Errorf("Not found: %s", name)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ShieldConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ShieldClient(ctx)
 
 		input := &shield.DescribeProtectionGroupInput{
 			ProtectionGroupId: aws.String(rs.Primary.ID),
 		}
 
-		_, err := conn.DescribeProtectionGroupWithContext(ctx, input)
+		_, err := conn.DescribeProtectionGroup(ctx, input)
 
 		return err
 	}

--- a/internal/service/shield/protection_health_check_association_test.go
+++ b/internal/service/shield/protection_health_check_association_test.go
@@ -8,15 +8,17 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/shield"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/shield"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/shield/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	tfshield "github.com/hashicorp/terraform-provider-aws/internal/service/shield"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccShieldProtectionHealthCheckAssociation_basic(t *testing.T) {
@@ -27,10 +29,10 @@ func TestAccShieldProtectionHealthCheckAssociation_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, shield.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.ShieldEndpointID)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, shield.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ShieldEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckProtectionHealthCheckAssociationDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -57,10 +59,10 @@ func TestAccShieldProtectionHealthCheckAssociation_disappears(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, shield.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.ShieldEndpointID)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, shield.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ShieldEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckProtectionHealthCheckAssociationDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -78,7 +80,7 @@ func TestAccShieldProtectionHealthCheckAssociation_disappears(t *testing.T) {
 
 func testAccCheckProtectionHealthCheckAssociationDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ShieldConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ShieldClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_shield_protection_health_check_association" {
@@ -95,9 +97,9 @@ func testAccCheckProtectionHealthCheckAssociationDestroy(ctx context.Context) re
 				ProtectionId: aws.String(protectionId),
 			}
 
-			resp, err := conn.DescribeProtectionWithContext(ctx, input)
+			resp, err := conn.DescribeProtection(ctx, input)
 
-			if tfawserr.ErrCodeEquals(err, shield.ErrCodeResourceNotFoundException) {
+			if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 				continue
 			}
 
@@ -105,8 +107,8 @@ func testAccCheckProtectionHealthCheckAssociationDestroy(ctx context.Context) re
 				return err
 			}
 
-			if resp != nil && resp.Protection != nil && len(aws.StringValueSlice(resp.Protection.HealthCheckIds)) == 0 {
-				return fmt.Errorf("The Shield protection HealthCheck with IDs %v still exists", aws.StringValueSlice(resp.Protection.HealthCheckIds))
+			if resp != nil && resp.Protection != nil && len(resp.Protection.HealthCheckIds) == 0 {
+				return fmt.Errorf("The Shield protection HealthCheck with IDs %v still exists", resp.Protection.HealthCheckIds)
 			}
 		}
 
@@ -131,13 +133,13 @@ func testAccCheckProtectionHealthCheckAssociationExists(ctx context.Context, res
 			return err
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ShieldConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ShieldClient(ctx)
 
 		input := &shield.DescribeProtectionInput{
 			ProtectionId: aws.String(protectionId),
 		}
 
-		resp, err := conn.DescribeProtectionWithContext(ctx, input)
+		resp, err := conn.DescribeProtection(ctx, input)
 
 		if err != nil {
 			return err
@@ -147,7 +149,7 @@ func testAccCheckProtectionHealthCheckAssociationExists(ctx context.Context, res
 			return fmt.Errorf("The Shield protection does not exist")
 		}
 
-		if resp.Protection.HealthCheckIds == nil || len(aws.StringValueSlice(resp.Protection.HealthCheckIds)) != 1 {
+		if resp.Protection.HealthCheckIds == nil || len(resp.Protection.HealthCheckIds) != 1 {
 			return fmt.Errorf("The Shield protection HealthCheck does not exist")
 		}
 

--- a/internal/service/shield/protection_test.go
+++ b/internal/service/shield/protection_test.go
@@ -9,16 +9,19 @@ import (
 	"os"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/shield"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/shield/types"
 	"github.com/aws/aws-sdk-go/service/cloudfront"
-	"github.com/aws/aws-sdk-go/service/shield"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	tfshield "github.com/hashicorp/terraform-provider-aws/internal/service/shield"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccShieldProtection_globalAccelerator(t *testing.T) {
@@ -29,10 +32,10 @@ func TestAccShieldProtection_globalAccelerator(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, shield.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.ShieldEndpointID)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, shield.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ShieldEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckProtectionDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -61,10 +64,10 @@ func TestAccShieldProtection_elasticIPAddress(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, shield.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.ShieldEndpointID)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, shield.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ShieldEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckProtectionDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -93,10 +96,10 @@ func TestAccShieldProtection_disappears(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, shield.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.ShieldEndpointID)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, shield.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ShieldEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckProtectionDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -120,10 +123,10 @@ func TestAccShieldProtection_alb(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, shield.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.ShieldEndpointID)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, shield.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ShieldEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckProtectionDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -152,10 +155,10 @@ func TestAccShieldProtection_elb(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, shield.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.ShieldEndpointID)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, shield.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ShieldEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckProtectionDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -184,11 +187,11 @@ func TestAccShieldProtection_cloudFront(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, shield.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.ShieldEndpointID)
 			acctest.PreCheckPartitionHasService(t, cloudfront.EndpointsID)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, shield.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ShieldEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckProtectionDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -217,11 +220,11 @@ func TestAccShieldProtection_CloudFront_tags(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, shield.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.ShieldEndpointID)
 			acctest.PreCheckPartitionHasService(t, cloudfront.EndpointsID)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, shield.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ShieldEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckProtectionDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -270,10 +273,10 @@ func TestAccShieldProtection_route53(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, shield.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.ShieldEndpointID)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, shield.EndpointsID, "route53"),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ShieldEndpointID, "route53"),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckProtectionDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -294,7 +297,7 @@ func TestAccShieldProtection_route53(t *testing.T) {
 
 func testAccCheckProtectionDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ShieldConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ShieldClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_shield_protection" {
@@ -305,9 +308,9 @@ func testAccCheckProtectionDestroy(ctx context.Context) resource.TestCheckFunc {
 				ProtectionId: aws.String(rs.Primary.ID),
 			}
 
-			resp, err := conn.DescribeProtectionWithContext(ctx, input)
+			resp, err := conn.DescribeProtection(ctx, input)
 
-			if tfawserr.ErrCodeEquals(err, shield.ErrCodeResourceNotFoundException) {
+			if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 				continue
 			}
 
@@ -315,7 +318,7 @@ func testAccCheckProtectionDestroy(ctx context.Context) resource.TestCheckFunc {
 				return err
 			}
 
-			if resp != nil && resp.Protection != nil && aws.StringValue(resp.Protection.Id) == rs.Primary.ID {
+			if resp != nil && resp.Protection != nil && aws.ToString(resp.Protection.Id) == rs.Primary.ID {
 				return fmt.Errorf("The Shield protection with ID %v still exists", rs.Primary.ID)
 			}
 		}
@@ -331,26 +334,28 @@ func testAccCheckProtectionExists(ctx context.Context, name string) resource.Tes
 			return fmt.Errorf("Not found: %s", name)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ShieldConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ShieldClient(ctx)
 
 		input := &shield.DescribeProtectionInput{
 			ProtectionId: aws.String(rs.Primary.ID),
 		}
 
-		_, err := conn.DescribeProtectionWithContext(ctx, input)
+		_, err := conn.DescribeProtection(ctx, input)
 
 		return err
 	}
 }
 
 func testAccPreCheck(ctx context.Context, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).ShieldConn(ctx)
+	conn := acctest.Provider.Meta().(*conns.AWSClient).ShieldClient(ctx)
 
 	input := &shield.ListProtectionsInput{}
 
-	_, err := conn.ListProtectionsWithContext(ctx, input)
+	errResourceNotFoundException := &awstypes.ResourceNotFoundException{}
 
-	if acctest.PreCheckSkipError(err) || tfawserr.ErrMessageContains(err, shield.ErrCodeResourceNotFoundException, "subscription does not exist") {
+	_, err := conn.ListProtections(ctx, input)
+
+	if acctest.PreCheckSkipError(err) || tfawserr.ErrMessageContains(err, errResourceNotFoundException.ErrorCode(), "subscription does not exist") {
 		t.Skipf("skipping acceptance testing: %s", err)
 	}
 

--- a/internal/service/shield/service_endpoints_gen_test.go
+++ b/internal/service/shield/service_endpoints_gen_test.go
@@ -4,15 +4,16 @@ package shield_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	shield_sdkv2 "github.com/aws/aws-sdk-go-v2/service/shield"
 	shield_sdkv1 "github.com/aws/aws-sdk-go/service/shield"
 	"github.com/aws/smithy-go/middleware"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
@@ -202,33 +203,69 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 		},
 	}
 
-	for name, testcase := range testcases { //nolint:paralleltest // uses t.Setenv
-		testcase := testcase
+	t.Run("v1", func(t *testing.T) {
+		for name, testcase := range testcases { //nolint:paralleltest // uses t.Setenv
+			testcase := testcase
 
-		t.Run(name, func(t *testing.T) {
-			testEndpointCase(t, region, testcase, callService)
-		})
-	}
+			t.Run(name, func(t *testing.T) {
+				testEndpointCase(t, region, testcase, callServiceV1)
+			})
+		}
+	})
+
+	t.Run("v2", func(t *testing.T) {
+		for name, testcase := range testcases { //nolint:paralleltest // uses t.Setenv
+			testcase := testcase
+
+			t.Run(name, func(t *testing.T) {
+				testEndpointCase(t, region, testcase, callServiceV2)
+			})
+		}
+	})
 }
 
 func defaultEndpoint(region string) string {
-	r := endpoints.DefaultResolver()
+	r := shield_sdkv2.NewDefaultEndpointResolverV2()
 
-	ep, err := r.EndpointFor(shield_sdkv1.EndpointsID, region)
+	ep, err := r.ResolveEndpoint(context.Background(), shield_sdkv2.EndpointParameters{
+		Region: aws_sdkv2.String(region),
+	})
 	if err != nil {
 		return err.Error()
 	}
 
-	url, _ := url.Parse(ep.URL)
-
-	if url.Path == "" {
-		url.Path = "/"
+	if ep.URI.Path == "" {
+		ep.URI.Path = "/"
 	}
 
-	return url.String()
+	return ep.URI.String()
 }
 
-func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) string {
+func callServiceV2(ctx context.Context, t *testing.T, meta *conns.AWSClient) string {
+	t.Helper()
+
+	var endpoint string
+
+	client := meta.ShieldClient(ctx)
+
+	_, err := client.ListProtectionGroups(ctx, &shield_sdkv2.ListProtectionGroupsInput{},
+		func(opts *shield_sdkv2.Options) {
+			opts.APIOptions = append(opts.APIOptions,
+				addRetrieveEndpointURLMiddleware(t, &endpoint),
+				addCancelRequestMiddleware(),
+			)
+		},
+	)
+	if err == nil {
+		t.Fatal("Expected an error, got none")
+	} else if !errors.Is(err, errCancelOperation) {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+
+	return endpoint
+}
+
+func callServiceV1(ctx context.Context, t *testing.T, meta *conns.AWSClient) string {
 	t.Helper()
 
 	client := meta.ShieldConn(ctx)

--- a/internal/service/shield/service_endpoints_gen_test.go
+++ b/internal/service/shield/service_endpoints_gen_test.go
@@ -14,7 +14,6 @@ import (
 
 	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
 	shield_sdkv2 "github.com/aws/aws-sdk-go-v2/service/shield"
-	shield_sdkv1 "github.com/aws/aws-sdk-go/service/shield"
 	"github.com/aws/smithy-go/middleware"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
@@ -203,25 +202,13 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 		},
 	}
 
-	t.Run("v1", func(t *testing.T) {
-		for name, testcase := range testcases { //nolint:paralleltest // uses t.Setenv
-			testcase := testcase
+	for name, testcase := range testcases { //nolint:paralleltest // uses t.Setenv
+		testcase := testcase
 
-			t.Run(name, func(t *testing.T) {
-				testEndpointCase(t, region, testcase, callServiceV1)
-			})
-		}
-	})
-
-	t.Run("v2", func(t *testing.T) {
-		for name, testcase := range testcases { //nolint:paralleltest // uses t.Setenv
-			testcase := testcase
-
-			t.Run(name, func(t *testing.T) {
-				testEndpointCase(t, region, testcase, callServiceV2)
-			})
-		}
-	})
+		t.Run(name, func(t *testing.T) {
+			testEndpointCase(t, region, testcase, callService)
+		})
+	}
 }
 
 func defaultEndpoint(region string) string {
@@ -241,7 +228,7 @@ func defaultEndpoint(region string) string {
 	return ep.URI.String()
 }
 
-func callServiceV2(ctx context.Context, t *testing.T, meta *conns.AWSClient) string {
+func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) string {
 	t.Helper()
 
 	var endpoint string
@@ -261,20 +248,6 @@ func callServiceV2(ctx context.Context, t *testing.T, meta *conns.AWSClient) str
 	} else if !errors.Is(err, errCancelOperation) {
 		t.Fatalf("Unexpected error: %s", err)
 	}
-
-	return endpoint
-}
-
-func callServiceV1(ctx context.Context, t *testing.T, meta *conns.AWSClient) string {
-	t.Helper()
-
-	client := meta.ShieldConn(ctx)
-
-	req, _ := client.ListProtectionGroupsRequest(&shield_sdkv1.ListProtectionGroupsInput{})
-
-	req.HTTPRequest.URL.Path = "/"
-
-	endpoint := req.HTTPRequest.URL.String()
 
 	return endpoint
 }

--- a/internal/service/shield/service_package.go
+++ b/internal/service/shield/service_package.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	awsPartitionID  = "aws" //nosempgrep:aws-in-const-name
+	partitionID     = "aws"
 	usEast1RegionID = "us-east-1"
 )
 
@@ -20,7 +20,7 @@ func (p *servicePackage) NewClient(_ context.Context, config map[string]any) (*s
 	cfg := *(config["aws_sdkv2_config"].(*aws_sdkv2.Config))
 
 	// Force "global" services to correct Regions.
-	if config["partition"].(string) == awsPartitionID {
+	if config["partition"].(string) == partitionID {
 		cfg.Region = usEast1RegionID
 	}
 

--- a/internal/service/shield/service_package.go
+++ b/internal/service/shield/service_package.go
@@ -10,18 +10,13 @@ import (
 	shield_sdkv2 "github.com/aws/aws-sdk-go-v2/service/shield"
 )
 
-const (
-	partitionID     = "aws"
-	usEast1RegionID = "us-east-1"
-)
-
 // NewClient returns a new AWS SDK for Go v2 client for this service package's AWS API.
 func (p *servicePackage) NewClient(_ context.Context, config map[string]any) (*shield_sdkv2.Client, error) {
 	cfg := *(config["aws_sdkv2_config"].(*aws_sdkv2.Config))
 
 	// Force "global" services to correct Regions.
-	if config["partition"].(string) == partitionID {
-		cfg.Region = usEast1RegionID
+	if config["partition"].(string) == "aws" {
+		cfg.Region = "us-east-1"
 	}
 
 	return shield_sdkv2.NewFromConfig(cfg, func(o *shield_sdkv2.Options) {

--- a/internal/service/shield/service_package.go
+++ b/internal/service/shield/service_package.go
@@ -8,6 +8,7 @@ import (
 
 	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
 	shield_sdkv2 "github.com/aws/aws-sdk-go-v2/service/shield"
+	endpoints_sdkv1 "github.com/aws/aws-sdk-go/aws/endpoints"
 )
 
 // NewClient returns a new AWS SDK for Go v2 client for this service package's AWS API.
@@ -15,8 +16,8 @@ func (p *servicePackage) NewClient(_ context.Context, config map[string]any) (*s
 	cfg := *(config["aws_sdkv2_config"].(*aws_sdkv2.Config))
 
 	// Force "global" services to correct Regions.
-	if config["partition"].(string) == "aws" {
-		cfg.Region = "us-east-1"
+	if config["partition"].(string) == endpoints_sdkv1.AwsPartitionID {
+		cfg.Region = endpoints_sdkv1.UsEast1RegionID
 	}
 
 	return shield_sdkv2.NewFromConfig(cfg, func(o *shield_sdkv2.Options) {

--- a/internal/service/shield/service_package.go
+++ b/internal/service/shield/service_package.go
@@ -6,21 +6,27 @@ package shield
 import (
 	"context"
 
-	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
-	endpoints_sdkv1 "github.com/aws/aws-sdk-go/aws/endpoints"
-	session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
-	shield_sdkv1 "github.com/aws/aws-sdk-go/service/shield"
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	shield_sdkv2 "github.com/aws/aws-sdk-go-v2/service/shield"
 )
 
-// NewConn returns a new AWS SDK for Go v1 client for this service package's AWS API.
-func (p *servicePackage) NewConn(ctx context.Context, m map[string]any) (*shield_sdkv1.Shield, error) {
-	sess := m["session"].(*session_sdkv1.Session)
-	config := &aws_sdkv1.Config{Endpoint: aws_sdkv1.String(m["endpoint"].(string))}
+const (
+	awsPartitionID  = "aws"
+	usEast1RegionID = "us-east-1"
+)
+
+// NewClient returns a new AWS SDK for Go v2 client for this service package's AWS API.
+func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (*shield_sdkv2.Client, error) {
+	cfg := *(config["aws_sdkv2_config"].(*aws_sdkv2.Config))
 
 	// Force "global" services to correct Regions.
-	if m["partition"].(string) == endpoints_sdkv1.AwsPartitionID {
-		config.Region = aws_sdkv1.String(endpoints_sdkv1.UsEast1RegionID)
+	if config["partition"].(string) == awsPartitionID {
+		cfg.Region = usEast1RegionID
 	}
 
-	return shield_sdkv1.New(sess.Copy(config)), nil
+	return shield_sdkv2.NewFromConfig(cfg, func(o *shield_sdkv2.Options) {
+		if endpoint := config["endpoint"].(string); endpoint != "" {
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
+		}
+	}), nil
 }

--- a/internal/service/shield/service_package.go
+++ b/internal/service/shield/service_package.go
@@ -16,7 +16,7 @@ const (
 )
 
 // NewClient returns a new AWS SDK for Go v2 client for this service package's AWS API.
-func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (*shield_sdkv2.Client, error) {
+func (p *servicePackage) NewClient(_ context.Context, config map[string]any) (*shield_sdkv2.Client, error) {
 	cfg := *(config["aws_sdkv2_config"].(*aws_sdkv2.Config))
 
 	// Force "global" services to correct Regions.

--- a/internal/service/shield/service_package.go
+++ b/internal/service/shield/service_package.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	awsPartitionID  = "aws"
+	awsPartitionID  = "aws" //nosempgrep:aws-in-const-name
 	usEast1RegionID = "us-east-1"
 )
 

--- a/internal/service/shield/service_package_gen.go
+++ b/internal/service/shield/service_package_gen.go
@@ -5,11 +5,6 @@ package shield
 import (
 	"context"
 
-	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
-	shield_sdkv2 "github.com/aws/aws-sdk-go-v2/service/shield"
-	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
-	session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
-	shield_sdkv1 "github.com/aws/aws-sdk-go/service/shield"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -69,24 +64,6 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 
 func (p *servicePackage) ServicePackageName() string {
 	return names.Shield
-}
-
-// NewConn returns a new AWS SDK for Go v1 client for this service package's AWS API.
-func (p *servicePackage) NewConn(ctx context.Context, config map[string]any) (*shield_sdkv1.Shield, error) {
-	sess := config["session"].(*session_sdkv1.Session)
-
-	return shield_sdkv1.New(sess.Copy(&aws_sdkv1.Config{Endpoint: aws_sdkv1.String(config["endpoint"].(string))})), nil
-}
-
-// NewClient returns a new AWS SDK for Go v2 client for this service package's AWS API.
-func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (*shield_sdkv2.Client, error) {
-	cfg := *(config["aws_sdkv2_config"].(*aws_sdkv2.Config))
-
-	return shield_sdkv2.NewFromConfig(cfg, func(o *shield_sdkv2.Options) {
-		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.BaseEndpoint = aws_sdkv2.String(endpoint)
-		}
-	}), nil
 }
 
 func ServicePackage(ctx context.Context) conns.ServicePackage {

--- a/internal/service/shield/service_package_gen.go
+++ b/internal/service/shield/service_package_gen.go
@@ -5,6 +5,11 @@ package shield
 import (
 	"context"
 
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	shield_sdkv2 "github.com/aws/aws-sdk-go-v2/service/shield"
+	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
+	session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
+	shield_sdkv1 "github.com/aws/aws-sdk-go/service/shield"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -64,6 +69,24 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 
 func (p *servicePackage) ServicePackageName() string {
 	return names.Shield
+}
+
+// NewConn returns a new AWS SDK for Go v1 client for this service package's AWS API.
+func (p *servicePackage) NewConn(ctx context.Context, config map[string]any) (*shield_sdkv1.Shield, error) {
+	sess := config["session"].(*session_sdkv1.Session)
+
+	return shield_sdkv1.New(sess.Copy(&aws_sdkv1.Config{Endpoint: aws_sdkv1.String(config["endpoint"].(string))})), nil
+}
+
+// NewClient returns a new AWS SDK for Go v2 client for this service package's AWS API.
+func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (*shield_sdkv2.Client, error) {
+	cfg := *(config["aws_sdkv2_config"].(*aws_sdkv2.Config))
+
+	return shield_sdkv2.NewFromConfig(cfg, func(o *shield_sdkv2.Options) {
+		if endpoint := config["endpoint"].(string); endpoint != "" {
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
+		}
+	}), nil
 }
 
 func ServicePackage(ctx context.Context) conns.ServicePackage {

--- a/internal/service/shield/tags_gen.go
+++ b/internal/service/shield/tags_gen.go
@@ -5,9 +5,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/shield"
-	"github.com/aws/aws-sdk-go/service/shield/shieldiface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/shield"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/shield/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/logging"
@@ -19,12 +19,12 @@ import (
 // listTags lists shield service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn shieldiface.ShieldAPI, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *shield.Client, identifier string, optFns ...func(*shield.Options)) (tftags.KeyValueTags, error) {
 	input := &shield.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResourceWithContext(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -36,7 +36,7 @@ func listTags(ctx context.Context, conn shieldiface.ShieldAPI, identifier string
 // ListTags lists shield service tags and set them in Context.
 // It is called from outside this package.
 func (p *servicePackage) ListTags(ctx context.Context, meta any, identifier string) error {
-	tags, err := listTags(ctx, meta.(*conns.AWSClient).ShieldConn(ctx), identifier)
+	tags, err := listTags(ctx, meta.(*conns.AWSClient).ShieldClient(ctx), identifier)
 
 	if err != nil {
 		return err
@@ -52,11 +52,11 @@ func (p *servicePackage) ListTags(ctx context.Context, meta any, identifier stri
 // []*SERVICE.Tag handling
 
 // Tags returns shield service tags.
-func Tags(tags tftags.KeyValueTags) []*shield.Tag {
-	result := make([]*shield.Tag, 0, len(tags))
+func Tags(tags tftags.KeyValueTags) []awstypes.Tag {
+	result := make([]awstypes.Tag, 0, len(tags))
 
 	for k, v := range tags.Map() {
-		tag := &shield.Tag{
+		tag := awstypes.Tag{
 			Key:   aws.String(k),
 			Value: aws.String(v),
 		}
@@ -68,11 +68,11 @@ func Tags(tags tftags.KeyValueTags) []*shield.Tag {
 }
 
 // KeyValueTags creates tftags.KeyValueTags from shield service tags.
-func KeyValueTags(ctx context.Context, tags []*shield.Tag) tftags.KeyValueTags {
+func KeyValueTags(ctx context.Context, tags []awstypes.Tag) tftags.KeyValueTags {
 	m := make(map[string]*string, len(tags))
 
 	for _, tag := range tags {
-		m[aws.StringValue(tag.Key)] = tag.Value
+		m[aws.ToString(tag.Key)] = tag.Value
 	}
 
 	return tftags.New(ctx, m)
@@ -80,7 +80,7 @@ func KeyValueTags(ctx context.Context, tags []*shield.Tag) tftags.KeyValueTags {
 
 // getTagsIn returns shield service tags from Context.
 // nil is returned if there are no input tags.
-func getTagsIn(ctx context.Context) []*shield.Tag {
+func getTagsIn(ctx context.Context) []awstypes.Tag {
 	if inContext, ok := tftags.FromContext(ctx); ok {
 		if tags := Tags(inContext.TagsIn.UnwrapOrDefault()); len(tags) > 0 {
 			return tags
@@ -91,7 +91,7 @@ func getTagsIn(ctx context.Context) []*shield.Tag {
 }
 
 // setTagsOut sets shield service tags in Context.
-func setTagsOut(ctx context.Context, tags []*shield.Tag) {
+func setTagsOut(ctx context.Context, tags []awstypes.Tag) {
 	if inContext, ok := tftags.FromContext(ctx); ok {
 		inContext.TagsOut = option.Some(KeyValueTags(ctx, tags))
 	}
@@ -100,7 +100,7 @@ func setTagsOut(ctx context.Context, tags []*shield.Tag) {
 // updateTags updates shield service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn shieldiface.ShieldAPI, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *shield.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*shield.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -111,10 +111,10 @@ func updateTags(ctx context.Context, conn shieldiface.ShieldAPI, identifier stri
 	if len(removedTags) > 0 {
 		input := &shield.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.Keys()),
+			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResourceWithContext(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -129,7 +129,7 @@ func updateTags(ctx context.Context, conn shieldiface.ShieldAPI, identifier stri
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResourceWithContext(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)
@@ -142,5 +142,5 @@ func updateTags(ctx context.Context, conn shieldiface.ShieldAPI, identifier stri
 // UpdateTags updates shield service tags.
 // It is called from outside this package.
 func (p *servicePackage) UpdateTags(ctx context.Context, meta any, identifier string, oldTags, newTags any) error {
-	return updateTags(ctx, meta.(*conns.AWSClient).ShieldConn(ctx), identifier, oldTags, newTags)
+	return updateTags(ctx, meta.(*conns.AWSClient).ShieldClient(ctx), identifier, oldTags, newTags)
 }

--- a/names/data/names_data.csv
+++ b/names/data/names_data.csv
@@ -335,7 +335,7 @@ service-quotas,servicequotas,servicequotas,servicequotas,,servicequotas,,,Servic
 ses,ses,ses,ses,,ses,,,SES,SES,,1,,,aws_ses_,,ses_,SES (Simple Email),Amazon,,,,,,,SES,ListIdentities,,
 sesv2,sesv2,sesv2,sesv2,,sesv2,,,SESV2,SESV2,,,2,,aws_sesv2_,,sesv2_,SESv2 (Simple Email V2),Amazon,,,,,,,SESv2,ListContactLists,,
 stepfunctions,stepfunctions,sfn,sfn,,sfn,,stepfunctions,SFN,SFN,,1,,,aws_sfn_,,sfn_,SFN (Step Functions),AWS,,,,,,,SFN,ListActivities,,
-shield,shield,shield,shield,,shield,,,Shield,Shield,x,1,,,aws_shield_,,shield_,Shield,AWS,,,,,,,Shield,ListProtectionGroups,,
+shield,shield,shield,shield,,shield,,,Shield,Shield,,1,2,,aws_shield_,,shield_,Shield,AWS,,,,,,,Shield,ListProtectionGroups,,
 signer,signer,signer,signer,,signer,,,Signer,Signer,,,2,,aws_signer_,,signer_,Signer,AWS,,,,,,,signer,ListSigningJobs,,
 sms,sms,sms,sms,,sms,,,SMS,SMS,,1,,,aws_sms_,,sms_,SMS (Server Migration),AWS,,x,,,,,SMS,,,
 snow-device-management,snowdevicemanagement,snowdevicemanagement,snowdevicemanagement,,snowdevicemanagement,,,SnowDeviceManagement,SnowDeviceManagement,,1,,,aws_snowdevicemanagement_,,snowdevicemanagement_,Snow Device Management,AWS,,x,,,,,Snow Device Management,,,

--- a/names/data/names_data.csv
+++ b/names/data/names_data.csv
@@ -335,7 +335,7 @@ service-quotas,servicequotas,servicequotas,servicequotas,,servicequotas,,,Servic
 ses,ses,ses,ses,,ses,,,SES,SES,,1,,,aws_ses_,,ses_,SES (Simple Email),Amazon,,,,,,,SES,ListIdentities,,
 sesv2,sesv2,sesv2,sesv2,,sesv2,,,SESV2,SESV2,,,2,,aws_sesv2_,,sesv2_,SESv2 (Simple Email V2),Amazon,,,,,,,SESv2,ListContactLists,,
 stepfunctions,stepfunctions,sfn,sfn,,sfn,,stepfunctions,SFN,SFN,,1,,,aws_sfn_,,sfn_,SFN (Step Functions),AWS,,,,,,,SFN,ListActivities,,
-shield,shield,shield,shield,,shield,,,Shield,Shield,x,1,2,,aws_shield_,,shield_,Shield,AWS,,,,,,,Shield,ListProtectionGroups,,
+shield,shield,shield,shield,,shield,,,Shield,Shield,x,,2,,aws_shield_,,shield_,Shield,AWS,,,,,,,Shield,ListProtectionGroups,,
 signer,signer,signer,signer,,signer,,,Signer,Signer,,,2,,aws_signer_,,signer_,Signer,AWS,,,,,,,signer,ListSigningJobs,,
 sms,sms,sms,sms,,sms,,,SMS,SMS,,1,,,aws_sms_,,sms_,SMS (Server Migration),AWS,,x,,,,,SMS,,,
 snow-device-management,snowdevicemanagement,snowdevicemanagement,snowdevicemanagement,,snowdevicemanagement,,,SnowDeviceManagement,SnowDeviceManagement,,1,,,aws_snowdevicemanagement_,,snowdevicemanagement_,Snow Device Management,AWS,,x,,,,,Snow Device Management,,,

--- a/names/data/names_data.csv
+++ b/names/data/names_data.csv
@@ -335,7 +335,7 @@ service-quotas,servicequotas,servicequotas,servicequotas,,servicequotas,,,Servic
 ses,ses,ses,ses,,ses,,,SES,SES,,1,,,aws_ses_,,ses_,SES (Simple Email),Amazon,,,,,,,SES,ListIdentities,,
 sesv2,sesv2,sesv2,sesv2,,sesv2,,,SESV2,SESV2,,,2,,aws_sesv2_,,sesv2_,SESv2 (Simple Email V2),Amazon,,,,,,,SESv2,ListContactLists,,
 stepfunctions,stepfunctions,sfn,sfn,,sfn,,stepfunctions,SFN,SFN,,1,,,aws_sfn_,,sfn_,SFN (Step Functions),AWS,,,,,,,SFN,ListActivities,,
-shield,shield,shield,shield,,shield,,,Shield,Shield,,1,2,,aws_shield_,,shield_,Shield,AWS,,,,,,,Shield,ListProtectionGroups,,
+shield,shield,shield,shield,,shield,,,Shield,Shield,x,1,2,,aws_shield_,,shield_,Shield,AWS,,,,,,,Shield,ListProtectionGroups,,
 signer,signer,signer,signer,,signer,,,Signer,Signer,,,2,,aws_signer_,,signer_,Signer,AWS,,,,,,,signer,ListSigningJobs,,
 sms,sms,sms,sms,,sms,,,SMS,SMS,,1,,,aws_sms_,,sms_,SMS (Server Migration),AWS,,x,,,,,SMS,,,
 snow-device-management,snowdevicemanagement,snowdevicemanagement,snowdevicemanagement,,snowdevicemanagement,,,SnowDeviceManagement,SnowDeviceManagement,,1,,,aws_snowdevicemanagement_,,snowdevicemanagement_,Snow Device Management,AWS,,x,,,,,Snow Device Management,,,

--- a/names/names.go
+++ b/names/names.go
@@ -104,6 +104,7 @@ const (
 	S3ControlEndpointID                  = "s3-control"
 	SecurityHubEndpointID                = "securityhub"
 	SESV2EndpointID                      = "sesv2"
+	ShieldEndpointID                     = "shield"
 	SNSEndpointID                        = "sns"
 	SQSEndpointID                        = "sqs"
 	SSMEndpointID                        = "ssm"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Relates #32976

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% AWS_DEFAULT_REGION=us-east-1 make testacc TESTARGS='-run=TestAccShield' PKG=shield

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/shield/... -v -count 1 -parallel 20  -run=TestAccShield -timeout 360m
--- PASS: TestAccShieldProtectionGroup_disappears (20.00s)
--- PASS: TestAccShieldProtection_disappears (21.74s)
--- PASS: TestAccShieldProtectionHealthCheckAssociation_disappears (23.31s)
--- PASS: TestAccShieldProtection_elasticIPAddress (35.05s)
--- PASS: TestAccShieldProtectionGroup_members (40.88s)
--- PASS: TestAccShieldProtection_elb (42.01s)
--- PASS: TestAccShieldProtectionGroup_basic (48.32s)
--- PASS: TestAccShieldProtectionGroup_tags (56.18s)
--- PASS: TestAccShieldProtectionGroup_protectionGroupID (58.99s)
--- PASS: TestAccShieldProtectionHealthCheckAssociation_basic (64.10s)
--- PASS: TestAccShieldProtectionGroup_resourceType (67.09s)
--- PASS: TestAccShield_serial (74.17s)
    --- PASS: TestAccShield_serial/DRTAccessRoleARNAssociation (40.84s)
        --- PASS: TestAccShield_serial/DRTAccessRoleARNAssociation/basic (30.23s)
        --- PASS: TestAccShield_serial/DRTAccessRoleARNAssociation/disappears (10.61s)
    --- PASS: TestAccShield_serial/DRTAccessLogBucketAssociation (33.34s)
        --- PASS: TestAccShield_serial/DRTAccessLogBucketAssociation/multibucket (11.34s)
        --- PASS: TestAccShield_serial/DRTAccessLogBucketAssociation/disappears (11.39s)
        --- PASS: TestAccShield_serial/DRTAccessLogBucketAssociation/basic (10.60s)
--- PASS: TestAccShieldProtectionGroup_aggregation (77.68s)
--- PASS: TestAccShieldProtection_route53 (81.48s)
--- PASS: TestAccShieldProtection_globalAccelerator (122.62s)
--- PASS: TestAccShieldProtection_alb (225.21s)
--- PASS: TestAccShieldProtection_CloudFront_tags (479.13s)
--- PASS: TestAccShieldApplicationLayerAutomaticResponse_basic (481.39s)
--- PASS: TestAccShieldApplicationLayerAutomaticResponse_disappears (485.41s)
--- PASS: TestAccShieldProtection_cloudFront (487.39s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/shield	494.611s
```
