### PR TITLE
fix: aws_cognito_identity_provider update ProviderDetails ActiveEncryptionCertificate on update

### DIFF
--- a/.changelog/36311.txt
+++ b/.changelog/36311.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cognito_identity_provider: Ensure read-only property ActiveEncryptionCertificate is not used in UpdateIdentityProvider request
+```

--- a/internal/service/cognitoidp/identity_provider.go
+++ b/internal/service/cognitoidp/identity_provider.go
@@ -201,7 +201,9 @@ func resourceIdentityProviderUpdate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if d.HasChange("provider_details") {
-		params.ProviderDetails = flex.ExpandStringMap(d.Get("provider_details").(map[string]interface{}))
+		providerDetailsForUpdate := flex.ExpandStringMap(d.Get("provider_details").(map[string]interface{}))
+		delete(providerDetailsForUpdate, "ActiveEncryptionCertificate")
+		params.ProviderDetails = providerDetailsForUpdate
 	}
 
 	if d.HasChange("idp_identifiers") {


### PR DESCRIPTION
### Description
A recent AWS feature release for Cognito added read-only ActiveEncryptionCertificate property to Cognito Identity Provider describe ProviderDetails map. UpdateIdentityProvider API call responds with the following error if ActiveEncryptionCertificate is included in the ProviderDetails map in the request. For example:
```
Error: Error updating Cognito Identity Provider: InvalidParameterException: ActiveEncryptionCertificate is not a valid key for SAML identity provider details.
```
If the Terraform plan for aws_cognito_identity_provider includes changes on the `provider_details` argument then we'll run into the above error during apply.


### Relations
Closes #35588 


### References
[AWS announcement for the feature that introduced the API change](https://aws.amazon.com/about-aws/whats-new/2024/02/amazon-cognito-signing-encryption-identity-provider-initiated-sso/
)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ AWS_DEFAULT_REGION=us-west-1 make testacc TESTS=TestAccCognitoIDPIdentityProvider PKG=cognitoidp

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cognitoidp/... -v -count 1 -parallel 20 -run='TestAccCognitoIDPIdentityProvider'  -timeout 360m
=== RUN   TestAccCognitoIDPIdentityProvider_basic
=== PAUSE TestAccCognitoIDPIdentityProvider_basic
=== RUN   TestAccCognitoIDPIdentityProvider_idpIdentifiers
=== PAUSE TestAccCognitoIDPIdentityProvider_idpIdentifiers
=== RUN   TestAccCognitoIDPIdentityProvider_disappears
=== PAUSE TestAccCognitoIDPIdentityProvider_disappears
=== RUN   TestAccCognitoIDPIdentityProvider_Disappears_userPool
=== PAUSE TestAccCognitoIDPIdentityProvider_Disappears_userPool
=== CONT  TestAccCognitoIDPIdentityProvider_basic
=== CONT  TestAccCognitoIDPIdentityProvider_disappears
=== CONT  TestAccCognitoIDPIdentityProvider_idpIdentifiers
=== CONT  TestAccCognitoIDPIdentityProvider_Disappears_userPool
--- PASS: TestAccCognitoIDPIdentityProvider_disappears (22.24s)
--- PASS: TestAccCognitoIDPIdentityProvider_Disappears_userPool (22.85s)
--- PASS: TestAccCognitoIDPIdentityProvider_basic (36.34s)
--- PASS: TestAccCognitoIDPIdentityProvider_idpIdentifiers (36.98s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp 43.565s```
