### PR TITLE
Add eventual consistency protection on queue policy attributes

### DIFF
--- a/.changelog/35861.txt
+++ b/.changelog/35861.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_sqs_queue_policy: Retry IAM eventual consistency errors
+```

--- a/internal/service/sqs/attribute_funcs.go
+++ b/internal/service/sqs/attribute_funcs.go
@@ -5,6 +5,8 @@ package sqs
 
 import (
 	"context"
+	"log"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
@@ -16,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
-	"log"
 )
 
 type queueAttributeHandler struct {

--- a/internal/service/sqs/consts.go
+++ b/internal/service/sqs/consts.go
@@ -3,6 +3,12 @@
 
 package sqs
 
+import "time"
+
+const (
+	propagationTimeout = 1 * time.Minute
+)
+
 const (
 	fifoQueueNameSuffix = ".fifo"
 )
@@ -41,6 +47,7 @@ func fifoThroughputLimit_Values() []string {
 }
 
 const (
-	errCodeQueueDoesNotExist    = "AWS.SimpleQueueService.NonExistentQueue"
-	errCodeQueueDeletedRecently = "AWS.SimpleQueueService.QueueDeletedRecently"
+	errCodeQueueDoesNotExist     = "AWS.SimpleQueueService.NonExistentQueue"
+	errCodeQueueDeletedRecently  = "AWS.SimpleQueueService.QueueDeletedRecently"
+	errCodeInvalidAttributeValue = "InvalidAttributeValue"
 )


### PR DESCRIPTION
### Description
A dependency race condition occurs where the AWS API would sometimes return an ID instead of a correct ARN, resulting in an InvalidAttributeValue when trying to set the SQS Queue Policy. Adding a retry on applying the SQS Queue Policy results in fixing this eventual consistency bug.  

### Relations

Relates #21355 
Relates #13980 

### Output from Acceptance Testing

```console
% make testacc TESTARGS='-run=TestAccSQSQueuePolicy_basic' PKG_NAME=internal/service/sqs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sqs/... -v -count 1 -parallel 20  -run=TestAccSQSQueuePolicy_basic -timeout 360m
=== RUN   TestAccSQSQueuePolicy_basic
=== PAUSE TestAccSQSQueuePolicy_basic
=== CONT  TestAccSQSQueuePolicy_basic
--- PASS: TestAccSQSQueuePolicy_basic (96.09s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sqs	103.314s
...
```
