### PR TITLE
redshift: add v2 aws sdk client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -103,6 +103,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/qldb v1.20.2
 	github.com/aws/aws-sdk-go-v2/service/rbin v1.15.2
 	github.com/aws/aws-sdk-go-v2/service/rds v1.71.2
+	github.com/aws/aws-sdk-go-v2/service/redshift v1.42.2
 	github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.24.3
 	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.16.4
 	github.com/aws/aws-sdk-go-v2/service/rekognition v1.38.2

--- a/go.sum
+++ b/go.sum
@@ -240,6 +240,8 @@ github.com/aws/aws-sdk-go-v2/service/rbin v1.15.2 h1:3WgCnpykFdYVMEqe48VSSDEtHlV
 github.com/aws/aws-sdk-go-v2/service/rbin v1.15.2/go.mod h1:twjAy0rzJI3a4gLElW+9kGq9POXxMZrVZgy8/m3s7vA=
 github.com/aws/aws-sdk-go-v2/service/rds v1.71.2 h1:RjlhYRut7x9YB2osQkEXqpDZxbWlK1B6Oqq1GTgh6e0=
 github.com/aws/aws-sdk-go-v2/service/rds v1.71.2/go.mod h1:DSeprnsj3WlGLGUZOSNopiS9vAJ8O3mELgOk6xdYxHI=
+github.com/aws/aws-sdk-go-v2/service/redshift v1.42.2 h1:zueJxn5Ib3djyG1Q8YRuOOsIbnPkB4W7v2McIsjrzGI=
+github.com/aws/aws-sdk-go-v2/service/redshift v1.42.2/go.mod h1:dz/YBEp+Bq5tJka7Of0J3mW+FKXEWrCOXPU7x/OCsr4=
 github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.24.3 h1:yt16uONP3LGMhvTfeZmA1JWOzCAxNxbm5U6vry2Rd+g=
 github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.24.3/go.mod h1:r1F7/i9zaT/1pv0wsERnNVgT+VZMbrRV7eH54ea1EnA=
 github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.16.4 h1:PN3J849dN9LDP/HJ18Jv3iA/koME2J3W+2qUyNzjOrk=

--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -96,6 +96,7 @@ import (
 	qldb_sdkv2 "github.com/aws/aws-sdk-go-v2/service/qldb"
 	rbin_sdkv2 "github.com/aws/aws-sdk-go-v2/service/rbin"
 	rds_sdkv2 "github.com/aws/aws-sdk-go-v2/service/rds"
+	redshift_sdkv2 "github.com/aws/aws-sdk-go-v2/service/redshift"
 	redshiftdata_sdkv2 "github.com/aws/aws-sdk-go-v2/service/redshiftdata"
 	redshiftserverless_sdkv2 "github.com/aws/aws-sdk-go-v2/service/redshiftserverless"
 	rekognition_sdkv2 "github.com/aws/aws-sdk-go-v2/service/rekognition"
@@ -980,6 +981,10 @@ func (c *AWSClient) RUMConn(ctx context.Context) *cloudwatchrum_sdkv1.CloudWatch
 
 func (c *AWSClient) RedshiftConn(ctx context.Context) *redshift_sdkv1.Redshift {
 	return errs.Must(conn[*redshift_sdkv1.Redshift](ctx, c, names.Redshift, make(map[string]any)))
+}
+
+func (c *AWSClient) RedshiftClient(ctx context.Context) *redshift_sdkv2.Client {
+	return errs.Must(client[*redshift_sdkv2.Client](ctx, c, names.Redshift, make(map[string]any)))
 }
 
 func (c *AWSClient) RedshiftDataClient(ctx context.Context) *redshiftdata_sdkv2.Client {

--- a/internal/service/redshift/service_endpoints_gen_test.go
+++ b/internal/service/redshift/service_endpoints_gen_test.go
@@ -4,16 +4,17 @@ package redshift_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
-	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	redshift_sdkv2 "github.com/aws/aws-sdk-go-v2/service/redshift"
 	redshift_sdkv1 "github.com/aws/aws-sdk-go/service/redshift"
 	"github.com/aws/smithy-go/middleware"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
@@ -202,33 +203,69 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 		},
 	}
 
