### PR TITLE
r/medialive_input: export destinations attribute

### DIFF
--- a/.changelog/36243.txt
+++ b/.changelog/36243.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_medialive_input: Export attribute `destinations`
+```

--- a/internal/service/medialive/input.go
+++ b/internal/service/medialive/input.go
@@ -60,11 +60,24 @@ func ResourceInput() *schema.Resource {
 			"destinations": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"stream_name": {
 							Type:     schema.TypeString,
 							Required: true,
+						},
+						"ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"port": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"url": {
+							Type:     schema.TypeString,
+							Computed: true,
 						},
 					},
 				},
@@ -282,6 +295,7 @@ func resourceInputRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	d.Set("input_partner_ids", out.InputPartnerIds)
 	d.Set("input_security_groups", out.SecurityGroups)
 	d.Set("input_source_type", out.InputSourceType)
+	d.Set("destinations", flattenInputDestinations(out.Destinations))
 	d.Set("role_arn", out.RoleArn)
 	d.Set("sources", flattenSources(out.Sources))
 	d.Set("type", out.Type)
@@ -565,6 +579,43 @@ func flattenSources(apiObjects []types.InputSource) []interface{} {
 		}
 
 		l = append(l, flattenSource(apiObject))
+	}
+
+	return l
+}
+
+func flattenInputDestination(apiObject types.InputDestination) map[string]interface{} {
+	if apiObject == (types.InputDestination{}) {
+		return nil
+	}
+
+	m := map[string]interface{}{}
+
+	if v := apiObject.Ip; v != nil {
+		m["ip"] = aws.ToString(v)
+	}
+	if v := apiObject.Port; v != nil {
+		m["port"] = aws.ToString(v)
+	}
+	if v := apiObject.Url; v != nil {
+		m["url"] = aws.ToString(v)
+	}
+	return m
+}
+
+func flattenInputDestinations(apiObjects []types.InputDestination) []interface{} {
+	if len(apiObjects) == 0 {
+		return nil
+	}
+
+	var l []interface{}
+
+	for _, apiObject := range apiObjects {
+		if apiObject == (types.InputDestination{}) {
+			continue
+		}
+
+		l = append(l, flattenInputDestination(apiObject))
 	}
 
 	return l

--- a/website/docs/r/medialive_input.html.markdown
+++ b/website/docs/r/medialive_input.html.markdown
@@ -86,6 +86,7 @@ This resource exports the following attributes in addition to the arguments abov
 * `input_class` - The input class.
 * `input_partner_ids` - A list of IDs for all Inputs which are partners of this one.
 * `input_source_type` - Source type of the input.
+* `destinations` - Destination settings for PUSH type inputs.
 
 ## Timeouts
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Destination attributes are not currently exported on the medialive_input resource.  
And with no data source available, its not possible to access the url, port, ip of the endpoints associated with the input.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

- [Go AWS SDK for InputDestinations](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/medialive@v1.48.1/types#InputDestination)
- [AWS Docs](https://docs.aws.amazon.com/medialive/latest/ug/input-rtp-push.html)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccMediaLiveInput_ PKG=medialive 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/medialive/... -v -count 1 -parallel 20 -run='TestAccMediaLiveInput_'  -timeout 360m
=== RUN   TestAccMediaLiveInput_basic
=== PAUSE TestAccMediaLiveInput_basic
=== RUN   TestAccMediaLiveInput_destinations
=== PAUSE TestAccMediaLiveInput_destinations
=== RUN   TestAccMediaLiveInput_update
=== PAUSE TestAccMediaLiveInput_update
=== RUN   TestAccMediaLiveInput_updateTags
=== PAUSE TestAccMediaLiveInput_updateTags
=== RUN   TestAccMediaLiveInput_disappears
=== PAUSE TestAccMediaLiveInput_disappears
=== CONT  TestAccMediaLiveInput_basic
=== CONT  TestAccMediaLiveInput_disappears
=== CONT  TestAccMediaLiveInput_update
=== CONT  TestAccMediaLiveInput_destinations
=== CONT  TestAccMediaLiveInput_updateTags
--- PASS: TestAccMediaLiveInput_disappears (60.35s)
--- PASS: TestAccMediaLiveInput_basic (64.54s)
--- PASS: TestAccMediaLiveInput_destinations (76.24s)
--- PASS: TestAccMediaLiveInput_updateTags (87.87s)
--- PASS: TestAccMediaLiveInput_update (107.61s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/medialive  107.693s
```
