### PR TITLE
resource/aws_prometheus_scraper: Fix `Provider returned invalid result object after apply` error

### DIFF
--- a/.changelog/35844.txt
+++ b/.changelog/35844.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_prometheus_scraper: Fixes invalid result after apply error.
+```

--- a/internal/service/amp/scraper.go
+++ b/internal/service/amp/scraper.go
@@ -72,6 +72,9 @@ func (r *scraperResource) Schema(ctx context.Context, req resource.SchemaRequest
 			names.AttrID:  framework.IDAttribute(),
 			"role_arn": schema.StringAttribute{
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"scrape_configuration": schema.StringAttribute{
 				Required: true,

--- a/internal/service/amp/scraper_test.go
+++ b/internal/service/amp/scraper_test.go
@@ -29,7 +29,6 @@ func TestAccAMPScraper_basic(t *testing.T) {
 
 	var scraper types.ScraperDescription
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	eksClusterVersion := "1.28"
 	resourceName := "aws_prometheus_scraper.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -39,7 +38,7 @@ func TestAccAMPScraper_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckScraperDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccScraperConfig_basic(rName, eksClusterVersion),
+				Config: testAccScraperConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScraperExists(ctx, resourceName, &scraper),
 					resource.TestCheckNoResourceAttr(resourceName, "alias"),
@@ -71,7 +70,6 @@ func TestAccAMPScraper_disappears(t *testing.T) {
 
 	var scraper types.ScraperDescription
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	eksClusterVersion := "1.28"
 	resourceName := "aws_prometheus_scraper.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -81,7 +79,7 @@ func TestAccAMPScraper_disappears(t *testing.T) {
 		CheckDestroy:             testAccCheckScraperDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccScraperConfig_basic(rName, eksClusterVersion),
+				Config: testAccScraperConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScraperExists(ctx, resourceName, &scraper),
 					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfamp.ResourceScraper, resourceName),
@@ -101,7 +99,6 @@ func TestAccAMPScraper_tags(t *testing.T) {
 
 	var scraper types.ScraperDescription
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	eksClusterVersion := "1.28"
 	resourceName := "aws_prometheus_scraper.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -111,7 +108,7 @@ func TestAccAMPScraper_tags(t *testing.T) {
 		CheckDestroy:             testAccCheckScraperDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccScraperConfig_tags1(rName, eksClusterVersion, "key1", "value1"),
+				Config: testAccScraperConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScraperExists(ctx, resourceName, &scraper),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -124,7 +121,7 @@ func TestAccAMPScraper_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccScraperConfig_tags2(rName, eksClusterVersion, "key1", "value1updated", "key2", "value2"),
+				Config: testAccScraperConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScraperExists(ctx, resourceName, &scraper),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -133,7 +130,7 @@ func TestAccAMPScraper_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccScraperConfig_tags1(rName, eksClusterVersion, "key2", "value2"),
+				Config: testAccScraperConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScraperExists(ctx, resourceName, &scraper),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -153,7 +150,6 @@ func TestAccAMPScraper_alias(t *testing.T) {
 
 	var scraper types.ScraperDescription
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	eksClusterVersion := "1.28"
 	resourceName := "aws_prometheus_scraper.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -163,7 +159,7 @@ func TestAccAMPScraper_alias(t *testing.T) {
 		CheckDestroy:             testAccCheckScraperDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccScraperConfig_alias(rName, eksClusterVersion),
+				Config: testAccScraperConfig_alias(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScraperExists(ctx, resourceName, &scraper),
 					resource.TestCheckResourceAttr(resourceName, "alias", rName),
@@ -187,7 +183,6 @@ func TestAccAMPScraper_securityGroups(t *testing.T) {
 
 	var scraper types.ScraperDescription
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	eksClusterVersion := "1.28"
 	resourceName := "aws_prometheus_scraper.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -197,7 +192,7 @@ func TestAccAMPScraper_securityGroups(t *testing.T) {
 		CheckDestroy:             testAccCheckScraperDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccScraperConfig_securityGroups(rName, eksClusterVersion),
+				Config: testAccScraperConfig_securityGroups(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScraperExists(ctx, resourceName, &scraper),
 					resource.TestCheckResourceAttr(resourceName, "source.0.eks.0.security_group_ids.#", "1"),
@@ -332,7 +327,7 @@ scrape_configs:
       replacement: $1:10249
 `
 
