### PR TITLE
[Docs]: In aws_quicksight_data_set resource physical_table_map.custom_sql.columns is mandatory

### DIFF
--- a/website/docs/r/quicksight_data_set.html.markdown
+++ b/website/docs/r/quicksight_data_set.html.markdown
@@ -197,7 +197,7 @@ For a `physical_table_map` item to be valid, only one of `custom_sql`, `relation
 * `data_source_arn` - (Required) ARN of the data source.
 * `name` - (Required) Display name for the SQL query result.
 * `sql_query` - (Required) SQL query.
-* `columns` - (Optional) Column schema from the SQL query result set. See [columns](#columns).
+* `columns` - (Required) Column schema from the SQL query result set. See [columns](#columns).
 
 ### columns
 


### PR DESCRIPTION
Description:

In aws_quicksight_data_set resource documentation "columns" variable is mentioned as optional for custom_sql but when we try using without column we are getting below error

Error: error creating QuickSight Data Set: ValidationException: 1 validation error detected: Value null at 'physicalTableMap.physical-table-id.member.customSql.columns' failed to satisfy constraint: Member must not be null

Relations:

Closes #35052

References:

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_data_set#custom_sql
