### PR TITLE
aws_route53domains_registered_domain: Add billing_contact and billing_privacy

### DIFF
--- a/.changelog/36285.txt
+++ b/.changelog/36285.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_route53domains_registered_domain: Add billing contact and billing privacy support
+resource/aws_route53domains_registered_domain: Add `billing_contact` and `billing_privacy` arguments
 ```

--- a/.changelog/36285.txt
+++ b/.changelog/36285.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_route53domains_registered_domain: Add billing contact and billing privacy support
+```

--- a/internal/service/route53domains/exports_test.go
+++ b/internal/service/route53domains/exports_test.go
@@ -6,6 +6,7 @@ package route53domains
 // Exports for use in tests only.
 var (
 	ResourceDelegationSignerRecord = newDelegationSignerRecordResource
+	ResourceRegisteredDomain       = resourceRegisteredDomain
 
 	FindDNSSECKeyByTwoPartKey = findDNSSECKeyByTwoPartKey
 )

--- a/internal/service/route53domains/registered_domain.go
+++ b/internal/service/route53domains/registered_domain.go
@@ -30,102 +30,7 @@ import (
 
 // @SDKResource("aws_route53domains_registered_domain", name="Registered Domain")
 // @Tags(identifierAttribute="id")
-func ResourceRegisteredDomain() *schema.Resource {
-	contactSchema := &schema.Schema{
-		Type:     schema.TypeList,
-		Optional: true,
-		Computed: true,
-		MaxItems: 1,
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"address_line_1": {
-					Type:         schema.TypeString,
-					Optional:     true,
-					Computed:     true,
-					ValidateFunc: validation.StringLenBetween(0, 255),
-				},
-				"address_line_2": {
-					Type:         schema.TypeString,
-					Optional:     true,
-					Computed:     true,
-					ValidateFunc: validation.StringLenBetween(0, 255),
-				},
-				"city": {
-					Type:         schema.TypeString,
-					Optional:     true,
-					Computed:     true,
-					ValidateFunc: validation.StringLenBetween(0, 255),
-				},
-				"contact_type": {
-					Type:             schema.TypeString,
-					Optional:         true,
-					Computed:         true,
-					ValidateDiagFunc: enum.Validate[types.ContactType](),
-				},
-				"country_code": {
-					Type:             schema.TypeString,
-					Optional:         true,
-					Computed:         true,
-					ValidateDiagFunc: enum.Validate[types.CountryCode](),
-				},
-				"email": {
-					Type:         schema.TypeString,
-					Optional:     true,
-					Computed:     true,
-					ValidateFunc: validation.StringLenBetween(0, 254),
-				},
-				"extra_params": {
-					Type:     schema.TypeMap,
-					Optional: true,
-					Computed: true,
-					Elem:     &schema.Schema{Type: schema.TypeString},
-				},
-				"fax": {
-					Type:         schema.TypeString,
-					Optional:     true,
-					Computed:     true,
-					ValidateFunc: validation.StringLenBetween(0, 30),
-				},
-				"first_name": {
-					Type:         schema.TypeString,
-					Optional:     true,
-					Computed:     true,
-					ValidateFunc: validation.StringLenBetween(0, 255),
-				},
-				"last_name": {
-					Type:         schema.TypeString,
-					Optional:     true,
-					Computed:     true,
-					ValidateFunc: validation.StringLenBetween(0, 255),
-				},
-				"organization_name": {
-					Type:         schema.TypeString,
-					Optional:     true,
-					Computed:     true,
-					ValidateFunc: validation.StringLenBetween(0, 255),
-				},
-				"phone_number": {
-					Type:         schema.TypeString,
-					Optional:     true,
-					Computed:     true,
-					ValidateFunc: validation.StringLenBetween(0, 30),
-				},
-				"state": {
-					Type:         schema.TypeString,
-					Optional:     true,
-					Computed:     true,
-					ValidateFunc: validation.StringLenBetween(0, 255),
-				},
-				"zip_code": {
-					Type:         schema.TypeString,
-					Optional:     true,
-					Computed:     true,
-					ValidateFunc: validation.StringLenBetween(0, 255),
-				},
-			},
-		},
-	}
-
+func resourceRegisteredDomain() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceRegisteredDomainCreate,
 		ReadWithoutTimeout:   resourceRegisteredDomainRead,
