### PR TITLE
f/aws_codepipeline add support for triggers

### DIFF
--- a/.changelog/35475.txt
+++ b/.changelog/35475.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_codepipeline: Add `trigger` attribute
+```

--- a/.changelog/35475.txt
+++ b/.changelog/35475.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_codepipeline: Add `trigger` attribute
+resource/aws_codepipeline: Add `trigger` configuration block
 ```

--- a/internal/service/codepipeline/codepipeline.go
+++ b/internal/service/codepipeline/codepipeline.go
@@ -222,26 +222,6 @@ func resourcePipeline() *schema.Resource {
 			},
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			"variable": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"default_value": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"description": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"name": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-					},
-				},
-			},
 			"trigger": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -448,6 +428,26 @@ func resourcePipeline() *schema.Resource {
 					},
 				},
 			},
+			"variable": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"default_value": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -520,11 +520,11 @@ func resourcePipelineRead(ctx context.Context, d *schema.ResourceData, meta inte
 	if err := d.Set("stage", flattenStageDeclarations(d, pipeline.Stages)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting stage: %s", err)
 	}
-	if err := d.Set("variable", flattenVariableDeclarations(pipeline.Variables)); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting variable: %s", err)
-	}
 	if err := d.Set("trigger", flattenTriggerDeclarations(pipeline.Triggers)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting trigger: %s", err)
+	}
+	if err := d.Set("variable", flattenVariableDeclarations(pipeline.Variables)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting variable: %s", err)
 	}
 
 	return diags
@@ -695,12 +695,12 @@ func expandPipelineDeclaration(d *schema.ResourceData) (*types.PipelineDeclarati
 		apiObject.Stages = expandStageDeclarations(v.([]interface{}))
 	}
 
-	if v, ok := d.GetOk("variable"); ok && len(v.([]interface{})) > 0 {
-		apiObject.Variables = expandVariableDeclarations(v.([]interface{}))
-	}
-
 	if v, ok := d.GetOk("trigger"); ok && len(v.([]interface{})) > 0 {
 		apiObject.Triggers = expandTriggerDeclarations(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("variable"); ok && len(v.([]interface{})) > 0 {
+		apiObject.Variables = expandVariableDeclarations(v.([]interface{}))
 	}
 
 	return apiObject, nil

--- a/internal/service/codepipeline/codepipeline.go
+++ b/internal/service/codepipeline/codepipeline.go
@@ -242,6 +242,212 @@ func resourcePipeline() *schema.Resource {
 					},
 				},
 			},
