### PR TITLE
resource/aws_opensearch_domain: Fixes eventual consistency error when adding role to access policy

### DIFF
--- a/internal/service/opensearch/domain.go
+++ b/internal/service/opensearch/domain.go
@@ -763,45 +763,14 @@ func resourceDomainCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	// IAM Roles can take some time to propagate if set in AccessPolicies and created in the same terraform
-	var out *opensearchservice.CreateDomainOutput
-	err = retry.RetryContext(ctx, propagationTimeout, func() *retry.RetryError {
-		var err error
-		out, err = conn.CreateDomainWithContext(ctx, input)
-		if err != nil {
-			if tfawserr.ErrMessageContains(err, "InvalidTypeException", "Error setting policy") {
-				return retry.RetryableError(err)
-			}
-			if tfawserr.ErrMessageContains(err, "ValidationException", "enable a service-linked role to give Amazon ES permissions") {
-				return retry.RetryableError(err)
-			}
-			if tfawserr.ErrMessageContains(err, "ValidationException", "Domain is still being deleted") {
-				return retry.RetryableError(err)
-			}
-			if tfawserr.ErrMessageContains(err, "ValidationException", "Amazon OpenSearch Service must be allowed to use the passed role") {
-				return retry.RetryableError(err)
-			}
-			if tfawserr.ErrMessageContains(err, "ValidationException", "The passed role has not propagated yet") {
-				return retry.RetryableError(err)
-			}
-			if tfawserr.ErrMessageContains(err, "ValidationException", "Authentication error") {
-				return retry.RetryableError(err)
-			}
-			if tfawserr.ErrMessageContains(err, "ValidationException", "Unauthorized Operation: OpenSearch Service must be authorised to describe") {
-				return retry.RetryableError(err)
-			}
-			if tfawserr.ErrMessageContains(err, "ValidationException", "The passed role must authorize Amazon OpenSearch Service to describe") {
-				return retry.RetryableError(err)
-			}
-			return retry.NonRetryableError(err)
-		}
-		return nil
-	})
-	if tfresource.TimedOut(err) {
-		out, err = conn.CreateDomainWithContext(ctx, input)
-	}
+	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout, func() (any, error) {
+		return conn.CreateDomainWithContext(ctx, input)
+	},
+		domainErrorRetryable)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating OpenSearch Domain: %s", err)
 	}
+	out := outputRaw.(*opensearchservice.CreateDomainOutput)
 
 	d.SetId(aws.StringValue(out.DomainStatus.ARN))
 
@@ -982,7 +951,11 @@ func resourceDomainUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			o, n := d.GetChange("access_policies")
 
 			if equivalent, err := awspolicy.PoliciesAreEquivalent(o.(string), n.(string)); err != nil || !equivalent {
-				input.AccessPolicies = aws.String(d.Get("access_policies").(string))
+				policy, err := structure.NormalizeJsonString(n.(string))
+				if err != nil {
+					return sdkdiag.AppendErrorf(diags, "policy (%s) is invalid JSON: %s", policy, err)
+				}
+				input.AccessPolicies = aws.String(policy)
 			}
 		}
 
@@ -1095,7 +1068,10 @@ func resourceDomainUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			input.VPCOptions = expandVPCOptions(s)
 		}
 
-		_, err := conn.UpdateDomainConfigWithContext(ctx, &input)
+		_, err := tfresource.RetryWhen(ctx, propagationTimeout, func() (any, error) {
+			return conn.UpdateDomainConfigWithContext(ctx, &input)
+		},
+			domainErrorRetryable)
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating OpenSearch Domain (%s): %s", d.Id(), err)
 		}
@@ -1462,4 +1438,21 @@ func EBSVolumeTypePermitsThroughputInput(volumeType string) bool {
 		}
 	}
 	return false
+}
+
+func domainErrorRetryable(err error) (bool, error) {
+	switch {
+	case tfawserr.ErrMessageContains(err, "InvalidTypeException", "Error setting policy"),
+		tfawserr.ErrMessageContains(err, "ValidationException", "enable a service-linked role to give Amazon ES permissions"),
+		tfawserr.ErrMessageContains(err, "ValidationException", "Domain is still being deleted"),
+		tfawserr.ErrMessageContains(err, "ValidationException", "Amazon OpenSearch Service must be allowed to use the passed role"),
+		tfawserr.ErrMessageContains(err, "ValidationException", "The passed role has not propagated yet"),
+		tfawserr.ErrMessageContains(err, "ValidationException", "Authentication error"),
+		tfawserr.ErrMessageContains(err, "ValidationException", "Unauthorized Operation: OpenSearch Service must be authorised to describe"),
+		tfawserr.ErrMessageContains(err, "ValidationException", "The passed role must authorize Amazon OpenSearch Service to describe"):
+		return true, err
+
+	default:
+		return false, err
+	}
 }