@@ -141,115 +46,214 @@ func ResourceRegisteredDomain() *schema.Resource {
 			Update: schema.DefaultTimeout(30 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			"abuse_contact_email": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"abuse_contact_phone": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"admin_contact": contactSchema,
-			"admin_privacy": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-			"auto_renew": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-			"billing_contact": contactSchema,
-			"billing_privacy": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-			"creation_date": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"domain_name": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"expiration_date": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"name_server": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 6,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"glue_ips": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							MaxItems: 2,
-							Elem: &schema.Schema{
+		SchemaFunc: func() map[string]*schema.Schema {
+			contactSchema := func() *schema.Schema {
+				return &schema.Schema{
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"address_line_1": {
 								Type:         schema.TypeString,
-								ValidateFunc: validation.IsIPAddress,
+								Optional:     true,
+								Computed:     true,
+								ValidateFunc: validation.StringLenBetween(0, 255),
+							},
+							"address_line_2": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								Computed:     true,
+								ValidateFunc: validation.StringLenBetween(0, 255),
+							},
+							"city": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								Computed:     true,
+								ValidateFunc: validation.StringLenBetween(0, 255),
+							},
+							"contact_type": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Computed:         true,
+								ValidateDiagFunc: enum.Validate[types.ContactType](),
+							},
+							"country_code": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Computed:         true,
+								ValidateDiagFunc: enum.Validate[types.CountryCode](),
+							},
+							"email": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								Computed:     true,
+								ValidateFunc: validation.StringLenBetween(0, 254),
+							},
+							"extra_params": {
+								Type:     schema.TypeMap,
+								Optional: true,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							"fax": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								Computed:     true,
+								ValidateFunc: validation.StringLenBetween(0, 30),
+							},
+							"first_name": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								Computed:     true,
+								ValidateFunc: validation.StringLenBetween(0, 255),
+							},
+							"last_name": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								Computed:     true,
+								ValidateFunc: validation.StringLenBetween(0, 255),
+							},
+							"organization_name": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								Computed:     true,
+								ValidateFunc: validation.StringLenBetween(0, 255),
+							},
+							"phone_number": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								Computed:     true,
+								ValidateFunc: validation.StringLenBetween(0, 30),
+							},
+							"state": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								Computed:     true,
+								ValidateFunc: validation.StringLenBetween(0, 255),
+							},
+							"zip_code": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								Computed:     true,
+								ValidateFunc: validation.StringLenBetween(0, 255),
 							},
 						},
-						"name": {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.All(
-								validation.StringLenBetween(1, 255),
-								validation.StringMatch(regexache.MustCompile(`[0-9A-Za-z_.-]*`), "can contain only alphabetical characters (A-Z or a-z), numeric characters (0-9), underscore (_), the minus sign (-), and the period (.)"),
-							),
+					},
+				}
+			}
+
+			return map[string]*schema.Schema{
+				"abuse_contact_email": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"abuse_contact_phone": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"admin_contact": contactSchema(),
+				"admin_privacy": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  true,
+				},
+				"auto_renew": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  true,
+				},
+				"billing_contact": contactSchema(),
+				"billing_privacy": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  true,
+				},
+				"creation_date": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"domain_name": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"expiration_date": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"name_server": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					MaxItems: 6,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"glue_ips": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								MaxItems: 2,
+								Elem: &schema.Schema{
+									Type:         schema.TypeString,
+									ValidateFunc: validation.IsIPAddress,
+								},
+							},
+							"name": {
+								Type:     schema.TypeString,
+								Required: true,
+								ValidateFunc: validation.All(
+									validation.StringLenBetween(1, 255),
+									validation.StringMatch(regexache.MustCompile(`[0-9A-Za-z_.-]*`), "can contain only alphabetical characters (A-Z or a-z), numeric characters (0-9), underscore (_), the minus sign (-), and the period (.)"),
+								),
+							},
 						},
 					},
 				},
-			},
-			"registrant_contact": contactSchema,
-			"registrant_privacy": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-			"registrar_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"registrar_url": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"reseller": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"status_list": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			"tech_contact":    contactSchema,
-			"tech_privacy": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-			"transfer_lock": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-			"updated_date": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"whois_server": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+				"registrant_contact": contactSchema(),
+				"registrant_privacy": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  true,
+				},
+				"registrar_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"registrar_url": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"reseller": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"status_list": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"tech_contact":    contactSchema(),
+				"tech_privacy": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  true,
+				},
+				"transfer_lock": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  true,
+				},
+				"updated_date": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"whois_server": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,

--- a/internal/service/route53domains/registered_domain_test.go
+++ b/internal/service/route53domains/registered_domain_test.go
@@ -118,7 +118,7 @@ func testAccRegisteredDomain_contacts(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "billing_contact.0.fax", "+61.412345678"),
 					resource.TestCheckResourceAttr(resourceName, "billing_contact.0.first_name", "John"),
 					resource.TestCheckResourceAttr(resourceName, "billing_contact.0.last_name", "Cleese"),