+			"trigger": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 50,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"provider_type": {
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateDiagFunc: enum.Validate[types.PipelineTriggerProviderType](),
+						},
+						"git_configuration": {
+							Type:     schema.TypeList,
+							Required: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"source_action_name": {
+										Type:     schema.TypeString,
+										Required: true,
+										ValidateFunc: validation.All(
+											validation.StringLenBetween(1, 100),
+											validation.StringMatch(regexache.MustCompile(`[0-9A-Za-z_.@-]+`), ""),
+										),
+									},
+									"pull_request": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MinItems: 1,
+										MaxItems: 3,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"branches": {
+													Type:     schema.TypeList,
+													Optional: true,
+													MaxItems: 1,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"excludes": {
+																Type:     schema.TypeList,
+																Optional: true,
+																MinItems: 1,
+																MaxItems: 8,
+																Elem: &schema.Schema{
+																	Type:         schema.TypeString,
+																	ValidateFunc: validation.StringLenBetween(1, 255),
+																},
+															},
+															"includes": {
+																Type:     schema.TypeList,
+																Optional: true,
+																MinItems: 1,
+																MaxItems: 8,
+																Elem: &schema.Schema{
+																	Type:         schema.TypeString,
+																	ValidateFunc: validation.StringLenBetween(1, 255),
+																},
+															},
+														},
+													},
+												},
+												"events": {
+													Type:     schema.TypeList,
+													Optional: true,
+													MinItems: 1,
+													MaxItems: 3,
+													Elem: &schema.Schema{
+														Type:             schema.TypeString,
+														ValidateDiagFunc: enum.Validate[types.GitPullRequestEventType](),
+													},
+												},
+												"file_paths": {
+													Type:     schema.TypeList,
+													Optional: true,
+													MaxItems: 1,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"excludes": {
+																Type:     schema.TypeList,
+																Optional: true,
+																MinItems: 1,
+																MaxItems: 8,
+																Elem: &schema.Schema{
+																	Type:         schema.TypeString,
+																	ValidateFunc: validation.StringLenBetween(1, 255),
+																},
+															},
+															"includes": {
+																Type:     schema.TypeList,
+																Optional: true,
+																MinItems: 1,
+																MaxItems: 8,
+																Elem: &schema.Schema{
+																	Type:         schema.TypeString,
+																	ValidateFunc: validation.StringLenBetween(1, 255),
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+									"push": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MinItems: 1,
+										MaxItems: 3,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"branches": {
+													Type:     schema.TypeList,
+													Optional: true,
+													MaxItems: 1,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"excludes": {
+																Type:     schema.TypeList,
+																Optional: true,
+																MinItems: 1,
+																MaxItems: 8,
+																Elem: &schema.Schema{
+																	Type:         schema.TypeString,
+																	ValidateFunc: validation.StringLenBetween(1, 255),
+																},
+															},
+															"includes": {
+																Type:     schema.TypeList,
+																Optional: true,
+																MinItems: 1,
+																MaxItems: 8,
+																Elem: &schema.Schema{
+																	Type:         schema.TypeString,
+																	ValidateFunc: validation.StringLenBetween(1, 255),
+																},
+															},
+														},
+													},
+												},
+												"file_paths": {
+													Type:     schema.TypeList,
+													Optional: true,
+													MaxItems: 1,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"excludes": {
+																Type:     schema.TypeList,
+																Optional: true,
+																MinItems: 1,
+																MaxItems: 8,
+																Elem: &schema.Schema{
+																	Type:         schema.TypeString,
+																	ValidateFunc: validation.StringLenBetween(1, 255),
+																},
+															},
+															"includes": {
+																Type:     schema.TypeList,
+																Optional: true,
+																MinItems: 1,
+																MaxItems: 8,
+																Elem: &schema.Schema{
+																	Type:         schema.TypeString,
+																	ValidateFunc: validation.StringLenBetween(1, 255),
+																},
+															},
+														},
+													},
+												},
+												"tags": {
+													Type:     schema.TypeList,
+													Optional: true,
+													MaxItems: 1,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"excludes": {
+																Type:     schema.TypeList,
+																Optional: true,
+																MinItems: 1,
+																MaxItems: 8,
+																Elem: &schema.Schema{
+																	Type:         schema.TypeString,
+																	ValidateFunc: validation.StringLenBetween(1, 255),
+																},
+															},
+															"includes": {
+																Type:     schema.TypeList,
+																Optional: true,
+																MinItems: 1,
+																MaxItems: 8,
+																Elem: &schema.Schema{
+																	Type:         schema.TypeString,
+																	ValidateFunc: validation.StringLenBetween(1, 255),
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -316,6 +522,9 @@ func resourcePipelineRead(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 	if err := d.Set("variable", flattenVariableDeclarations(pipeline.Variables)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting variable: %s", err)
+	}
+	if err := d.Set("trigger", flattenTriggerDeclarations(d, pipeline.Triggers)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting trigger: %s", err)
 	}
 
 	return diags
@@ -488,6 +697,10 @@ func expandPipelineDeclaration(d *schema.ResourceData) (*types.PipelineDeclarati
 
 	if v, ok := d.GetOk("variable"); ok && len(v.([]interface{})) > 0 {
 		apiObject.Variables = expandVariableDeclarations(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("trigger"); ok && len(v.([]interface{})) > 0 {
+		apiObject.Triggers = expandTriggerDeclarations(v.([]interface{}))
 	}
 
 	return apiObject, nil
@@ -791,6 +1004,222 @@ func expandVariableDeclarations(tfList []interface{}) []types.PipelineVariableDe
 	return apiObjects
 }
 
+func expandGitBranchFilterCriteria(tfMap map[string]interface{}) *types.GitBranchFilterCriteria {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &types.GitBranchFilterCriteria{}
+
+	if v, ok := tfMap["excludes"].([]interface{}); ok && len(v) != 0 {
+		for _, exclude := range v {
+			apiObject.Excludes = append(apiObject.Excludes, exclude.(string))
+		}
+	}
+
+	if v, ok := tfMap["includes"].([]interface{}); ok && len(v) != 0 {
+		for _, include := range v {
+			apiObject.Includes = append(apiObject.Includes, include.(string))
+		}
+	}
+
+	return apiObject
+}
+
+func expandGitFilePathFilterCriteria(tfMap map[string]interface{}) *types.GitFilePathFilterCriteria {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &types.GitFilePathFilterCriteria{}
+
+	if v, ok := tfMap["excludes"].([]interface{}); ok && len(v) != 0 {
+		for _, exclude := range v {
+			apiObject.Excludes = append(apiObject.Excludes, exclude.(string))
+		}
+	}
+
+	if v, ok := tfMap["includes"].([]interface{}); ok && len(v) != 0 {
+		for _, include := range v {
+			apiObject.Includes = append(apiObject.Includes, include.(string))
+		}
+	}
+
+	return apiObject
+}
+
+func expandGitTagFilterCriteria(tfMap map[string]interface{}) *types.GitTagFilterCriteria {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &types.GitTagFilterCriteria{}
+
+	if v, ok := tfMap["excludes"].([]interface{}); ok && len(v) != 0 {
+		for _, exclude := range v {
+			apiObject.Excludes = append(apiObject.Excludes, exclude.(string))
+		}
+	}
+
+	if v, ok := tfMap["includes"].([]interface{}); ok && len(v) != 0 {
+		for _, include := range v {
+			apiObject.Includes = append(apiObject.Includes, include.(string))
+		}
+	}
+
+	return apiObject
+}
+
+func expandGitPullRequestEventTypes(tfList []interface{}) []types.GitPullRequestEventType {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	apiObjects := []types.GitPullRequestEventType{}
+
+	for _, tfMapRaw := range tfList {
+		tfMap, ok := tfMapRaw.(string)
+
+		if !ok {
+			continue
+		}
+
+		apiObjects = append(apiObjects, types.GitPullRequestEventType(tfMap))
+	}
+
+	return apiObjects
+}
+
+func expandGitPullRequestFilters(tfList []interface{}) []types.GitPullRequestFilter {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	apiObjects := []types.GitPullRequestFilter{}
+
+	for _, tfMapRaw := range tfList {
+		tfMap, ok := tfMapRaw.(map[string]interface{})
+
+		if !ok {
+			continue
+		}
+
+		apiObject := types.GitPullRequestFilter{}
+
+		if v, ok := tfMap["branches"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+			apiObject.Branches = expandGitBranchFilterCriteria(v[0].(map[string]interface{}))
+		}
+
+		if v, ok := tfMap["events"].([]interface{}); ok && len(v) > 0 && v != nil {
+			apiObject.Events = expandGitPullRequestEventTypes(v)
+		}
+
+		if v, ok := tfMap["file_paths"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+			apiObject.FilePaths = expandGitFilePathFilterCriteria(v[0].(map[string]interface{}))
+		}
+
+		apiObjects = append(apiObjects, apiObject)
+	}
+
+	return apiObjects
+}
+
+func expandGitPushFilters(tfList []interface{}) []types.GitPushFilter {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	apiObjects := []types.GitPushFilter{}
+
+	for _, tfMapRaw := range tfList {
+		tfMap, ok := tfMapRaw.(map[string]interface{})
+
+		if !ok {
+			continue
+		}
+
+		apiObject := types.GitPushFilter{}
+
+		if v, ok := tfMap["branches"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+			apiObject.Branches = expandGitBranchFilterCriteria(v[0].(map[string]interface{}))
+		}
+
+		if v, ok := tfMap["file_paths"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+			apiObject.FilePaths = expandGitFilePathFilterCriteria(v[0].(map[string]interface{}))
+		}
+
+		if v, ok := tfMap["tags"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+			apiObject.Tags = expandGitTagFilterCriteria(v[0].(map[string]interface{}))
+		}
+
+		apiObjects = append(apiObjects, apiObject)
+	}
+
+	return apiObjects
+}
+
+func expandGitConfigurationDeclaration(tfMap map[string]interface{}) *types.GitConfiguration {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &types.GitConfiguration{}
+
+	if v, ok := tfMap["pull_request"].([]interface{}); ok && len(v) > 0 && v != nil {
+		apiObject.PullRequest = expandGitPullRequestFilters(v)
+	}
+
+	if v, ok := tfMap["push"].([]interface{}); ok && len(v) > 0 && v != nil {
+		apiObject.Push = expandGitPushFilters(v)
+	}
+
+	apiObject.SourceActionName = aws.String(tfMap["source_action_name"].(string))
+
+	return apiObject
+}
+
+func expandTriggerDeclaration(tfMap map[string]interface{}) *types.PipelineTriggerDeclaration {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &types.PipelineTriggerDeclaration{}
+
+	if v, ok := tfMap["git_configuration"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+		apiObject.GitConfiguration = expandGitConfigurationDeclaration(v[0].(map[string]interface{}))
+	}
+
+	apiObject.ProviderType = types.PipelineTriggerProviderType(tfMap["provider_type"].(string))
+
+	return apiObject
+}
+
+func expandTriggerDeclarations(tfList []interface{}) []types.PipelineTriggerDeclaration {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	var apiObjects []types.PipelineTriggerDeclaration
+
+	for _, tfMapRaw := range tfList {
+		tfMap, ok := tfMapRaw.(map[string]interface{})
+
+		if !ok {
+			continue
+		}
+
+		apiObject := expandTriggerDeclaration(tfMap)
+
+		if apiObject == nil {
+			continue
+		}
+
+		apiObjects = append(apiObjects, *apiObject)
+	}
+
+	return apiObjects
+}
+
 func flattenArtifactStore(apiObject *types.ArtifactStore) map[string]interface{} {
 	tfMap := map[string]interface{}{
 		"type": apiObject.Type,
@@ -998,6 +1427,186 @@ func flattenVariableDeclarations(apiObjects []types.PipelineVariableDeclaration)
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenVariableDeclaration(apiObject))
+	}
+
+	return tfList
+}
+
+func flattenGitBranchFilterCriteria(apiObject *types.GitBranchFilterCriteria) map[string]interface{} {
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.Excludes; v != nil {
+		var tfList []interface{}
+		for _, exclude := range apiObject.Excludes {
+			tfList = append(tfList, exclude)
+		}
+		tfMap["excludes"] = tfList
+	}
+
+	if v := apiObject.Includes; v != nil {
+		var tfList []interface{}
+		for _, include := range apiObject.Includes {
+			tfList = append(tfList, include)
+		}
+		tfMap["includes"] = tfList
+	}
+
+	return tfMap
+}
+
+func flattenGitFilePathFilterCriteria(apiObject *types.GitFilePathFilterCriteria) map[string]interface{} {
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.Excludes; v != nil {
+		var tfList []interface{}
+		for _, exclude := range apiObject.Excludes {
+			tfList = append(tfList, exclude)
+		}
+		tfMap["excludes"] = tfList
+	}
+
+	if v := apiObject.Includes; v != nil {
+		var tfList []interface{}
+		for _, include := range apiObject.Includes {
+			tfList = append(tfList, include)
+		}
+		tfMap["includes"] = tfList
+	}
+
+	return tfMap
+}
+
+func flattenGitPullRequestEventTypes(apiObjects []types.GitPullRequestEventType) []interface{} {
+	var tfList []interface{}
+
+	for _, apiObject := range apiObjects {
+		tfList = append(tfList, apiObject)
+	}
+
+	return tfList
+}
+
+func flattenGitTagFilterCriteria(apiObject *types.GitTagFilterCriteria) map[string]interface{} {
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.Excludes; v != nil {
+		var tfList []interface{}
+		for _, exclude := range apiObject.Excludes {
+			tfList = append(tfList, exclude)
+		}
+		tfMap["excludes"] = tfList
+	}
+
+	if v := apiObject.Includes; v != nil {
+		var tfList []interface{}
+		for _, include := range apiObject.Includes {
+			tfList = append(tfList, include)
+		}
+		tfMap["includes"] = tfList
+	}
+
+	return tfMap
+}
+
+func flattenPullRequestFilter(apiObject types.GitPullRequestFilter) map[string]interface{} {
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.Branches; v != nil {
+		tfMap["branches"] = []interface{}{flattenGitBranchFilterCriteria(apiObject.Branches)}
+	}
+
+	if v := apiObject.Events; v != nil {
+		tfMap["events"] = flattenGitPullRequestEventTypes(apiObject.Events)
+	}
+
+	if v := apiObject.FilePaths; v != nil {
+		tfMap["file_paths"] = []interface{}{flattenGitFilePathFilterCriteria(apiObject.FilePaths)}
+	}
+
+	return tfMap
+}
+
+func flattenPullRequestFilters(apiObjects []types.GitPullRequestFilter) []interface{} {
+	if len(apiObjects) == 0 {
+		return nil
+	}
+
+	var tfList []interface{}
+
+	for _, apiObject := range apiObjects {
+		tfList = append(tfList, flattenPullRequestFilter(apiObject))
+	}
+
+	return tfList
+}
+
+func flattenGitPushFilter(apiObject types.GitPushFilter) map[string]interface{} {
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.Branches; v != nil {
+		tfMap["branches"] = []interface{}{flattenGitBranchFilterCriteria(apiObject.Branches)}
+	}
+
+	if v := apiObject.FilePaths; v != nil {
+		tfMap["file_paths"] = []interface{}{flattenGitFilePathFilterCriteria(apiObject.FilePaths)}
+	}
+
+	if v := apiObject.Tags; v != nil {
+		tfMap["tags"] = []interface{}{flattenGitTagFilterCriteria(apiObject.Tags)}
+	}
+
+	return tfMap
+}
+
+func flattenGitPushFilters(apiObjects []types.GitPushFilter) []interface{} {
+	if len(apiObjects) == 0 {
+		return nil
+	}
+
+	var tfList []interface{}
+
+	for _, apiObject := range apiObjects {
+		tfList = append(tfList, flattenGitPushFilter(apiObject))
+	}
+
+	return tfList
+}
+
+func flattenGitConfiguration(apiObject *types.GitConfiguration) map[string]interface{} {
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.PullRequest; v != nil {
+		tfMap["pull_request"] = flattenPullRequestFilters(apiObject.PullRequest)
+	}
+
+	if v := apiObject.Push; v != nil {
+		tfMap["push"] = flattenGitPushFilters(apiObject.Push)
+	}
+
+	tfMap["source_action_name"] = apiObject.SourceActionName
+
+	return tfMap
+}
+
+func flattenTriggerDeclaration(apiObject types.PipelineTriggerDeclaration) map[string]interface{} {
+	tfMap := map[string]interface{}{}
+
+	tfMap["provider_type"] = apiObject.ProviderType
+
+	tfMap["git_configuration"] = []interface{}{flattenGitConfiguration(apiObject.GitConfiguration)}
+
+	return tfMap
+}
+
+func flattenTriggerDeclarations(d *schema.ResourceData, apiObjects []types.PipelineTriggerDeclaration) []interface{} {
+	if len(apiObjects) == 0 {
+		return nil
+	}
+
+	var tfList []interface{}
+
+	for _, apiObject := range apiObjects {
+		tfList = append(tfList, flattenTriggerDeclaration(apiObject))
 	}
 
 	return tfList

--- a/internal/service/codepipeline/codepipeline.go
+++ b/internal/service/codepipeline/codepipeline.go
@@ -523,7 +523,7 @@ func resourcePipelineRead(ctx context.Context, d *schema.ResourceData, meta inte
 	if err := d.Set("variable", flattenVariableDeclarations(pipeline.Variables)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting variable: %s", err)
 	}
-	if err := d.Set("trigger", flattenTriggerDeclarations(d, pipeline.Triggers)); err != nil {
+	if err := d.Set("trigger", flattenTriggerDeclarations(pipeline.Triggers)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting trigger: %s", err)
 	}
 
@@ -1597,7 +1597,7 @@ func flattenTriggerDeclaration(apiObject types.PipelineTriggerDeclaration) map[s
 	return tfMap
 }
 
-func flattenTriggerDeclarations(d *schema.ResourceData, apiObjects []types.PipelineTriggerDeclaration) []interface{} {
+func flattenTriggerDeclarations(apiObjects []types.PipelineTriggerDeclaration) []interface{} {
 	if len(apiObjects) == 0 {
 		return nil
 	}

--- a/internal/service/codepipeline/codepipeline.go
+++ b/internal/service/codepipeline/codepipeline.go
@@ -248,25 +248,12 @@ func resourcePipeline() *schema.Resource {
 				MaxItems: 50,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"provider_type": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[types.PipelineTriggerProviderType](),
-						},
 						"git_configuration": {
 							Type:     schema.TypeList,
 							Required: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"source_action_name": {
-										Type:     schema.TypeString,
-										Required: true,
-										ValidateFunc: validation.All(
-											validation.StringLenBetween(1, 100),
-											validation.StringMatch(regexache.MustCompile(`[0-9A-Za-z_.@-]+`), ""),
-										),
-									},
 									"pull_request": {
 										Type:     schema.TypeList,
 										Optional: true,
@@ -442,8 +429,21 @@ func resourcePipeline() *schema.Resource {
 											},
 										},
 									},
+									"source_action_name": {
+										Type:     schema.TypeString,
+										Required: true,
+										ValidateFunc: validation.All(
+											validation.StringLenBetween(1, 100),
+											validation.StringMatch(regexache.MustCompile(`[0-9A-Za-z_.@-]+`), ""),
+										),
+									},
 								},
 							},
+						},
+						"provider_type": {
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateDiagFunc: enum.Validate[types.PipelineTriggerProviderType](),
 						},
 					},
 				},
@@ -1591,9 +1591,8 @@ func flattenGitConfiguration(apiObject *types.GitConfiguration) map[string]inter
 func flattenTriggerDeclaration(apiObject types.PipelineTriggerDeclaration) map[string]interface{} {
 	tfMap := map[string]interface{}{}
 
-	tfMap["provider_type"] = apiObject.ProviderType
-
 	tfMap["git_configuration"] = []interface{}{flattenGitConfiguration(apiObject.GitConfiguration)}
+	tfMap["provider_type"] = apiObject.ProviderType
 
 	return tfMap
 }

--- a/internal/service/codepipeline/codepipeline_test.go
+++ b/internal/service/codepipeline/codepipeline_test.go
@@ -1234,7 +1234,7 @@ func testAccCodePipelineConfig_basicUpdated(rName string) string { // nosemgrep:
 		testAccServiceIAMRole(rName),
 		fmt.Sprintf(`
 resource "aws_codepipeline" "test" {
-  name     = "test-pipeline-%s"
+  name     = "test-pipeline-%[1]s"
   role_arn = aws_iam_role.codepipeline_role.arn
 
   artifact_store {
@@ -1363,7 +1363,7 @@ func testAccCodePipelineConfig_pipelinetypeUpdated1(rName string) string { // no
 		testAccServiceIAMRole(rName),
 		fmt.Sprintf(`
 resource "aws_codepipeline" "test" {
-  name     = "test-pipeline-%s"
+  name     = "test-pipeline-%[1]s"
   role_arn = aws_iam_role.codepipeline_role.arn
 
   artifact_store {
@@ -1475,7 +1475,7 @@ func testAccCodePipelineConfig_pipelinetypeUpdated2(rName string) string { // no
 		testAccServiceIAMRole(rName),
 		fmt.Sprintf(`
 resource "aws_codepipeline" "test" {
-  name     = "test-pipeline-%s"
+  name     = "test-pipeline-%[1]s"
   role_arn = aws_iam_role.codepipeline_role.arn
 
   artifact_store {
@@ -1587,7 +1587,7 @@ func testAccCodePipelineConfig_pipelinetypeUpdated3(rName string) string { // no
 		testAccServiceIAMRole(rName),
 		fmt.Sprintf(`
 resource "aws_codepipeline" "test" {
-  name     = "test-pipeline-%s"
+  name     = "test-pipeline-%[1]s"
   role_arn = aws_iam_role.codepipeline_role.arn
 
   artifact_store {
@@ -1725,7 +1725,7 @@ data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 
 resource "aws_iam_role" "codepipeline_action_role" {
-  name = "codepipeline-action-role-%s"
+  name = "codepipeline-action-role-%[1]s"
 
   assume_role_policy = <<EOF
 {
@@ -1777,7 +1777,7 @@ func testAccCodePipelineConfig_deployServiceRole(rName string) string { // nosem
 		testAccDeployActionIAMRole(rName),
 		fmt.Sprintf(`
 resource "aws_codepipeline" "test" {
-  name     = "test-pipeline-%s"
+  name     = "test-pipeline-%[1]s"
   role_arn = aws_iam_role.codepipeline_role.arn
 
   artifact_store {
@@ -2011,7 +2011,7 @@ resource "aws_codepipeline" "test" {
       type = "KMS"
     }
 
-    region = "%[2]s"
+    region = %[2]q
   }
 
   artifact_store {
@@ -2023,7 +2023,7 @@ resource "aws_codepipeline" "test" {
       type = "KMS"
     }
 
-    region = "%[3]s"
+    region = %[3]q
   }
 
   stage {
@@ -2049,7 +2049,7 @@ resource "aws_codepipeline" "test" {
     name = "Build"
 
     action {
-      region          = "%[2]s"
+      region          = %[2]q
       name            = "Build"
       category        = "Build"
       owner           = "AWS"
@@ -2063,7 +2063,7 @@ resource "aws_codepipeline" "test" {
     }
 
     action {
-      region          = "%[3]s"
+      region          = %[3]q
       name            = "%[3]s-Build"
       category        = "Build"
       owner           = "AWS"
@@ -2105,7 +2105,7 @@ resource "aws_codepipeline" "test" {
       type = "KMS"
     }
 
-    region = "%[2]s"
+    region = %[2]q
   }
 
   artifact_store {
@@ -2117,7 +2117,7 @@ resource "aws_codepipeline" "test" {
       type = "KMS"
     }
 
-    region = "%[3]s"
+    region = %[3]q
   }
 
   stage {
@@ -2143,7 +2143,7 @@ resource "aws_codepipeline" "test" {
     name = "Build"
 
     action {
-      region          = "%[2]s"
+      region          = %[2]q
       name            = "BuildUpdated"
       category        = "Build"
       owner           = "AWS"
@@ -2157,7 +2157,7 @@ resource "aws_codepipeline" "test" {
     }
 
     action {
-      region          = "%[3]s"
+      region          = %[3]q
       name            = "%[3]s-BuildUpdated"
       category        = "Build"
       owner           = "AWS"

--- a/internal/service/codepipeline/codepipeline_test.go
+++ b/internal/service/codepipeline/codepipeline_test.go
@@ -654,6 +654,7 @@ func TestAccCodePipeline_pipelinetype(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.role_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.run_order", "1"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.region", ""),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.#", "0"),
 				),
 			},
 			{
@@ -662,7 +663,147 @@ func TestAccCodePipeline_pipelinetype(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccCodePipelineConfig_pipelinetypeUpdated(rName),
+				Config: testAccCodePipelineConfig_pipelinetypeUpdated1(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPipelineExists(ctx, resourceName, &p),
+					resource.TestCheckResourceAttr(resourceName, "execution_mode", string(types.ExecutionModeQueued)),
+					resource.TestCheckResourceAttr(resourceName, "pipeline_type", string(types.PipelineTypeV2)),
+					resource.TestCheckResourceAttr(resourceName, "stage.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.name", "Source"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.name", "Source"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.input_artifacts.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.output_artifacts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.output_artifacts.0", "artifacts"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.FullRepositoryId", "test-terraform/test-repo"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.BranchName", "stable"),
+					resource.TestCheckResourceAttrPair(resourceName, "stage.0.action.0.configuration.ConnectionArn", codestarConnectionResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.name", "Build"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.name", "Build"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.input_artifacts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.input_artifacts.0", "artifacts"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.configuration.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.configuration.ProjectName", "test"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.provider_type", "CodeStarSourceConnection"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.source_action_name", "Source"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.branches.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.branches.0.includes.#", "8"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.branches.0.includes.0", "main"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.branches.0.includes.1", "sub1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.branches.0.includes.2", "sub2"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.branches.0.includes.3", "sub3"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.branches.0.includes.4", "sub4"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.branches.0.includes.5", "sub5"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.branches.0.includes.6", "sub6"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.branches.0.includes.7", "sub7"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.branches.0.excludes.#", "8"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.branches.0.excludes.0", "feature/test1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.branches.0.excludes.1", "feature/test2"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.branches.0.excludes.2", "feature/test3"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.branches.0.excludes.3", "feature/test4"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.branches.0.excludes.4", "feature/test5"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.branches.0.excludes.5", "feature/test6"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.branches.0.excludes.6", "feature/test7"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.branches.0.excludes.7", "feature/wildcard*"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.file_paths.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.file_paths.0.includes.#", "8"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.file_paths.0.includes.0", "src/production1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.file_paths.0.includes.1", "src/production2"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.file_paths.0.includes.2", "src/production3"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.file_paths.0.includes.3", "src/production4"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.file_paths.0.includes.4", "src/production5"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.file_paths.0.includes.5", "src/production6"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.file_paths.0.includes.6", "src/production7"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.file_paths.0.includes.7", "src/production8"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.file_paths.0.excludes.#", "8"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.file_paths.0.excludes.0", "test/production1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.file_paths.0.excludes.1", "test/production2"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.file_paths.0.excludes.2", "test/production3"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.file_paths.0.excludes.3", "test/production4"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.file_paths.0.excludes.4", "test/production5"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.file_paths.0.excludes.5", "test/production6"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.file_paths.0.excludes.6", "test/production7"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.file_paths.0.excludes.7", "test/production8"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.tags.0.includes.#", "8"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.tags.0.includes.0", "tag1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.tags.0.includes.1", "tag2"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.tags.0.includes.2", "tag3"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.tags.0.includes.3", "tag4"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.tags.0.includes.4", "tag5"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.tags.0.includes.5", "tag6"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.tags.0.includes.6", "tag7"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.tags.0.includes.7", "tag8"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.tags.0.excludes.#", "8"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.tags.0.excludes.0", "tag11"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.tags.0.excludes.1", "tag12"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.tags.0.excludes.2", "tag13"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.tags.0.excludes.3", "tag14"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.tags.0.excludes.4", "tag15"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.tags.0.excludes.5", "tag16"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.tags.0.excludes.6", "tag17"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.tags.0.excludes.7", "tag18"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.events.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.events.0", "OPEN"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.events.1", "UPDATED"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.events.2", "CLOSED"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.branches.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.branches.0.includes.#", "8"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.branches.0.includes.0", "main1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.branches.0.includes.1", "sub11"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.branches.0.includes.2", "sub12"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.branches.0.includes.3", "sub13"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.branches.0.includes.4", "sub14"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.branches.0.includes.5", "sub15"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.branches.0.includes.6", "sub16"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.branches.0.includes.7", "sub17"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.branches.0.excludes.#", "8"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.branches.0.excludes.0", "feature/test11"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.branches.0.excludes.1", "feature/test12"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.branches.0.excludes.2", "feature/test13"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.branches.0.excludes.3", "feature/test14"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.branches.0.excludes.4", "feature/test15"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.branches.0.excludes.5", "feature/test16"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.branches.0.excludes.6", "feature/test17"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.branches.0.excludes.7", "feature/wildcard1*"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.file_paths.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.file_paths.0.includes.#", "8"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.file_paths.0.includes.0", "src/production11"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.file_paths.0.includes.1", "src/production12"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.file_paths.0.includes.2", "src/production13"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.file_paths.0.includes.3", "src/production14"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.file_paths.0.includes.4", "src/production15"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.file_paths.0.includes.5", "src/production16"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.file_paths.0.includes.6", "src/production17"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.file_paths.0.includes.7", "src/production18"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.file_paths.0.excludes.#", "8"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.file_paths.0.excludes.0", "test/production11"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.file_paths.0.excludes.1", "test/production12"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.file_paths.0.excludes.2", "test/production13"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.file_paths.0.excludes.3", "test/production14"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.file_paths.0.excludes.4", "test/production15"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.file_paths.0.excludes.5", "test/production16"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.file_paths.0.excludes.6", "test/production17"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.file_paths.0.excludes.7", "test/production18"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"stage.0.action.0.configuration.%",
+					"stage.0.action.0.configuration.OAuthToken",
+				},
+			},
+			{
+				Config: testAccCodePipelineConfig_pipelinetypeUpdated2(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPipelineExists(ctx, resourceName, &p),
 					resource.TestCheckResourceAttr(resourceName, "execution_mode", string(types.ExecutionModeQueued)),
@@ -692,6 +833,82 @@ func TestAccCodePipeline_pipelinetype(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "variable.1.name", "test_var2"),
 					resource.TestCheckResourceAttr(resourceName, "variable.1.description", "This is test pipeline variable 2."),
 					resource.TestCheckResourceAttr(resourceName, "variable.1.default_value", "value2"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.provider_type", "CodeStarSourceConnection"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.source_action_name", "Source"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.branches.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.branches.0.includes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.branches.0.includes.0", "main"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.branches.0.excludes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.branches.0.excludes.0", "feature/test*"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.file_paths.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.file_paths.0.includes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.file_paths.0.includes.0", "src/production1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.file_paths.0.excludes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.file_paths.0.excludes.0", "test/production1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.tags.0.includes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.tags.0.includes.0", "tag1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.tags.0.excludes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.push.0.tags.0.excludes.0", "tag11"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.events.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.events.0", "OPEN"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.branches.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.branches.0.includes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.branches.0.includes.0", "main1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.branches.0.excludes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.branches.0.excludes.0", "feature/test1*"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.file_paths.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.file_paths.0.includes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.file_paths.0.includes.0", "src/production11"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.file_paths.0.excludes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.pull_request.0.file_paths.0.excludes.0", "test/production11"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"stage.0.action.0.configuration.%",
+					"stage.0.action.0.configuration.OAuthToken",
+				},
+			},
+			{
+				Config: testAccCodePipelineConfig_pipelinetypeUpdated3(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPipelineExists(ctx, resourceName, &p),
+					resource.TestCheckResourceAttr(resourceName, "execution_mode", string(types.ExecutionModeQueued)),
+					resource.TestCheckResourceAttr(resourceName, "pipeline_type", string(types.PipelineTypeV2)),
+					resource.TestCheckResourceAttr(resourceName, "stage.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.name", "Source"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.name", "Source"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.input_artifacts.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.output_artifacts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.output_artifacts.0", "artifacts"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.FullRepositoryId", "test-terraform/test-repo"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.BranchName", "stable"),
+					resource.TestCheckResourceAttrPair(resourceName, "stage.0.action.0.configuration.ConnectionArn", codestarConnectionResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.name", "Build"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.name", "Build"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.input_artifacts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.input_artifacts.0", "artifacts"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.configuration.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.configuration.ProjectName", "test"),
+					resource.TestCheckResourceAttr(resourceName, "variable.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "variable.0.name", "test_var1"),
+					resource.TestCheckResourceAttr(resourceName, "variable.0.description", "This is test pipeline variable 1."),
+					resource.TestCheckResourceAttr(resourceName, "variable.0.default_value", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "variable.1.name", "test_var2"),
+					resource.TestCheckResourceAttr(resourceName, "variable.1.description", "This is test pipeline variable 2."),
+					resource.TestCheckResourceAttr(resourceName, "variable.1.default_value", "value2"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.#", "0"),
 				),
 			},
 			{
@@ -745,6 +962,7 @@ func TestAccCodePipeline_pipelinetype(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.role_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.run_order", "1"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.region", ""),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.#", "0"),
 				),
 			},
 			{
@@ -1138,7 +1356,231 @@ resource "aws_codestarconnections_connection" "test" {
 `, rName))
 }
 
-func testAccCodePipelineConfig_pipelinetypeUpdated(rName string) string { // nosemgrep:ci.codepipeline-in-func-name
+func testAccCodePipelineConfig_pipelinetypeUpdated1(rName string) string { // nosemgrep:ci.codepipeline-in-func-name
+	return acctest.ConfigCompose(
+		testAccS3DefaultBucket(rName),
+		testAccS3Bucket("updated", rName),
+		testAccServiceIAMRole(rName),
+		fmt.Sprintf(`
+resource "aws_codepipeline" "test" {
+  name     = "test-pipeline-%s"
+  role_arn = aws_iam_role.codepipeline_role.arn
+
+  artifact_store {
+    location = aws_s3_bucket.updated.bucket
+    type     = "S3"
+
+    encryption_key {
+      id   = "4567"
+      type = "KMS"
+    }
+  }
+
+  stage {
+    name = "Source"
+
+    action {
+      name             = "Source"
+      category         = "Source"
+      owner            = "AWS"
+      provider         = "CodeStarSourceConnection"
+      version          = "1"
+      output_artifacts = ["artifacts"]
+
+      configuration = {
+        ConnectionArn    = aws_codestarconnections_connection.test.arn
+        FullRepositoryId = "test-terraform/test-repo"
+        BranchName       = "stable"
+      }
+    }
+  }
+
+  stage {
+    name = "Build"
+
+    action {
+      name            = "Build"
+      category        = "Build"
+      owner           = "AWS"
+      provider        = "CodeBuild"
+      input_artifacts = ["artifacts"]
+      version         = "1"
+
+      configuration = {
+        ProjectName = "test"
+      }
+    }
+  }
+
+  execution_mode = "QUEUED"
+
+  pipeline_type = "V2"
+
+  variable {
+    name          = "test_var1"
+    description   = "This is test pipeline variable 1."
+    default_value = "value1"
+  }
+
+  variable {
+    name          = "test_var2"
+    description   = "This is test pipeline variable 2."
+    default_value = "value2"
+  }
+
+  trigger {
+    provider_type = "CodeStarSourceConnection"
+    git_configuration {
+      source_action_name = "Source"
+      push {
+        branches {
+          includes = ["main", "sub1", "sub2", "sub3", "sub4", "sub5", "sub6", "sub7"]
+          excludes = ["feature/test1", "feature/test2", "feature/test3", "feature/test4", "feature/test5", "feature/test6", "feature/test7", "feature/wildcard*"]
+        }
+        file_paths {
+          includes = ["src/production1", "src/production2", "src/production3", "src/production4", "src/production5", "src/production6", "src/production7", "src/production8"]
+          excludes = ["test/production1", "test/production2", "test/production3", "test/production4", "test/production5", "test/production6", "test/production7", "test/production8"]
+        }
+        tags {
+          includes = ["tag1", "tag2", "tag3", "tag4", "tag5", "tag6", "tag7", "tag8"]
+          excludes = ["tag11", "tag12", "tag13", "tag14", "tag15", "tag16", "tag17", "tag18"]
+        }
+      }
+      pull_request {
+        events = ["OPEN", "UPDATED", "CLOSED"]
+        branches {
+          includes = ["main1", "sub11", "sub12", "sub13", "sub14", "sub15", "sub16", "sub17"]
+          excludes = ["feature/test11", "feature/test12", "feature/test13", "feature/test14", "feature/test15", "feature/test16", "feature/test17", "feature/wildcard1*"]
+        }
+        file_paths {
+          includes = ["src/production11", "src/production12", "src/production13", "src/production14", "src/production15", "src/production16", "src/production17", "src/production18"]
+          excludes = ["test/production11", "test/production12", "test/production13", "test/production14", "test/production15", "test/production16", "test/production17", "test/production18"]
+        }
+      }
+    }
+  }
+}
+
+resource "aws_codestarconnections_connection" "test" {
+  name          = %[1]q
+  provider_type = "GitHub"
+}
+`, rName))
+}
+
+func testAccCodePipelineConfig_pipelinetypeUpdated2(rName string) string { // nosemgrep:ci.codepipeline-in-func-name
+	return acctest.ConfigCompose(
+		testAccS3DefaultBucket(rName),
+		testAccS3Bucket("updated", rName),
+		testAccServiceIAMRole(rName),
+		fmt.Sprintf(`
+resource "aws_codepipeline" "test" {
+  name     = "test-pipeline-%s"
+  role_arn = aws_iam_role.codepipeline_role.arn
+
+  artifact_store {
+    location = aws_s3_bucket.updated.bucket
+    type     = "S3"
+
+    encryption_key {
+      id   = "4567"
+      type = "KMS"
+    }
+  }
+
+  stage {
+    name = "Source"
+
+    action {
+      name             = "Source"
+      category         = "Source"
+      owner            = "AWS"
+      provider         = "CodeStarSourceConnection"
+      version          = "1"
+      output_artifacts = ["artifacts"]
+
+      configuration = {
+        ConnectionArn    = aws_codestarconnections_connection.test.arn
+        FullRepositoryId = "test-terraform/test-repo"
+        BranchName       = "stable"
+      }
+    }
+  }
+
+  stage {
+    name = "Build"
+
+    action {
+      name            = "Build"
+      category        = "Build"
+      owner           = "AWS"
+      provider        = "CodeBuild"
+      input_artifacts = ["artifacts"]
+      version         = "1"
+
+      configuration = {
+        ProjectName = "test"
+      }
+    }
+  }
+
+  execution_mode = "QUEUED"
+
+  pipeline_type = "V2"
+
+  variable {
+    name          = "test_var1"
+    description   = "This is test pipeline variable 1."
+    default_value = "value1"
+  }
+
+  variable {
+    name          = "test_var2"
+    description   = "This is test pipeline variable 2."
+    default_value = "value2"
+  }
+
+  trigger {
+    provider_type = "CodeStarSourceConnection"
+    git_configuration {
+      source_action_name = "Source"
+      push {
+        branches {
+          includes = ["main"]
+          excludes = ["feature/test*"]
+        }
+        file_paths {
+          includes = ["src/production1"]
+          excludes = ["test/production1"]
+        }
+        tags {
+          includes = ["tag1"]
+          excludes = ["tag11"]
+        }
+      }
+      pull_request {
+        events = ["OPEN"]
+        branches {
+          includes = ["main1"]
+          excludes = ["feature/test1*"]
+        }
+        file_paths {
+          includes = ["src/production11"]
+          excludes = ["test/production11"]
+        }
+      }
+    }
+  }
+}
+
+resource "aws_codestarconnections_connection" "test" {
+  name          = %[1]q
+  provider_type = "GitHub"
+}
+`, rName))
+}
+
+func testAccCodePipelineConfig_pipelinetypeUpdated3(rName string) string { // nosemgrep:ci.codepipeline-in-func-name
 	return acctest.ConfigCompose(
 		testAccS3DefaultBucket(rName),
 		testAccS3Bucket("updated", rName),

--- a/website/docs/r/codepipeline.html.markdown
+++ b/website/docs/r/codepipeline.html.markdown
@@ -182,6 +182,7 @@ This resource supports the following arguments:
   **Note:** `QUEUED` or `PARALLEL` mode can only be used with V2 pipelines.
 * `stage` (Minimum of at least two `stage` blocks is required) A stage block. Stages are documented below.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `trigger` - (Optional) A trigger block. Valid only when `pipeline_type` is `V2`. Triggers are documented below.
 * `variable` - (Optional) A pipeline-level variable block. Valid only when `pipeline_type` is `V2`. Variable are documented below.
 
 An `artifact_store` block supports the following arguments:
@@ -215,6 +216,44 @@ An `action` block supports the following arguments:
 * `run_order` - (Optional) The order in which actions are run.
 * `region` - (Optional) The region in which to run the action.
 * `namespace` - (Optional) The namespace all output variables will be accessed from.
+
+A `trigger` block supports the following arguments:
+
+* `provider_type` - (Required) The source provider for the event. Possible value is `CodeStarSourceConnection`.
+* `git_configuration` - (Required) Provides the filter criteria and the source stage for the repository event that starts the pipeline. For more information, refer to the [AWS documentation](https://docs.aws.amazon.com/codepipeline/latest/userguide/pipelines-filter.html). A `git_configuration` block is documented below.
+
+A `git_configuration` block supports the following arguments:
+
+* `source_action_name` - (Required) The name of the pipeline source action where the trigger configuration.
+* `pull_request` - (Optional) The field where the repository event that will start the pipeline is specified as pull requests. A `pull_request` block is documented below.
+* `push` - (Optional) The field where the repository event that will start the pipeline, such as pushing Git tags, is specified with details. A `push` block is documented below.
+
+A `pull_request` block supports the following arguments:
+
+* `events` - (Optional) A list that specifies which pull request events to filter on (opened, updated, closed) for the trigger configuration. Possible values are `OPEN`, `UPDATED ` and `CLOSED`.
+* `branches` - (Optional) The field that specifies to filter on branches for the pull request trigger configuration. A `branches` block is documented below.
+* `file_paths` - (Optional) The field that specifies to filter on file paths for the pull request trigger configuration. A `file_paths` block is documented below.
+
+A `push` block supports the following arguments:
+
+* `branches` - (Optional) The field that specifies to filter on branches for the push trigger configuration. A `branches` block is documented below.
+* `file_paths` - (Optional) The field that specifies to filter on file paths for the push trigger configuration. A `file_paths` block is documented below.
+* `tags` - (Optional) The field that contains the details for the Git tags trigger configuration. A `tags` block is documented below.
+
+A `branches` block supports the following arguments:
+
+* `includes` - (Optional) A list of patterns of Git branches that, when a commit is pushed, are to be included as criteria that starts the pipeline.
+* `excludes` - (Optional) A list of patterns of Git branches that, when a commit is pushed, are to be excluded from starting the pipeline.
+
+A `file_paths` block supports the following arguments:
+
+* `includes` - (Optional) A list of patterns of Git repository file paths that, when a commit is pushed, are to be included as criteria that starts the pipeline.
+* `excludes` - (Optional) A list of patterns of Git repository file paths that, when a commit is pushed, are to be excluded from starting the pipeline.
+
+A `tags` block supports the following arguments:
+
+* `includes` - (Optional) A list of patterns of Git tags that, when pushed, are to be included as criteria that starts the pipeline.
+* `excludes` - (Optional) A list of patterns of Git tags that, when pushed, are to be excluded from starting the pipeline.
 
 A `variable` block supports the following arguments:
 


### PR DESCRIPTION
resource/aws_codepipeline: Add trigger attribute

### Description
Add attribute: trigger

### Relations
Closes #35475

### References
[Announcement](https://aws.amazon.com/about-aws/whats-new/2023/10/aws-codepipeline-triggering-git-tags/)
[Documentation](https://docs.aws.amazon.com/codepipeline/latest/userguide/concepts.html#concepts-triggers)
[API Reference](https://docs.aws.amazon.com/codepipeline/latest/APIReference/API_PipelineDeclaration.html#CodePipeline-Type-PipelineDeclaration-triggers)
[CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/codepipeline/create-pipeline.html)

### Output from Acceptance Testing
```console
% make testacc TESTS=TestAccXXX PKG=ec2
make testacc TESTS='TestAccCodePipeline_' PKG=codepipeline
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/codepipeline/... -v -count 1 -parallel 10 -run='TestAccCodePipeline_'  -timeout 360m
=== RUN   TestAccCodePipeline_basic
=== PAUSE TestAccCodePipeline_basic
=== RUN   TestAccCodePipeline_disappears
=== PAUSE TestAccCodePipeline_disappears
=== RUN   TestAccCodePipeline_emptyStageArtifacts
=== PAUSE TestAccCodePipeline_emptyStageArtifacts
=== RUN   TestAccCodePipeline_deployWithServiceRole
=== PAUSE TestAccCodePipeline_deployWithServiceRole
=== RUN   TestAccCodePipeline_tags
=== PAUSE TestAccCodePipeline_tags
=== RUN   TestAccCodePipeline_MultiRegion_basic
=== PAUSE TestAccCodePipeline_MultiRegion_basic
=== RUN   TestAccCodePipeline_MultiRegion_update
=== PAUSE TestAccCodePipeline_MultiRegion_update
=== RUN   TestAccCodePipeline_MultiRegion_convertSingleRegion
=== PAUSE TestAccCodePipeline_MultiRegion_convertSingleRegion
=== RUN   TestAccCodePipeline_withNamespace
=== PAUSE TestAccCodePipeline_withNamespace
=== RUN   TestAccCodePipeline_withGitHubV1SourceAction
    codepipeline_test.go:479: Environment variable GITHUB_TOKEN is not set, skipping test
--- SKIP: TestAccCodePipeline_withGitHubV1SourceAction (0.00s)
=== RUN   TestAccCodePipeline_ecr
=== PAUSE TestAccCodePipeline_ecr
=== RUN   TestAccCodePipeline_pipelinetype
=== PAUSE TestAccCodePipeline_pipelinetype
=== CONT  TestAccCodePipeline_basic
=== CONT  TestAccCodePipeline_MultiRegion_update
=== CONT  TestAccCodePipeline_ecr
=== CONT  TestAccCodePipeline_pipelinetype
=== CONT  TestAccCodePipeline_MultiRegion_convertSingleRegion
=== CONT  TestAccCodePipeline_MultiRegion_basic
=== CONT  TestAccCodePipeline_emptyStageArtifacts
=== CONT  TestAccCodePipeline_disappears
=== CONT  TestAccCodePipeline_withNamespace
=== CONT  TestAccCodePipeline_deployWithServiceRole
--- PASS: TestAccCodePipeline_disappears (75.43s)
=== CONT  TestAccCodePipeline_tags
--- PASS: TestAccCodePipeline_ecr (81.10s)
--- PASS: TestAccCodePipeline_emptyStageArtifacts (87.67s)
--- PASS: TestAccCodePipeline_withNamespace (90.70s)
--- PASS: TestAccCodePipeline_deployWithServiceRole (95.29s)
--- PASS: TestAccCodePipeline_MultiRegion_basic (111.03s)
--- PASS: TestAccCodePipeline_basic (149.28s)
--- PASS: TestAccCodePipeline_MultiRegion_update (165.48s)
--- PASS: TestAccCodePipeline_MultiRegion_convertSingleRegion (201.26s)
--- PASS: TestAccCodePipeline_tags (131.39s)
--- PASS: TestAccCodePipeline_pipelinetype (248.47s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codepipeline       248.574s
```