### PR TITLE
add application integration url as exported attribute

### DIFF
--- a/.changelog/35974.txt
+++ b/.changelog/35974.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_wafv2_web_acl: Add `application_integration_url` attribute
+```

--- a/internal/service/wafv2/web_acl.go
+++ b/internal/service/wafv2/web_acl.go
@@ -63,6 +63,11 @@ func ResourceWebACL() *schema.Resource {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
+				"application_integration_url": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
 				"association_config": associationConfigSchema(),
 				"capacity": {
 					Type:     schema.TypeInt,
@@ -253,6 +258,7 @@ func resourceWebACLRead(ctx context.Context, d *schema.ResourceData, meta interf
 	d.Set("description", webACL.Description)
 	d.Set("lock_token", output.LockToken)
 	d.Set("name", webACL.Name)
+	d.Set("application_integration_url", output.ApplicationIntegrationURL)
 	rules := filterWebACLRules(webACL.Rules, expandWebACLRules(d.Get("rule").(*schema.Set).List()))
 	if err := d.Set("rule", flattenWebACLRules(rules)); err != nil {
 		return diag.Errorf("setting rule: %s", err)

--- a/internal/service/wafv2/web_acl.go
+++ b/internal/service/wafv2/web_acl.go
@@ -65,7 +65,6 @@ func ResourceWebACL() *schema.Resource {
 				},
 				"application_integration_url": {
 					Type:     schema.TypeString,
-					Optional: true,
 					Computed: true,
 				},
 				"association_config": associationConfigSchema(),
@@ -237,8 +236,8 @@ func resourceWebACLRead(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	webACL := output.WebACL
-	arn := aws.StringValue(webACL.ARN)
-	d.Set("arn", arn)
+	d.Set("application_integration_url", output.ApplicationIntegrationURL)
+	d.Set("arn", webACL.ARN)
 	d.Set("capacity", webACL.Capacity)
 	if err := d.Set("association_config", flattenAssociationConfig(webACL.AssociationConfig)); err != nil {
 		return diag.Errorf("setting association_config: %s", err)
@@ -258,7 +257,6 @@ func resourceWebACLRead(ctx context.Context, d *schema.ResourceData, meta interf
 	d.Set("description", webACL.Description)
 	d.Set("lock_token", output.LockToken)
 	d.Set("name", webACL.Name)
-	d.Set("application_integration_url", output.ApplicationIntegrationURL)
 	rules := filterWebACLRules(webACL.Rules, expandWebACLRules(d.Get("rule").(*schema.Set).List()))
 	if err := d.Set("rule", flattenWebACLRules(rules)); err != nil {
 		return diag.Errorf("setting rule: %s", err)

--- a/internal/service/wafv2/web_acl_test.go
+++ b/internal/service/wafv2/web_acl_test.go
@@ -51,6 +51,7 @@ func TestAccWAFV2WebACL_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckWebACLExists(ctx, resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexache.MustCompile(`regional/webacl/.+$`)),
+					resource.TestCheckResourceAttr(resourceName, "application_integration_url", ""),
 					resource.TestCheckResourceAttr(resourceName, "association_config.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "captcha_config.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "challenge_config.#", "0"),
@@ -523,6 +524,7 @@ func TestAccWAFV2WebACL_ManagedRuleGroup_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWebACLExists(ctx, resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexache.MustCompile(`regional/webacl/.+$`)),
+					resource.TestCheckResourceAttr(resourceName, "application_integration_url", ""),
 					resource.TestCheckResourceAttr(resourceName, "name", webACLName),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
@@ -731,6 +733,7 @@ func TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet(t *t
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWebACLExists(ctx, resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexache.MustCompile(`regional/webacl/.+$`)),
+					resource.TestMatchResourceAttr(resourceName, "application_integration_url", regexache.MustCompile(`https:\/\/.*\.sdk\.awswaf\.com.*`)),
 					resource.TestCheckResourceAttr(resourceName, "name", webACLName),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
@@ -823,6 +826,7 @@ func TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet(t *te
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWebACLExists(ctx, resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexache.MustCompile(`regional/webacl/.+$`)),
+					resource.TestMatchResourceAttr(resourceName, "application_integration_url", regexache.MustCompile(`https:\/\/.*\.sdk\.awswaf\.com.*`)),
 					resource.TestCheckResourceAttr(resourceName, "name", webACLName),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
@@ -909,6 +913,7 @@ func TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl(t *te
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWebACLExists(ctx, resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexache.MustCompile(`regional/webacl/.+$`)),
+					resource.TestMatchResourceAttr(resourceName, "application_integration_url", regexache.MustCompile(`https:\/\/.*\.sdk\.awswaf\.com.*`)),
 					resource.TestCheckResourceAttr(resourceName, "name", webACLName),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{

--- a/website/docs/r/wafv2_web_acl.html.markdown
+++ b/website/docs/r/wafv2_web_acl.html.markdown
@@ -1052,8 +1052,8 @@ The `uri_path` block supports the following arguments:
 
 This resource exports the following attributes in addition to the arguments above:
 
+* `application_integration_url` - The URL to use in SDK integrations with managed rule groups.
 * `arn` - The ARN of the WAF WebACL.
-* `application_integration_url` - The URL to use in SDK integrations with managed rule groups
 * `capacity` - Web ACL capacity units (WCUs) currently being used by this web ACL.
 * `id` - The ID of the WAF WebACL.
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).

--- a/website/docs/r/wafv2_web_acl.html.markdown
+++ b/website/docs/r/wafv2_web_acl.html.markdown
@@ -1053,6 +1053,7 @@ The `uri_path` block supports the following arguments:
 This resource exports the following attributes in addition to the arguments above:
 
 * `arn` - The ARN of the WAF WebACL.
+* `application_integration_url` - The URL to use in SDK integrations with managed rule groups
 * `capacity` - Web ACL capacity units (WCUs) currently being used by this web ACL.
 * `id` - The ID of the WAF WebACL.
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).


### PR DESCRIPTION
### Description

- Adds the `application_integration_url` as an exported attribute of the `aws_wafv2_web_acl` resource

### References

- https://docs.aws.amazon.com/waf/latest/developerguide/waf-javascript-api.html

### Output from Acceptance Testing

```console
╰─❯ make testacc TESTS=TestAccWAFV2WebACL PKG=wafv2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/wafv2/... -v -count 1 -parallel 20 -run='TestAccWAFV2WebACL'  -timeout 360m
=== RUN   TestAccWAFV2WebACLAssociation_basic
=== PAUSE TestAccWAFV2WebACLAssociation_basic
=== RUN   TestAccWAFV2WebACLAssociation_disappears
=== PAUSE TestAccWAFV2WebACLAssociation_disappears
=== RUN   TestAccWAFV2WebACLDataSource_basic
=== PAUSE TestAccWAFV2WebACLDataSource_basic
=== RUN   TestAccWAFV2WebACLLoggingConfiguration_basic
=== PAUSE TestAccWAFV2WebACLLoggingConfiguration_basic
=== RUN   TestAccWAFV2WebACLLoggingConfiguration_updateSingleHeaderRedactedField
=== PAUSE TestAccWAFV2WebACLLoggingConfiguration_updateSingleHeaderRedactedField
=== RUN   TestAccWAFV2WebACLLoggingConfiguration_updateMethodRedactedField
=== PAUSE TestAccWAFV2WebACLLoggingConfiguration_updateMethodRedactedField
=== RUN   TestAccWAFV2WebACLLoggingConfiguration_updateQueryStringRedactedField
=== PAUSE TestAccWAFV2WebACLLoggingConfiguration_updateQueryStringRedactedField
=== RUN   TestAccWAFV2WebACLLoggingConfiguration_updateURIPathRedactedField
=== PAUSE TestAccWAFV2WebACLLoggingConfiguration_updateURIPathRedactedField
=== RUN   TestAccWAFV2WebACLLoggingConfiguration_updateMultipleRedactedFields
=== PAUSE TestAccWAFV2WebACLLoggingConfiguration_updateMultipleRedactedFields
=== RUN   TestAccWAFV2WebACLLoggingConfiguration_changeResourceARNForceNew
=== PAUSE TestAccWAFV2WebACLLoggingConfiguration_changeResourceARNForceNew
=== RUN   TestAccWAFV2WebACLLoggingConfiguration_changeLogDestinationsForceNew
=== PAUSE TestAccWAFV2WebACLLoggingConfiguration_changeLogDestinationsForceNew
=== RUN   TestAccWAFV2WebACLLoggingConfiguration_disappears
=== PAUSE TestAccWAFV2WebACLLoggingConfiguration_disappears
=== RUN   TestAccWAFV2WebACLLoggingConfiguration_emptyRedactedFields
=== PAUSE TestAccWAFV2WebACLLoggingConfiguration_emptyRedactedFields
=== RUN   TestAccWAFV2WebACLLoggingConfiguration_updateEmptyRedactedFields
=== PAUSE TestAccWAFV2WebACLLoggingConfiguration_updateEmptyRedactedFields
=== RUN   TestAccWAFV2WebACLLoggingConfiguration_Disappears_webACL
=== PAUSE TestAccWAFV2WebACLLoggingConfiguration_Disappears_webACL
=== RUN   TestAccWAFV2WebACLLoggingConfiguration_loggingFilter
=== PAUSE TestAccWAFV2WebACLLoggingConfiguration_loggingFilter
=== RUN   TestAccWAFV2WebACL_basic
=== PAUSE TestAccWAFV2WebACL_basic
=== RUN   TestAccWAFV2WebACL_Update_rule
=== PAUSE TestAccWAFV2WebACL_Update_rule
=== RUN   TestAccWAFV2WebACL_Update_ruleProperties
=== PAUSE TestAccWAFV2WebACL_Update_ruleProperties
=== RUN   TestAccWAFV2WebACL_Update_nameForceNew
=== PAUSE TestAccWAFV2WebACL_Update_nameForceNew
=== RUN   TestAccWAFV2WebACL_disappears
=== PAUSE TestAccWAFV2WebACL_disappears
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_basic
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_basic
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion
=== RUN   TestAccWAFV2WebACL_minimal
=== PAUSE TestAccWAFV2WebACL_minimal
=== RUN   TestAccWAFV2WebACL_RateBased_basic
=== PAUSE TestAccWAFV2WebACL_RateBased_basic
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_basic
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_basic
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_jsonBody
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_jsonBody
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_body
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_body
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_headerOrder
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_headerOrder
=== RUN   TestAccWAFV2WebACL_GeoMatch_basic
=== PAUSE TestAccWAFV2WebACL_GeoMatch_basic
=== RUN   TestAccWAFV2WebACL_GeoMatch_forwardedIP
=== PAUSE TestAccWAFV2WebACL_GeoMatch_forwardedIP
=== RUN   TestAccWAFV2WebACL_LabelMatchStatement
=== PAUSE TestAccWAFV2WebACL_LabelMatchStatement
=== RUN   TestAccWAFV2WebACL_RuleLabels
=== PAUSE TestAccWAFV2WebACL_RuleLabels
=== RUN   TestAccWAFV2WebACL_IPSetReference_basic
=== PAUSE TestAccWAFV2WebACL_IPSetReference_basic
=== RUN   TestAccWAFV2WebACL_IPSetReference_forwardedIP
=== PAUSE TestAccWAFV2WebACL_IPSetReference_forwardedIP
=== RUN   TestAccWAFV2WebACL_RateBased_customKeys
=== PAUSE TestAccWAFV2WebACL_RateBased_customKeys
=== RUN   TestAccWAFV2WebACL_RateBased_forwardedIP
=== PAUSE TestAccWAFV2WebACL_RateBased_forwardedIP
=== RUN   TestAccWAFV2WebACL_RuleGroupReference_basic
=== PAUSE TestAccWAFV2WebACL_RuleGroupReference_basic
=== RUN   TestAccWAFV2WebACL_RuleGroupReference_shieldMitigation
=== PAUSE TestAccWAFV2WebACL_RuleGroupReference_shieldMitigation
=== RUN   TestAccWAFV2WebACL_RuleGroupReference_manageShieldMitigationRule
=== PAUSE TestAccWAFV2WebACL_RuleGroupReference_manageShieldMitigationRule
=== RUN   TestAccWAFV2WebACL_Custom_requestHandling
=== PAUSE TestAccWAFV2WebACL_Custom_requestHandling
=== RUN   TestAccWAFV2WebACL_Custom_response
=== PAUSE TestAccWAFV2WebACL_Custom_response
=== RUN   TestAccWAFV2WebACL_tags
=== PAUSE TestAccWAFV2WebACL_tags
=== RUN   TestAccWAFV2WebACL_RateBased_maxNested
=== PAUSE TestAccWAFV2WebACL_RateBased_maxNested
=== RUN   TestAccWAFV2WebACL_Operators_maxNested
=== PAUSE TestAccWAFV2WebACL_Operators_maxNested
=== RUN   TestAccWAFV2WebACL_tokenDomains
=== PAUSE TestAccWAFV2WebACL_tokenDomains
=== RUN   TestAccWAFV2WebACL_associationConfig
=== PAUSE TestAccWAFV2WebACL_associationConfig
=== RUN   TestAccWAFV2WebACL_CloudFrontScope
=== PAUSE TestAccWAFV2WebACL_CloudFrontScope
=== CONT  TestAccWAFV2WebACLAssociation_basic
=== CONT  TestAccWAFV2WebACL_minimal
=== CONT  TestAccWAFV2WebACL_RateBased_customKeys
=== CONT  TestAccWAFV2WebACL_GeoMatch_basic
=== CONT  TestAccWAFV2WebACL_RuleLabels
=== CONT  TestAccWAFV2WebACL_tags
=== CONT  TestAccWAFV2WebACL_RuleGroupReference_manageShieldMitigationRule
=== CONT  TestAccWAFV2WebACL_RuleGroupReference_basic
=== CONT  TestAccWAFV2WebACL_RuleGroupReference_shieldMitigation
=== CONT  TestAccWAFV2WebACL_IPSetReference_basic
=== CONT  TestAccWAFV2WebACL_LabelMatchStatement
=== CONT  TestAccWAFV2WebACL_GeoMatch_forwardedIP
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_jsonBody
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_headerOrder
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_body
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_basic
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint
=== CONT  TestAccWAFV2WebACL_RateBased_basic
=== CONT  TestAccWAFV2WebACL_Custom_response
=== CONT  TestAccWAFV2WebACL_Custom_requestHandling
--- PASS: TestAccWAFV2WebACL_IPSetReference_basic (50.03s)
=== CONT  TestAccWAFV2WebACLLoggingConfiguration_Disappears_webACL
--- PASS: TestAccWAFV2WebACL_minimal (57.67s)
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_jsonBody (91.43s)
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl
--- PASS: TestAccWAFV2WebACL_GeoMatch_basic (100.27s)
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet
--- PASS: TestAccWAFV2WebACL_GeoMatch_forwardedIP (104.69s)
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet
--- PASS: TestAccWAFV2WebACLAssociation_basic (105.31s)
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_headerOrder (106.61s)
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_basic
--- PASS: TestAccWAFV2WebACL_RuleLabels (120.21s)
=== CONT  TestAccWAFV2WebACL_disappears
--- PASS: TestAccWAFV2WebACL_RateBased_basic (122.07s)
=== CONT  TestAccWAFV2WebACL_Update_nameForceNew
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_basic (124.08s)
=== CONT  TestAccWAFV2WebACL_Update_ruleProperties
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_body (129.28s)
=== CONT  TestAccWAFV2WebACL_Update_rule
--- PASS: TestAccWAFV2WebACL_Custom_response (141.98s)
=== CONT  TestAccWAFV2WebACL_basic
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl (52.99s)
=== CONT  TestAccWAFV2WebACLLoggingConfiguration_loggingFilter
--- PASS: TestAccWAFV2WebACL_LabelMatchStatement (145.17s)
=== CONT  TestAccWAFV2WebACL_tokenDomains
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint (152.95s)
=== CONT  TestAccWAFV2WebACL_CloudFrontScope
    web_acl_test.go:2896: skipping tests; AWS_DEFAULT_REGION (us-west-2) not supported. Supported: [us-east-1]