-	for name, testcase := range testcases { //nolint:paralleltest // uses t.Setenv
-		testcase := testcase
+	t.Run("v1", func(t *testing.T) {
+		for name, testcase := range testcases { //nolint:paralleltest // uses t.Setenv
+			testcase := testcase
 
-		t.Run(name, func(t *testing.T) {
-			testEndpointCase(t, region, testcase, callService)
-		})
-	}
+			t.Run(name, func(t *testing.T) {
+				testEndpointCase(t, region, testcase, callServiceV1)
+			})
+		}
+	})
+
+	t.Run("v2", func(t *testing.T) {
+		for name, testcase := range testcases { //nolint:paralleltest // uses t.Setenv
+			testcase := testcase
+
+			t.Run(name, func(t *testing.T) {
+				testEndpointCase(t, region, testcase, callServiceV2)
+			})
+		}
+	})
 }
 
 func defaultEndpoint(region string) string {
-	r := endpoints.DefaultResolver()
+	r := redshift_sdkv2.NewDefaultEndpointResolverV2()
 
-	ep, err := r.EndpointFor(redshift_sdkv1.EndpointsID, region)
+	ep, err := r.ResolveEndpoint(context.Background(), redshift_sdkv2.EndpointParameters{
+		Region: aws_sdkv2.String(region),
+	})
 	if err != nil {
 		return err.Error()
 	}
 
-	url, _ := url.Parse(ep.URL)
-
-	if url.Path == "" {
-		url.Path = "/"
+	if ep.URI.Path == "" {
+		ep.URI.Path = "/"
 	}
 
-	return url.String()
+	return ep.URI.String()
 }
 
-func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) string {
+func callServiceV2(ctx context.Context, t *testing.T, meta *conns.AWSClient) string {
+	t.Helper()
+
+	var endpoint string
+
+	client := meta.RedshiftClient(ctx)
+
+	_, err := client.DescribeClusters(ctx, &redshift_sdkv2.DescribeClustersInput{},
+		func(opts *redshift_sdkv2.Options) {
+			opts.APIOptions = append(opts.APIOptions,
+				addRetrieveEndpointURLMiddleware(t, &endpoint),
+				addCancelRequestMiddleware(),
+			)
+		},
+	)
+	if err == nil {
+		t.Fatal("Expected an error, got none")
+	} else if !errors.Is(err, errCancelOperation) {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+
+	return endpoint
+}
+
+func callServiceV1(ctx context.Context, t *testing.T, meta *conns.AWSClient) string {
 	t.Helper()
 
 	client := meta.RedshiftConn(ctx)

--- a/internal/service/redshift/service_package_gen.go
+++ b/internal/service/redshift/service_package_gen.go
@@ -5,6 +5,8 @@ package redshift
 import (
 	"context"
 
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	redshift_sdkv2 "github.com/aws/aws-sdk-go-v2/service/redshift"
 	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
 	session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
 	redshift_sdkv1 "github.com/aws/aws-sdk-go/service/redshift"
@@ -184,6 +186,17 @@ func (p *servicePackage) NewConn(ctx context.Context, config map[string]any) (*r
 	sess := config["session"].(*session_sdkv1.Session)
 
 	return redshift_sdkv1.New(sess.Copy(&aws_sdkv1.Config{Endpoint: aws_sdkv1.String(config["endpoint"].(string))})), nil
+}
+
+// NewClient returns a new AWS SDK for Go v2 client for this service package's AWS API.
+func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (*redshift_sdkv2.Client, error) {
+	cfg := *(config["aws_sdkv2_config"].(*aws_sdkv2.Config))
+
+	return redshift_sdkv2.NewFromConfig(cfg, func(o *redshift_sdkv2.Options) {
+		if endpoint := config["endpoint"].(string); endpoint != "" {
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
+		}
+	}), nil
 }
 
 func ServicePackage(ctx context.Context) conns.ServicePackage {

--- a/names/data/names_data.csv
+++ b/names/data/names_data.csv
@@ -295,7 +295,7 @@ rds-data,rdsdata,rdsdataservice,rdsdata,,rdsdata,,rdsdataservice,RDSData,RDSData
 pi,pi,pi,pi,,pi,,,PI,PI,,1,,,aws_pi_,,pi_,RDS Performance Insights (PI),Amazon,,x,,,,,PI,,,
 rbin,rbin,recyclebin,rbin,,rbin,,recyclebin,RBin,RecycleBin,,,2,,aws_rbin_,,rbin_,Recycle Bin (RBin),Amazon,,,,,,,rbin,ListRules,ResourceType: awstypes.ResourceTypeEc2Image,
 ,,,,,,,,,,,,,,,,,Red Hat OpenShift Service on AWS (ROSA),AWS,x,,,,,,,,,No SDK support
-redshift,redshift,redshift,redshift,,redshift,,,Redshift,Redshift,,1,,,aws_redshift_,,redshift_,Redshift,Amazon,,,,,,,Redshift,DescribeClusters,,
+redshift,redshift,redshift,redshift,,redshift,,,Redshift,Redshift,,1,2,,aws_redshift_,,redshift_,Redshift,Amazon,,,,,,,Redshift,DescribeClusters,,
 redshift-data,redshiftdata,redshiftdataapiservice,redshiftdata,,redshiftdata,,redshiftdataapiservice,RedshiftData,RedshiftDataAPIService,,,2,,aws_redshiftdata_,,redshiftdata_,Redshift Data,Amazon,,,,,,,Redshift Data,ListDatabases,"Database: aws_sdkv2.String(""test"")",
 redshift-serverless,redshiftserverless,redshiftserverless,redshiftserverless,,redshiftserverless,,,RedshiftServerless,RedshiftServerless,,1,2,,aws_redshiftserverless_,,redshiftserverless_,Redshift Serverless,Amazon,,,,,,,Redshift Serverless,ListNamespaces,,
 rekognition,rekognition,rekognition,rekognition,,rekognition,,,Rekognition,Rekognition,,,2,,aws_rekognition_,,rekognition_,Rekognition,Amazon,,,,,,,Rekognition,ListCollections,,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Does not include migration of existing resources, just creation of both V1 and V2 clients to enable net-new resources to utilize the V2 SDK.
