### PR TITLE
`.ci/providerlint`: `protobuf` should only be updated via `terraform-plugin-go`/`terraform-plugin-framework`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,6 +48,7 @@ updates:
     ignore:
       - dependency-name: "golang.org/x/tools"
       - dependency-name: "google.golang.org/grpc"
+      - dependency-name: "google.golang.org/protobuf"
     schedule:
       interval: "daily"
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Missed `.ci/providerlint`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/36378.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/36367.