### PR TITLE
feat: Add execution_mode arg to aws_codepipeline

### DIFF
--- a/.changelog/35875.txt
+++ b/.changelog/35875.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_codepipeline: Add `execution_mode` attribute
+```

--- a/internal/service/codepipeline/codepipeline.go
+++ b/internal/service/codepipeline/codepipeline.go
@@ -85,7 +85,6 @@ func resourcePipeline() *schema.Resource {
 						"region": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Computed: true,
 						},
 						"type": {
 							Type:             schema.TypeString,

--- a/internal/service/codepipeline/codepipeline.go
+++ b/internal/service/codepipeline/codepipeline.go
@@ -95,6 +95,12 @@ func resourcePipeline() *schema.Resource {
 					},
 				},
 			},
+			"execution_mode": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Default:          types.ExecutionModeSuperseded,
+				ValidateDiagFunc: enum.Validate[types.ExecutionMode](),
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -302,6 +308,7 @@ func resourcePipelineRead(ctx context.Context, d *schema.ResourceData, meta inte
 			return sdkdiag.AppendErrorf(diags, "setting artifact_store: %s", err)
 		}
 	}
+	d.Set("execution_mode", pipeline.ExecutionMode)
 	d.Set("name", pipeline.Name)
 	d.Set("pipeline_type", pipeline.PipelineType)
 	d.Set("role_arn", pipeline.RoleArn)
@@ -458,6 +465,10 @@ func expandPipelineDeclaration(d *schema.ResourceData) (*types.PipelineDeclarati
 			}
 			apiObject.ArtifactStores = artifactStores
 		}
+	}
+
+	if v, ok := d.GetOk("execution_mode"); ok {
+		apiObject.ExecutionMode = types.ExecutionMode(v.(string))
 	}
 
 	if v, ok := d.GetOk("name"); ok {

--- a/internal/service/codepipeline/codepipeline_test.go
+++ b/internal/service/codepipeline/codepipeline_test.go
@@ -615,6 +615,7 @@ func TestAccCodePipeline_pipelinetype(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "role_arn", "aws_iam_role.codepipeline_role", "arn"),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "codepipeline", regexache.MustCompile(fmt.Sprintf("test-pipeline-%s", rName))),
 					resource.TestCheckResourceAttr(resourceName, "artifact_store.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "execution_mode", string(types.ExecutionModeSuperseded)),
 					resource.TestCheckResourceAttr(resourceName, "pipeline_type", string(types.PipelineTypeV1)),
 					resource.TestCheckResourceAttr(resourceName, "stage.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.name", "Source"),
@@ -660,6 +661,7 @@ func TestAccCodePipeline_pipelinetype(t *testing.T) {
 				Config: testAccCodePipelineConfig_pipelinetypeUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPipelineExists(ctx, resourceName, &p),
+					resource.TestCheckResourceAttr(resourceName, "execution_mode", string(types.ExecutionModeQueued)),
 					resource.TestCheckResourceAttr(resourceName, "pipeline_type", string(types.PipelineTypeV2)),
 					resource.TestCheckResourceAttr(resourceName, "stage.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.name", "Source"),
@@ -704,6 +706,7 @@ func TestAccCodePipeline_pipelinetype(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "role_arn", "aws_iam_role.codepipeline_role", "arn"),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "codepipeline", regexache.MustCompile(fmt.Sprintf("test-pipeline-%s", rName))),
 					resource.TestCheckResourceAttr(resourceName, "artifact_store.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "execution_mode", string(types.ExecutionModeSuperseded)),
 					resource.TestCheckResourceAttr(resourceName, "pipeline_type", string(types.PipelineTypeV1)),
 					resource.TestCheckResourceAttr(resourceName, "stage.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.name", "Source"),
@@ -1186,6 +1189,8 @@ resource "aws_codepipeline" "test" {
       }
     }
   }
+
+  execution_mode = "QUEUED"
 
   pipeline_type = "V2"
 

--- a/internal/service/codepipeline/codepipeline_test.go
+++ b/internal/service/codepipeline/codepipeline_test.go
@@ -397,6 +397,7 @@ func TestAccCodePipeline_MultiRegion_convertSingleRegion(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPipelineExists(ctx, resourceName, &p),
 					resource.TestCheckResourceAttr(resourceName, "artifact_store.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "artifact_store.0.region", ""),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.name", "Build"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.name", "Build"),
@@ -408,6 +409,8 @@ func TestAccCodePipeline_MultiRegion_convertSingleRegion(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPipelineExists(ctx, resourceName, &p),
 					resource.TestCheckResourceAttr(resourceName, "artifact_store.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "artifact_store.0.region", acctest.Region()),
+					resource.TestCheckResourceAttr(resourceName, "artifact_store.1.region", acctest.AlternateRegion()),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.name", "Build"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.name", "Build"),
@@ -421,6 +424,7 @@ func TestAccCodePipeline_MultiRegion_convertSingleRegion(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPipelineExists(ctx, resourceName, &p),
 					resource.TestCheckResourceAttr(resourceName, "artifact_store.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "artifact_store.0.region", ""),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.name", "Build"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.name", "Build"),

--- a/website/docs/r/codepipeline.html.markdown
+++ b/website/docs/r/codepipeline.html.markdown
@@ -177,6 +177,9 @@ This resource supports the following arguments:
 * `pipeline_type` - (Optional) Type of the pipeline. Possible values are: `V1` and `V2`. Default value is `V1`.
 * `role_arn` - (Required) A service role Amazon Resource Name (ARN) that grants AWS CodePipeline permission to make calls to AWS services on your behalf.
 * `artifact_store` (Required) One or more artifact_store blocks. Artifact stores are documented below.
+* `execution_mode` (Optional) The method that the pipeline will use to handle multiple executions. The default mode is `SUPERSEDED`. For value values, refer to the [AWS documentation](https://docs.aws.amazon.com/codepipeline/latest/APIReference/API_PipelineDeclaration.html#CodePipeline-Type-PipelineDeclaration-executionMode).
+
+  **Note:** `QUEUED` or `PARALLEL` mode can only be used with V2 pipelines.
 * `stage` (Minimum of at least two `stage` blocks is required) A stage block. Stages are documented below.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `variable` - (Optional) A pipeline-level variable block. Valid only when `pipeline_type` is `V2`. Variable are documented below.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR adds a new argument called `execution_mode` to the `aws_codepipeline` resource to support additional execution mode for V2 pipelines per https://aws.amazon.com/about-aws/whats-new/2024/02/codepipeline-trigger-filters-execution-modes/.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #35810

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to the [AWS API reference](https://docs.aws.amazon.com/codepipeline/latest/APIReference/API_CreatePipeline.html) for specs of the new argument.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Note that `TestAccCodePipeline_pipelinetype` was enhanced to validate the new `execution_mode` argument.

Separately, there is a failure in the `TestAccCodePipeline_MultiRegion_convertSingleRegion` test case which is unrelated. I will try to see if I can fix it, but it's not caused by this PR's changes.

**Updated:** It looks like the test case is failing because the `region` attribute for `artifact_store` has `Computed` set when it probably shouldn't have. Removing it seems to fix the test case, and I've also added region checks to `TestAccCodePipeline_MultiRegion_convertSingleRegion`. Here are the updated results:

```console
$ make testacc TESTS=TestAccCodePipeline_ PKG=codepipeline ACCTEST_PARALLELISM=10
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/codepipeline/... -v -count 1 -parallel 10 -run='TestAccCodePipeline_'  -timeout 360m
=== RUN   TestAccCodePipeline_basic
=== PAUSE TestAccCodePipeline_basic
=== RUN   TestAccCodePipeline_disappears
=== PAUSE TestAccCodePipeline_disappears
=== RUN   TestAccCodePipeline_emptyStageArtifacts
=== PAUSE TestAccCodePipeline_emptyStageArtifacts
=== RUN   TestAccCodePipeline_deployWithServiceRole
=== PAUSE TestAccCodePipeline_deployWithServiceRole
=== RUN   TestAccCodePipeline_tags
=== PAUSE TestAccCodePipeline_tags
=== RUN   TestAccCodePipeline_MultiRegion_basic
=== PAUSE TestAccCodePipeline_MultiRegion_basic
=== RUN   TestAccCodePipeline_MultiRegion_update
=== PAUSE TestAccCodePipeline_MultiRegion_update
=== RUN   TestAccCodePipeline_MultiRegion_convertSingleRegion
=== PAUSE TestAccCodePipeline_MultiRegion_convertSingleRegion
=== RUN   TestAccCodePipeline_withNamespace
=== PAUSE TestAccCodePipeline_withNamespace
=== RUN   TestAccCodePipeline_withGitHubV1SourceAction
    acctest.go:2482: Environment variable GITHUB_TOKEN is not set, skipping test
