### PR TITLE
docs: Add origin_snapshot block decription for aws_fsx_openzfs_volume

### DIFF
--- a/website/docs/r/fsx_openzfs_volume.html.markdown
+++ b/website/docs/r/fsx_openzfs_volume.html.markdown
@@ -26,28 +26,41 @@ This resource supports the following arguments:
 
 * `name` - (Required) The name of the Volume. You can use a maximum of 203 alphanumeric characters, plus the underscore (_) special character.
 * `parent_volume_id` - (Required) The volume id of volume that will be the parent volume for the volume being created, this could be the root volume created from the `aws_fsx_openzfs_file_system` resource with the `root_volume_id` or the `id` property of another `aws_fsx_openzfs_volume`.
-* `origin_snapshot` - (Optional) The ARN of the source snapshot to create the volume from.
 * `copy_tags_to_snapshots` - (Optional) A boolean flag indicating whether tags for the file system should be copied to snapshots. The default value is false.
 * `data_compression_type` - (Optional) Method used to compress the data on the volume. Valid values are `NONE` or `ZSTD`. Child volumes that don't specify compression option will inherit from parent volume. This option on file system applies to the root volume.
 * `delete_volume_options` - (Optional) Whether to delete all child volumes and snapshots. Valid values: `DELETE_CHILD_VOLUMES_AND_SNAPSHOTS`. This configuration must be applied separately before attempting to delete the resource to have the desired behavior..
-* `nfs_exports` - (Optional) NFS export configuration for the root volume. Exactly 1 item. See [NFS Exports](#nfs-exports) Below.
+* `nfs_exports` - (Optional) NFS export configuration for the root volume. Exactly 1 item. See [`nfs_exports` Block](#nfs_exports-block) Below for details.
 * `read_only` - (Optional) specifies whether the volume is read-only. Default is false.
 * `record_size_kib` - (Optional) The record size of an OpenZFS volume, in kibibytes (KiB). Valid values are `4`, `8`, `16`, `32`, `64`, `128`, `256`, `512`, or `1024` KiB. The default is `128` KiB.
+* `origin_snapshot` - (Optional) Specifies the configuration to use when creating the OpenZFS volume. See [`origin_snapshot` Block](#origin_snapshot-block) below for details.
 * `storage_capacity_quota_gib`  - (Optional) The maximum amount of storage in gibibytes (GiB) that the volume can use from its parent.
 * `storage_capacity_reservation_gib`  - (Optional) The amount of storage in gibibytes (GiB) to reserve from the parent volume.
-* `user_and_group_quotas` - (Optional) - Specify how much storage users or groups can use on the volume. Maximum of 100 items. See [User and Group Quotas](#user-and-group-quotas) Below.
+* `user_and_group_quotas` - (Optional) - Specify how much storage users or groups can use on the volume. Maximum of 100 items. See [`user_and_group_quotas` Block](#user_and_group_quotas-block) Below.
 * `tags` - (Optional) A map of tags to assign to the file system. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
-### NFS Exports
+### `nfs_exports` Block
 
-* `client_configurations` - (Required) - A list of configuration objects that contain the client and options for mounting the OpenZFS file system. Maximum of 25 items. See [Client Configurations](#client configurations) Below.
+The `nfs_exports` configuration block supports the following arguments:
 
-### Client Configurations
+* `client_configurations` - (Required) - A list of configuration objects that contain the client and options for mounting the OpenZFS file system. Maximum of 25 items. See [`client_configurations` Block](#client_configurations-block) below for details.
+
+### `client_configurations` Block
+
+The `client_configurations` configuration block supports the following arguments:
 
 * `clients` - (Required) - A value that specifies who can mount the file system. You can provide a wildcard character (*), an IP address (0.0.0.0), or a CIDR address (192.0.2.0/24. By default, Amazon FSx uses the wildcard character when specifying the client.
 * `options` - (Required) -  The options to use when mounting the file system. Maximum of 20 items. See the [Linix NFS exports man page](https://linux.die.net/man/5/exports) for more information. `crossmount` and `sync` are used by default.
 
-### User and Group Quotas
+### `origin_snapshot` Block
+
+The `origin_snapshot` configuration block supports the following arguments:
+
+- `copy_strategy` - (Required) - Specifies the strategy used when copying data from the snapshot to the new volume. Valid values are `CLONE`, `FULL_COPY`, `INCREMENTAL_COPY`.
+- `snapshot_arn` - (Required) - The Amazon Resource Name (ARN) of the origin snapshot.
+
+### `user_and_group_quotas` Block
+
+The `user_and_group_quotas` configuration block supports the following arguments:
 
 * `id` - (Required) - The ID of the user or group. Valid values between `0` and `2147483647`
 * `storage_capacity_quota_gib` - (Required) - The amount of storage that the user or group can use in gibibytes (GiB). Valid values between `0` and `2147483647`


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add the missing description for the `origin_snapshot` block for the `aws_fsx_openzfs_filesystem` resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #30434

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referenced [CreateOpenZFSVolumeConfiguration](https://docs.aws.amazon.com/fsx/latest/APIReference/API_CreateOpenZFSVolumeConfiguration.html) for API object specs and descriptions.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
n/a