### PR TITLE
[Enhancement] : Validation function for RDS performance_insights_retention_period attribute

### DIFF
--- a/.changelog/35870.txt
+++ b/.changelog/35870.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_db_instance: Validation function for performance_insights_retention_period attribute
+```

--- a/.changelog/35870.txt
+++ b/.changelog/35870.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_db_instance: Validation function for performance_insights_retention_period attribute
+resource/aws_db_instance: Add plan-time validation of `performance_insights_retention_period`
 ```

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -481,6 +481,10 @@ func ResourceInstance() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Computed: true,
+				ValidateFunc: validation.Any(
+					validation.IntInSlice([]int{7,731}),
+					validation.IntDivisibleBy(31),
+				),
 			},
 			"port": {
 				Type:     schema.TypeInt,

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -482,7 +482,7 @@ func ResourceInstance() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ValidateFunc: validation.Any(
-					validation.IntInSlice([]int{7,731}),
+					validation.IntInSlice([]int{7, 731}),
 					validation.IntDivisibleBy(31),
 				),
 			},

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -4231,6 +4231,14 @@ func TestAccRDSInstance_PerformanceInsights_retentionPeriod(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_retention_period", "155"),
 				),
 			},
+			{
+				Config: testAccInstanceConfig_performanceInsightsRetentionPeriod(rName, 5),
+				ExpectError: regexache.MustCompile(`expected [\w]+ to be one of \[7 731\], got 5`),	
+			},
+			{
+				Config: testAccInstanceConfig_performanceInsightsRetentionPeriod(rName, 45),
+				ExpectError: regexache.MustCompile(`expected 45 to be divisible by 31, got [\w]+`),	
+			},
 		},
 	})
 }

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -4231,14 +4231,6 @@ func TestAccRDSInstance_PerformanceInsights_retentionPeriod(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_retention_period", "155"),
 				),
 			},
-			{
-				Config:      testAccInstanceConfig_performanceInsightsRetentionPeriod(rName, 5),
-				ExpectError: regexache.MustCompile(`expected [\w]+ to be one of \[7 731\], got 5`),
-			},
-			{
-				Config:      testAccInstanceConfig_performanceInsightsRetentionPeriod(rName, 45),
-				ExpectError: regexache.MustCompile(`expected 45 to be divisible by 31, got [\w]+`),
-			},
 		},
 	})
 }

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -4232,12 +4232,12 @@ func TestAccRDSInstance_PerformanceInsights_retentionPeriod(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccInstanceConfig_performanceInsightsRetentionPeriod(rName, 5),
-				ExpectError: regexache.MustCompile(`expected [\w]+ to be one of \[7 731\], got 5`),	
+				Config:      testAccInstanceConfig_performanceInsightsRetentionPeriod(rName, 5),
+				ExpectError: regexache.MustCompile(`expected [\w]+ to be one of \[7 731\], got 5`),
 			},
 			{
-				Config: testAccInstanceConfig_performanceInsightsRetentionPeriod(rName, 45),
-				ExpectError: regexache.MustCompile(`expected 45 to be divisible by 31, got [\w]+`),	
+				Config:      testAccInstanceConfig_performanceInsightsRetentionPeriod(rName, 45),
+				ExpectError: regexache.MustCompile(`expected 45 to be divisible by 31, got [\w]+`),
 			},
 		},
 	})


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
The valid values for the performance insights retention period are 7, 731 (2 years) or a multiple of 31. This is properly documented. However, in case of an invalid value terraform plan does not complain, you will get the error only after trying to apply the change.


Terraform will perform the following actions:
```
  # module.db.aws_db_instance.this will be updated in-place
  ~ resource "aws_db_instance" "this" {
        id                                    = "db-XXXXXX"
      ~ performance_insights_retention_period = 7 -> 8
        tags                                  = {
            "Name" = "db-dev"
        }
        # (56 unchanged attributes hidden)
    }
```

### Relations


Closes #34342

### References

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#performance_insights_retention_period


### Output from Acceptance Testing

```
