### PR TITLE
r/aws_vpc_default_network_acl: Migrate to AWS SDK v2

### DIFF
--- a/internal/service/ec2/exports_test.go
+++ b/internal/service/ec2/exports_test.go
@@ -12,9 +12,8 @@ var (
 	ResourceTag                      = resourceTag
 
 	FindEBSFastSnapshotRestoreByID = findEBSFastSnapshotRestoreByID
-
-	UpdateTags   = updateTags
-	UpdateTagsV2 = updateTagsV2
-
-	StopInstance = stopInstance
+	FindNetworkACLByIDV2           = findNetworkACLByIDV2
+	StopInstance                   = stopInstance
+	UpdateTags                     = updateTags
+	UpdateTagsV2                   = updateTagsV2
 )

--- a/internal/service/ec2/exports_test.go
+++ b/internal/service/ec2/exports_test.go
@@ -5,8 +5,10 @@ package ec2
 
 // Exports for use in tests only.
 var (
+	ResourceDefaultNetworkACL        = resourceDefaultNetworkACL
 	ResourceEBSFastSnapshotRestore   = newResourceEBSFastSnapshotRestore
 	ResourceInstanceConnectEndpoint  = newResourceInstanceConnectEndpoint
+	ResourceNetworkACL               = resourceNetworkACL
 	ResourceSecurityGroupEgressRule  = newResourceSecurityGroupEgressRule
 	ResourceSecurityGroupIngressRule = newResourceSecurityGroupIngressRule
 	ResourceTag                      = resourceTag

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -432,7 +432,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			},
 		},
 		{
-			Factory:  ResourceDefaultNetworkACL,
+			Factory:  resourceDefaultNetworkACL,
 			TypeName: "aws_default_network_acl",
 			Name:     "Network ACL",
 			Tags: &types.ServicePackageResourceTags{
@@ -858,7 +858,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			},
 		},
 		{
-			Factory:  ResourceNetworkACL,
+			Factory:  resourceNetworkACL,
 			TypeName: "aws_network_acl",
 			Name:     "Network ACL",
 			Tags: &types.ServicePackageResourceTags{

--- a/internal/service/ec2/sweep.go
+++ b/internal/service/ec2/sweep.go
@@ -1282,7 +1282,7 @@ func sweepNetworkACLs(region string) error {
 				continue
 			}
 
-			r := ResourceNetworkACL()
+			r := resourceNetworkACL()
 			d := r.Data(nil)
 			d.SetId(aws.StringValue(v.NetworkAclId))
 

--- a/internal/service/ec2/vpc_default_network_acl.go
+++ b/internal/service/ec2/vpc_default_network_acl.go
@@ -27,14 +27,7 @@ const (
 
 // @SDKResource("aws_default_network_acl", name="Network ACL")
 // @Tags(identifierAttribute="id")
-func ResourceDefaultNetworkACL() *schema.Resource {
-	networkACLRuleSetNestedBlock := &schema.Schema{
-		Type:     schema.TypeSet,
-		Optional: true,
-		Elem:     networkACLRuleNestedBlock,
-		Set:      networkACLRuleHash,
-	}
-
+func resourceDefaultNetworkACL() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceDefaultNetworkACLCreate,
 		ReadWithoutTimeout:   resourceNetworkACLRead,
@@ -54,42 +47,53 @@ func ResourceDefaultNetworkACL() *schema.Resource {
 		//    - subnet_ids is not Computed
 		// and additions:
 		//   - default_network_acl_id Required/ForceNew
-		Schema: map[string]*schema.Schema{
-			"arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"default_network_acl_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			// We want explicit management of Rules here, so we do not allow them to be
-			// computed. Instead, an empty config will enforce just that; removal of the
-			// rules
-			"egress":  networkACLRuleSetNestedBlock,
-			"ingress": networkACLRuleSetNestedBlock,
-			"owner_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			// We want explicit management of Subnets here, so we do not allow them to be
-			// computed. Instead, an empty config will enforce just that; removal of the
-			// any Subnets that have been assigned to the Default Network ACL. Because we
-			// can't actually remove them, this will be a continual plan until the
-			// Subnets are themselves destroyed or reassigned to a different Network
-			// ACL
-			"subnet_ids": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			"vpc_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			networkACLRuleSetNestedBlock := func() *schema.Schema {
+				return &schema.Schema{
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem:     networkACLRuleNestedBlock(),
+					Set:      networkACLRuleHash,
+				}
+			}
+
+			return map[string]*schema.Schema{
+				"arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"default_network_acl_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				// We want explicit management of Rules here, so we do not allow them to be
+				// computed. Instead, an empty config will enforce just that; removal of the
+				// rules
+				"egress":  networkACLRuleSetNestedBlock(),
+				"ingress": networkACLRuleSetNestedBlock(),
+				"owner_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				// We want explicit management of Subnets here, so we do not allow them to be
+				// computed. Instead, an empty config will enforce just that; removal of the
+				// any Subnets that have been assigned to the Default Network ACL. Because we
+				// can't actually remove them, this will be a continual plan until the
+				// Subnets are themselves destroyed or reassigned to a different Network
+				// ACL
+				"subnet_ids": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"vpc_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,

--- a/internal/service/ec2/vpc_default_network_acl.go
+++ b/internal/service/ec2/vpc_default_network_acl.go
@@ -6,7 +6,7 @@ package ec2
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -107,7 +107,7 @@ func resourceDefaultNetworkACLCreate(ctx context.Context, d *schema.ResourceData
 		return sdkdiag.AppendErrorf(diags, "reading EC2 Network ACL (%s): %s", naclID, err)
 	}
 
-	if !aws.BoolValue(nacl.IsDefault) {
+	if !aws.ToBool(nacl.IsDefault) {
 		return sdkdiag.AppendErrorf(diags, "use the `aws_network_acl` resource instead")
 	}
 

--- a/internal/service/ec2/vpc_default_network_acl_test.go
+++ b/internal/service/ec2/vpc_default_network_acl_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 
 	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -22,7 +22,7 @@ import (
 
 func TestAccVPCDefaultNetworkACL_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	var v ec2.NetworkAcl
+	var v types.NetworkAcl
 	resourceName := "aws_default_network_acl.test"
 	vpcResourceName := "aws_vpc.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -57,7 +57,7 @@ func TestAccVPCDefaultNetworkACL_basic(t *testing.T) {
 
 func TestAccVPCDefaultNetworkACL_basicIPv6VPC(t *testing.T) {
 	ctx := acctest.Context(t)
-	var v ec2.NetworkAcl
+	var v types.NetworkAcl
 	resourceName := "aws_default_network_acl.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -86,7 +86,7 @@ func TestAccVPCDefaultNetworkACL_basicIPv6VPC(t *testing.T) {
 
 func TestAccVPCDefaultNetworkACL_tags(t *testing.T) {
 	ctx := acctest.Context(t)
-	var v ec2.NetworkAcl
+	var v types.NetworkAcl
 	resourceName := "aws_default_network_acl.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -132,7 +132,7 @@ func TestAccVPCDefaultNetworkACL_tags(t *testing.T) {
 
 func TestAccVPCDefaultNetworkACL_Deny_ingress(t *testing.T) {
 	ctx := acctest.Context(t)
-	var v ec2.NetworkAcl
+	var v types.NetworkAcl
 	resourceName := "aws_default_network_acl.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -169,7 +169,7 @@ func TestAccVPCDefaultNetworkACL_Deny_ingress(t *testing.T) {
 
 func TestAccVPCDefaultNetworkACL_withIPv6Ingress(t *testing.T) {
 	ctx := acctest.Context(t)
-	var v ec2.NetworkAcl
+	var v types.NetworkAcl
 	resourceName := "aws_default_network_acl.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -206,7 +206,7 @@ func TestAccVPCDefaultNetworkACL_withIPv6Ingress(t *testing.T) {
 
 func TestAccVPCDefaultNetworkACL_subnetRemoval(t *testing.T) {
 	ctx := acctest.Context(t)
-	var v ec2.NetworkAcl
+	var v types.NetworkAcl
 	resourceName := "aws_default_network_acl.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -251,7 +251,7 @@ func TestAccVPCDefaultNetworkACL_subnetRemoval(t *testing.T) {
 
 func TestAccVPCDefaultNetworkACL_subnetReassign(t *testing.T) {
 	ctx := acctest.Context(t)
-	var v ec2.NetworkAcl
+	var v types.NetworkAcl
 	resourceName := "aws_default_network_acl.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -308,7 +308,7 @@ func testAccCheckDefaultNetworkACLDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckDefaultNetworkACLExists(ctx context.Context, n string, v *ec2.NetworkAcl) resource.TestCheckFunc {
+func testAccCheckDefaultNetworkACLExists(ctx context.Context, n string, v *types.NetworkAcl) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -319,15 +319,15 @@ func testAccCheckDefaultNetworkACLExists(ctx context.Context, n string, v *ec2.N
 			return fmt.Errorf("No EC2 Default Network ACL ID is set: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Conn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Client(ctx)
 
-		output, err := tfec2.FindNetworkACLByID(ctx, conn, rs.Primary.ID)
+		output, err := tfec2.FindNetworkACLByIDV2(ctx, conn, rs.Primary.ID)
 
 		if err != nil {
 			return err
 		}
 
-		if !aws.BoolValue(output.IsDefault) {
+		if !aws.ToBool(output.IsDefault) {
 			return fmt.Errorf("EC2 Network ACL %s is not a default NACL", rs.Primary.ID)
 		}
 

--- a/internal/service/ec2/vpc_default_network_acl_test.go
+++ b/internal/service/ec2/vpc_default_network_acl_test.go
@@ -158,11 +158,6 @@ func TestAccVPCDefaultNetworkACL_Deny_ingress(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "ingress.#", "0"),
 				),
 			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
 		},
 	})
 }
@@ -195,11 +190,6 @@ func TestAccVPCDefaultNetworkACL_withIPv6Ingress(t *testing.T) {
 					}),
 				),
 			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
 		},
 	})
 }
@@ -225,11 +215,6 @@ func TestAccVPCDefaultNetworkACL_subnetRemoval(t *testing.T) {
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "subnet_ids.*", "aws_subnet.test2", "id"),
 				),
 			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
 			// Here the Subnets have been removed from the Default Network ACL Config,
 			// but have not been reassigned. The result is that the Subnets are still
 			// there, and we have a non-empty plan
@@ -239,11 +224,6 @@ func TestAccVPCDefaultNetworkACL_subnetRemoval(t *testing.T) {
 					testAccCheckDefaultNetworkACLExists(ctx, resourceName, &v),
 				),
 				ExpectNonEmptyPlan: true,
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})

--- a/internal/service/ec2/vpc_network_acl.go
+++ b/internal/service/ec2/vpc_network_acl.go
@@ -30,16 +30,7 @@ import (
 
 // @SDKResource("aws_network_acl", name="Network ACL")
 // @Tags(identifierAttribute="id")
-func ResourceNetworkACL() *schema.Resource {
-	networkACLRuleSetNestedBlock := &schema.Schema{
-		Type:       schema.TypeSet,
-		Optional:   true,
-		Computed:   true,
-		ConfigMode: schema.SchemaConfigModeAttr,
-		Elem:       networkACLRuleNestedBlock,
-		Set:        networkACLRuleHash,
-	}
-
+func resourceNetworkACL() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceNetworkACLCreate,
 		ReadWithoutTimeout:   resourceNetworkACLRead,
@@ -66,30 +57,43 @@ func ResourceNetworkACL() *schema.Resource {
 
 		// Keep in sync with aws_default_network_acl's schema.
 		// See notes in default_network_acl.go.
-		Schema: map[string]*schema.Schema{
-			"arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"egress":  networkACLRuleSetNestedBlock,
-			"ingress": networkACLRuleSetNestedBlock,
-			"owner_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"subnet_ids": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			"vpc_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			networkACLRuleSetNestedBlock := func() *schema.Schema {
+				return &schema.Schema{
+					Type:       schema.TypeSet,
+					Optional:   true,
+					Computed:   true,
+					ConfigMode: schema.SchemaConfigModeAttr,
+					Elem:       networkACLRuleNestedBlock(),
+					Set:        networkACLRuleHash,
+				}
+			}
+
+			return map[string]*schema.Schema{
+				"arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"egress":  networkACLRuleSetNestedBlock(),
+				"ingress": networkACLRuleSetNestedBlock(),
+				"owner_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"subnet_ids": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"vpc_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -98,63 +102,65 @@ func ResourceNetworkACL() *schema.Resource {
 
 // NACL rule nested block definition.
 // Used in aws_network_acl and aws_default_network_acl ingress and egress rule sets.
-var networkACLRuleNestedBlock = &schema.Resource{
-	Schema: map[string]*schema.Schema{
-		"action": {
-			Type:     schema.TypeString,
-			Required: true,
-			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-				return strings.EqualFold(old, new)
+func networkACLRuleNestedBlock() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"action": {
+				Type:     schema.TypeString,
+				Required: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return strings.EqualFold(old, new)
+				},
+				ValidateFunc: validation.StringInSlice(ec2.RuleAction_Values(), true),
 			},
-			ValidateFunc: validation.StringInSlice(ec2.RuleAction_Values(), true),
-		},
-		"cidr_block": {
-			Type:         schema.TypeString,
-			Optional:     true,
-			ValidateFunc: verify.ValidIPv4CIDRNetworkAddress,
-		},
-		"from_port": {
-			Type:         schema.TypeInt,
-			Required:     true,
-			ValidateFunc: validation.IsPortNumberOrZero,
-		},
-		"icmp_code": {
-			Type:     schema.TypeInt,
-			Optional: true,
-		},
-		"icmp_type": {
-			Type:     schema.TypeInt,
-			Optional: true,
-		},
-		"ipv6_cidr_block": {
-			Type:         schema.TypeString,
-			Optional:     true,
-			ValidateFunc: verify.ValidIPv6CIDRNetworkAddress,
-		},
-		"protocol": {
-			Type:     schema.TypeString,
-			Required: true,
-			ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-				_, err := networkACLProtocolNumber(v.(string))
+			"cidr_block": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: verify.ValidIPv4CIDRNetworkAddress,
+			},
+			"from_port": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ValidateFunc: validation.IsPortNumberOrZero,
+			},
+			"icmp_code": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"icmp_type": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"ipv6_cidr_block": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: verify.ValidIPv6CIDRNetworkAddress,
+			},
+			"protocol": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					_, err := networkACLProtocolNumber(v.(string))
 
-				if err != nil {
-					errors = append(errors, fmt.Errorf("%q : %w", k, err))
-				}
+					if err != nil {
+						errors = append(errors, fmt.Errorf("%q : %w", k, err))
+					}
 
-				return
+					return
+				},
+			},
+			"rule_no": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ValidateFunc: validation.IntBetween(1, 32766),
+			},
+			"to_port": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ValidateFunc: validation.IsPortNumberOrZero,
 			},
 		},
-		"rule_no": {
-			Type:         schema.TypeInt,
-			Required:     true,
-			ValidateFunc: validation.IntBetween(1, 32766),
-		},
-		"to_port": {
-			Type:         schema.TypeInt,
-			Required:     true,
-			ValidateFunc: validation.IsPortNumberOrZero,
-		},
-	},
+	}
 }
 
 func resourceNetworkACLCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/service/ec2/vpc_network_acl.go
