### PR TITLE
elasticache: Allow for tagging retries

### DIFF
--- a/.changelog/36310.txt
+++ b/.changelog/36310.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_elasticache_replication_group: Fix bugs causing errors like `InvalidReplicationGroupState: Cluster not in available state to perform tagging operations.`
+```

--- a/internal/generate/tags/main.go
+++ b/internal/generate/tags/main.go
@@ -54,6 +54,10 @@ var (
 	listTagsOp                 = flag.String("ListTagsOp", "ListTagsForResource", "listTagsOp")
 	listTagsOpPaginated        = flag.Bool("ListTagsOpPaginated", false, "whether ListTagsOp is paginated")
 	listTagsOutTagsElem        = flag.String("ListTagsOutTagsElem", "Tags", "listTagsOutTagsElem")
+	retryTagsListTagsType      = flag.String("RetryTagsListTagsType", "", "type of the first ListTagsOp return value such as TagListMessage")
+	retryTagsErrorCodes        = flag.String("RetryTagsErrorCodes", "", "comma-separated list of error codes to retry, must be used with RetryTagsListTagsType and same length as RetryTagsErrorMessages")
+	retryTagsErrorMessages     = flag.String("RetryTagsErrorMessages", "", "comma-separated list of error messages to retry, must be used with RetryTagsListTagsType and same length as RetryTagsErrorCodes")
+	retryTagsTimeout           = flag.Duration("RetryTagsTimeout", 1*time.Minute, "Timeout for retrying tag operations")
 	setTagsOutFunc             = flag.String("SetTagsOutFunc", "setTagsOut", "setTagsOutFunc")
 	tagInCustomVal             = flag.String("TagInCustomVal", "", "tagInCustomVal")
 	tagInIDElem                = flag.String("TagInIDElem", "ResourceArn", "tagInIDElem")
@@ -171,7 +175,11 @@ type TemplateData struct {
 	ListTagsOutTagsElem        string
 	ParentNotFoundErrCode      string
 	ParentNotFoundErrMsg       string
-	RetryCreateOnNotFound      string
+	RetryCreateOnNotFound      string // is this used?
+	RetryTagsListTagsType      string
+	RetryTagsErrorCodes        []string
+	RetryTagsErrorMessages     []string
+	RetryTagsTimeout           string
 	ServiceTagsMap             bool
 	SetTagsOutFunc             string
 	TagInCustomVal             string
@@ -295,6 +303,15 @@ func main() {
 		}
 	}
 
+	var cleanRetryErrorCodes []string
+	for _, c := range strings.Split(*retryTagsErrorCodes, ",") {
+		if strings.HasPrefix(c, fmt.Sprintf("%s.", servicePackage)) || strings.HasPrefix(c, "types.") {
+			cleanRetryErrorCodes = append(cleanRetryErrorCodes, c)
+		} else {
+			cleanRetryErrorCodes = append(cleanRetryErrorCodes, fmt.Sprintf(`"%s"`, c))
+		}
+	}
+
 	templateData := TemplateData{
 		AWSService:             awsPkg,
 		AWSServiceIfacePackage: awsIntfPkg,
@@ -312,8 +329,8 @@ func main() {
 		SkipServiceImp:    *skipServiceImp,
 		SkipTypesImp:      *skipTypesImp,
 		TfLogPkg:          *updateTags,
-		TfResourcePkg:     (*getTag || *waitForPropagation),
-		TimePkg:           *waitForPropagation,
+		TfResourcePkg:     *getTag || *waitForPropagation || *retryTagsListTagsType != "",
+		TimePkg:           *waitForPropagation || *retryTagsListTagsType != "",
 
 		CreateTagsFunc:             createTagsFunc,
 		GetTagFunc:                 *getTagFunc,
@@ -329,6 +346,10 @@ func main() {
 		ListTagsOutTagsElem:        *listTagsOutTagsElem,
 		ParentNotFoundErrCode:      *parentNotFoundErrCode,
 		ParentNotFoundErrMsg:       *parentNotFoundErrMsg,
+		RetryTagsListTagsType:      *retryTagsListTagsType,
+		RetryTagsErrorCodes:        cleanRetryErrorCodes,
+		RetryTagsErrorMessages:     strings.Split(*retryTagsErrorMessages, ","),
+		RetryTagsTimeout:           formatDuration(*retryTagsTimeout),
 		ServiceTagsMap:             *serviceTagsMap,
 		SetTagsOutFunc:             *setTagsOutFunc,
 		TagInCustomVal:             *tagInCustomVal,

--- a/internal/generate/tags/templates/v1/get_tag_body.tmpl
+++ b/internal/generate/tags/templates/v1/get_tag_body.tmpl
@@ -23,7 +23,25 @@ func {{ .GetTagFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier{{
 		},
 	}
 
+	{{ if .RetryTagsListTagsType }}
+	output, err := tfresource.RetryGWhenMessageContains(ctx, {{ .RetryTagsTimeout }},
+		func() (*{{ .TagPackage  }}.{{ .RetryTagsListTagsType }}, error) {
+			return conn.{{ .ListTagsOp }}WithContext(ctx, input)
+		},
+		[]string{
+			{{- range .RetryTagsErrorCodes }}
+			{{ . }},
+			{{- end }}
+		},
+		[]string{
+			{{- range .RetryTagsErrorMessages }}
+			"{{ . }}",
+			{{- end }}
+		},
+	)
+	{{ else }}
 	output, err := conn.{{ .ListTagsOp }}WithContext(ctx, input)
+	{{- end }}
 
 	if err != nil {
 		return nil, err

--- a/internal/generate/tags/templates/v1/list_tags_body.tmpl
+++ b/internal/generate/tags/templates/v1/list_tags_body.tmpl
@@ -28,6 +28,39 @@ func {{ .ListTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier
 	var output []*{{ .TagPackage }}.{{ or .TagType2 .TagType }}
     {{- end }}
 
+	{{ if .RetryTagsListTagsType }}
+	_, err := tfresource.RetryWhenMessageContains(ctx, {{ .RetryTagsTimeout }},
+		func() (string, error) {
+			return "", conn.{{ .ListTagsOp }}PagesWithContext(ctx, input, func(page *{{ .TagPackage  }}.{{ .ListTagsOp }}Output, lastPage bool) bool {
+				if page == nil {
+					return !lastPage
+				}
+
+			{{ if .ServiceTagsMap }}
+				maps.Copy(output, page.{{ .ListTagsOutTagsElem }})
+			{{- else }}
+				for _, v := range page.{{ .ListTagsOutTagsElem }} {
+					if v != nil {
+						output = append(output, v)
+					}
+				}
+			{{- end }}
+
+				return !lastPage
+			})
+		},
+		[]string{
+			{{- range .RetryTagsErrorCodes }}
+			{{ . }},
+			{{- end }}
+		},
+		[]string{
+			{{- range .RetryTagsErrorMessages }}
+			"{{ . }}",
+			{{- end }}
+		},
+	)
+	{{ else }}
 	err := conn.{{ .ListTagsOp }}PagesWithContext(ctx, input, func(page *{{ .TagPackage  }}.{{ .ListTagsOp }}Output, lastPage bool) bool {
 		if page == nil {
 			return !lastPage
@@ -45,9 +78,29 @@ func {{ .ListTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier
 
 		return !lastPage
 	})
+	{{- end }}
 {{ else }}
+	{{- if .RetryTagsListTagsType }}
+
+	output, err := tfresource.RetryGWhenMessageContains(ctx, {{ .RetryTagsTimeout }},
+		func() (*{{ .TagPackage  }}.{{ .RetryTagsListTagsType }}, error) {
+			return conn.{{ .ListTagsOp }}WithContext(ctx, input)
+		},
+		[]string{
+			{{- range .RetryTagsErrorCodes }}
+			{{ . }},
+			{{- end }}
+		},
+		[]string{
+			{{- range .RetryTagsErrorMessages }}
+			"{{ . }}",
+			{{- end }}
+		},
+	)
+	{{- else }}
 
 	output, err := conn.{{ .ListTagsOp }}WithContext(ctx, input)
+	{{- end }}
 {{- end }}
 
 	{{ if and ( .ParentNotFoundErrCode ) ( .ParentNotFoundErrMsg ) }}

--- a/internal/generate/tags/templates/v1/update_tags_body.tmpl
+++ b/internal/generate/tags/templates/v1/update_tags_body.tmpl
@@ -60,7 +60,25 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 		{{- end }}
 	}
 
+	{{ if .RetryTagsListTagsType }}
+	_, err := tfresource.RetryWhenMessageContains(ctx, {{ .RetryTagsTimeout }},
+		func() (any, error) {
+			return conn.{{ .TagOp }}WithContext(ctx, input)
+		},
+		[]string{
+			{{- range .RetryTagsErrorCodes }}
+			{{ . }},
+			{{- end }}
+		},
+		[]string{
+			{{- range .RetryTagsErrorMessages }}
+			"{{ . }}",
+			{{- end }}
+		},
+	)
+	{{ else }}
 	_, err := conn.{{ .TagOp }}WithContext(ctx, input)
+	{{- end }}
 
 	if err != nil {
 		return fmt.Errorf("tagging resource (%s): %w", identifier, err)
@@ -100,7 +118,25 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 			{{- end }}
 		}
 
+		{{ if .RetryTagsListTagsType }}
+		_, err := tfresource.RetryWhenMessageContains(ctx, {{ .RetryTagsTimeout }},
+			func() (any, error) {
+				return conn.{{ .UntagOp }}WithContext(ctx, input)
+			},
+			[]string{
+				{{- range .RetryTagsErrorCodes }}
+				{{ . }},
+				{{- end }}
+			},
+			[]string{
+				{{- range .RetryTagsErrorMessages }}
+				"{{ . }}",
+				{{- end }}
+			},
+		)
+		{{ else }}
 		_, err := conn.{{ .UntagOp }}WithContext(ctx, input)
+		{{- end }}
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -138,7 +174,25 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 			{{- end }}
 		}
 
+		{{ if .RetryTagsListTagsType }}
+		_, err := tfresource.RetryWhenMessageContains(ctx, {{ .RetryTagsTimeout }},
+			func() (any, error) {
+				return conn.{{ .TagOp }}WithContext(ctx, input)
+			},
+			[]string{
+				{{- range .RetryTagsErrorCodes }}
+				{{ . }},
+				{{- end }}
+			},
+			[]string{
+				{{- range .RetryTagsErrorMessages }}
+				"{{ . }}",
+				{{- end }}
+			},
+		)
+		{{ else }}
 		_, err := conn.{{ .TagOp }}WithContext(ctx, input)
+		{{- end }}
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/elasticache/generate.go
+++ b/internal/service/elasticache/generate.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-//go:generate go run ../../generate/tags/main.go -ListTags -ListTagsInIDElem=ResourceName -ListTagsOutTagsElem=TagList -ServiceTagsSlice -TagOp=AddTagsToResource -TagInIDElem=ResourceName -UntagOp=RemoveTagsFromResource -UpdateTags -CreateTags
+//go:generate go run ../../generate/tags/main.go -ListTags -ListTagsInIDElem=ResourceName -ListTagsOutTagsElem=TagList -ServiceTagsSlice -TagOp=AddTagsToResource -TagInIDElem=ResourceName -UntagOp=RemoveTagsFromResource -UpdateTags -CreateTags -RetryTagsListTagsType=TagListMessage -RetryTagsErrorCodes=elasticache.ErrCodeInvalidReplicationGroupStateFault "-RetryTagsErrorMessages=not in available state" -RetryTagsTimeout=15m
 //go:generate go run ../../generate/tags/main.go -AWSSDKVersion=2 -TagsFunc=TagsV2 -KeyValueTagsFunc=keyValueTagsV2 -GetTagsInFunc=getTagsInV2 -SetTagsOutFunc=setTagsOutV2 -SkipAWSServiceImp -KVTValues -ServiceTagsSlice -- tagsv2_gen.go
 //go:generate go run ../../generate/servicepackage/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.

--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -862,7 +862,13 @@ func resourceReplicationGroupUpdate(ctx context.Context, d *schema.ResourceData,
 		}
 
 		if requestUpdate {
-			_, err := conn.ModifyReplicationGroupWithContext(ctx, input)
+			// tagging may cause this resource to not yet be available, so wait for it to be available
+			_, err := WaitReplicationGroupAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
+			if err != nil {
+				return sdkdiag.AppendErrorf(diags, "waiting for ElastiCache Replication Group (%s) to update: %s", d.Id(), err)
+			}
+
+			_, err = conn.ModifyReplicationGroupWithContext(ctx, input)
 			if err != nil {
 				return sdkdiag.AppendErrorf(diags, "updating ElastiCache Replication Group (%s): %s", d.Id(), err)
 			}
@@ -881,7 +887,13 @@ func resourceReplicationGroupUpdate(ctx context.Context, d *schema.ResourceData,
 				AuthToken:               aws.String(d.Get("auth_token").(string)),
 			}
 
-			_, err := conn.ModifyReplicationGroupWithContext(ctx, params)
+			// tagging may cause this resource to not yet be available, so wait for it to be available
+			_, err := WaitReplicationGroupAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
+			if err != nil {
+				return sdkdiag.AppendErrorf(diags, "waiting for ElastiCache Replication Group (%s) to update: %s", d.Id(), err)
+			}
+
+			_, err = conn.ModifyReplicationGroupWithContext(ctx, params)
 			if err != nil {
 				return sdkdiag.AppendErrorf(diags, "changing auth_token for ElastiCache Replication Group (%s): %s", d.Id(), err)
 			}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #31819
Closes #30444
Closes #33859
Closes #23219

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccElastiCacheReplicationGroup K=elasticache P=10
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elasticache/... -v -count 1 -parallel 10 -run='TestAccElastiCacheReplicationGroup'  -timeout 360m
=== RUN   TestAccElastiCacheReplicationGroupDataSource_basic
=== PAUSE TestAccElastiCacheReplicationGroupDataSource_basic
=== RUN   TestAccElastiCacheReplicationGroupDataSource_clusterMode
=== PAUSE TestAccElastiCacheReplicationGroupDataSource_clusterMode
=== RUN   TestAccElastiCacheReplicationGroupDataSource_multiAZ
=== PAUSE TestAccElastiCacheReplicationGroupDataSource_multiAZ
=== RUN   TestAccElastiCacheReplicationGroupDataSource_nonExistent
=== PAUSE TestAccElastiCacheReplicationGroupDataSource_nonExistent
=== RUN   TestAccElastiCacheReplicationGroupDataSource_Engine_Redis_LogDeliveryConfigurations
=== PAUSE TestAccElastiCacheReplicationGroupDataSource_Engine_Redis_LogDeliveryConfigurations
=== RUN   TestAccElastiCacheReplicationGroup_basic
=== PAUSE TestAccElastiCacheReplicationGroup_basic
=== RUN   TestAccElastiCacheReplicationGroup_basic_v5
=== PAUSE TestAccElastiCacheReplicationGroup_basic_v5
=== RUN   TestAccElastiCacheReplicationGroup_uppercase
=== PAUSE TestAccElastiCacheReplicationGroup_uppercase
=== RUN   TestAccElastiCacheReplicationGroup_EngineVersion_v7
=== PAUSE TestAccElastiCacheReplicationGroup_EngineVersion_v7
=== RUN   TestAccElastiCacheReplicationGroup_EngineVersion_update
=== PAUSE TestAccElastiCacheReplicationGroup_EngineVersion_update
=== RUN   TestAccElastiCacheReplicationGroup_EngineVersion_6xToRealVersion
=== PAUSE TestAccElastiCacheReplicationGroup_EngineVersion_6xToRealVersion
=== RUN   TestAccElastiCacheReplicationGroup_disappears
=== PAUSE TestAccElastiCacheReplicationGroup_disappears
=== RUN   TestAccElastiCacheReplicationGroup_updateDescription
=== PAUSE TestAccElastiCacheReplicationGroup_updateDescription
=== RUN   TestAccElastiCacheReplicationGroup_updateMaintenanceWindow
=== PAUSE TestAccElastiCacheReplicationGroup_updateMaintenanceWindow
=== RUN   TestAccElastiCacheReplicationGroup_updateUserGroups
=== PAUSE TestAccElastiCacheReplicationGroup_updateUserGroups
=== RUN   TestAccElastiCacheReplicationGroup_updateNodeSize
=== PAUSE TestAccElastiCacheReplicationGroup_updateNodeSize
=== RUN   TestAccElastiCacheReplicationGroup_updateParameterGroup
=== PAUSE TestAccElastiCacheReplicationGroup_updateParameterGroup
=== RUN   TestAccElastiCacheReplicationGroup_authToken
=== PAUSE TestAccElastiCacheReplicationGroup_authToken
=== RUN   TestAccElastiCacheReplicationGroup_stateUpgrade5270
=== PAUSE TestAccElastiCacheReplicationGroup_stateUpgrade5270
=== RUN   TestAccElastiCacheReplicationGroup_vpc
=== PAUSE TestAccElastiCacheReplicationGroup_vpc
=== RUN   TestAccElastiCacheReplicationGroup_multiAzNotInVPC
=== PAUSE TestAccElastiCacheReplicationGroup_multiAzNotInVPC
=== RUN   TestAccElastiCacheReplicationGroup_multiAzNotInVPC_repeated
=== PAUSE TestAccElastiCacheReplicationGroup_multiAzNotInVPC_repeated
=== RUN   TestAccElastiCacheReplicationGroup_multiAzInVPC
=== PAUSE TestAccElastiCacheReplicationGroup_multiAzInVPC
=== RUN   TestAccElastiCacheReplicationGroup_deprecatedAvailabilityZones_multiAzInVPC
=== PAUSE TestAccElastiCacheReplicationGroup_deprecatedAvailabilityZones_multiAzInVPC
=== RUN   TestAccElastiCacheReplicationGroup_ValidationMultiAz_noAutomaticFailover
=== PAUSE TestAccElastiCacheReplicationGroup_ValidationMultiAz_noAutomaticFailover
=== RUN   TestAccElastiCacheReplicationGroup_ipDiscovery
=== PAUSE TestAccElastiCacheReplicationGroup_ipDiscovery
=== RUN   TestAccElastiCacheReplicationGroup_networkType
=== PAUSE TestAccElastiCacheReplicationGroup_networkType
=== RUN   TestAccElastiCacheReplicationGroup_ClusterMode_basic
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterMode_basic
=== RUN   TestAccElastiCacheReplicationGroup_ClusterMode_nonClusteredParameterGroup
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterMode_nonClusteredParameterGroup
=== RUN   TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp
=== RUN   TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleDown
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleDown
=== RUN   TestAccElastiCacheReplicationGroup_ClusterMode_updateReplicasPerNodeGroup
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterMode_updateReplicasPerNodeGroup
=== RUN   TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleUp
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleUp
=== RUN   TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleDown
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleDown
=== RUN   TestAccElastiCacheReplicationGroup_ClusterMode_singleNode
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterMode_singleNode
=== RUN   TestAccElastiCacheReplicationGroup_clusteringAndCacheNodesCausesError
=== PAUSE TestAccElastiCacheReplicationGroup_clusteringAndCacheNodesCausesError
=== RUN   TestAccElastiCacheReplicationGroup_enableSnapshotting
=== PAUSE TestAccElastiCacheReplicationGroup_enableSnapshotting
=== RUN   TestAccElastiCacheReplicationGroup_enableAuthTokenTransitEncryption
=== PAUSE TestAccElastiCacheReplicationGroup_enableAuthTokenTransitEncryption
=== RUN   TestAccElastiCacheReplicationGroup_enableAtRestEncryption
=== PAUSE TestAccElastiCacheReplicationGroup_enableAtRestEncryption
=== RUN   TestAccElastiCacheReplicationGroup_useCMKKMSKeyID
=== PAUSE TestAccElastiCacheReplicationGroup_useCMKKMSKeyID
=== RUN   TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic
=== PAUSE TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic
=== RUN   TestAccElastiCacheReplicationGroup_NumberCacheClustersFailover_autoFailoverDisabled
=== PAUSE TestAccElastiCacheReplicationGroup_NumberCacheClustersFailover_autoFailoverDisabled
=== RUN   TestAccElastiCacheReplicationGroup_NumberCacheClustersFailover_autoFailoverEnabled
=== PAUSE TestAccElastiCacheReplicationGroup_NumberCacheClustersFailover_autoFailoverEnabled
=== RUN   TestAccElastiCacheReplicationGroup_NumberCacheClusters_multiAZEnabled
=== PAUSE TestAccElastiCacheReplicationGroup_NumberCacheClusters_multiAZEnabled
=== RUN   TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_noChange
=== PAUSE TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_noChange
=== RUN   TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_addMemberCluster
=== PAUSE TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_addMemberCluster
=== RUN   TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_atTargetSize
=== PAUSE TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_atTargetSize
=== RUN   TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_scaleDown
=== PAUSE TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_scaleDown
=== RUN   TestAccElastiCacheReplicationGroup_tags
=== PAUSE TestAccElastiCacheReplicationGroup_tags
=== RUN   TestAccElastiCacheReplicationGroup_tagWithOtherModification
=== PAUSE TestAccElastiCacheReplicationGroup_tagWithOtherModification
=== RUN   TestAccElastiCacheReplicationGroup_finalSnapshot
=== PAUSE TestAccElastiCacheReplicationGroup_finalSnapshot
=== RUN   TestAccElastiCacheReplicationGroup_autoMinorVersionUpgrade
=== PAUSE TestAccElastiCacheReplicationGroup_autoMinorVersionUpgrade
=== RUN   TestAccElastiCacheReplicationGroup_Validation_noNodeType
=== PAUSE TestAccElastiCacheReplicationGroup_Validation_noNodeType
=== RUN   TestAccElastiCacheReplicationGroup_Validation_globalReplicationGroupIdAndNodeType
=== PAUSE TestAccElastiCacheReplicationGroup_Validation_globalReplicationGroupIdAndNodeType
=== RUN   TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_basic
=== PAUSE TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_basic
=== RUN   TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_full
=== PAUSE TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_full
=== RUN   TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears
=== PAUSE TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears
=== RUN   TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basic
=== PAUSE TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basic
=== RUN   TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterModeValidation_numNodeGroupsOnSecondary
=== PAUSE TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterModeValidation_numNodeGroupsOnSecondary
=== RUN   TestAccElastiCacheReplicationGroup_dataTiering
=== PAUSE TestAccElastiCacheReplicationGroup_dataTiering
=== RUN   TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Disabled
=== PAUSE TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Disabled
=== RUN   TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Enabled
=== PAUSE TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Enabled
=== CONT  TestAccElastiCacheReplicationGroupDataSource_basic
=== CONT  TestAccElastiCacheReplicationGroup_ClusterMode_updateReplicasPerNodeGroup
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_scaleDown
=== CONT  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_full
=== CONT  TestAccElastiCacheReplicationGroup_autoMinorVersionUpgrade
=== CONT  TestAccElastiCacheReplicationGroup_tagWithOtherModification
=== CONT  TestAccElastiCacheReplicationGroup_tags
=== CONT  TestAccElastiCacheReplicationGroup_dataTiering
=== CONT  TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Enabled
=== CONT  TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Disabled
--- PASS: TestAccElastiCacheReplicationGroup_dataTiering (836.18s)
=== CONT  TestAccElastiCacheReplicationGroup_useCMKKMSKeyID
--- PASS: TestAccElastiCacheReplicationGroupDataSource_basic (888.65s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_atTargetSize
--- PASS: TestAccElastiCacheReplicationGroup_autoMinorVersionUpgrade (1056.82s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_addMemberCluster
--- PASS: TestAccElastiCacheReplicationGroup_tags (1656.75s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_noChange
--- PASS: TestAccElastiCacheReplicationGroup_useCMKKMSKeyID (829.98s)
=== CONT  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basic
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_scaleDown (1723.47s)
=== CONT  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears
--- PASS: TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Enabled (1885.84s)
=== CONT  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterModeValidation_numNodeGroupsOnSecondary
--- PASS: TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Disabled (1938.74s)
=== CONT  TestAccElastiCacheReplicationGroup_finalSnapshot
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_atTargetSize (1270.72s)
=== CONT  TestAccElastiCacheReplicationGroup_updateParameterGroup
--- PASS: TestAccElastiCacheReplicationGroup_tagWithOtherModification (2199.33s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClusters_multiAZEnabled
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_updateReplicasPerNodeGroup (2407.51s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleDown
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_addMemberCluster (1673.63s)
=== CONT  TestAccElastiCacheReplicationGroup_enableAtRestEncryption
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterModeValidation_numNodeGroupsOnSecondary (1108.36s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClustersFailover_autoFailoverEnabled
--- PASS: TestAccElastiCacheReplicationGroup_finalSnapshot (1143.17s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClustersFailover_autoFailoverDisabled
--- PASS: TestAccElastiCacheReplicationGroup_updateParameterGroup (1056.37s)
=== CONT  TestAccElastiCacheReplicationGroup_Validation_globalReplicationGroupIdAndNodeType
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_full (3276.99s)
=== CONT  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_basic
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_noChange (1628.46s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp
--- PASS: TestAccElastiCacheReplicationGroup_enableAtRestEncryption (831.97s)
=== CONT  TestAccElastiCacheReplicationGroup_EngineVersion_v7
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_multiAZEnabled (1674.13s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterMode_nonClusteredParameterGroup
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears (2333.00s)
=== CONT  TestAccElastiCacheReplicationGroup_updateNodeSize
--- PASS: TestAccElastiCacheReplicationGroup_Validation_globalReplicationGroupIdAndNodeType (862.67s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterMode_basic
--- PASS: TestAccElastiCacheReplicationGroup_EngineVersion_v7 (833.20s)
=== CONT  TestAccElastiCacheReplicationGroup_updateUserGroups
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleDown (2019.41s)
=== CONT  TestAccElastiCacheReplicationGroup_enableAuthTokenTransitEncryption
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersFailover_autoFailoverEnabled (1544.49s)
=== CONT  TestAccElastiCacheReplicationGroup_updateMaintenanceWindow
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersFailover_autoFailoverDisabled (1495.22s)
=== CONT  TestAccElastiCacheReplicationGroup_enableSnapshotting
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_nonClusteredParameterGroup (894.88s)
=== CONT  TestAccElastiCacheReplicationGroup_updateDescription
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_basic (1065.15s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp (1946.80s)
=== CONT  TestAccElastiCacheReplicationGroup_Validation_noNodeType
--- PASS: TestAccElastiCacheReplicationGroup_Validation_noNodeType (6.55s)
=== CONT  TestAccElastiCacheReplicationGroup_clusteringAndCacheNodesCausesError
--- PASS: TestAccElastiCacheReplicationGroup_clusteringAndCacheNodesCausesError (1.00s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterMode_singleNode
--- PASS: TestAccElastiCacheReplicationGroup_enableAuthTokenTransitEncryption (893.47s)
=== CONT  TestAccElastiCacheReplicationGroup_networkType
--- PASS: TestAccElastiCacheReplicationGroup_updateMaintenanceWindow (993.99s)
=== CONT  TestAccElastiCacheReplicationGroup_ipDiscovery
--- PASS: TestAccElastiCacheReplicationGroup_enableSnapshotting (1036.64s)
=== CONT  TestAccElastiCacheReplicationGroup_ValidationMultiAz_noAutomaticFailover
--- PASS: TestAccElastiCacheReplicationGroup_ValidationMultiAz_noAutomaticFailover (1.54s)
=== CONT  TestAccElastiCacheReplicationGroupDataSource_multiAZ
--- PASS: TestAccElastiCacheReplicationGroup_updateUserGroups (1231.07s)
=== CONT  TestAccElastiCacheReplicationGroupDataSource_Engine_Redis_LogDeliveryConfigurations
--- PASS: TestAccElastiCacheReplicationGroup_updateDescription (1037.12s)
=== CONT  TestAccElastiCacheReplicationGroup_disappears
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basic (4158.35s)
=== CONT  TestAccElastiCacheReplicationGroup_EngineVersion_6xToRealVersion
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_basic (2585.94s)
=== CONT  TestAccElastiCacheReplicationGroup_deprecatedAvailabilityZones_multiAzInVPC
--- PASS: TestAccElastiCacheReplicationGroup_updateNodeSize (1855.29s)
=== CONT  TestAccElastiCacheReplicationGroup_EngineVersion_update
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_singleNode (916.37s)
=== CONT  TestAccElastiCacheReplicationGroup_multiAzInVPC
--- PASS: TestAccElastiCacheReplicationGroup_networkType (1093.65s)
=== CONT  TestAccElastiCacheReplicationGroup_multiAzNotInVPC_repeated
--- PASS: TestAccElastiCacheReplicationGroupDataSource_multiAZ (860.57s)
=== CONT  TestAccElastiCacheReplicationGroup_basic
--- PASS: TestAccElastiCacheReplicationGroupDataSource_Engine_Redis_LogDeliveryConfigurations (855.42s)
=== CONT  TestAccElastiCacheReplicationGroup_multiAzNotInVPC
--- PASS: TestAccElastiCacheReplicationGroup_ipDiscovery (1010.06s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleDown
--- PASS: TestAccElastiCacheReplicationGroup_disappears (859.75s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleUp
--- PASS: TestAccElastiCacheReplicationGroup_deprecatedAvailabilityZones_multiAzInVPC (968.02s)
=== CONT  TestAccElastiCacheReplicationGroupDataSource_clusterMode
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic (1790.77s)
=== CONT  TestAccElastiCacheReplicationGroup_stateUpgrade5270
--- PASS: TestAccElastiCacheReplicationGroup_EngineVersion_6xToRealVersion (1233.28s)
=== CONT  TestAccElastiCacheReplicationGroup_authToken
--- PASS: TestAccElastiCacheReplicationGroup_multiAzInVPC (903.91s)
=== CONT  TestAccElastiCacheReplicationGroup_uppercase
--- PASS: TestAccElastiCacheReplicationGroup_basic (811.08s)
=== CONT  TestAccElastiCacheReplicationGroup_vpc
--- PASS: TestAccElastiCacheReplicationGroup_multiAzNotInVPC_repeated (982.22s)
=== CONT  TestAccElastiCacheReplicationGroup_basic_v5
--- PASS: TestAccElastiCacheReplicationGroup_multiAzNotInVPC (949.23s)
=== CONT  TestAccElastiCacheReplicationGroupDataSource_nonExistent
--- PASS: TestAccElastiCacheReplicationGroupDataSource_nonExistent (1.95s)
--- PASS: TestAccElastiCacheReplicationGroup_stateUpgrade5270 (955.53s)
--- PASS: TestAccElastiCacheReplicationGroup_uppercase (830.16s)
--- PASS: TestAccElastiCacheReplicationGroupDataSource_clusterMode (1175.04s)
--- PASS: TestAccElastiCacheReplicationGroup_vpc (892.98s)
--- PASS: TestAccElastiCacheReplicationGroup_basic_v5 (862.30s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleDown (2283.43s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleUp (2230.67s)
--- PASS: TestAccElastiCacheReplicationGroup_authToken (2080.48s)
```