### PR TITLE
r/aws_ec2_instance/spot_instance_request: add configurable `read` timeout

### DIFF
--- a/.changelog/35955.txt
+++ b/.changelog/35955.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_instance: Add configurable `read` timeout
+```
+
+```release-note:enhancement
+resource/aws_spot_instance_request: Add configurable `read` timeout
+```

--- a/internal/service/ec2/ec2_instance_data_source.go
+++ b/internal/service/ec2/ec2_instance_data_source.go
@@ -435,7 +435,7 @@ func dataSourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	if d.Get("get_password_data").(bool) {
-		passwordData, err := getInstancePasswordData(ctx, aws.StringValue(instance.InstanceId), conn)
+		passwordData, err := getInstancePasswordData(ctx, aws.StringValue(instance.InstanceId), conn, d.Timeout(schema.TimeoutRead))
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "reading EC2 Instance (%s): %s", aws.StringValue(instance.InstanceId), err)
 		}

--- a/internal/service/ec2/ec2_spot_instance_request.go
+++ b/internal/service/ec2/ec2_spot_instance_request.go
@@ -40,6 +40,7 @@ func ResourceSpotInstanceRequest() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
+			Read:   schema.DefaultTimeout(15 * time.Minute),
 			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
@@ -348,7 +349,7 @@ func readInstance(ctx context.Context, d *schema.ResourceData, meta interface{})
 	}
 
 	if d.Get("get_password_data").(bool) {
-		passwordData, err := getInstancePasswordData(ctx, *instance.InstanceId, conn)
+		passwordData, err := getInstancePasswordData(ctx, *instance.InstanceId, conn, d.Timeout(schema.TimeoutRead))
 		if err != nil {
 			return sdkdiag.AppendFromErr(diags, err)
 		}

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -440,6 +440,7 @@ For `instance_market_options`, in addition to the arguments above, the following
 [Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
 
 * `create` - (Default `10m`)
+* `read` - (Default `15m`)
 * `update` - (Default `10m`)
 * `delete` - (Default `20m`)
 

--- a/website/docs/r/spot_instance_request.html.markdown
+++ b/website/docs/r/spot_instance_request.html.markdown
@@ -101,4 +101,5 @@ should only be used for informational purposes, not for resource dependencies:
 [Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
 
 * `create` - (Default `10m`)
+* `read` - (Default `15m`)
 * `delete` - (Default `20m`)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #19313

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccEC2InstanceDataSource_GetPasswordData_falseToTrue\|TestAccEC2Instance_basic\|TestAccEC2Instance_GetPasswordData_falseToTrue\|TestAccEC2Instance_disappears\|TestAccEC2SpotInstanceRequest_basic\|TestAccEC2SpotInstanceRequest_getPasswordData' PKG=ec2

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccEC2InstanceDataSource_GetPasswordData_falseToTrue\|TestAccEC2Instance_basic\|TestAccEC2Instance_GetPasswordData_falseToTrue\|TestAccEC2Instance_disappears\|TestAccEC2SpotInstanceRequest_basic\|TestAccEC2SpotInstanceRequest_getPasswordData -timeout 360m
--- PASS: TestAccEC2InstanceDataSource_GetPasswordData_falseToTrue (143.07s)
--- PASS: TestAccEC2Instance_GetPasswordData_falseToTrue (153.60s)
--- PASS: TestAccEC2SpotInstanceRequest_getPasswordData (159.60s)
--- PASS: TestAccEC2Instance_basicWithSpot (299.26s)
--- PASS: TestAccEC2Instance_basic (299.62s)
--- PASS: TestAccEC2SpotInstanceRequest_basic (307.09s)
--- PASS: TestAccEC2Instance_disappears (353.29s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	360.974s

```
