### PR TITLE
FIX: `aws_nat_gateway` resource `secondary_private_ip_address_count` logic

### DIFF
--- a/internal/service/ec2/vpc_nat_gateway.go
+++ b/internal/service/ec2/vpc_nat_gateway.go
@@ -370,16 +370,15 @@ func resourceNATGatewayCustomizeDiff(ctx context.Context, diff *schema.ResourceD
 		if v, ok := diff.GetOk("secondary_allocation_ids"); ok && v.(*schema.Set).Len() > 0 {
 			return fmt.Errorf(`secondary_allocation_ids is not supported with connectivity_type = "%s"`, connectivityType)
 		}
-
-	case ec2.ConnectivityTypePublic:
-		if v := diff.GetRawConfig().GetAttr("secondary_private_ip_address_count"); v.IsKnown() && !v.IsNull() {
-			return fmt.Errorf(`secondary_private_ip_address_count is not supported with connectivity_type = "%s"`, connectivityType)
-		}
-
 		if diff.Id() != "" && diff.HasChange("secondary_private_ip_address_count") {
 			if err := diff.ForceNew("secondary_private_ip_address_count"); err != nil {
 				return fmt.Errorf("setting secondary_private_ip_address_count forcenew: %s", err)
 			}
+		}
+
+	case ec2.ConnectivityTypePublic:
+		if v := diff.GetRawConfig().GetAttr("secondary_private_ip_address_count"); v.IsKnown() && !v.IsNull() {
+			return fmt.Errorf(`secondary_private_ip_address_count is not supported with connectivity_type = "%s"`, connectivityType)
 		}
 
 		if diff.Id() != "" && diff.HasChange("secondary_allocation_ids") {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

Move logic for `secondary_private_ip_address_count` for `forceNew` to **customizeDiff**

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #33964

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```

I am unable to run the tests in my organization due to VPC limits, so some help would be appreciated but I was able to run the following tests

**From the use case in #33964 adding `secondary_allocation_ids` to and existing configuration yields**

```hcl
# aws_nat_gateway.nat_gw_a will be updated in-place
  ~ resource "aws_nat_gateway" "nat_gw_a" {
        id                                 = "nat-0170c9d03350baaf0"
      ~ secondary_allocation_ids           = [
          + "eipalloc-08574d36e606017b4",
        ]
      ~ secondary_private_ip_address_count = 0 -> (known after apply)
        tags                               = {
            "Name" = "NAT GW AZ1"
        }
        # (9 unchanged attributes hidden)
    }
```

**Removing `secondary_allocation_ids`** 

``` hcl
# aws_nat_gateway.nat_gw_a will be updated in-place
  ~ resource "aws_nat_gateway" "nat_gw_a" {
        id                                 = "nat-0261dc97eaf02d40c"
      ~ secondary_allocation_ids           = [
          - "eipalloc-0781fde3477527f3b",
        ]
      ~ secondary_private_ip_address_count = 1 -> (known after apply)
        tags                               = {
            "Name" = "NAT GW AZ1"
        }
        # (9 unchanged attributes hidden)
    }
```

**Changing `secondary_private_ip_address_count ` yields the following plan**

``` hcl
 # aws_nat_gateway.nat_gw_a must be replaced
-/+ resource "aws_nat_gateway" "nat_gw_a" {
      + association_id                     = (known after apply)
      ~ id                                 = "nat-04b77581c7710320b" -> (known after apply)
      ~ network_interface_id               = "eni-082b81dfd210cd7c2" -> (known after apply)
      ~ private_ip                         = "10.5.247.41" -> (known after apply)
      + public_ip                          = (known after apply)
      - secondary_allocation_ids           = [] -> null
      ~ secondary_private_ip_address_count = 2 -> 1 # forces replacement
      ~ secondary_private_ip_addresses     = [
          - "10.5.247.40",
          - "10.5.247.61",
        ] -> (known after apply)
        tags                               = {
            "Name" = "NAT GW AZ1"
        }
        # (3 unchanged attributes hidden)
    }
```




