### PR TITLE
Update ec2_client_vpn_network_association.html.markdown.

### DIFF
--- a/website/docs/r/ec2_client_vpn_network_association.html.markdown
+++ b/website/docs/r/ec2_client_vpn_network_association.html.markdown
@@ -49,12 +49,12 @@ In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashico
 ```terraform
 import {
   to = aws_ec2_client_vpn_network_association.example
-  id = "cvpn-endpoint-0ac3a1abbccddd666,vpn-assoc-0b8db902465d069ad"
+  id = "cvpn-endpoint-0ac3a1abbccddd666,cvpn-assoc-0b8db902465d069ad"
 }
 ```
 
 Using `terraform import`, import AWS Client VPN network associations using the endpoint ID and the association ID. Values are separated by a `,`. For example:
 
 ```console
-% terraform import aws_ec2_client_vpn_network_association.example cvpn-endpoint-0ac3a1abbccddd666,vpn-assoc-0b8db902465d069ad
+% terraform import aws_ec2_client_vpn_network_association.example cvpn-endpoint-0ac3a1abbccddd666,cvpn-assoc-0b8db902465d069ad
 ```


### PR DESCRIPTION
### Description

I want to update aws_ec2_client_vpn_network_association document import example, from vpn-assoc-0b8db902465d069ad to cvpn-assoc-0b8db902465d069ad.

Align with the AWS Client VPN Target Network Association ID format as specified in the AWS CLI documentation ([AWS CLI Documentation](https://docs.aws.amazon.com/cli/latest/reference/ec2/associate-client-vpn-target-network.html)), which uses the `cvpn-assoc-` prefix format.

If there are any concerns, please let me know. Thank you.