### PR TITLE
r/medialive_channel: allow empty audio descriptions

### DIFF
--- a/.changelog/36097.txt
+++ b/.changelog/36097.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_medialive_channel: ensure medialive audio descriptions are optional
+resource/aws_medialive_channel: Fix handling of optional `encoder_settings.audio_descriptions` arguments
 ```

--- a/.changelog/36097.txt
+++ b/.changelog/36097.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_medialive_channel: ensure medialive audio descriptions are optional
+```

--- a/internal/service/medialive/channel_encoder_settings_schema.go
+++ b/internal/service/medialive/channel_encoder_settings_schema.go
@@ -3063,7 +3063,7 @@ func expandChannelEncoderSettings(tfList []interface{}) *types.EncoderSettings {
 	m := tfList[0].(map[string]interface{})
 
 	var settings types.EncoderSettings
-	if v, ok := m["audio_descriptions"].(*schema.Set); ok && v.Len() > 0 {
+	if v, ok := m["audio_descriptions"].(*schema.Set); ok {
 		settings.AudioDescriptions = expandChannelEncoderSettingsAudioDescriptions(v.List())
 	}
 	if v, ok := m["output_groups"].([]interface{}); ok && len(v) > 0 {
@@ -3108,7 +3108,7 @@ func expandChannelEncoderSettingsAudioDescriptions(tfList []interface{}) []types
 		return nil
 	}
 
-	var audioDesc []types.AudioDescription
+	audioDesc := []types.AudioDescription{}
 	for _, tfItem := range tfList {
 		m, ok := tfItem.(map[string]interface{})
 		if !ok {

--- a/internal/service/medialive/channel_test.go
+++ b/internal/service/medialive/channel_test.go
@@ -1904,8 +1904,8 @@ resource "aws_medialive_channel" "test" {
       }
 
       outputs {
-        output_name             = "test-output-name"
-        video_description_name  = "test-video-name"
+        output_name            = "test-output-name"
+        video_description_name = "test-video-name"
         output_settings {
           archive_output_settings {
             name_modifier = "_1"

--- a/internal/service/medialive/channel_test.go
+++ b/internal/service/medialive/channel_test.go
@@ -642,6 +642,54 @@ func TestAccMediaLiveChannel_hls(t *testing.T) {
 	})
 }
 
+func TestAccMediaLiveChannel_noAudio(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var channel medialive.DescribeChannelOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_medialive_channel.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.MediaLiveEndpointID)
+			testAccChannelsPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckChannelDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccChannelConfig_noAudio(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckChannelExists(ctx, resourceName, &channel),
+					resource.TestCheckResourceAttrSet(resourceName, "channel_id"),
+					resource.TestCheckResourceAttr(resourceName, "channel_class", "STANDARD"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "role_arn"),
+					resource.TestCheckResourceAttr(resourceName, "input_specification.0.codec", "AVC"),
+					resource.TestCheckResourceAttr(resourceName, "input_specification.0.input_resolution", "HD"),
+					resource.TestCheckResourceAttr(resourceName, "input_specification.0.maximum_bitrate", "MAX_20_MBPS"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "input_attachments.*", map[string]string{
+						"input_attachment_name": "example-input1",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "destinations.*", map[string]string{
+						"id": rName,
+					}),
+					resource.TestCheckResourceAttr(resourceName, "encoder_settings.0.timecode_config.0.source", "EMBEDDED"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "encoder_settings.0.video_descriptions.*", map[string]string{
+						"name": "test-video-name",
+					}),
+					resource.TestCheckNoResourceAttr(resourceName, "encoder_settings.0.audio_descriptions.*"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccMediaLiveChannel_status(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -1792,6 +1840,81 @@ resource "aws_medialive_channel" "test" {
                 m3u8_settings {
                   audio_frames_per_pes = 4
                 }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`, rName))
+}
+
+func testAccChannelConfig_noAudio(rName string) string {
+	return acctest.ConfigCompose(
+		testAccChannelConfig_base(rName),
+		testAccChannelConfig_baseS3(rName),
+		testAccChannelConfig_baseMultiplex(rName),
+		fmt.Sprintf(`
+resource "aws_medialive_channel" "test" {
+  name          = %[1]q
+  channel_class = "STANDARD"
+  role_arn      = aws_iam_role.test.arn
+
+  input_specification {
+    codec            = "AVC"
+    input_resolution = "HD"
+    maximum_bitrate  = "MAX_20_MBPS"
+  }
+
+  input_attachments {
+    input_attachment_name = "example-input1"
+    input_id              = aws_medialive_input.test.id
+  }
+
+  destinations {
+    id = %[1]q
+
+    settings {
+      url = "s3://${aws_s3_bucket.test1.id}/test1"
+    }
+
+    settings {
+      url = "s3://${aws_s3_bucket.test2.id}/test2"
+    }
+  }
+
+  encoder_settings {
+    timecode_config {
+      source = "EMBEDDED"
+    }
+
+    video_descriptions {
+      name = "test-video-name"
+    }
+
+    output_groups {
+      output_group_settings {
+        archive_group_settings {
+          destination {
+            destination_ref_id = %[1]q
+          }
+        }
+      }
+
+      outputs {
+        output_name             = "test-output-name"
+        video_description_name  = "test-video-name"
+        output_settings {
+          archive_output_settings {
+            name_modifier = "_1"
+            extension     = "m2ts"
+            container_settings {
+              m2ts_settings {
+                audio_buffer_model = "ATSC"
+                buffer_model       = "MULTIPLEX"
+                rate_mode          = "CBR"
               }
             }
           }

--- a/website/docs/r/medialive_channel.html.markdown
+++ b/website/docs/r/medialive_channel.html.markdown
@@ -124,7 +124,7 @@ The following arguments are optional:
 
 ### Encoder Settings
 
-* `audio_descriptions` - (Required) Audio descriptions for the channel. See [Audio Descriptions](#audio-descriptions) for more details.
+* `audio_descriptions` - (Optional) Audio descriptions for the channel. See [Audio Descriptions](#audio-descriptions) for more details.
 * `output_groups` - (Required) Output groups for the channel. See [Output Groups](#output-groups) for more details.
 * `timecode_config` - (Required) Contains settings used to acquire and adjust timecode information from inputs. See [Timecode Config](#timecode-config) for more details.
 * `video_descriptions` - (Required) Video Descriptions. See [Video Descriptions](#video-descriptions) for more details.

--- a/website/docs/r/medialive_channel.html.markdown
+++ b/website/docs/r/medialive_channel.html.markdown
@@ -124,15 +124,15 @@ The following arguments are optional:
 
 ### Encoder Settings
 
-* `audio_descriptions` - (Optional) Audio descriptions for the channel. See [Audio Descriptions](#audio-descriptions) for more details.
 * `output_groups` - (Required) Output groups for the channel. See [Output Groups](#output-groups) for more details.
 * `timecode_config` - (Required) Contains settings used to acquire and adjust timecode information from inputs. See [Timecode Config](#timecode-config) for more details.
 * `video_descriptions` - (Required) Video Descriptions. See [Video Descriptions](#video-descriptions) for more details.
+* `audio_descriptions` - (Optional) Audio descriptions for the channel. See [Audio Descriptions](#audio-descriptions) for more details.
+* `avail_blanking` - (Optional) Settings for ad avail blanking. See [Avail Blanking](#avail-blanking) for more details.
 * `caption_descriptions` - (Optional) Caption Descriptions. See [Caption Descriptions](#caption-descriptions) for more details.
 * `global_configuration` - (Optional) Configuration settings that apply to the event as a whole. See [Global Configuration](#global-configuration) for more details.
 * `motion_graphics_configuration` - (Optional) Settings for motion graphics. See [Motion Graphics Configuration](#motion-graphics-configuration) for more details.
 * `nielsen_configuration` - (Optional) Nielsen configuration settings. See [Nielsen Configuration](#nielsen-configuration) for more details.
-* `avail_blanking` - (Optional) Settings for ad avail blanking. See [Avail Blanking](#avail-blanking) for more details.
 
 ### Input Attachments
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Audio descriptions are not actually required.
Useful for when you are creating a video only channel with no audio.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/27824

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-medialive-channel-encodersettings.html#aws-properties-medialive-channel-encodersettings-properties

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccMediaLiveChannel_ PKG=medialive
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/medialive/... -v -count 1 -parallel 20 -run='TestAccMediaLiveChannel_'  -timeout 360m
=== RUN   TestAccMediaLiveChannel_basic
=== PAUSE TestAccMediaLiveChannel_basic
=== RUN   TestAccMediaLiveChannel_captionDescriptions
=== PAUSE TestAccMediaLiveChannel_captionDescriptions
=== RUN   TestAccMediaLiveChannel_M2TS_settings
=== PAUSE TestAccMediaLiveChannel_M2TS_settings
=== RUN   TestAccMediaLiveChannel_UDP_outputSettings
=== PAUSE TestAccMediaLiveChannel_UDP_outputSettings
=== RUN   TestAccMediaLiveChannel_MsSmooth_outputSettings
=== PAUSE TestAccMediaLiveChannel_MsSmooth_outputSettings
=== RUN   TestAccMediaLiveChannel_AudioDescriptions_codecSettings
=== PAUSE TestAccMediaLiveChannel_AudioDescriptions_codecSettings
=== RUN   TestAccMediaLiveChannel_VideoDescriptions_CodecSettings_h264Settings
=== PAUSE TestAccMediaLiveChannel_VideoDescriptions_CodecSettings_h264Settings
=== RUN   TestAccMediaLiveChannel_VideoDescriptions_CodecSettings_h265Settings
=== PAUSE TestAccMediaLiveChannel_VideoDescriptions_CodecSettings_h265Settings
=== RUN   TestAccMediaLiveChannel_hls
=== PAUSE TestAccMediaLiveChannel_hls
=== RUN   TestAccMediaLiveChannel_noAudio
=== PAUSE TestAccMediaLiveChannel_noAudio
=== RUN   TestAccMediaLiveChannel_status
=== PAUSE TestAccMediaLiveChannel_status
=== RUN   TestAccMediaLiveChannel_update
=== PAUSE TestAccMediaLiveChannel_update
=== RUN   TestAccMediaLiveChannel_updateTags
=== PAUSE TestAccMediaLiveChannel_updateTags
=== RUN   TestAccMediaLiveChannel_disappears
=== PAUSE TestAccMediaLiveChannel_disappears
=== CONT  TestAccMediaLiveChannel_basic
=== CONT  TestAccMediaLiveChannel_VideoDescriptions_CodecSettings_h265Settings
=== CONT  TestAccMediaLiveChannel_update
=== CONT  TestAccMediaLiveChannel_disappears
=== CONT  TestAccMediaLiveChannel_updateTags
=== CONT  TestAccMediaLiveChannel_noAudio
=== CONT  TestAccMediaLiveChannel_status
=== CONT  TestAccMediaLiveChannel_hls
=== CONT  TestAccMediaLiveChannel_VideoDescriptions_CodecSettings_h264Settings
=== CONT  TestAccMediaLiveChannel_MsSmooth_outputSettings
=== CONT  TestAccMediaLiveChannel_UDP_outputSettings
=== CONT  TestAccMediaLiveChannel_M2TS_settings
=== CONT  TestAccMediaLiveChannel_captionDescriptions
=== CONT  TestAccMediaLiveChannel_AudioDescriptions_codecSettings
--- PASS: TestAccMediaLiveChannel_MsSmooth_outputSettings (89.93s)
--- PASS: TestAccMediaLiveChannel_VideoDescriptions_CodecSettings_h264Settings (106.42s)
--- PASS: TestAccMediaLiveChannel_AudioDescriptions_codecSettings (107.26s)
--- PASS: TestAccMediaLiveChannel_UDP_outputSettings (117.68s)
--- PASS: TestAccMediaLiveChannel_hls (164.27s)
--- PASS: TestAccMediaLiveChannel_disappears (181.91s)
--- PASS: TestAccMediaLiveChannel_captionDescriptions (184.58s)
--- PASS: TestAccMediaLiveChannel_M2TS_settings (195.75s)
--- PASS: TestAccMediaLiveChannel_status (229.23s)
--- PASS: TestAccMediaLiveChannel_VideoDescriptions_CodecSettings_h265Settings (252.59s)
--- PASS: TestAccMediaLiveChannel_noAudio (271.53s)
--- PASS: TestAccMediaLiveChannel_update (275.12s)
--- PASS: TestAccMediaLiveChannel_updateTags (308.22s)
--- PASS: TestAccMediaLiveChannel_basic (321.91s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/medialive  322.015s
...
```
