### PR TITLE
docs: Fix lambda_arn casing in pre_token_generation_config

### DIFF
--- a/website/docs/cdktf/python/r/cognito_user_pool.html.markdown
+++ b/website/docs/cdktf/python/r/cognito_user_pool.html.markdown
@@ -162,7 +162,7 @@ The following arguments are optional:
 * `post_confirmation` - (Optional) Post-confirmation AWS Lambda trigger.
 * `pre_authentication` - (Optional) Pre-authentication AWS Lambda trigger.
 * `pre_sign_up` - (Optional) Pre-registration AWS Lambda trigger.
-* `pre_token_generation` - (Optional) Allow to customize identity token claims before token generation. Set this parameter for legacy purposes; for new instances of pre token generation triggers, set the LambdaArn of `pre_token_generation_config`.
+* `pre_token_generation` - (Optional) Allow to customize identity token claims before token generation. Set this parameter for legacy purposes; for new instances of pre token generation triggers, set the lambda_arn of `pre_token_generation_config`.
 * `pre_token_generation_config` - (Optional) Allow to customize access tokens. See [pre_token_configuration_type](#pre_token_configuration_type)
 * `user_migration` - (Optional) User migration Lambda config type.
 * `verify_auth_challenge_response` - (Optional) Verifies the authentication challenge response.
@@ -182,8 +182,8 @@ The following arguments are optional:
 
 #### pre_token_configuration
 
-* `lambdaArn` - (Required) The Lambda Amazon Resource Name of the Lambda function that Amazon Cognito triggers to customize access tokens. If you also set an ARN in `PreTokenGeneration`, its value must be identical to this one.
-* `lambdaVersion` - (Required) The Lambda version represents the signature of the "version" attribute in the "event" information Amazon Cognito passes to your pre Token Generation Lambda function. The supported values are `V1_0`, `V2_0`.
+* `lambda_arn` - (Required) The Lambda Amazon Resource Name of the Lambda function that Amazon Cognito triggers to customize access tokens. If you also set an ARN in `pre_token_generation`, its value must be identical to this one.
+* `lambda_version` - (Required) The Lambda version represents the signature of the "version" attribute in the "event" information Amazon Cognito passes to your pre Token Generation Lambda function. The supported values are `V1_0`, `V2_0`.
 
 ### password_policy
 

--- a/website/docs/r/cognito_user_pool.html.markdown
+++ b/website/docs/r/cognito_user_pool.html.markdown
@@ -132,7 +132,7 @@ The following arguments are optional:
 * `post_confirmation` - (Optional) Post-confirmation AWS Lambda trigger.
 * `pre_authentication` - (Optional) Pre-authentication AWS Lambda trigger.
 * `pre_sign_up` - (Optional) Pre-registration AWS Lambda trigger.
-* `pre_token_generation` - (Optional) Allow to customize identity token claims before token generation. Set this parameter for legacy purposes; for new instances of pre token generation triggers, set the LambdaArn of `pre_token_generation_config`.
+* `pre_token_generation` - (Optional) Allow to customize identity token claims before token generation. Set this parameter for legacy purposes; for new instances of pre token generation triggers, set the lambda_arn of `pre_token_generation_config`.
 * `pre_token_generation_config` - (Optional) Allow to customize access tokens. See [pre_token_configuration_type](#pre_token_configuration_type)
 * `user_migration` - (Optional) User migration Lambda config type.
 * `verify_auth_challenge_response` - (Optional) Verifies the authentication challenge response.
@@ -152,8 +152,8 @@ The following arguments are optional:
 
 #### pre_token_configuration_type
 
-* `lambdaArn` - (Required) The Lambda Amazon Resource Name of the Lambda function that Amazon Cognito triggers to customize access tokens. If you also set an ARN in `PreTokenGeneration`, its value must be identical to this one.
-* `lambdaVersion` - (Required) The Lambda version represents the signature of the "version" attribute in the "event" information Amazon Cognito passes to your pre Token Generation Lambda function. The supported values are `V1_0`, `V2_0`.
+* `lambda_arn` - (Required) The Lambda Amazon Resource Name of the Lambda function that Amazon Cognito triggers to customize access tokens. If you also set an ARN in `pre_token_generation`, its value must be identical to this one.
+* `lambda_version` - (Required) The Lambda version represents the signature of the "version" attribute in the "event" information Amazon Cognito passes to your pre Token Generation Lambda function. The supported values are `V1_0`, `V2_0`.
 
 ### password_policy
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR corrects the casing of the lambda_arn variable in the documentation for the pre-token generation configuration. Previously, the casing may have been incorrect, leading to potential confusion or errors. The correction ensures that users referencing the documentation will use the correct casing for lambda_arn in their own configurations.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #36420.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/35236.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
![CleanShot 2024-03-16 at 20 26 08](https://github.com/hashicorp/terraform-provider-aws/assets/6563162/24114ce4-6629-4639-b589-2c2640ec3b05)


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2
Not needed since is documentation
...
```
