### PR TITLE
Add import support to aws_inspector_resource_group

### DIFF
--- a/internal/service/inspector/resource_group.go
+++ b/internal/service/inspector/resource_group.go
@@ -21,6 +21,9 @@ func ResourceResourceGroup() *schema.Resource {
 		CreateWithoutTimeout: resourceResourceGroupCreate,
 		ReadWithoutTimeout:   resourceResourceGroupRead,
 		DeleteWithoutTimeout: resourceResourceGroupDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"tags": {

--- a/internal/service/inspector/resource_group_test.go
+++ b/internal/service/inspector/resource_group_test.go
@@ -38,6 +38,11 @@ func TestAccInspectorResourceGroup_basic(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccResourceGroupConfig_modified,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGroupExists(ctx, resourceName, &v2),


### PR DESCRIPTION
### Description

Add `import` support to `aws_inspector_resource_group`

### Relations

Closes https://github.com/hashicorp/terraform-provider-aws/issues/36392

### References

### Output from Acceptance Testing

I haven't run the tests locally, hoping to just see if CI passes :) (haven't got things setup infra wise to run these tests locally atm)
