### PR TITLE
resource/aws_s3_object_copy: Fixes acceptance test

### DIFF
--- a/internal/service/s3/object_copy_test.go
+++ b/internal/service/s3/object_copy_test.go
@@ -571,7 +571,7 @@ func TestAccS3ObjectCopy_basicViaAccessPoint(t *testing.T) {
 					resource.TestCheckNoResourceAttr(resourceName, "source_customer_algorithm"),
 					resource.TestCheckNoResourceAttr(resourceName, "source_customer_key"),
 					resource.TestCheckNoResourceAttr(resourceName, "source_customer_key_md5"),
-					resource.TestCheckResourceAttrSet(resourceName, "source_version_id"),
+					resource.TestCheckResourceAttr(resourceName, "source_version_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "storage_class", "STANDARD"),
 					resource.TestCheckNoResourceAttr(resourceName, "tagging_directive"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),


### PR DESCRIPTION
### Description

Corrects check in acceptance test `TestAccS3ObjectCopy_basicViaAccessPoint`

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=s3 TESTS=TestAccS3ObjectCopy_basicViaAccessPoint

--- PASS: TestAccS3ObjectCopy_basicViaAccessPoint (16.45s)
```
