### PR TITLE
r/aws_iot_role_alias Add tagging support

### DIFF
--- a/internal/service/iot/role_alias.go
+++ b/internal/service/iot/role_alias.go
@@ -14,9 +14,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 // @SDKResource("aws_iot_role_alias")
+// @Tags(identifierAttribute="arn")
 func ResourceRoleAlias() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceRoleAliasCreate,
@@ -46,7 +50,11 @@ func ResourceRoleAlias() *schema.Resource {
 				Default:      3600,
 				ValidateFunc: validation.IntBetween(900, 43200),
 			},
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
+
+		CustomizeDiff: verify.SetTagsDiff,
 	}
 }
 
@@ -62,6 +70,7 @@ func resourceRoleAliasCreate(ctx context.Context, d *schema.ResourceData, meta i
 		RoleAlias:                 aws.String(roleAlias),
 		RoleArn:                   aws.String(roleArn),
 		CredentialDurationSeconds: aws.Int64(int64(credentialDuration)),
+		Tags:                      getTagsIn(ctx),
 	})
 
 	if err != nil {

--- a/internal/service/iot/role_alias_test.go
+++ b/internal/service/iot/role_alias_test.go
@@ -40,6 +40,8 @@ func TestAccIoTRoleAlias_basic(t *testing.T) {
 					testAccCheckRoleAliasExists(ctx, resourceName),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "iot", fmt.Sprintf("rolealias/%s", alias)),
 					resource.TestCheckResourceAttr(resourceName, "credential_duration", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "0"),
 				),
 			},
 			{
@@ -130,6 +132,51 @@ func testAccCheckRoleAliasExists(ctx context.Context, n string) resource.TestChe
 
 		return nil
 	}
+}
+
+func TestAccIoTRoleAlias_tags(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_iot_role_alias.tags"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IoTServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPolicyDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoleAliasConfig_tags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoleAliasExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccRoleAliasConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoleAliasExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccRoleAliasConfig_tags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoleAliasExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
 }
 
 func testAccRoleAliasConfig_basic(alias string) string {
@@ -339,4 +386,67 @@ resource "aws_iot_role_alias" "ra2" {
   role_arn = "${aws_iam_role.role.arn}bogus"
 }
 `, alias2)
+}
+
+func testAccRoleAliasConfig_tags1(alias, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "role" {
+  name = "tag_role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Principal": {
+      "Service": "credentials.iot.amazonaws.com"
+    },
+    "Action": "sts:AssumeRole"
+  }
+}
+EOF
+
+}
+
+resource "aws_iot_role_alias" "tags" {
+  alias    = %[1]q
+  role_arn = aws_iam_role.role.arn
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, alias, tagKey1, tagValue1)
+}
+
+func testAccRoleAliasConfig_tags2(alias, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "role" {
+  name = "tag_role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Principal": {
+      "Service": "credentials.iot.amazonaws.com"
+    },
+    "Action": "sts:AssumeRole"
+  }
+}
+EOF
+
+}
+
+resource "aws_iot_role_alias" "tags" {
+  alias    = %[1]q
+  role_arn = aws_iam_role.role.arn
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, alias, tagKey1, tagValue1, tagKey2, tagValue2)
 }

--- a/internal/service/iot/service_package_gen.go
+++ b/internal/service/iot/service_package_gen.go
@@ -107,6 +107,9 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceRoleAlias,
 			TypeName: "aws_iot_role_alias",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceThing,

--- a/website/docs/r/iot_role_alias.html.markdown
+++ b/website/docs/r/iot_role_alias.html.markdown
@@ -42,12 +42,14 @@ This resource supports the following arguments:
 * `alias` - (Required) The name of the role alias.
 * `role_arn` - (Required) The identity of the role to which the alias refers.
 * `credential_duration` - (Optional) The duration of the credential, in seconds. If you do not specify a value for this setting, the default maximum of one hour is applied. This setting can have a value from 900 seconds (15 minutes) to 43200 seconds (12 hours).
+* `tags` - (Optional) Key-value mapping of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:
 
 * `arn` - The ARN assigned by AWS to this role alias.
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
 
 ## Import
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Add tags to `aws_iot_role_alias`


### Relations
Closes https://github.com/hashicorp/terraform-provider-aws/issues/31415.

### Output from Acceptance Testing

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
```console
% make testacc TESTS=TestAccIoTRoleAlias_ PKG=iot

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iot/... -v -count 1 -parallel 20 -run='TestAccIoTRoleAlias_'  -timeout 360m
=== RUN   TestAccIoTRoleAlias_basic
=== PAUSE TestAccIoTRoleAlias_basic
=== RUN   TestAccIoTRoleAlias_tags
=== PAUSE TestAccIoTRoleAlias_tags
=== CONT  TestAccIoTRoleAlias_basic
=== CONT  TestAccIoTRoleAlias_tags
--- PASS: TestAccIoTRoleAlias_tags (22.99s)
--- PASS: TestAccIoTRoleAlias_basic (38.91s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iot	42.145s
...
```
