### PR TITLE
Added data source for aws_apigatewayv2_domain_name

### DIFF
--- a/docs/data-handling-and-conversion.md
+++ b/docs/data-handling-and-conversion.md
@@ -46,7 +46,7 @@ Typically these types of drift detection issues can be discovered by implementin
 
 Perhaps the most distinct difference between [Terraform Plugin Framework](https://developer.hashicorp.com/terraform/plugin/framework) and [Terraform Plugin SDKv2](https://developer.hashicorp.com/terraform/plugin/sdkv2) is data handling.
 With Terraform Plugin Framework state data is strongly typed, while Plugin SDK V2 based resources represent state data generically (each attribute is an `interface{}`) and types must be asserted at runtime.
-Strongly typed data eliminates an entire class of runtime bugs and crashes, but does require compile type type declarations and a slightly different approach to reading and writing data.
+Strongly typed data eliminates an entire class of runtime bugs and crashes, but does require compile time type declarations and a slightly different approach to reading and writing data.
 The sections below contain examples for both plugin libraries, but Terraform Plugin Framework should be preferred whenever possible.
 
 ## Data Conversions in the Terraform AWS Provider

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/account v1.16.1
 	github.com/aws/aws-sdk-go-v2/service/acm v1.25.1
 	github.com/aws/aws-sdk-go-v2/service/amp v1.25.1
+	github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.20.1
 	github.com/aws/aws-sdk-go-v2/service/appconfig v1.28.1
 	github.com/aws/aws-sdk-go-v2/service/appfabric v1.7.1
 	github.com/aws/aws-sdk-go-v2/service/appflow v1.41.1

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/aws/aws-sdk-go-v2/service/acm v1.25.1 h1:PwTzrPPB/L3vasKiNwmTpprzWEaH
 github.com/aws/aws-sdk-go-v2/service/acm v1.25.1/go.mod h1:qqnNK9+yQECVaR2XiY7CNp3CfsomNDUEGOYGlQk4qWU=
 github.com/aws/aws-sdk-go-v2/service/amp v1.25.1 h1:kdytWcOvNUmqSVWSRNeAirv4e1j397UQC3d6ofS2CxQ=
 github.com/aws/aws-sdk-go-v2/service/amp v1.25.1/go.mod h1:cG/8NqEsOGrLYBgIeixa7aaHzY8RvbUhMQYJBbSdD+c=
+github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.20.1 h1:nOJwQpU2wDe2qtw+vwkywJ44UhK66P6+1UIRotE7Jmo=
+github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.20.1/go.mod h1:A95FM8hxO6umoiROudoYtTmZYl7KN9nbez8deLDOCnA=
 github.com/aws/aws-sdk-go-v2/service/appconfig v1.28.1 h1:9Ss8U7qTM7Wbb2MYk38kBYB+TC7b/hBikj3nzWZMkJo=
 github.com/aws/aws-sdk-go-v2/service/appconfig v1.28.1/go.mod h1:AvJvRRqTqSEk3q43uYwKxP9HkHBzV9k+Ok04cpbJd9U=
 github.com/aws/aws-sdk-go-v2/service/appfabric v1.7.1 h1:QnHeYwIVPpBk5YSFq4OHppMi5VXAHVJcsM8FBEXc4hk=

--- a/internal/service/apigatewayv2/domain_name_data_source.go
+++ b/internal/service/apigatewayv2/domain_name_data_source.go
@@ -1,0 +1,132 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package apigatewayv2
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func newDataSourceDomainName(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &dataSourceDomainName{}, nil
+}
+
+const (
+	DSNameDomainName = "Domain Name Data Source"
+)
+
+type dataSourceDomainName struct {
+	framework.DataSourceWithConfigure
+}
+
+func (d *dataSourceDomainName) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) { // nosemgrep:ci.meta-in-func-name
+	resp.TypeName = "aws_apigatewayv2_domain_name"
+}
+
+func (d *dataSourceDomainName) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"api_mapping_selection_expression": schema.StringAttribute{
+				Computed: true,
+			},
+			"domain_name": schema.StringAttribute{
+				Required: true,
+			},
+			"domain_name_configurations": schema.ListAttribute{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[dataSourceDomainNameConfigurationData](ctx),
+				Computed:   true,
+				ElementType: types.ObjectType{
+					AttrTypes: map[string]attr.Type{
+						"certificate_arn":                        types.StringType,
+						"certificate_name":                       types.StringType,
+						"certificate_upload_date":                fwtypes.TimestampType,
+						"domain_name_status":                     types.StringType,
+						"domain_name_status_message":             types.StringType,
+						"endpoint_type":                          types.StringType,
+						"hosted_zone_id":                         types.StringType,
+						"ownership_verification_certificate_arn": types.StringType,
+						"security_policy":                        types.StringType,
+					},
+				},
+			},
+			"mutual_tls_authentication": schema.ObjectAttribute{
+				Computed:   true,
+				CustomType: fwtypes.NewObjectTypeOf[dataSourceMutualTlsAuthenticationData](ctx),
+				AttributeTypes: map[string]attr.Type{
+					"truststore_uri":      types.StringType,
+					"truststore_version":  types.StringType,
+					"truststore_warnings": fwtypes.ListOfStringType,
+				},
+			},
+			names.AttrTags: tftags.TagsAttributeComputedOnly(),
+		},
+	}
+}
+
+func (d *dataSourceDomainName) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	conn := d.Meta().APIGatewayV2Conn(ctx)
+
+	var data dataSourceDomainNameData
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := FindDomainName(ctx, conn, data.DomainName.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.APIGatewayV2, create.ErrActionReading, DSNameDomainName, data.DomainName.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	diags := flex.Flatten(ctx, out, &data)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+
+	ignoreTagsConfig := d.Meta().IgnoreTagsConfig
+	tags := KeyValueTags(ctx, out.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+	data.Tags = flex.FlattenFrameworkStringValueMapLegacy(ctx, tags.Map())
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+type dataSourceDomainNameData struct {
+	ApiMappingSelectionExpression types.String                                                           `tfsdk:"api_mapping_selection_expression"`
+	DomainName                    types.String                                                           `tfsdk:"domain_name"`
+	DomainNameConfigurations      fwtypes.ListNestedObjectValueOf[dataSourceDomainNameConfigurationData] `tfsdk:"domain_name_configurations"`
+	MutualTlsAuthentication       fwtypes.ObjectValueOf[dataSourceMutualTlsAuthenticationData]           `tfsdk:"mutual_tls_authentication"`
+	Tags                          types.Map                                                              `tfsdk:"tags"`
+}
+
+type dataSourceDomainNameConfigurationData struct {
+	CertificateArn                      types.String      `tfsdk:"certificate_arn"`
+	CertificateName                     types.String      `tfsdk:"certificate_name"`
+	CertificateUploadDate               fwtypes.Timestamp `tfsdk:"certificate_upload_date"`
+	DomainNameStatus                    types.String      `tfsdk:"domain_name_status"`
+	DomainNameStatusMessage             types.String      `tfsdk:"domain_name_status_message"`
+	EndpointType                        types.String      `tfsdk:"endpoint_type"`
+	HostedZoneId                        types.String      `tfsdk:"hosted_zone_id"`
+	OwnershipVerificationCertificateArn types.String      `tfsdk:"ownership_verification_certificate_arn"`
+	SecurityPolicy                      types.String      `tfsdk:"security_policy"`
+}
+
+type dataSourceMutualTlsAuthenticationData struct {
+	TruststoreUri      types.String                      `tfsdk:"truststore_uri"`
+	TruststoreVersion  types.String                      `tfsdk:"truststore_version"`
+	TruststoreWarnings fwtypes.ListValueOf[types.String] `tfsdk:"truststore_warnings"`
+}

--- a/internal/service/apigatewayv2/domain_name_data_source_test.go
+++ b/internal/service/apigatewayv2/domain_name_data_source_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package apigatewayv2_test
+
+import (
+	"fmt"
+	"testing"
+
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccAPIGatewayV2DomainNameDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	testName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_apigatewayv2_domain_name.test"
+
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+	domainName := fmt.Sprintf("%s.example.com", testName)
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, domainName)
+
+	resourceName := fmt.Sprintf("aws_apigatewayv2_domain_name.%s", testName)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDomainNameDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainNameDataSourceConfig_basic(testName, key, certificate),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "domain_name", dataSourceName, "domain_name"),
+					resource.TestCheckResourceAttr(dataSourceName, "domain_name_configurations.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "domain_name_configuration.0.certificate_arn", dataSourceName, "domain_name_configurations.0.certificate_arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "domain_name_configuration.0.certificate_name", dataSourceName, "domain_name_configurations.0.certificate_name"),
+					resource.TestCheckResourceAttrPair(resourceName, "domain_name_configuration.0.certificate_upload_date", dataSourceName, "domain_name_configurations.0.certificate_upload_date"),
+					resource.TestCheckResourceAttrPair(resourceName, "domain_name_configuration.0.endpoint_type", dataSourceName, "domain_name_configurations.0.endpoint_type"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.%", dataSourceName, "tags.%"),
+					resource.TestCheckResourceAttr(dataSourceName, "domain_name_configurations.0.domain_name_status", "AVAILABLE"),
+					resource.TestCheckResourceAttr(dataSourceName, "domain_name_configurations.0.security_policy", "TLS_1_2"),
+					resource.TestCheckNoResourceAttr(dataSourceName, "domain_name_configurations.0.domain_name_status_message"),
+					resource.TestCheckNoResourceAttr(dataSourceName, "domain_name_configurations.0.ownership_verification_certificate_arn"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDomainNameDataSourceConfig_basic(rName, key, certificate string) string {
+	return fmt.Sprintf(`
+resource "aws_acm_certificate" "%[1]s" {	
+  certificate_body = "%[2]s"
+  private_key      = "%[3]s"
+}
+
+resource "aws_apigatewayv2_domain_name" "%[1]s" {
+  domain_name              = aws_acm_certificate.%[1]s.domain_name
+
+  domain_name_configuration {
+    certificate_arn = aws_acm_certificate.%[1]s.arn
+    endpoint_type   = "REGIONAL"
+    security_policy = "TLS_1_2"
+  }
+
+  tags = {
+    Description = "No mutual TLS"
+  }
+}
+
+data "aws_apigatewayv2_domain_name" "test" {
+  domain_name = aws_apigatewayv2_domain_name.%[1]s.domain_name
+}
+`, rName, acctest.TLSPEMEscapeNewlines(certificate), acctest.TLSPEMEscapeNewlines(key))
+}

--- a/internal/service/apigatewayv2/service_package_gen.go
+++ b/internal/service/apigatewayv2/service_package_gen.go
@@ -16,7 +16,12 @@ import (
 type servicePackage struct{}
 
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.ServicePackageFrameworkDataSource {
-	return []*types.ServicePackageFrameworkDataSource{}
+	return []*types.ServicePackageFrameworkDataSource{
+		{
+			Factory: newDataSourceDomainName,
+			Name:    "Domain Name",
+		},
+	}
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.ServicePackageFrameworkResource {

--- a/website/docs/d/apigatewayv2_domain_name.html.markdown
+++ b/website/docs/d/apigatewayv2_domain_name.html.markdown
@@ -1,0 +1,68 @@
+---
+subcategory: "API Gateway V2"
+layout: "aws"
+page_title: "AWS: aws_apigatewayv2_domain_name"
+description: |-
+  Terraform data source for managing an AWS API Gateway V2 Domain Name.
+---
+
+# Data Source: aws_apigatewayv2_domain_name
+
+Terraform data source for managing an AWS API Gateway V2 Domain Name. 
+
+More information can be found in [Terraform Apigateway V2 Domain Name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_domain_name) and [Amazon API Gateway Developer Guide](https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains.html).
+
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_apigatewayv2_domain_name" "example" {
+  domain_name              = "example.terraform.com"
+
+  domain_name_configuration {
+    certificate_arn = aws_acm_certificate.example.arn
+    endpoint_type   = "REGIONAL"
+    security_policy = "TLS_1_2"
+  }
+}
+
+data "aws_apigatewayv2_domain_name" "example" {
+  domain_name = aws_apigatewayv2_domain_name.example.domain_name
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `domain_name` - (Required) Domain name of resource.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `api_mapping_selection_expression` - This expression is evaluated to determine which API stage is selected when a request is made using a custom domain. [AWS Docs](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-selection-expressions.html#apigateway-websocket-api-mapping-selection-expressions)
+* `domain_name` - The name of the domain_name resource.
+* `domain_name_configurations` - The list of domain name configurations.
+* `mutual_tls_authentication` - The mutual TLS authentication configuration for a custom domain name.
+* `tags` - The collection of tags associated with a domain name.
+
+### `domain_name_configuration`
+
+* `certificate_arn` - An AWS-managed certificate that will be used by the edge-optimized endpoint for this domain name. AWS Certificate Manager is the only supported source.
+* `certificate_name` - The user-friendly name of the certificate that will be used by the edge-optimized endpoint for this domain name.
+* `certificate_upload_date` - The timestamp when the certificate that was used by edge-optimized endpoint for this domain name was uploaded.
+* `domain_name_status` - The status of the domain name migration. The valid values are AVAILABLE, UPDATING, PENDING_CERTIFICATE_REIMPORT, and PENDING_OWNERSHIP_VERIFICATION. If the status is UPDATING, the domain cannot be modified further until the existing operation is complete. If it is AVAILABLE, the domain can be updated.
+* `domain_name_status_message` - An optional text message containing detailed information about status of the domain name migration.
+* `endpoint_type` - The endpoint type.
+* `hosted_zone_id` - The Amazon Route 53 Hosted Zone ID of the endpoint.
+* `ownership_verification_certificate_arn` - The ARN of the public certificate issued by ACM to validate ownership of your custom domain. Only required when configuring mutual TLS and using an ACM imported or private CA certificate ARN as the regionalCertificateArn
+* `security_policy` - The Transport Layer Security (TLS) version of the security policy for this domain name.
+
+### `mutual_tls_authentication`
+
+* `truststore_uri` - An Amazon S3 URL that specifies the truststore for mutual TLS authentication, for example, s3://bucket-name/key-name. The truststore can contain certificates from public or private certificate authorities. To update the truststore, upload a new version to S3, and then update your custom domain name to use the new version. To update the truststore, you must have permissions to access the S3 object.
+* `truststore_version` - The version of the S3 object that contains your truststore. To specify a version, you must have versioning enabled for the S3 bucket.
+* `truststore_warnings` - A list of warnings that API Gateway returns while processing your truststore. Invalid certificates produce warnings. Mutual TLS is still enabled, but some clients might not be able to access your API. To resolve warnings, upload a new truststore to S3, and then update you domain name to use the new version.


### PR DESCRIPTION
### Description
Created a new data source for API Gateway V2 domain name

### Relations
Closes #36027


### References
[Amazon API Gateway Developer Guide](https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains.html)


### Output from Acceptance Testing
```console
% make testacc TESTS=TestAccAPIGatewayV2DomainNameDataSource PKG=apigatewayv2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/apigatewayv2/... -v -count 1 -parallel 20 -run='TestAccAPIGatewayV2DomainNameDataSource'  -timeout 360m
=== RUN   TestAccAPIGatewayV2DomainNameDataSource_basic
=== PAUSE TestAccAPIGatewayV2DomainNameDataSource_basic
=== CONT  TestAccAPIGatewayV2DomainNameDataSource_basic
--- PASS: TestAccAPIGatewayV2DomainNameDataSource_basic (19.82s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/apigatewayv2       20.004s

```
