### PR TITLE
Modified CostOptimizationHub service to use a custom client

### DIFF
--- a/internal/service/costoptimizationhub/service_endpoints_gen_test.go
+++ b/internal/service/costoptimizationhub/service_endpoints_gen_test.go
@@ -68,7 +68,7 @@ const (
 )
 
 func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.Setenv
-	const region = "us-west-2" //lintignore:AWSAT003
+	const region = "us-east-1" //lintignore:AWSAT003
 
 	testcases := map[string]endpointTestCase{
 		"no config": {

--- a/internal/service/costoptimizationhub/service_package.go
+++ b/internal/service/costoptimizationhub/service_package.go
@@ -1,0 +1,23 @@
+package costoptimizationhub
+
+import (
+	"context"
+
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	costoptimizationhub_sdkv2 "github.com/aws/aws-sdk-go-v2/service/costoptimizationhub"
+	endpoints_sdkv1 "github.com/aws/aws-sdk-go/aws/endpoints"
+)
+
+// NewClient returns a new AWS SDK for Go v2 client for this service package's AWS API.
+func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (*costoptimizationhub_sdkv2.Client, error) {
+	cfg := *(config["aws_sdkv2_config"].(*aws_sdkv2.Config))
+
+	return costoptimizationhub_sdkv2.NewFromConfig(cfg, func(o *costoptimizationhub_sdkv2.Options) {
+		if endpoint := config["endpoint"].(string); endpoint != "" {
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
+		} else if config["partition"].(string) == endpoints_sdkv1.AwsPartitionID {
+			// Cost Optimization Hub endpoint is available only in us-east-1 Region.
+			o.Region = endpoints_sdkv1.UsEast1RegionID
+		}
+	}), nil
+}

--- a/internal/service/costoptimizationhub/service_package_gen.go
+++ b/internal/service/costoptimizationhub/service_package_gen.go
@@ -5,8 +5,6 @@ package costoptimizationhub
 import (
 	"context"
 
-	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
-	costoptimizationhub_sdkv2 "github.com/aws/aws-sdk-go-v2/service/costoptimizationhub"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -32,17 +30,6 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 
 func (p *servicePackage) ServicePackageName() string {
 	return names.CostOptimizationHub
-}
-
-// NewClient returns a new AWS SDK for Go v2 client for this service package's AWS API.
-func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (*costoptimizationhub_sdkv2.Client, error) {
-	cfg := *(config["aws_sdkv2_config"].(*aws_sdkv2.Config))
-
-	return costoptimizationhub_sdkv2.NewFromConfig(cfg, func(o *costoptimizationhub_sdkv2.Options) {
-		if endpoint := config["endpoint"].(string); endpoint != "" {
-			o.BaseEndpoint = aws_sdkv2.String(endpoint)
-		}
-	}), nil
 }
 
 func ServicePackage(ctx context.Context) conns.ServicePackage {

--- a/names/data/names_data.csv
+++ b/names/data/names_data.csv
@@ -102,7 +102,7 @@ voice-id,voiceid,voiceid,voiceid,,voiceid,,,VoiceID,VoiceID,,1,,,aws_voiceid_,,v
 wisdom,wisdom,connectwisdomservice,wisdom,,wisdom,,connectwisdomservice,Wisdom,ConnectWisdomService,,1,,,aws_wisdom_,,wisdom_,Connect Wisdom,Amazon,,x,,,,,Wisdom,,,
 ,,,,,,,,,,,,,,,,,Console Mobile Application,AWS,x,,,,,,,,,No SDK support
 controltower,controltower,controltower,controltower,,controltower,,,ControlTower,ControlTower,,,2,,aws_controltower_,,controltower_,Control Tower,AWS,,,,,,,ControlTower,ListLandingZones,,
-cost-optimization-hub,costoptimizationhub,costoptimizationhub,costoptimizationhub,,costoptimizationhub,,,CostOptimizationHub,CostOptimizationHub,,,2,,aws_costoptimizationhub_,,costoptimizationhub_,Cost Optimization Hub,AWS,,,,,,,Cost Optimization Hub,GetPreferences,,
+cost-optimization-hub,costoptimizationhub,costoptimizationhub,costoptimizationhub,,costoptimizationhub,,,CostOptimizationHub,CostOptimizationHub,x,,2,,aws_costoptimizationhub_,,costoptimizationhub_,Cost Optimization Hub,AWS,,,,,,,Cost Optimization Hub,GetPreferences,,
 cur,cur,costandusagereportservice,costandusagereportservice,,cur,,costandusagereportservice,CUR,CostandUsageReportService,,1,,,aws_cur_,,cur_,Cost and Usage Report,AWS,,,,,,,Cost and Usage Report Service,DescribeReportDefinitions,,
 ,,,,,,,,,,,,,,,,,Crypto Tools,AWS,x,,,,,,,,,No SDK support
 ,,,,,,,,,,,,,,,,,Cryptographic Services Overview,AWS,x,,,,,,,,,No SDK support


### PR DESCRIPTION
Modified CostOptimizationHub service to use a custom client as the service is supported only in us-east-1

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Modified CostOptimizationHub service to use a custom client as the service is supported only in us-east-1. I earlier added the service without a custom client, but when developing resources fro this service, I realized that the service fails for non us-east-1 regions. Hence providing a fix now.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #36021

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
The us-east-1 endpoint is given here - https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/costoptimizationhub

### Output from Acceptance Testing
<!--
-->

```
make testacc PKG=costoptimizationhub
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/costoptimizationhub/... -v -count 1 -parallel 20   -timeout 360m
=== RUN   TestEndpointConfiguration
=== RUN   TestEndpointConfiguration/service_aws_envvar
=== RUN   TestEndpointConfiguration/base_endpoint_envvar
=== RUN   TestEndpointConfiguration/service_config_file_overrides_base_config_file
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_aws_service_envvar
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_base_envvar
=== RUN   TestEndpointConfiguration/service_aws_envvar_overrides_service_config_file
=== RUN   TestEndpointConfiguration/base_endpoint_config_file
=== RUN   TestEndpointConfiguration/package_name_endpoint_config
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_base_config_file
=== RUN   TestEndpointConfiguration/service_aws_envvar_overrides_base_envvar
=== RUN   TestEndpointConfiguration/service_aws_envvar_overrides_base_config_file
=== RUN   TestEndpointConfiguration/base_endpoint_envvar_overrides_base_config_file
=== RUN   TestEndpointConfiguration/service_config_file
=== RUN   TestEndpointConfiguration/no_config
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_service_config_file
=== RUN   TestEndpointConfiguration/base_endpoint_envvar_overrides_service_config_file
--- PASS: TestEndpointConfiguration (1.28s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar (0.14s)
    --- PASS: TestEndpointConfiguration/base_endpoint_envvar (0.09s)
    --- PASS: TestEndpointConfiguration/service_config_file_overrides_base_config_file (0.07s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_aws_service_envvar (0.10s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_base_envvar (0.08s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar_overrides_service_config_file (0.05s)
    --- PASS: TestEndpointConfiguration/base_endpoint_config_file (0.07s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config (0.08s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_base_config_file (0.10s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar_overrides_base_envvar (0.05s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar_overrides_base_config_file (0.05s)
    --- PASS: TestEndpointConfiguration/base_endpoint_envvar_overrides_base_config_file (0.07s)
    --- PASS: TestEndpointConfiguration/service_config_file (0.06s)
    --- PASS: TestEndpointConfiguration/no_config (0.06s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_service_config_file (0.11s)
    --- PASS: TestEndpointConfiguration/base_endpoint_envvar_overrides_service_config_file (0.07s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/costoptimizationhub        88.858s
```
