### PR TITLE
[Bug]: aws_vpn_connection removes transit gateway id dependency for IPv6 tunnel options

### DIFF
--- a/.changelog/36075.txt
+++ b/.changelog/36075.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_vpn_connection: Remove transit_gateway_id dependency for ipv6 tunnel options`
+```

--- a/internal/service/ec2/vpnsite_connection.go
+++ b/internal/service/ec2/vpnsite_connection.go
@@ -66,11 +66,10 @@ func ResourceVPNConnection() *schema.Resource {
 				Required: true,
 			},
 			"enable_acceleration": {
-				Type:         schema.TypeBool,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				RequiredWith: []string{"transit_gateway_id"},
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
 			"local_ipv4_network_cidr": {
 				Type:         schema.TypeString,
@@ -83,7 +82,6 @@ func ResourceVPNConnection() *schema.Resource {
 				Optional:     true,
 				Computed:     true,
 				ValidateFunc: validation.IsCIDRNetwork(0, 128),
-				RequiredWith: []string{"transit_gateway_id"},
 			},
 			"outside_ip_address_type": {
 				Type:         schema.TypeString,
@@ -102,7 +100,6 @@ func ResourceVPNConnection() *schema.Resource {
 				Optional:     true,
 				Computed:     true,
 				ValidateFunc: validation.IsCIDRNetwork(0, 128),
-				RequiredWith: []string{"transit_gateway_id"},
 			},
 			"routes": {
 				Type:     schema.TypeSet,
@@ -215,7 +212,6 @@ func ResourceVPNConnection() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				ValidateFunc: validVPNConnectionTunnelInsideIPv6CIDR(),
-				RequiredWith: []string{"transit_gateway_id"},
 			},
 			"tunnel1_log_options": {
 				Type:     schema.TypeList,
@@ -432,7 +428,6 @@ func ResourceVPNConnection() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				ValidateFunc: validVPNConnectionTunnelInsideIPv6CIDR(),
-				RequiredWith: []string{"transit_gateway_id"},
 			},
 			"tunnel2_log_options": {
 				Type:     schema.TypeList,

--- a/internal/service/ec2/vpnsite_connection_test.go
+++ b/internal/service/ec2/vpnsite_connection_test.go
@@ -347,6 +347,101 @@ func TestAccSiteVPNConnection_withoutTGWorVGW(t *testing.T) {
 	})
 }
 
+func TestAccSiteVPNConnection_ipv6_withoutTGWorVGW(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rBgpAsn := sdkacctest.RandIntRange(64512, 65534)
+	resourceName := "aws_vpn_connection.test"
+	var vpn ec2.VpnConnection
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckVPNConnectionDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSiteVPNConnectionConfig_ipv6_withoutTGWorVGW(rName, rBgpAsn),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccVPNConnectionExists(ctx, resourceName, &vpn),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexache.MustCompile(`vpn-connection/vpn-.+`)),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_attachment_arn", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "customer_gateway_configuration"),
+					resource.TestCheckResourceAttr(resourceName, "enable_acceleration", "false"),
+					resource.TestCheckResourceAttr(resourceName, "local_ipv4_network_cidr", ""),
+					resource.TestCheckResourceAttr(resourceName, "local_ipv6_network_cidr", "::/0"),
+					resource.TestCheckResourceAttr(resourceName, "outside_ip_address_type", "PublicIpv4"),
+					resource.TestCheckResourceAttr(resourceName, "remote_ipv4_network_cidr", ""),
+					resource.TestCheckResourceAttr(resourceName, "remote_ipv6_network_cidr", "::/0"),
+					resource.TestCheckResourceAttr(resourceName, "routes.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "static_routes_only", "false"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_attachment_id", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "tunnel1_address"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel1_bgp_holdtime", "30"),
+					resource.TestCheckResourceAttrSet(resourceName, "tunnel1_cgw_inside_address"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel1_dpd_timeout_action", ""),
+					resource.TestCheckResourceAttr(resourceName, "tunnel1_dpd_timeout_seconds", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "tunnel1_ike_versions"),
+					resource.TestCheckResourceAttrSet(resourceName, "tunnel1_inside_cidr"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel1_inside_ipv6_cidr", "fd00:2001:db8:2:2d1:81ff:fe41:d200/126"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel1_log_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel1_log_options.0.cloudwatch_log_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel1_log_options.0.cloudwatch_log_options.0.log_enabled", "false"),
+					resource.TestCheckNoResourceAttr(resourceName, "tunnel1_phase1_dh_group_numbers"),
+					resource.TestCheckNoResourceAttr(resourceName, "tunnel1_phase1_encryption_algorithms"),
+					resource.TestCheckNoResourceAttr(resourceName, "tunnel1_phase1_integrity_algorithms"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel1_phase1_lifetime_seconds", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "tunnel1_phase2_dh_group_numbers"),
+					resource.TestCheckNoResourceAttr(resourceName, "tunnel1_phase2_encryption_algorithms"),
+					resource.TestCheckNoResourceAttr(resourceName, "tunnel1_phase2_integrity_algorithms"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel1_phase2_lifetime_seconds", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "tunnel1_preshared_key"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel1_rekey_fuzz_percentage", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel1_rekey_margin_time_seconds", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel1_replay_window_size", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel1_startup_action", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "tunnel1_vgw_inside_address"),
+					resource.TestCheckResourceAttrSet(resourceName, "tunnel2_address"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel2_bgp_holdtime", "30"),
+					resource.TestCheckResourceAttrSet(resourceName, "tunnel2_cgw_inside_address"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel2_dpd_timeout_action", ""),
+					resource.TestCheckResourceAttr(resourceName, "tunnel2_dpd_timeout_seconds", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "tunnel2_ike_versions"),
+					resource.TestCheckResourceAttrSet(resourceName, "tunnel2_inside_cidr"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel2_inside_ipv6_cidr", "fdff:2001:db8:2:2d1:81ff:fe41:d204/126"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel2_log_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel2_log_options.0.cloudwatch_log_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel2_log_options.0.cloudwatch_log_options.0.log_enabled", "false"),
+					resource.TestCheckNoResourceAttr(resourceName, "tunnel2_phase1_dh_group_numbers"),
+					resource.TestCheckNoResourceAttr(resourceName, "tunnel2_phase1_encryption_algorithms"),
+					resource.TestCheckNoResourceAttr(resourceName, "tunnel2_phase1_integrity_algorithms"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel2_phase1_lifetime_seconds", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "tunnel2_phase2_dh_group_numbers"),
+					resource.TestCheckNoResourceAttr(resourceName, "tunnel2_phase2_encryption_algorithms"),
+					resource.TestCheckNoResourceAttr(resourceName, "tunnel2_phase2_integrity_algorithms"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel2_phase2_lifetime_seconds", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "tunnel2_preshared_key"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel2_rekey_fuzz_percentage", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel2_rekey_margin_time_seconds", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel2_replay_window_size", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel2_startup_action", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "tunnel2_vgw_inside_address"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel_inside_ip_version", "ipv6"),
+					resource.TestCheckResourceAttr(resourceName, "vgw_telemetry.#", "2"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"vgw_telemetry"},
+			},
+		},
+	})
+}
+
 func TestAccSiteVPNConnection_cloudWatchLogOptions(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -1810,6 +1905,28 @@ resource "aws_vpn_connection" "test" {
 `, rName, rBgpAsn)
 }
 
+func testAccSiteVPNConnectionConfig_ipv6_withoutTGWorVGW(rName string, rBgpAsn int) string {
+	return fmt.Sprintf(`
+resource "aws_customer_gateway" "test" {
+  bgp_asn    = %[2]d
+  ip_address = "178.0.0.1"
+  type       = "ipsec.1"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpn_connection" "test" {
+	customer_gateway_id      = aws_customer_gateway.test.id
+	tunnel_inside_ip_version = "ipv6"
+	tunnel1_inside_ipv6_cidr = "fd00:2001:db8:2:2d1:81ff:fe41:d200/126"
+	tunnel2_inside_ipv6_cidr = "fdff:2001:db8:2:2d1:81ff:fe41:d204/126"
+	type                     = "ipsec.1"
+  }
+  `, rName, rBgpAsn)
+}
+
 func testAccSiteVPNConnectionConfig_cloudWatchLogOptions(rName string, rBgpAsn int) string {
 	return fmt.Sprintf(`
 resource "aws_vpn_gateway" "test" {
@@ -2390,7 +2507,6 @@ resource "aws_customer_gateway" "test" {
 
 resource "aws_vpn_connection" "test" {
   customer_gateway_id      = aws_customer_gateway.test.id
-  transit_gateway_id       = aws_ec2_transit_gateway.test.id
   tunnel_inside_ip_version = "ipv6"
   tunnel1_inside_ipv6_cidr = %[3]q
   tunnel2_inside_ipv6_cidr = %[4]q


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Fixes the requirement of transit gateway id when creating IPv6 VPN connection and accelerator. VPN tunnel with ipv6 options should be allowed to created without transit gateway.  Such tunnel can attach to core-network, CloudWAN. 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000 
or 
Closes #0000
--->

Closes #36075

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

``` ❯ make testacc TESTS=TestAccSiteVPNConnection_ipv6_withoutTGWorVGW PKG=ec2

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccSiteVPNConnection_ipv6_withoutTGWorVGW'  -timeout 360m
=== RUN   TestAccSiteVPNConnection_ipv6_withoutTGWorVGW
=== PAUSE TestAccSiteVPNConnection_ipv6_withoutTGWorVGW
=== CONT  TestAccSiteVPNConnection_ipv6_withoutTGWorVGW
--- PASS: TestAccSiteVPNConnection_ipv6_withoutTGWorVGW (43.86s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	49.249s
```

```
❯ make testacc TESTS=TestAccSiteVPNConnection_tunnel1InsideIPv6CIDR PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccSiteVPNConnection_tunnel1InsideIPv6CIDR'  -timeout 360m
=== RUN   TestAccSiteVPNConnection_tunnel1InsideIPv6CIDR
=== PAUSE TestAccSiteVPNConnection_tunnel1InsideIPv6CIDR
=== CONT  TestAccSiteVPNConnection_tunnel1InsideIPv6CIDR
--- PASS: TestAccSiteVPNConnection_tunnel1InsideIPv6CIDR (138.03s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	143.167s
```

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
