### PR TITLE
docs: Add status arg desc for  the aws_iot_domain_configuration resource

### DIFF
--- a/website/docs/r/iot_domain_configuration.html.markdown
+++ b/website/docs/r/iot_domain_configuration.html.markdown
@@ -26,14 +26,14 @@ resource "aws_iot_domain_configuration" "iot" {
 
 ## Argument Reference
 
-* `authorizer_config` - (Optional) An object that specifies the authorization service for a domain. See [`authorizer_config` Block](#authorizer_config-block) below for details.
+* `authorizer_config` - (Optional) An object that specifies the authorization service for a domain. See the [`authorizer_config` Block](#authorizer_config-block) below for details.
 * `domain_name` - (Optional) Fully-qualified domain name.
 * `name` - (Required) The name of the domain configuration. This value must be unique to a region.
 * `server_certificate_arns` - (Optional) The ARNs of the certificates that IoT passes to the device during the TLS handshake. Currently you can specify only one certificate ARN. This value is not required for Amazon Web Services-managed domains. When using a custom `domain_name`, the cert must include it.
 * `service_type` - (Optional) The type of service delivered by the endpoint. Note: Amazon Web Services IoT Core currently supports only the `DATA` service type.
-* `status` - (Optional) The status to which the domain configuration should be set. Valid values: `ENABLED`, `DISABLED`.
+* `status` - (Optional) The status to which the domain configuration should be set. Valid values are `ENABLED` and `DISABLED`.
 * `tags` - (Optional) Map of tags to assign to this resource. If configured with a provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
-* `tls_config` - (Optional) An object that specifies the TLS configuration for a domain. See [`tls_config` Block](#tls_config-block) below for details.
+* `tls_config` - (Optional) An object that specifies the TLS configuration for a domain. See the [`tls_config` Block](#tls_config-block) below for details.
 * `validation_certificate_arn` - (Optional) The certificate used to validate the server certificate and prove domain name ownership. This certificate must be signed by a public certificate authority. This value is not required for Amazon Web Services-managed domains.
 
 ### `authorizer_config` Block

--- a/website/docs/r/iot_domain_configuration.html.markdown
+++ b/website/docs/r/iot_domain_configuration.html.markdown
@@ -26,21 +26,26 @@ resource "aws_iot_domain_configuration" "iot" {
 
 ## Argument Reference
 
-* `authorizer_config` - (Optional) An object that specifies the authorization service for a domain. See below.
+* `authorizer_config` - (Optional) An object that specifies the authorization service for a domain. See [`authorizer_config` Block](#authorizer_config-block) below for details.
 * `domain_name` - (Optional) Fully-qualified domain name.
 * `name` - (Required) The name of the domain configuration. This value must be unique to a region.
 * `server_certificate_arns` - (Optional) The ARNs of the certificates that IoT passes to the device during the TLS handshake. Currently you can specify only one certificate ARN. This value is not required for Amazon Web Services-managed domains. When using a custom `domain_name`, the cert must include it.
 * `service_type` - (Optional) The type of service delivered by the endpoint. Note: Amazon Web Services IoT Core currently supports only the `DATA` service type.
+* `status` - (Optional) The status to which the domain configuration should be set. Valid values: `ENABLED`, `DISABLED`.
 * `tags` - (Optional) Map of tags to assign to this resource. If configured with a provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
-* `tls_config` - (Optional) An object that specifies the TLS configuration for a domain. See below.
+* `tls_config` - (Optional) An object that specifies the TLS configuration for a domain. See [`tls_config` Block](#tls_config-block) below for details.
 * `validation_certificate_arn` - (Optional) The certificate used to validate the server certificate and prove domain name ownership. This certificate must be signed by a public certificate authority. This value is not required for Amazon Web Services-managed domains.
 
-### authorizer_config
+### `authorizer_config` Block
+
+The `authorizer_config` configuration block supports the following arguments:
 
 * `allow_authorizer_override` - (Optional) A Boolean that specifies whether the domain configuration's authorization service can be overridden.
 * `default_authorizer_name` - (Optional) The name of the authorization service for a domain configuration.
 
-### tls_config
+### `tls_config` Block
+
+The `tls_config` configuration block supports the following arguments:
 
 * `security_policy` - (Optional) The security policy for a domain configuration.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR adds the `status` argument description to the `aws_iot_domain_configuration` resource documentation. I've also added links to the two configuration block arguments that were missing.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #35928

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [UpdateDomainConfiguration](https://docs.aws.amazon.com/iot/latest/apireference/API_UpdateDomainConfiguration.html) for wording.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
n/a