-func testAccScraperConfig_base(rName, eksClusterVersion string) string {
+func testAccScraperConfig_base(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -405,11 +400,11 @@ resource "aws_prometheus_workspace" "test" {
     AMPAgentlessScraper = ""
   }
 }
-`, rName, eksClusterVersion))
+`, rName))
 }
 
-func testAccScraperConfig_basic(rName, eksClusterVersion string) string {
-	return acctest.ConfigCompose(testAccScraperConfig_base(rName, eksClusterVersion), fmt.Sprintf(`
+func testAccScraperConfig_basic(rName string) string {
+	return acctest.ConfigCompose(testAccScraperConfig_base(rName), fmt.Sprintf(`
 resource "aws_prometheus_scraper" "test" {
   scrape_configuration = %[1]q
 
@@ -429,8 +424,8 @@ resource "aws_prometheus_scraper" "test" {
 `, scrapeConfigBlob))
 }
 
-func testAccScraperConfig_tags1(rName, eksClusterVersion, tagKey1, tagValue1 string) string {
-	return acctest.ConfigCompose(testAccScraperConfig_base(rName, eksClusterVersion), fmt.Sprintf(`
+func testAccScraperConfig_tags1(rName, tagKey1, tagValue1 string) string {
+	return acctest.ConfigCompose(testAccScraperConfig_base(rName), fmt.Sprintf(`
 resource "aws_prometheus_scraper" "test" {
   scrape_configuration = %[3]q
 
@@ -454,8 +449,8 @@ resource "aws_prometheus_scraper" "test" {
 `, tagKey1, tagValue1, scrapeConfigBlob))
 }
 
-func testAccScraperConfig_tags2(rName, eksClusterVersion, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return acctest.ConfigCompose(testAccScraperConfig_base(rName, eksClusterVersion), fmt.Sprintf(`
+func testAccScraperConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return acctest.ConfigCompose(testAccScraperConfig_base(rName), fmt.Sprintf(`
 resource "aws_prometheus_scraper" "test" {
   scrape_configuration = %[5]q
 
@@ -480,8 +475,8 @@ resource "aws_prometheus_scraper" "test" {
 `, tagKey1, tagValue1, tagKey2, tagValue2, scrapeConfigBlob))
 }
 
-func testAccScraperConfig_alias(rName, eksClusterVersion string) string {
-	return acctest.ConfigCompose(testAccScraperConfig_base(rName, eksClusterVersion), fmt.Sprintf(`
+func testAccScraperConfig_alias(rName string) string {
+	return acctest.ConfigCompose(testAccScraperConfig_base(rName), fmt.Sprintf(`
 resource "aws_prometheus_scraper" "test" {
   alias                = %[1]q
   scrape_configuration = %[2]q
@@ -502,8 +497,8 @@ resource "aws_prometheus_scraper" "test" {
 `, rName, scrapeConfigBlob))
 }
 
-func testAccScraperConfig_securityGroups(rName, eksClusterVersion string) string {
-	return acctest.ConfigCompose(testAccScraperConfig_base(rName, eksClusterVersion), fmt.Sprintf(`
+func testAccScraperConfig_securityGroups(rName string) string {
+	return acctest.ConfigCompose(testAccScraperConfig_base(rName), fmt.Sprintf(`
 resource "aws_prometheus_scraper" "test" {
   alias                = %[1]q
   scrape_configuration = %[2]q


### PR DESCRIPTION
### Description

When updating `tags` on `aws_prometheus_scraper`, the apply fails with the error

> Provider returned invalid result object after apply

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=amp TESTS=TestAccAMPScraper_

--- PASS: TestAccAMPScraper_securityGroups (2005.56s)
--- PASS: TestAccAMPScraper_disappears (2053.51s)
--- PASS: TestAccAMPScraper_basic (2053.55s)
--- PASS: TestAccAMPScraper_alias (2188.96s)
--- PASS: TestAccAMPScraper_tags (2205.76s)
```
