### PR TITLE
docs: Add note about aws_ecr_registry_policy resource being singleton

### DIFF
--- a/website/docs/r/ecr_registry_policy.html.markdown
+++ b/website/docs/r/ecr_registry_policy.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides an Elastic Container Registry Policy.
 
+~> **NOTE on ECR Registry Policies:** While the AWS Management Console interface may suggest the ability to define multiple policies by creating multiple statements, ECR registry policies are effectively managed as singular entities at the regional level by the AWS APIs. Therefore, the `aws_ecr_registry_policy` resource should be configured only once per region with all necessary statements defined in the same policy. Attempting to define multiple `aws_ecr_registry_policy` resources may result in perpetual differences, with one policy overriding another.
+
 ## Example Usage
 
 ```terraform


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add a note/warning about the `aws_ecr_registry_policy` resource being singleton at the regional level, thus it should not be used multiple times to define different policies/statements.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #35940

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to the relevant [Actions](https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_Operations.html) in the AWS API reference doc to confirm schema for ECR registry policies.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
n/a