### PR TITLE
resource/aws_ecs_task_definition: prevent spurious container definition diffs

### DIFF
--- a/.changelog/36029.txt
+++ b/.changelog/36029.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ecs_task_definition: Fix perpetual `container_definitions` diffs when `Name`s are ordered differently
+```

--- a/internal/service/ecs/task_definition.go
+++ b/internal/service/ecs/task_definition.go
@@ -83,6 +83,7 @@ func ResourceTaskDefinition() *schema.Resource {
 					// spurious reorderings in plans (diff is suppressed if the environment variables haven't changed,
 					// but they still show in the plan if some other property changes).
 					orderedCDs, _ := expandContainerDefinitions(v.(string))
+					containerDefinitions(orderedCDs).OrderContainers()
 					containerDefinitions(orderedCDs).OrderEnvironmentVariables()
 					containerDefinitions(orderedCDs).OrderSecrets()
 					unnormalizedJson, _ := flattenContainerDefinitions(orderedCDs)
@@ -613,6 +614,7 @@ func resourceTaskDefinitionRead(ctx context.Context, d *schema.ResourceData, met
 	// Sort the lists of environment variables as they come in, so we won't get spurious reorderings in plans
 	// (diff is suppressed if the environment variables haven't changed, but they still show in the plan if
 	// some other property changes).
+	containerDefinitions(taskDefinition.ContainerDefinitions).OrderContainers()
 	containerDefinitions(taskDefinition.ContainerDefinitions).OrderEnvironmentVariables()
 	containerDefinitions(taskDefinition.ContainerDefinitions).OrderSecrets()
 

--- a/internal/service/ecs/task_definition_equivalency.go
+++ b/internal/service/ecs/task_definition_equivalency.go
@@ -60,6 +60,7 @@ type containerDefinitions []*ecs.ContainerDefinition
 
 func (cd containerDefinitions) Reduce(isAWSVPC bool) error {
 	// Deal with fields which may be re-ordered in the API
+	cd.OrderContainers()
 	cd.OrderEnvironmentVariables()
 	cd.OrderSecrets()
 
@@ -120,4 +121,12 @@ func (cd containerDefinitions) OrderSecrets() {
 			return aws.StringValue(def.Secrets[i].Name) < aws.StringValue(def.Secrets[j].Name)
 		})
 	}
+}
+
+func (cd containerDefinitions) OrderContainers() {
+
+	sort.Slice(cd, func(i, j int) bool {
+		return aws.StringValue(cd[i].Name) < aws.StringValue(cd[j].Name)
+	})
+
 }

--- a/internal/service/ecs/task_definition_equivalency.go
+++ b/internal/service/ecs/task_definition_equivalency.go
@@ -124,9 +124,7 @@ func (cd containerDefinitions) OrderSecrets() {
 }
 
 func (cd containerDefinitions) OrderContainers() {
-
 	sort.Slice(cd, func(i, j int) bool {
 		return aws.StringValue(cd[i].Name) < aws.StringValue(cd[j].Name)
 	})
-
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

When the order of the container definitions does not match between AWS API and aws_ecs_task_definition, terraform tries to replace the task definition to match the container definitions order. This is unnecessary as the container order does not mean anything. 

I am trying to to import bunch of  different task definitions using a single module, and I keep getting diffs due to container definitions order. This PR prevents unnecessary diffs for when the container definitions order does not match between API and Terraform.

```hcl
resource "aws_ecs_task_definition" "test" {
    family = "testtaskdef1"
    container_definitions = jsonencode([
        {
            "name": "sidecard",
            "image": "sidecar:1",
            "cpu": 0,
            "portMappings": [],
            "essential": false,
            "environment": [
                {
                    "name": "sidecarenv",
                    "value": "sidecarenvvalue"
                },
                {
                    "name": "sidecarenv2",
                    "value": "sidecarenvvalue"
                }
            ],
            "environmentFiles": [],
            "mountPoints": [],
            "volumesFrom": [],
            "systemControls": []
        },
        {
            "name": "app",
            "image": "busybox:1",
            "cpu": 0,
            "portMappings": [
                {
                    "name": "app-80-tcp",
                    "containerPort": 80,
                    "hostPort": 80,
                    "protocol": "tcp",
                    "appProtocol": "http"
                }
            ],
            "essential": true,
            "environment": [
                {
                    "name": "appenv",
                    "value": "appenvvalue"
                }
            ],
            "environmentFiles": [],
            "mountPoints": [],
            "volumesFrom": [],
            "ulimits": [],
            "systemControls": []
        }
      ])
}
```
```bash
  # aws_ecs_task_definition.test must be replaced
  # (imported from "arn:aws:ecs:eu-central-1:zz:task-definition/testtaskdef1:2")
  # Warning: this will destroy the imported resource
-/+ resource "aws_ecs_task_definition" "test" {
      ~ arn                      = "arn:aws:ecs:eu-central-1:zz:task-definition/testtaskdef1:2" -> (known after apply)
      ~ arn_without_revision     = "arn:aws:ecs:eu-central-1:zz:task-definition/testtaskdef1" -> (known after apply)
      ~ container_definitions    = jsonencode(
          ~ [
              - {
                  - cpu              = 0
                  - environment      = [
                      - {
                          - name  = "appenv"
                          - value = "appenvvalue"
                        },
                    ]
                  - environmentFiles = []
                  - essential        = true
                  - image            = "busybox:1"
                  - mountPoints      = []
                  - name             = "app"
                  - portMappings     = [
                      - {
                          - appProtocol   = "http"
                          - containerPort = 80
                          - hostPort      = 80
                          - name          = "app-80-tcp"
                          - protocol      = "tcp"
                        },
                    ]
                  - systemControls   = []
                  - ulimits          = []
                  - volumesFrom      = []
                },
                {
                    cpu              = 0
                    environment      = [
                        {
                            name  = "sidecarenv"
                            value = "sidecarenvvalue"
                        },
                    ]
                    environmentFiles = []
                    essential        = false
                    image            = "sidecar:1"
                    mountPoints      = []
                    name             = "sidecard"
                    portMappings     = []
                    systemControls   = []
                    volumesFrom      = []
                },
              + {
                  + cpu              = 0
                  + environment      = [
                      + {
                          + name  = "appenv"
                          + value = "appenvvalue"
                        },
                    ]
                  + environmentFiles = []
                  + essential        = true
                  + image            = "busybox:1"
                  + mountPoints      = []
                  + name             = "app"
                  + portMappings     = [
                      + {
                          + appProtocol   = "http"
                          + containerPort = 80
                          + hostPort      = 80
                          + name          = "app-80-tcp"
                          + protocol      = "tcp"
                        },
                    ]
                  + systemControls   = []
                  + ulimits          = []
                  + volumesFrom      = []
                },
            ] # forces replacement
        )
```
### Relations

Relates https://github.com/hashicorp/terraform-provider-aws/pull/11463.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/35792.


