### PR TITLE
r/aws_appflow_flow: suppress diff when `task_type` value of `Map_all` is used

### DIFF
--- a/.changelog/35993.txt
+++ b/.changelog/35993.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_appflow_flow: Fix perpetual diff when `task.task_type` is set to `Map_all`
+```
+
+```release-note:enhancement
+resource/aws_appflow_flow: Allow `task.source_fields` to be a `null` value
+```

--- a/internal/service/appflow/flow.go
+++ b/internal/service/appflow/flow.go
@@ -1153,7 +1153,7 @@ func resourceFlow() *schema.Resource {
 							DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
 								if v, ok := d.Get("task").(*schema.Set); ok && v.Len() == 1 {
 									if tl, ok := v.List()[0].(map[string]interface{}); ok && len(tl) > 0 {
-										if sf, ok := tl["source_fields"].([]interface{}); ok && len(sf) > 0 {
+										if sf, ok := tl["source_fields"].([]interface{}); ok && len(sf) == 1 {
 											if sf[0] == "" {
 												return oldValue == "0" && newValue == "1"
 											}

--- a/internal/service/appflow/flow.go
+++ b/internal/service/appflow/flow.go
@@ -6,6 +6,7 @@ package appflow
 import (
 	"context"
 	"log"
+	"slices"
 	"time"
 
 	"github.com/YakDriver/regexache"
@@ -1143,10 +1144,23 @@ func resourceFlow() *schema.Resource {
 						},
 						"source_fields": {
 							Type:     schema.TypeList,
-							Required: true,
+							Optional: true,
+							Computed: true,
 							Elem: &schema.Schema{
 								Type:         schema.TypeString,
 								ValidateFunc: validation.StringLenBetween(0, 2048),
+							},
+							DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+								if v, ok := d.Get("task").(*schema.Set); ok && v.Len() == 1 {
+									if tl, ok := v.List()[0].(map[string]interface{}); ok && len(tl) > 0 {
+										if sf, ok := tl["source_fields"].([]interface{}); ok && len(sf) > 0 {
+											if sf[0] == "" {
+												return oldValue == "0" && newValue == "1"
+											}
+										}
+									}
+								}
+								return false
 							},
 						},
 						"task_properties": {
@@ -1341,8 +1355,9 @@ func resourceFlowUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 			TriggerConfig:             expandTriggerConfig(d.Get("trigger_config").([]interface{})[0].(map[string]interface{})),
 		}
 
-		if d.HasChange(names.AttrDescription) {
-			input.Description = aws.String(d.Get(names.AttrDescription).(string))
+		// always send description when updating a task
+		if v, ok := d.GetOk(names.AttrDescription); ok {
+			input.Description = aws.String(v.(string))
 		}
 
 		_, err := conn.UpdateFlow(ctx, input)
@@ -2440,6 +2455,8 @@ func expandTask(tfMap map[string]interface{}) *types.Task {
 
 	if v, ok := tfMap["source_fields"].([]interface{}); ok && len(v) > 0 {
 		a.SourceFields = flex.ExpandStringValueList(v)
+	} else {
+		a.SourceFields = []string{} // send an empty object if source_fields is empty (required by API)
 	}
 
 	if v, ok := tfMap["task_properties"].(map[string]interface{}); ok && len(v) > 0 {
@@ -3465,6 +3482,15 @@ func flattenTasks(tasks []types.Task) []interface{} {
 	}
 
 	var l []interface{}
+
+	t := slices.IndexFunc(tasks, func(t types.Task) bool {
+		return t.TaskType == types.TaskTypeMapAll
+	})
+
+	if t != -1 {
+		l = append(l, flattenTask(tasks[t]))
+		return l
+	}
 
 	for _, task := range tasks {
 		l = append(l, flattenTask(task))

--- a/internal/service/appflow/flow_test.go
+++ b/internal/service/appflow/flow_test.go
@@ -266,6 +266,35 @@ func TestAccAppFlowFlow_taskUpdate(t *testing.T) {
 	})
 }
 
+func TestAccAppFlowFlow_task_mapAll(t *testing.T) {
+	ctx := acctest.Context(t)
+	var flowOutput types.FlowDefinition
+	rSourceName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rDestinationName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rFlowName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_appflow_flow.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AppFlowServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFlowDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFlowConfig_task_mapAll(rSourceName, rDestinationName, rFlowName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFlowExists(ctx, resourceName, &flowOutput),
+					resource.TestCheckResourceAttr(resourceName, "task.#", "1"),
+				),
+			},
+			{
+				Config:   testAccFlowConfig_task_mapAll(rSourceName, rDestinationName, rFlowName),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func TestAccAppFlowFlow_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var flowOutput types.FlowDefinition
@@ -738,6 +767,59 @@ resource "aws_appflow_flow" "test" {
   }
 }
 `, rFlowName, fieldName),
+	)
+}
+
+func testAccFlowConfig_task_mapAll(rSourceName, rDestinationName, rFlowName string) string {
+	return acctest.ConfigCompose(
+		testAccFlowConfig_base(rSourceName, rDestinationName),
+		fmt.Sprintf(`
+resource "aws_appflow_flow" "test" {
+  name = %[1]q
+
+  source_flow_config {
+    connector_type = "S3"
+    source_connector_properties {
+      s3 {
+        bucket_name   = aws_s3_bucket_policy.test_source.bucket
+        bucket_prefix = "flow"
+      }
+    }
+  }
+
+  destination_flow_config {
+    connector_type = "S3"
+    destination_connector_properties {
+      s3 {
+        bucket_name = aws_s3_bucket_policy.test_destination.bucket
+
+        s3_output_format_config {
+          prefix_config {
+            prefix_type = "PATH"
+          }
+        }
+      }
+    }
+  }
+
+  task {
+    task_type         = "Map_all"
+
+    connector_operator {
+      s3 = "NO_OP"
+    }
+
+    task_properties = {
+      "DESTINATION_DATA_TYPE" = "id"
+      "SOURCE_DATA_TYPE"      = "id"
+    }
+  }
+
+  trigger_config {
+    trigger_type = "OnDemand"
+  }
+}
+`, rFlowName),
 	)
 }
 

--- a/internal/service/appflow/flow_test.go
+++ b/internal/service/appflow/flow_test.go
@@ -803,7 +803,7 @@ resource "aws_appflow_flow" "test" {
   }
 
   task {
-    task_type         = "Map_all"
+    task_type = "Map_all"
 
     connector_operator {
       s3 = "NO_OP"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

- Allows `source_fields` to be an empty list.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #25095
Closes #35992

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS="-run=TestAccAppFlowFlow_" PKG=appflow

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/appflow/... -v -count 1 -parallel 20  -run=TestAccAppFlowFlow_ -timeout 360m
--- PASS: TestAccAppFlowFlow_taskProperties (19.10s)
--- PASS: TestAccAppFlowFlow_disappears (19.59s)
--- PASS: TestAccAppFlowFlow_basic (21.72s)
--- PASS: TestAccAppFlowFlow_task_mapAll (23.49s)
--- PASS: TestAccAppFlowFlow_update (29.12s)
--- PASS: TestAccAppFlowFlow_S3_outputFormatConfig_ParquetFileType (29.65s)
--- PASS: TestAccAppFlowFlow_taskUpdate (29.71s)
--- PASS: TestAccAppFlowFlow_tags (40.47s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/appflow	44.530s
```
