### PR TITLE
[Documentation] Update `aws_guardduty_detector_feature`documentation with runtime monitoring values

### DIFF
--- a/website/docs/r/guardduty_detector_feature.html.markdown
+++ b/website/docs/r/guardduty_detector_feature.html.markdown
@@ -35,17 +35,17 @@ resource "aws_guardduty_detector_feature" "eks_runtime_monitoring" {
 
 This resource supports the following arguments:
 
-- `detector_id` - (Required) Amazon GuardDuty detector ID.
-- `name` - (Required) The name of the detector feature. Valid values: `S3_DATA_EVENTS`, `EKS_AUDIT_LOGS`, `EBS_MALWARE_PROTECTION`, `RDS_LOGIN_EVENTS`, `EKS_RUNTIME_MONITORING`, `LAMBDA_NETWORK_LOGS`, `RUNTIME_MONITORING`.
-- `status` - (Required) The status of the detector feature. Valid values: `ENABLED`, `DISABLED`.
-- `additional_configuration` - (Optional) Additional feature configuration block. See [below](#additional-configuration).
+* `detector_id` - (Required) Amazon GuardDuty detector ID.
+* `name` - (Required) The name of the detector feature. Valid values: `S3_DATA_EVENTS`, `EKS_AUDIT_LOGS`, `EBS_MALWARE_PROTECTION`, `RDS_LOGIN_EVENTS`, `EKS_RUNTIME_MONITORING`, `LAMBDA_NETWORK_LOGS`, `RUNTIME_MONITORING`.
+* `status` - (Required) The status of the detector feature. Valid values: `ENABLED`, `DISABLED`.
+* `additional_configuration` - (Optional) Additional feature configuration block. See [below](#additional-configuration).
 
 ### Additional Configuration
 
 The `additional_configuration` block supports the following:
 
-- `name` - (Required) The name of the additional configuration. Valid values: `EKS_ADDON_MANAGEMENT`, `ECS_FARGATE_AGENT_MANAGEMENT`.
-- `status` - (Required) The status of the additional configuration. Valid values: `ENABLED`, `DISABLED`.
+* `name` - (Required) The name of the additional configuration. Valid values: `EKS_ADDON_MANAGEMENT`, `ECS_FARGATE_AGENT_MANAGEMENT`.
+* `status` - (Required) The status of the additional configuration. Valid values: `ENABLED`, `DISABLED`.
 
 ## Attribute Reference
 

--- a/website/docs/r/guardduty_detector_feature.html.markdown
+++ b/website/docs/r/guardduty_detector_feature.html.markdown
@@ -35,17 +35,17 @@ resource "aws_guardduty_detector_feature" "eks_runtime_monitoring" {
 
 This resource supports the following arguments:
 
-* `detector_id` - (Required) Amazon GuardDuty detector ID.
-* `name` - (Required) The name of the detector feature. Valid values: `S3_DATA_EVENTS`, `EKS_AUDIT_LOGS`, `EBS_MALWARE_PROTECTION`, `RDS_LOGIN_EVENTS`, `EKS_RUNTIME_MONITORING`, `LAMBDA_NETWORK_LOGS`.
-* `status` - (Required) The status of the detector feature. Valid values: `ENABLED`, `DISABLED`.
-* `additional_configuration` - (Optional) Additional feature configuration block. See [below](#additional-configuration).
+- `detector_id` - (Required) Amazon GuardDuty detector ID.
+- `name` - (Required) The name of the detector feature. Valid values: `S3_DATA_EVENTS`, `EKS_AUDIT_LOGS`, `EBS_MALWARE_PROTECTION`, `RDS_LOGIN_EVENTS`, `EKS_RUNTIME_MONITORING`, `LAMBDA_NETWORK_LOGS`, `RUNTIME_MONITORING`.
+- `status` - (Required) The status of the detector feature. Valid values: `ENABLED`, `DISABLED`.
+- `additional_configuration` - (Optional) Additional feature configuration block. See [below](#additional-configuration).
 
 ### Additional Configuration
 
 The `additional_configuration` block supports the following:
 
-* `name` - (Required) The name of the additional configuration. Valid values: `EKS_ADDON_MANAGEMENT`.
-* `status` - (Required) The status of the additional configuration. Valid values: `ENABLED`, `DISABLED`.
+- `name` - (Required) The name of the additional configuration. Valid values: `EKS_ADDON_MANAGEMENT`, `ECS_FARGATE_AGENT_MANAGEMENT`.
+- `status` - (Required) The status of the additional configuration. Valid values: `ENABLED`, `DISABLED`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Runtime monitoring is already supported, however the values required for configuration are not present in the documention.

### Relations

Closes #34973

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
 
- https://docs.aws.amazon.com/guardduty/latest/APIReference/API_DetectorAdditionalConfiguration.html
- https://docs.aws.amazon.com/guardduty/latest/APIReference/API_DetectorFeatureConfiguration.html