### PR TITLE
Fix RDS ClusterInstanceEngine Validation

### DIFF
--- a/internal/service/rds/consts.go
+++ b/internal/service/rds/consts.go
@@ -148,6 +148,8 @@ func ClusterInstanceEngine_Values() []string {
 	return []string{
 		ClusterEngineAuroraMySQL,
 		ClusterEngineAuroraPostgreSQL,
+		ClusterEngineMySQL,
+		ClusterEnginePostgres,
 	}
 }
 

--- a/website/docs/r/rds_cluster_instance.html.markdown
+++ b/website/docs/r/rds_cluster_instance.html.markdown
@@ -64,7 +64,7 @@ This argument supports the following arguments:
 * `db_subnet_group_name` - (Required if `publicly_accessible = false`, Optional otherwise, Forces new resource) DB subnet group to associate with this DB instance. **NOTE:** This must match the `db_subnet_group_name` of the attached [`aws_rds_cluster`](/docs/providers/aws/r/rds_cluster.html).
 * `engine_version` - (Optional) Database engine version.
 * `engine` - (Required, Forces new resource) Name of the database engine to be used for the RDS cluster instance.
-  Valid Values: `aurora-mysql`, `aurora-postgresql`.
+  Valid Values: `aurora-mysql`, `aurora-postgresql`, `mysql`, `postgres`.(Note that `mysql` and `postgres` are Multi-AZ RDS clusters).
 * `identifier_prefix` - (Optional, Forces new resource) Creates a unique identifier beginning with the specified prefix. Conflicts with `identifier`.
 * `identifier` - (Optional, Forces new resource) Identifier for the RDS instance, if omitted, Terraform will assign a random, unique identifier.
 * `instance_class` - (Required) Instance class to use. For details on CPU and memory, see [Scaling Aurora DB Instances][4]. Aurora uses `db.*` instance classes/types. Please see [AWS Documentation][7] for currently available instance classes and complete details.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
## Description

resource `aws_rds_cluster` and resource `aws_rds_cluster_instance`, 

- if `aurora-mysql` or `aurora-postgres` is specified in the `engine`, it means Aurora Cluster.
- if `mysql` or `postgres` is specified in the `engine`, it means RDS Multi-AZ Cluster.

Therefore resouce `aws_rds_cluster_instance` shoud be supported not only "aurora-mysql" and "aurora-postgres" but also "mysql" and "postgres".

### Sample Settings

<details>
<summary>sample.tf</summary>

```terraform
terraform {
  required_providers {
    aws = {
      source  = "hashicorp/aws"
      version = "5.28.0"
    }
  }

  required_version = ">= 1.2.0"
}

provider "aws" {
  region  = "ap-northeast-1"
}

# RDS Multi-AZ Cluster
resource "aws_rds_cluster" "rds_cluster" {
  cluster_identifier                  = "im-a-db-cluster"
  allocated_storage                   = 100
  availability_zones                  = ["ap-northeast-1a", "ap-northeast-1c"]
  database_name                       = "im_a_database"
  db_cluster_parameter_group_name     = "default.mysql8.0"
  db_cluster_instance_class           = "db.m5d.large"
  db_subnet_group_name                = "ssssssssssssss"
  deletion_protection                 = false
  enabled_cloudwatch_logs_exports     = ["error", "general", "slowquery"]
  engine                              = "mysql"
  engine_version                      = "8.0.33"
  iam_database_authentication_enabled = false
  iops                                = 2000
  master_password                     = "im_a_passwowrd"
  master_username                     = "im_a_user"
  storage_encrypted                   = true
  storage_type                        = "io1"
  vpc_security_group_ids              = ["sg-xxxxxxxx"]
  skip_final_snapshot                 = true
}

resource "aws_rds_cluster_instance" "this" {
  count = 1

  identifier                 = "im-a-db-cluster-instance-${count.index + 1}"
  cluster_identifier         = aws_rds_cluster.rds_cluster.id
  instance_class             = "db.t3.medium"
  engine                     = aws_rds_cluster.rds_cluster.engine # 🌟 this parameter shoud be supported not only "aurora-mysql" and "aurora-postgres" but also "mysql" and "postgres"."aurora-mysql" and "aurora-postgres" means Aurora Cluster."mysql" and "postgres" means RDS Multi-AZ Cluster.
  engine_version             = aws_rds_cluster.rds_cluster.engine_version
  auto_minor_version_upgrade = false
  promotion_tier             = 1
}
```
</details>

### Before

`terraform plan`. And it occurs error below.

