### PR TITLE
docs: add missing attribute for aws_sfn_state_machine

### DIFF
--- a/website/docs/r/sfn_state_machine.html.markdown
+++ b/website/docs/r/sfn_state_machine.html.markdown
@@ -154,6 +154,7 @@ This resource exports the following attributes in addition to the arguments abov
 * `id` - The ARN of the state machine.
 * `arn` - The ARN of the state machine.
 * `creation_date` - The date the state machine was created.
+* `state_machine_version_arn` - The ARN of the state machine version. 
 * `status` - The current status of the state machine. Either `ACTIVE` or `DELETING`.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 

--- a/website/docs/r/sfn_state_machine.html.markdown
+++ b/website/docs/r/sfn_state_machine.html.markdown
@@ -154,7 +154,7 @@ This resource exports the following attributes in addition to the arguments abov
 * `id` - The ARN of the state machine.
 * `arn` - The ARN of the state machine.
 * `creation_date` - The date the state machine was created.
-* `state_machine_version_arn` - The ARN of the state machine version. 
+* `state_machine_version_arn` - The ARN of the state machine version.
 * `status` - The current status of the state machine. Either `ACTIVE` or `DELETING`.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 


### PR DESCRIPTION
### Description

Add the attribute `state_machine_version_arn` to the attribute reference of the state machine.

### Relations

Closes #36274.

### References

* [SFN State Machine Attribute Reference (current version)](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sfn_state_machine#attribute-reference)
* [SFN Alias Example usage (current version)](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sfn_alias#example-usage) already using the not documented attribute

```hcl
resource "aws_sfn_alias" "sfn_alias" {
  name = "my_sfn_alias"

  routing_configuration {
    state_machine_version_arn = aws_sfn_state_machine.sfn_test.state_machine_version_arn
    weight                    = 100
  }
}

resource "aws_sfn_alias" "my_sfn_alias" {
  name = "my_sfn_alias"

  routing_configuration {
    state_machine_version_arn = "arn:aws:states:us-east-1:12345:stateMachine:demo:3"
    weight                    = 50
  }

  routing_configuration {
    state_machine_version_arn = "arn:aws:states:us-east-1:12345:stateMachine:demo:2"
    weight                    = 50
  }
}
```



### Output from Acceptance Testing

No tests were added/ updated. 