-					resource.TestCheckResourceAttr(resourceName, "billing_contact.0.organization_name", "Monty Python"),
+					resource.TestCheckResourceAttr(resourceName, "billing_contact.0.organization_name", ""),
 					resource.TestCheckResourceAttr(resourceName, "billing_contact.0.phone_number", "+61.412345679"),
 					resource.TestCheckResourceAttr(resourceName, "billing_contact.0.state", "ACT"),
 					resource.TestCheckResourceAttr(resourceName, "billing_contact.0.zip_code", "2606"),
@@ -371,7 +371,6 @@ resource "aws_route53domains_registered_domain" "test" {
     fax               = "+61.412345678"
     first_name        = "John"
     last_name         = "Cleese"
-    organization_name = "Monty Python"
     phone_number      = "+61.412345679"
     state             = "ACT"
     zip_code          = "2606"

--- a/internal/service/route53domains/registered_domain_test.go
+++ b/internal/service/route53domains/registered_domain_test.go
@@ -108,6 +108,20 @@ func testAccRegisteredDomain_contacts(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "admin_contact.0.organization_name", "Support"),
 					resource.TestCheckResourceAttr(resourceName, "admin_contact.0.phone_number", "+44.123456789"),
 					resource.TestCheckResourceAttr(resourceName, "admin_contact.0.zip_code", "ST1 1AB"),
+					resource.TestCheckResourceAttr(resourceName, "billing_contact.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "billing_contact.0.address_line_1", "1 Mawson Street"),
+					resource.TestCheckResourceAttr(resourceName, "billing_contact.0.address_line_2", "Unit 2"),
+					resource.TestCheckResourceAttr(resourceName, "billing_contact.0.city", "Mawson"),
+					resource.TestCheckResourceAttr(resourceName, "billing_contact.0.contact_type", "PERSON"),
+					resource.TestCheckResourceAttr(resourceName, "billing_contact.0.country_code", "AU"),
+					resource.TestCheckResourceAttr(resourceName, "billing_contact.0.email", "terraform-acctest+aws-route53domains-test4@hashicorp.com"),
+					resource.TestCheckResourceAttr(resourceName, "billing_contact.0.fax", "+61.412345678"),
+					resource.TestCheckResourceAttr(resourceName, "billing_contact.0.first_name", "John"),
+					resource.TestCheckResourceAttr(resourceName, "billing_contact.0.last_name", "Cleese"),
+					resource.TestCheckResourceAttr(resourceName, "billing_contact.0.organization_name", "Monty Python"),
+					resource.TestCheckResourceAttr(resourceName, "billing_contact.0.phone_number", "+61.412345679"),
+					resource.TestCheckResourceAttr(resourceName, "billing_contact.0.state", "ACT"),
+					resource.TestCheckResourceAttr(resourceName, "billing_contact.0.zip_code", "2606"),
 					resource.TestCheckResourceAttr(resourceName, "registrant_contact.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "registrant_contact.0.address_line_1", "100 Main Street"),
 					resource.TestCheckResourceAttr(resourceName, "registrant_contact.0.city", "New York City"),
@@ -148,6 +162,19 @@ func testAccRegisteredDomain_contacts(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "admin_contact.0.phone_number", "+1.4155551234"),
 					resource.TestCheckResourceAttr(resourceName, "admin_contact.0.state", "CA"),
 					resource.TestCheckResourceAttr(resourceName, "admin_contact.0.zip_code", "94105"),
+					resource.TestCheckResourceAttr(resourceName, "billing_contact.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "billing_contact.0.address_line_1", "101 2nd St #700"),
+					resource.TestCheckResourceAttr(resourceName, "billing_contact.0.city", "San Francisco"),
+					resource.TestCheckResourceAttr(resourceName, "billing_contact.0.contact_type", "COMPANY"),
+					resource.TestCheckResourceAttr(resourceName, "billing_contact.0.country_code", "US"),
+					resource.TestCheckResourceAttr(resourceName, "billing_contact.0.email", "terraform-acctest+aws@hashicorp.com"),
+					resource.TestCheckResourceAttr(resourceName, "billing_contact.0.fax", "+1.4155551234"),
+					resource.TestCheckResourceAttr(resourceName, "billing_contact.0.first_name", "Terraform"),
+					resource.TestCheckResourceAttr(resourceName, "billing_contact.0.last_name", "Team"),
+					resource.TestCheckResourceAttr(resourceName, "billing_contact.0.organization_name", "HashiCorp"),
+					resource.TestCheckResourceAttr(resourceName, "billing_contact.0.phone_number", "+1.4155551234"),
+					resource.TestCheckResourceAttr(resourceName, "billing_contact.0.state", "CA"),
+					resource.TestCheckResourceAttr(resourceName, "billing_contact.0.zip_code", "94105"),
 					resource.TestCheckResourceAttr(resourceName, "registrant_contact.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "registrant_contact.0.address_line_1", "101 2nd St #700"),
 					resource.TestCheckResourceAttr(resourceName, "registrant_contact.0.city", "San Francisco"),
@@ -192,17 +219,19 @@ func testAccRegisteredDomain_contactPrivacy(t *testing.T) {
 		CheckDestroy:             acctest.CheckDestroyNoop,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRegisteredDomainConfig_contactPrivacy(domainName, true, true, true),
+				Config: testAccRegisteredDomainConfig_contactPrivacy(domainName, true, true, true, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "admin_privacy", "true"),
+					resource.TestCheckResourceAttr(resourceName, "billing_privacy", "true"),
 					resource.TestCheckResourceAttr(resourceName, "registrant_privacy", "true"),
 					resource.TestCheckResourceAttr(resourceName, "tech_privacy", "true"),
 				),
 			},
 			{
-				Config: testAccRegisteredDomainConfig_contactPrivacy(domainName, false, false, false),
+				Config: testAccRegisteredDomainConfig_contactPrivacy(domainName, false, false, false, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "admin_privacy", "false"),
+					resource.TestCheckResourceAttr(resourceName, "billing_privacy", "false"),
 					resource.TestCheckResourceAttr(resourceName, "registrant_privacy", "false"),
 					resource.TestCheckResourceAttr(resourceName, "tech_privacy", "false"),
 				),
@@ -332,6 +361,22 @@ resource "aws_route53domains_registered_domain" "test" {
     zip_code          = "ST1 1AB"
   }
 
+  billing_contact {
+    address_line_1    = "1 Mawson Street"
+    address_line_2    = "Unit 2"
+    city              = "Mawson"
+    contact_type      = "PERSON"
+    country_code      = "AU"
+    email             = "terraform-acctest+aws-route53domains-test4@hashicorp.com"
+    fax               = "+61.412345678"
+    first_name        = "John"
+    last_name         = "Cleese"
+    organization_name = "Monty Python"
+    phone_number      = "+61.412345679"
+    state             = "ACT"
+    zip_code          = "2606"
+  }
+
   registrant_contact {
     address_line_1    = "100 Main Street"
     city              = "New York City"
@@ -381,6 +426,21 @@ resource "aws_route53domains_registered_domain" "test" {
     zip_code          = "94105"
   }
 
+  billing_contact {
+    address_line_1    = "101 2nd St #700"
+    city              = "San Francisco"
+    contact_type      = "COMPANY"
+    country_code      = "US"
+    email             = "terraform-acctest+aws@hashicorp.com"
+    fax               = "+1.4155551234"
+    first_name        = "Terraform"
+    last_name         = "Team"
+    organization_name = "HashiCorp"
+    phone_number      = "+1.4155551234"
+    state             = "CA"
+    zip_code          = "94105"
+  }
+
   registrant_contact {
     address_line_1    = "101 2nd St #700"
     city              = "San Francisco"
@@ -414,16 +474,17 @@ resource "aws_route53domains_registered_domain" "test" {
 `, domainName)
 }
 
-func testAccRegisteredDomainConfig_contactPrivacy(domainName string, adminPrivacy, registrantPrivacy, techPrivacy bool) string {
+func testAccRegisteredDomainConfig_contactPrivacy(domainName string, adminPrivacy, billingPrivacy, registrantPrivacy, techPrivacy bool) string {
 	return fmt.Sprintf(`
 resource "aws_route53domains_registered_domain" "test" {
   domain_name = %[1]q
 
   admin_privacy      = %[2]t
-  registrant_privacy = %[3]t
-  tech_privacy       = %[4]t
+  billing_privacy    = %[3]t
+  registrant_privacy = %[4]t
+  tech_privacy       = %[5]t
 }
-`, domainName, adminPrivacy, registrantPrivacy, techPrivacy)
+`, domainName, adminPrivacy, billingPrivacy, registrantPrivacy, techPrivacy)
 }
 
 func testAccRegisteredDomainConfig_nameservers(domainName string) string {

--- a/internal/service/route53domains/registered_domain_test.go
+++ b/internal/service/route53domains/registered_domain_test.go
@@ -362,18 +362,18 @@ resource "aws_route53domains_registered_domain" "test" {
   }
 
   billing_contact {
-    address_line_1    = "1 Mawson Street"
-    address_line_2    = "Unit 2"
-    city              = "Mawson"
-    contact_type      = "PERSON"
-    country_code      = "AU"
-    email             = "terraform-acctest+aws-route53domains-test4@hashicorp.com"
-    fax               = "+61.412345678"
-    first_name        = "John"
-    last_name         = "Cleese"
-    phone_number      = "+61.412345679"
-    state             = "ACT"
-    zip_code          = "2606"
+    address_line_1 = "1 Mawson Street"
+    address_line_2 = "Unit 2"
+    city           = "Mawson"
+    contact_type   = "PERSON"
+    country_code   = "AU"
+    email          = "terraform-acctest+aws-route53domains-test4@hashicorp.com"
+    fax            = "+61.412345678"
+    first_name     = "John"
+    last_name      = "Cleese"
+    phone_number   = "+61.412345679"
+    state          = "ACT"
+    zip_code       = "2606"
   }
 
   registrant_contact {

--- a/internal/service/route53domains/registered_domain_test.go
+++ b/internal/service/route53domains/registered_domain_test.go
@@ -99,7 +99,7 @@ func testAccRegisteredDomain_contacts(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "admin_contact.0.address_line_1", "99 High Street"),
 					resource.TestCheckResourceAttr(resourceName, "admin_contact.0.address_line_2", "Flat 1a"),
 					resource.TestCheckResourceAttr(resourceName, "admin_contact.0.city", "Little Nowhere"),
-					resource.TestCheckResourceAttr(resourceName, "admin_contact.0.contact_type", "ASSOCIATION"),
+					resource.TestCheckResourceAttr(resourceName, "admin_contact.0.contact_type", "COMPANY"),
 					resource.TestCheckResourceAttr(resourceName, "admin_contact.0.country_code", "GB"),
 					resource.TestCheckResourceAttr(resourceName, "admin_contact.0.email", "terraform-acctest+aws-route53domains-test1@hashicorp.com"),
 					resource.TestCheckResourceAttr(resourceName, "admin_contact.0.fax", "+44.123456788"),
@@ -350,7 +350,7 @@ resource "aws_route53domains_registered_domain" "test" {
     address_line_1    = "99 High Street"
     address_line_2    = "Flat 1a"
     city              = "Little Nowhere"
-    contact_type      = "ASSOCIATION"
+    contact_type      = "COMPANY"
     country_code      = "GB"
     email             = "terraform-acctest+aws-route53domains-test1@hashicorp.com"
     fax               = "+44.123456788"

--- a/internal/service/route53domains/service_package_gen.go
+++ b/internal/service/route53domains/service_package_gen.go
@@ -32,7 +32,7 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePackageSDKResource {
 	return []*types.ServicePackageSDKResource{
 		{
-			Factory:  ResourceRegisteredDomain,
+			Factory:  resourceRegisteredDomain,
 			TypeName: "aws_route53domains_registered_domain",
 			Name:     "Registered Domain",
 			Tags: &types.ServicePackageResourceTags{

--- a/website/docs/r/route53domains_registered_domain.html.markdown
+++ b/website/docs/r/route53domains_registered_domain.html.markdown
@@ -43,6 +43,8 @@ This argument supports the following arguments:
 * `admin_contact` - (Optional) Details about the domain administrative contact. See [Contact Blocks](#contact-blocks) for more details.
 * `admin_privacy` - (Optional) Whether domain administrative contact information is concealed from WHOIS queries. Default: `true`.
 * `auto_renew` - (Optional) Whether the domain registration is set to renew automatically. Default: `true`.
+* `billing_contact` - (Optional) Details about the domain billing contact. See [Contact Blocks](#contact-blocks) for more details.
+* `billing_privacy` - (Optional) Whether domain billing contact information is concealed from WHOIS queries. Default: `true`.
 * `domain_name` - (Required) The name of the registered domain.
 * `name_server` - (Optional) The list of nameservers for the domain. See [`name_server` Blocks](#name_server-blocks) for more details.
 * `registrant_contact` - (Optional) Details about the domain registrant. See [Contact Blocks](#contact-blocks) for more details.


### PR DESCRIPTION
### Description
This changeset adds billing_contact and billing_privacy to the aws_route53domains_registered_domain resource.


### Relations
Closes #36269 


### References
Please see the corresponding issue for references


### Output from Acceptance Testing
No acceptance tests were executed as I don't have a test domain to execute them on at the moment.