--- a/internal/service/opensearch/domain_test.go
+++ b/internal/service/opensearch/domain_test.go
@@ -2885,18 +2885,18 @@ resource "aws_opensearch_domain" "test" {
 }
 
 data "aws_iam_policy_document" "test" {
-	statement {
-		actions = ["es:*"]
-		resources = ["arn:${data.aws_partition.current.partition}:es:*"]
-		principals {
-			type = "AWS"
-			identifiers = aws_iam_role.test[*].arn
-		}
-	}
+  statement {
+    actions   = ["es:*"]
+    resources = ["arn:${data.aws_partition.current.partition}:es:*"]
+    principals {
+      type        = "AWS"
+      identifiers = aws_iam_role.test[*].arn
+    }
+  }
 }
 
 resource "aws_iam_role" "test" {
-  count			  = %[2]d
+  count              = %[2]d
   name               = "%[1]s-${count.index}"
   assume_role_policy = data.aws_iam_policy_document.role.json
 }

--- a/internal/service/opensearch/domain_test.go
+++ b/internal/service/opensearch/domain_test.go
@@ -1252,6 +1252,51 @@ func TestAccOpenSearchDomain_Policy_basic(t *testing.T) {
 	})
 }
 
+func TestAccOpenSearchDomain_Policy_addPrincipal(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var domain opensearchservice.DomainStatus
+	resourceName := "aws_opensearch_domain.test"
+	rName := testAccRandomDomainName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIAMServiceLinkedRole(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.OpenSearchServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDomainDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainConfig_policyDocument(rName, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName, &domain),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateId:     rName,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDomainConfig_policyDocument(rName, 2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName, &domain),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateId:           rName,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"access_policies"}, // Principals is a set, and `structure.NormalizeJsonString` doesn't guarantee order
+			},
+		},
+	})
+}
+
 func TestAccOpenSearchDomain_Policy_ignoreEquivalent(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -2822,6 +2867,51 @@ data "aws_iam_policy_document" "test" {
   }
 }
 `, rName)
+}
+
+func testAccDomainConfig_policyDocument(rName string, roleCount int) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_opensearch_domain" "test" {
+  domain_name = %[1]q
+
+  ebs_options {
+    ebs_enabled = true
+    volume_size = 10
+  }
+
+  access_policies = data.aws_iam_policy_document.test.json
+}
+
+data "aws_iam_policy_document" "test" {
+	statement {
+		actions = ["es:*"]
+		resources = ["arn:${data.aws_partition.current.partition}:es:*"]
+		principals {
+			type = "AWS"
+			identifiers = aws_iam_role.test[*].arn
+		}
+	}
+}
+
+resource "aws_iam_role" "test" {
+  count			  = %[2]d
+  name               = "%[1]s-${count.index}"
+  assume_role_policy = data.aws_iam_policy_document.role.json
+}
+
+data "aws_iam_policy_document" "role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.${data.aws_partition.current.dns_suffix}"]
+    }
+  }
+}
+`, rName, roleCount)
 }
 
 func testAccDomainConfig_encryptAtRestDefaultKey(rName, version string, enabled bool) string {

--- a/internal/service/opensearch/wait.go
+++ b/internal/service/opensearch/wait.go
@@ -44,6 +44,9 @@ func WaitForDomainCreation(ctx context.Context, conn *opensearchservice.OpenSear
 	err := tfresource.Retry(ctx, timeout, func() *retry.RetryError {
 		var err error
 		out, err = FindDomainByName(ctx, conn, domainName)
+		if tfresource.NotFound(err) {
+			return retry.RetryableError(err)
+		}
 		if err != nil {
 			return retry.NonRetryableError(err)
 		}


### PR DESCRIPTION
### Description

When adding an IAM Role to the OpenSearch Domain's access policy, IAM eventual consistency sometimes leads to an error such as

> Error: updating OpenSearch Domain (...): InvalidTypeException: Error setting policy:

The error message also wraps the policy in `[` and `]`, suggesting that the policy is unexpectedly a single-element array.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #26433

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=opensearch TESTS=TestAccOpenSearchDomain_Policy_

--- PASS: TestAccOpenSearchDomain_Policy_ignoreEquivalent (2133.95s)
--- PASS: TestAccOpenSearchDomain_Policy_addPrincipal (2116.35s)
--- PASS: TestAccOpenSearchDomain_Policy_basic (2080.24s)
```

Note that there are other existing errors for `aws_opensearch_domain`, mostly

> Error: updating OpenSearch Domain (...): ValidationException: A change/update is in progress. Please wait for it to complete before requesting another change.