### PR TITLE
fix ecpupersecond description for elasticache_serverless_cache

### DIFF
--- a/website/docs/r/elasticache_serverless_cache.html.markdown
+++ b/website/docs/r/elasticache_serverless_cache.html.markdown
@@ -94,7 +94,7 @@ The following arguments are optional:
 
 ### ECPUPerSecond Configuration
 
-* `maximum` - The upper limit for data storage the cache is set to use. Set as Integer.
+* `maximum` - The maximum number of ECPUs the cache can consume per second. Set as Integer.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Fix what seem to be a copy-paste error of the ECPUPerSecond description.


### Relations

### References
[AWSdocs](https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_ECPUPerSecond.html)