### PR TITLE
td/elasticbeanstalk: fix multiple tests in service

### DIFF
--- a/internal/service/elasticbeanstalk/configuration_template.go
+++ b/internal/service/elasticbeanstalk/configuration_template.go
@@ -205,6 +205,10 @@ func resourceConfigurationTemplateDelete(ctx context.Context, d *schema.Resource
 		TemplateName:    aws.String(d.Id()),
 	})
 
+	if tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, "No Configuration Template named") || tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, "No Application named") || tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, "No Platform named") {
+		return diags
+	}
+
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "deleting Elastic Beanstalk Configuration Template (%s): %s", d.Id(), err)
 	}

--- a/internal/service/elasticbeanstalk/configuration_template_test.go
+++ b/internal/service/elasticbeanstalk/configuration_template_test.go
@@ -188,8 +188,17 @@ func testAccCheckConfigurationTemplateExists(ctx context.Context, n string, v *e
 	}
 }
 
+const testAccConfigurationTemplateConfig_base = `
+data "aws_elastic_beanstalk_solution_stack" "test" {
+  most_recent = true
+  name_regex  = "64bit Amazon Linux .* running Python .*"
+}
+`
+
 func testAccConfigurationTemplateConfig_basic(rName string) string {
-	return fmt.Sprintf(`
+	return acctest.ConfigCompose(
+		testAccConfigurationTemplateConfig_base,
+		fmt.Sprintf(`
 resource "aws_elastic_beanstalk_application" "test" {
   name        = %[1]q
   description = "testing"
@@ -198,13 +207,16 @@ resource "aws_elastic_beanstalk_application" "test" {
 resource "aws_elastic_beanstalk_configuration_template" "test" {
   name                = %[1]q
   application         = aws_elastic_beanstalk_application.test.name
-  solution_stack_name = "64bit Amazon Linux running Python"
+  solution_stack_name = data.aws_elastic_beanstalk_solution_stack.test.name
 }
-`, rName)
+`, rName))
 }
 
 func testAccConfigurationTemplateConfig_vpc(rName string) string {
-	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 1), fmt.Sprintf(`
+	return acctest.ConfigCompose(
+		testAccConfigurationTemplateConfig_base,
+		acctest.ConfigVPCWithSubnets(rName, 1),
+		fmt.Sprintf(`
 resource "aws_elastic_beanstalk_application" "test" {
   name        = %[1]q
   description = "testing"
@@ -214,7 +226,7 @@ resource "aws_elastic_beanstalk_configuration_template" "test" {
   name        = %[1]q
   application = aws_elastic_beanstalk_application.test.name
 
-  solution_stack_name = "64bit Amazon Linux running Python"
+  solution_stack_name = data.aws_elastic_beanstalk_solution_stack.test.name
 
   setting {
     namespace = "aws:ec2:vpc"
@@ -232,7 +244,9 @@ resource "aws_elastic_beanstalk_configuration_template" "test" {
 }
 
 func testAccConfigurationTemplateConfig_setting(rName string) string {
-	return fmt.Sprintf(`
+	return acctest.ConfigCompose(
+		testAccConfigurationTemplateConfig_base,
+		fmt.Sprintf(`
 resource "aws_elastic_beanstalk_application" "test" {
   name        = %[1]q
   description = "testing"
@@ -242,7 +256,7 @@ resource "aws_elastic_beanstalk_configuration_template" "test" {
   name        = %[1]q
   application = aws_elastic_beanstalk_application.test.name
 
-  solution_stack_name = "64bit Amazon Linux running Python"
+  solution_stack_name = data.aws_elastic_beanstalk_solution_stack.test.name
 
   setting {
     namespace = "aws:autoscaling:launchconfiguration"
@@ -250,5 +264,5 @@ resource "aws_elastic_beanstalk_configuration_template" "test" {
     value     = "m1.small"
   }
 }
-`, rName)
+`, rName))
 }

--- a/internal/service/elasticbeanstalk/environment.go
+++ b/internal/service/elasticbeanstalk/environment.go
@@ -585,6 +585,10 @@ func resourceEnvironmentDelete(ctx context.Context, d *schema.ResourceData, meta
 
 	// Environment must be Ready before it can be deleted.
 	if _, err := waitEnvironmentReady(ctx, conn, d.Id(), pollInterval, waitForReadyTimeOut); err != nil {
+		if tfresource.NotFound(err) {
+			return diags
+		}
+
 		return sdkdiag.AppendErrorf(diags, "waiting for Elastic Beanstalk Environment (%s) update: %s", d.Id(), err)
 	}
 

--- a/internal/service/elasticbeanstalk/environment_test.go
+++ b/internal/service/elasticbeanstalk/environment_test.go
@@ -454,7 +454,7 @@ func TestAccElasticBeanstalkEnvironment_platformARN(t *testing.T) {
 				Config: testAccEnvironmentConfig_platformARN(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEnvironmentExists(ctx, resourceName, &app),
-					acctest.CheckResourceAttrRegionalARNNoAccount(resourceName, "platform_arn", "elasticbeanstalk", "platform/Python 3.6 running on 64bit Amazon Linux/2.9.6"),
+					acctest.CheckResourceAttrRegionalARNNoAccount(resourceName, "platform_arn", "elasticbeanstalk", "platform/Python 3.9 running on 64bit Amazon Linux 2023/4.0.9"),
 				),
 			},
 			{
@@ -778,7 +778,7 @@ func testAccEnvironmentConfig_platformARN(rName string) string {
 resource "aws_elastic_beanstalk_environment" "test" {
   application  = aws_elastic_beanstalk_application.test.name
   name         = %[1]q
-  platform_arn = "arn:${data.aws_partition.current.partition}:elasticbeanstalk:${data.aws_region.current.name}::platform/Python 3.6 running on 64bit Amazon Linux/2.9.6"
+  platform_arn = "arn:${data.aws_partition.current.partition}:elasticbeanstalk:${data.aws_region.current.name}::platform/Python 3.9 running on 64bit Amazon Linux 2023/4.0.9"
 
   setting {
     namespace = "aws:ec2:vpc"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

```
------- Stdout: -------
=== RUN   TestAccElasticBeanstalkEnvironment_disappears
=== PAUSE TestAccElasticBeanstalkEnvironment_disappears
=== CONT  TestAccElasticBeanstalkEnvironment_disappears
    testing_new.go:91: Error running post-test destroy, there may be dangling resources: exit status 1
        Error: waiting for Elastic Beanstalk Environment (e-pi4wxzyprr) update: couldn't find resource (21 retries)
--- FAIL: TestAccElasticBeanstalkEnvironment_disappears (678.47s)
FAIL
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS="-run=TestAccElasticBeanstalk" PKG=elasticbeanstalk

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elasticbeanstalk/... -v -count 1 -parallel 20  -run=TestAccElasticBeanstalk -timeout 360m
--- PASS: TestAccElasticBeanstalkHostedZoneDataSource_basic (13.80s)
--- PASS: TestAccElasticBeanstalkSolutionStackDataSource_basic (16.46s)
--- PASS: TestAccElasticBeanstalkHostedZoneDataSource_region (20.88s)
--- PASS: TestAccElasticBeanstalkApplicationDataSource_basic (21.67s)
--- PASS: TestAccElasticBeanstalkConfigurationTemplate_Disappears_application (25.27s)
--- PASS: TestAccElasticBeanstalkConfigurationTemplate_settings (25.57s)
--- PASS: TestAccElasticBeanstalkConfigurationTemplate_basic (25.75s)
--- PASS: TestAccElasticBeanstalkConfigurationTemplate_vpc (28.91s)
--- PASS: TestAccElasticBeanstalkApplicationVersion_BeanstalkApp_duplicateLabels (19.29s)
--- PASS: TestAccElasticBeanstalkApplication_disappears (14.68s)
--- PASS: TestAccElasticBeanstalkApplication_description (24.54s)
--- PASS: TestAccElasticBeanstalkApplicationVersion_BeanstalkApp_basic (17.46s)
--- PASS: TestAccElasticBeanstalkConfigurationTemplate_disappears (17.87s)
--- PASS: TestAccElasticBeanstalkApplication_basic (14.83s)
--- PASS: TestAccElasticBeanstalkApplication_tags (33.55s)
--- PASS: TestAccElasticBeanstalkApplicationVersion_BeanstalkApp_tags (69.76s)
--- PASS: TestAccElasticBeanstalkApplication_appVersionLifecycle (46.22s)
--- PASS: TestAccElasticBeanstalkEnvironment_basic (328.08s)
--- PASS: TestAccElasticBeanstalkEnvironment_settingWithJSONValue (354.67s)
--- PASS: TestAccElasticBeanstalkEnvironment_beanstalkEnv (362.95s)
--- PASS: TestAccElasticBeanstalkEnvironment_cnamePrefix (366.03s)
--- PASS: TestAccElasticBeanstalkEnvironment_label (395.46s)
--- PASS: TestAccElasticBeanstalkEnvironment_platformARN (426.69s)
--- PASS: TestAccElasticBeanstalkEnvironment_resource (427.71s)
--- PASS: TestAccElasticBeanstalkEnvironment_update (485.21s)
--- PASS: TestAccElasticBeanstalkEnvironment_changeStack (489.04s)
--- PASS: TestAccElasticBeanstalkEnvironment_tier (505.83s)
--- PASS: TestAccElasticBeanstalkEnvironment_tags (512.55s)
--- PASS: TestAccElasticBeanstalkEnvironment_disappears (542.26s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticbeanstalk	546.347s
```
