### PR TITLE
fix: Fix EKS cluster name regex

### DIFF
--- a/.changelog/35874.txt
+++ b/.changelog/35874.txt
@@ -1,3 +1,35 @@
 ```release-note:bug
-resource/aws_eks_cluster: Fix cluster name regex that incorrectly disallowed single-character names
+resource/aws_eks_access_entry: Fix `cluster_name` plan-time validation, allowing single-character names
+```
+
+```release-note:bug
+data-source/aws_eks_access_entry: Fix `cluster_name` plan-time validation, allowing single-character names
+```
+
+```release-note:bug
+resource/aws_eks_access_policy_association: Fix `cluster_name` plan-time validation, allowing single-character names
+```
+
+```release-note:bug
+resource/aws_eks_addon: Fix `cluster_name` plan-time validation, allowing single-character names
+```
+
+```release-note:bug
+data-source/aws_eks_addon: Fix `cluster_name` plan-time validation, allowing single-character names
+```
+
+```release-note:bug
+resource/aws_eks_cluster: Fix `name` plan-time validation, allowing single-character names
+```
+
+```release-note:bug
+data-source/aws_eks_cluster: Fix `name` plan-time validation, allowing single-character names
+```
+
+```release-note:bug
+resource/aws_eks_fargate_profile: Fix `cluster_name` plan-time validation, allowing single-character names
+```
+
+```release-note:bug
+resource/aws_eks_node_group: Fix `cluster_name` plan-time validation, allowing single-character names
 ```

