### PR TITLE
r/aws_mq_broker: enable cross-region data replication

### DIFF
--- a/.changelog/35990.txt
+++ b/.changelog/35990.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_mq_broker: Add `data_replication_mode` and `data_replication_primary_broker_arn` arguments, enabling support for cross-region data replication
+```

--- a/internal/service/mq/broker.go
+++ b/internal/service/mq/broker.go
@@ -104,6 +104,28 @@ func resourceBroker() *schema.Resource {
 					},
 				},
 			},
+			"data_replication_mode": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				ValidateDiagFunc: enum.Validate[types.DataReplicationMode](),
+				DiffSuppressFunc: func(k, o, n string, d *schema.ResourceData) bool {
+					// Suppress differences when the configured data replication mode
+					// matches a non-empty, pending replication mode. This scenario
+					// can exist when the mode has been set, but the broker has not
+					// yet been rebooted.
+					if n != "" && n == d.Get("pending_data_replication_mode").(string) {
+						return true
+					}
+					return false
+				},
+			},
+			"data_replication_primary_broker_arn": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true, // Can only be set on Create
+				ValidateFunc: verify.ValidARN,
+			},
 			"deployment_mode": {
 				Type:             schema.TypeString,
 				Optional:         true,
@@ -269,6 +291,10 @@ func resourceBroker() *schema.Resource {
 					},
 				},
 			},
+			"pending_data_replication_mode": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"publicly_accessible": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -392,6 +418,12 @@ func resourceBrokerCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	if v, ok := d.GetOk("deployment_mode"); ok {
 		input.DeploymentMode = types.DeploymentMode(v.(string))
 	}
+	if v, ok := d.GetOk("data_replication_mode"); ok {
+		input.DataReplicationMode = types.DataReplicationMode(v.(string))
+	}
+	if v, ok := d.GetOk("data_replication_primary_broker_arn"); ok {
+		input.DataReplicationPrimaryBrokerArn = aws.String(v.(string))
+	}
 	if v, ok := d.GetOk("encryption_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 		input.EncryptionOptions = expandEncryptionOptions(d.Get("encryption_options").([]interface{}))
 	}
@@ -451,11 +483,13 @@ func resourceBrokerRead(ctx context.Context, d *schema.ResourceData, meta interf
 	d.Set("authentication_strategy", output.AuthenticationStrategy)
 	d.Set("auto_minor_version_upgrade", output.AutoMinorVersionUpgrade)
 	d.Set("broker_name", output.BrokerName)
+	d.Set("data_replication_mode", output.DataReplicationMode)
 	d.Set("deployment_mode", output.DeploymentMode)
 	d.Set("engine_type", output.EngineType)
 	d.Set("engine_version", output.EngineVersion)
 	d.Set("host_instance_type", output.HostInstanceType)
 	d.Set("instances", flattenBrokerInstances(output.BrokerInstances))
+	d.Set("pending_data_replication_mode", output.PendingDataReplicationMode)
 	d.Set("publicly_accessible", output.PubliclyAccessible)
 	d.Set("security_groups", output.SecurityGroups)
 	d.Set("storage_type", output.StorageType)
@@ -595,6 +629,21 @@ func resourceBrokerUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating MQ Broker (%s) maintenance window start time: %s", d.Id(), err)
+		}
+
+		requiresReboot = true
+	}
+
+	if d.HasChange("data_replication_mode") {
+		input := &mq.UpdateBrokerInput{
+			BrokerId:            aws.String(d.Id()),
+			DataReplicationMode: types.DataReplicationMode(d.Get("data_replication_mode").(string)),
+		}
+
+		_, err := conn.UpdateBroker(ctx, input)
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "updating MQ Broker (%s) data replication mode: %s", d.Id(), err)
 		}
 
 		requiresReboot = true

--- a/internal/service/mq/exports_test.go
+++ b/internal/service/mq/exports_test.go
@@ -10,4 +10,7 @@ var (
 
 	FindBrokerByID        = findBrokerByID
 	FindConfigurationByID = findConfigurationByID
+
+	WaitBrokerRebooted = waitBrokerRebooted
+	WaitBrokerDeleted  = waitBrokerDeleted
 )


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This change adds the `data_replication_mode` and `data_replication_primary_broker_arn` arguments, enabling support for cross-region data replication. See the AWS MQ documentation for configuration details.

- https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/crdr-for-active-mq.html


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #32566

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/amazon-mq/latest/api-reference/brokers.html#brokers-schemas

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=mq TESTS=TestAccMQBroker_dataReplicationMode
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/mq/... -v -count 1 -parallel 20 -run='TestAccMQBroker_dataReplicationMode'  -timeout 360m

--- PASS: TestAccMQBroker_dataReplicationMode (511.53s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/mq 518.736s
```

```console
% make testacc PKG=mq TESTS=TestAccMQBroker_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/mq/... -v -count 1 -parallel 20 -run='TestAccMQBroker_'  -timeout 360m

--- PASS: TestAccMQBroker_RabbitMQ_basic (526.84s)
--- PASS: TestAccMQBroker_RabbitMQ_validationAuditLog (662.77s)
--- PASS: TestAccMQBroker_RabbitMQ_logs (681.95s)
--- PASS: TestAccMQBroker_RabbitMQ_config (754.07s)
--- PASS: TestAccMQBroker_RabbitMQ_cluster (796.26s)
--- PASS: TestAccMQBroker_throughputOptimized (833.05s)
--- PASS: TestAccMQBroker_tags (860.41s)
--- PASS: TestAccMQBroker_ldap (862.65s)
--- PASS: TestAccMQBroker_EncryptionOptions_managedKeyEnabled (864.26s)
--- PASS: TestAccMQBroker_basic (866.91s)
--- PASS: TestAccMQBroker_EncryptionOptions_kmsKeyID (877.54s)
--- PASS: TestAccMQBroker_disappears (885.05s)
--- PASS: TestAccMQBroker_EncryptionOptions_managedKeyDisabled (894.47s)
--- PASS: TestAccMQBroker_Update_securityGroup (1063.63s)
--- PASS: TestAccMQBroker_Update_engineVersion (1070.81s)
--- PASS: TestAccMQBroker_Update_users (1370.02s)
--- PASS: TestAccMQBroker_Update_hostInstanceType (1377.49s)
--- PASS: TestAccMQBroker_AllFields_defaultVPC (1483.88s)
--- PASS: TestAccMQBroker_AllFields_customVPC (1606.21s)
--- PASS: TestAccMQBroker_dataReplicationMode (3081.61s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/mq 3089.017s
```
