### PR TITLE
Sweeper fixes

### DIFF
--- a/internal/service/cloudsearch/sweep.go
+++ b/internal/service/cloudsearch/sweep.go
@@ -33,6 +33,15 @@ func sweepDomains(region string) error {
 
 	domains, err := conn.DescribeDomains(ctx, input)
 
+	if awsv2.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping CloudSearch Domain sweep for %s: %s", region, err)
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error listing CloudSearch Domains (%s): %w", region, err)
+	}
+
 	for _, v := range domains.DomainStatusList {
 		name := aws.ToString(v.DomainName)
 
@@ -46,15 +55,6 @@ func sweepDomains(region string) error {
 		d.SetId(name)
 
 		sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
-	}
-
-	if awsv2.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping CloudSearch Domain sweep for %s: %s", region, err)
-		return nil
-	}
-
-	if err != nil {
-		return fmt.Errorf("error listing CloudSearch Domains (%s): %w", region, err)
 	}
 
 	err = sweep.SweepOrchestrator(ctx, sweepResources)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fixes:

```
2024/02/27 08:05:04 [DEBUG] Running Sweeper (aws_cloudsearch_domain) in region (us-gov-east-1)
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xc9cb1b9]

goroutine 1 [running]:
github.com/hashicorp/terraform-provider-aws/internal/service/cloudsearch.sweepDomains({0x7ff7bfeff693, 0xd})
	/Users/ewbankkit/altsrc.2/github.com/terraform-providers/terraform-provider-aws/internal/service/cloudsearch/sweep.go:36 +0xd9
github.com/hashicorp/terraform-plugin-testing/helper/resource.runSweeperWithRegion({0x7ff7bfeff693, 0xd}, 0xc000a7ec00, 0xc000b87d08?, 0xc000843510?, 0x0)
	/Users/ewbankkit/go/pkg/mod/github.com/hashicorp/terraform-plugin-testing@v1.6.0/helper/resource/testing.go:272 +0x642
github.com/hashicorp/terraform-plugin-testing/helper/resource.runSweepers({0xc000843500, 0x1, 0x13494270?}, 0x1?, 0x0)
	/Users/ewbankkit/go/pkg/mod/github.com/hashicorp/terraform-plugin-testing@v1.6.0/helper/resource/testing.go:150 +0x5f2
github.com/hashicorp/terraform-plugin-testing/helper/resource.TestMain({0x134b6740, 0xc0008c9860})
	/Users/ewbankkit/go/pkg/mod/github.com/hashicorp/terraform-plugin-testing@v1.6.0/helper/resource/testing.go:128 +0xee
github.com/hashicorp/terraform-provider-aws/internal/sweep_test.TestMain(0x107137a?)
	/Users/ewbankkit/altsrc.2/github.com/terraform-providers/terraform-provider-aws/internal/sweep/sweep_test.go:21 +0x70
main.main()
	_testmain.go:49 +0x1c6
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #35764.