### PR TITLE
d/aws_acm_certificate: Migrate tests to AWS SDK v2

### DIFF
--- a/internal/service/acm/certificate_data_source_test.go
+++ b/internal/service/acm/certificate_data_source_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go/service/acm"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/acm/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
@@ -52,23 +52,23 @@ func TestAccACMCertificateDataSource_singleIssued(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					//lintignore:AWSAT001
 					resource.TestMatchResourceAttr(resourceName, "arn", arnRe),
-					resource.TestCheckResourceAttr(resourceName, "status", acm.CertificateStatusIssued),
+					resource.TestCheckResourceAttr(resourceName, "status", string(awstypes.CertificateStatusIssued)),
 					resource.TestCheckResourceAttrSet(resourceName, "certificate"),
 					resource.TestCheckResourceAttrSet(resourceName, "certificate_chain"),
 				),
 			},
 			{
-				Config: testAccCertificateDataSourceConfig_status(domain, acm.CertificateStatusIssued),
+				Config: testAccCertificateDataSourceConfig_status(domain, string(awstypes.CertificateStatusIssued)),
 				Check: resource.ComposeTestCheckFunc(
 					//lintignore:AWSAT001
 					resource.TestMatchResourceAttr(resourceName, "arn", arnRe),
-					resource.TestCheckResourceAttr(resourceName, "status", acm.CertificateStatusIssued),
+					resource.TestCheckResourceAttr(resourceName, "status", string(awstypes.CertificateStatusIssued)),
 					resource.TestCheckResourceAttrSet(resourceName, "certificate"),
 					resource.TestCheckResourceAttrSet(resourceName, "certificate_chain"),
 				),
 			},
 			{
-				Config: testAccCertificateDataSourceConfig_types(domain, acm.CertificateTypeAmazonIssued),
+				Config: testAccCertificateDataSourceConfig_types(domain, string(awstypes.CertificateTypeAmazonIssued)),
 				Check: resource.ComposeTestCheckFunc(
 					//lintignore:AWSAT001
 					resource.TestMatchResourceAttr(resourceName, "arn", arnRe),
@@ -86,7 +86,7 @@ func TestAccACMCertificateDataSource_singleIssued(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCertificateDataSourceConfig_mostRecentAndStatus(domain, acm.CertificateStatusIssued, true),
+				Config: testAccCertificateDataSourceConfig_mostRecentAndStatus(domain, string(awstypes.CertificateStatusIssued), true),
 				Check: resource.ComposeTestCheckFunc(
 					//lintignore:AWSAT001
 					resource.TestMatchResourceAttr(resourceName, "arn", arnRe),
@@ -95,7 +95,7 @@ func TestAccACMCertificateDataSource_singleIssued(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCertificateDataSourceConfig_mostRecentAndTypes(domain, acm.CertificateTypeAmazonIssued, true),
+				Config: testAccCertificateDataSourceConfig_mostRecentAndTypes(domain, string(awstypes.CertificateTypeAmazonIssued), true),
 				Check: resource.ComposeTestCheckFunc(
 					//lintignore:AWSAT001
 					resource.TestMatchResourceAttr(resourceName, "arn", arnRe),
@@ -140,11 +140,11 @@ func TestAccACMCertificateDataSource_multipleIssued(t *testing.T) {
 				ExpectError: regexache.MustCompile(`multiple ACM Certificates matching domain`),
 			},
 			{
-				Config:      testAccCertificateDataSourceConfig_status(domain, acm.CertificateStatusIssued),
+				Config:      testAccCertificateDataSourceConfig_status(domain, string(awstypes.CertificateStatusIssued)),
 				ExpectError: regexache.MustCompile(`multiple ACM Certificates matching domain`),
 			},
 			{
-				Config:      testAccCertificateDataSourceConfig_types(domain, acm.CertificateTypeAmazonIssued),
+				Config:      testAccCertificateDataSourceConfig_types(domain, string(awstypes.CertificateTypeAmazonIssued)),
 				ExpectError: regexache.MustCompile(`multiple ACM Certificates matching domain`),
 			},
 			{
@@ -155,14 +155,14 @@ func TestAccACMCertificateDataSource_multipleIssued(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCertificateDataSourceConfig_mostRecentAndStatus(domain, acm.CertificateStatusIssued, true),
+				Config: testAccCertificateDataSourceConfig_mostRecentAndStatus(domain, string(awstypes.CertificateStatusIssued), true),
 				Check: resource.ComposeTestCheckFunc(
 					//lintignore:AWSAT001
 					resource.TestMatchResourceAttr(resourceName, "arn", arnRe),
 				),
 			},
 			{
-				Config: testAccCertificateDataSourceConfig_mostRecentAndTypes(domain, acm.CertificateTypeAmazonIssued, true),
+				Config: testAccCertificateDataSourceConfig_mostRecentAndTypes(domain, string(awstypes.CertificateTypeAmazonIssued), true),
 				Check: resource.ComposeTestCheckFunc(
 					//lintignore:AWSAT001
 					resource.TestMatchResourceAttr(resourceName, "arn", arnRe),
@@ -190,11 +190,11 @@ func TestAccACMCertificateDataSource_noMatchReturnsError(t *testing.T) {
 				ExpectError: regexache.MustCompile(`no ACM Certificate matching domain`),
 			},
 			{
-				Config:      testAccCertificateDataSourceConfig_status(domain, acm.CertificateStatusIssued),
+				Config:      testAccCertificateDataSourceConfig_status(domain, string(awstypes.CertificateStatusIssued)),
 				ExpectError: regexache.MustCompile(`no ACM Certificate matching domain`),
 			},
 			{
-				Config:      testAccCertificateDataSourceConfig_types(domain, acm.CertificateTypeAmazonIssued),
+				Config:      testAccCertificateDataSourceConfig_types(domain, string(awstypes.CertificateTypeAmazonIssued)),
 				ExpectError: regexache.MustCompile(`no ACM Certificate matching domain`),
 			},
 			{
@@ -202,11 +202,11 @@ func TestAccACMCertificateDataSource_noMatchReturnsError(t *testing.T) {
 				ExpectError: regexache.MustCompile(`no ACM Certificate matching domain`),
 			},
 			{
-				Config:      testAccCertificateDataSourceConfig_mostRecentAndStatus(domain, acm.CertificateStatusIssued, true),
+				Config:      testAccCertificateDataSourceConfig_mostRecentAndStatus(domain, string(awstypes.CertificateStatusIssued), true),
 				ExpectError: regexache.MustCompile(`no ACM Certificate matching domain`),
 			},
 			{
-				Config:      testAccCertificateDataSourceConfig_mostRecentAndTypes(domain, acm.CertificateTypeAmazonIssued, true),
+				Config:      testAccCertificateDataSourceConfig_mostRecentAndTypes(domain, string(awstypes.CertificateTypeAmazonIssued), true),
 				ExpectError: regexache.MustCompile(`no ACM Certificate matching domain`),
 			},
 		},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #32976

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS='TestAccACMCertificateDataSource_' PKG=acm
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/acm/... -v -count 1 -parallel 20 -run='TestAccACMCertificateDataSource_'  -timeout 360m
=== RUN   TestAccACMCertificateDataSource_singleIssued
=== PAUSE TestAccACMCertificateDataSource_singleIssued
=== RUN   TestAccACMCertificateDataSource_multipleIssued
=== PAUSE TestAccACMCertificateDataSource_multipleIssued
=== RUN   TestAccACMCertificateDataSource_noMatchReturnsError
=== PAUSE TestAccACMCertificateDataSource_noMatchReturnsError
=== RUN   TestAccACMCertificateDataSource_keyTypes
=== PAUSE TestAccACMCertificateDataSource_keyTypes
=== CONT  TestAccACMCertificateDataSource_singleIssued
=== CONT  TestAccACMCertificateDataSource_noMatchReturnsError
=== CONT  TestAccACMCertificateDataSource_keyTypes
=== CONT  TestAccACMCertificateDataSource_multipleIssued
=== NAME  TestAccACMCertificateDataSource_keyTypes
    certificate_data_source_test.go:224: Step 1/1 error: Error running apply: exit status 1
        
        Error: no ACM Certificate matching domain (wnw0wv9k.test)
        
          with data.aws_acm_certificate.test,
          on terraform_plugin_test.tf line 21, in data "aws_acm_certificate" "test":
          21: data "aws_acm_certificate" "test" {
        
--- FAIL: TestAccACMCertificateDataSource_keyTypes (7.68s)
--- PASS: TestAccACMCertificateDataSource_noMatchReturnsError (8.65s)
--- PASS: TestAccACMCertificateDataSource_multipleIssued (32.13s)
--- PASS: TestAccACMCertificateDataSource_singleIssued (46.72s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/acm	47.429s
FAIL
make: *** [GNUmakefile:368: testacc] Error 1
...
```