### PR TITLE
Remove max target group limit

### DIFF
--- a/.changelog/36095.txt
+++ b/.changelog/36095.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_vpclattice_listener_rule: Remove `action.forward.target_groups` maximum item limit
+```

--- a/internal/service/vpclattice/listener_rule.go
+++ b/internal/service/vpclattice/listener_rule.go
@@ -90,7 +90,6 @@ func ResourceListenerRule() *schema.Resource {
 										Type:     schema.TypeList,
 										Required: true,
 										MinItems: 1,
-										MaxItems: 2,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"target_group_identifier": {


### PR DESCRIPTION
### Description
Registering VPC Lattice target groups to a listener rule is limited to a max of 2 by the provider. However, it's perfectly possible to add more than 2 to a rule using AWS CLI.
```
aws vpc-lattice create-rule \
--action '{"forward":{"targetGroups":[{"targetGroupIdentifier":"tg-xxxx","weight":1},{"targetGroupIdentifier":"tg-yyyy","weight":1},{"targetGroupIdentifier":"tg-zzzz","weight":1}]}}' \
--listener-identifier "arn:aws:vpc-lattice:us-east-1:..." \
--match '{"httpMatch":{"pathMatch":{"caseSensitive":false,"match":{"prefix":"/"}}}}' \
--name "ms-1" \
--priority 10 \
--service-identifier "arn:aws:vpc-lattice:us-east-1:..."
```

Attempting this with the current provider leads to an error:
```terraform
│ Error: Too many target_groups blocks
│ 
│   on main.tf line 55, in resource "aws_vpclattice_listener_rule" "lattice_listener_rule":
│   55:       target_groups {
│ 
│ No more than 2 "target_groups" blocks are allowed
```

Removing this restriction allows more target groups to be added. I'm not sure if there is some max resource quota for the number of target groups that can be registered on a listener rule but I didn't come across any issues adding more than 2. At the very least, the limit should be raised to a number greater than 2 seeing as this is possible using CLI commands.

### Relations

### References

### Output from Acceptance Testing

I can't afford any acceptance testing but i was able to check that 3 target groups were able to be added to a listener rule by removing the max limit:

```terraform
resource "aws_vpclattice_service" "lattice_service" {
 
  name               = "ms-1-svc"
  auth_type          = "NONE"
  certificate_arn    = "arn:aws:acm:us-east-1:..."
  custom_domain_name = "ms-1.example.com"

}

resource "aws_vpclattice_service_network_service_association" "lattice_service_association" {
   service_identifier         = aws_vpclattice_service.lattice_service.id
   service_network_identifier = "sn-xxx"
}

resource "aws_vpclattice_listener" "lattice_listener" {
  name               = "http-80"
  protocol           = "HTTP"
  service_identifier = aws_vpclattice_service.lattice_service.id
  default_action {
    fixed_response {
      status_code = 404
    }
  }
}

resource "aws_vpclattice_listener_rule" "lattice_listener_rule" {
  name                = "ms-1-http"
  listener_identifier = aws_vpclattice_listener.lattice_listener.listener_id
  service_identifier  = aws_vpclattice_service.lattice_service.id
  priority            = 10
  match {
    http_match {
      path_match {
        case_sensitive = false
        match {
          exact = "/"
        }
      }
    }
  }
  action {
    forward {
      target_groups {
        target_group_identifier = "tg-xxx"
        weight                  = 1
      }
      target_groups {
        target_group_identifier = "tg-yyy"
        weight                  = 1
      }
      target_groups {
        target_group_identifier = "tg-zzz"
        weight                  = 1
      }
    }
  }
}
```

Apply Terraform:
```terraform
Terraform will perform the following actions:

  # aws_vpclattice_listener_rule.lattice_listener_rule will be created
  + resource "aws_vpclattice_listener_rule" "lattice_listener_rule" {
      + arn                 = (known after apply)
      + id                  = (known after apply)
      + listener_identifier = "listener-03c30421c2048c3a6"
      + name                = "ms-1-http"
      + priority            = 10
      + rule_id             = (known after apply)
      + service_identifier  = "svc-055e08f58e907dbdd"
      + tags_all            = (known after apply)

      + action {
          + forward {
              + target_groups {
                  + target_group_identifier = "tg-0f2e9b98e62b97d12"
                  + weight                  = 1
                }
              + target_groups {
                  + target_group_identifier = "tg-005c0cdc9c7e27486"
                  + weight                  = 1
                }
              + target_groups {
                  + target_group_identifier = "tg-0ad9ab430a3751d4a"
                  + weight                  = 1
                }
            }
        }

      + match {
          + http_match {
              + path_match {
                  + case_sensitive = false

                  + match {
                      + exact = "/"
                    }
                }
            }
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

aws_vpclattice_listener_rule.lattice_listener_rule: Creating...
aws_vpclattice_listener_rule.lattice_listener_rule: Creation complete after 0s [id=svc-055e08f58e907dbdd/listener-03c30421c2048c3a6/rule-0398c8603d8676e87]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

![image](https://github.com/hashicorp/terraform-provider-aws/assets/108732119/a89b3d81-113e-4417-b034-eee936b64362)

