### PR TITLE
[feat] add arn attribute to aws_codedeploy_deployment_config

### DIFF
--- a/.changelog/35888.txt
+++ b/.changelog/35888.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_codedeploy_deployment_config: Add `arn` attribute
+```

--- a/internal/service/deploy/deployment_config.go
+++ b/internal/service/deploy/deployment_config.go
@@ -5,7 +5,6 @@ package deploy
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -183,12 +182,12 @@ func resourceDeploymentConfigRead(ctx context.Context, d *schema.ResourceData, m
 		Service:   "codedeploy",
 		Region:    meta.(*conns.AWSClient).Region,
 		AccountID: meta.(*conns.AWSClient).AccountID,
-		Resource:  fmt.Sprintf("deploymentconfig:%s", deploymentConfigName),
+		Resource:  "deploymentconfig:" + deploymentConfigName,
 	}.String()
 	d.Set("arn", arn)
 	d.Set("compute_platform", deploymentConfig.ComputePlatform)
 	d.Set("deployment_config_id", deploymentConfig.DeploymentConfigId)
-	d.Set("deployment_config_name", deploymentConfig.DeploymentConfigName)
+	d.Set("deployment_config_name", deploymentConfigName)
 	if err := d.Set("minimum_healthy_hosts", flattenMinimumHealthHosts(deploymentConfig.MinimumHealthyHosts)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting minimum_healthy_hosts: %s", err)
 	}

--- a/internal/service/deploy/deployment_config.go
+++ b/internal/service/deploy/deployment_config.go
@@ -5,9 +5,11 @@ package deploy
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/codedeploy"
 	"github.com/aws/aws-sdk-go-v2/service/codedeploy/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -32,6 +34,10 @@ func resourceDeploymentConfig() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"compute_platform": {
 				Type:             schema.TypeString,
 				Optional:         true,
@@ -171,6 +177,15 @@ func resourceDeploymentConfigRead(ctx context.Context, d *schema.ResourceData, m
 		return sdkdiag.AppendErrorf(diags, "reading CodeDeploy Deployment Config (%s): %s", d.Id(), err)
 	}
 
+	deploymentConfigName := aws.ToString(deploymentConfig.DeploymentConfigName)
+	arn := arn.ARN{
+		Partition: meta.(*conns.AWSClient).Partition,
+		Service:   "codedeploy",
+		Region:    meta.(*conns.AWSClient).Region,
+		AccountID: meta.(*conns.AWSClient).AccountID,
+		Resource:  fmt.Sprintf("deploymentconfig:%s", deploymentConfigName),
+	}.String()
+	d.Set("arn", arn)
 	d.Set("compute_platform", deploymentConfig.ComputePlatform)
 	d.Set("deployment_config_id", deploymentConfig.DeploymentConfigId)
 	d.Set("deployment_config_name", deploymentConfig.DeploymentConfigName)

--- a/internal/service/deploy/deployment_config_test.go
+++ b/internal/service/deploy/deployment_config_test.go
@@ -37,6 +37,7 @@ func TestAccDeployDeploymentConfig_basic(t *testing.T) {
 				Config: testAccDeploymentConfigConfig_fleet(rName, 75),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeploymentConfigExists(ctx, resourceName, &config1),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "codedeploy", fmt.Sprintf("deploymentconfig:%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "deployment_config_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "compute_platform", "Server"),
 					resource.TestCheckResourceAttr(resourceName, "traffic_routing_config.#", "0"),

--- a/internal/service/deploy/deployment_config_test.go
+++ b/internal/service/deploy/deployment_config_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestAccDeployDeploymentConfig_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	var config1 types.DeploymentConfigInfo
+	var config types.DeploymentConfigInfo
 	resourceName := "aws_codedeploy_deployment_config.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -36,8 +36,8 @@ func TestAccDeployDeploymentConfig_basic(t *testing.T) {
 			{
 				Config: testAccDeploymentConfigConfig_fleet(rName, 75),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeploymentConfigExists(ctx, resourceName, &config1),
-					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "codedeploy", fmt.Sprintf("deploymentconfig:%s", rName)),
+					testAccCheckDeploymentConfigExists(ctx, resourceName, &config),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "deployment_config_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "compute_platform", "Server"),
 					resource.TestCheckResourceAttr(resourceName, "traffic_routing_config.#", "0"),

--- a/website/docs/r/codedeploy_deployment_config.html.markdown
+++ b/website/docs/r/codedeploy_deployment_config.html.markdown
@@ -126,6 +126,7 @@ The `time_based_linear` block supports the following:
 
 This resource exports the following attributes in addition to the arguments above:
 
+* `arn` - The ARN of the deployment config.
 * `id` - The deployment group's config name.
 * `deployment_config_id` - The AWS Assigned deployment config id
 


### PR DESCRIPTION
### Description

- Added `arn` attribute to `aws_codedeploy_deployment_config`
- Modified `TestAccDeployDeploymentConfig_basic` to check whether `arn` is correct.

### Relations

Closes #35281.

### Output from Acceptance Testing

```console
$ make testacc TESTS=TestAccDeployDeploymentConfig_basic PKG=deploy

==> Checking that code complies with gofmt requirements...
Notice: Behaving like ASDF_GOLANG_MOD_VERSION_ENABLED=true
        In the future this will have to be set to continue
        reading from the go.mod and go.work files
Notice: Behaving like ASDF_GOLANG_MOD_VERSION_ENABLED=true
        In the future this will have to be set to continue
        reading from the go.mod and go.work files
TF_ACC=1 go test ./internal/service/deploy/... -v -count 1 -parallel 20 -run='TestAccDeployDeploymentConfig_basic'  -timeout 360m
Notice: Behaving like ASDF_GOLANG_MOD_VERSION_ENABLED=true
        In the future this will have to be set to continue
        reading from the go.mod and go.work files
=== RUN   TestAccDeployDeploymentConfig_basic
=== PAUSE TestAccDeployDeploymentConfig_basic
=== CONT  TestAccDeployDeploymentConfig_basic
--- PASS: TestAccDeployDeploymentConfig_basic (15.37s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/deploy	21.322s
```
