### PR TITLE
d/aws_waf_regex_pattern_set: new data source

### DIFF
--- a/internal/service/waf/regex_pattern_set_data_source.go
+++ b/internal/service/waf/regex_pattern_set_data_source.go
@@ -1,0 +1,104 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package waf
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/waf"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+)
+
+// @SDKDataSource("aws_waf_regex_pattern_set")
+func DataSourceRegexPatternSet() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceRegexPatternSetRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"regex_pattern_strings": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceRegexPatternSetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).WAFConn(ctx)
+	name := d.Get("name").(string)
+
+	var foundRegexPatternSet *waf.RegexPatternSetSummary
+	input := &waf.ListRegexPatternSetsInput{
+		Limit: aws.Int64(100),
+	}
+
+	for {
+		resp, err := conn.ListRegexPatternSetsWithContext(ctx, input)
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "reading WAF RegexPatternSets: %s", err)
+		}
+
+		if resp == nil || resp.RegexPatternSets == nil {
+			return sdkdiag.AppendErrorf(diags, "reading WAF RegexPatternSets")
+		}
+
+		for _, regexPatternSet := range resp.RegexPatternSets {
+			if regexPatternSet != nil && aws.StringValue(regexPatternSet.Name) == name {
+				foundRegexPatternSet = regexPatternSet
+				break
+			}
+		}
+
+		if resp.NextMarker == nil || foundRegexPatternSet != nil {
+			break
+		}
+		input.NextMarker = resp.NextMarker
+	}
+
+	if foundRegexPatternSet == nil {
+		return sdkdiag.AppendErrorf(diags, "WAF RegexPatternSet not found for name: %s", name)
+	}
+
+	resp, err := conn.GetRegexPatternSetWithContext(ctx, &waf.GetRegexPatternSetInput{
+		RegexPatternSetId: foundRegexPatternSet.RegexPatternSetId,
+	})
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading WAF RegexPatternSet: %s", err)
+	}
+
+	if resp == nil || resp.RegexPatternSet == nil {
+		return sdkdiag.AppendErrorf(diags, "reading WAF RegexPatternSet")
+	}
+
+	d.SetId(aws.StringValue(resp.RegexPatternSet.RegexPatternSetId))
+	d.Set("name", resp.RegexPatternSet.Name)
+	d.Set("regex_pattern_strings", aws.StringValueSlice(resp.RegexPatternSet.RegexPatternStrings))
+
+	arn := arn.ARN{
+		Partition: meta.(*conns.AWSClient).Partition,
+		Service:   "waf",
+		AccountID: meta.(*conns.AWSClient).AccountID,
+		Resource:  fmt.Sprintf("regexpatternset/%s", d.Id()),
+	}
+	d.Set("arn", arn.String())
+
+	return diags
+}

--- a/internal/service/waf/regex_pattern_set_data_source_test.go
+++ b/internal/service/waf/regex_pattern_set_data_source_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package waf_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/YakDriver/regexache"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccWAFRegexPatternSetDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_waf_regex_pattern_set.test"
+	datasourceName := "data.aws_waf_regex_pattern_set.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.WAFServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccRegexPatternSetDataSourceConfig_nonExistent(name),
+				ExpectError: regexache.MustCompile(`WAF RegexPatternSet not found`),
+			},
+			{
+				Config: testAccRegexPatternSetDataSourceConfig_name(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "regex_pattern_strings", resourceName, "regex_pattern_strings"),
+				),
+			},
+		},
+	})
+}
+
+func testAccRegexPatternSetDataSourceConfig_name(name string) string {
+	return fmt.Sprintf(`
+resource "aws_waf_regex_pattern_set" "test" {
+  name  = "%s"
+
+  regex_pattern_strings = ["one"]
+}
+
+data "aws_waf_regex_pattern_set" "test" {
+  name  = aws_waf_regex_pattern_set.test.name
+}
+`, name)
+}
+
+func testAccRegexPatternSetDataSourceConfig_nonExistent(name string) string {
+	return fmt.Sprintf(`
+resource "aws_waf_regex_pattern_set" "test" {
+  name  = "%s"
+
+  regex_pattern_strings = ["one"]
+}
+
+data "aws_waf_regex_pattern_set" "test" {
+  name  = "tf-acc-test-does-not-exist"
+}
+`, name)
+}

--- a/website/docs/d/waf_regex_pattern_set.html.markdown
+++ b/website/docs/d/waf_regex_pattern_set.html.markdown
@@ -1,0 +1,33 @@
+---
+subcategory: "WAF Classic"
+layout: "aws"
+page_title: "AWS: aws_waf_regex_pattern_set"
+description: |-
+  Retrieves the summary of a AWS WAF Regex Pattern Set.
+---
+
+# Resource: aws_waf_regex_pattern_set
+
+Retrieves the summary of a AWS WAF Regex Pattern Set
+
+## Example Usage
+
+```terraform
+data "aws_waf_regex_pattern_set" "example" {
+  name = "tf_waf_regex_pattern_set"
+}
+```
+
+## Argument Reference
+
+This data source supports the following arguments:
+
+* `name` - (Required) The name of the WAF Regex Pattern Set.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `id` - The ID of the WAF Regex Pattern Set.
+* `arn` - Amazon Resource Name (ARN)
+* `regex_pattern_strings` - A list of regular expression (regex) patterns that AWS WAF is searching for, such as `B[a@]dB[o0]t`.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Add a new data source for `aws_waf_regex_pattern_set`.

### Relations
Closes #36025

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
```console
% make testacc PKG=waf TESTS=TestAccWAFRegexPatternSetDataSource_

...
```
no output (so PR is untested) but I think this command should be right