### PR TITLE
[Enhancement]: Add vpc_id output of aws_elasticache_subnet_group data source

### DIFF
--- a/internal/service/elasticache/subnet_group_data_source.go
+++ b/internal/service/elasticache/subnet_group_data_source.go
@@ -33,6 +33,10 @@ func DataSourceSubnetGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
 			"subnet_ids": {
 				Type:     schema.TypeSet,
 				Computed: true,
@@ -67,6 +71,7 @@ func dataSourceSubnetGroupRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set("description", group.CacheSubnetGroupDescription)
 	d.Set("subnet_ids", flex.FlattenStringSet(subnetIds))
 	d.Set("name", group.CacheSubnetGroupName)
+	d.Set("vpc_id", group.VpcId)
 
 	tags, err := listTags(ctx, conn, d.Get("arn").(string))
 

--- a/internal/service/elasticache/subnet_group_data_source_test.go
+++ b/internal/service/elasticache/subnet_group_data_source_test.go
@@ -35,6 +35,7 @@ func TestAccElastiCacheSubnetGroupDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "vpc_id", resourceName, "vpc_id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "subnet_ids.#", resourceName, "subnet_ids.#"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "tags.%", resourceName, "tags.%"),
 				),

--- a/website/docs/d/elasticache_subnet_group.html.markdown
+++ b/website/docs/d/elasticache_subnet_group.html.markdown
@@ -31,5 +31,6 @@ This data source exports the following attributes in addition to the arguments a
 * `id` - Name of the subnet group.
 * `arn` - ARN of the subnet group.
 * `description` - Description of the subnet group.
+* `vpc_id` - The Amazon Virtual Private Cloud identifier (VPC ID) of the cache subnet group.
 * `subnet_ids` - Set of VPC Subnet ID-s of the subnet group.
 * `tags` - Map of tags assigned to the subnet group.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
`vpc_id`  attr is missing in aws_elasticache_subnet_group data source.
The `vpc_id` can be used for creating a security group of the ElastiCache cluster like the below.

```
data "aws_elasticache_subnet_group" "this" {
  name = "default"
}

resource "aws_security_group" "this" {
  name        = "example"
  description = "Example Security Group."
  vpc_id      = data.aws_elasticache_subnet_group.this.vpc_id
}
```
Affected Resource(s) and/or Data Source(s)

```
aws_elasticache_subnet_group
Potential Terraform Configuration
data "aws_elasticache_subnet_group" "this" {
  name = "default"
}

resource "aws_security_group" "this" {
  name        = "example"
  description = "Example Security Group."
  vpc_id      = data.aws_elasticache_subnet_group.this.vpc_id
}
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #27398

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

```
> aws elasticache describe-cache-subnet-groups --cache-subnet-group-name default
{
    "CacheSubnetGroups": [
        {
            "CacheSubnetGroupName": "default",
            "CacheSubnetGroupDescription": "Default CacheSubnetGroup",
            "VpcId": "vpc-xxxxxxx",
            "Subnets": [
                {
                    "SubnetIdentifier": "subnet-aaaaaaa
                    "SubnetAvailabilityZone": {
                        "Name": "ap-northeast-2d"
                    }
                },
                {
                    "SubnetIdentifier": "subnet-bbbbbbb",
                    "SubnetAvailabilityZone": {
                        "Name": "ap-northeast-2a"
                    }
                },
                {
                    "SubnetIdentifier": "subnet-ccccccc",
                    "SubnetAvailabilityZone": {
                        "Name": "ap-northeast-2c"
                    }
                },
                {
                    "SubnetIdentifier": "subnet-ddddddd",
                    "SubnetAvailabilityZone": {
                        "Name": "ap-northeast-2b"
                    }
                }
            ],
            "ARN": "arn:aws:elasticache:ap-northeast-2:xxxxxxx:subnetgroup:default"
        }
    ]
}
```


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->


