### PR TITLE
Documentation - Updated the example for adding a Custom Service Client

### DIFF
--- a/docs/add-a-new-service.md
+++ b/docs/add-a-new-service.md
@@ -79,28 +79,28 @@ If an AWS service must be created in a non-standard way, for example the service
 === "AWS Go SDK V2 (Preferred)"
 
     ```go
-    package route53domains
-    
+    package costoptimizationhub
+
     import (
-    	"context"
-    
-    	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
-    	route53domains_sdkv2 "github.com/aws/aws-sdk-go-v2/service/route53domains"
-    	endpoints_sdkv1 "github.com/aws/aws-sdk-go/aws/endpoints"
+        "context"
+
+        "github.com/aws/aws-sdk-go-v2/aws"
+        "github.com/aws/aws-sdk-go-v2/service/costoptimizationhub"
+        "github.com/hashicorp/terraform-provider-aws/names"
     )
-    
+
     // NewClient returns a new AWS SDK for Go v2 client for this service package's AWS API.
-    func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (*route53domains_sdkv2.Client, error) {
-    	cfg := *(config["aws_sdkv2_config"].(*aws_sdkv2.Config))
-    
-    	return route53domains_sdkv2.NewFromConfig(cfg, func(o *route53domains_sdkv2.Options) {
-    		if endpoint := config["endpoint"].(string); endpoint != "" {
-    			o.BaseEndpoint = aws_sdkv2.String(endpoint)
-    		} else if config["partition"].(string) == endpoints_sdkv1.AwsPartitionID {
-    			// Route 53 Domains is only available in AWS Commercial us-east-1 Region.
-    			o.Region = endpoints_sdkv1.UsEast1RegionID
-    		}
-    	}), nil
+    func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (*costoptimizationhub.Client, error) {
+        cfg := *(config["aws_sdkv2_config"].(*aws.Config))
+
+        return costoptimizationhub.NewFromConfig(cfg, func(o *costoptimizationhub.Options) {
+            if endpoint := config["endpoint"].(string); endpoint != "" {
+                o.BaseEndpoint = aws.String(endpoint)
+            } else if config["partition"].(string) == names.StandardPartitionID {
+                // Cost Optimization Hub endpoint is available only in us-east-1 Region.
+                o.Region = names.USEast1RegionID
+            }
+        }), nil
     }
     ```
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Updated the SDK V2 example for adding a Custom Service Client based on the changes in the pull request #36023 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

None

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

#36023 

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
make testacc PKG=costoptimizationhub
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/costoptimizationhub/... -v -count 1 -parallel 20   -timeout 360m
=== RUN   TestEndpointConfiguration
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_service_config_file
=== RUN   TestEndpointConfiguration/service_aws_envvar
=== RUN   TestEndpointConfiguration/service_aws_envvar_overrides_base_config_file
=== RUN   TestEndpointConfiguration/service_config_file
=== RUN   TestEndpointConfiguration/no_config
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_aws_service_envvar
=== RUN   TestEndpointConfiguration/service_aws_envvar_overrides_service_config_file
=== RUN   TestEndpointConfiguration/base_endpoint_envvar
=== RUN   TestEndpointConfiguration/package_name_endpoint_config
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_base_envvar
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_base_config_file
=== RUN   TestEndpointConfiguration/service_aws_envvar_overrides_base_envvar
=== RUN   TestEndpointConfiguration/base_endpoint_envvar_overrides_base_config_file
=== RUN   TestEndpointConfiguration/service_config_file_overrides_base_config_file
=== RUN   TestEndpointConfiguration/base_endpoint_envvar_overrides_service_config_file
=== RUN   TestEndpointConfiguration/base_endpoint_config_file
--- PASS: TestEndpointConfiguration (0.74s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_service_config_file (0.14s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar (0.04s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar_overrides_base_config_file (0.03s)
    --- PASS: TestEndpointConfiguration/service_config_file (0.04s)
    --- PASS: TestEndpointConfiguration/no_config (0.04s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_aws_service_envvar (0.05s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar_overrides_service_config_file (0.04s)
    --- PASS: TestEndpointConfiguration/base_endpoint_envvar (0.03s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config (0.05s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_base_envvar (0.05s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_base_config_file (0.05s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar_overrides_base_envvar (0.03s)
    --- PASS: TestEndpointConfiguration/base_endpoint_envvar_overrides_base_config_file (0.05s)
    --- PASS: TestEndpointConfiguration/service_config_file_overrides_base_config_file (0.04s)
    --- PASS: TestEndpointConfiguration/base_endpoint_envvar_overrides_service_config_file (0.04s)
    --- PASS: TestEndpointConfiguration/base_endpoint_config_file (0.04s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/costoptimizationhub        35.187s
```
