### PR TITLE
Adding msk serverless cluster data source.

### DIFF
--- a/internal/service/kafka/serverless_cluster_data_source.go
+++ b/internal/service/kafka/serverless_cluster_data_source.go
@@ -1,0 +1,122 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package kafka
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/kafka"
+	"github.com/aws/aws-sdk-go-v2/service/kafka/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+// @SDKDataSource("aws_msk_serverless_cluster", name="Serverless Cluster")
+func dataSourceServerlessCluster() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceServerlessClusterRead,
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"bootstrap_brokers_sasl_iam": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cluster_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, 64),
+			},
+			"cluster_uuid": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"kafka_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": tftags.TagsSchemaComputed(),
+		},
+	}
+}
+
+func dataSourceServerlessClusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).KafkaClient(ctx)
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	clusterName := d.Get("cluster_name").(string)
+	input := &kafka.ListClustersV2Input{
+		ClusterTypeFilter: aws.String("SERVERLESS"),
+		ClusterNameFilter: aws.String(clusterName),
+	}
+	cluster, err := findServerlessCluster(ctx, conn, input, func(v *types.Cluster) bool {
+		return aws.ToString(v.ClusterName) == clusterName
+	})
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading MSK Cluster (%s): %s", clusterName, err)
+	}
+
+	clusterARN := aws.ToString(cluster.ClusterArn)
+	bootstrapBrokersOutput, err := findBootstrapBrokersByARN(ctx, conn, clusterARN)
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading MSK Cluster (%s) bootstrap brokers: %s", clusterARN, err)
+	}
+
+	d.SetId(clusterARN)
+	d.Set("arn", clusterARN)
+	d.Set("bootstrap_brokers_sasl_iam", SortEndpointsString(aws.ToString(bootstrapBrokersOutput.BootstrapBrokerStringSaslIam)))
+	d.Set("cluster_name", cluster.ClusterName)
+	clusterUUID, _ := clusterUUIDFromARN(clusterARN)
+	d.Set("cluster_uuid", clusterUUID)
+
+	if err := d.Set("tags", KeyValueTags(ctx, cluster.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
+	}
+
+	return diags
+}
+
+func findServerlessCluster(ctx context.Context, conn *kafka.Client, input *kafka.ListClustersV2Input, filter tfslices.Predicate[*types.Cluster]) (*types.Cluster, error) {
+	output, err := findServerlessClusters(ctx, conn, input, filter)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfresource.AssertFirstValueResult(output)
+}
+
+func findServerlessClusters(ctx context.Context, conn *kafka.Client, input *kafka.ListClustersV2Input, filter tfslices.Predicate[*types.Cluster]) ([]types.Cluster, error) {
+	var output []types.Cluster
+
+	pages := kafka.NewListClustersV2Paginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+
+		if err != nil {
+			return nil, err
+		}
+
+		for _, v := range page.ClusterInfoList {
+			if filter(&v) {
+				output = append(output, v)
+			}
+		}
+	}
+
+	return output, nil
+}

--- a/internal/service/kafka/serverless_cluster_data_source_test.go
+++ b/internal/service/kafka/serverless_cluster_data_source_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package kafka_test
+
+import (
+	"fmt"
+	"testing"
+
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccKafkaServerlessClusterDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_msk_cluster.test"
+	resourceName := "aws_msk_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.KafkaServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterDataSourceConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "bootstrap_brokers_sasl_iam", resourceName, "bootstrap_brokers_sasl_iam"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "cluster_name", resourceName, "cluster_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "cluster_uuid", resourceName, "cluster_uuid"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags.%", resourceName, "tags.%"),
+				),
+			},
+		},
+	})
+}
+
+func testAccServleressClusterDataSourceConfig_basic(rName string) string {
+	return acctest.ConfigCompose(testAccServerlessClusterConfig_base(rName), fmt.Sprintf(`
+resource "aws_msk_serverless_cluster" "test" {
+  cluster_name = %[1]q
+
+  client_authentication {
+    sasl {
+      iam {
+        enabled = true
+      }
+    }
+  }
+
+  vpc_config {
+    subnet_ids = aws_subnet.test[*].id
+  }
+  
+  tags = {
+    Name = %[1]q
+  }
+}
+
+data "aws_msk_cluster" "test" {
+  cluster_name = aws_msk_cluster.test.cluster_name
+}
+`, rName))
+}

--- a/website/docs/d/msk_serverless_cluster.html.markdown
+++ b/website/docs/d/msk_serverless_cluster.html.markdown
@@ -1,0 +1,36 @@
+---
+subcategory: "Managed Streaming for Kafka"
+layout: "aws"
+page_title: "AWS: aws_msk_cluster"
+description: |-
+  Get information on an Amazon MSK Cluster
+---
+
+# Data Source: aws_msk_serverless_cluster
+
+Get information on an Amazon MSK Serverless Cluster.
+
+-> **Note:** This data sources returns information on _serverless_ clusters.
+
+## Example Usage
+
+```terraform
+data "aws_msk_serverless_cluster" "example" {
+  cluster_name = "example"
+}
+```
+
+## Argument Reference
+
+This data source supports the following arguments:
+
+* `cluster_name` - (Required) Name of the cluster.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `arn` - ARN of the MSK cluster.
+* `bootstrap_brokers_sasl_iam` - The DNS name (or IP addresses) and SASL IAM port pair. For example, `b-1.exampleClusterName.abcde.c2.kafka.us-east-1.amazonaws.com:9098`
+* `cluster_uuid` - UUID of the MSK cluster, for use in IAM policies.
+* `tags` - Map of key-value pairs assigned to the cluster.


### PR DESCRIPTION
### Description

This adds a data source to support retrieval of MSK Serverless Cluster properties.

### Relations
Closes #35909 


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.


```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
-->
