### PR TITLE
resource/aws_db_instance: Sets `parameter_group_name` on replica when source is in different region

### DIFF
--- a/.changelog/36080.txt
+++ b/.changelog/36080.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_db_instance: Correctly sets `parameter_group_name` when `replicate_source_db` is in different region.
+```

--- a/docs/running-and-writing-acceptance-tests.md
+++ b/docs/running-and-writing-acceptance-tests.md
@@ -897,7 +897,8 @@ func TestAccExample_basic(t *testing.T) {
 }
 
 func testAccExampleConfig() string {
-  return acctest.ConfigAlternateAccountProvider() + fmt.Sprintf(`
+  return acctest.ConfigCompose(
+    acctest.ConfigAlternateAccountProvider(), fmt.Sprintf(`
 # Cross account resources should be handled by the cross account provider.
 # The standardized provider block to use is awsalternate as seen below.
 resource "aws_cross_account_example" "test" {
@@ -911,7 +912,7 @@ resource "aws_cross_account_example" "test" {
 resource "aws_example" "test" {
   # ... configuration ...
 }
-`)
+`, ...))
 }
 ```
 
@@ -961,7 +962,8 @@ func TestAccExample_basic(t *testing.T) {
 }
 
 func testAccExampleConfig() string {
-  return acctest.ConfigMultipleRegionProvider(2) + fmt.Sprintf(`
+  return acctest.ConfigCompose(
+    acctest.ConfigMultipleRegionProvider(2), fmt.Sprintf(`
 # Cross region resources should be handled by the cross region provider.
 # The standardized provider is awsalternate as seen below.
 resource "aws_cross_region_example" "test" {
@@ -975,7 +977,7 @@ resource "aws_cross_region_example" "test" {
 resource "aws_example" "test" {
   # ... configuration ...
 }
-`)
+`, ...))
 }
 ```
 

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -768,6 +768,20 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 			input.OptionGroupName = aws.String(v.(string))
 		}
 
+		if v, ok := d.GetOk("parameter_group_name"); ok {
+			crossRegion := false
+			if arn.IsARN(sourceDBInstanceID) {
+				sourceARN, err := arn.Parse(sourceDBInstanceID)
+				if err != nil {
+					return sdkdiag.AppendErrorf(diags, "creating RDS DB Instance (read replica) (%s): %s", identifier, err)
+				}
+				crossRegion = sourceARN.Region != meta.(*conns.AWSClient).Region
+			}
+			if crossRegion {
+				input.DBParameterGroupName = aws.String(v.(string))
+			}
+		}
+
 		if v, ok := d.GetOk("performance_insights_enabled"); ok {
 			input.EnablePerformanceInsights = aws.Bool(v.(bool))
 		}


### PR DESCRIPTION
### Description

When creating a replica RDS Instance, the parameter group was set during a modify step after creation. This is because the parameter group cannot be set when creating a replica in the same region as the source. When using parameter values that cannot be changed after creation, such as the `max_string_size` for Oracle, this would cause errors when creating a replica.

Now sets the parameter group on creation when the source DB is located in a different region.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #31719

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=rds TESTS=TestAccRDSInstance_ReplicateSourceDB

--- PASS: TestAccRDSInstance_ReplicateSourceDB_allowMajorVersionUpgrade (1313.53s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_iops (1374.11s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_allocatedStorage (1496.60s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_availabilityZone (1505.49s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_backupWindow (1506.24s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_maintenanceWindow (1506.33s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupNameVPCSecurityGroupIDs (1556.60s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_performanceInsightsEnabled (1567.78s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_autoMinorVersionUpgrade (1576.46s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_iamDatabaseAuthenticationEnabled (1576.64s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_allocatedStorageAndIops (1623.85s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_addLater (1628.32s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_nameGenerated (1642.10s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_maxAllocatedStorage (1706.99s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_basic (1707.61s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSetOnReplica (1737.21s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName (1833.15s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_backupRetentionPeriod (1920.85s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_namePrefix (1452.86s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_networkType (1423.24s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_replicaMode (2847.91s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_vpcSecurityGroupIDs (1329.94s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSameSetOnBoth (1409.32s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_caCertificateIdentifier (1481.40s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_port (1622.38s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_monitoring (1677.64s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameReplicaCopiesValue (1804.33s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_monitoring_sourceAlreadyExists (1733.31s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameDifferentSetOnBoth (1904.54s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_multiAZ (2119.87s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_CrossRegion_parameterGroupNameEquivalent (3843.25s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupTwoStep (3090.11s)
```
