### PR TITLE
fix: Fix bad detect_and_copy_new_topics state mapping on read for aws_msk_replicator

### DIFF
--- a/.changelog/35966.txt
+++ b/.changelog/35966.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_msk_replicator: Fix incorrect `detect_and_copy_new_topics` attribute value from state read/refresh
+```

--- a/internal/service/kafka/replicator.go
+++ b/internal/service/kafka/replicator.go
@@ -564,7 +564,7 @@ func flattenTopicReplication(apiObject *types.TopicReplication) map[string]inter
 	}
 
 	if aws.ToBool(apiObject.DetectAndCopyNewTopics) {
-		tfMap["detect_and_copy_new_topics"] = apiObject.CopyAccessControlListsForTopics
+		tfMap["detect_and_copy_new_topics"] = apiObject.DetectAndCopyNewTopics
 	}
 
 	return tfMap


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR fixes the issue where the value of `detect_and_copy_new_topics` is incorrectly set to the value of `CopyAccessControlListsForTopics` from the API when reading the state (flattening).

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #35964

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
n/a

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccKafkaReplicator_update PKG=kafka
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/kafka/... -v -count 1 -parallel 20 -run='TestAccKafkaReplicator_update'  -timeout 360m
=== RUN   TestAccKafkaReplicator_update
=== PAUSE TestAccKafkaReplicator_update
=== CONT  TestAccKafkaReplicator_update
--- PASS: TestAccKafkaReplicator_update (7517.64s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kafka      7517.820s

$
```
