### PR TITLE
d/aws_vpc_peering_connection: Add IPv6 CIDR block attributes

### DIFF
--- a/.changelog/36391.txt
+++ b/.changelog/36391.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_vpc_peering_connection: Add ipv6_cidr_block_set and peer_ipv6_cidr_block_set attributes
+```

--- a/.changelog/36391.txt
+++ b/.changelog/36391.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-data-source/aws_vpc_peering_connection: Add ipv6_cidr_block_set and peer_ipv6_cidr_block_set attributes
+data-source/aws_vpc_peering_connection: Add `ipv6_cidr_block_set` and `peer_ipv6_cidr_block_set` attributes
 ```

--- a/internal/service/ec2/vpc_peering_connection_data_source.go
+++ b/internal/service/ec2/vpc_peering_connection_data_source.go
@@ -55,6 +55,18 @@ func DataSourceVPCPeeringConnection() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"ipv6_cidr_block_set": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ipv6_cidr_block": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 			"owner_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -71,6 +83,18 @@ func DataSourceVPCPeeringConnection() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"cidr_block": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"peer_ipv6_cidr_block_set": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ipv6_cidr_block": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
@@ -176,6 +200,16 @@ func dataSourceVPCPeeringConnectionRead(ctx context.Context, d *schema.ResourceD
 		return sdkdiag.AppendErrorf(diags, "setting cidr_block_set: %s", err)
 	}
 
+	ipv6CidrBlockSet := []interface{}{}
+	for _, v := range vpcPeeringConnection.RequesterVpcInfo.Ipv6CidrBlockSet {
+		ipv6CidrBlockSet = append(ipv6CidrBlockSet, map[string]interface{}{
+			"ipv6_cidr_block": aws.StringValue(v.Ipv6CidrBlock),
+		})
+	}
+	if err := d.Set("ipv6_cidr_block_set", ipv6CidrBlockSet); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting ipv6_cidr_block_set: %s", err)
+	}
+
 	d.Set("region", vpcPeeringConnection.RequesterVpcInfo.Region)
 	d.Set("peer_vpc_id", vpcPeeringConnection.AccepterVpcInfo.VpcId)
 	d.Set("peer_owner_id", vpcPeeringConnection.AccepterVpcInfo.OwnerId)
@@ -189,6 +223,16 @@ func dataSourceVPCPeeringConnectionRead(ctx context.Context, d *schema.ResourceD
 	}
 	if err := d.Set("peer_cidr_block_set", peerCidrBlockSet); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting peer_cidr_block_set: %s", err)
+	}
+
+	peerIpv6CidrBlockSet := []interface{}{}
+	for _, v := range vpcPeeringConnection.AccepterVpcInfo.Ipv6CidrBlockSet {
+		peerIpv6CidrBlockSet = append(peerIpv6CidrBlockSet, map[string]interface{}{
+			"ipv6_cidr_block": aws.StringValue(v.Ipv6CidrBlock),
+		})
+	}
+	if err := d.Set("peer_ipv6_cidr_block_set", peerIpv6CidrBlockSet); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting peer_ipv6_cidr_block_set: %s", err)
 	}
 
 	d.Set("peer_region", vpcPeeringConnection.AccepterVpcInfo.Region)

