### PR TITLE
elbv2: Fix occasionally crashing acceptance tests

### DIFF
--- a/internal/service/elbv2/listener_rule_test.go
+++ b/internal/service/elbv2/listener_rule_test.go
@@ -186,9 +186,7 @@ func TestAccELBV2ListenerRule_updateForwardBasic(t *testing.T) {
 	var conf awstypes.Rule
 	resourceName := "aws_lb_listener_rule.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	if len(rName) > 30 {
-		rName = rName[:min(len(rName), 30)]
-	}
+	rName = rName[:min(len(rName), 30)]
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -848,9 +846,7 @@ func TestAccELBV2ListenerRule_ActionForward_IgnoreFields(t *testing.T) {
 	var conf awstypes.Rule
 	resourceName := "aws_lb_listener_rule.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	if len(rName) > 30 {
-		rName = rName[:min(len(rName), 30)]
-	}
+	rName = rName[:min(len(rName), 30)]
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 

--- a/internal/service/elbv2/listener_rule_test.go
+++ b/internal/service/elbv2/listener_rule_test.go
@@ -187,7 +187,7 @@ func TestAccELBV2ListenerRule_updateForwardBasic(t *testing.T) {
 	resourceName := "aws_lb_listener_rule.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	if len(rName) > 30 {
-		rName = rName[:30]
+		rName = rName[:min(len(rName), 30)]
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -849,7 +849,7 @@ func TestAccELBV2ListenerRule_ActionForward_IgnoreFields(t *testing.T) {
 	resourceName := "aws_lb_listener_rule.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	if len(rName) > 30 {
-		rName = rName[:30]
+		rName = rName[:min(len(rName), 30)]
 	}
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")

--- a/internal/service/elbv2/listener_test.go
+++ b/internal/service/elbv2/listener_test.go
@@ -277,7 +277,7 @@ func TestAccELBV2Listener_updateForwardBasic(t *testing.T) {
 	var conf awstypes.Listener
 	resourceName := "aws_lb_listener.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	rName = rName[:30]
+	rName = rName[:min(len(rName), 30)]
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -942,7 +942,7 @@ func TestAccELBV2Listener_ActionForward_IgnoreFields(t *testing.T) {
 	var conf awstypes.Listener
 	resourceName := "aws_lb_listener.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	rName = rName[:30]
+	rName = rName[:min(len(rName), 30)]
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fixes `panic: runtime error: slice bounds out of range [:30] with length 29` errors.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/36351.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccELBV2ListenerRule_updateForwardBasic\|TestAccELBV2ListenerRule_ActionForward_IgnoreFields\|TestAccELBV2Listener_updateForwardBasic\|TestAccELBV2Listener_ActionForward_IgnoreFields' PKG=elbv2 ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.7 test ./internal/service/elbv2/... -v -count 1 -parallel 3  -run=TestAccELBV2ListenerRule_updateForwardBasic\|TestAccELBV2ListenerRule_ActionForward_IgnoreFields\|TestAccELBV2Listener_updateForwardBasic\|TestAccELBV2Listener_ActionForward_IgnoreFields -timeout 360m
=== RUN   TestAccELBV2ListenerRule_updateForwardBasic
=== PAUSE TestAccELBV2ListenerRule_updateForwardBasic
=== RUN   TestAccELBV2ListenerRule_ActionForward_IgnoreFields
=== PAUSE TestAccELBV2ListenerRule_ActionForward_IgnoreFields
=== RUN   TestAccELBV2Listener_updateForwardBasic
=== PAUSE TestAccELBV2Listener_updateForwardBasic
=== RUN   TestAccELBV2Listener_ActionForward_IgnoreFields
=== PAUSE TestAccELBV2Listener_ActionForward_IgnoreFields
=== CONT  TestAccELBV2ListenerRule_updateForwardBasic
=== CONT  TestAccELBV2Listener_updateForwardBasic
=== CONT  TestAccELBV2Listener_ActionForward_IgnoreFields
--- PASS: TestAccELBV2Listener_ActionForward_IgnoreFields (217.59s)
=== CONT  TestAccELBV2ListenerRule_ActionForward_IgnoreFields
--- PASS: TestAccELBV2Listener_updateForwardBasic (244.28s)
--- PASS: TestAccELBV2ListenerRule_updateForwardBasic (253.95s)
--- PASS: TestAccELBV2ListenerRule_ActionForward_IgnoreFields (215.75s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	441.101s
```
