### PR TITLE
docs: add details on restrictions for maximum ecpus and data storage

### DIFF
--- a/website/docs/r/elasticache_serverless_cache.html.markdown
+++ b/website/docs/r/elasticache_serverless_cache.html.markdown
@@ -24,7 +24,7 @@ resource "aws_elasticache_serverless_cache" "example" {
       unit    = "GB"
     }
     ecpu_per_second {
-      maximum = 5
+      maximum = 5000
     }
   }
   description          = "Test Server"
@@ -47,7 +47,7 @@ resource "aws_elasticache_serverless_cache" "example" {
       unit    = "GB"
     }
     ecpu_per_second {
-      maximum = 5
+      maximum = 5000
     }
   }
   daily_snapshot_time      = "09:00"
@@ -89,12 +89,12 @@ The following arguments are optional:
 
 ### DataStorage Configuration
 
-* `maximum` - The upper limit for data storage the cache is set to use. Set as Integer.
+* `maximum` - The upper limit for data storage the cache is set to use. Must be between 1 and 5,000.
 * `unit` - The unit that the storage is measured in, in GB.
 
 ### ECPUPerSecond Configuration
 
-* `maximum` - The maximum number of ECPUs the cache can consume per second. Set as Integer.
+* `maximum` - The maximum number of ECPUs the cache can consume per second. Must be between 1,000 and 15,000,000.
 
 ## Attribute Reference
 


### PR DESCRIPTION
### Description
Update the [Memcached Serverless](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_serverless_cache#memcached-serverless) and [Redis Serverless]( https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_serverless_cache#redis-serverless) examples by replacing the invalid value of 5 for maximum ecpus per second.

```hcl
ecpu_per_second {
  maximum = 5
}
```

with an allowed value of 5000.
The allowed range has been added to the documentation. At same time the allowed range for the maximum cache size has been added.

### Relations

Closes #35648 

### References

When setting up a serverless cache via AWS Management Console details on the expected/ allowed range can be seen.
The value of 5 that is at present in the documentation is not allowed here.

![image](https://github.com/hashicorp/terraform-provider-aws/assets/10981698/d01f9f56-627e-4c9d-892d-5d7ae160a149)


### Output from Acceptance Testing

No tests are affected by this PR. 