--- a/internal/service/ec2/vpc_peering_connection_data_source_test.go
+++ b/internal/service/ec2/vpc_peering_connection_data_source_test.go
@@ -191,7 +191,7 @@ data "aws_vpc_peering_connection" "test" {
 func testAccVPCPeeringConnectionDataSourceConfig_id(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "requester" {
-  cidr_block = "10.1.0.0/16"
+  cidr_block                       = "10.1.0.0/16"
   assign_generated_ipv6_cidr_block = true
 
   tags = {
@@ -200,7 +200,7 @@ resource "aws_vpc" "requester" {
 }
 
 resource "aws_vpc" "accepter" {
-  cidr_block = "10.2.0.0/16"
+  cidr_block                       = "10.2.0.0/16"
   assign_generated_ipv6_cidr_block = true
 
   tags = {

--- a/internal/service/ec2/vpc_peering_connection_data_source_test.go
+++ b/internal/service/ec2/vpc_peering_connection_data_source_test.go
@@ -58,12 +58,16 @@ func TestAccVPCPeeringConnectionDataSource_id(t *testing.T) {
 					// resource.TestCheckResourceAttrPair(dataSourceName, "cidr_block_set.#", resourceName, "cidr_block_set.#"), // not in resource
 					resource.TestCheckResourceAttr(dataSourceName, "cidr_block_set.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "cidr_block_set.*.cidr_block", requesterVpcResourceName, "cidr_block"),
+					resource.TestCheckResourceAttr(dataSourceName, "ipv6_cidr_block_set.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "ipv6_cidr_block_set.*.ipv6_cidr_block", requesterVpcResourceName, "ipv6_cidr_block"),
 					// resource.TestCheckResourceAttrPair(dataSourceName, "region", resourceName, "region"), // not in resource
 					// resource.TestCheckResourceAttrPair(dataSourceName, "peer_cidr_block", resourceName, "peer_cidr_block"), // not in resource
 					resource.TestCheckResourceAttrPair(dataSourceName, "peer_cidr_block", accepterVpcResourceName, "cidr_block"),
 					// resource.TestCheckResourceAttrPair(dataSourceName, "peer_cidr_block_set.#", resourceName, "peer_cidr_block_set.#"), // not in resource
 					resource.TestCheckResourceAttr(dataSourceName, "peer_cidr_block_set.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "peer_cidr_block_set.*.cidr_block", accepterVpcResourceName, "cidr_block"),
+					resource.TestCheckResourceAttr(dataSourceName, "peer_ipv6_cidr_block_set.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "peer_ipv6_cidr_block_set.*.ipv6_cidr_block", accepterVpcResourceName, "ipv6_cidr_block"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "peer_owner_id", resourceName, "peer_owner_id"),
 					// resource.TestCheckResourceAttrPair(dataSourceName, "peer_region", resourceName, "peer_region"), //not in resource
 					resource.TestCheckResourceAttrPair(dataSourceName, "peer_vpc_id", resourceName, "peer_vpc_id"),
@@ -188,6 +192,7 @@ func testAccVPCPeeringConnectionDataSourceConfig_id(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "requester" {
   cidr_block = "10.1.0.0/16"
+  assign_generated_ipv6_cidr_block = true
 
   tags = {
     Name = %[1]q
@@ -196,6 +201,7 @@ resource "aws_vpc" "requester" {
 
 resource "aws_vpc" "accepter" {
   cidr_block = "10.2.0.0/16"
+  assign_generated_ipv6_cidr_block = true
 
   tags = {
     Name = %[1]q

--- a/website/docs/d/vpc_peering_connection.html.markdown
+++ b/website/docs/d/vpc_peering_connection.html.markdown
@@ -79,9 +79,13 @@ All of the argument attributes except `filter` are also exported as result attri
 * `accepter` - Configuration block that describes [VPC Peering Connection]
 (https://docs.aws.amazon.com/vpc/latest/peering/what-is-vpc-peering.html) options set for the accepter VPC.
 
-* `cidr_block_set` - List of objects with CIDR blocks of the requester VPC.
+* `cidr_block_set` - List of objects with IPv4 CIDR blocks of the requester VPC.
 
-* `peer_cidr_block_set` - List of objects with CIDR blocks of the accepter VPC.
+* `ipv6_cidr_block_set` - List of objects with IPv6 CIDR blocks of the requester VPC.
+
+* `peer_cidr_block_set` - List of objects with IPv4 CIDR blocks of the accepter VPC.
+
+* `peer_ipv6_cidr_block_set` - List of objects with IPv6 CIDR blocks of the accepter VPC.
 
 * `requester` - Configuration block that describes [VPC Peering Connection]
 (https://docs.aws.amazon.com/vpc/latest/peering/what-is-vpc-peering.html) options set for the requester VPC.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds the `ipv6_cidr_block_set` and `peer_ipv6_cidr_block_set` attributes to the vpc_peering_connection data source.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #25746

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
None

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccVPCPeeringConnectionDataSource_id PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCPeeringConnectionDataSource_id'  -timeout 360m
=== RUN   TestAccVPCPeeringConnectionDataSource_id
=== PAUSE TestAccVPCPeeringConnectionDataSource_id
=== CONT  TestAccVPCPeeringConnectionDataSource_id
--- PASS: TestAccVPCPeeringConnectionDataSource_id (58.20s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        76.192s
```
