### PR TITLE
b/aws_caller_identity: fix error when `sts_region` is different from `default_region`

### DIFF
--- a/.changelog/35860.txt
+++ b/.changelog/35860.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_caller_identity: Fix authentication signature error when alternate `sts_region` is specified
+```

--- a/internal/service/sts/caller_identity_data_source_test.go
+++ b/internal/service/sts/caller_identity_data_source_test.go
@@ -64,6 +64,7 @@ data "aws_caller_identity" "current" {}
 `
 
 func testAccCallerIdentityConfig_alternateRegion(defaultRegion, alternateRegion string) string {
+	//lintignore:AT004
 	return fmt.Sprintf(`
 provider "aws" {
   region = %[1]q

--- a/internal/service/sts/caller_identity_data_source_test.go
+++ b/internal/service/sts/caller_identity_data_source_test.go
@@ -31,7 +31,7 @@ func TestAccSTSCallerIdentityDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccSTSCallerIdentityDataSource_stsRegion(t *testing.T) {
+func TestAccSTSCallerIdentityDataSource_alternateRegion(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	defaultRegion := os.Getenv(envvar.DefaultRegion)
@@ -50,7 +50,7 @@ func TestAccSTSCallerIdentityDataSource_stsRegion(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCallerIdentityConfig_stsRegion(defaultRegion, alternateRegion),
+				Config: testAccCallerIdentityConfig_alternateRegion(defaultRegion, alternateRegion),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckCallerIdentityAccountID("data.aws_caller_identity.current"),
 				),
@@ -63,7 +63,7 @@ const testAccCallerIdentityConfig_basic = `
 data "aws_caller_identity" "current" {}
 `
 
-func testAccCallerIdentityConfig_stsRegion(defaultRegion, alternateRegion string) string {
+func testAccCallerIdentityConfig_alternateRegion(defaultRegion, alternateRegion string) string {
 	return fmt.Sprintf(`
 provider "aws" {
   region = %[1]q

--- a/internal/service/sts/service_package.go
+++ b/internal/service/sts/service_package.go
@@ -32,7 +32,9 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 	return sts_sdkv2.NewFromConfig(cfg, func(o *sts_sdkv2.Options) {
 		if endpoint := config["endpoint"].(string); endpoint != "" {
 			o.BaseEndpoint = aws_sdkv2.String(endpoint)
-		} else if stsRegion := config["sts_region"].(string); stsRegion != "" {
+		}
+
+		if stsRegion := config["sts_region"].(string); stsRegion != "" {
 			o.Region = stsRegion
 		}
 	}), nil


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Error: `SignatureDoesNotMatch: Credential should be scoped to a valid region.`

```console
% AWS_DEFAULT_REGION=us-west-2 AWS_ALTERNATE_REGION=us-east-1 make testacc TESTARGS='-run=TestAccSTSCallerIdentityDataSource_stsRegion' PKG=sts

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sts/... -v -count 1 -parallel 20  -run=TestAccSTSCallerIdentityDataSource_stsRegion -timeout 360m
    caller_identity_data_source_test.go:47: Step 1/1 error: Error running pre-apply plan: exit status 1

        Error: reading STS Caller Identity

          with data.aws_caller_identity.current,
          on terraform_plugin_test.tf line 21, in data "aws_caller_identity" "current":
          21: data "aws_caller_identity" "current" {}

        operation error STS: GetCallerIdentity, https response error StatusCode: 403,
        RequestID: fe4eadc7-14ba-4419-92e5-18c95845c089, api error
        SignatureDoesNotMatch: Credential should be scoped to a valid region.
--- FAIL: TestAccSTSCallerIdentityDataSource_stsRegion (3.90s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/sts	11.052s
FAIL
make: *** [testacc] Error 1
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #34865

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% AWS_DEFAULT_REGION=us-west-2 AWS_ALTERNATE_REGION=us-east-1 make testacc TESTARGS='-run=TestAccSTSCallerIdentityDataSource_' PKG=sts

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sts/... -v -count 1 -parallel 20  -run=TestAccSTSCallerIdentityDataSource_ -timeout 360m
--- PASS: TestAccSTSCallerIdentityDataSource_basic (6.57s)
--- PASS: TestAccSTSCallerIdentityDataSource_stsRegion (15.27s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sts	22.641s
```
