### PR TITLE
r/aws_cloudsearch_domain: fix index_field crash on read

### DIFF
--- a/internal/service/cloudsearch/domain.go
+++ b/internal/service/cloudsearch/domain.go
@@ -1049,6 +1049,9 @@ func flattenIndexFieldStatus(apiObject types.IndexFieldStatus) (map[string]inter
 	switch fieldType {
 	case types.IndexFieldTypeDate:
 		options := field.DateOptions
+		if options == nil {
+			break
+		}
 
 		if v := options.DefaultValue; v != nil {
 			tfMap["default_value"] = aws.ToString(v)
@@ -1080,6 +1083,9 @@ func flattenIndexFieldStatus(apiObject types.IndexFieldStatus) (map[string]inter
 
 	case types.IndexFieldTypeDateArray:
 		options := field.DateArrayOptions
+		if options == nil {
+			break
+		}
 
 		if v := options.DefaultValue; v != nil {
 			tfMap["default_value"] = aws.ToString(v)
@@ -1108,6 +1114,9 @@ func flattenIndexFieldStatus(apiObject types.IndexFieldStatus) (map[string]inter
 
 	case types.IndexFieldTypeDouble:
 		options := field.DoubleOptions
+		if options == nil {
+			break
+		}
 
 		if v := options.DefaultValue; v != nil {
 			tfMap["default_value"] = flex.Float64ToStringValue(v)
@@ -1139,6 +1148,9 @@ func flattenIndexFieldStatus(apiObject types.IndexFieldStatus) (map[string]inter
 
 	case types.IndexFieldTypeDoubleArray:
 		options := field.DoubleArrayOptions
+		if options == nil {
+			break
+		}
 
 		if v := options.DefaultValue; v != nil {
 			tfMap["default_value"] = flex.Float64ToStringValue(v)
@@ -1167,6 +1179,9 @@ func flattenIndexFieldStatus(apiObject types.IndexFieldStatus) (map[string]inter
 
 	case types.IndexFieldTypeInt:
 		options := field.IntOptions
+		if options == nil {
+			break
+		}
 
 		if v := options.DefaultValue; v != nil {
 			tfMap["default_value"] = flex.Int64ToStringValue(v)
@@ -1198,6 +1213,9 @@ func flattenIndexFieldStatus(apiObject types.IndexFieldStatus) (map[string]inter
 
 	case types.IndexFieldTypeIntArray:
 		options := field.IntArrayOptions
+		if options == nil {
+			break
+		}
 
 		if v := options.DefaultValue; v != nil {
 			tfMap["default_value"] = flex.Int64ToStringValue(v)
@@ -1226,6 +1244,9 @@ func flattenIndexFieldStatus(apiObject types.IndexFieldStatus) (map[string]inter
 
 	case types.IndexFieldTypeLatlon:
 		options := field.LatLonOptions
+		if options == nil {
+			break
+		}
 
 		if v := options.DefaultValue; v != nil {
 			tfMap["default_value"] = aws.ToString(v)
@@ -1257,6 +1278,9 @@ func flattenIndexFieldStatus(apiObject types.IndexFieldStatus) (map[string]inter
 
 	case types.IndexFieldTypeLiteral:
 		options := field.LiteralOptions
+		if options == nil {
+			break
+		}
 
 		if v := options.DefaultValue; v != nil {
 			tfMap["default_value"] = aws.ToString(v)
@@ -1288,6 +1312,9 @@ func flattenIndexFieldStatus(apiObject types.IndexFieldStatus) (map[string]inter
 
 	case types.IndexFieldTypeLiteralArray:
 		options := field.LiteralArrayOptions
+		if options == nil {
+			break
+		}
 
 		if v := options.DefaultValue; v != nil {
 			tfMap["default_value"] = aws.ToString(v)
@@ -1316,6 +1343,9 @@ func flattenIndexFieldStatus(apiObject types.IndexFieldStatus) (map[string]inter
 
 	case types.IndexFieldTypeText:
 		options := field.TextOptions
+		if options == nil {
+			break
+		}
 
 		if v := options.AnalysisScheme; v != nil {
 			tfMap["analysis_scheme"] = aws.ToString(v)
@@ -1347,6 +1377,9 @@ func flattenIndexFieldStatus(apiObject types.IndexFieldStatus) (map[string]inter
 
 	case types.IndexFieldTypeTextArray:
 		options := field.TextArrayOptions
+		if options == nil {
+			break
+		}
 
 		if v := options.AnalysisScheme; v != nil {
 			tfMap["analysis_scheme"] = aws.ToString(v)


### PR DESCRIPTION



<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
A missing nil check in the flattener for the `index_field` argument could, under certain conditions, cause the read operation to panic.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #35884

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=cloudsearch TESTS=TestAccCloudSearchDomain_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudsearch/... -v -count 1 -parallel 20 -run='TestAccCloudSearchDomain_'  -timeout 360m

--- PASS: TestAccCloudSearchDomain_basic (708.55s)
--- PASS: TestAccCloudSearchDomain_disappears (746.41s)
--- PASS: TestAccCloudSearchDomain_sourceFields (1712.89s)
--- PASS: TestAccCloudSearchDomain_indexFields (1859.65s)
--- PASS: TestAccCloudSearchDomain_update (2328.91s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudsearch        2336.129s
```
