### PR TITLE
aws_ec2_instance: allow adjusting ipv6_address_count without replacing the instance

### DIFF
--- a/.changelog/36308.txt
+++ b/.changelog/36308.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ec2_instance: Don't force an instance rebuild when modifying `ipv6_address_count`
+```

--- a/.changelog/36308.txt
+++ b/.changelog/36308.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_ec2_instance: Don't force an instance rebuild when modifying `ipv6_address_count`
+resource/aws_ec2_instance: Remove [ForceNew](https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-behaviors#forcenew) from `ipv6_address_count`
 ```

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -1637,7 +1637,7 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 			}
 		} else if os > ns {
 			// Remove IP addresses.
-			if len(primaryInterface.Ipv6Addresses) != int(os) {
+			if len(primaryInterface.Ipv6Addresses) != os {
 				return sdkdiag.AppendErrorf(diags, "IPv6 address count (%d) on the instance does not match state's count (%d), we're in a race with something else", len(primaryInterface.Ipv6Addresses), os)
 			}
 

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -1641,7 +1641,7 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 				return sdkdiag.AppendErrorf(diags, "IPv6 address count (%d) on the instance does not match state's count (%d), we're in a race with something else", len(primaryInterface.Ipv6Addresses), os)
 			}
 
-			toRemove := make([]*string, ns)
+			toRemove := make([]*string, 0)
 			for _, addr := range primaryInterface.Ipv6Addresses[ns:] { // Can I assume this is strongly ordered?
 				toRemove = append(toRemove, addr.Ipv6Address)
 			}

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -467,7 +467,6 @@ func ResourceInstance() *schema.Resource {
 			"ipv6_address_count": {
 				Type:          schema.TypeInt,
 				Optional:      true,
-				ForceNew:      true,
 				Computed:      true,
 				ConflictsWith: []string{"ipv6_addresses"},
 			},

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -1603,6 +1603,66 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 	}
 
+	if d.HasChange("ipv6_address_count") && !d.IsNewResource() {
+		instance, err := FindInstanceByID(ctx, conn, d.Id())
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "reading EC2 Instance (%s): %s", d.Id(), err)
+		}
+
+		var primaryInterface *ec2.InstanceNetworkInterface
+		for _, ni := range instance.NetworkInterfaces {
+			if aws.Int64Value(ni.Attachment.DeviceIndex) == 0 {
+				primaryInterface = ni
+			}
+		}
+
+		if primaryInterface == nil {
+			return sdkdiag.AppendErrorf(diags, "Failed to update ipv6_address_count on %q, which does not contain a primary network interface", d.Id())
+		}
+
+		o, n := d.GetChange("ipv6_address_count")
+
+		os := o.(int)
+		ns := n.(int)
+
+		if ns > os {
+			// Add more to the primary NIC
+			net_new_ips := int64(ns - os)
+			input := &ec2.AssignIpv6AddressesInput{
+				NetworkInterfaceId: primaryInterface.NetworkInterfaceId,
+				Ipv6AddressCount: &net_new_ips,
+			}
+			log.Printf("[INFO] Assigning ipv6 address on Instance %q", d.Id())
+			_, err := conn.AssignIpv6AddressesWithContext(ctx, input)
+			if err != nil {
+				return sdkdiag.AppendErrorf(diags, "Failure to increase ipv6_address_count: %s", err)
+			}
+
+		} else if os > ns {
+			// Remove IP addresses
+			if len(primaryInterface.Ipv6Addresses) != int(os) {
+				return sdkdiag.AppendErrorf(diags, "IPv6 address count (%d) on the instance does not match state's count (%d), we're in a race with something else", len(primaryInterface.Ipv6Addresses), os)
+			}
+
+			addresses_to_remove := make([]*string, ns)
+
+			for _, addr := range primaryInterface.Ipv6Addresses[ns:] { // Can I assume this is strongly ordered?
+				addresses_to_remove = append(addresses_to_remove, addr.Ipv6Address)
+			}
+
+			input := &ec2.UnassignIpv6AddressesInput{
+				NetworkInterfaceId: primaryInterface.NetworkInterfaceId,
+				Ipv6Addresses: addresses_to_remove,
+			}
+			log.Printf("[INFO] Unassigning ipv6 address on Instance %q", d.Id())
+			_, err := conn.UnassignIpv6AddressesWithContext(ctx, input)
+			if err != nil {
+				return sdkdiag.AppendErrorf(diags, "Failure to decrease ipv6_address_count: %s", err)
+			}
+		}
+
+	}
+
 	if d.HasChanges("secondary_private_ips", "vpc_security_group_ids") && !d.IsNewResource() {
 		instance, err := FindInstanceByID(ctx, conn, d.Id())
 

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -1630,7 +1630,7 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 			net_new_ips := int64(ns - os)
 			input := &ec2.AssignIpv6AddressesInput{
 				NetworkInterfaceId: primaryInterface.NetworkInterfaceId,
-				Ipv6AddressCount: &net_new_ips,
+				Ipv6AddressCount:   &net_new_ips,
 			}
 			log.Printf("[INFO] Assigning ipv6 address on Instance %q", d.Id())
 			_, err := conn.AssignIpv6AddressesWithContext(ctx, input)
@@ -1652,7 +1652,7 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 
 			input := &ec2.UnassignIpv6AddressesInput{
 				NetworkInterfaceId: primaryInterface.NetworkInterfaceId,
-				Ipv6Addresses: addresses_to_remove,
+				Ipv6Addresses:      addresses_to_remove,
 			}
 			log.Printf("[INFO] Unassigning ipv6 address on Instance %q", d.Id())
 			_, err := conn.UnassignIpv6AddressesWithContext(ctx, input)

--- a/internal/service/ec2/ec2_instance_test.go
+++ b/internal/service/ec2/ec2_instance_test.go
@@ -3284,14 +3284,14 @@ func TestAccEC2Instance_IPv6AddressCount(t *testing.T) {
 		CheckDestroy:             testAccCheckInstanceDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstance_IPv6AddressCount(rName, originalCount),
+				Config: testAccInstance_ipv6AddressCount(rName, originalCount),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(ctx, resourceName, &original),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", fmt.Sprint(originalCount)),
 				),
 			},
 			{
-				Config: testAccInstance_IPv6AddressCount(rName, updatedCount),
+				Config: testAccInstance_ipv6AddressCount(rName, updatedCount),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(ctx, resourceName, &updated),
 					testAccCheckInstanceNotRecreated(&original, &updated),
@@ -3299,7 +3299,7 @@ func TestAccEC2Instance_IPv6AddressCount(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccInstance_IPv6AddressCount(rName, shrunkenCount),
+				Config: testAccInstance_ipv6AddressCount(rName, shrunkenCount),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(ctx, resourceName, &updated),
 					testAccCheckInstanceNotRecreated(&original, &updated),
@@ -6373,7 +6373,7 @@ func testAccInstanceConfig_rootBlockDevice(rName, size, delete, volumeType strin
 	return testAccInstanceConfig_rootBlockDeviceIOPS(rName, size, delete, volumeType, "")
 }
 
-func testAccInstance_IPv6AddressCount(rName string, ipv6_address_count int) string {
+func testAccInstance_ipv6AddressCount(rName string, ipv6AddressCount int) string {
 	return acctest.ConfigCompose(
 		testAccInstanceAMIWithEBSRootVolume,
 		fmt.Sprintf(`
@@ -6387,7 +6387,7 @@ resource "aws_instance" "test" {
     Name = %[1]q
   }
 }
-`, rName, ipv6_address_count))
+`, rName, ipv6AddressCount))
 }
 
 func testAccInstanceConfig_rootBlockDeviceIOPS(rName, size, delete, volumeType, iops string) string {

--- a/internal/service/ec2/ec2_instance_test.go
+++ b/internal/service/ec2/ec2_instance_test.go
@@ -6816,9 +6816,9 @@ func testAccInstance_ipv6AddressCount(rName string, ipv6AddressCount int) string
 		testAccInstanceVPCIPv6Config(rName),
 		fmt.Sprintf(`
 resource "aws_instance" "test" {
-  ami           = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.id
-  instance_type = "t2.medium"
-
+  ami                = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.id
+  instance_type      = "t2.medium"
+  subnet_id          = aws_subnet.test.id
   ipv6_address_count = %[2]d
 
   tags = {

--- a/internal/service/ec2/ec2_instance_test.go
+++ b/internal/service/ec2/ec2_instance_test.go
@@ -6370,7 +6370,7 @@ resource "aws_instance" "test" {
 }
 
 func testAccInstanceConfig_rootBlockDevice(rName, size, delete, volumeType string) string {
-       return testAccInstanceConfig_rootBlockDeviceIOPS(rName, size, delete, volumeType, "")
+	return testAccInstanceConfig_rootBlockDeviceIOPS(rName, size, delete, volumeType, "")
 }
 
 func testAccInstance_IPv6AddressCount(rName string, ipv6_address_count int) string {

--- a/internal/service/ec2/ec2_instance_test.go
+++ b/internal/service/ec2/ec2_instance_test.go
@@ -1337,6 +1337,50 @@ func TestAccEC2Instance_IPv6_supportAddressCountWithIPv4(t *testing.T) {
 	})
 }
 
+func TestAccEC2Instance_IPv6AddressCount(t *testing.T) {
+	ctx := acctest.Context(t)
+	var original ec2.Instance
+	var updated ec2.Instance
+	resourceName := "aws_instance.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	originalCount := 0
+	updatedCount := 2
+	shrunkenCount := 1
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInstanceDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstance_ipv6AddressCount(rName, originalCount),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(ctx, resourceName, &original),
+					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", fmt.Sprint(originalCount)),
+				),
+			},
+			{
+				Config: testAccInstance_ipv6AddressCount(rName, updatedCount),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(ctx, resourceName, &updated),
+					testAccCheckInstanceNotRecreated(&original, &updated),
+					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", fmt.Sprint(updatedCount)),
+				),
+			},
+			{
+				Config: testAccInstance_ipv6AddressCount(rName, shrunkenCount),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(ctx, resourceName, &updated),
+					testAccCheckInstanceNotRecreated(&original, &updated),
+					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", fmt.Sprint(shrunkenCount)),
+				),
+			},
+		},
+	})
+}
+
 func TestAccEC2Instance_networkInstanceSecurityGroups(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v ec2.Instance
@@ -3261,50 +3305,6 @@ func TestAccEC2Instance_NewNetworkInterface_privateIPAndSecondaryPrivateIPsUpdat
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"user_data_replace_on_change"},
-			},
-		},
-	})
-}
-
-func TestAccEC2Instance_IPv6AddressCount(t *testing.T) {
-	ctx := acctest.Context(t)
-	var original ec2.Instance
-	var updated ec2.Instance
-	resourceName := "aws_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-
-	originalCount := 0
-	updatedCount := 2
-	shrunkenCount := 1
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckInstanceDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccInstance_ipv6AddressCount(rName, originalCount),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists(ctx, resourceName, &original),
-					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", fmt.Sprint(originalCount)),
-				),
-			},
-			{
-				Config: testAccInstance_ipv6AddressCount(rName, updatedCount),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists(ctx, resourceName, &updated),
-					testAccCheckInstanceNotRecreated(&original, &updated),
-					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", fmt.Sprint(updatedCount)),
-				),
-			},
-			{
-				Config: testAccInstance_ipv6AddressCount(rName, shrunkenCount),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists(ctx, resourceName, &updated),
-					testAccCheckInstanceNotRecreated(&original, &updated),
-					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", fmt.Sprint(shrunkenCount)),
-				),
 			},
 		},
 	})
