### PR TITLE
internal/acctest: custom framework disappears state function

### DIFF
--- a/internal/acctest/framework.go
+++ b/internal/acctest/framework.go
@@ -21,45 +21,41 @@ import (
 
 // Terraform Plugin Framework variants of standard acceptance test helpers.
 
-func deleteFrameworkResource(ctx context.Context, factory func(context.Context) (fwresource.ResourceWithConfigure, error), is *terraform.InstanceState, meta interface{}) error {
-	resource, err := factory(ctx)
-
-	if err != nil {
-		return err
-	}
-
-	resource.Configure(ctx, fwresource.ConfigureRequest{ProviderData: meta}, &fwresource.ConfigureResponse{})
-
-	schemaResp := fwresource.SchemaResponse{}
-	resource.Schema(ctx, fwresource.SchemaRequest{}, &schemaResp)
-
-	// Construct a simple Framework State that contains just top-level attributes.
-	state := tfsdk.State{
-		Raw:    tftypes.NewValue(schemaResp.Schema.Type().TerraformType(ctx), nil),
-		Schema: schemaResp.Schema,
-	}
-
-	for name, v := range is.Attributes {
-		if name == "%" || strings.Contains(name, ".") {
-			continue
-		}
-
-		if err := fwdiag.DiagnosticsError(state.SetAttribute(ctx, path.Root(name), v)); err != nil {
-			log.Printf("[WARN] %s(%s): %s", name, v, err)
-		}
-	}
-
-	response := fwresource.DeleteResponse{}
-	resource.Delete(ctx, fwresource.DeleteRequest{State: state}, &response)
-
-	if response.Diagnostics.HasError() {
-		return fwdiag.DiagnosticsError(response.Diagnostics)
-	}
-
-	return nil
+// CheckFrameworkResourceDisappears destroys an existing resource out of band
+//
+// By default, this check will only copy root-level string arguments into the state
+// used to delete the remote resource. For resources requiring nested or non-string
+// arguments to be available for the delete operation, consider using
+// CheckFrameworkResourceDisappearsWithStateFunc with a custom state function
+// instead.
+func CheckFrameworkResourceDisappears(
+	ctx context.Context,
+	provo *schema.Provider,
+	factory func(context.Context) (fwresource.ResourceWithConfigure, error),
+	n string,
+) resource.TestCheckFunc {
+	return deleteFrameworkResource(ctx, provo, factory, n, rootStringStateFunc())
 }
 
-func CheckFrameworkResourceDisappears(ctx context.Context, provo *schema.Provider, factory func(context.Context) (fwresource.ResourceWithConfigure, error), n string) resource.TestCheckFunc {
+// CheckFrameworkResourceDisappearsWithStateFunc destroys an existing resource
+// out of band, constructing state from the provided state function
+func CheckFrameworkResourceDisappearsWithStateFunc(
+	ctx context.Context,
+	provo *schema.Provider,
+	factory func(context.Context) (fwresource.ResourceWithConfigure, error),
+	n string,
+	stateFunc func(ctx context.Context, state *tfsdk.State, is *terraform.InstanceState) error,
+) resource.TestCheckFunc {
+	return deleteFrameworkResource(ctx, provo, factory, n, stateFunc)
+}
+
+func deleteFrameworkResource(
+	ctx context.Context,
+	provo *schema.Provider,
+	factory func(context.Context) (fwresource.ResourceWithConfigure, error),
+	n string,
+	stateFunc func(ctx context.Context, state *tfsdk.State, is *terraform.InstanceState) error,
+) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -70,6 +66,50 @@ func CheckFrameworkResourceDisappears(ctx context.Context, provo *schema.Provide
 			return fmt.Errorf("resource ID missing: %s", n)
 		}
 
-		return deleteFrameworkResource(ctx, factory, rs.Primary, provo.Meta())
+		resource, err := factory(ctx)
+		if err != nil {
+			return err
+		}
+
+		resource.Configure(ctx, fwresource.ConfigureRequest{ProviderData: provo.Meta()}, &fwresource.ConfigureResponse{})
+
+		schemaResp := fwresource.SchemaResponse{}
+		resource.Schema(ctx, fwresource.SchemaRequest{}, &schemaResp)
+
+		// Construct a simple Framework State that contains just top-level attributes.
+		state := tfsdk.State{
+			Raw:    tftypes.NewValue(schemaResp.Schema.Type().TerraformType(ctx), nil),
+			Schema: schemaResp.Schema,
+		}
+
+		err = stateFunc(ctx, &state, rs.Primary)
+		if err != nil {
+			return err
+		}
+
+		response := fwresource.DeleteResponse{}
+		resource.Delete(ctx, fwresource.DeleteRequest{State: state}, &response)
+
+		if response.Diagnostics.HasError() {
+			return fwdiag.DiagnosticsError(response.Diagnostics)
+		}
+
+		return nil
+	}
+}
+
+// rootStringStateFunc copies root-level string arguments into `state`
+func rootStringStateFunc() func(ctx context.Context, state *tfsdk.State, is *terraform.InstanceState) error {
+	return func(ctx context.Context, state *tfsdk.State, is *terraform.InstanceState) error {
+		for name, v := range is.Attributes {
+			if name == "%" || strings.Contains(name, ".") {
+				continue
+			}
+
+			if err := fwdiag.DiagnosticsError(state.SetAttribute(ctx, path.Root(name), v)); err != nil {
+				log.Printf("[WARN] %s(%s): %s", name, v, err)
+			}
+		}
+		return nil
 	}
 }


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This change adds a new helper function to the `acctest` package, `CheckFrameworkResourceDisappearsWithStateFunc`, that allows for a custom function to be provided which constructs the plugin framework state from the Terraform instance state. This is helpful for resources where the default behavior of the `CheckFrameworkResourceDisappears` helper (which only copies root level string arguments into the plugin framework state) results in missing inputs for the delete operation. Cases where nested or non-string arguments must be copied can now rely on custom state functions local to the service testing package.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #35746

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Verifying the existing behavior of `CheckFrameworkResourceDisappears` is not impacted:

```console
% make testacc PKG=auditmanager TESTS=TestAccAuditManagerControl_disappears
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/auditmanager/... -v -count 1 -parallel 20 -run='TestAccAuditManagerControl_disappears'  -timeout 360m
=== RUN   TestAccAuditManagerControl_disappears
=== PAUSE TestAccAuditManagerControl_disappears
=== CONT  TestAccAuditManagerControl_disappears
--- PASS: TestAccAuditManagerControl_disappears (10.69s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/auditmanager       14.884s
```