--- SKIP: TestAccWAFV2WebACL_CloudFrontScope (0.00s)
=== CONT  TestAccWAFV2WebACL_associationConfig
    web_acl_test.go:2850: skipping tests; AWS_DEFAULT_REGION (us-west-2) not supported. Supported: [us-east-1]
--- SKIP: TestAccWAFV2WebACL_associationConfig (0.00s)
=== CONT  TestAccWAFV2WebACL_Operators_maxNested
--- PASS: TestAccWAFV2WebACL_tags (155.23s)
=== CONT  TestAccWAFV2WebACLLoggingConfiguration_updateURIPathRedactedField
--- PASS: TestAccWAFV2WebACL_RuleGroupReference_basic (165.89s)
=== CONT  TestAccWAFV2WebACLLoggingConfiguration_updateEmptyRedactedFields
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion (116.53s)
=== CONT  TestAccWAFV2WebACLLoggingConfiguration_emptyRedactedFields
--- PASS: TestAccWAFV2WebACL_RuleGroupReference_manageShieldMitigationRule (174.95s)
=== CONT  TestAccWAFV2WebACLLoggingConfiguration_disappears
--- PASS: TestAccWAFV2WebACL_disappears (63.08s)
=== CONT  TestAccWAFV2WebACLLoggingConfiguration_changeLogDestinationsForceNew
--- PASS: TestAccWAFV2WebACL_Custom_requestHandling (192.69s)
=== CONT  TestAccWAFV2WebACLLoggingConfiguration_changeResourceARNForceNew
--- PASS: TestAccWAFV2WebACL_RuleGroupReference_shieldMitigation (194.14s)
=== CONT  TestAccWAFV2WebACLLoggingConfiguration_updateMultipleRedactedFields
--- PASS: TestAccWAFV2WebACL_basic (61.28s)
=== CONT  TestAccWAFV2WebACL_RateBased_forwardedIP
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet (104.53s)
=== CONT  TestAccWAFV2WebACL_RateBased_maxNested
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet (102.33s)
=== CONT  TestAccWAFV2WebACLLoggingConfiguration_updateSingleHeaderRedactedField
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_Disappears_webACL (157.46s)
=== CONT  TestAccWAFV2WebACLLoggingConfiguration_updateQueryStringRedactedField
--- PASS: TestAccWAFV2WebACL_tokenDomains (63.20s)
=== CONT  TestAccWAFV2WebACLLoggingConfiguration_updateMethodRedactedField
=== CONT  TestAccWAFV2WebACLDataSource_basic
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig (103.11s)
--- PASS: TestAccWAFV2WebACL_Operators_maxNested (57.95s)
=== CONT  TestAccWAFV2WebACLLoggingConfiguration_basic
--- PASS: TestAccWAFV2WebACL_Update_nameForceNew (88.85s)
=== CONT  TestAccWAFV2WebACLAssociation_disappears
--- PASS: TestAccWAFV2WebACL_Update_rule (94.53s)
=== CONT  TestAccWAFV2WebACL_IPSetReference_forwardedIP
--- PASS: TestAccWAFV2WebACL_RateBased_maxNested (32.94s)
--- PASS: TestAccWAFV2WebACLDataSource_basic (30.87s)
--- PASS: TestAccWAFV2WebACL_Update_ruleProperties (120.85s)
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_basic (139.49s)
--- PASS: TestAccWAFV2WebACL_RateBased_forwardedIP (49.32s)
--- PASS: TestAccWAFV2WebACLAssociation_disappears (77.04s)
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_updateURIPathRedactedField (149.99s)
--- PASS: TestAccWAFV2WebACL_IPSetReference_forwardedIP (88.64s)
--- PASS: TestAccWAFV2WebACL_RateBased_customKeys (315.75s)
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_disappears (152.13s)
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_updateEmptyRedactedFields (170.96s)
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_basic (126.84s)
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_loggingFilter (196.67s)
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_emptyRedactedFields (177.57s)
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_updateSingleHeaderRedactedField (154.00s)
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_updateQueryStringRedactedField (174.41s)
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_updateMultipleRedactedFields (187.83s)
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_updateMethodRedactedField (174.35s)
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_changeLogDestinationsForceNew (259.67s)
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_changeResourceARNForceNew (290.30s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/wafv2      487.259s
...
```