@@ -6373,23 +6373,6 @@ func testAccInstanceConfig_rootBlockDevice(rName, size, delete, volumeType strin
 	return testAccInstanceConfig_rootBlockDeviceIOPS(rName, size, delete, volumeType, "")
 }
 
-func testAccInstance_ipv6AddressCount(rName string, ipv6AddressCount int) string {
-	return acctest.ConfigCompose(
-		testAccInstanceAMIWithEBSRootVolume,
-		fmt.Sprintf(`
-resource "aws_instance" "test" {
-  ami           = data.aws_ami.ami.id
-  instance_type = "t2.medium"
-
-  ipv6_address_count = %[2]d
-
-  tags = {
-    Name = %[1]q
-  }
-}
-`, rName, ipv6AddressCount))
-}
-
 func testAccInstanceConfig_rootBlockDeviceIOPS(rName, size, delete, volumeType, iops string) string {
 	if iops == "" {
 		iops = "null"
@@ -6825,6 +6808,24 @@ resource "aws_instance" "test" {
   }
 }
 `, rName))
+}
+
+func testAccInstance_ipv6AddressCount(rName string, ipv6AddressCount int) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigLatestAmazonLinux2HVMEBSX8664AMI(),
+		testAccInstanceVPCIPv6Config(rName),
+		fmt.Sprintf(`
+resource "aws_instance" "test" {
+  ami           = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.id
+  instance_type = "t2.medium"
+
+  ipv6_address_count = %[2]d
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName, ipv6AddressCount))
 }
 
 func testAccInstanceConfig_ebsKMSKeyARN(rName string) string {


### PR DESCRIPTION
### Description
This will allow adjusting the `ipv6_address_count` address on an instance's primary NIC without replacing the instance.

### Relations 
Closes #33707

### Output from Acceptance Testing
```console
% make testacc TESTS=TestAccEC2Instance_IPv6AddressCount PKG=ec2
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2Instance_IPv6AddressCount'  -timeout 360m
=== RUN   TestAccEC2Instance_IPv6AddressCount
=== PAUSE TestAccEC2Instance_IPv6AddressCount
=== CONT  TestAccEC2Instance_IPv6AddressCount
--- PASS: TestAccEC2Instance_IPv6AddressCount (140.24s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	144.286s
```
