### PR TITLE
docs: updated s3_bucket_notification docs

### DIFF
--- a/website/docs/r/s3_bucket_notification.html.markdown
+++ b/website/docs/r/s3_bucket_notification.html.markdown
@@ -160,14 +160,16 @@ resource "aws_s3_bucket_notification" "bucket_notification" {
 
 ```terraform
 data "aws_iam_policy_document" "assume_role" {
-  effect = "Allow"
+  statement {
+    effect = "Allow"
 
-  principals {
-    type        = "Service"
-    identifiers = ["lambda.amazonaws.com"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
   }
-
-  actions = ["sts:AssumeRole"]
 }
 
 resource "aws_iam_role" "iam_for_lambda" {


### PR DESCRIPTION
### Description

aws_iam_policy_document has statement property missing in its body in [Trigger multiple Lambda functions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification#trigger-multiple-lambda-functions) section. This change, fixes it.

### Relations

Closes [#35871](https://github.com/hashicorp/terraform-provider-aws/issues/35871)

### References

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification#trigger-multiple-lambda-functions

### Output from Acceptance Testing

Not applicable