+++ b/internal/service/ec2/vpc_network_acl.go
@@ -272,6 +272,10 @@ func resourceNetworkACLDelete(ctx context.Context, d *schema.ResourceData, meta 
 	// Delete all NACL/Subnet associations, even if they are managed via aws_network_acl_association resources.
 	nacl, err := FindNetworkACLByID(ctx, conn, d.Id())
 
+	if tfresource.NotFound(err) {
+		return diags
+	}
+
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading EC2 Network ACL (%s): %s", d.Id(), err)
 	}

--- a/internal/service/ec2/vpc_network_acl_test.go
+++ b/internal/service/ec2/vpc_network_acl_test.go
@@ -145,11 +145,6 @@ func TestAccVPCNetworkACL_Egress_mode(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
 				Config: testAccVPCNetworkACLConfig_egressModeNoBlocks(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNetworkACLExists(ctx, resourceName, &v),
@@ -157,21 +152,11 @@ func TestAccVPCNetworkACL_Egress_mode(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
 				Config: testAccVPCNetworkACLConfig_egressModeZeroed(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNetworkACLExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "egress.#", "0"),
 				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})
@@ -197,11 +182,6 @@ func TestAccVPCNetworkACL_Ingress_mode(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
 				Config: testAccVPCNetworkACLConfig_ingressModeNoBlocks(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNetworkACLExists(ctx, resourceName, &v),
@@ -209,21 +189,11 @@ func TestAccVPCNetworkACL_Ingress_mode(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
 				Config: testAccVPCNetworkACLConfig_ingressModeZeroed(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNetworkACLExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "ingress.#", "0"),
 				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})
@@ -263,11 +233,6 @@ func TestAccVPCNetworkACL_egressAndIngressRules(t *testing.T) {
 					}),
 				),
 			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
 		},
 	})
 }
