### PR TITLE
docs: Refer to AWS doc for source_access_configuration.type valid values for aws_lambda_event_source_mapping

### DIFF
--- a/website/docs/r/lambda_event_source_mapping.html.markdown
+++ b/website/docs/r/lambda_event_source_mapping.html.markdown
@@ -211,7 +211,7 @@ resource "aws_lambda_event_source_mapping" "example" {
 
 ### source_access_configuration Configuration Block
 
-* `type` - (Required) The type of this configuration.  For Self Managed Kafka you will need to supply blocks for type `VPC_SUBNET` and `VPC_SECURITY_GROUP`.
+* `type` - (Required) The type of authentication protocol, VPC components, or virtual host for your event source. For valid values, refer to the [AWS documentation](https://docs.aws.amazon.com/lambda/latest/api/API_SourceAccessConfiguration.html).
 * `uri` - (Required) The URI for this configuration.  For type `VPC_SUBNET` the value should be `subnet:subnet_id` where `subnet_id` is the value you would find in an aws_subnet resource's id attribute.  For type `VPC_SECURITY_GROUP` the value should be `security_group:security_group_id` where `security_group_id` is the value you would find in an aws_security_group resource's id attribute.
 
 ## Attribute Reference


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR adds a link to the AWS documentation for the full list of valid values for the `type` argument of the `source_access_configuration` config block for the `aws_lambda_event_source_mapping` resource. The list of valid values is so long that it makes more sense to just refer to the AWS API reference which is constantly updated by AWS. The code uses an enum from the AWS SDK so it should be fine to always refer to the latest doc.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #25911

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [SourceAccessConfiguration](https://docs.aws.amazon.com/lambda/latest/api/API_SourceAccessConfiguration.html).

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
n/a