### PR TITLE
Migrate LakeFormation Service to AWS Go SDKv2

### DIFF
--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -208,7 +208,6 @@ import (
 	kinesisanalyticsv2_sdkv1 "github.com/aws/aws-sdk-go/service/kinesisanalyticsv2"
 	kinesisvideo_sdkv1 "github.com/aws/aws-sdk-go/service/kinesisvideo"
 	kms_sdkv1 "github.com/aws/aws-sdk-go/service/kms"
-	lakeformation_sdkv1 "github.com/aws/aws-sdk-go/service/lakeformation"
 	lambda_sdkv1 "github.com/aws/aws-sdk-go/service/lambda"
 	lexmodelbuildingservice_sdkv1 "github.com/aws/aws-sdk-go/service/lexmodelbuildingservice"
 	licensemanager_sdkv1 "github.com/aws/aws-sdk-go/service/licensemanager"
@@ -803,10 +802,6 @@ func (c *AWSClient) KinesisAnalyticsV2Conn(ctx context.Context) *kinesisanalytic
 
 func (c *AWSClient) KinesisVideoConn(ctx context.Context) *kinesisvideo_sdkv1.KinesisVideo {
 	return errs.Must(conn[*kinesisvideo_sdkv1.KinesisVideo](ctx, c, names.KinesisVideo, make(map[string]any)))
-}
-
-func (c *AWSClient) LakeFormationConn(ctx context.Context) *lakeformation_sdkv1.LakeFormation {
-	return errs.Must(conn[*lakeformation_sdkv1.LakeFormation](ctx, c, names.LakeFormation, make(map[string]any)))
 }
 
 func (c *AWSClient) LakeFormationClient(ctx context.Context) *lakeformation_sdkv2.Client {

--- a/internal/service/lakeformation/data_lake_settings.go
+++ b/internal/service/lakeformation/data_lake_settings.go
@@ -308,7 +308,7 @@ func expandDataLakeSettingsCreateDefaultPermissions(tfMaps []interface{}) []awst
 
 func expandDataLakeSettingsCreateDefaultPermission(tfMap map[string]interface{}) awstypes.PrincipalPermissions {
 	apiObject := awstypes.PrincipalPermissions{
-		Permissions: expandDataLakePermissions(tfMap["permissions"].(*schema.Set).List()),
+		Permissions: expandPermissions(tfMap["permissions"].(*schema.Set).List()),
 		Principal: &awstypes.DataLakePrincipal{
 			DataLakePrincipalIdentifier: aws.String(tfMap["principal"].(string)),
 		},
@@ -338,7 +338,7 @@ func flattenDataLakeSettingsCreateDefaultPermission(apiObject awstypes.Principal
 	}
 
 	if apiObject.Permissions != nil {
-		tfMap["permissions"] = flex.FlattenStringValueSet(flattenDataLakePermissions(apiObject.Permissions))
+		tfMap["permissions"] = flex.FlattenStringValueSet(flattenPermissions(apiObject.Permissions))
 	}
 
 	if v := aws.ToString(apiObject.Principal.DataLakePrincipalIdentifier); v != "" {
@@ -348,7 +348,7 @@ func flattenDataLakeSettingsCreateDefaultPermission(apiObject awstypes.Principal
 	return tfMap
 }
 
-func expandDataLakePermissions(in []interface{}) []awstypes.Permission {
+func expandPermissions(in []interface{}) []awstypes.Permission {
 	if len(in) == 0 {
 		return nil
 	}
@@ -362,7 +362,7 @@ func expandDataLakePermissions(in []interface{}) []awstypes.Permission {
 	return out
 }
 
-func flattenDataLakePermissions(apiObjects []awstypes.Permission) []string {
+func flattenPermissions(apiObjects []awstypes.Permission) []string {
 	if len(apiObjects) == 0 {
 		return nil
 	}

--- a/internal/service/lakeformation/data_lake_settings.go
+++ b/internal/service/lakeformation/data_lake_settings.go
@@ -373,7 +373,6 @@ func flattenPermissions(apiObjects []awstypes.Permission) []string {
 	}
 
 	return out
-
 }
 
 func expandDataLakeSettingsAdmins(tfSet *schema.Set) []awstypes.DataLakePrincipal {

--- a/internal/service/lakeformation/data_lake_settings.go
+++ b/internal/service/lakeformation/data_lake_settings.go
@@ -7,16 +7,18 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"reflect"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/lakeformation"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lakeformation"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/lakeformation/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -81,8 +83,8 @@ func ResourceDataLakeSettings() *schema.Resource {
 							Optional: true,
 							Computed: true,
 							Elem: &schema.Schema{
-								Type:         schema.TypeString,
-								ValidateFunc: validation.StringInSlice(lakeformation.Permission_Values(), false),
+								Type:             schema.TypeString,
+								ValidateDiagFunc: enum.Validate[awstypes.Permission](),
 							},
 						},
 						"principal": {
@@ -106,8 +108,8 @@ func ResourceDataLakeSettings() *schema.Resource {
 							Optional: true,
 							Computed: true,
 							Elem: &schema.Schema{
-								Type:         schema.TypeString,
-								ValidateFunc: validation.StringInSlice(lakeformation.Permission_Values(), false),
+								Type:             schema.TypeString,
+								ValidateDiagFunc: enum.Validate[awstypes.Permission](),
 							},
 						},
 						"principal": {
@@ -143,7 +145,7 @@ func ResourceDataLakeSettings() *schema.Resource {
 
 func resourceDataLakeSettingsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).LakeFormationConn(ctx)
+	conn := meta.(*conns.AWSClient).LakeFormationClient(ctx)
 
 	input := &lakeformation.PutDataLakeSettingsInput{}
 
@@ -151,7 +153,7 @@ func resourceDataLakeSettingsCreate(ctx context.Context, d *schema.ResourceData,
 		input.CatalogId = aws.String(v.(string))
 	}
 
-	settings := &lakeformation.DataLakeSettings{}
+	settings := &awstypes.DataLakeSettings{}
 
 	if v, ok := d.GetOk("admins"); ok {
 		settings.DataLakeAdmins = expandDataLakeSettingsAdmins(v.(*schema.Set))
@@ -166,7 +168,7 @@ func resourceDataLakeSettingsCreate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if v, ok := d.GetOk("authorized_session_tag_value_list"); ok {
-		settings.AuthorizedSessionTagValueList = flex.ExpandStringList(v.([]interface{}))
+		settings.AuthorizedSessionTagValueList = flex.ExpandStringValueList(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("create_database_default_permissions"); ok {
@@ -182,7 +184,7 @@ func resourceDataLakeSettingsCreate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if v, ok := d.GetOk("trusted_resource_owners"); ok {
-		settings.TrustedResourceOwners = flex.ExpandStringList(v.([]interface{}))
+		settings.TrustedResourceOwners = flex.ExpandStringValueList(v.([]interface{}))
 	}
 
 	input.DataLakeSettings = settings
@@ -190,12 +192,13 @@ func resourceDataLakeSettingsCreate(ctx context.Context, d *schema.ResourceData,
 	var output *lakeformation.PutDataLakeSettingsOutput
 	err := retry.RetryContext(ctx, IAMPropagationTimeout, func() *retry.RetryError {
 		var err error
-		output, err = conn.PutDataLakeSettingsWithContext(ctx, input)
+		output, err = conn.PutDataLakeSettings(ctx, input)
 		if err != nil {
-			if tfawserr.ErrMessageContains(err, lakeformation.ErrCodeInvalidInputException, "Invalid principal") {
+			if errs.IsAErrorMessageContains[*awstypes.InvalidInputException](err, "Invalid principal") {
 				return retry.RetryableError(err)
 			}
-			if tfawserr.ErrCodeEquals(err, lakeformation.ErrCodeConcurrentModificationException) {
+
+			if errs.IsA[*awstypes.ConcurrentModificationException](err) {
 				return retry.RetryableError(err)
 			}
 
@@ -205,7 +208,7 @@ func resourceDataLakeSettingsCreate(ctx context.Context, d *schema.ResourceData,
 	})
 
 	if tfresource.TimedOut(err) {
-		output, err = conn.PutDataLakeSettingsWithContext(ctx, input)
+		output, err = conn.PutDataLakeSettings(ctx, input)
 	}
 
 	if err != nil {
@@ -216,14 +219,14 @@ func resourceDataLakeSettingsCreate(ctx context.Context, d *schema.ResourceData,
 		return sdkdiag.AppendErrorf(diags, "creating Lake Formation data lake settings: empty response")
 	}
 
-	d.SetId(fmt.Sprintf("%d", create.StringHashcode(input.String())))
+	d.SetId(fmt.Sprintf("%d", create.StringHashcode(prettify(input))))
 
 	return append(diags, resourceDataLakeSettingsRead(ctx, d, meta)...)
 }
 
 func resourceDataLakeSettingsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).LakeFormationConn(ctx)
+	conn := meta.(*conns.AWSClient).LakeFormationClient(ctx)
 
 	input := &lakeformation.GetDataLakeSettingsInput{}
 
@@ -231,9 +234,9 @@ func resourceDataLakeSettingsRead(ctx context.Context, d *schema.ResourceData, m
 		input.CatalogId = aws.String(v.(string))
 	}
 
-	output, err := conn.GetDataLakeSettingsWithContext(ctx, input)
+	output, err := conn.GetDataLakeSettings(ctx, input)
 
-	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, lakeformation.ErrCodeEntityNotFoundException) {
+	if !d.IsNewResource() && errs.IsA[*awstypes.EntityNotFoundException](err) {
 		log.Printf("[WARN] Lake Formation data lake settings (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
@@ -252,26 +255,26 @@ func resourceDataLakeSettingsRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set("admins", flattenDataLakeSettingsAdmins(settings.DataLakeAdmins))
 	d.Set("read_only_admins", flattenDataLakeSettingsAdmins(settings.ReadOnlyAdmins))
 	d.Set("allow_external_data_filtering", settings.AllowExternalDataFiltering)
-	d.Set("authorized_session_tag_value_list", flex.FlattenStringList(settings.AuthorizedSessionTagValueList))
+	d.Set("authorized_session_tag_value_list", flex.FlattenStringValueList(settings.AuthorizedSessionTagValueList))
 	d.Set("create_database_default_permissions", flattenDataLakeSettingsCreateDefaultPermissions(settings.CreateDatabaseDefaultPermissions))
 	d.Set("create_table_default_permissions", flattenDataLakeSettingsCreateDefaultPermissions(settings.CreateTableDefaultPermissions))
 	d.Set("external_data_filtering_allow_list", flattenDataLakeSettingsDataFilteringAllowList(settings.ExternalDataFilteringAllowList))
-	d.Set("trusted_resource_owners", flex.FlattenStringList(settings.TrustedResourceOwners))
+	d.Set("trusted_resource_owners", flex.FlattenStringValueList(settings.TrustedResourceOwners))
 
 	return diags
 }
 
 func resourceDataLakeSettingsDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).LakeFormationConn(ctx)
+	conn := meta.(*conns.AWSClient).LakeFormationClient(ctx)
 
 	input := &lakeformation.PutDataLakeSettingsInput{
-		DataLakeSettings: &lakeformation.DataLakeSettings{
-			CreateDatabaseDefaultPermissions: make([]*lakeformation.PrincipalPermissions, 0),
-			CreateTableDefaultPermissions:    make([]*lakeformation.PrincipalPermissions, 0),
-			DataLakeAdmins:                   make([]*lakeformation.DataLakePrincipal, 0),
-			ReadOnlyAdmins:                   make([]*lakeformation.DataLakePrincipal, 0),
-			TrustedResourceOwners:            make([]*string, 0),
+		DataLakeSettings: &awstypes.DataLakeSettings{
+			CreateDatabaseDefaultPermissions: make([]awstypes.PrincipalPermissions, 0),
+			CreateTableDefaultPermissions:    make([]awstypes.PrincipalPermissions, 0),
+			DataLakeAdmins:                   make([]awstypes.DataLakePrincipal, 0),
+			ReadOnlyAdmins:                   make([]awstypes.DataLakePrincipal, 0),
+			TrustedResourceOwners:            make([]string, 0),
 		},
 	}
 
@@ -279,9 +282,9 @@ func resourceDataLakeSettingsDelete(ctx context.Context, d *schema.ResourceData,
 		input.CatalogId = aws.String(v.(string))
 	}
 
-	_, err := conn.PutDataLakeSettingsWithContext(ctx, input)
+	_, err := conn.PutDataLakeSettings(ctx, input)
 
-	if tfawserr.ErrCodeEquals(err, lakeformation.ErrCodeEntityNotFoundException) {
+	if errs.IsA[*awstypes.EntityNotFoundException](err) {
 		log.Printf("[WARN] Lake Formation data lake settings (%s) not found, removing from state", d.Id())
 		return diags
 	}
@@ -293,8 +296,8 @@ func resourceDataLakeSettingsDelete(ctx context.Context, d *schema.ResourceData,
 	return diags
 }
 
-func expandDataLakeSettingsCreateDefaultPermissions(tfMaps []interface{}) []*lakeformation.PrincipalPermissions {
-	apiObjects := make([]*lakeformation.PrincipalPermissions, 0, len(tfMaps))
+func expandDataLakeSettingsCreateDefaultPermissions(tfMaps []interface{}) []awstypes.PrincipalPermissions {
+	apiObjects := make([]awstypes.PrincipalPermissions, 0, len(tfMaps))
 
 	for _, tfMap := range tfMaps {
 		apiObjects = append(apiObjects, expandDataLakeSettingsCreateDefaultPermission(tfMap.(map[string]interface{})))
@@ -303,10 +306,10 @@ func expandDataLakeSettingsCreateDefaultPermissions(tfMaps []interface{}) []*lak
 	return apiObjects
 }
 
-func expandDataLakeSettingsCreateDefaultPermission(tfMap map[string]interface{}) *lakeformation.PrincipalPermissions {
-	apiObject := &lakeformation.PrincipalPermissions{
-		Permissions: flex.ExpandStringSet(tfMap["permissions"].(*schema.Set)),
-		Principal: &lakeformation.DataLakePrincipal{
+func expandDataLakeSettingsCreateDefaultPermission(tfMap map[string]interface{}) awstypes.PrincipalPermissions {
+	apiObject := awstypes.PrincipalPermissions{
+		Permissions: expandDataLakePermissions(tfMap["permissions"].(*schema.Set).List()),
+		Principal: &awstypes.DataLakePrincipal{
 			DataLakePrincipalIdentifier: aws.String(tfMap["principal"].(string)),
 		},
 	}
@@ -314,7 +317,7 @@ func expandDataLakeSettingsCreateDefaultPermission(tfMap map[string]interface{})
 	return apiObject
 }
 
-func flattenDataLakeSettingsCreateDefaultPermissions(apiObjects []*lakeformation.PrincipalPermissions) []map[string]interface{} {
+func flattenDataLakeSettingsCreateDefaultPermissions(apiObjects []awstypes.PrincipalPermissions) []map[string]interface{} {
 	if apiObjects == nil {
 		return nil
 	}
@@ -327,32 +330,60 @@ func flattenDataLakeSettingsCreateDefaultPermissions(apiObjects []*lakeformation
 	return tfMaps
 }
 
-func flattenDataLakeSettingsCreateDefaultPermission(apiObject *lakeformation.PrincipalPermissions) map[string]interface{} {
+func flattenDataLakeSettingsCreateDefaultPermission(apiObject awstypes.PrincipalPermissions) map[string]interface{} {
 	tfMap := make(map[string]interface{})
 
-	if apiObject == nil {
+	if reflect.ValueOf(apiObject).IsZero() {
 		return tfMap
 	}
 
 	if apiObject.Permissions != nil {
-		tfMap["permissions"] = flex.FlattenStringSet(apiObject.Permissions)
+		tfMap["permissions"] = flex.FlattenStringValueSet(flattenDataLakePermissions(apiObject.Permissions))
 	}
 
-	if v := aws.StringValue(apiObject.Principal.DataLakePrincipalIdentifier); v != "" {
+	if v := aws.ToString(apiObject.Principal.DataLakePrincipalIdentifier); v != "" {
 		tfMap["principal"] = v
 	}
 
 	return tfMap
 }
 
-func expandDataLakeSettingsAdmins(tfSet *schema.Set) []*lakeformation.DataLakePrincipal {
+func expandDataLakePermissions(in []interface{}) []awstypes.Permission {
+	if len(in) == 0 {
+		return nil
+	}
+
+	var out []awstypes.Permission
+
+	for _, v := range in {
+		out = append(out, awstypes.Permission(v.(string)))
+	}
+
+	return out
+}
+
+func flattenDataLakePermissions(apiObjects []awstypes.Permission) []string {
+	if len(apiObjects) == 0 {
+		return nil
+	}
+
+	var out []string
+	for _, apiObject := range apiObjects {
+		out = append(out, string(apiObject))
+	}
+
+	return out
+
+}
+
+func expandDataLakeSettingsAdmins(tfSet *schema.Set) []awstypes.DataLakePrincipal {
 	tfSlice := tfSet.List()
-	apiObjects := make([]*lakeformation.DataLakePrincipal, 0, len(tfSlice))
+	apiObjects := make([]awstypes.DataLakePrincipal, 0, len(tfSlice))
 
 	for _, tfItem := range tfSlice {
 		val, ok := tfItem.(string)
 		if ok && val != "" {
-			apiObjects = append(apiObjects, &lakeformation.DataLakePrincipal{
+			apiObjects = append(apiObjects, awstypes.DataLakePrincipal{
 				DataLakePrincipalIdentifier: aws.String(tfItem.(string)),
 			})
 		}
@@ -361,7 +392,7 @@ func expandDataLakeSettingsAdmins(tfSet *schema.Set) []*lakeformation.DataLakePr
 	return apiObjects
 }
 
-func flattenDataLakeSettingsAdmins(apiObjects []*lakeformation.DataLakePrincipal) []interface{} {
+func flattenDataLakeSettingsAdmins(apiObjects []awstypes.DataLakePrincipal) []interface{} {
 	if apiObjects == nil {
 		return nil
 	}
@@ -369,20 +400,20 @@ func flattenDataLakeSettingsAdmins(apiObjects []*lakeformation.DataLakePrincipal
 	tfSlice := make([]interface{}, 0, len(apiObjects))
 
 	for _, apiObject := range apiObjects {
-		tfSlice = append(tfSlice, aws.StringValue(apiObject.DataLakePrincipalIdentifier))
+		tfSlice = append(tfSlice, aws.ToString(apiObject.DataLakePrincipalIdentifier))
 	}
 
 	return tfSlice
 }
 
-func expandDataLakeSettingsDataFilteringAllowList(tfSet *schema.Set) []*lakeformation.DataLakePrincipal {
+func expandDataLakeSettingsDataFilteringAllowList(tfSet *schema.Set) []awstypes.DataLakePrincipal {
 	tfSlice := tfSet.List()
-	apiObjects := make([]*lakeformation.DataLakePrincipal, 0, len(tfSlice))
+	apiObjects := make([]awstypes.DataLakePrincipal, 0, len(tfSlice))
 
 	for _, tfItem := range tfSlice {
 		val, ok := tfItem.(string)
 		if ok && val != "" {
-			apiObjects = append(apiObjects, &lakeformation.DataLakePrincipal{
+			apiObjects = append(apiObjects, awstypes.DataLakePrincipal{
 				DataLakePrincipalIdentifier: aws.String(tfItem.(string)),
 			})
 		}
@@ -391,7 +422,7 @@ func expandDataLakeSettingsDataFilteringAllowList(tfSet *schema.Set) []*lakeform
 	return apiObjects
 }
 
-func flattenDataLakeSettingsDataFilteringAllowList(apiObjects []*lakeformation.DataLakePrincipal) []interface{} {
+func flattenDataLakeSettingsDataFilteringAllowList(apiObjects []awstypes.DataLakePrincipal) []interface{} {
 	if apiObjects == nil {
 		return nil
 	}
@@ -399,7 +430,7 @@ func flattenDataLakeSettingsDataFilteringAllowList(apiObjects []*lakeformation.D
 	tfSlice := make([]interface{}, 0, len(apiObjects))
 
 	for _, apiObject := range apiObjects {
-		tfSlice = append(tfSlice, aws.StringValue(apiObject.DataLakePrincipalIdentifier))
+		tfSlice = append(tfSlice, aws.ToString(apiObject.DataLakePrincipalIdentifier))
 	}
 
 	return tfSlice

--- a/internal/service/lakeformation/data_lake_settings_data_source.go
+++ b/internal/service/lakeformation/data_lake_settings_data_source.go
@@ -8,13 +8,14 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/lakeformation"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lakeformation"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/lakeformation/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 )
@@ -98,18 +99,18 @@ func DataSourceDataLakeSettings() *schema.Resource {
 
 func dataSourceDataLakeSettingsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).LakeFormationConn(ctx)
+	conn := meta.(*conns.AWSClient).LakeFormationClient(ctx)
 
 	input := &lakeformation.GetDataLakeSettingsInput{}
 
 	if v, ok := d.GetOk("catalog_id"); ok {
 		input.CatalogId = aws.String(v.(string))
 	}
-	d.SetId(fmt.Sprintf("%d", create.StringHashcode(input.String())))
+	d.SetId(fmt.Sprintf("%d", create.StringHashcode(prettify(input))))
 
-	output, err := conn.GetDataLakeSettingsWithContext(ctx, input)
+	output, err := conn.GetDataLakeSettings(ctx, input)
 
-	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, lakeformation.ErrCodeEntityNotFoundException) {
+	if !d.IsNewResource() && errs.IsA[*awstypes.EntityNotFoundException](err) {
 		log.Printf("[WARN] Lake Formation data lake settings (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
@@ -128,11 +129,11 @@ func dataSourceDataLakeSettingsRead(ctx context.Context, d *schema.ResourceData,
 	d.Set("admins", flattenDataLakeSettingsAdmins(settings.DataLakeAdmins))
 	d.Set("read_only_admins", flattenDataLakeSettingsAdmins(settings.ReadOnlyAdmins))
 	d.Set("allow_external_data_filtering", settings.AllowExternalDataFiltering)
-	d.Set("authorized_session_tag_value_list", flex.FlattenStringList(settings.AuthorizedSessionTagValueList))
+	d.Set("authorized_session_tag_value_list", flex.FlattenStringValueList(settings.AuthorizedSessionTagValueList))
 	d.Set("create_database_default_permissions", flattenDataLakeSettingsCreateDefaultPermissions(settings.CreateDatabaseDefaultPermissions))
 	d.Set("create_table_default_permissions", flattenDataLakeSettingsCreateDefaultPermissions(settings.CreateTableDefaultPermissions))
 	d.Set("external_data_filtering_allow_list", flattenDataLakeSettingsDataFilteringAllowList(settings.ExternalDataFilteringAllowList))
-	d.Set("trusted_resource_owners", flex.FlattenStringList(settings.TrustedResourceOwners))
+	d.Set("trusted_resource_owners", flex.FlattenStringValueList(settings.TrustedResourceOwners))
 
 	return diags
 }

--- a/internal/service/lakeformation/data_lake_settings_data_source_test.go
+++ b/internal/service/lakeformation/data_lake_settings_data_source_test.go
@@ -6,7 +6,6 @@ package lakeformation_test
 import (
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/lakeformation"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -17,7 +16,7 @@ func testAccDataLakeSettingsDataSource_basic(t *testing.T) {
 	resourceName := "data.aws_lakeformation_data_lake_settings.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, lakeformation.EndpointsID) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.LakeFormation) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LakeFormationServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDataLakeSettingsDestroy(ctx),
@@ -42,7 +41,7 @@ func testAccDataLakeSettingsDataSource_readOnlyAdmins(t *testing.T) {
 	resourceName := "data.aws_lakeformation_data_lake_settings.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, lakeformation.EndpointsID) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.LakeFormation) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LakeFormationServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDataLakeSettingsDestroy(ctx),

--- a/internal/service/lakeformation/filter.go
+++ b/internal/service/lakeformation/filter.go
@@ -4,11 +4,12 @@
 package lakeformation
 
 import (
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/lakeformation"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lakeformation"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/lakeformation/types"
 )
 
-func FilterPermissions(input *lakeformation.ListPermissionsInput, tableType string, columnNames []*string, excludedColumnNames []*string, columnWildcard bool, allPermissions []*lakeformation.PrincipalResourcePermissions) []*lakeformation.PrincipalResourcePermissions {
+func FilterPermissions(input *lakeformation.ListPermissionsInput, tableType string, columnNames []string, excludedColumnNames []string, columnWildcard bool, allPermissions []awstypes.PrincipalResourcePermissions) []awstypes.PrincipalResourcePermissions {
 	// For most Lake Formation resources, filtering within the provider is unnecessary. The input
 	// contains everything for AWS to give you back exactly what you want. However, many challenges
 	// arise with tables and tables with columns. Perhaps the two biggest problems (so far) are as
@@ -57,7 +58,7 @@ func FilterPermissions(input *lakeformation.ListPermissionsInput, tableType stri
 	return nil
 }
 
-func FilterTablePermissions(principal *string, table *lakeformation.TableResource, allPermissions []*lakeformation.PrincipalResourcePermissions) []*lakeformation.PrincipalResourcePermissions {
+func FilterTablePermissions(principal *string, table *awstypes.TableResource, allPermissions []awstypes.PrincipalResourcePermissions) []awstypes.PrincipalResourcePermissions {
 	// CREATE PERMS (in)     = ALL, ALTER, DELETE, DESCRIBE, DROP, INSERT, SELECT on Table, Name = (Table Name)
 	//      LIST PERMS (out) = ALL, ALTER, DELETE, DESCRIBE, DROP, INSERT         on Table, Name = (Table Name)
 	//      LIST PERMS (out) = SELECT                                             on TableWithColumns, Name = (Table Name), ColumnWildcard
@@ -66,29 +67,29 @@ func FilterTablePermissions(principal *string, table *lakeformation.TableResourc
 	//        LIST PERMS (out) = ALL, ALTER, DELETE, DESCRIBE, DROP, INSERT         on Table, TableWildcard, Name = ALL_TABLES
 	//        LIST PERMS (out) = SELECT                                             on TableWithColumns, Name = ALL_TABLES, ColumnWildcard
 
-	var cleanPermissions []*lakeformation.PrincipalResourcePermissions
+	var cleanPermissions []awstypes.PrincipalResourcePermissions
 
 	for _, perm := range allPermissions {
-		if aws.StringValue(principal) != aws.StringValue(perm.Principal.DataLakePrincipalIdentifier) {
+		if aws.ToString(principal) != aws.ToString(perm.Principal.DataLakePrincipalIdentifier) {
 			continue
 		}
 
 		if perm.Resource.TableWithColumns != nil && perm.Resource.TableWithColumns.ColumnWildcard != nil {
-			if aws.StringValue(perm.Resource.TableWithColumns.Name) == aws.StringValue(table.Name) || (table.TableWildcard != nil && aws.StringValue(perm.Resource.TableWithColumns.Name) == TableNameAllTables) {
-				if len(perm.Permissions) > 0 && aws.StringValue(perm.Permissions[0]) == lakeformation.PermissionSelect {
+			if aws.ToString(perm.Resource.TableWithColumns.Name) == aws.ToString(table.Name) || (table.TableWildcard != nil && aws.ToString(perm.Resource.TableWithColumns.Name) == TableNameAllTables) {
+				if len(perm.Permissions) > 0 && perm.Permissions[0] == awstypes.PermissionSelect {
 					cleanPermissions = append(cleanPermissions, perm)
 					continue
 				}
 
-				if len(perm.PermissionsWithGrantOption) > 0 && aws.StringValue(perm.PermissionsWithGrantOption[0]) == lakeformation.PermissionSelect {
+				if len(perm.PermissionsWithGrantOption) > 0 && perm.PermissionsWithGrantOption[0] == awstypes.PermissionSelect {
 					cleanPermissions = append(cleanPermissions, perm)
 					continue
 				}
 			}
 		}
 
-		if perm.Resource.Table != nil && aws.StringValue(perm.Resource.Table.DatabaseName) == aws.StringValue(table.DatabaseName) {
-			if aws.StringValue(perm.Resource.Table.Name) == aws.StringValue(table.Name) {
+		if perm.Resource.Table != nil && aws.ToString(perm.Resource.Table.DatabaseName) == aws.ToString(table.DatabaseName) {
+			if aws.ToString(perm.Resource.Table.Name) == aws.ToString(table.Name) {
 				cleanPermissions = append(cleanPermissions, perm)
 				continue
 			}
@@ -104,15 +105,15 @@ func FilterTablePermissions(principal *string, table *lakeformation.TableResourc
 	return cleanPermissions
 }
 
-func FilterTableWithColumnsPermissions(principal *string, twc *lakeformation.TableResource, columnNames []*string, excludedColumnNames []*string, columnWildcard bool, allPermissions []*lakeformation.PrincipalResourcePermissions) []*lakeformation.PrincipalResourcePermissions {
+func FilterTableWithColumnsPermissions(principal *string, twc *awstypes.TableResource, columnNames []string, excludedColumnNames []string, columnWildcard bool, allPermissions []awstypes.PrincipalResourcePermissions) []awstypes.PrincipalResourcePermissions {
 	// CREATE PERMS (in)       = ALL, ALTER, DELETE, DESCRIBE, DROP, INSERT, SELECT on TableWithColumns, Name = (Table Name), ColumnWildcard
 	//        LIST PERMS (out) = ALL, ALTER, DELETE, DESCRIBE, DROP, INSERT         on Table, Name = (Table Name)
 	//        LIST PERMS (out) = SELECT                                             on TableWithColumns, Name = (Table Name), ColumnWildcard
 
-	var cleanPermissions []*lakeformation.PrincipalResourcePermissions
+	var cleanPermissions []awstypes.PrincipalResourcePermissions
 
 	for _, perm := range allPermissions {
-		if aws.StringValue(principal) != aws.StringValue(perm.Principal.DataLakePrincipalIdentifier) {
+		if aws.ToString(principal) != aws.ToString(perm.Principal.DataLakePrincipalIdentifier) {
 			continue
 		}
 
@@ -135,7 +136,7 @@ func FilterTableWithColumnsPermissions(principal *string, twc *lakeformation.Tab
 			}
 		}
 
-		if perm.Resource.Table != nil && aws.StringValue(perm.Resource.Table.Name) == aws.StringValue(twc.Name) {
+		if perm.Resource.Table != nil && aws.ToString(perm.Resource.Table.Name) == aws.ToString(twc.Name) {
 			cleanPermissions = append(cleanPermissions, perm)
 			continue
 		}
@@ -144,11 +145,11 @@ func FilterTableWithColumnsPermissions(principal *string, twc *lakeformation.Tab
 	return cleanPermissions
 }
 
-func FilterCatalogPermissions(principal *string, allPermissions []*lakeformation.PrincipalResourcePermissions) []*lakeformation.PrincipalResourcePermissions {
-	var cleanPermissions []*lakeformation.PrincipalResourcePermissions
+func FilterCatalogPermissions(principal *string, allPermissions []awstypes.PrincipalResourcePermissions) []awstypes.PrincipalResourcePermissions {
+	var cleanPermissions []awstypes.PrincipalResourcePermissions
 
 	for _, perm := range allPermissions {
-		if aws.StringValue(principal) != aws.StringValue(perm.Principal.DataLakePrincipalIdentifier) {
+		if aws.ToString(principal) != aws.ToString(perm.Principal.DataLakePrincipalIdentifier) {
 			continue
 		}
 
@@ -160,11 +161,11 @@ func FilterCatalogPermissions(principal *string, allPermissions []*lakeformation
 	return cleanPermissions
 }
 
-func filterDataCellsFilter(principal *string, allPermissions []*lakeformation.PrincipalResourcePermissions) []*lakeformation.PrincipalResourcePermissions {
-	var cleanPermissions []*lakeformation.PrincipalResourcePermissions
+func filterDataCellsFilter(principal *string, allPermissions []awstypes.PrincipalResourcePermissions) []awstypes.PrincipalResourcePermissions {
+	var cleanPermissions []awstypes.PrincipalResourcePermissions
 
 	for _, perm := range allPermissions {
-		if aws.StringValue(principal) != aws.StringValue(perm.Principal.DataLakePrincipalIdentifier) {
+		if aws.ToString(principal) != aws.ToString(perm.Principal.DataLakePrincipalIdentifier) {
 			continue
 		}
 
@@ -176,11 +177,11 @@ func filterDataCellsFilter(principal *string, allPermissions []*lakeformation.Pr
 	return cleanPermissions
 }
 
-func FilterDataLocationPermissions(principal *string, allPermissions []*lakeformation.PrincipalResourcePermissions) []*lakeformation.PrincipalResourcePermissions {
-	var cleanPermissions []*lakeformation.PrincipalResourcePermissions
+func FilterDataLocationPermissions(principal *string, allPermissions []awstypes.PrincipalResourcePermissions) []awstypes.PrincipalResourcePermissions {
+	var cleanPermissions []awstypes.PrincipalResourcePermissions
 
 	for _, perm := range allPermissions {
-		if aws.StringValue(principal) != aws.StringValue(perm.Principal.DataLakePrincipalIdentifier) {
+		if aws.ToString(principal) != aws.ToString(perm.Principal.DataLakePrincipalIdentifier) {
 			continue
 		}
 
@@ -192,11 +193,11 @@ func FilterDataLocationPermissions(principal *string, allPermissions []*lakeform
 	return cleanPermissions
 }
 
-func FilterDatabasePermissions(principal *string, allPermissions []*lakeformation.PrincipalResourcePermissions) []*lakeformation.PrincipalResourcePermissions {
-	var cleanPermissions []*lakeformation.PrincipalResourcePermissions
+func FilterDatabasePermissions(principal *string, allPermissions []awstypes.PrincipalResourcePermissions) []awstypes.PrincipalResourcePermissions {
+	var cleanPermissions []awstypes.PrincipalResourcePermissions
 
 	for _, perm := range allPermissions {
-		if aws.StringValue(principal) != aws.StringValue(perm.Principal.DataLakePrincipalIdentifier) {
+		if aws.ToString(principal) != aws.ToString(perm.Principal.DataLakePrincipalIdentifier) {
 			continue
 		}
 
@@ -208,11 +209,11 @@ func FilterDatabasePermissions(principal *string, allPermissions []*lakeformatio
 	return cleanPermissions
 }
 
-func FilterLFTagPermissions(principal *string, allPermissions []*lakeformation.PrincipalResourcePermissions) []*lakeformation.PrincipalResourcePermissions {
-	var cleanPermissions []*lakeformation.PrincipalResourcePermissions
+func FilterLFTagPermissions(principal *string, allPermissions []awstypes.PrincipalResourcePermissions) []awstypes.PrincipalResourcePermissions {
+	var cleanPermissions []awstypes.PrincipalResourcePermissions
 
 	for _, perm := range allPermissions {
-		if aws.StringValue(principal) != aws.StringValue(perm.Principal.DataLakePrincipalIdentifier) {
+		if aws.ToString(principal) != aws.ToString(perm.Principal.DataLakePrincipalIdentifier) {
 			continue
 		}
 
@@ -224,11 +225,11 @@ func FilterLFTagPermissions(principal *string, allPermissions []*lakeformation.P
 	return cleanPermissions
 }
 
-func FilterLFTagPolicyPermissions(principal *string, allPermissions []*lakeformation.PrincipalResourcePermissions) []*lakeformation.PrincipalResourcePermissions {
-	var cleanPermissions []*lakeformation.PrincipalResourcePermissions
+func FilterLFTagPolicyPermissions(principal *string, allPermissions []awstypes.PrincipalResourcePermissions) []awstypes.PrincipalResourcePermissions {
+	var cleanPermissions []awstypes.PrincipalResourcePermissions
 
 	for _, perm := range allPermissions {
-		if aws.StringValue(principal) != aws.StringValue(perm.Principal.DataLakePrincipalIdentifier) {
+		if aws.ToString(principal) != aws.ToString(perm.Principal.DataLakePrincipalIdentifier) {
 			continue
 		}
 

--- a/internal/service/lakeformation/filter_test.go
+++ b/internal/service/lakeformation/filter_test.go
@@ -8,8 +8,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/lakeformation"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lakeformation"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/lakeformation/types"
 	tflakeformation "github.com/hashicorp/terraform-provider-aws/internal/service/lakeformation"
 )
 
@@ -22,7 +23,7 @@ func TestFilterPermissions(t *testing.T) {
 	altDBName := "Hiuhbum"
 	tableName := "Ladocmoc"
 
-	principal := &lakeformation.DataLakePrincipal{
+	principal := &awstypes.DataLakePrincipal{
 		//lintignore:AWSAT005
 		DataLakePrincipalIdentifier: aws.String(fmt.Sprintf("arn:aws-us-gov:iam::%s:role/Zepotiz-Bulgaria", accountID)),
 	}
@@ -31,17 +32,17 @@ func TestFilterPermissions(t *testing.T) {
 		Name                string
 		Input               *lakeformation.ListPermissionsInput
 		TableType           string
-		ColumnNames         []*string
-		ExcludedColumnNames []*string
+		ColumnNames         []string
+		ExcludedColumnNames []string
 		ColumnWildcard      bool
-		All                 []*lakeformation.PrincipalResourcePermissions
-		ExpectedClean       []*lakeformation.PrincipalResourcePermissions
+		All                 []awstypes.PrincipalResourcePermissions
+		ExpectedClean       []awstypes.PrincipalResourcePermissions
 	}{
 		{
 			Name: "empty",
 			Input: &lakeformation.ListPermissionsInput{
 				Principal: principal,
-				Resource:  &lakeformation.Resource{},
+				Resource:  &awstypes.Resource{},
 			},
 			All:           nil,
 			ExpectedClean: nil,
@@ -50,8 +51,8 @@ func TestFilterPermissions(t *testing.T) {
 			Name: "emptyWithInput",
 			Input: &lakeformation.ListPermissionsInput{
 				Principal: principal,
-				Resource: &lakeformation.Resource{
-					Table: &lakeformation.TableResource{
+				Resource: &awstypes.Resource{
+					Table: &awstypes.TableResource{
 						CatalogId:    aws.String(accountID),
 						DatabaseName: aws.String(dbName),
 						Name:         aws.String(tableName),
@@ -65,21 +66,21 @@ func TestFilterPermissions(t *testing.T) {
 			Name: "wrongTableResource", // this may not actually be possible but we account for it
 			Input: &lakeformation.ListPermissionsInput{
 				Principal: principal,
-				Resource: &lakeformation.Resource{
-					Table: &lakeformation.TableResource{
+				Resource: &awstypes.Resource{
+					Table: &awstypes.TableResource{
 						CatalogId:    aws.String(accountID),
 						DatabaseName: aws.String(dbName),
 						Name:         aws.String(tableName),
 					},
 				},
 			},
-			All: []*lakeformation.PrincipalResourcePermissions{
+			All: []awstypes.PrincipalResourcePermissions{
 				{
-					Permissions:                aws.StringSlice([]string{lakeformation.PermissionSelect}),
-					PermissionsWithGrantOption: aws.StringSlice([]string{}),
+					Permissions:                []awstypes.Permission{awstypes.PermissionSelect},
+					PermissionsWithGrantOption: []awstypes.Permission{},
 					Principal:                  principal,
-					Resource: &lakeformation.Resource{
-						Table: &lakeformation.TableResource{
+					Resource: &awstypes.Resource{
+						Table: &awstypes.TableResource{
 							CatalogId:    aws.String(accountID),
 							DatabaseName: aws.String(altDBName),
 							Name:         aws.String(tableName),
@@ -93,21 +94,21 @@ func TestFilterPermissions(t *testing.T) {
 			Name: "tableResource",
 			Input: &lakeformation.ListPermissionsInput{
 				Principal: principal,
-				Resource: &lakeformation.Resource{
-					Table: &lakeformation.TableResource{
+				Resource: &awstypes.Resource{
+					Table: &awstypes.TableResource{
 						CatalogId:    aws.String(accountID),
 						DatabaseName: aws.String(dbName),
 						Name:         aws.String(tableName),
 					},
 				},
 			},
-			All: []*lakeformation.PrincipalResourcePermissions{
+			All: []awstypes.PrincipalResourcePermissions{
 				{
-					Permissions:                aws.StringSlice([]string{lakeformation.PermissionSelect}),
-					PermissionsWithGrantOption: aws.StringSlice([]string{}),
+					Permissions:                []awstypes.Permission{awstypes.PermissionSelect},
+					PermissionsWithGrantOption: []awstypes.Permission{},
 					Principal:                  principal,
-					Resource: &lakeformation.Resource{
-						Table: &lakeformation.TableResource{
+					Resource: &awstypes.Resource{
+						Table: &awstypes.TableResource{
 							CatalogId:    aws.String(accountID),
 							DatabaseName: aws.String(dbName),
 							Name:         aws.String(tableName),
@@ -115,13 +116,13 @@ func TestFilterPermissions(t *testing.T) {
 					},
 				},
 			},
-			ExpectedClean: []*lakeformation.PrincipalResourcePermissions{
+			ExpectedClean: []awstypes.PrincipalResourcePermissions{
 				{
-					Permissions:                aws.StringSlice([]string{lakeformation.PermissionSelect}),
-					PermissionsWithGrantOption: aws.StringSlice([]string{}),
+					Permissions:                []awstypes.Permission{awstypes.PermissionSelect},
+					PermissionsWithGrantOption: []awstypes.Permission{},
 					Principal:                  principal,
-					Resource: &lakeformation.Resource{
-						Table: &lakeformation.TableResource{
+					Resource: &awstypes.Resource{
+						Table: &awstypes.TableResource{
 							CatalogId:    aws.String(accountID),
 							DatabaseName: aws.String(dbName),
 							Name:         aws.String(tableName),
@@ -134,21 +135,21 @@ func TestFilterPermissions(t *testing.T) {
 			Name: "tableResourceSelectPerm",
 			Input: &lakeformation.ListPermissionsInput{
 				Principal: principal,
-				Resource: &lakeformation.Resource{
-					Table: &lakeformation.TableResource{
+				Resource: &awstypes.Resource{
+					Table: &awstypes.TableResource{
 						CatalogId:    aws.String(accountID),
 						DatabaseName: aws.String(dbName),
 						Name:         aws.String(tableName),
 					},
 				},
 			},
-			All: []*lakeformation.PrincipalResourcePermissions{
+			All: []awstypes.PrincipalResourcePermissions{
 				{
-					Permissions:                aws.StringSlice([]string{lakeformation.PermissionAlter, lakeformation.PermissionDelete}),
-					PermissionsWithGrantOption: aws.StringSlice([]string{}),
+					Permissions:                []awstypes.Permission{awstypes.PermissionAlter, awstypes.PermissionDelete},
+					PermissionsWithGrantOption: []awstypes.Permission{},
 					Principal:                  principal,
-					Resource: &lakeformation.Resource{
-						Table: &lakeformation.TableResource{
+					Resource: &awstypes.Resource{
+						Table: &awstypes.TableResource{
 							CatalogId:    aws.String(accountID),
 							DatabaseName: aws.String(dbName),
 							Name:         aws.String(tableName),
@@ -156,24 +157,24 @@ func TestFilterPermissions(t *testing.T) {
 					},
 				},
 				{
-					Permissions:                aws.StringSlice([]string{lakeformation.PermissionSelect}),
-					PermissionsWithGrantOption: aws.StringSlice([]string{}),
+					Permissions:                []awstypes.Permission{awstypes.PermissionSelect},
+					PermissionsWithGrantOption: []awstypes.Permission{},
 					Principal:                  principal,
-					Resource: &lakeformation.Resource{
-						TableWithColumns: &lakeformation.TableWithColumnsResource{
+					Resource: &awstypes.Resource{
+						TableWithColumns: &awstypes.TableWithColumnsResource{
 							CatalogId:      aws.String(accountID),
 							DatabaseName:   aws.String(dbName),
 							Name:           aws.String(tableName),
-							ColumnWildcard: &lakeformation.ColumnWildcard{},
+							ColumnWildcard: &awstypes.ColumnWildcard{},
 						},
 					},
 				},
 				{
-					Permissions:                aws.StringSlice([]string{lakeformation.PermissionAlter}),
-					PermissionsWithGrantOption: aws.StringSlice([]string{}),
+					Permissions:                []awstypes.Permission{awstypes.PermissionAlter},
+					PermissionsWithGrantOption: []awstypes.Permission{},
 					Principal:                  principal,
-					Resource: &lakeformation.Resource{
-						TableWithColumns: &lakeformation.TableWithColumnsResource{
+					Resource: &awstypes.Resource{
+						TableWithColumns: &awstypes.TableWithColumnsResource{
 							CatalogId:    aws.String(accountID),
 							DatabaseName: aws.String(dbName),
 							Name:         aws.String(tableName),
@@ -181,13 +182,13 @@ func TestFilterPermissions(t *testing.T) {
 					},
 				},
 			},
-			ExpectedClean: []*lakeformation.PrincipalResourcePermissions{
+			ExpectedClean: []awstypes.PrincipalResourcePermissions{
 				{
-					Permissions:                aws.StringSlice([]string{lakeformation.PermissionAlter, lakeformation.PermissionDelete}),
-					PermissionsWithGrantOption: aws.StringSlice([]string{}),
+					Permissions:                []awstypes.Permission{awstypes.PermissionAlter, awstypes.PermissionDelete},
+					PermissionsWithGrantOption: []awstypes.Permission{},
 					Principal:                  principal,
-					Resource: &lakeformation.Resource{
-						Table: &lakeformation.TableResource{
+					Resource: &awstypes.Resource{
+						Table: &awstypes.TableResource{
 							CatalogId:    aws.String(accountID),
 							DatabaseName: aws.String(dbName),
 							Name:         aws.String(tableName),
@@ -195,15 +196,15 @@ func TestFilterPermissions(t *testing.T) {
 					},
 				},
 				{
-					Permissions:                aws.StringSlice([]string{lakeformation.PermissionSelect}),
-					PermissionsWithGrantOption: aws.StringSlice([]string{}),
+					Permissions:                []awstypes.Permission{awstypes.PermissionSelect},
+					PermissionsWithGrantOption: []awstypes.Permission{},
 					Principal:                  principal,
-					Resource: &lakeformation.Resource{
-						TableWithColumns: &lakeformation.TableWithColumnsResource{
+					Resource: &awstypes.Resource{
+						TableWithColumns: &awstypes.TableWithColumnsResource{
 							CatalogId:      aws.String(accountID),
 							DatabaseName:   aws.String(dbName),
 							Name:           aws.String(tableName),
-							ColumnWildcard: &lakeformation.ColumnWildcard{},
+							ColumnWildcard: &awstypes.ColumnWildcard{},
 						},
 					},
 				},
@@ -213,21 +214,21 @@ func TestFilterPermissions(t *testing.T) {
 			Name: "tableResourceSelectPermGrant",
 			Input: &lakeformation.ListPermissionsInput{
 				Principal: principal,
-				Resource: &lakeformation.Resource{
-					Table: &lakeformation.TableResource{
+				Resource: &awstypes.Resource{
+					Table: &awstypes.TableResource{
 						CatalogId:    aws.String(accountID),
 						DatabaseName: aws.String(dbName),
 						Name:         aws.String(tableName),
 					},
 				},
 			},
-			All: []*lakeformation.PrincipalResourcePermissions{
+			All: []awstypes.PrincipalResourcePermissions{
 				{
-					Permissions:                aws.StringSlice([]string{lakeformation.PermissionAlter, lakeformation.PermissionDelete}),
-					PermissionsWithGrantOption: aws.StringSlice([]string{lakeformation.PermissionAlter, lakeformation.PermissionDelete}),
+					Permissions:                []awstypes.Permission{awstypes.PermissionAlter, awstypes.PermissionDelete},
+					PermissionsWithGrantOption: []awstypes.Permission{awstypes.PermissionAlter, awstypes.PermissionDelete},
 					Principal:                  principal,
-					Resource: &lakeformation.Resource{
-						Table: &lakeformation.TableResource{
+					Resource: &awstypes.Resource{
+						Table: &awstypes.TableResource{
 							CatalogId:    aws.String(accountID),
 							DatabaseName: aws.String(dbName),
 							Name:         aws.String(tableName),
@@ -235,24 +236,24 @@ func TestFilterPermissions(t *testing.T) {
 					},
 				},
 				{
-					Permissions:                aws.StringSlice([]string{lakeformation.PermissionSelect}),
-					PermissionsWithGrantOption: aws.StringSlice([]string{lakeformation.PermissionSelect}),
+					Permissions:                []awstypes.Permission{awstypes.PermissionSelect},
+					PermissionsWithGrantOption: []awstypes.Permission{awstypes.PermissionSelect},
 					Principal:                  principal,
-					Resource: &lakeformation.Resource{
-						TableWithColumns: &lakeformation.TableWithColumnsResource{
+					Resource: &awstypes.Resource{
+						TableWithColumns: &awstypes.TableWithColumnsResource{
 							CatalogId:      aws.String(accountID),
 							DatabaseName:   aws.String(dbName),
 							Name:           aws.String(tableName),
-							ColumnWildcard: &lakeformation.ColumnWildcard{},
+							ColumnWildcard: &awstypes.ColumnWildcard{},
 						},
 					},
 				},
 				{
-					Permissions:                aws.StringSlice([]string{lakeformation.PermissionAlter}),
-					PermissionsWithGrantOption: aws.StringSlice([]string{lakeformation.PermissionAlter}),
+					Permissions:                []awstypes.Permission{awstypes.PermissionAlter},
+					PermissionsWithGrantOption: []awstypes.Permission{awstypes.PermissionAlter},
 					Principal:                  principal,
-					Resource: &lakeformation.Resource{
-						TableWithColumns: &lakeformation.TableWithColumnsResource{
+					Resource: &awstypes.Resource{
+						TableWithColumns: &awstypes.TableWithColumnsResource{
 							CatalogId:    aws.String(accountID),
 							DatabaseName: aws.String(dbName),
 							Name:         aws.String(tableName),
@@ -260,13 +261,13 @@ func TestFilterPermissions(t *testing.T) {
 					},
 				},
 			},
-			ExpectedClean: []*lakeformation.PrincipalResourcePermissions{
+			ExpectedClean: []awstypes.PrincipalResourcePermissions{
 				{
-					Permissions:                aws.StringSlice([]string{lakeformation.PermissionAlter, lakeformation.PermissionDelete}),
-					PermissionsWithGrantOption: aws.StringSlice([]string{lakeformation.PermissionAlter, lakeformation.PermissionDelete}),
+					Permissions:                []awstypes.Permission{awstypes.PermissionAlter, awstypes.PermissionDelete},
+					PermissionsWithGrantOption: []awstypes.Permission{awstypes.PermissionAlter, awstypes.PermissionDelete},
 					Principal:                  principal,
-					Resource: &lakeformation.Resource{
-						Table: &lakeformation.TableResource{
+					Resource: &awstypes.Resource{
+						Table: &awstypes.TableResource{
 							CatalogId:    aws.String(accountID),
 							DatabaseName: aws.String(dbName),
 							Name:         aws.String(tableName),
@@ -274,15 +275,15 @@ func TestFilterPermissions(t *testing.T) {
 					},
 				},
 				{
-					Permissions:                aws.StringSlice([]string{lakeformation.PermissionSelect}),
-					PermissionsWithGrantOption: aws.StringSlice([]string{lakeformation.PermissionSelect}),
+					Permissions:                []awstypes.Permission{awstypes.PermissionSelect},
+					PermissionsWithGrantOption: []awstypes.Permission{awstypes.PermissionSelect},
 					Principal:                  principal,
-					Resource: &lakeformation.Resource{
-						TableWithColumns: &lakeformation.TableWithColumnsResource{
+					Resource: &awstypes.Resource{
+						TableWithColumns: &awstypes.TableWithColumnsResource{
 							CatalogId:      aws.String(accountID),
 							DatabaseName:   aws.String(dbName),
 							Name:           aws.String(tableName),
-							ColumnWildcard: &lakeformation.ColumnWildcard{},
+							ColumnWildcard: &awstypes.ColumnWildcard{},
 						},
 					},
 				},
@@ -292,8 +293,8 @@ func TestFilterPermissions(t *testing.T) {
 			Name: "twcBasic",
 			Input: &lakeformation.ListPermissionsInput{
 				Principal: principal,
-				Resource: &lakeformation.Resource{
-					Table: &lakeformation.TableResource{
+				Resource: &awstypes.Resource{
+					Table: &awstypes.TableResource{
 						CatalogId:    aws.String(accountID),
 						DatabaseName: aws.String(dbName),
 						Name:         aws.String(tableName),
@@ -301,14 +302,14 @@ func TestFilterPermissions(t *testing.T) {
 				},
 			},
 			TableType:   tflakeformation.TableTypeTableWithColumns,
-			ColumnNames: aws.StringSlice([]string{"value"}),
-			All: []*lakeformation.PrincipalResourcePermissions{
+			ColumnNames: []string{"value"},
+			All: []awstypes.PrincipalResourcePermissions{
 				{
-					Permissions:                aws.StringSlice([]string{lakeformation.PermissionAlter, lakeformation.PermissionDelete}),
-					PermissionsWithGrantOption: aws.StringSlice([]string{}),
+					Permissions:                []awstypes.Permission{awstypes.PermissionAlter, awstypes.PermissionDelete},
+					PermissionsWithGrantOption: []awstypes.Permission{},
 					Principal:                  principal,
-					Resource: &lakeformation.Resource{
-						Table: &lakeformation.TableResource{
+					Resource: &awstypes.Resource{
+						Table: &awstypes.TableResource{
 							CatalogId:    aws.String(accountID),
 							DatabaseName: aws.String(dbName),
 							Name:         aws.String(tableName),
@@ -316,39 +317,39 @@ func TestFilterPermissions(t *testing.T) {
 					},
 				},
 				{
-					Permissions:                aws.StringSlice([]string{lakeformation.PermissionSelect}),
-					PermissionsWithGrantOption: aws.StringSlice([]string{}),
+					Permissions:                []awstypes.Permission{awstypes.PermissionSelect},
+					PermissionsWithGrantOption: []awstypes.Permission{},
 					Principal:                  principal,
-					Resource: &lakeformation.Resource{
-						TableWithColumns: &lakeformation.TableWithColumnsResource{
+					Resource: &awstypes.Resource{
+						TableWithColumns: &awstypes.TableWithColumnsResource{
 							CatalogId:    aws.String(accountID),
-							ColumnNames:  aws.StringSlice([]string{"value"}),
+							ColumnNames:  []string{"value"},
 							DatabaseName: aws.String(dbName),
 							Name:         aws.String(tableName),
 						},
 					},
 				},
 				{
-					Permissions:                aws.StringSlice([]string{lakeformation.PermissionSelect}),
-					PermissionsWithGrantOption: aws.StringSlice([]string{}),
+					Permissions:                []awstypes.Permission{awstypes.PermissionSelect},
+					PermissionsWithGrantOption: []awstypes.Permission{},
 					Principal:                  principal,
-					Resource: &lakeformation.Resource{
-						TableWithColumns: &lakeformation.TableWithColumnsResource{
+					Resource: &awstypes.Resource{
+						TableWithColumns: &awstypes.TableWithColumnsResource{
 							CatalogId:    aws.String(accountID),
-							ColumnNames:  aws.StringSlice([]string{"fred"}),
+							ColumnNames:  []string{"fred"},
 							DatabaseName: aws.String(dbName),
 							Name:         aws.String(tableName),
 						},
 					},
 				},
 			},
-			ExpectedClean: []*lakeformation.PrincipalResourcePermissions{
+			ExpectedClean: []awstypes.PrincipalResourcePermissions{
 				{
-					Permissions:                aws.StringSlice([]string{lakeformation.PermissionAlter, lakeformation.PermissionDelete}),
-					PermissionsWithGrantOption: aws.StringSlice([]string{}),
+					Permissions:                []awstypes.Permission{awstypes.PermissionAlter, awstypes.PermissionDelete},
+					PermissionsWithGrantOption: []awstypes.Permission{},
 					Principal:                  principal,
-					Resource: &lakeformation.Resource{
-						Table: &lakeformation.TableResource{
+					Resource: &awstypes.Resource{
+						Table: &awstypes.TableResource{
 							CatalogId:    aws.String(accountID),
 							DatabaseName: aws.String(dbName),
 							Name:         aws.String(tableName),
@@ -356,13 +357,13 @@ func TestFilterPermissions(t *testing.T) {
 					},
 				},
 				{
-					Permissions:                aws.StringSlice([]string{lakeformation.PermissionSelect}),
-					PermissionsWithGrantOption: aws.StringSlice([]string{}),
+					Permissions:                []awstypes.Permission{awstypes.PermissionSelect},
+					PermissionsWithGrantOption: []awstypes.Permission{},
 					Principal:                  principal,
-					Resource: &lakeformation.Resource{
-						TableWithColumns: &lakeformation.TableWithColumnsResource{
+					Resource: &awstypes.Resource{
+						TableWithColumns: &awstypes.TableWithColumnsResource{
 							CatalogId:    aws.String(accountID),
-							ColumnNames:  aws.StringSlice([]string{"value"}),
+							ColumnNames:  []string{"value"},
 							DatabaseName: aws.String(dbName),
 							Name:         aws.String(tableName),
 						},
@@ -374,8 +375,8 @@ func TestFilterPermissions(t *testing.T) {
 			Name: "twcWildcard",
 			Input: &lakeformation.ListPermissionsInput{
 				Principal: principal,
-				Resource: &lakeformation.Resource{
-					Table: &lakeformation.TableResource{
+				Resource: &awstypes.Resource{
+					Table: &awstypes.TableResource{
 						CatalogId:    aws.String(accountID),
 						DatabaseName: aws.String(dbName),
 						Name:         aws.String(tableName),
@@ -384,13 +385,13 @@ func TestFilterPermissions(t *testing.T) {
 			},
 			TableType:      tflakeformation.TableTypeTableWithColumns,
 			ColumnWildcard: true,
-			All: []*lakeformation.PrincipalResourcePermissions{
+			All: []awstypes.PrincipalResourcePermissions{
 				{
-					Permissions:                aws.StringSlice([]string{lakeformation.PermissionAlter, lakeformation.PermissionDelete}),
-					PermissionsWithGrantOption: aws.StringSlice([]string{}),
+					Permissions:                []awstypes.Permission{awstypes.PermissionAlter, awstypes.PermissionDelete},
+					PermissionsWithGrantOption: []awstypes.Permission{},
 					Principal:                  principal,
-					Resource: &lakeformation.Resource{
-						Table: &lakeformation.TableResource{
+					Resource: &awstypes.Resource{
+						Table: &awstypes.TableResource{
 							CatalogId:    aws.String(accountID),
 							DatabaseName: aws.String(dbName),
 							Name:         aws.String(tableName),
@@ -398,39 +399,39 @@ func TestFilterPermissions(t *testing.T) {
 					},
 				},
 				{
-					Permissions:                aws.StringSlice([]string{lakeformation.PermissionSelect}),
-					PermissionsWithGrantOption: aws.StringSlice([]string{}),
+					Permissions:                []awstypes.Permission{awstypes.PermissionSelect},
+					PermissionsWithGrantOption: []awstypes.Permission{},
 					Principal:                  principal,
-					Resource: &lakeformation.Resource{
-						TableWithColumns: &lakeformation.TableWithColumnsResource{
+					Resource: &awstypes.Resource{
+						TableWithColumns: &awstypes.TableWithColumnsResource{
 							CatalogId:      aws.String(accountID),
-							ColumnWildcard: &lakeformation.ColumnWildcard{},
+							ColumnWildcard: &awstypes.ColumnWildcard{},
 							DatabaseName:   aws.String(dbName),
 							Name:           aws.String(tableName),
 						},
 					},
 				},
 				{
-					Permissions:                aws.StringSlice([]string{lakeformation.PermissionSelect}),
-					PermissionsWithGrantOption: aws.StringSlice([]string{}),
+					Permissions:                []awstypes.Permission{awstypes.PermissionSelect},
+					PermissionsWithGrantOption: []awstypes.Permission{},
 					Principal:                  principal,
-					Resource: &lakeformation.Resource{
-						TableWithColumns: &lakeformation.TableWithColumnsResource{
+					Resource: &awstypes.Resource{
+						TableWithColumns: &awstypes.TableWithColumnsResource{
 							CatalogId:    aws.String(accountID),
-							ColumnNames:  aws.StringSlice([]string{"fred"}),
+							ColumnNames:  []string{"fred"},
 							DatabaseName: aws.String(dbName),
 							Name:         aws.String(tableName),
 						},
 					},
 				},
 			},
-			ExpectedClean: []*lakeformation.PrincipalResourcePermissions{
+			ExpectedClean: []awstypes.PrincipalResourcePermissions{
 				{
-					Permissions:                aws.StringSlice([]string{lakeformation.PermissionAlter, lakeformation.PermissionDelete}),
-					PermissionsWithGrantOption: aws.StringSlice([]string{}),
+					Permissions:                []awstypes.Permission{awstypes.PermissionAlter, awstypes.PermissionDelete},
+					PermissionsWithGrantOption: []awstypes.Permission{},
 					Principal:                  principal,
-					Resource: &lakeformation.Resource{
-						Table: &lakeformation.TableResource{
+					Resource: &awstypes.Resource{
+						Table: &awstypes.TableResource{
 							CatalogId:    aws.String(accountID),
 							DatabaseName: aws.String(dbName),
 							Name:         aws.String(tableName),
@@ -438,13 +439,13 @@ func TestFilterPermissions(t *testing.T) {
 					},
 				},
 				{
-					Permissions:                aws.StringSlice([]string{lakeformation.PermissionSelect}),
-					PermissionsWithGrantOption: aws.StringSlice([]string{}),
+					Permissions:                []awstypes.Permission{awstypes.PermissionSelect},
+					PermissionsWithGrantOption: []awstypes.Permission{},
 					Principal:                  principal,
-					Resource: &lakeformation.Resource{
-						TableWithColumns: &lakeformation.TableWithColumnsResource{
+					Resource: &awstypes.Resource{
+						TableWithColumns: &awstypes.TableWithColumnsResource{
 							CatalogId:      aws.String(accountID),
-							ColumnWildcard: &lakeformation.ColumnWildcard{},
+							ColumnWildcard: &awstypes.ColumnWildcard{},
 							DatabaseName:   aws.String(dbName),
 							Name:           aws.String(tableName),
 						},
@@ -456,8 +457,8 @@ func TestFilterPermissions(t *testing.T) {
 			Name: "twcWildcardExcluded",
 			Input: &lakeformation.ListPermissionsInput{
 				Principal: principal,
-				Resource: &lakeformation.Resource{
-					Table: &lakeformation.TableResource{
+				Resource: &awstypes.Resource{
+					Table: &awstypes.TableResource{
 						CatalogId:    aws.String(accountID),
 						DatabaseName: aws.String(dbName),
 						Name:         aws.String(tableName),
@@ -466,14 +467,14 @@ func TestFilterPermissions(t *testing.T) {
 			},
 			TableType:           tflakeformation.TableTypeTableWithColumns,
 			ColumnWildcard:      true,
-			ExcludedColumnNames: aws.StringSlice([]string{"value"}),
-			All: []*lakeformation.PrincipalResourcePermissions{
+			ExcludedColumnNames: []string{"value"},
+			All: []awstypes.PrincipalResourcePermissions{
 				{
-					Permissions:                aws.StringSlice([]string{lakeformation.PermissionAlter, lakeformation.PermissionDelete}),
-					PermissionsWithGrantOption: aws.StringSlice([]string{}),
+					Permissions:                []awstypes.Permission{awstypes.PermissionAlter, awstypes.PermissionDelete},
+					PermissionsWithGrantOption: []awstypes.Permission{},
 					Principal:                  principal,
-					Resource: &lakeformation.Resource{
-						Table: &lakeformation.TableResource{
+					Resource: &awstypes.Resource{
+						Table: &awstypes.TableResource{
 							CatalogId:    aws.String(accountID),
 							DatabaseName: aws.String(dbName),
 							Name:         aws.String(tableName),
@@ -481,14 +482,14 @@ func TestFilterPermissions(t *testing.T) {
 					},
 				},
 				{
-					Permissions:                aws.StringSlice([]string{lakeformation.PermissionSelect}),
-					PermissionsWithGrantOption: aws.StringSlice([]string{}),
+					Permissions:                []awstypes.Permission{awstypes.PermissionSelect},
+					PermissionsWithGrantOption: []awstypes.Permission{},
 					Principal:                  principal,
-					Resource: &lakeformation.Resource{
-						TableWithColumns: &lakeformation.TableWithColumnsResource{
+					Resource: &awstypes.Resource{
+						TableWithColumns: &awstypes.TableWithColumnsResource{
 							CatalogId: aws.String(accountID),
-							ColumnWildcard: &lakeformation.ColumnWildcard{
-								ExcludedColumnNames: aws.StringSlice([]string{"value"}),
+							ColumnWildcard: &awstypes.ColumnWildcard{
+								ExcludedColumnNames: []string{"value"},
 							},
 							DatabaseName: aws.String(dbName),
 							Name:         aws.String(tableName),
@@ -496,26 +497,26 @@ func TestFilterPermissions(t *testing.T) {
 					},
 				},
 				{
-					Permissions:                aws.StringSlice([]string{lakeformation.PermissionSelect}),
-					PermissionsWithGrantOption: aws.StringSlice([]string{}),
+					Permissions:                []awstypes.Permission{awstypes.PermissionSelect},
+					PermissionsWithGrantOption: []awstypes.Permission{},
 					Principal:                  principal,
-					Resource: &lakeformation.Resource{
-						TableWithColumns: &lakeformation.TableWithColumnsResource{
+					Resource: &awstypes.Resource{
+						TableWithColumns: &awstypes.TableWithColumnsResource{
 							CatalogId:    aws.String(accountID),
-							ColumnNames:  aws.StringSlice([]string{"fred"}),
+							ColumnNames:  []string{"fred"},
 							DatabaseName: aws.String(dbName),
 							Name:         aws.String(tableName),
 						},
 					},
 				},
 			},
-			ExpectedClean: []*lakeformation.PrincipalResourcePermissions{
+			ExpectedClean: []awstypes.PrincipalResourcePermissions{
 				{
-					Permissions:                aws.StringSlice([]string{lakeformation.PermissionAlter, lakeformation.PermissionDelete}),
-					PermissionsWithGrantOption: aws.StringSlice([]string{}),
+					Permissions:                []awstypes.Permission{awstypes.PermissionAlter, awstypes.PermissionDelete},
+					PermissionsWithGrantOption: []awstypes.Permission{},
 					Principal:                  principal,
-					Resource: &lakeformation.Resource{
-						Table: &lakeformation.TableResource{
+					Resource: &awstypes.Resource{
+						Table: &awstypes.TableResource{
 							CatalogId:    aws.String(accountID),
 							DatabaseName: aws.String(dbName),
 							Name:         aws.String(tableName),
@@ -523,14 +524,14 @@ func TestFilterPermissions(t *testing.T) {
 					},
 				},
 				{
-					Permissions:                aws.StringSlice([]string{lakeformation.PermissionSelect}),
-					PermissionsWithGrantOption: aws.StringSlice([]string{}),
+					Permissions:                []awstypes.Permission{awstypes.PermissionSelect},
+					PermissionsWithGrantOption: []awstypes.Permission{},
 					Principal:                  principal,
-					Resource: &lakeformation.Resource{
-						TableWithColumns: &lakeformation.TableWithColumnsResource{
+					Resource: &awstypes.Resource{
+						TableWithColumns: &awstypes.TableWithColumnsResource{
 							CatalogId: aws.String(accountID),
-							ColumnWildcard: &lakeformation.ColumnWildcard{
-								ExcludedColumnNames: aws.StringSlice([]string{"value"}),
+							ColumnWildcard: &awstypes.ColumnWildcard{
+								ExcludedColumnNames: []string{"value"},
 							},
 							DatabaseName: aws.String(dbName),
 							Name:         aws.String(tableName),

--- a/internal/service/lakeformation/lf_tag.go
+++ b/internal/service/lakeformation/lf_tag.go
@@ -222,6 +222,11 @@ func resourceLFTagDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	_, err = conn.DeleteLFTag(ctx, input)
+
+	if errs.IsA[*awstypes.EntityNotFoundException](err) {
+		return diags
+	}
+
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "deleting Lake Formation LF-Tag (%s): %s", d.Id(), err)
 	}
@@ -244,23 +249,4 @@ func validateLFTagValues() schema.SchemaValidateFunc {
 		validation.StringLenBetween(1, 255),
 		validation.StringMatch(regexache.MustCompile(`^([\p{L}\p{Z}\p{N}_.:\*\/=+\-@%]*)$`), ""),
 	)
-}
-
-func splitLFTagValues(in []interface{}, size int) [][]interface{} {
-	var out [][]interface{}
-
-	for {
-		if len(in) == 0 {
-			break
-		}
-
-		if len(in) < size {
-			size = len(in)
-		}
-
-		out = append(out, in[0:size])
-		in = in[size:]
-	}
-
-	return out
 }

--- a/internal/service/lakeformation/lf_tag.go
+++ b/internal/service/lakeformation/lf_tag.go
@@ -187,11 +187,11 @@ func resourceLFTagUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		toAddEnd, toDeleteEnd := len(toAddChunks), len(toDeleteChunks)
 		var indexAdd, indexDelete int
 		if indexAdd < toAddEnd {
-			input.TagValuesToAdd = flex.ExpandStringValueList(toAddChunks[indexAdd])
+			input.TagValuesToAdd = flex.ExpandStringValueList(toAddChunks[0])
 			indexAdd++
 		}
 		if indexDelete < toDeleteEnd {
-			input.TagValuesToDelete = flex.ExpandStringValueList(toDeleteChunks[indexDelete])
+			input.TagValuesToDelete = flex.ExpandStringValueList(toDeleteChunks[0])
 			indexDelete++
 		}
 

--- a/internal/service/lakeformation/lf_tag_test.go
+++ b/internal/service/lakeformation/lf_tag_test.go
@@ -6,6 +6,7 @@ package lakeformation_test
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -20,7 +21,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	tflakeformation "github.com/hashicorp/terraform-provider-aws/internal/service/lakeformation"
-	"github.com/hashicorp/terraform-provider-aws/internal/slices"
+	providerslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -200,7 +201,8 @@ func testAccLFTag_Values_overFifty(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	generatedValues := generateLFTagValueList(1, 52)
-	generatedValues2 := append(generatedValues, generateLFTagValueList(53, 120)...)
+	generatedValues2 := slices.Clone(generatedValues)
+	generatedValues2 = append(generatedValues2, generateLFTagValueList(53, 120)...)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.LakeFormation) },
@@ -230,7 +232,7 @@ func testAccLFTag_Values_overFifty(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccLFTagConfig_values(rName, slices.RemoveAll(generatedValues, "value36")),
+				Config: testAccLFTagConfig_values(rName, providerslices.RemoveAll(generatedValues, "value36")),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLFTagExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "key", rName),

--- a/internal/service/lakeformation/lf_tag_test.go
+++ b/internal/service/lakeformation/lf_tag_test.go
@@ -200,7 +200,7 @@ func testAccLFTag_Values_overFifty(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	generatedValues := generateLFTagValueList(1, 52)
-	generatedValues = append(generatedValues, generateLFTagValueList(53, 60)...)
+	generatedValues2 := append(generatedValues, generateLFTagValueList(53, 120)...)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.LakeFormation) },
@@ -219,12 +219,12 @@ func testAccLFTag_Values_overFifty(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccLFTagConfig_values(rName, generatedValues),
+				Config: testAccLFTagConfig_values(rName, generatedValues2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLFTagExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "key", rName),
 					resource.TestCheckResourceAttr(resourceName, "values.0", "value1"),
-					testAccCheckLFTagValuesLen(ctx, resourceName, len(generatedValues)),
+					testAccCheckLFTagValuesLen(ctx, resourceName, len(generatedValues2)),
 					resource.TestCheckTypeSetElemAttr(resourceName, "values.*", "value59"),
 					acctest.CheckResourceAttrAccountID(resourceName, "catalog_id"),
 				),

--- a/internal/service/lakeformation/lf_tag_test.go
+++ b/internal/service/lakeformation/lf_tag_test.go
@@ -263,13 +263,10 @@ func testAccCheckLFTagsDestroy(ctx context.Context) resource.TestCheckFunc {
 			}
 
 			if _, err := conn.GetLFTag(ctx, input); err != nil {
-				if errs.IsA[*awstypes.EntityNotFoundException](err) {
+				if errs.IsA[*awstypes.EntityNotFoundException](err) || errs.IsA[*awstypes.AccessDeniedException](err) {
 					continue
 				}
-				// If the lake formation admin has been revoked, there will be access denied instead of entity not found
-				if errs.IsA[*awstypes.AccessDeniedException](err) {
-					continue
-				}
+
 				return err
 			}
 			return fmt.Errorf("Lake Formation LF-Tag (%s) still exists", rs.Primary.ID)

--- a/internal/service/lakeformation/permissions.go
+++ b/internal/service/lakeformation/permissions.go
@@ -10,15 +10,17 @@ import (
 	"reflect"
 	"sort"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/lakeformation"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lakeformation"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/lakeformation/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -241,10 +243,10 @@ func ResourcePermissions() *schema.Resource {
 							},
 						},
 						"resource_type": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ForceNew:     true,
-							ValidateFunc: validation.StringInSlice(lakeformation.ResourceType_Values(), false),
+							Type:             schema.TypeString,
+							Required:         true,
+							ForceNew:         true,
+							ValidateDiagFunc: enum.Validate[awstypes.ResourceType](),
 						},
 					},
 				},
@@ -255,8 +257,8 @@ func ResourcePermissions() *schema.Resource {
 				MinItems: 1,
 				Required: true,
 				Elem: &schema.Schema{
-					Type:         schema.TypeString,
-					ValidateFunc: validation.StringInSlice(lakeformation.Permission_Values(), false),
+					Type:             schema.TypeString,
+					ValidateDiagFunc: enum.Validate[awstypes.Permission](),
 				},
 			},
 			"permissions_with_grant_option": {
@@ -265,8 +267,8 @@ func ResourcePermissions() *schema.Resource {
 				ForceNew: true,
 				Optional: true,
 				Elem: &schema.Schema{
-					Type:         schema.TypeString,
-					ValidateFunc: validation.StringInSlice(lakeformation.Permission_Values(), false),
+					Type:             schema.TypeString,
+					ValidateDiagFunc: enum.Validate[awstypes.Permission](),
 				},
 			},
 			"principal": {
@@ -415,14 +417,14 @@ func ResourcePermissions() *schema.Resource {
 
 func resourcePermissionsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).LakeFormationConn(ctx)
+	conn := meta.(*conns.AWSClient).LakeFormationClient(ctx)
 
 	input := &lakeformation.GrantPermissionsInput{
-		Permissions: flex.ExpandStringList(d.Get("permissions").([]interface{})),
-		Principal: &lakeformation.DataLakePrincipal{
+		Permissions: expandPermissions(d.Get("permissions").([]interface{})),
+		Principal: &awstypes.DataLakePrincipal{
 			DataLakePrincipalIdentifier: aws.String(d.Get("principal").(string)),
 		},
-		Resource: &lakeformation.Resource{},
+		Resource: &awstypes.Resource{},
 	}
 
 	if v, ok := d.GetOk("catalog_id"); ok {
@@ -434,7 +436,7 @@ func resourcePermissionsCreate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if v, ok := d.GetOk("permissions_with_grant_option"); ok {
-		input.PermissionsWithGrantOption = flex.ExpandStringList(v.([]interface{}))
+		input.PermissionsWithGrantOption = expandPermissions(v.([]interface{}))
 	}
 
 	if _, ok := d.GetOk("catalog_resource"); ok {
@@ -468,21 +470,21 @@ func resourcePermissionsCreate(ctx context.Context, d *schema.ResourceData, meta
 	var output *lakeformation.GrantPermissionsOutput
 	err := retry.RetryContext(ctx, IAMPropagationTimeout, func() *retry.RetryError {
 		var err error
-		output, err = conn.GrantPermissionsWithContext(ctx, input)
+		output, err = conn.GrantPermissions(ctx, input)
 		if err != nil {
-			if tfawserr.ErrMessageContains(err, lakeformation.ErrCodeInvalidInputException, "Invalid principal") {
+			if errs.IsAErrorMessageContains[*awstypes.InvalidInputException](err, "Invalid principal") {
 				return retry.RetryableError(err)
 			}
-			if tfawserr.ErrMessageContains(err, lakeformation.ErrCodeInvalidInputException, "Grantee has no permissions") {
+			if errs.IsAErrorMessageContains[*awstypes.InvalidInputException](err, "Grantee has no permissions") {
 				return retry.RetryableError(err)
 			}
-			if tfawserr.ErrMessageContains(err, lakeformation.ErrCodeInvalidInputException, "register the S3 path") {
+			if errs.IsAErrorMessageContains[*awstypes.InvalidInputException](err, "register the S3 path") {
 				return retry.RetryableError(err)
 			}
-			if tfawserr.ErrCodeEquals(err, lakeformation.ErrCodeConcurrentModificationException) {
+			if errs.IsA[*awstypes.ConcurrentModificationException](err) {
 				return retry.RetryableError(err)
 			}
-			if tfawserr.ErrMessageContains(err, "AccessDeniedException", "is not authorized to access requested permissions") {
+			if errs.IsAErrorMessageContains[*awstypes.AccessDeniedException](err, "is not authorized to access requested permissions") {
 				return retry.RetryableError(err)
 			}
 
@@ -492,7 +494,7 @@ func resourcePermissionsCreate(ctx context.Context, d *schema.ResourceData, meta
 	})
 
 	if tfresource.TimedOut(err) {
-		output, err = conn.GrantPermissionsWithContext(ctx, input)
+		output, err = conn.GrantPermissions(ctx, input)
 	}
 
 	if err != nil {
@@ -503,20 +505,20 @@ func resourcePermissionsCreate(ctx context.Context, d *schema.ResourceData, meta
 		return sdkdiag.AppendErrorf(diags, "creating Lake Formation Permissions: empty response")
 	}
 
-	d.SetId(fmt.Sprintf("%d", create.StringHashcode(input.String())))
+	d.SetId(fmt.Sprintf("%d", create.StringHashcode(prettify(input))))
 
 	return append(diags, resourcePermissionsRead(ctx, d, meta)...)
 }
 
 func resourcePermissionsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).LakeFormationConn(ctx)
+	conn := meta.(*conns.AWSClient).LakeFormationClient(ctx)
 
 	input := &lakeformation.ListPermissionsInput{
-		Principal: &lakeformation.DataLakePrincipal{
+		Principal: &awstypes.DataLakePrincipal{
 			DataLakePrincipalIdentifier: aws.String(d.Get("principal").(string)),
 		},
-		Resource: &lakeformation.Resource{},
+		Resource: &awstypes.Resource{},
 	}
 
 	if v, ok := d.GetOk("catalog_id"); ok {
@@ -560,8 +562,8 @@ func resourcePermissionsRead(ctx context.Context, d *schema.ResourceData, meta i
 		tableType = TableTypeTableWithColumns
 	}
 
-	columnNames := make([]*string, 0)
-	excludedColumnNames := make([]*string, 0)
+	columnNames := make([]string, 0)
+	excludedColumnNames := make([]string, 0)
 	columnWildcard := false
 
 	if tableType == TableTypeTableWithColumns {
@@ -571,13 +573,13 @@ func resourcePermissionsRead(ctx context.Context, d *schema.ResourceData, meta i
 
 		if v, ok := d.GetOk("table_with_columns.0.column_names"); ok {
 			if v, ok := v.(*schema.Set); ok && v.Len() > 0 {
-				columnNames = flex.ExpandStringSet(v)
+				columnNames = flex.ExpandStringValueSet(v)
 			}
 		}
 
 		if v, ok := d.GetOk("table_with_columns.0.excluded_column_names"); ok {
 			if v, ok := v.(*schema.Set); ok && v.Len() > 0 {
-				excludedColumnNames = flex.ExpandStringSet(v)
+				excludedColumnNames = flex.ExpandStringValueSet(v)
 			}
 		}
 	}
@@ -587,13 +589,13 @@ func resourcePermissionsRead(ctx context.Context, d *schema.ResourceData, meta i
 	allPermissions, err := waitPermissionsReady(ctx, conn, input, tableType, columnNames, excludedColumnNames, columnWildcard)
 
 	if !d.IsNewResource() {
-		if tfawserr.ErrCodeEquals(err, lakeformation.ErrCodeEntityNotFoundException) {
+		if errs.IsA[*awstypes.EntityNotFoundException](err) {
 			log.Printf("[WARN] Resource Lake Formation permissions (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return diags
 		}
 
-		if tfawserr.ErrMessageContains(err, "AccessDeniedException", "Resource does not exist") {
+		if errs.IsAErrorMessageContains[*awstypes.AccessDeniedException](err, "Resource does not exist") {
 			log.Printf("[WARN] Resource Lake Formation permissions (%s) not found, removing from state: %s", d.Id(), err)
 			d.SetId("")
 			return diags
@@ -630,7 +632,7 @@ func resourcePermissionsRead(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	d.Set("principal", cleanPermissions[0].Principal.DataLakePrincipalIdentifier)
-	d.Set("permissions", flattenPermissions(cleanPermissions))
+	d.Set("permissions", flattenResourcePermissions(cleanPermissions))
 	d.Set("permissions_with_grant_option", flattenGrantPermissions(cleanPermissions))
 
 	if cleanPermissions[0].Resource.Catalog != nil {
@@ -734,15 +736,15 @@ func resourcePermissionsRead(ctx context.Context, d *schema.ResourceData, meta i
 
 func resourcePermissionsDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).LakeFormationConn(ctx)
+	conn := meta.(*conns.AWSClient).LakeFormationClient(ctx)
 
 	input := &lakeformation.RevokePermissionsInput{
-		Permissions:                flex.ExpandStringList(d.Get("permissions").([]interface{})),
-		PermissionsWithGrantOption: flex.ExpandStringList(d.Get("permissions_with_grant_option").([]interface{})),
-		Principal: &lakeformation.DataLakePrincipal{
+		Permissions:                expandPermissions(d.Get("permissions").([]interface{})),
+		PermissionsWithGrantOption: expandPermissions(d.Get("permissions_with_grant_option").([]interface{})),
+		Principal: &awstypes.DataLakePrincipal{
 			DataLakePrincipalIdentifier: aws.String(d.Get("principal").(string)),
 		},
-		Resource: &lakeformation.Resource{},
+		Resource: &awstypes.Resource{},
 	}
 
 	if v, ok := d.GetOk("catalog_id"); ok {
@@ -777,7 +779,7 @@ func resourcePermissionsDelete(ctx context.Context, d *schema.ResourceData, meta
 		input.Resource.TableWithColumns = expandTableColumnsResource(v.([]interface{})[0].(map[string]interface{}))
 	}
 
-	if input.Resource == nil || reflect.DeepEqual(input.Resource, &lakeformation.Resource{}) {
+	if input.Resource == nil || reflect.DeepEqual(input.Resource, &awstypes.Resource{}) {
 		// if resource is empty, don't delete = it won't delete anything since this is the predicate
 		log.Printf("[WARN] No Lake Formation Resource with permissions to revoke")
 		return diags
@@ -785,15 +787,15 @@ func resourcePermissionsDelete(ctx context.Context, d *schema.ResourceData, meta
 
 	err := retry.RetryContext(ctx, permissionsDeleteRetryTimeout, func() *retry.RetryError {
 		var err error
-		_, err = conn.RevokePermissionsWithContext(ctx, input)
+		_, err = conn.RevokePermissions(ctx, input)
 		if err != nil {
-			if tfawserr.ErrMessageContains(err, lakeformation.ErrCodeInvalidInputException, "register the S3 path") {
+			if errs.IsAErrorMessageContains[*awstypes.InvalidInputException](err, "register the S3 path") {
 				return retry.RetryableError(err)
 			}
-			if tfawserr.ErrCodeEquals(err, lakeformation.ErrCodeConcurrentModificationException) {
+			if errs.IsA[*awstypes.ConcurrentModificationException](err) {
 				return retry.RetryableError(err)
 			}
-			if tfawserr.ErrMessageContains(err, "AccessDeniedException", "is not authorized to access requested permissions") {
+			if errs.IsAErrorMessageContains[*awstypes.AccessDeniedException](err, "is not authorized to access requested permissions") {
 				return retry.RetryableError(err)
 			}
 
@@ -803,14 +805,14 @@ func resourcePermissionsDelete(ctx context.Context, d *schema.ResourceData, meta
 	})
 
 	if tfresource.TimedOut(err) {
-		_, err = conn.RevokePermissionsWithContext(ctx, input)
+		_, err = conn.RevokePermissions(ctx, input)
 	}
 
-	if tfawserr.ErrMessageContains(err, lakeformation.ErrCodeInvalidInputException, "No permissions revoked. Grantee") {
+	if errs.IsAErrorMessageContains[*awstypes.InvalidInputException](err, "No permissions revoked. Grantee") {
 		return diags
 	}
 
-	if tfawserr.ErrMessageContains(err, lakeformation.ErrCodeInvalidInputException, "cannot grant/revoke permission on non-existent column") {
+	if errs.IsAErrorMessageContains[*awstypes.InvalidInputException](err, "cannot grant/revoke permission on non-existent column") {
 		return diags
 	}
 
@@ -828,9 +830,9 @@ func resourcePermissionsDelete(ctx context.Context, d *schema.ResourceData, meta
 
 	err = retry.RetryContext(ctx, permissionsDeleteRetryTimeout, func() *retry.RetryError {
 		var err error
-		_, err = conn.RevokePermissionsWithContext(ctx, input)
+		_, err = conn.RevokePermissions(ctx, input)
 
-		if !tfawserr.ErrMessageContains(err, lakeformation.ErrCodeInvalidInputException, "No permissions revoked. Grantee has no") {
+		if !errs.IsAErrorMessageContains[*awstypes.InvalidInputException](err, "No permissions revoked. Grantee has no") {
 			return retry.RetryableError(err)
 		}
 
@@ -838,10 +840,10 @@ func resourcePermissionsDelete(ctx context.Context, d *schema.ResourceData, meta
 	})
 
 	if tfresource.TimedOut(err) {
-		_, err = conn.RevokePermissionsWithContext(ctx, input)
+		_, err = conn.RevokePermissions(ctx, input)
 	}
 
-	if tfawserr.ErrMessageContains(err, lakeformation.ErrCodeInvalidInputException, "No permissions revoked. Grantee") {
+	if errs.IsAErrorMessageContains[*awstypes.InvalidInputException](err, "No permissions revoked. Grantee") {
 		return diags
 	}
 
@@ -852,17 +854,17 @@ func resourcePermissionsDelete(ctx context.Context, d *schema.ResourceData, meta
 	return diags
 }
 
-func ExpandCatalogResource() *lakeformation.CatalogResource {
-	return &lakeformation.CatalogResource{}
+func ExpandCatalogResource() *awstypes.CatalogResource {
+	return &awstypes.CatalogResource{}
 }
 
-func ExpandDataCellsFilter(in []interface{}) *lakeformation.DataCellsFilterResource {
+func ExpandDataCellsFilter(in []interface{}) *awstypes.DataCellsFilterResource {
 	if len(in) == 0 {
 		return nil
 	}
 
 	m := in[0].(map[string]interface{})
-	var out lakeformation.DataCellsFilterResource
+	var out awstypes.DataCellsFilterResource
 
 	if v, ok := m["database_name"].(string); ok && v != "" {
 		out.DatabaseName = aws.String(v)
@@ -883,27 +885,27 @@ func ExpandDataCellsFilter(in []interface{}) *lakeformation.DataCellsFilterResou
 	return &out
 }
 
-func flattenDataCellsFilter(in *lakeformation.DataCellsFilterResource) []interface{} {
+func flattenDataCellsFilter(in *awstypes.DataCellsFilterResource) []interface{} {
 	if in == nil {
 		return nil
 	}
 
 	m := map[string]interface{}{
-		"database_name":    aws.StringValue(in.DatabaseName),
-		"name":             aws.StringValue(in.Name),
-		"table_catalog_id": aws.StringValue(in.TableCatalogId),
-		"table_name":       aws.StringValue(in.TableName),
+		"database_name":    aws.ToString(in.DatabaseName),
+		"name":             aws.ToString(in.Name),
+		"table_catalog_id": aws.ToString(in.TableCatalogId),
+		"table_name":       aws.ToString(in.TableName),
 	}
 
 	return []interface{}{m}
 }
 
-func ExpandDataLocationResource(tfMap map[string]interface{}) *lakeformation.DataLocationResource {
+func ExpandDataLocationResource(tfMap map[string]interface{}) *awstypes.DataLocationResource {
 	if tfMap == nil {
 		return nil
 	}
 
-	apiObject := &lakeformation.DataLocationResource{}
+	apiObject := &awstypes.DataLocationResource{}
 
 	if v, ok := tfMap["catalog_id"].(string); ok && v != "" {
 		apiObject.CatalogId = aws.String(v)
@@ -916,7 +918,7 @@ func ExpandDataLocationResource(tfMap map[string]interface{}) *lakeformation.Dat
 	return apiObject
 }
 
-func flattenDataLocationResource(apiObject *lakeformation.DataLocationResource) map[string]interface{} {
+func flattenDataLocationResource(apiObject *awstypes.DataLocationResource) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}
@@ -924,22 +926,22 @@ func flattenDataLocationResource(apiObject *lakeformation.DataLocationResource) 
 	tfMap := map[string]interface{}{}
 
 	if v := apiObject.CatalogId; v != nil {
-		tfMap["catalog_id"] = aws.StringValue(v)
+		tfMap["catalog_id"] = aws.ToString(v)
 	}
 
 	if v := apiObject.ResourceArn; v != nil {
-		tfMap["arn"] = aws.StringValue(v)
+		tfMap["arn"] = aws.ToString(v)
 	}
 
 	return tfMap
 }
 
-func ExpandDatabaseResource(tfMap map[string]interface{}) *lakeformation.DatabaseResource {
+func ExpandDatabaseResource(tfMap map[string]interface{}) *awstypes.DatabaseResource {
 	if tfMap == nil {
 		return nil
 	}
 
-	apiObject := &lakeformation.DatabaseResource{}
+	apiObject := &awstypes.DatabaseResource{}
 
 	if v, ok := tfMap["catalog_id"].(string); ok && v != "" {
 		apiObject.CatalogId = aws.String(v)
@@ -952,7 +954,7 @@ func ExpandDatabaseResource(tfMap map[string]interface{}) *lakeformation.Databas
 	return apiObject
 }
 
-func flattenDatabaseResource(apiObject *lakeformation.DatabaseResource) map[string]interface{} {
+func flattenDatabaseResource(apiObject *awstypes.DatabaseResource) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}
@@ -960,22 +962,22 @@ func flattenDatabaseResource(apiObject *lakeformation.DatabaseResource) map[stri
 	tfMap := map[string]interface{}{}
 
 	if v := apiObject.CatalogId; v != nil {
-		tfMap["catalog_id"] = aws.StringValue(v)
+		tfMap["catalog_id"] = aws.ToString(v)
 	}
 
 	if v := apiObject.Name; v != nil {
-		tfMap["name"] = aws.StringValue(v)
+		tfMap["name"] = aws.ToString(v)
 	}
 
 	return tfMap
 }
 
-func ExpandLFTagPolicyResource(tfMap map[string]interface{}) *lakeformation.LFTagPolicyResource {
+func ExpandLFTagPolicyResource(tfMap map[string]interface{}) *awstypes.LFTagPolicyResource {
 	if tfMap == nil {
 		return nil
 	}
 
-	apiObject := &lakeformation.LFTagPolicyResource{}
+	apiObject := &awstypes.LFTagPolicyResource{}
 
 	if v, ok := tfMap["catalog_id"].(string); ok && v != "" {
 		apiObject.CatalogId = aws.String(v)
@@ -986,20 +988,20 @@ func ExpandLFTagPolicyResource(tfMap map[string]interface{}) *lakeformation.LFTa
 	}
 
 	if v, ok := tfMap["resource_type"].(string); ok && v != "" {
-		apiObject.ResourceType = aws.String(v)
+		apiObject.ResourceType = awstypes.ResourceType(v)
 	}
 
 	return apiObject
 }
 
-func ExpandLFTagExpression(expression []interface{}) []*lakeformation.LFTag {
-	tagSlice := []*lakeformation.LFTag{}
+func ExpandLFTagExpression(expression []interface{}) []awstypes.LFTag {
+	tagSlice := []awstypes.LFTag{}
 	for _, element := range expression {
 		elementMap := element.(map[string]interface{})
 
-		tag := &lakeformation.LFTag{
+		tag := awstypes.LFTag{
 			TagKey:    aws.String(elementMap["key"].(string)),
-			TagValues: flex.ExpandStringSet(elementMap["values"].(*schema.Set)),
+			TagValues: flex.ExpandStringValueSet(elementMap["values"].(*schema.Set)),
 		}
 
 		tagSlice = append(tagSlice, tag)
@@ -1008,7 +1010,7 @@ func ExpandLFTagExpression(expression []interface{}) []*lakeformation.LFTag {
 	return tagSlice
 }
 
-func flattenLFTagPolicyResource(apiObject *lakeformation.LFTagPolicyResource) map[string]interface{} {
+func flattenLFTagPolicyResource(apiObject *awstypes.LFTagPolicyResource) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}
@@ -1016,31 +1018,31 @@ func flattenLFTagPolicyResource(apiObject *lakeformation.LFTagPolicyResource) ma
 	tfMap := map[string]interface{}{}
 
 	if v := apiObject.CatalogId; v != nil {
-		tfMap["catalog_id"] = aws.StringValue(v)
+		tfMap["catalog_id"] = aws.ToString(v)
 	}
 
 	if v := apiObject.Expression; v != nil {
 		tfMap["expression"] = flattenLFTagExpression(v)
 	}
 
-	if v := apiObject.ResourceType; v != nil {
-		tfMap["resource_type"] = aws.StringValue(v)
+	if v := apiObject.ResourceType; v != "" {
+		tfMap["resource_type"] = string(v)
 	}
 
 	return tfMap
 }
 
-func flattenLFTagExpression(ts []*lakeformation.LFTag) []map[string]interface{} {
+func flattenLFTagExpression(ts []awstypes.LFTag) []map[string]interface{} {
 	tagSlice := make([]map[string]interface{}, len(ts))
 	if len(ts) > 0 {
 		for i, t := range ts {
 			tag := make(map[string]interface{})
 
-			if v := aws.StringValue(t.TagKey); v != "" {
+			if v := aws.ToString(t.TagKey); v != "" {
 				tag["key"] = v
 			}
 
-			if v := flex.FlattenStringList(t.TagValues); v != nil {
+			if v := flex.FlattenStringValueList(t.TagValues); v != nil {
 				tag["values"] = v
 			}
 
@@ -1051,12 +1053,12 @@ func flattenLFTagExpression(ts []*lakeformation.LFTag) []map[string]interface{} 
 	return tagSlice
 }
 
-func ExpandLFTagKeyResource(tfMap map[string]interface{}) *lakeformation.LFTagKeyResource {
+func ExpandLFTagKeyResource(tfMap map[string]interface{}) *awstypes.LFTagKeyResource {
 	if tfMap == nil {
 		return nil
 	}
 
-	apiObject := &lakeformation.LFTagKeyResource{}
+	apiObject := &awstypes.LFTagKeyResource{}
 
 	if v, ok := tfMap["catalog_id"].(string); ok && v != "" {
 		apiObject.CatalogId = aws.String(v)
@@ -1067,13 +1069,13 @@ func ExpandLFTagKeyResource(tfMap map[string]interface{}) *lakeformation.LFTagKe
 	}
 
 	if v, ok := tfMap["values"].(*schema.Set); ok && v != nil {
-		apiObject.TagValues = flex.ExpandStringSet(v)
+		apiObject.TagValues = flex.ExpandStringValueSet(v)
 	}
 
 	return apiObject
 }
 
-func flattenLFTagKeyResource(apiObject *lakeformation.LFTagKeyResource) map[string]interface{} {
+func flattenLFTagKeyResource(apiObject *awstypes.LFTagKeyResource) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}
@@ -1081,26 +1083,26 @@ func flattenLFTagKeyResource(apiObject *lakeformation.LFTagKeyResource) map[stri
 	tfMap := map[string]interface{}{}
 
 	if v := apiObject.CatalogId; v != nil {
-		tfMap["catalog_id"] = aws.StringValue(v)
+		tfMap["catalog_id"] = aws.ToString(v)
 	}
 
 	if v := apiObject.TagKey; v != nil {
-		tfMap["key"] = aws.StringValue(v)
+		tfMap["key"] = aws.ToString(v)
 	}
 
 	if v := apiObject.TagValues; v != nil {
-		tfMap["values"] = flex.FlattenStringSet(v)
+		tfMap["values"] = flex.FlattenStringValueSet(v)
 	}
 
 	return tfMap
 }
 
-func ExpandTableResource(tfMap map[string]interface{}) *lakeformation.TableResource {
+func ExpandTableResource(tfMap map[string]interface{}) *awstypes.TableResource {
 	if tfMap == nil {
 		return nil
 	}
 
-	apiObject := &lakeformation.TableResource{}
+	apiObject := &awstypes.TableResource{}
 
 	if v, ok := tfMap["catalog_id"].(string); ok && v != "" {
 		apiObject.CatalogId = aws.String(v)
@@ -1115,18 +1117,18 @@ func ExpandTableResource(tfMap map[string]interface{}) *lakeformation.TableResou
 	}
 
 	if v, ok := tfMap["wildcard"].(bool); ok && v {
-		apiObject.TableWildcard = &lakeformation.TableWildcard{}
+		apiObject.TableWildcard = &awstypes.TableWildcard{}
 	}
 
 	return apiObject
 }
 
-func ExpandTableWithColumnsResourceAsTable(tfMap map[string]interface{}) *lakeformation.TableResource {
+func ExpandTableWithColumnsResourceAsTable(tfMap map[string]interface{}) *awstypes.TableResource {
 	if tfMap == nil {
 		return nil
 	}
 
-	apiObject := &lakeformation.TableResource{}
+	apiObject := &awstypes.TableResource{}
 
 	if v, ok := tfMap["catalog_id"].(string); ok && v != "" {
 		apiObject.CatalogId = aws.String(v)
@@ -1143,7 +1145,7 @@ func ExpandTableWithColumnsResourceAsTable(tfMap map[string]interface{}) *lakefo
 	return apiObject
 }
 
-func flattenTableResource(apiObject *lakeformation.TableResource) map[string]interface{} {
+func flattenTableResource(apiObject *awstypes.TableResource) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}
@@ -1151,16 +1153,16 @@ func flattenTableResource(apiObject *lakeformation.TableResource) map[string]int
 	tfMap := map[string]interface{}{}
 
 	if v := apiObject.CatalogId; v != nil {
-		tfMap["catalog_id"] = aws.StringValue(v)
+		tfMap["catalog_id"] = aws.ToString(v)
 	}
 
 	if v := apiObject.DatabaseName; v != nil {
-		tfMap["database_name"] = aws.StringValue(v)
+		tfMap["database_name"] = aws.ToString(v)
 	}
 
 	if v := apiObject.Name; v != nil {
-		if aws.StringValue(v) != TableNameAllTables || apiObject.TableWildcard == nil {
-			tfMap["name"] = aws.StringValue(v)
+		if aws.ToString(v) != TableNameAllTables || apiObject.TableWildcard == nil {
+			tfMap["name"] = aws.ToString(v)
 		}
 	}
 
@@ -1171,12 +1173,12 @@ func flattenTableResource(apiObject *lakeformation.TableResource) map[string]int
 	return tfMap
 }
 
-func expandTableColumnsResource(tfMap map[string]interface{}) *lakeformation.TableWithColumnsResource {
+func expandTableColumnsResource(tfMap map[string]interface{}) *awstypes.TableWithColumnsResource {
 	if tfMap == nil {
 		return nil
 	}
 
-	apiObject := &lakeformation.TableWithColumnsResource{}
+	apiObject := &awstypes.TableWithColumnsResource{}
 
 	if v, ok := tfMap["catalog_id"].(string); ok && v != "" {
 		apiObject.CatalogId = aws.String(v)
@@ -1184,7 +1186,7 @@ func expandTableColumnsResource(tfMap map[string]interface{}) *lakeformation.Tab
 
 	if v, ok := tfMap["column_names"]; ok {
 		if v, ok := v.(*schema.Set); ok && v.Len() > 0 {
-			apiObject.ColumnNames = flex.ExpandStringSet(v)
+			apiObject.ColumnNames = flex.ExpandStringValueSet(v)
 		}
 	}
 
@@ -1194,8 +1196,8 @@ func expandTableColumnsResource(tfMap map[string]interface{}) *lakeformation.Tab
 
 	if v, ok := tfMap["excluded_column_names"]; ok {
 		if v, ok := v.(*schema.Set); ok && v.Len() > 0 {
-			apiObject.ColumnWildcard = &lakeformation.ColumnWildcard{
-				ExcludedColumnNames: flex.ExpandStringSet(v),
+			apiObject.ColumnWildcard = &awstypes.ColumnWildcard{
+				ExcludedColumnNames: flex.ExpandStringValueSet(v),
 			}
 		}
 	}
@@ -1205,13 +1207,13 @@ func expandTableColumnsResource(tfMap map[string]interface{}) *lakeformation.Tab
 	}
 
 	if v, ok := tfMap["wildcard"].(bool); ok && v && apiObject.ColumnWildcard == nil {
-		apiObject.ColumnWildcard = &lakeformation.ColumnWildcard{}
+		apiObject.ColumnWildcard = &awstypes.ColumnWildcard{}
 	}
 
 	return apiObject
 }
 
-func flattenTableColumnsResource(apiObject *lakeformation.TableWithColumnsResource) map[string]interface{} {
+func flattenTableColumnsResource(apiObject *awstypes.TableWithColumnsResource) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}
@@ -1219,22 +1221,22 @@ func flattenTableColumnsResource(apiObject *lakeformation.TableWithColumnsResour
 	tfMap := map[string]interface{}{}
 
 	if v := apiObject.CatalogId; v != nil {
-		tfMap["catalog_id"] = aws.StringValue(v)
+		tfMap["catalog_id"] = aws.ToString(v)
 	}
 
-	tfMap["column_names"] = flex.FlattenStringSet(apiObject.ColumnNames)
+	tfMap["column_names"] = flex.FlattenStringValueSet(apiObject.ColumnNames)
 
 	if v := apiObject.DatabaseName; v != nil {
-		tfMap["database_name"] = aws.StringValue(v)
+		tfMap["database_name"] = aws.ToString(v)
 	}
 
 	if v := apiObject.ColumnWildcard; v != nil {
 		tfMap["wildcard"] = true
-		tfMap["excluded_column_names"] = flex.FlattenStringSet(v.ExcludedColumnNames)
+		tfMap["excluded_column_names"] = flex.FlattenStringValueSet(v.ExcludedColumnNames)
 	}
 
 	if v := apiObject.Name; v != nil {
-		tfMap["name"] = aws.StringValue(v)
+		tfMap["name"] = aws.ToString(v)
 	}
 
 	return tfMap
@@ -1243,7 +1245,7 @@ func flattenTableColumnsResource(apiObject *lakeformation.TableWithColumnsResour
 // This only happens in very specific situations:
 // (Select) TWC + ColumnWildcard              = (Select) Table
 // (Select) TWC + ColumnWildcard + ALL_TABLES = (Select) Table + TableWildcard
-func flattenTableColumnsResourceAsTable(apiObject *lakeformation.TableWithColumnsResource) map[string]interface{} {
+func flattenTableColumnsResourceAsTable(apiObject *awstypes.TableWithColumnsResource) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}
@@ -1251,23 +1253,23 @@ func flattenTableColumnsResourceAsTable(apiObject *lakeformation.TableWithColumn
 	tfMap := map[string]interface{}{}
 
 	if v := apiObject.CatalogId; v != nil {
-		tfMap["catalog_id"] = aws.StringValue(v)
+		tfMap["catalog_id"] = aws.ToString(v)
 	}
 
 	if v := apiObject.DatabaseName; v != nil {
-		tfMap["database_name"] = aws.StringValue(v)
+		tfMap["database_name"] = aws.ToString(v)
 	}
 
-	if v := apiObject.Name; v != nil && aws.StringValue(v) == TableNameAllTables && apiObject.ColumnWildcard != nil {
+	if v := apiObject.Name; v != nil && aws.ToString(v) == TableNameAllTables && apiObject.ColumnWildcard != nil {
 		tfMap["wildcard"] = true
 	} else if v := apiObject.Name; v != nil {
-		tfMap["name"] = aws.StringValue(v)
+		tfMap["name"] = aws.ToString(v)
 	}
 
 	return tfMap
 }
 
-func flattenPermissions(apiObjects []*lakeformation.PrincipalResourcePermissions) []string {
+func flattenResourcePermissions(apiObjects []awstypes.PrincipalResourcePermissions) []string {
 	if apiObjects == nil {
 		return nil
 	}
@@ -1276,7 +1278,7 @@ func flattenPermissions(apiObjects []*lakeformation.PrincipalResourcePermissions
 
 	for _, resourcePermission := range apiObjects {
 		for _, permission := range resourcePermission.Permissions {
-			tfList = append(tfList, aws.StringValue(permission))
+			tfList = append(tfList, string(permission))
 		}
 	}
 
@@ -1285,7 +1287,7 @@ func flattenPermissions(apiObjects []*lakeformation.PrincipalResourcePermissions
 	return tfList
 }
 
-func flattenGrantPermissions(apiObjects []*lakeformation.PrincipalResourcePermissions) []string {
+func flattenGrantPermissions(apiObjects []awstypes.PrincipalResourcePermissions) []string {
 	if apiObjects == nil {
 		return nil
 	}
@@ -1294,7 +1296,7 @@ func flattenGrantPermissions(apiObjects []*lakeformation.PrincipalResourcePermis
 
 	for _, resourcePermission := range apiObjects {
 		for _, grantPermission := range resourcePermission.PermissionsWithGrantOption {
-			tfList = append(tfList, aws.StringValue(grantPermission))
+			tfList = append(tfList, string(grantPermission))
 		}
 	}
 

--- a/internal/service/lakeformation/permissions_data_source.go
+++ b/internal/service/lakeformation/permissions_data_source.go
@@ -8,13 +8,15 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/lakeformation"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lakeformation"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/lakeformation/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -169,9 +171,9 @@ func DataSourcePermissions() *schema.Resource {
 							},
 						},
 						"resource_type": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringInSlice(lakeformation.ResourceType_Values(), false),
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateDiagFunc: enum.Validate[awstypes.ResourceType](),
 						},
 					},
 				},
@@ -275,13 +277,13 @@ func DataSourcePermissions() *schema.Resource {
 
 func dataSourcePermissionsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).LakeFormationConn(ctx)
+	conn := meta.(*conns.AWSClient).LakeFormationClient(ctx)
 
 	input := &lakeformation.ListPermissionsInput{
-		Principal: &lakeformation.DataLakePrincipal{
+		Principal: &awstypes.DataLakePrincipal{
 			DataLakePrincipalIdentifier: aws.String(d.Get("principal").(string)),
 		},
-		Resource: &lakeformation.Resource{},
+		Resource: &awstypes.Resource{},
 	}
 
 	if v, ok := d.GetOk("catalog_id"); ok {
@@ -325,8 +327,8 @@ func dataSourcePermissionsRead(ctx context.Context, d *schema.ResourceData, meta
 		tableType = TableTypeTableWithColumns
 	}
 
-	columnNames := make([]*string, 0)
-	excludedColumnNames := make([]*string, 0)
+	columnNames := make([]string, 0)
+	excludedColumnNames := make([]string, 0)
 	columnWildcard := false
 
 	if tableType == TableTypeTableWithColumns {
@@ -336,13 +338,13 @@ func dataSourcePermissionsRead(ctx context.Context, d *schema.ResourceData, meta
 
 		if v, ok := d.GetOk("table_with_columns.0.column_names"); ok {
 			if v, ok := v.(*schema.Set); ok && v.Len() > 0 {
-				columnNames = flex.ExpandStringSet(v)
+				columnNames = flex.ExpandStringValueSet(v)
 			}
 		}
 
 		if v, ok := d.GetOk("table_with_columns.0.excluded_column_names"); ok {
 			if v, ok := v.(*schema.Set); ok && v.Len() > 0 {
-				excludedColumnNames = flex.ExpandStringSet(v)
+				excludedColumnNames = flex.ExpandStringValueSet(v)
 			}
 		}
 	}
@@ -351,7 +353,7 @@ func dataSourcePermissionsRead(ctx context.Context, d *schema.ResourceData, meta
 
 	allPermissions, err := waitPermissionsReady(ctx, conn, input, tableType, columnNames, excludedColumnNames, columnWildcard)
 
-	d.SetId(fmt.Sprintf("%d", create.StringHashcode(input.String())))
+	d.SetId(fmt.Sprintf("%d", create.StringHashcode(prettify(input))))
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading Lake Formation permissions: %s", err)
@@ -365,7 +367,7 @@ func dataSourcePermissionsRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	d.Set("principal", cleanPermissions[0].Principal.DataLakePrincipalIdentifier)
-	d.Set("permissions", flattenPermissions(cleanPermissions))
+	d.Set("permissions", flattenResourcePermissions(cleanPermissions))
 	d.Set("permissions_with_grant_option", flattenGrantPermissions(cleanPermissions))
 
 	if cleanPermissions[0].Resource.Catalog != nil {

--- a/internal/service/lakeformation/prettify.go
+++ b/internal/service/lakeformation/prettify.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package lakeformation
 
 import (

--- a/internal/service/lakeformation/prettify.go
+++ b/internal/service/lakeformation/prettify.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"log"
 	"reflect"
 	"strings"
 )
@@ -57,7 +58,7 @@ func prettifyInternal(v reflect.Value, indent int, buf *bytes.Buffer) {
 			val := v.FieldByName(n)
 			ft, ok := v.Type().FieldByName(n)
 			if !ok {
-				panic(fmt.Sprintf("expected to find field %v on type %v, but was not found", n, v.Type()))
+				log.Printf("expected to find field %v on type %v, but was not found", n, v.Type())
 			}
 
 			buf.WriteString(strings.Repeat(" ", indent+2))

--- a/internal/service/lakeformation/prettify.go
+++ b/internal/service/lakeformation/prettify.go
@@ -21,6 +21,8 @@ func prettify(i interface{}) string {
 	return buf.String()
 }
 
+const indentValue = 2
+
 // prettifyInternal will recursively walk value v to build a textual
 // representation of the value.
 func prettifyInternal(v reflect.Value, indent int, buf *bytes.Buffer) {
@@ -61,13 +63,13 @@ func prettifyInternal(v reflect.Value, indent int, buf *bytes.Buffer) {
 				log.Printf("expected to find field %v on type %v, but was not found", n, v.Type())
 			}
 
-			buf.WriteString(strings.Repeat(" ", indent+2))
+			buf.WriteString(strings.Repeat(" ", indent+indentValue))
 			buf.WriteString(n + ": ")
 
 			if tag := ft.Tag.Get("sensitive"); tag == "true" {
 				buf.WriteString("<sensitive>")
 			} else {
-				prettifyInternal(val, indent+2, buf)
+				prettifyInternal(val, indent+indentValue, buf)
 			}
 
 			if i < len(names)-1 {
@@ -85,12 +87,12 @@ func prettifyInternal(v reflect.Value, indent int, buf *bytes.Buffer) {
 
 		nl, id, id2 := "", "", ""
 		if v.Len() > 3 {
-			nl, id, id2 = "\n", strings.Repeat(" ", indent), strings.Repeat(" ", indent+2)
+			nl, id, id2 = "\n", strings.Repeat(" ", indent), strings.Repeat(" ", indent+indentValue)
 		}
 		buf.WriteString("[" + nl)
 		for i := 0; i < v.Len(); i++ {
 			buf.WriteString(id2)
-			prettifyInternal(v.Index(i), indent+2, buf)
+			prettifyInternal(v.Index(i), indent+indentValue, buf)
 
 			if i < v.Len()-1 {
 				buf.WriteString("," + nl)
@@ -102,9 +104,9 @@ func prettifyInternal(v reflect.Value, indent int, buf *bytes.Buffer) {
 		buf.WriteString("{\n")
 
 		for i, k := range v.MapKeys() {
-			buf.WriteString(strings.Repeat(" ", indent+2))
+			buf.WriteString(strings.Repeat(" ", indent+indentValue))
 			buf.WriteString(k.String() + ": ")
-			prettifyInternal(v.MapIndex(k), indent+2, buf)
+			prettifyInternal(v.MapIndex(k), indent+indentValue, buf)
 
 			if i < v.Len()-1 {
 				buf.WriteString(",\n")

--- a/internal/service/lakeformation/prettify.go
+++ b/internal/service/lakeformation/prettify.go
@@ -9,6 +9,8 @@ import (
 )
 
 // prettify returns the string representation of a value.
+// replaces the String() method that existed on structs in AWS SDK v1
+// https://github.com/aws/aws-sdk-go/blob/main/aws/awsutil/prettify.go
 func prettify(i interface{}) string {
 	var buf bytes.Buffer
 	prettifyInternal(reflect.ValueOf(i), 0, &buf)

--- a/internal/service/lakeformation/prettify.go
+++ b/internal/service/lakeformation/prettify.go
@@ -1,0 +1,123 @@
+package lakeformation
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+)
+
+// prettify returns the string representation of a value.
+func prettify(i interface{}) string {
+	var buf bytes.Buffer
+	prettifyInternal(reflect.ValueOf(i), 0, &buf)
+	return buf.String()
+}
+
+// prettifyInternal will recursively walk value v to build a textual
+// representation of the value.
+func prettifyInternal(v reflect.Value, indent int, buf *bytes.Buffer) {
+	for v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+
+	switch v.Kind() {
+	case reflect.Struct:
+		strtype := v.Type().String()
+		if strtype == "time.Time" {
+			fmt.Fprintf(buf, "%s", v.Interface())
+			break
+		} else if strings.HasPrefix(strtype, "io.") {
+			buf.WriteString("<buffer>")
+			break
+		}
+
+		buf.WriteString("{\n")
+
+		names := []string{}
+		for i := 0; i < v.Type().NumField(); i++ {
+			name := v.Type().Field(i).Name
+			f := v.Field(i)
+			if name[0:1] == strings.ToLower(name[0:1]) {
+				continue // ignore unexported fields
+			}
+			if (f.Kind() == reflect.Ptr || f.Kind() == reflect.Slice || f.Kind() == reflect.Map) && f.IsNil() {
+				continue // ignore unset fields
+			}
+			names = append(names, name)
+		}
+
+		for i, n := range names {
+			val := v.FieldByName(n)
+			ft, ok := v.Type().FieldByName(n)
+			if !ok {
+				panic(fmt.Sprintf("expected to find field %v on type %v, but was not found", n, v.Type()))
+			}
+
+			buf.WriteString(strings.Repeat(" ", indent+2))
+			buf.WriteString(n + ": ")
+
+			if tag := ft.Tag.Get("sensitive"); tag == "true" {
+				buf.WriteString("<sensitive>")
+			} else {
+				prettifyInternal(val, indent+2, buf)
+			}
+
+			if i < len(names)-1 {
+				buf.WriteString(",\n")
+			}
+		}
+
+		buf.WriteString("\n" + strings.Repeat(" ", indent) + "}")
+	case reflect.Slice:
+		strtype := v.Type().String()
+		if strtype == "[]uint8" {
+			fmt.Fprintf(buf, "<binary> len %d", v.Len())
+			break
+		}
+
+		nl, id, id2 := "", "", ""
+		if v.Len() > 3 {
+			nl, id, id2 = "\n", strings.Repeat(" ", indent), strings.Repeat(" ", indent+2)
+		}
+		buf.WriteString("[" + nl)
+		for i := 0; i < v.Len(); i++ {
+			buf.WriteString(id2)
+			prettifyInternal(v.Index(i), indent+2, buf)
+
+			if i < v.Len()-1 {
+				buf.WriteString("," + nl)
+			}
+		}
+
+		buf.WriteString(nl + id + "]")
+	case reflect.Map:
+		buf.WriteString("{\n")
+
+		for i, k := range v.MapKeys() {
+			buf.WriteString(strings.Repeat(" ", indent+2))
+			buf.WriteString(k.String() + ": ")
+			prettifyInternal(v.MapIndex(k), indent+2, buf)
+
+			if i < v.Len()-1 {
+				buf.WriteString(",\n")
+			}
+		}
+
+		buf.WriteString("\n" + strings.Repeat(" ", indent) + "}")
+	default:
+		if !v.IsValid() {
+			fmt.Fprint(buf, "<invalid value>")
+			return
+		}
+		format := "%v"
+		switch v.Interface().(type) {
+		case string:
+			format = "%q"
+		case io.ReadSeeker, io.Reader:
+			format = "buffer(%p)"
+		}
+		fmt.Fprintf(buf, format, v.Interface())
+	}
+}

--- a/internal/service/lakeformation/resource_data_source_test.go
+++ b/internal/service/lakeformation/resource_data_source_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/lakeformation"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
@@ -21,7 +20,7 @@ func TestAccLakeFormationResourceDataSource_basic(t *testing.T) {
 	resourceName := "aws_lakeformation_resource.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, lakeformation.EndpointsID) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.LakeFormation) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LakeFormationServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckResourceDestroy(ctx),

--- a/internal/service/lakeformation/resource_lf_tags.go
+++ b/internal/service/lakeformation/resource_lf_tags.go
@@ -6,14 +6,14 @@ package lakeformation
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/service/lakeformation"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lakeformation"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/lakeformation/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -228,7 +228,7 @@ func ResourceResourceLFTags() *schema.Resource {
 func resourceResourceLFTagsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	conn := meta.(*conns.AWSClient).LakeFormationConn(ctx)
+	conn := meta.(*conns.AWSClient).LakeFormationClient(ctx)
 
 	input := &lakeformation.AddLFTagsToResourceInput{}
 
@@ -251,12 +251,12 @@ func resourceResourceLFTagsCreate(ctx context.Context, d *schema.ResourceData, m
 	var output *lakeformation.AddLFTagsToResourceOutput
 	err := retry.RetryContext(ctx, IAMPropagationTimeout, func() *retry.RetryError {
 		var err error
-		output, err = conn.AddLFTagsToResourceWithContext(ctx, input)
+		output, err = conn.AddLFTagsToResource(ctx, input)
 		if err != nil {
-			if tfawserr.ErrCodeEquals(err, lakeformation.ErrCodeConcurrentModificationException) {
+			if errs.IsA[*awstypes.ConcurrentModificationException](err) {
 				return retry.RetryableError(err)
 			}
-			if tfawserr.ErrMessageContains(err, "AccessDeniedException", "is not authorized") {
+			if errs.IsA[*awstypes.AccessDeniedException](err) {
 				return retry.RetryableError(err)
 			}
 
@@ -266,11 +266,11 @@ func resourceResourceLFTagsCreate(ctx context.Context, d *schema.ResourceData, m
 	})
 
 	if tfresource.TimedOut(err) {
-		output, err = conn.AddLFTagsToResourceWithContext(ctx, input)
+		output, err = conn.AddLFTagsToResource(ctx, input)
 	}
 
 	if err != nil {
-		return create.AppendDiagError(diags, names.LakeFormation, create.ErrActionCreating, ResNameLFTags, input.String(), err)
+		return create.AppendDiagError(diags, names.LakeFormation, create.ErrActionCreating, ResNameLFTags, prettify(input), err)
 	}
 
 	if output != nil && len(output.Failures) > 0 {
@@ -283,8 +283,8 @@ func resourceResourceLFTagsCreate(ctx context.Context, d *schema.ResourceData, m
 				names.LakeFormation,
 				create.ErrActionCreating,
 				ResNameLFTags,
-				fmt.Sprintf("catalog id:%s, tag key:%s, values:%+v", aws.StringValue(v.LFTag.CatalogId), aws.StringValue(v.LFTag.TagKey), aws.StringValueSlice(v.LFTag.TagValues)),
-				awserr.New(aws.StringValue(v.Error.ErrorCode), aws.StringValue(v.Error.ErrorMessage), nil),
+				fmt.Sprintf("catalog id:%s, tag key:%s, values:%+v", aws.ToString(v.LFTag.CatalogId), aws.ToString(v.LFTag.TagKey), v.LFTag.TagValues),
+				errors.New(fmt.Sprintf("%s: %s", aws.ToString(v.Error.ErrorCode), aws.ToString(v.Error.ErrorMessage))),
 			)
 		}
 	}
@@ -292,7 +292,7 @@ func resourceResourceLFTagsCreate(ctx context.Context, d *schema.ResourceData, m
 		return diags
 	}
 
-	d.SetId(fmt.Sprintf("%d", create.StringHashcode(input.String())))
+	d.SetId(fmt.Sprintf("%d", create.StringHashcode(prettify(input))))
 
 	return append(diags, resourceResourceLFTagsRead(ctx, d, meta)...)
 }
@@ -300,7 +300,7 @@ func resourceResourceLFTagsCreate(ctx context.Context, d *schema.ResourceData, m
 func resourceResourceLFTagsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	conn := meta.(*conns.AWSClient).LakeFormationConn(ctx)
+	conn := meta.(*conns.AWSClient).LakeFormationClient(ctx)
 
 	input := &lakeformation.GetResourceLFTagsInput{
 		ShowAssignedLFTags: aws.Bool(true),
@@ -318,7 +318,7 @@ func resourceResourceLFTagsRead(ctx context.Context, d *schema.ResourceData, met
 
 	input.Resource = tagger.ExpandResource(d)
 
-	output, err := conn.GetResourceLFTagsWithContext(ctx, input)
+	output, err := conn.GetResourceLFTags(ctx, input)
 
 	if err != nil {
 		return create.AppendDiagError(diags, names.LakeFormation, create.ErrActionReading, ResNameLFTags, d.Id(), err)
@@ -334,7 +334,7 @@ func resourceResourceLFTagsRead(ctx context.Context, d *schema.ResourceData, met
 func resourceResourceLFTagsDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	conn := meta.(*conns.AWSClient).LakeFormationConn(ctx)
+	conn := meta.(*conns.AWSClient).LakeFormationClient(ctx)
 
 	input := &lakeformation.RemoveLFTagsFromResourceInput{}
 
@@ -354,19 +354,19 @@ func resourceResourceLFTagsDelete(ctx context.Context, d *schema.ResourceData, m
 
 	input.Resource = tagger.ExpandResource(d)
 
-	if input.Resource == nil || reflect.DeepEqual(input.Resource, &lakeformation.Resource{}) || len(input.LFTags) == 0 {
+	if input.Resource == nil || reflect.DeepEqual(input.Resource, &awstypes.Resource{}) || len(input.LFTags) == 0 {
 		// if resource is empty, don't delete = it won't delete anything since this is the predicate
 		return create.AppendDiagWarningMessage(diags, names.LakeFormation, create.ErrActionSetting, ResNameLFTags, d.Id(), "no LF-Tags to remove")
 	}
 
 	err := retry.RetryContext(ctx, d.Timeout(schema.TimeoutDelete), func() *retry.RetryError {
 		var err error
-		_, err = conn.RemoveLFTagsFromResourceWithContext(ctx, input)
+		_, err = conn.RemoveLFTagsFromResource(ctx, input)
 		if err != nil {
-			if tfawserr.ErrCodeEquals(err, lakeformation.ErrCodeConcurrentModificationException) {
+			if errs.IsA[*awstypes.ConcurrentModificationException](err) {
 				return retry.RetryableError(err)
 			}
-			if tfawserr.ErrMessageContains(err, "AccessDeniedException", "is not authorized") {
+			if errs.IsAErrorMessageContains[*awstypes.AccessDeniedException](err, "is not authorized") {
 				return retry.RetryableError(err)
 			}
 
@@ -376,7 +376,7 @@ func resourceResourceLFTagsDelete(ctx context.Context, d *schema.ResourceData, m
 	})
 
 	if tfresource.TimedOut(err) {
-		_, err = conn.RemoveLFTagsFromResourceWithContext(ctx, input)
+		_, err = conn.RemoveLFTagsFromResource(ctx, input)
 	}
 
 	if err != nil {
@@ -407,15 +407,15 @@ func lfTagsTagger(d *schema.ResourceData) (tagger, diag.Diagnostics) {
 }
 
 type tagger interface {
-	ExpandResource(*schema.ResourceData) *lakeformation.Resource
+	ExpandResource(*schema.ResourceData) *awstypes.Resource
 	FlattenTags(*lakeformation.GetResourceLFTagsOutput) []any
 }
 
 type databaseTagger struct{}
 
-func (t *databaseTagger) ExpandResource(d *schema.ResourceData) *lakeformation.Resource {
+func (t *databaseTagger) ExpandResource(d *schema.ResourceData) *awstypes.Resource {
 	v := d.Get("database").([]any)[0].(map[string]any)
-	return &lakeformation.Resource{
+	return &awstypes.Resource{
 		Database: ExpandDatabaseResource(v),
 	}
 }
@@ -426,9 +426,9 @@ func (t *databaseTagger) FlattenTags(output *lakeformation.GetResourceLFTagsOutp
 
 type tableTagger struct{}
 
-func (t *tableTagger) ExpandResource(d *schema.ResourceData) *lakeformation.Resource {
+func (t *tableTagger) ExpandResource(d *schema.ResourceData) *awstypes.Resource {
 	v := d.Get("table").([]any)[0].(map[string]any)
-	return &lakeformation.Resource{
+	return &awstypes.Resource{
 		Table: ExpandTableResource(v),
 	}
 }
@@ -439,9 +439,9 @@ func (t *tableTagger) FlattenTags(output *lakeformation.GetResourceLFTagsOutput)
 
 type columnTagger struct{}
 
-func (t *columnTagger) ExpandResource(d *schema.ResourceData) *lakeformation.Resource {
+func (t *columnTagger) ExpandResource(d *schema.ResourceData) *awstypes.Resource {
 	v := d.Get("table_with_columns").([]any)[0].(map[string]any)
-	return &lakeformation.Resource{
+	return &awstypes.Resource{
 		TableWithColumns: expandTableColumnsResource(v),
 	}
 }
@@ -452,7 +452,7 @@ func (t *columnTagger) FlattenTags(output *lakeformation.GetResourceLFTagsOutput
 	}
 
 	tags := output.LFTagsOnColumns[0]
-	if tags == nil {
+	if reflect.ValueOf(tags).IsZero() {
 		return []any{}
 	}
 
@@ -474,12 +474,12 @@ func lfTagsHash(v interface{}) int {
 	return create.StringHashcode(buf.String())
 }
 
-func expandLFTagPair(tfMap map[string]interface{}) *lakeformation.LFTagPair {
+func expandLFTagPair(tfMap map[string]interface{}) awstypes.LFTagPair {
 	if tfMap == nil {
-		return nil
+		return awstypes.LFTagPair{}
 	}
 
-	apiObject := &lakeformation.LFTagPair{}
+	apiObject := awstypes.LFTagPair{}
 
 	if v, ok := tfMap["catalog_id"].(string); ok && v != "" {
 		apiObject.CatalogId = aws.String(v)
@@ -490,18 +490,18 @@ func expandLFTagPair(tfMap map[string]interface{}) *lakeformation.LFTagPair {
 	}
 
 	if v, ok := tfMap["value"].(string); ok && v != "" {
-		apiObject.TagValues = aws.StringSlice([]string{v})
+		apiObject.TagValues = []string{v}
 	}
 
 	return apiObject
 }
 
-func expandLFTagPairs(tfList []interface{}) []*lakeformation.LFTagPair {
+func expandLFTagPairs(tfList []interface{}) []awstypes.LFTagPair {
 	if len(tfList) == 0 {
 		return nil
 	}
 
-	var apiObjects []*lakeformation.LFTagPair
+	var apiObjects []awstypes.LFTagPair
 
 	for _, tfMapRaw := range tfList {
 		tfMap, ok := tfMapRaw.(map[string]interface{})
@@ -512,7 +512,7 @@ func expandLFTagPairs(tfList []interface{}) []*lakeformation.LFTagPair {
 
 		apiObject := expandLFTagPair(tfMap)
 
-		if apiObject == nil {
+		if reflect.ValueOf(apiObject).IsZero() {
 			continue
 		}
 
@@ -522,29 +522,29 @@ func expandLFTagPairs(tfList []interface{}) []*lakeformation.LFTagPair {
 	return apiObjects
 }
 
-func flattenLFTagPair(apiObject *lakeformation.LFTagPair) map[string]interface{} {
-	if apiObject == nil {
+func flattenLFTagPair(apiObject awstypes.LFTagPair) map[string]interface{} {
+	if reflect.ValueOf(apiObject).IsZero() {
 		return nil
 	}
 
 	tfMap := map[string]interface{}{}
 
 	if v := apiObject.CatalogId; v != nil {
-		tfMap["catalog_id"] = aws.StringValue(v)
+		tfMap["catalog_id"] = aws.ToString(v)
 	}
 
 	if v := apiObject.TagKey; v != nil {
-		tfMap["key"] = aws.StringValue(v)
+		tfMap["key"] = aws.ToString(v)
 	}
 
 	if v := apiObject.TagValues; len(v) > 0 {
-		tfMap["value"] = aws.StringValue(apiObject.TagValues[0])
+		tfMap["value"] = apiObject.TagValues[0]
 	}
 
 	return tfMap
 }
 
-func flattenLFTagPairs(apiObjects []*lakeformation.LFTagPair) []interface{} {
+func flattenLFTagPairs(apiObjects []awstypes.LFTagPair) []interface{} {
 	if len(apiObjects) == 0 {
 		return nil
 	}
@@ -552,7 +552,7 @@ func flattenLFTagPairs(apiObjects []*lakeformation.LFTagPair) []interface{} {
 	var tfList []interface{}
 
 	for _, apiObject := range apiObjects {
-		if apiObject == nil {
+		if reflect.ValueOf(apiObject).IsZero() {
 			continue
 		}
 

--- a/internal/service/lakeformation/resource_lf_tags.go
+++ b/internal/service/lakeformation/resource_lf_tags.go
@@ -253,10 +253,7 @@ func resourceResourceLFTagsCreate(ctx context.Context, d *schema.ResourceData, m
 		var err error
 		output, err = conn.AddLFTagsToResource(ctx, input)
 		if err != nil {
-			if errs.IsA[*awstypes.ConcurrentModificationException](err) {
-				return retry.RetryableError(err)
-			}
-			if errs.IsA[*awstypes.AccessDeniedException](err) {
+			if errs.IsA[*awstypes.ConcurrentModificationException](err) || errs.IsA[*awstypes.AccessDeniedException](err) {
 				return retry.RetryableError(err)
 			}
 

--- a/internal/service/lakeformation/resource_lf_tags.go
+++ b/internal/service/lakeformation/resource_lf_tags.go
@@ -6,7 +6,6 @@ package lakeformation
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"reflect"
 	"time"
@@ -281,7 +280,7 @@ func resourceResourceLFTagsCreate(ctx context.Context, d *schema.ResourceData, m
 				create.ErrActionCreating,
 				ResNameLFTags,
 				fmt.Sprintf("catalog id:%s, tag key:%s, values:%+v", aws.ToString(v.LFTag.CatalogId), aws.ToString(v.LFTag.TagKey), v.LFTag.TagValues),
-				errors.New(fmt.Sprintf("%s: %s", aws.ToString(v.Error.ErrorCode), aws.ToString(v.Error.ErrorMessage))),
+				fmt.Errorf("%s: %s", aws.ToString(v.Error.ErrorCode), aws.ToString(v.Error.ErrorMessage)),
 			)
 		}
 	}

--- a/internal/service/lakeformation/resource_lf_tags_test.go
+++ b/internal/service/lakeformation/resource_lf_tags_test.go
@@ -11,13 +11,14 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go/service/lakeformation"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/service/lakeformation"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/lakeformation/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	tflakeformation "github.com/hashicorp/terraform-provider-aws/internal/service/lakeformation"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -28,7 +29,7 @@ func testAccResourceLFTags_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, lakeformation.EndpointsID) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.LakeFormation) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LakeFormationServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDatabaseLFTagsDestroy(ctx),
@@ -55,7 +56,7 @@ func testAccResourceLFTags_disappears(t *testing.T) {
 	resourceName := "aws_lakeformation_resource_lf_tags.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, lakeformation.EndpointsID) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.LakeFormation) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LakeFormationServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckResourceDestroy(ctx),
@@ -78,7 +79,7 @@ func testAccResourceLFTags_database(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, lakeformation.EndpointsID) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.LakeFormation) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LakeFormationServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDatabaseLFTagsDestroy(ctx),
@@ -114,7 +115,7 @@ func testAccResourceLFTags_databaseMultipleTags(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, lakeformation.EndpointsID) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.LakeFormation) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LakeFormationServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDatabaseLFTagsDestroy(ctx),
@@ -160,7 +161,7 @@ func testAccResourceLFTags_hierarchy(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, lakeformation.EndpointsID) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.LakeFormation) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LakeFormationServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDatabaseLFTagsDestroy(ctx),
@@ -235,7 +236,7 @@ func testAccResourceLFTags_table(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, lakeformation.EndpointsID) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.LakeFormation) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LakeFormationServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDatabaseLFTagsDestroy(ctx),
@@ -271,7 +272,7 @@ func testAccResourceLFTags_tableWithColumns(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, lakeformation.EndpointsID) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.LakeFormation) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LakeFormationServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDatabaseLFTagsDestroy(ctx),
@@ -311,7 +312,7 @@ func testAccResourceLFTags_tableWithColumns(t *testing.T) {
 
 func testAccCheckDatabaseLFTagsDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).LakeFormationConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).LakeFormationClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_lakeformation_resource_lf_tags" {
@@ -319,7 +320,7 @@ func testAccCheckDatabaseLFTagsDestroy(ctx context.Context) resource.TestCheckFu
 			}
 
 			input := &lakeformation.GetResourceLFTagsInput{
-				Resource:           &lakeformation.Resource{},
+				Resource:           &awstypes.Resource{},
 				ShowAssignedLFTags: aws.Bool(true),
 			}
 
@@ -328,7 +329,7 @@ func testAccCheckDatabaseLFTagsDestroy(ctx context.Context) resource.TestCheckFu
 			}
 
 			if v, ok := rs.Primary.Attributes["database.0.name"]; ok {
-				input.Resource.Database = &lakeformation.DatabaseResource{
+				input.Resource.Database = &awstypes.DatabaseResource{
 					Name: aws.String(v),
 				}
 
@@ -338,7 +339,7 @@ func testAccCheckDatabaseLFTagsDestroy(ctx context.Context) resource.TestCheckFu
 			}
 
 			if v, ok := rs.Primary.Attributes["table.0.database_name"]; ok {
-				input.Resource.Table = &lakeformation.TableResource{
+				input.Resource.Table = &awstypes.TableResource{
 					DatabaseName: aws.String(v),
 				}
 
@@ -351,12 +352,12 @@ func testAccCheckDatabaseLFTagsDestroy(ctx context.Context) resource.TestCheckFu
 				}
 
 				if v, ok := rs.Primary.Attributes["table.0.wildcard"]; ok && v == "true" {
-					input.Resource.Table.TableWildcard = &lakeformation.TableWildcard{}
+					input.Resource.Table.TableWildcard = &awstypes.TableWildcard{}
 				}
 			}
 
 			if v, ok := rs.Primary.Attributes["table_with_columns.0.database_name"]; ok {
-				input.Resource.TableWithColumns = &lakeformation.TableWithColumnsResource{
+				input.Resource.TableWithColumns = &awstypes.TableWithColumnsResource{
 					DatabaseName: aws.String(v),
 				}
 
@@ -373,11 +374,11 @@ func testAccCheckDatabaseLFTagsDestroy(ctx context.Context) resource.TestCheckFu
 					for i := 0; i < n; i++ {
 						cols = append(cols, rs.Primary.Attributes[fmt.Sprintf("table_with_columns.0.column_names.%d", i)])
 					}
-					input.Resource.TableWithColumns.ColumnNames = aws.StringSlice(cols)
+					input.Resource.TableWithColumns.ColumnNames = cols
 				}
 
 				if v, ok := rs.Primary.Attributes["table_with_columns.0.wildcard"]; ok && v == "true" {
-					input.Resource.TableWithColumns.ColumnWildcard = &lakeformation.ColumnWildcard{}
+					input.Resource.TableWithColumns.ColumnWildcard = &awstypes.ColumnWildcard{}
 				}
 
 				if n, err := strconv.Atoi(rs.Primary.Attributes["table_with_columns.0.excluded_column_names.#"]); err == nil && n > 0 {
@@ -385,23 +386,23 @@ func testAccCheckDatabaseLFTagsDestroy(ctx context.Context) resource.TestCheckFu
 					for i := 0; i < n; i++ {
 						cols = append(cols, rs.Primary.Attributes[fmt.Sprintf("table_with_columns.0.excluded_column_names.%d", i)])
 					}
-					input.Resource.TableWithColumns.ColumnWildcard = &lakeformation.ColumnWildcard{
-						ExcludedColumnNames: aws.StringSlice(cols),
+					input.Resource.TableWithColumns.ColumnWildcard = &awstypes.ColumnWildcard{
+						ExcludedColumnNames: cols,
 					}
 				}
 			}
 
-			if _, err := conn.GetResourceLFTagsWithContext(ctx, input); err != nil {
-				if tfawserr.ErrCodeEquals(err, lakeformation.ErrCodeEntityNotFoundException) {
+			if _, err := conn.GetResourceLFTags(ctx, input); err != nil {
+				if errs.IsA[*awstypes.EntityNotFoundException](err) {
 					continue
 				}
 
-				if tfawserr.ErrMessageContains(err, lakeformation.ErrCodeInvalidInputException, "not found") {
+				if errs.IsAErrorMessageContains[*awstypes.InvalidInputException](err, "not found") {
 					continue
 				}
 
 				// If the lake formation admin has been revoked, there will be access denied instead of entity not found
-				if tfawserr.ErrCodeEquals(err, lakeformation.ErrCodeAccessDeniedException) {
+				if errs.IsA[*awstypes.AccessDeniedException](err) {
 					continue
 				}
 				return err
@@ -426,7 +427,7 @@ func testAccCheckDatabaseLFTagsExists(ctx context.Context, resourceName string) 
 		}
 
 		input := &lakeformation.GetResourceLFTagsInput{
-			Resource:           &lakeformation.Resource{},
+			Resource:           &awstypes.Resource{},
 			ShowAssignedLFTags: aws.Bool(true),
 		}
 
@@ -435,7 +436,7 @@ func testAccCheckDatabaseLFTagsExists(ctx context.Context, resourceName string) 
 		}
 
 		if v, ok := rs.Primary.Attributes["database.0.name"]; ok {
-			input.Resource.Database = &lakeformation.DatabaseResource{
+			input.Resource.Database = &awstypes.DatabaseResource{
 				Name: aws.String(v),
 			}
 
@@ -445,7 +446,7 @@ func testAccCheckDatabaseLFTagsExists(ctx context.Context, resourceName string) 
 		}
 
 		if v, ok := rs.Primary.Attributes["table.0.database_name"]; ok {
-			input.Resource.Table = &lakeformation.TableResource{
+			input.Resource.Table = &awstypes.TableResource{
 				DatabaseName: aws.String(v),
 			}
 
@@ -458,12 +459,12 @@ func testAccCheckDatabaseLFTagsExists(ctx context.Context, resourceName string) 
 			}
 
 			if v, ok := rs.Primary.Attributes["table.0.wildcard"]; ok && v == "true" {
-				input.Resource.Table.TableWildcard = &lakeformation.TableWildcard{}
+				input.Resource.Table.TableWildcard = &awstypes.TableWildcard{}
 			}
 		}
 
 		if v, ok := rs.Primary.Attributes["table_with_columns.0.database_name"]; ok {
-			input.Resource.TableWithColumns = &lakeformation.TableWithColumnsResource{
+			input.Resource.TableWithColumns = &awstypes.TableWithColumnsResource{
 				DatabaseName: aws.String(v),
 			}
 
@@ -480,11 +481,11 @@ func testAccCheckDatabaseLFTagsExists(ctx context.Context, resourceName string) 
 				for i := 0; i < n; i++ {
 					cols = append(cols, rs.Primary.Attributes[fmt.Sprintf("table_with_columns.0.column_names.%d", i)])
 				}
-				input.Resource.TableWithColumns.ColumnNames = aws.StringSlice(cols)
+				input.Resource.TableWithColumns.ColumnNames = cols
 			}
 
 			if v, ok := rs.Primary.Attributes["table_with_columns.0.wildcard"]; ok && v == "true" {
-				input.Resource.TableWithColumns.ColumnWildcard = &lakeformation.ColumnWildcard{}
+				input.Resource.TableWithColumns.ColumnWildcard = &awstypes.ColumnWildcard{}
 			}
 
 			if n, err := strconv.Atoi(rs.Primary.Attributes["table_with_columns.0.excluded_column_names.#"]); err == nil && n > 0 {
@@ -492,14 +493,14 @@ func testAccCheckDatabaseLFTagsExists(ctx context.Context, resourceName string) 
 				for i := 0; i < n; i++ {
 					cols = append(cols, rs.Primary.Attributes[fmt.Sprintf("table_with_columns.0.excluded_column_names.%d", i)])
 				}
-				input.Resource.TableWithColumns.ColumnWildcard = &lakeformation.ColumnWildcard{
-					ExcludedColumnNames: aws.StringSlice(cols),
+				input.Resource.TableWithColumns.ColumnWildcard = &awstypes.ColumnWildcard{
+					ExcludedColumnNames: cols,
 				}
 			}
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).LakeFormationConn(ctx)
-		_, err := conn.GetResourceLFTagsWithContext(ctx, input)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).LakeFormationClient(ctx)
+		_, err := conn.GetResourceLFTags(ctx, input)
 
 		return err
 	}

--- a/internal/service/lakeformation/resource_test.go
+++ b/internal/service/lakeformation/resource_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/lakeformation"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -28,7 +27,7 @@ func TestAccLakeFormationResource_basic(t *testing.T) {
 	roleResourceName := "aws_iam_role.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, lakeformation.EndpointsID) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.LakeFormation) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LakeFormationServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckResourceDestroy(ctx),
@@ -53,7 +52,7 @@ func TestAccLakeFormationResource_disappears(t *testing.T) {
 	resourceName := "aws_lakeformation_resource.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, lakeformation.EndpointsID) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.LakeFormation) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LakeFormationServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckResourceDestroy(ctx),
@@ -79,7 +78,7 @@ func TestAccLakeFormationResource_serviceLinkedRole(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, lakeformation.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.LakeFormation)
 			acctest.PreCheckIAMServiceLinkedRole(ctx, t, "/aws-service-role/lakeformation.amazonaws.com")
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.LakeFormationServiceID),
@@ -108,7 +107,7 @@ func TestAccLakeFormationResource_updateRoleToRole(t *testing.T) {
 	roleResourceName := "aws_iam_role.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, lakeformation.EndpointsID) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.LakeFormation) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LakeFormationServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckResourceDestroy(ctx),
@@ -144,7 +143,7 @@ func TestAccLakeFormationResource_updateSLRToRole(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, lakeformation.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.LakeFormation)
 			acctest.PreCheckIAMServiceLinkedRole(ctx, t, "/aws-service-role/lakeformation.amazonaws.com")
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.LakeFormationServiceID),
@@ -180,7 +179,7 @@ func TestAccLakeFormationResource_hybridAccessEnabled(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, lakeformation.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.LakeFormation)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.LakeFormationServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -205,7 +204,7 @@ func TestAccLakeFormationResource_hybridAccessEnabled(t *testing.T) {
 
 func testAccCheckResourceDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).LakeFormationConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).LakeFormationClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_lakeformation_resource" {
@@ -236,7 +235,7 @@ func testAccCheckResourceExists(ctx context.Context, n string) resource.TestChec
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).LakeFormationConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).LakeFormationClient(ctx)
 
 		_, err := tflakeformation.FindResourceByARN(ctx, conn, rs.Primary.ID)
 

--- a/internal/service/lakeformation/service_endpoints_gen_test.go
+++ b/internal/service/lakeformation/service_endpoints_gen_test.go
@@ -15,7 +15,6 @@ import (
 
 	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
 	lakeformation_sdkv2 "github.com/aws/aws-sdk-go-v2/service/lakeformation"
-	lakeformation_sdkv1 "github.com/aws/aws-sdk-go/service/lakeformation"
 	"github.com/aws/smithy-go/middleware"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
@@ -203,25 +202,13 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 		},
 	}
 
-	t.Run("v1", func(t *testing.T) {
-		for name, testcase := range testcases { //nolint:paralleltest // uses t.Setenv
-			testcase := testcase
+	for name, testcase := range testcases { //nolint:paralleltest // uses t.Setenv
+		testcase := testcase
 
-			t.Run(name, func(t *testing.T) {
-				testEndpointCase(t, region, testcase, callServiceV1)
-			})
-		}
-	})
-
-	t.Run("v2", func(t *testing.T) {
-		for name, testcase := range testcases { //nolint:paralleltest // uses t.Setenv
-			testcase := testcase
-
-			t.Run(name, func(t *testing.T) {
-				testEndpointCase(t, region, testcase, callServiceV2)
-			})
-		}
-	})
+		t.Run(name, func(t *testing.T) {
+			testEndpointCase(t, region, testcase, callService)
+		})
+	}
 }
 
 func defaultEndpoint(region string) string {
@@ -241,7 +228,7 @@ func defaultEndpoint(region string) string {
 	return ep.URI.String()
 }
 
-func callServiceV2(ctx context.Context, t *testing.T, meta *conns.AWSClient) string {
+func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) string {
 	t.Helper()
 
 	var endpoint string
@@ -261,20 +248,6 @@ func callServiceV2(ctx context.Context, t *testing.T, meta *conns.AWSClient) str
 	} else if !errors.Is(err, errCancelOperation) {
 		t.Fatalf("Unexpected error: %s", err)
 	}
-
-	return endpoint
-}
-
-func callServiceV1(ctx context.Context, t *testing.T, meta *conns.AWSClient) string {
-	t.Helper()
-
-	client := meta.LakeFormationConn(ctx)
-
-	req, _ := client.ListResourcesRequest(&lakeformation_sdkv1.ListResourcesInput{})
-
-	req.HTTPRequest.URL.Path = "/"
-
-	endpoint := req.HTTPRequest.URL.String()
 
 	return endpoint
 }

--- a/internal/service/lakeformation/service_package_gen.go
+++ b/internal/service/lakeformation/service_package_gen.go
@@ -7,9 +7,6 @@ import (
 
 	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
 	lakeformation_sdkv2 "github.com/aws/aws-sdk-go-v2/service/lakeformation"
-	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
-	session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
-	lakeformation_sdkv1 "github.com/aws/aws-sdk-go/service/lakeformation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -75,13 +72,6 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 
 func (p *servicePackage) ServicePackageName() string {
 	return names.LakeFormation
-}
-
-// NewConn returns a new AWS SDK for Go v1 client for this service package's AWS API.
-func (p *servicePackage) NewConn(ctx context.Context, config map[string]any) (*lakeformation_sdkv1.LakeFormation, error) {
-	sess := config["session"].(*session_sdkv1.Session)
-
-	return lakeformation_sdkv1.New(sess.Copy(&aws_sdkv1.Config{Endpoint: aws_sdkv1.String(config["endpoint"].(string))})), nil
 }
 
 // NewClient returns a new AWS SDK for Go v2 client for this service package's AWS API.

--- a/internal/service/lakeformation/status.go
+++ b/internal/service/lakeformation/status.go
@@ -23,12 +23,8 @@ func statusPermissions(ctx context.Context, conn *lakeformation.Client, input *l
 		for pages.HasMorePages() {
 			page, err := pages.NextPage(ctx)
 
-			if errs.IsA[*awstypes.EntityNotFoundException](err) {
+			if errs.IsA[*awstypes.EntityNotFoundException](err) || errs.IsA[*awstypes.InvalidInputException](err) {
 				return nil, statusNotFound, err
-			}
-
-			if errs.IsA[*awstypes.InvalidInputException](err) {
-				return nil, statusIAMDelay, nil
 			}
 
 			if err != nil {

--- a/internal/service/lakeformation/status.go
+++ b/internal/service/lakeformation/status.go
@@ -23,8 +23,12 @@ func statusPermissions(ctx context.Context, conn *lakeformation.Client, input *l
 		for pages.HasMorePages() {
 			page, err := pages.NextPage(ctx)
 
-			if errs.IsA[*awstypes.EntityNotFoundException](err) || errs.IsA[*awstypes.InvalidInputException](err) {
+			if errs.IsA[*awstypes.EntityNotFoundException](err) {
 				return nil, statusNotFound, err
+			}
+			
+			if errs.IsAContains[*awstypes.InvalidInputException](err, "Invalid principal") {
+				return nil, statusIAMDelay, err
 			}
 
 			if err != nil {

--- a/internal/service/lakeformation/status.go
+++ b/internal/service/lakeformation/status.go
@@ -28,12 +28,13 @@ func statusPermissions(ctx context.Context, conn *lakeformation.Client, input *l
 			}
 
 			if errs.IsAErrorMessageContains[*awstypes.InvalidInputException](err, "Invalid principal") {
-				return nil, statusIAMDelay, err
+				return nil, statusIAMDelay, nil
 			}
 
 			if err != nil {
 				return nil, statusFailed, fmt.Errorf("listing permissions: %w", err)
 			}
+
 			for _, permission := range page.PrincipalResourcePermissions {
 				if reflect.ValueOf(permission).IsZero() {
 					continue

--- a/internal/service/lakeformation/status.go
+++ b/internal/service/lakeformation/status.go
@@ -26,8 +26,8 @@ func statusPermissions(ctx context.Context, conn *lakeformation.Client, input *l
 			if errs.IsA[*awstypes.EntityNotFoundException](err) {
 				return nil, statusNotFound, err
 			}
-			
-			if errs.IsAContains[*awstypes.InvalidInputException](err, "Invalid principal") {
+
+			if errs.IsAErrorMessageContains[*awstypes.InvalidInputException](err, "Invalid principal") {
 				return nil, statusIAMDelay, err
 			}
 

--- a/internal/service/lakeformation/status.go
+++ b/internal/service/lakeformation/status.go
@@ -6,42 +6,45 @@ package lakeformation
 import (
 	"context"
 	"fmt"
+	"reflect"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/lakeformation"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lakeformation"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/lakeformation/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 )
 
-func statusPermissions(ctx context.Context, conn *lakeformation.LakeFormation, input *lakeformation.ListPermissionsInput, tableType string, columnNames []*string, excludedColumnNames []*string, columnWildcard bool) retry.StateRefreshFunc {
+func statusPermissions(ctx context.Context, conn *lakeformation.Client, input *lakeformation.ListPermissionsInput, tableType string, columnNames []string, excludedColumnNames []string, columnWildcard bool) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		var permissions []*lakeformation.PrincipalResourcePermissions
+		var permissions []awstypes.PrincipalResourcePermissions
 
-		err := conn.ListPermissionsPagesWithContext(ctx, input, func(resp *lakeformation.ListPermissionsOutput, lastPage bool) bool {
-			for _, permission := range resp.PrincipalResourcePermissions {
-				if permission == nil {
+		pages := lakeformation.NewListPermissionsPaginator(conn, input)
+		for pages.HasMorePages() {
+			page, err := pages.NextPage(ctx)
+
+			if errs.IsA[*awstypes.EntityNotFoundException](err) {
+				return nil, statusNotFound, err
+			}
+
+			if errs.IsA[*awstypes.InvalidInputException](err) {
+				return nil, statusIAMDelay, nil
+			}
+
+			if err != nil {
+				return nil, statusFailed, fmt.Errorf("listing permissions: %w", err)
+			}
+			for _, permission := range page.PrincipalResourcePermissions {
+				if reflect.ValueOf(permission).IsZero() {
 					continue
 				}
 
-				if aws.StringValue(input.Principal.DataLakePrincipalIdentifier) != aws.StringValue(permission.Principal.DataLakePrincipalIdentifier) {
+				if aws.ToString(input.Principal.DataLakePrincipalIdentifier) != aws.ToString(permission.Principal.DataLakePrincipalIdentifier) {
 					continue
 				}
 
 				permissions = append(permissions, permission)
 			}
-			return !lastPage
-		})
-
-		if tfawserr.ErrCodeEquals(err, lakeformation.ErrCodeEntityNotFoundException) {
-			return nil, statusNotFound, err
-		}
-
-		if tfawserr.ErrMessageContains(err, lakeformation.ErrCodeInvalidInputException, "Invalid principal") {
-			return nil, statusIAMDelay, nil
-		}
-
-		if err != nil {
-			return nil, statusFailed, fmt.Errorf("listing permissions: %w", err)
 		}
 
 		// clean permissions = filter out permissions that do not pertain to this specific resource

--- a/internal/service/lakeformation/strings.go
+++ b/internal/service/lakeformation/strings.go
@@ -6,17 +6,15 @@ package lakeformation
 import (
 	"reflect"
 	"sort"
-
-	"github.com/aws/aws-sdk-go/aws"
 )
 
-func StringSlicesEqualIgnoreOrder(s1, s2 []*string) bool {
+func StringSlicesEqualIgnoreOrder(s1, s2 []string) bool {
 	if len(s1) != len(s2) {
 		return false
 	}
 
-	v1 := aws.StringValueSlice(s1)
-	v2 := aws.StringValueSlice(s2)
+	v1 := s1
+	v2 := s2
 
 	sort.Strings(v1)
 	sort.Strings(v2)

--- a/internal/service/lakeformation/strings_test.go
+++ b/internal/service/lakeformation/strings_test.go
@@ -6,7 +6,6 @@ package lakeformation_test
 import (
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
 	tflakeformation "github.com/hashicorp/terraform-provider-aws/internal/service/lakeformation"
 )
 
@@ -32,7 +31,7 @@ func TestStringSlicesEqualIgnoreOrder(t *testing.T) {
 		},
 	}
 	for _, v := range equal {
-		if !tflakeformation.StringSlicesEqualIgnoreOrder(aws.StringSlice(v.([]interface{})[0].([]string)), aws.StringSlice(v.([]interface{})[1].([]string))) {
+		if !tflakeformation.StringSlicesEqualIgnoreOrder(v.([]interface{})[0].([]string), v.([]interface{})[1].([]string)) {
 			t.Fatalf("%v should be equal: %v", v.([]interface{})[0].([]string), v.([]interface{})[1].([]string))
 		}
 	}
@@ -60,7 +59,7 @@ func TestStringSlicesEqualIgnoreOrder(t *testing.T) {
 		},
 	}
 	for _, v := range notEqual {
-		if tflakeformation.StringSlicesEqualIgnoreOrder(aws.StringSlice(v.([]interface{})[0].([]string)), aws.StringSlice(v.([]interface{})[1].([]string))) {
+		if tflakeformation.StringSlicesEqualIgnoreOrder(v.([]interface{})[0].([]string), v.([]interface{})[1].([]string)) {
 			t.Fatalf("%v should not be equal: %v", v.([]interface{})[0].([]string), v.([]interface{})[1].([]string))
 		}
 	}

--- a/internal/service/lakeformation/wait.go
+++ b/internal/service/lakeformation/wait.go
@@ -7,7 +7,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/aws/aws-sdk-go/service/lakeformation"
+	"github.com/aws/aws-sdk-go-v2/service/lakeformation"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/lakeformation/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 )
 
@@ -21,7 +22,7 @@ const (
 	statusIAMDelay  = "IAM DELAY"
 )
 
-func waitPermissionsReady(ctx context.Context, conn *lakeformation.LakeFormation, input *lakeformation.ListPermissionsInput, tableType string, columnNames []*string, excludedColumnNames []*string, columnWildcard bool) ([]*lakeformation.PrincipalResourcePermissions, error) {
+func waitPermissionsReady(ctx context.Context, conn *lakeformation.Client, input *lakeformation.ListPermissionsInput, tableType string, columnNames []string, excludedColumnNames []string, columnWildcard bool) ([]awstypes.PrincipalResourcePermissions, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{statusNotFound, statusIAMDelay},
 		Target:  []string{statusAvailable},
@@ -31,7 +32,7 @@ func waitPermissionsReady(ctx context.Context, conn *lakeformation.LakeFormation
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
-	if output, ok := outputRaw.([]*lakeformation.PrincipalResourcePermissions); ok {
+	if output, ok := outputRaw.([]awstypes.PrincipalResourcePermissions); ok {
 		return output, err
 	}
 

--- a/names/data/names_data.csv
+++ b/names/data/names_data.csv
@@ -215,7 +215,7 @@ kinesis-video-archived-media,kinesisvideoarchivedmedia,kinesisvideoarchivedmedia
 kinesis-video-media,kinesisvideomedia,kinesisvideomedia,kinesisvideomedia,,kinesisvideomedia,,,KinesisVideoMedia,KinesisVideoMedia,,1,,,aws_kinesisvideomedia_,,kinesisvideomedia_,Kinesis Video Media,Amazon,,x,,,,,Kinesis Video Media,,,
 kinesis-video-signaling,kinesisvideosignaling,kinesisvideosignalingchannels,kinesisvideosignaling,,kinesisvideosignaling,,kinesisvideosignalingchannels,KinesisVideoSignaling,KinesisVideoSignalingChannels,,1,,,aws_kinesisvideosignaling_,,kinesisvideosignaling_,Kinesis Video Signaling,Amazon,,x,,,,,Kinesis Video Signaling,,,
 kms,kms,kms,kms,,kms,,,KMS,KMS,,1,,,aws_kms_,,kms_,KMS (Key Management),AWS,,,,,,,KMS,ListKeys,,
-lakeformation,lakeformation,lakeformation,lakeformation,,lakeformation,,,LakeFormation,LakeFormation,,1,2,,aws_lakeformation_,,lakeformation_,Lake Formation,AWS,,,,,,,LakeFormation,ListResources,,
+lakeformation,lakeformation,lakeformation,lakeformation,,lakeformation,,,LakeFormation,LakeFormation,,,2,,aws_lakeformation_,,lakeformation_,Lake Formation,AWS,,,,,,,LakeFormation,ListResources,,
 lambda,lambda,lambda,lambda,,lambda,,,Lambda,Lambda,,1,2,,aws_lambda_,,lambda_,Lambda,AWS,,,,,,,Lambda,ListFunctions,,
 launch-wizard,launchwizard,launchwizard,launchwizard,,launchwizard,,,LaunchWizard,LaunchWizard,,,2,,aws_launchwizard_,,launchwizard_,Launch Wizard,AWS,,,,,,,Launch Wizard,ListWorkloads,,
 lex-models,lexmodels,lexmodelbuildingservice,lexmodelbuildingservice,,lexmodels,,lexmodelbuilding;lexmodelbuildingservice;lex,LexModels,LexModelBuildingService,,1,,aws_lex_,aws_lexmodels_,,lex_,Lex Model Building,Amazon,,,,,,,Lex Model Building Service,GetBots,,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #36179

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS="-run=TestAccLakeFormation" PKG=lakeformation

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lakeformation/... -v -count 1 -parallel 20  -run=TestAccLakeFormation -timeout 360m
--- PASS: TestAccLakeFormationResource_basic (16.64s)
--- PASS: TestAccLakeFormationResourceDataSource_basic (17.17s)
--- PASS: TestAccLakeFormationResource_disappears (17.29s)
--- PASS: TestAccLakeFormationResource_hybridAccessEnabled (17.51s)
--- PASS: TestAccLakeFormationResource_serviceLinkedRole (17.56s)
--- PASS: TestAccLakeFormationResource_updateRoleToRole (27.31s)
--- PASS: TestAccLakeFormationResource_updateSLRToRole (27.70s)
--- PASS: TestAccLakeFormation_serial (1160.88s)
    --- PASS: TestAccLakeFormation_serial/DataLakeSettingsDataSource (23.79s)
        --- PASS: TestAccLakeFormation_serial/DataLakeSettingsDataSource/basic (12.72s)
        --- PASS: TestAccLakeFormation_serial/DataLakeSettingsDataSource/readOnlyAdmins (11.06s)
    --- PASS: TestAccLakeFormation_serial/PermissionsBasic (289.85s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/lfTagPolicyMultiple (18.91s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/databaseIAMAllowed (41.65s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/dataLocation (18.77s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/disappears (83.31s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/lfTag (20.37s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/lfTagPolicy (21.24s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/basic (20.06s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/database (21.13s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/databaseMultiple (21.50s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/dataCellsFilter (22.91s)
    --- PASS: TestAccLakeFormation_serial/PermissionsTableWithColumns (139.45s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTableWithColumns/implicit (21.49s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTableWithColumns/wildcardExcludedColumns (23.07s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTableWithColumns/wildcardSelectOnly (22.55s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTableWithColumns/wildcardSelectPlus (23.07s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTableWithColumns/basic (49.27s)
    --- PASS: TestAccLakeFormation_serial/LFTags (87.71s)
        --- PASS: TestAccLakeFormation_serial/LFTags/basic (13.81s)
        --- PASS: TestAccLakeFormation_serial/LFTags/disappears (11.89s)
        --- PASS: TestAccLakeFormation_serial/LFTags/tagKeyComplex (11.12s)
        --- PASS: TestAccLakeFormation_serial/LFTags/values (23.48s)
        --- PASS: TestAccLakeFormation_serial/LFTags/valuesOverFifty (27.41s)
    --- PASS: TestAccLakeFormation_serial/ResourceLFTags (145.61s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/basic (12.65s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/database (22.53s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/databaseMultipleTags (22.04s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/disappears (12.75s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/hierarchy (27.40s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/table (24.34s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/tableWithColumns (23.90s)
    --- PASS: TestAccLakeFormation_serial/DataLakeSettings (43.13s)
        --- PASS: TestAccLakeFormation_serial/DataLakeSettings/basic (10.59s)
        --- PASS: TestAccLakeFormation_serial/DataLakeSettings/disappears (11.43s)
        --- PASS: TestAccLakeFormation_serial/DataLakeSettings/withoutCatalogId (10.63s)
        --- PASS: TestAccLakeFormation_serial/DataLakeSettings/readOnlyAdmins (10.48s)
    --- PASS: TestAccLakeFormation_serial/DataCellsFilter (43.52s)
        --- PASS: TestAccLakeFormation_serial/DataCellsFilter/basic (16.26s)
        --- PASS: TestAccLakeFormation_serial/DataCellsFilter/columnWildcard (13.12s)
        --- PASS: TestAccLakeFormation_serial/DataCellsFilter/disappears (14.15s)
    --- PASS: TestAccLakeFormation_serial/PermissionsDataSource (171.43s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/dataCellsFilter (18.85s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/database (19.94s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/dataLocation (23.71s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/lfTag (20.56s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/lfTagPolicy (21.25s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/table (23.47s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/tableWithColumns (23.07s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/basic (20.58s)
    --- PASS: TestAccLakeFormation_serial/PermissionsTable (216.40s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/wildcardSelectOnly (22.03s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/basic (18.57s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/multipleRoles (22.82s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/selectOnly (22.94s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/wildcardNoSelect (20.72s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/iamAllowed (43.46s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/implicit (21.42s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/selectPlus (22.42s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/wildcardSelectPlus (22.02s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lakeformation	1165.042s

```
