### PR TITLE
fix: Add missing use_off_peak_window arg to schema for aws_opensearch_domain data source

### DIFF
--- a/.changelog/36298.txt
+++ b/.changelog/36298.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-data-source/aws_opensearch_domain : Add missing `use_off_peak_window` attribute that caused an "invalid address" error
+data-source/aws_opensearch_domain : Add `auto_tune_options.use_off_peak_window` attribute. This fixes a regression introduced in [v5.40.0](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#5400-march--7-2024) causing `Invalid address to set` errors
 ```

--- a/.changelog/36298.txt
+++ b/.changelog/36298.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_opensearch_domain : Add missing `use_off_peak_window` attribute that caused an "invalid address" error
+```

--- a/internal/service/opensearch/domain_data_source.go
+++ b/internal/service/opensearch/domain_data_source.go
@@ -101,6 +101,10 @@ func DataSourceDomain() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"use_off_peak_window": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
 					},
 				},
 			},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to fix a regression introduced by #36067. The `use_off_peak_window` argument was added to the `aws_opensearch_domain` resource, however the the `aws_openserach_domain` data source wasn't updated accordingly.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #36291

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
n/a

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTARGS="-run=TestAccOpenSearchDomainDataSource_Data_" PKG=opensearch
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/opensearch/... -v -count 1 -parallel 20  -run=TestAccOpenSearchDomainDataSource_Data_ -timeout 360m       
=== RUN   TestAccOpenSearchDomainDataSource_Data_basic
=== PAUSE TestAccOpenSearchDomainDataSource_Data_basic
=== RUN   TestAccOpenSearchDomainDataSource_Data_advanced
=== PAUSE TestAccOpenSearchDomainDataSource_Data_advanced
=== CONT  TestAccOpenSearchDomainDataSource_Data_basic
=== CONT  TestAccOpenSearchDomainDataSource_Data_advanced
--- PASS: TestAccOpenSearchDomainDataSource_Data_basic (2215.90s)
--- PASS: TestAccOpenSearchDomainDataSource_Data_advanced (2572.29s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/opensearch 2572.460s

$
```
