### PR TITLE
Docs: Update Lightsail default bundle_id to reflect current availability

### DIFF
--- a/internal/service/lightsail/bucket_resource_access_test.go
+++ b/internal/service/lightsail/bucket_resource_access_test.go
@@ -160,7 +160,7 @@ resource "aws_lightsail_instance" "test" {
   name              = %[1]q
   availability_zone = data.aws_availability_zones.available.names[0]
   blueprint_id      = "amazon_linux_2"
-  bundle_id         = "nano_1_0"
+  bundle_id         = "nano_3_0"
 }
 
 resource "aws_lightsail_bucket_resource_access" "test" {

--- a/internal/service/lightsail/disk_attachment_test.go
+++ b/internal/service/lightsail/disk_attachment_test.go
@@ -160,7 +160,7 @@ resource "aws_lightsail_instance" "test" {
   name              = %[2]q
   availability_zone = data.aws_availability_zones.available.names[0]
   blueprint_id      = "amazon_linux_2"
-  bundle_id         = "nano_1_0"
+  bundle_id         = "nano_3_0"
 }
 
 resource "aws_lightsail_disk_attachment" "test" {

--- a/internal/service/lightsail/instance_public_ports_test.go
+++ b/internal/service/lightsail/instance_public_ports_test.go
@@ -278,7 +278,7 @@ resource "aws_lightsail_instance" "test" {
   name              = %[1]q
   availability_zone = data.aws_availability_zones.available.names[0]
   blueprint_id      = "amazon_linux_2"
-  bundle_id         = "nano_1_0"
+  bundle_id         = "nano_3_0"
 }
 
 resource "aws_lightsail_instance_public_ports" "test" {
@@ -308,7 +308,7 @@ resource "aws_lightsail_instance" "test" {
   name              = %[1]q
   availability_zone = data.aws_availability_zones.available.names[0]
   blueprint_id      = "amazon_linux_2"
-  bundle_id         = "nano_1_0"
+  bundle_id         = "nano_3_0"
 }
 
 resource "aws_lightsail_instance_public_ports" "test" {
@@ -344,7 +344,7 @@ resource "aws_lightsail_instance" "test" {
   name              = %[1]q
   availability_zone = data.aws_availability_zones.available.names[0]
   blueprint_id      = "amazon_linux_2"
-  bundle_id         = "nano_1_0"
+  bundle_id         = "nano_3_0"
 }
 
 resource "aws_lightsail_instance_public_ports" "test" {
@@ -375,7 +375,7 @@ resource "aws_lightsail_instance" "test" {
   name              = %[1]q
   availability_zone = data.aws_availability_zones.available.names[0]
   blueprint_id      = "amazon_linux_2"
-  bundle_id         = "nano_1_0"
+  bundle_id         = "nano_3_0"
 }
 
 resource "aws_lightsail_instance_public_ports" "test" {

--- a/internal/service/lightsail/instance_test.go
+++ b/internal/service/lightsail/instance_test.go
@@ -415,7 +415,7 @@ resource "aws_lightsail_instance" "test" {
   name              = "%s"
   availability_zone = data.aws_availability_zones.available.names[0]
   blueprint_id      = "amazon_linux_2"
-  bundle_id         = "nano_1_0"
+  bundle_id         = "nano_3_0"
 }
 `, rName))
 }
@@ -428,7 +428,7 @@ resource "aws_lightsail_instance" "test" {
   name              = %[1]q
   availability_zone = %[2]q
   blueprint_id      = "amazon_linux_2"
-  bundle_id         = "nano_1_0"
+  bundle_id         = "nano_3_0"
 }
 `, rName, availabilityZone))
 }
@@ -441,7 +441,7 @@ resource "aws_lightsail_instance" "test" {
   name              = "%s"
   availability_zone = data.aws_availability_zones.available.names[0]
   blueprint_id      = "amazon_linux_2"
-  bundle_id         = "nano_1_0"
+  bundle_id         = "nano_3_0"
 
   tags = {
     Name = "tf-test"
@@ -458,7 +458,7 @@ resource "aws_lightsail_instance" "test" {
   name              = "%s"
   availability_zone = data.aws_availability_zones.available.names[0]
   blueprint_id      = "amazon_linux_2"
-  bundle_id         = "nano_1_0"
+  bundle_id         = "nano_3_0"
 
   tags = {
     Name      = "tf-test",
@@ -476,7 +476,7 @@ resource "aws_lightsail_instance" "test" {
   name              = %[1]q
   availability_zone = data.aws_availability_zones.available.names[0]
   blueprint_id      = "amazon_linux_2"
-  bundle_id         = "nano_1_0"
+  bundle_id         = "nano_3_0"
   ip_address_type   = %[2]q
 }
 `, rName, rIPAddressType))
@@ -490,7 +490,7 @@ resource "aws_lightsail_instance" "test" {
   name              = %[1]q
   availability_zone = data.aws_availability_zones.available.names[0]
   blueprint_id      = "amazon_linux_2"
-  bundle_id         = "nano_1_0"
+  bundle_id         = "nano_3_0"
   add_on {
     type          = "AutoSnapshot"
     snapshot_time = %[2]q

--- a/internal/service/lightsail/lb_attachment_test.go
+++ b/internal/service/lightsail/lb_attachment_test.go
@@ -152,7 +152,7 @@ resource "aws_lightsail_instance" "test" {
   name              = %[2]q
   availability_zone = data.aws_availability_zones.available.names[0]
   blueprint_id      = "amazon_linux_2"
-  bundle_id         = "nano_1_0"
+  bundle_id         = "nano_3_0"
 }
 resource "aws_lightsail_lb_attachment" "test" {
   lb_name       = aws_lightsail_lb.test.name

--- a/website/docs/cdktf/python/r/lightsail_bucket_resource_access.html.markdown
+++ b/website/docs/cdktf/python/r/lightsail_bucket_resource_access.html.markdown
@@ -42,7 +42,7 @@ class MyConvertedCode(TerraformStack):
         aws_lightsail_instance_test = LightsailInstance(self, "test_2",
             availability_zone="us-east-1b",
             blueprint_id="amazon_linux_2",
-            bundle_id="nano_1_0",
+            bundle_id="nano_3_0",
             name="mytestinstance"
         )
         # This allows the Terraform resource name to match the original name. You can remove the call if you don't need them to match.

--- a/website/docs/cdktf/python/r/lightsail_disk_attachment.html.markdown
+++ b/website/docs/cdktf/python/r/lightsail_disk_attachment.html.markdown
@@ -45,7 +45,7 @@ class MyConvertedCode(TerraformStack):
         aws_lightsail_instance_test = LightsailInstance(self, "test_2",
             availability_zone=Token.as_string(Fn.lookup_nested(available.names, ["0"])),
             blueprint_id="amazon_linux_2",
-            bundle_id="nano_1_0",
+            bundle_id="nano_3_0",
             name="test-instance"
         )
         # This allows the Terraform resource name to match the original name. You can remove the call if you don't need them to match.

--- a/website/docs/cdktf/python/r/lightsail_distribution.html.markdown
+++ b/website/docs/cdktf/python/r/lightsail_distribution.html.markdown
@@ -166,7 +166,7 @@ class MyConvertedCode(TerraformStack):
         aws_lightsail_instance_test = LightsailInstance(self, "test_2",
             availability_zone=Token.as_string(Fn.lookup_nested(available.names, ["0"])),
             blueprint_id="amazon_linux_2",
-            bundle_id="nano_1_0",
+            bundle_id="nano_3_0",
             name="test-instance"
         )
         # This allows the Terraform resource name to match the original name. You can remove the call if you don't need them to match.

--- a/website/docs/cdktf/python/r/lightsail_instance.html.markdown
+++ b/website/docs/cdktf/python/r/lightsail_instance.html.markdown
@@ -35,7 +35,7 @@ class MyConvertedCode(TerraformStack):
         LightsailInstance(self, "gitlab_test",
             availability_zone="us-east-1b",
             blueprint_id="amazon_linux_2",
-            bundle_id="nano_1_0",
+            bundle_id="nano_3_0",
             key_pair_name="some_key_name",
             name="custom_gitlab",
             tags={
@@ -63,7 +63,7 @@ class MyConvertedCode(TerraformStack):
         LightsailInstance(self, "custom",
             availability_zone="us-east-1b",
             blueprint_id="amazon_linux_2",
-            bundle_id="nano_1_0",
+            bundle_id="nano_3_0",
             name="custom",
             user_data="sudo yum install -y httpd && sudo systemctl start httpd && sudo systemctl enable httpd && echo '<h1>Deployed via Terraform</h1>' | sudo tee /var/www/html/index.html"
         )
@@ -91,7 +91,7 @@ class MyConvertedCode(TerraformStack):
             ),
             availability_zone="us-east-1b",
             blueprint_id="amazon_linux_2",
-            bundle_id="nano_1_0",
+            bundle_id="nano_3_0",
             name="custom_instance",
             tags={
                 "foo": "bar"

--- a/website/docs/cdktf/python/r/lightsail_instance_public_ports.html.markdown
+++ b/website/docs/cdktf/python/r/lightsail_instance_public_ports.html.markdown
@@ -34,7 +34,7 @@ class MyConvertedCode(TerraformStack):
         test = LightsailInstance(self, "test",
             availability_zone=Token.as_string(Fn.lookup_nested(available.names, ["0"])),
             blueprint_id="amazon_linux_2",
-            bundle_id="nano_1_0",
+            bundle_id="nano_3_0",
             name="yak_sail"
         )
         aws_lightsail_instance_public_ports_test =

--- a/website/docs/cdktf/python/r/lightsail_lb_attachment.html.markdown
+++ b/website/docs/cdktf/python/r/lightsail_lb_attachment.html.markdown
@@ -48,7 +48,7 @@ class MyConvertedCode(TerraformStack):
         aws_lightsail_instance_test = LightsailInstance(self, "test_2",
             availability_zone=Token.as_string(Fn.lookup_nested(available.names, ["0"])),
             blueprint_id="amazon_linux_2",
-            bundle_id="nano_1_0",
+            bundle_id="nano_3_0",
             name="test-instance"
         )
         # This allows the Terraform resource name to match the original name. You can remove the call if you don't need them to match.

--- a/website/docs/cdktf/typescript/r/lightsail_bucket_resource_access.html.markdown
+++ b/website/docs/cdktf/typescript/r/lightsail_bucket_resource_access.html.markdown
@@ -42,7 +42,7 @@ class MyConvertedCode extends TerraformStack {
     const awsLightsailInstanceTest = new LightsailInstance(this, "test_2", {
       availabilityZone: "us-east-1b",
       blueprintId: "amazon_linux_2",
-      bundleId: "nano_1_0",
+      bundleId: "nano_3_0",
       name: "mytestinstance",
     });
     /*This allows the Terraform resource name to match the original name. You can remove the call if you don't need them to match.*/

--- a/website/docs/cdktf/typescript/r/lightsail_disk_attachment.html.markdown
+++ b/website/docs/cdktf/typescript/r/lightsail_disk_attachment.html.markdown
@@ -46,7 +46,7 @@ class MyConvertedCode extends TerraformStack {
     const awsLightsailInstanceTest = new LightsailInstance(this, "test_2", {
       availabilityZone: Token.asString(Fn.lookupNested(available.names, ["0"])),
       blueprintId: "amazon_linux_2",
-      bundleId: "nano_1_0",
+      bundleId: "nano_3_0",
       name: "test-instance",
     });
     /*This allows the Terraform resource name to match the original name. You can remove the call if you don't need them to match.*/

--- a/website/docs/cdktf/typescript/r/lightsail_distribution.html.markdown
+++ b/website/docs/cdktf/typescript/r/lightsail_distribution.html.markdown
@@ -186,7 +186,7 @@ class MyConvertedCode extends TerraformStack {
     const awsLightsailInstanceTest = new LightsailInstance(this, "test_2", {
       availabilityZone: Token.asString(Fn.lookupNested(available.names, ["0"])),
       blueprintId: "amazon_linux_2",
-      bundleId: "nano_1_0",
+      bundleId: "nano_3_0",
       name: "test-instance",
     });
     /*This allows the Terraform resource name to match the original name. You can remove the call if you don't need them to match.*/

--- a/website/docs/cdktf/typescript/r/lightsail_instance.html.markdown
+++ b/website/docs/cdktf/typescript/r/lightsail_instance.html.markdown
@@ -35,7 +35,7 @@ class MyConvertedCode extends TerraformStack {
     new LightsailInstance(this, "gitlab_test", {
       availabilityZone: "us-east-1b",
       blueprintId: "amazon_linux_2",
-      bundleId: "nano_1_0",
+      bundleId: "nano_3_0",
       keyPairName: "some_key_name",
       name: "custom_gitlab",
       tags: {
@@ -66,7 +66,7 @@ class MyConvertedCode extends TerraformStack {
     new LightsailInstance(this, "custom", {
       availabilityZone: "us-east-1b",
       blueprintId: "amazon_linux_2",
-      bundleId: "nano_1_0",
+      bundleId: "nano_3_0",
       name: "custom",
       userData:
         "sudo yum install -y httpd && sudo systemctl start httpd && sudo systemctl enable httpd && echo '<h1>Deployed via Terraform</h1>' | sudo tee /var/www/html/index.html",
@@ -98,7 +98,7 @@ class MyConvertedCode extends TerraformStack {
       },
       availabilityZone: "us-east-1b",
       blueprintId: "amazon_linux_2",
-      bundleId: "nano_1_0",
+      bundleId: "nano_3_0",
       name: "custom_instance",
       tags: {
         foo: "bar",

--- a/website/docs/cdktf/typescript/r/lightsail_instance_public_ports.html.markdown
+++ b/website/docs/cdktf/typescript/r/lightsail_instance_public_ports.html.markdown
@@ -34,7 +34,7 @@ class MyConvertedCode extends TerraformStack {
     const test = new LightsailInstance(this, "test", {
       availabilityZone: Token.asString(Fn.lookupNested(available.names, ["0"])),
       blueprintId: "amazon_linux_2",
-      bundleId: "nano_1_0",
+      bundleId: "nano_3_0",
       name: "yak_sail",
     });
     const awsLightsailInstancePublicPortsTest =

--- a/website/docs/cdktf/typescript/r/lightsail_lb_attachment.html.markdown
+++ b/website/docs/cdktf/typescript/r/lightsail_lb_attachment.html.markdown
@@ -49,7 +49,7 @@ class MyConvertedCode extends TerraformStack {
     const awsLightsailInstanceTest = new LightsailInstance(this, "test_2", {
       availabilityZone: Token.asString(Fn.lookupNested(available.names, ["0"])),
       blueprintId: "amazon_linux_2",
-      bundleId: "nano_1_0",
+      bundleId: "nano_3_0",
       name: "test-instance",
     });
     /*This allows the Terraform resource name to match the original name. You can remove the call if you don't need them to match.*/

--- a/website/docs/r/lightsail_bucket_resource_access.html.markdown
+++ b/website/docs/r/lightsail_bucket_resource_access.html.markdown
@@ -22,7 +22,7 @@ resource "aws_lightsail_instance" "test" {
   name              = "mytestinstance"
   availability_zone = "us-east-1b"
   blueprint_id      = "amazon_linux_2"
-  bundle_id         = "nano_1_0"
+  bundle_id         = "nano_3_0"
 }
 
 resource "aws_lightsail_bucket_resource_access" "test" {

--- a/website/docs/r/lightsail_disk_attachment.html.markdown
+++ b/website/docs/r/lightsail_disk_attachment.html.markdown
@@ -32,7 +32,7 @@ resource "aws_lightsail_instance" "test" {
   name              = "test-instance"
   availability_zone = data.aws_availability_zones.available.names[0]
   blueprint_id      = "amazon_linux_2"
-  bundle_id         = "nano_1_0"
+  bundle_id         = "nano_3_0"
 }
 
 resource "aws_lightsail_disk_attachment" "test" {

--- a/website/docs/r/lightsail_distribution.html.markdown
+++ b/website/docs/r/lightsail_distribution.html.markdown
@@ -121,7 +121,7 @@ resource "aws_lightsail_instance" "test" {
   name              = "test-instance"
   availability_zone = data.aws_availability_zones.available.names[0]
   blueprint_id      = "amazon_linux_2"
-  bundle_id         = "nano_1_0"
+  bundle_id         = "nano_3_0"
 }
 
 resource "aws_lightsail_lb_attachment" "test" {

--- a/website/docs/r/lightsail_instance.html.markdown
+++ b/website/docs/r/lightsail_instance.html.markdown
@@ -24,7 +24,7 @@ resource "aws_lightsail_instance" "gitlab_test" {
   name              = "custom_gitlab"
   availability_zone = "us-east-1b"
   blueprint_id      = "amazon_linux_2"
-  bundle_id         = "nano_1_0"
+  bundle_id         = "nano_3_0"
   key_pair_name     = "some_key_name"
   tags = {
     foo = "bar"
@@ -41,7 +41,7 @@ resource "aws_lightsail_instance" "custom" {
   name              = "custom"
   availability_zone = "us-east-1b"
   blueprint_id      = "amazon_linux_2"
-  bundle_id         = "nano_1_0"
+  bundle_id         = "nano_3_0"
   user_data         = "sudo yum install -y httpd && sudo systemctl start httpd && sudo systemctl enable httpd && echo '<h1>Deployed via Terraform</h1>' | sudo tee /var/www/html/index.html"
 }
 ```
@@ -53,7 +53,7 @@ resource "aws_lightsail_instance" "test" {
   name              = "custom_instance"
   availability_zone = "us-east-1b"
   blueprint_id      = "amazon_linux_2"
-  bundle_id         = "nano_1_0"
+  bundle_id         = "nano_3_0"
   add_on {
     type          = "AutoSnapshot"
     snapshot_time = "06:00"

--- a/website/docs/r/lightsail_instance_public_ports.html.markdown
+++ b/website/docs/r/lightsail_instance_public_ports.html.markdown
@@ -21,7 +21,7 @@ resource "aws_lightsail_instance" "test" {
   name              = "yak_sail"
   availability_zone = data.aws_availability_zones.available.names[0]
   blueprint_id      = "amazon_linux_2"
-  bundle_id         = "nano_1_0"
+  bundle_id         = "nano_3_0"
 }
 
 resource "aws_lightsail_instance_public_ports" "test" {

--- a/website/docs/r/lightsail_lb_attachment.html.markdown
+++ b/website/docs/r/lightsail_lb_attachment.html.markdown
@@ -35,7 +35,7 @@ resource "aws_lightsail_instance" "test" {
   name              = "test-instance"
   availability_zone = data.aws_availability_zones.available.names[0]
   blueprint_id      = "amazon_linux_2"
-  bundle_id         = "nano_1_0"
+  bundle_id         = "nano_3_0"
 }
 
 resource "aws_lightsail_lb_attachment" "test" {


### PR DESCRIPTION
## Description
Update Lightsail default bundle_id to reflect current availability. `nano_1_0` is an outdated bundle_id and I believe should be removed from the examples. 




