### PR TITLE
[Bug Fix] kx_cluster Init script and command line arg updates

### DIFF
--- a/.changelog/36361.txt
+++ b/.changelog/36361.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_finspace_kx_cluster: Fix command line args and init script updates removing each other
+```

--- a/.changelog/36361.txt
+++ b/.changelog/36361.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_finspace_kx_cluster: Fix command line args and init script updates removing each other
+resource/aws_finspace_kx_cluster: Prevent `command_line_arguments` and `initialization_script` updates from overwriting one another
 ```

--- a/internal/service/finspace/kx_cluster.go
+++ b/internal/service/finspace/kx_cluster.go
@@ -639,16 +639,25 @@ func resourceKxClusterUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		updateCode = true
 	}
 
-	if v, ok := d.GetOk("initialization_script"); ok && d.HasChanges("initialization_script") {
+	if v, ok := d.GetOk("initialization_script"); ok {
 		CodeConfigIn.Code = expandCode(d.Get("code").([]interface{}))
-		CodeConfigIn.InitializationScript = aws.String(v.(string))
-		updateCode = true
+		if d.HasChanges("initialization_script") {
+			CodeConfigIn.InitializationScript = aws.String(v.(string))
+			updateCode = true
+		} else {
+			CodeConfigIn.InitializationScript = aws.String(d.Get("initialization_script").(string))
+		}
 	}
 
-	if v, ok := d.GetOk("command_line_arguments"); ok && len(v.(map[string]interface{})) > 0 && d.HasChanges("command_line_arguments") {
+	if v, ok := d.GetOk("command_line_arguments"); ok && len(v.(map[string]interface{})) > 0 {
 		CodeConfigIn.Code = expandCode(d.Get("code").([]interface{}))
-		CodeConfigIn.CommandLineArguments = expandCommandLineArguments(v.(map[string]interface{}))
-		updateCode = true
+		if d.HasChanges("command_line_arguments") {
+			CodeConfigIn.CommandLineArguments = expandCommandLineArguments(v.(map[string]interface{}))
+			updateCode = true
+		} else {
+			CodeConfigIn.CommandLineArguments = expandCommandLineArguments(
+				d.Get("command_line_arguments").(map[string]interface{}))
+		}
 	}
 
 	if updateDb {

--- a/internal/service/finspace/kx_cluster_test.go
+++ b/internal/service/finspace/kx_cluster_test.go
@@ -781,7 +781,7 @@ resource "aws_finspace_kx_environment" "test" {
 data "aws_iam_policy_document" "key_policy" {
   statement {
     actions = [
-	  "kms:Encrypt",
+      "kms:Encrypt",
       "kms:Decrypt",
       "kms:GenerateDataKey"
     ]

--- a/internal/service/finspace/kx_cluster_test.go
+++ b/internal/service/finspace/kx_cluster_test.go
@@ -781,6 +781,7 @@ resource "aws_finspace_kx_environment" "test" {
 data "aws_iam_policy_document" "key_policy" {
   statement {
     actions = [
+	  "kms:Encrypt",
       "kms:Decrypt",
       "kms:GenerateDataKey"
     ]
@@ -1812,11 +1813,6 @@ resource "aws_s3_object" "object" {
   source = %[2]q
 }
 
-resource "aws_finspace_kx_database" "test" {
-  name           = %[1]q
-  environment_id = aws_finspace_kx_environment.test.id
-}
-
 resource "aws_finspace_kx_cluster" "test" {
   name                  = %[1]q
   environment_id        = aws_finspace_kx_environment.test.id
@@ -1835,19 +1831,6 @@ resource "aws_finspace_kx_cluster" "test" {
     security_group_ids = [aws_security_group.test.id]
     subnet_ids         = [aws_subnet.test.id]
     ip_address_type    = "IP_V4"
-  }
-
-  cache_storage_configurations {
-    type = "CACHE_1000"
-    size = 1200
-  }
-
-  database {
-    database_name = aws_finspace_kx_database.test.name
-    cache_configurations {
-      cache_type = "CACHE_1000"
-      db_paths   = ["/"]
-    }
   }
 
   code {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR fixes a bug where updating command line args on a cluster with an existing init script (not updated) would remove the init script from the cluster, and vice versa (updating init script on a cluster with command line args could remove command line args from cluster). This change has been tested both through manual testing (approaching both ends of the bug) and through rerunning relevant acceptance tests to ensure there are no regressions.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #31806


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccFinSpaceKxCluster_commandLineArgs PKG=finspace
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/finspace/... -v -count 1 -parallel 20 -run='TestAccFinSpaceKxCluster_commandLineArgs'  -timeout 360m
=== RUN   TestAccFinSpaceKxCluster_commandLineArgs
=== PAUSE TestAccFinSpaceKxCluster_commandLineArgs
=== CONT  TestAccFinSpaceKxCluster_commandLineArgs
--- PASS: TestAccFinSpaceKxCluster_commandLineArgs (5036.32s)
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/finspace	5040.365s

% make testacc TESTS=TestAccFinSpaceKxCluster_initializationScript PKG=finspace
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/finspace/... -v -count 1 -parallel 20 -run='TestAccFinSpaceKxCluster_initializationScript'  -timeout 360m
=== RUN   TestAccFinSpaceKxCluster_initializationScript
=== PAUSE TestAccFinSpaceKxCluster_initializationScript
=== CONT  TestAccFinSpaceKxCluster_initializationScript
--- PASS: TestAccFinSpaceKxCluster_initializationScript (5467.62s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/finspace	5471.630s

% make testacc TESTS=TestAccFinSpaceKxCluster_database PKG=finspace
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/finspace/... -v -count 1 -parallel 20 -run='TestAccFinSpaceKxCluster_database'  -timeout 360m
=== RUN   TestAccFinSpaceKxCluster_database
=== PAUSE TestAccFinSpaceKxCluster_database
=== CONT  TestAccFinSpaceKxCluster_database
--- PASS: TestAccFinSpaceKxCluster_database (4655.38s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/finspace	4659.377s
...
```
