### PR TITLE
resource/aws_vpn_connection: Fixes CIDR validation for inside_ipv6_cidr fields

### DIFF
--- a/.changelog/36236.txt
+++ b/.changelog/36236.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_vpn_connection: Correctly validates `tunnel1_inside_ipv6_cidr` and `tunnel2_inside_ipv6_cidr` are in `fd00::/8`.
+resource/aws_vpn_connection: Correct plan-time validation of `tunnel1_inside_ipv6_cidr` and `tunnel2_inside_ipv6_cidr`
 ```

--- a/.changelog/36236.txt
+++ b/.changelog/36236.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_vpn_connection: Correctly validates `tunnel1_inside_ipv6_cidr` and `tunnel2_inside_ipv6_cidr` are in `fd00::/8`.
+```

--- a/internal/service/ec2/vpnsite_connection.go
+++ b/internal/service/ec2/vpnsite_connection.go
@@ -1696,7 +1696,7 @@ func validVPNConnectionTunnelInsideCIDR() schema.SchemaValidateFunc {
 func validVPNConnectionTunnelInsideIPv6CIDR() schema.SchemaValidateFunc {
 	return validation.All(
 		validation.IsCIDRNetwork(126, 126),
-		validation.StringMatch(regexache.MustCompile(`^fd00:`), "must be within fd00::/8"),
+		validation.StringMatch(regexache.MustCompile(`^fd`), "must be within fd00::/8"),
 	)
 }
 

--- a/internal/service/ec2/vpnsite_connection_test.go
+++ b/internal/service/ec2/vpnsite_connection_test.go
@@ -473,11 +473,19 @@ func TestAccSiteVPNConnection_tunnel1InsideIPv6CIDR(t *testing.T) {
 		CheckDestroy:             testAccCheckVPNConnectionDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSiteVPNConnectionConfig_tunnel1InsideIPv6CIDR(rName, rBgpAsn, "fd00:2001:db8:2:2d1:81ff:fe41:d200/126", "fd00:2001:db8:2:2d1:81ff:fe41:d204/126"),
+				Config:      testAccSiteVPNConnectionConfig_tunnel1InsideIPv6CIDR(rName, rBgpAsn, "fd00:2001:db8::1:0/125", "fd00:2001:db8::2:0/125"),
+				ExpectError: regexache.MustCompile(`expected "\w+" to contain a network Value with between 126 and 126 significant bits`),
+			},
+			{
+				Config:      testAccSiteVPNConnectionConfig_tunnel1InsideIPv6CIDR(rName, rBgpAsn, "fcff:2001:db8:2:2d1:81ff:fe41:d200/126", "fcff:2001:db8:2:2d1:81ff:fe41:0/126"),
+				ExpectError: regexache.MustCompile(`must be within fd00::/8`),
+			},
+			{
+				Config: testAccSiteVPNConnectionConfig_tunnel1InsideIPv6CIDR(rName, rBgpAsn, "fd00:2001:db8:2:2d1:81ff:fe41:d200/126", "fdff:2001:db8:2:2d1:81ff:fe41:d204/126"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccVPNConnectionExists(ctx, resourceName, &vpn),
 					resource.TestCheckResourceAttr(resourceName, "tunnel1_inside_ipv6_cidr", "fd00:2001:db8:2:2d1:81ff:fe41:d200/126"),
-					resource.TestCheckResourceAttr(resourceName, "tunnel2_inside_ipv6_cidr", "fd00:2001:db8:2:2d1:81ff:fe41:d204/126"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel2_inside_ipv6_cidr", "fdff:2001:db8:2:2d1:81ff:fe41:d204/126"),
 				),
 			},
 			// NOTE: Import does not currently have access to the Terraform configuration,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Fixes incorrect regex to properly allow any CIDR in `fd00::/8` (the current regex incorrectly only allows CIDRs from `fd00::/16`).

### Relations

Closes #36232

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
```console
% make testacc TESTS=TestAccSiteVPNConnection_tunnel1InsideIPv6CIDR PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccSiteVPNConnection_tunnel1InsideIPv6CIDR'  -timeout 360m
=== RUN   TestAccSiteVPNConnection_tunnel1InsideIPv6CIDR
=== PAUSE TestAccSiteVPNConnection_tunnel1InsideIPv6CIDR
=== CONT  TestAccSiteVPNConnection_tunnel1InsideIPv6CIDR
--- PASS: TestAccSiteVPNConnection_tunnel1InsideIPv6CIDR (405.46s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	405.565s
...
```
