### PR TITLE
fix: Add nil check for empty blocks to fix crashes for aws_ecs_cluster

### DIFF
--- a/.changelog/36341.txt
+++ b/.changelog/36341.txt
@@ -1,3 +1,7 @@
 ```release-note:bug
-resource/aws_ecs_cluster: Add nil checks for the `configuration`, `execute_command_configuration`, and `log_configuration` blocks to prevent provider crashes when empty blocks are supplied
+resource/aws_ecs_cluster: Fix `panic: interface conversion: interface {} is nil, not map[string]interface {}` when `configuration`, `configuration.execute_command_configuration`, or `configuration.execute_command_configuration.log_configuration` are empty
+```
+
+```release-note:enhancement
+resource/aws_ecs_cluster: Add default value (`DEFAULT`) for `configuration.execute_command_configuration.logging`
 ```

--- a/.changelog/36341.txt
+++ b/.changelog/36341.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ecs_cluster: Add nil checks for the `configuration`, `execute_command_configuration`, and `log_configuration` blocks to prevent provider crashes when empty blocks are supplied
+```

--- a/internal/service/ecs/cluster.go
+++ b/internal/service/ecs/cluster.go
@@ -93,6 +93,7 @@ func ResourceCluster() *schema.Resource {
 									"logging": {
 										Type:         schema.TypeString,
 										Optional:     true,
+										Default:      ecs.ExecuteCommandLoggingDefault,
 										ValidateFunc: validation.StringInSlice(ecs.ExecuteCommandLogging_Values(), false),
 									},
 								},
@@ -576,7 +577,7 @@ func flattenClusterConfigurationExecuteCommandConfigurationLogConfiguration(apiO
 }
 
 func expandClusterConfiguration(nc []interface{}) *ecs.ClusterConfiguration {
-	if len(nc) == 0 {
+	if len(nc) == 0 || nc[0] == nil {
 		return &ecs.ClusterConfiguration{}
 	}
 	raw := nc[0].(map[string]interface{})
@@ -590,7 +591,7 @@ func expandClusterConfiguration(nc []interface{}) *ecs.ClusterConfiguration {
 }
 
 func expandClusterConfigurationExecuteCommandConfiguration(nc []interface{}) *ecs.ExecuteCommandConfiguration {
-	if len(nc) == 0 {
+	if len(nc) == 0 || nc[0] == nil {
 		return &ecs.ExecuteCommandConfiguration{}
 	}
 	raw := nc[0].(map[string]interface{})
@@ -612,7 +613,7 @@ func expandClusterConfigurationExecuteCommandConfiguration(nc []interface{}) *ec
 }
 
 func expandClusterConfigurationExecuteCommandLogConfiguration(nc []interface{}) *ecs.ExecuteCommandLogConfiguration {
-	if len(nc) == 0 {
+	if len(nc) == 0 || nc[0] == nil {
 		return &ecs.ExecuteCommandLogConfiguration{}
 	}
 	raw := nc[0].(map[string]interface{})


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to fix provider crashes in three locations due to empty configuration blocks (`configuration`, `execute_command_configuration` and `log_configuration`) being loaded as `nil` into the list of blocks from the config during expansion. The AWS API also seems to set a default value for the `logging` argument in the `execute_command_configuration` block, so I also had to set a default value to avoid perpetual differences.

**Note:** Since this is a widely used resource, I appreciate that a maintainer review this change to make sure I am not introducing any side effects. If there is anything I could do to help validate further, let me know.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #36330
or 
Closes #0000
--->

Closes #36330

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to other resource code like that of [`aws_openserach_domain`](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/opensearch/domain.go) to see how similar cases are handled and follow suit.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTARGS="-run=TestAccECSCluster_" PKG=ecs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 20  -run=TestAccECSCluster_ -timeout 360m
=== RUN   TestAccECSCluster_basic
=== PAUSE TestAccECSCluster_basic
=== RUN   TestAccECSCluster_disappears
=== PAUSE TestAccECSCluster_disappears
=== RUN   TestAccECSCluster_tags
=== PAUSE TestAccECSCluster_tags
=== RUN   TestAccECSCluster_serviceConnectDefaults
=== PAUSE TestAccECSCluster_serviceConnectDefaults
=== RUN   TestAccECSCluster_containerInsights
=== PAUSE TestAccECSCluster_containerInsights
=== RUN   TestAccECSCluster_configuration
=== PAUSE TestAccECSCluster_configuration
=== CONT  TestAccECSCluster_basic
=== CONT  TestAccECSCluster_serviceConnectDefaults
=== CONT  TestAccECSCluster_tags
=== CONT  TestAccECSCluster_disappears
=== CONT  TestAccECSCluster_configuration
=== CONT  TestAccECSCluster_containerInsights
--- PASS: TestAccECSCluster_disappears (57.86s)
--- PASS: TestAccECSCluster_basic (59.06s)
--- PASS: TestAccECSCluster_tags (105.20s)
--- PASS: TestAccECSCluster_containerInsights (123.99s)
--- PASS: TestAccECSCluster_configuration (156.98s)
--- PASS: TestAccECSCluster_serviceConnectDefaults (211.64s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecs        211.836s

$
```