--- a/.changelog/35874.txt
+++ b/.changelog/35874.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_eks_cluster: Fix cluster name regex that incorrectly disallowed single-character names
+```

--- a/internal/service/eks/validate.go
+++ b/internal/service/eks/validate.go
@@ -17,7 +17,7 @@ func validClusterName(v interface{}, k string) (ws []string, errors []error) {
 	}
 
 	// https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateCluster.html#API_CreateCluster_RequestSyntax
-	pattern := `^[0-9A-Za-z][0-9A-Za-z_-]+$`
+	pattern := `^[0-9A-Za-z][0-9A-Za-z_-]*$`
 	if !regexache.MustCompile(pattern).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
 			"%q doesn't comply with restrictions (%q): %q",

--- a/internal/service/eks/validate_test.go
+++ b/internal/service/eks/validate_test.go
@@ -21,6 +21,10 @@ func TestValidClusterName(t *testing.T) {
 			ErrCount: 0,
 		},
 		{
+			Value:    "a",
+			ErrCount: 0,
+		},
+		{
 			Value:    `_invalid`,
 			ErrCount: 1,
 		},

--- a/website/docs/d/eks_access_entry.html.markdown
+++ b/website/docs/d/eks_access_entry.html.markdown
@@ -25,7 +25,7 @@ output "eks_access_entry_outputs" {
 
 ## Argument Reference
 
-* `cluster_name` – (Required) Name of the EKS Cluster. Must be between 1-100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (`^[0-9A-Za-z][A-Za-z0-9\-_]+$`).
+* `cluster_name` – (Required) Name of the EKS Cluster.
 * `principal_arn` – (Required) The IAM Principal ARN which requires Authentication access to the EKS cluster.
 
 ## Attribute Reference

--- a/website/docs/d/eks_addon.html.markdown
+++ b/website/docs/d/eks_addon.html.markdown
@@ -27,7 +27,7 @@ output "eks_addon_outputs" {
 
 * `addon_name` – (Required) Name of the EKS add-on. The name must match one of
   the names returned by [list-addon](https://docs.aws.amazon.com/cli/latest/reference/eks/list-addons.html).
-* `cluster_name` – (Required) Name of the EKS Cluster. Must be between 1-100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (`^[0-9A-Za-z][A-Za-z0-9\-_]+$`).
+* `cluster_name` – (Required) Name of the EKS Cluster.
 
 ## Attribute Reference
 

--- a/website/docs/d/eks_cluster.html.markdown
+++ b/website/docs/d/eks_cluster.html.markdown
@@ -33,7 +33,7 @@ output "identity-oidc-issuer" {
 
 ## Argument Reference
 
-* `name` - (Required) Name of the cluster. Must be between 1-100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (`^[0-9A-Za-z][A-Za-z0-9\-_]+$`).
+* `name` - (Required) Name of the cluster.
 
 ## Attribute Reference
 

--- a/website/docs/r/eks_access_entry.html.markdown
+++ b/website/docs/r/eks_access_entry.html.markdown
@@ -25,7 +25,7 @@ resource "aws_eks_access_entry" "example" {
 
 The following arguments are required:
 
-* `cluster_name` – (Required) Name of the EKS Cluster. Must be between 1-100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (`^[0-9A-Za-z][A-Za-z0-9\-_]+$`).
+* `cluster_name` – (Required) Name of the EKS Cluster. Must be between 1-100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (`^[0-9A-Za-z][A-Za-z0-9\-_]*$`).
 * `principal_arn` – (Required) The IAM Principal ARN which requires Authentication access to the EKS cluster.
 
 The following arguments are optional:

--- a/website/docs/r/eks_access_entry.html.markdown
+++ b/website/docs/r/eks_access_entry.html.markdown
@@ -25,7 +25,7 @@ resource "aws_eks_access_entry" "example" {
 
 The following arguments are required:
 
-* `cluster_name` – (Required) Name of the EKS Cluster. Must be between 1-100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (`^[0-9A-Za-z][A-Za-z0-9\-_]*$`).
+* `cluster_name` – (Required) Name of the EKS Cluster.
 * `principal_arn` – (Required) The IAM Principal ARN which requires Authentication access to the EKS cluster.
 
 The following arguments are optional:

--- a/website/docs/r/eks_access_policy_association.html.markdown
+++ b/website/docs/r/eks_access_policy_association.html.markdown
@@ -29,7 +29,7 @@ resource "aws_eks_access_policy_association" "example" {
 
 The following arguments are required:
 
-* `cluster_name` – (Required) Name of the EKS Cluster. Must be between 1-100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (`^[0-9A-Za-z][A-Za-z0-9\-_]*$`).
+* `cluster_name` – (Required) Name of the EKS Cluster.
 * `policy_arn` – (Required) The ARN of the access policy that you're associating.
 * `principal_arn` – (Required) The IAM Principal ARN which requires Authentication access to the EKS cluster.
 * `access_scope` – (Required) The configuration block to determine the scope of the access. See [`access_scope` Block](#access_scope-block) below.

--- a/website/docs/r/eks_access_policy_association.html.markdown
+++ b/website/docs/r/eks_access_policy_association.html.markdown
@@ -29,7 +29,7 @@ resource "aws_eks_access_policy_association" "example" {
 
 The following arguments are required:
 
-* `cluster_name` – (Required) Name of the EKS Cluster. Must be between 1-100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (`^[0-9A-Za-z][A-Za-z0-9\-_]+$`).
+* `cluster_name` – (Required) Name of the EKS Cluster. Must be between 1-100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (`^[0-9A-Za-z][A-Za-z0-9\-_]*$`).
 * `policy_arn` – (Required) The ARN of the access policy that you're associating.
 * `principal_arn` – (Required) The IAM Principal ARN which requires Authentication access to the EKS cluster.
 * `access_scope` – (Required) The configuration block to determine the scope of the access. See [`access_scope` Block](#access_scope-block) below.

--- a/website/docs/r/eks_addon.html.markdown
+++ b/website/docs/r/eks_addon.html.markdown
@@ -124,7 +124,7 @@ The following arguments are required:
 
 * `addon_name` – (Required) Name of the EKS add-on. The name must match one of
   the names returned by [describe-addon-versions](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-versions.html).
-* `cluster_name` – (Required) Name of the EKS Cluster. Must be between 1-100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (`^[0-9A-Za-z][A-Za-z0-9\-_]+$`).
+* `cluster_name` – (Required) Name of the EKS Cluster. Must be between 1-100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (`^[0-9A-Za-z][A-Za-z0-9\-_]*$`).
 
 The following arguments are optional:
 

--- a/website/docs/r/eks_addon.html.markdown
+++ b/website/docs/r/eks_addon.html.markdown
@@ -124,7 +124,7 @@ The following arguments are required:
 
 * `addon_name` – (Required) Name of the EKS add-on. The name must match one of
   the names returned by [describe-addon-versions](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-versions.html).
-* `cluster_name` – (Required) Name of the EKS Cluster. Must be between 1-100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (`^[0-9A-Za-z][A-Za-z0-9\-_]*$`).
+* `cluster_name` – (Required) Name of the EKS Cluster.
 
 The following arguments are optional:
 

--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -208,7 +208,7 @@ After adding inline IAM Policies (e.g., [`aws_iam_role_policy` resource](/docs/p
 
 The following arguments are required:
 
-* `name` – (Required) Name of the cluster. Must be between 1-100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (`^[0-9A-Za-z][A-Za-z0-9\-_]+$`).
+* `name` – (Required) Name of the cluster. Must be between 1-100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (`^[0-9A-Za-z][A-Za-z0-9\-_]*$`).
 * `role_arn` - (Required) ARN of the IAM role that provides permissions for the Kubernetes control plane to make calls to AWS API operations on your behalf. Ensure the resource configuration includes explicit dependencies on the IAM Role permissions by adding [`depends_on`](https://www.terraform.io/docs/configuration/meta-arguments/depends_on.html) if using the [`aws_iam_role_policy` resource](/docs/providers/aws/r/iam_role_policy.html) or [`aws_iam_role_policy_attachment` resource](/docs/providers/aws/r/iam_role_policy_attachment.html), otherwise EKS cannot delete EKS managed EC2 infrastructure such as Security Groups on EKS Cluster deletion.
 * `vpc_config` - (Required) Configuration block for the VPC associated with your cluster. Amazon EKS VPC resources have specific requirements to work properly with Kubernetes. For more information, see [Cluster VPC Considerations](https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html) and [Cluster Security Group Considerations](https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html) in the Amazon EKS User Guide. Detailed below. Also contains attributes detailed in the Attributes section.
 

--- a/website/docs/r/eks_fargate_profile.html.markdown
+++ b/website/docs/r/eks_fargate_profile.html.markdown
@@ -53,7 +53,7 @@ resource "aws_iam_role_policy_attachment" "example-AmazonEKSFargatePodExecutionR
 
 The following arguments are required:
 
-* `cluster_name` – (Required) Name of the EKS Cluster. Must be between 1-100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (`^[0-9A-Za-z][A-Za-z0-9\-_]*$`).
+* `cluster_name` – (Required) Name of the EKS Cluster.
 * `fargate_profile_name` – (Required) Name of the EKS Fargate Profile.
 * `pod_execution_role_arn` – (Required) Amazon Resource Name (ARN) of the IAM Role that provides permissions for the EKS Fargate Profile.
 * `selector` - (Required) Configuration block(s) for selecting Kubernetes Pods to execute with this EKS Fargate Profile. Detailed below.

--- a/website/docs/r/eks_fargate_profile.html.markdown
+++ b/website/docs/r/eks_fargate_profile.html.markdown
@@ -53,7 +53,7 @@ resource "aws_iam_role_policy_attachment" "example-AmazonEKSFargatePodExecutionR
 
 The following arguments are required:
 
-* `cluster_name` – (Required) Name of the EKS Cluster. Must be between 1-100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (`^[0-9A-Za-z][A-Za-z0-9\-_]+$`).
+* `cluster_name` – (Required) Name of the EKS Cluster. Must be between 1-100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (`^[0-9A-Za-z][A-Za-z0-9\-_]*$`).
 * `fargate_profile_name` – (Required) Name of the EKS Fargate Profile.
 * `pod_execution_role_arn` – (Required) Amazon Resource Name (ARN) of the IAM Role that provides permissions for the EKS Fargate Profile.
 * `selector` - (Required) Configuration block(s) for selecting Kubernetes Pods to execute with this EKS Fargate Profile. Detailed below.

--- a/website/docs/r/eks_node_group.html.markdown
+++ b/website/docs/r/eks_node_group.html.markdown
@@ -134,7 +134,7 @@ resource "aws_subnet" "example" {
 
 The following arguments are required:
 
-* `cluster_name` – (Required) Name of the EKS Cluster. Must be between 1-100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (`^[0-9A-Za-z][A-Za-z0-9\-_]+$`).
+* `cluster_name` – (Required) Name of the EKS Cluster. Must be between 1-100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (`^[0-9A-Za-z][A-Za-z0-9\-_]*$`).
 * `node_role_arn` – (Required) Amazon Resource Name (ARN) of the IAM Role that provides permissions for the EKS Node Group.
 * `scaling_config` - (Required) Configuration block with scaling settings. See [`scaling_config`](#scaling_config-configuration-block) below for details.
 * `subnet_ids` – (Required) Identifiers of EC2 Subnets to associate with the EKS Node Group.

--- a/website/docs/r/eks_node_group.html.markdown
+++ b/website/docs/r/eks_node_group.html.markdown
@@ -134,7 +134,7 @@ resource "aws_subnet" "example" {
 
 The following arguments are required:
 
-* `cluster_name` – (Required) Name of the EKS Cluster. Must be between 1-100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (`^[0-9A-Za-z][A-Za-z0-9\-_]*$`).
+* `cluster_name` – (Required) Name of the EKS Cluster.
 * `node_role_arn` – (Required) Amazon Resource Name (ARN) of the IAM Role that provides permissions for the EKS Node Group.
 * `scaling_config` - (Required) Configuration block with scaling settings. See [`scaling_config`](#scaling_config-configuration-block) below for details.
 * `subnet_ids` – (Required) Identifiers of EC2 Subnets to associate with the EKS Node Group.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to fix the regex pattern for the EKS cluster name that is included in the documentation for numerous EKS-related resources.

I'd also like to ask the maintainers to see whether it makes sense to just remove the regex from the non-cluster resource docs. Once the EKS cluster is created (and it makes sense to provide the regex there), the name is simply referenced by other resources so I don't think providing the exact format is super useful. Let me know what you think - I can update the PR to remove them if you think it makes sense. Thanks.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #35843

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to the [API reference](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateCluster.html#AmazonEKS-CreateCluster-request-name) for the cluster name regex.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TESTS=TestValidClusterName PKG=eks
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/eks/... -v -count 1 -parallel 20 -run='TestValidClusterName'  -timeout 360m
=== RUN   TestValidClusterName
=== PAUSE TestValidClusterName
=== CONT  TestValidClusterName
--- PASS: TestValidClusterName (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/eks        0.186s

$
```