@@ -297,11 +262,6 @@ func TestAccVPCNetworkACL_OnlyIngressRules_basic(t *testing.T) {
 						"cidr_block": "10.2.0.0/18",
 					}),
 				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})
@@ -337,11 +297,6 @@ func TestAccVPCNetworkACL_OnlyIngressRules_update(t *testing.T) {
 						"rule_no":    "2",
 					}),
 				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 			{
 				Config: testAccVPCNetworkACLConfig_ingressChange(rName),
@@ -380,11 +335,6 @@ func TestAccVPCNetworkACL_caseSensitivityNoChanges(t *testing.T) {
 					testAccCheckNetworkACLExists(ctx, resourceName, &v),
 				),
 			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
 		},
 	})
 }
@@ -406,11 +356,6 @@ func TestAccVPCNetworkACL_onlyEgressRules(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkACLExists(ctx, resourceName, &v),
 				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})
@@ -559,11 +504,6 @@ func TestAccVPCNetworkACL_ipv6Rules(t *testing.T) {
 					}),
 				),
 			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
 		},
 	})
 }
@@ -612,11 +552,6 @@ func TestAccVPCNetworkACL_ipv6VPCRules(t *testing.T) {
 					}),
 				),
 			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
 		},
 	})
 }
@@ -638,11 +573,6 @@ func TestAccVPCNetworkACL_espProtocol(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkACLExists(ctx, resourceName, &v),
 				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #36219.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/35747.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS='TestAccVPCDefaultNetworkACL_basic' PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCDefaultNetworkACL_basic'  -timeout 360m
=== RUN   TestAccVPCDefaultNetworkACL_basic
=== PAUSE TestAccVPCDefaultNetworkACL_basic
=== RUN   TestAccVPCDefaultNetworkACL_basicIPv6VPC
=== PAUSE TestAccVPCDefaultNetworkACL_basicIPv6VPC
=== CONT  TestAccVPCDefaultNetworkACL_basic
=== CONT  TestAccVPCDefaultNetworkACL_basicIPv6VPC
--- PASS: TestAccVPCDefaultNetworkACL_basic (15.58s)
--- PASS: TestAccVPCDefaultNetworkACL_basicIPv6VPC (25.41s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	25.503s
```