```
╷
│ Error: invalid value for engine (must begin with custom-)
│ 
│   with aws_rds_cluster_instance.this[0],
│   on rds_cluster.tf line 48, in resource "aws_rds_cluster_instance" "this":
│   48:   engine                     = aws_rds_cluster.rds_cluster.engine
│ 
╵
╷
│ Error: expected engine to be one of ["aurora-mysql" "aurora-postgresql"], got mysql
│ 
│   with aws_rds_cluster_instance.this[0],
│   on rds_cluster.tf line 48, in resource "aws_rds_cluster_instance" "this":
│   48:   engine                     = aws_rds_cluster.rds_cluster.engine
│ 
╵
```

### After

`plan` and `apply` are successfull.

## Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #35146

## References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

#34580
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster
https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/multi-az-db-clusters-concepts.html

## Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console

make testacc PKG=rds TESTS='TestAccRDSClusterInstance_*'                                                                      <aws:default>
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSClusterInstance_*'  -timeout 360m
=== RUN   TestAccRDSClusterInstance_basic
=== PAUSE TestAccRDSClusterInstance_basic
=== RUN   TestAccRDSClusterInstance_disappears
=== PAUSE TestAccRDSClusterInstance_disappears
=== RUN   TestAccRDSClusterInstance_identifierGenerated
=== PAUSE TestAccRDSClusterInstance_identifierGenerated
=== RUN   TestAccRDSClusterInstance_identifierPrefix
=== PAUSE TestAccRDSClusterInstance_identifierPrefix
=== RUN   TestAccRDSClusterInstance_tags
=== PAUSE TestAccRDSClusterInstance_tags
=== RUN   TestAccRDSClusterInstance_isAlreadyBeingDeleted
=== PAUSE TestAccRDSClusterInstance_isAlreadyBeingDeleted
=== RUN   TestAccRDSClusterInstance_az
=== PAUSE TestAccRDSClusterInstance_az
=== RUN   TestAccRDSClusterInstance_kmsKey
=== PAUSE TestAccRDSClusterInstance_kmsKey
=== RUN   TestAccRDSClusterInstance_publiclyAccessible
=== PAUSE TestAccRDSClusterInstance_publiclyAccessible
=== RUN   TestAccRDSClusterInstance_copyTagsToSnapshot
=== PAUSE TestAccRDSClusterInstance_copyTagsToSnapshot
=== RUN   TestAccRDSClusterInstance_caCertificateIdentifier
=== PAUSE TestAccRDSClusterInstance_caCertificateIdentifier
=== RUN   TestAccRDSClusterInstance_monitoringInterval
=== PAUSE TestAccRDSClusterInstance_monitoringInterval
=== RUN   TestAccRDSClusterInstance_MonitoringRoleARN_enabledToDisabled
=== PAUSE TestAccRDSClusterInstance_MonitoringRoleARN_enabledToDisabled
=== RUN   TestAccRDSClusterInstance_MonitoringRoleARN_enabledToRemoved
=== PAUSE TestAccRDSClusterInstance_MonitoringRoleARN_enabledToRemoved
=== RUN   TestAccRDSClusterInstance_MonitoringRoleARN_removedToEnabled
=== PAUSE TestAccRDSClusterInstance_MonitoringRoleARN_removedToEnabled
=== RUN   TestAccRDSClusterInstance_PerformanceInsightsEnabled_auroraMySQL1
=== PAUSE TestAccRDSClusterInstance_PerformanceInsightsEnabled_auroraMySQL1
=== RUN   TestAccRDSClusterInstance_PerformanceInsightsEnabled_auroraPostgresql
=== PAUSE TestAccRDSClusterInstance_PerformanceInsightsEnabled_auroraPostgresql
=== RUN   TestAccRDSClusterInstance_PerformanceInsightsKMSKeyID_auroraMySQL1
=== PAUSE TestAccRDSClusterInstance_PerformanceInsightsKMSKeyID_auroraMySQL1
=== RUN   TestAccRDSClusterInstance_PerformanceInsightsKMSKeyIDAuroraMySQL1_defaultKeyToCustomKey
=== PAUSE TestAccRDSClusterInstance_PerformanceInsightsKMSKeyIDAuroraMySQL1_defaultKeyToCustomKey
=== RUN   TestAccRDSClusterInstance_performanceInsightsRetentionPeriod
=== PAUSE TestAccRDSClusterInstance_performanceInsightsRetentionPeriod
=== RUN   TestAccRDSClusterInstance_PerformanceInsightsKMSKeyID_auroraPostgresql
=== PAUSE TestAccRDSClusterInstance_PerformanceInsightsKMSKeyID_auroraPostgresql
=== RUN   TestAccRDSClusterInstance_PerformanceInsightsKMSKeyIDAuroraPostgresql_defaultKeyToCustomKey
=== PAUSE TestAccRDSClusterInstance_PerformanceInsightsKMSKeyIDAuroraPostgresql_defaultKeyToCustomKey
=== CONT  TestAccRDSClusterInstance_basic
=== CONT  TestAccRDSClusterInstance_monitoringInterval
=== CONT  TestAccRDSClusterInstance_PerformanceInsightsKMSKeyID_auroraMySQL1
=== CONT  TestAccRDSClusterInstance_PerformanceInsightsKMSKeyIDAuroraPostgresql_defaultKeyToCustomKey
=== CONT  TestAccRDSClusterInstance_az
=== CONT  TestAccRDSClusterInstance_caCertificateIdentifier
=== CONT  TestAccRDSClusterInstance_copyTagsToSnapshot
=== CONT  TestAccRDSClusterInstance_publiclyAccessible
=== CONT  TestAccRDSClusterInstance_kmsKey
=== CONT  TestAccRDSClusterInstance_identifierPrefix
=== CONT  TestAccRDSClusterInstance_isAlreadyBeingDeleted
=== CONT  TestAccRDSClusterInstance_tags
=== CONT  TestAccRDSClusterInstance_PerformanceInsightsKMSKeyID_auroraPostgresql
=== CONT  TestAccRDSClusterInstance_PerformanceInsightsEnabled_auroraPostgresql
=== CONT  TestAccRDSClusterInstance_PerformanceInsightsEnabled_auroraMySQL1
=== CONT  TestAccRDSClusterInstance_MonitoringRoleARN_removedToEnabled
=== CONT  TestAccRDSClusterInstance_MonitoringRoleARN_enabledToRemoved
=== CONT  TestAccRDSClusterInstance_MonitoringRoleARN_enabledToDisabled
=== CONT  TestAccRDSClusterInstance_identifierGenerated
=== CONT  TestAccRDSClusterInstance_disappears
--- PASS: TestAccRDSClusterInstance_PerformanceInsightsEnabled_auroraPostgresql (967.13s)
=== CONT  TestAccRDSClusterInstance_performanceInsightsRetentionPeriod
--- PASS: TestAccRDSClusterInstance_PerformanceInsightsEnabled_auroraMySQL1 (1152.30s)
=== CONT  TestAccRDSClusterInstance_PerformanceInsightsKMSKeyIDAuroraMySQL1_defaultKeyToCustomKey
--- PASS: TestAccRDSClusterInstance_copyTagsToSnapshot (1152.54s)
--- PASS: TestAccRDSClusterInstance_PerformanceInsightsKMSKeyID_auroraPostgresql (1193.50s)
--- PASS: TestAccRDSClusterInstance_identifierPrefix (1195.35s)
--- PASS: TestAccRDSClusterInstance_PerformanceInsightsKMSKeyIDAuroraPostgresql_defaultKeyToCustomKey (1234.36s)
--- PASS: TestAccRDSClusterInstance_PerformanceInsightsKMSKeyID_auroraMySQL1 (1313.95s)
--- PASS: TestAccRDSClusterInstance_kmsKey (1378.12s)
--- PASS: TestAccRDSClusterInstance_identifierGenerated (1395.35s)
--- PASS: TestAccRDSClusterInstance_disappears (1420.43s)
--- PASS: TestAccRDSClusterInstance_tags (1465.63s)
--- PASS: TestAccRDSClusterInstance_publiclyAccessible (1466.81s)
--- PASS: TestAccRDSClusterInstance_caCertificateIdentifier (1482.56s)
--- PASS: TestAccRDSClusterInstance_az (1485.69s)
--- PASS: TestAccRDSClusterInstance_isAlreadyBeingDeleted (1505.45s)
--- PASS: TestAccRDSClusterInstance_basic (1564.56s)
--- PASS: TestAccRDSClusterInstance_MonitoringRoleARN_removedToEnabled (1578.57s)
--- PASS: TestAccRDSClusterInstance_MonitoringRoleARN_enabledToRemoved (1672.06s)
--- PASS: TestAccRDSClusterInstance_MonitoringRoleARN_enabledToDisabled (1728.66s)
--- PASS: TestAccRDSClusterInstance_monitoringInterval (1900.09s)
--- PASS: TestAccRDSClusterInstance_performanceInsightsRetentionPeriod (1468.12s)
--- PASS: TestAccRDSClusterInstance_PerformanceInsightsKMSKeyIDAuroraMySQL1_defaultKeyToCustomKey (1298.16s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        2450.603s

...
```