--- SKIP: TestAccCodePipeline_withGitHubV1SourceAction (0.00s)
=== RUN   TestAccCodePipeline_ecr
=== PAUSE TestAccCodePipeline_ecr
=== RUN   TestAccCodePipeline_pipelinetype
=== PAUSE TestAccCodePipeline_pipelinetype
=== CONT  TestAccCodePipeline_basic
=== CONT  TestAccCodePipeline_MultiRegion_update
=== CONT  TestAccCodePipeline_ecr
=== CONT  TestAccCodePipeline_pipelinetype
=== CONT  TestAccCodePipeline_emptyStageArtifacts
=== CONT  TestAccCodePipeline_withNamespace
=== CONT  TestAccCodePipeline_deployWithServiceRole
=== CONT  TestAccCodePipeline_MultiRegion_basic
=== CONT  TestAccCodePipeline_MultiRegion_convertSingleRegion
=== CONT  TestAccCodePipeline_tags
--- PASS: TestAccCodePipeline_ecr (268.33s)
=== CONT  TestAccCodePipeline_disappears
--- PASS: TestAccCodePipeline_emptyStageArtifacts (319.04s)
--- PASS: TestAccCodePipeline_withNamespace (319.29s)
--- PASS: TestAccCodePipeline_MultiRegion_basic (379.88s)
--- PASS: TestAccCodePipeline_deployWithServiceRole (437.43s)
--- PASS: TestAccCodePipeline_basic (470.45s)
--- PASS: TestAccCodePipeline_disappears (212.93s)
--- PASS: TestAccCodePipeline_MultiRegion_update (526.93s)
--- PASS: TestAccCodePipeline_tags (546.19s)
--- PASS: TestAccCodePipeline_pipelinetype (562.44s)
--- PASS: TestAccCodePipeline_MultiRegion_convertSingleRegion (584.70s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codepipeline       584.885s
$
```