### PR TITLE
Fix documentation error for lb_listener mutual_authentication block

### DIFF
--- a/website/docs/r/lb_listener.html.markdown
+++ b/website/docs/r/lb_listener.html.markdown
@@ -241,7 +241,7 @@ resource "aws_lb_listener" "example" {
     type             = "forward"
   }
 
-  mutual_authentication = {
+  mutual_authentication {
     mode            = "verify"
     trust_store_arn = "..."
   }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The `lb_listener` resource has a `mutual_authentication` block that is incorrectly documented as an expression.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #35809


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
https://github.com/hashicorp/terraform-provider-aws/blob/20d3854c8acf036a3abcaa75344aca2f563be405/internal/service/elbv2/listener_data_source.go#L263-L264

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

