### PR TITLE
autoflex: wire up option functions, add `IgnoreFieldNames` option

### DIFF
--- a/internal/framework/flex/auto_expand.go
+++ b/internal/framework/flex/auto_expand.go
@@ -26,11 +26,7 @@ import (
 // target data type) are copied.
 func Expand(ctx context.Context, tfObject, apiObject any, optFns ...AutoFlexOptionsFunc) diag.Diagnostics {
 	var diags diag.Diagnostics
-	expander := &autoExpander{}
-
-	for _, optFn := range optFns {
-		optFn(expander)
-	}
+	expander := newAutoExpander(optFns)
 
 	diags.Append(autoFlexConvert(ctx, tfObject, apiObject, expander)...)
 	if diags.HasError() {
@@ -41,7 +37,29 @@ func Expand(ctx context.Context, tfObject, apiObject any, optFns ...AutoFlexOpti
 	return diags
 }
 
-type autoExpander struct{}
+type autoExpander struct {
+	Options AutoFlexOptions
+}
+
+// newAutoExpander initializes an auto-expander with defaults that can be overridden
+// via functional options
+func newAutoExpander(optFns []AutoFlexOptionsFunc) *autoExpander {
+	o := AutoFlexOptions{
+		ignoredFieldNames: DefaultIgnoredFieldNames,
+	}
+
+	for _, optFn := range optFns {
+		optFn(&o)
+	}
+
+	return &autoExpander{
+		Options: o,
+	}
+}
+
+func (expander autoExpander) getOptions() AutoFlexOptions {
+	return expander.Options
+}
 
 // convert converts a single Plugin Framework value to its AWS API equivalent.
 func (expander autoExpander) convert(ctx context.Context, valFrom, vTo reflect.Value) diag.Diagnostics {

--- a/internal/framework/flex/auto_expand_test.go
+++ b/internal/framework/flex/auto_expand_test.go
@@ -865,13 +865,96 @@ func TestExpandComplexNestedBlockWithStringEnum(t *testing.T) {
 	runAutoExpandTestCases(ctx, t, testCases)
 }
 
+func TestExpandOptions(t *testing.T) {
+	t.Parallel()
+
+	type tf01 struct {
+		Field1 types.Bool                       `tfsdk:"field1"`
+		Tags   fwtypes.MapValueOf[types.String] `tfsdk:"tags"`
+	}
+	type aws01 struct {
+		Field1 bool
+		Tags   map[string]string
+	}
+
+	ctx := context.Background()
+	testCases := autoFlexTestCases{
+		{
+			TestName:   "empty source with tags",
+			Source:     &tf01{},
+			Target:     &aws01{},
+			WantTarget: &aws01{},
+		},
+		{
+			TestName: "ignore tags by default",
+			Source: &tf01{
+				Field1: types.BoolValue(true),
+				Tags: fwtypes.NewMapValueOfMust[types.String](
+					ctx,
+					map[string]attr.Value{
+						"foo": types.StringValue("bar"),
+					},
+				),
+			},
+			Target:     &aws01{},
+			WantTarget: &aws01{Field1: true},
+		},
+		{
+			TestName: "include tags with option override",
+			Options: []AutoFlexOptionsFunc{
+				func(opts *AutoFlexOptions) {
+					opts.SetIgnoredFields([]string{})
+				},
+			},
+			Source: &tf01{
+				Field1: types.BoolValue(true),
+				Tags: fwtypes.NewMapValueOfMust[types.String](
+					ctx,
+					map[string]attr.Value{
+						"foo": types.StringValue("bar"),
+					},
+				),
+			},
+			Target: &aws01{},
+			WantTarget: &aws01{
+				Field1: true,
+				Tags:   map[string]string{"foo": "bar"},
+			},
+		},
+		{
+			TestName: "ignore custom field",
+			Options: []AutoFlexOptionsFunc{
+				func(opts *AutoFlexOptions) {
+					opts.SetIgnoredFields([]string{"Field1"})
+				},
+			},
+			Source: &tf01{
+				Field1: types.BoolValue(true),
+				Tags: fwtypes.NewMapValueOfMust[types.String](
+					ctx,
+					map[string]attr.Value{
+						"foo": types.StringValue("bar"),
+					},
+				),
+			},
+			Target: &aws01{},
+			WantTarget: &aws01{
+				Tags: map[string]string{"foo": "bar"},
+			},
+		},
+	}
+	runAutoExpandTestCases(ctx, t, testCases)
+}
+
 type autoFlexTestCase struct {
 	Context    context.Context //nolint:containedctx // testing context use
+	Options    []AutoFlexOptionsFunc
 	TestName   string
 	Source     any
 	Target     any
 	WantErr    bool
 	WantTarget any
+	WantDiff   bool
 }
 
 type autoFlexTestCases []autoFlexTestCase
@@ -889,7 +972,7 @@ func runAutoExpandTestCases(ctx context.Context, t *testing.T, testCases autoFle
 				testCtx = testCase.Context
 			}
 
-			err := Expand(testCtx, testCase.Source, testCase.Target)
+			err := Expand(testCtx, testCase.Source, testCase.Target, testCase.Options...)
 			gotErr := err != nil
 
 			if gotErr != testCase.WantErr {

--- a/internal/framework/flex/auto_flatten_test.go
+++ b/internal/framework/flex/auto_flatten_test.go
@@ -1016,6 +1016,107 @@ func TestFlattenComplexNestedBlockWithFloat64(t *testing.T) {
 	runAutoFlattenTestCases(ctx, t, testCases)
 }
 
+func TestFlattenOptions(t *testing.T) {
+	t.Parallel()
+
+	type tf01 struct {
+		Field1 types.Bool                       `tfsdk:"field1"`
+		Tags   fwtypes.MapValueOf[types.String] `tfsdk:"tags"`
+	}
+	type aws01 struct {
+		Field1 bool
+		Tags   map[string]string
+	}
+
+	// For test cases below where a field of `MapValue` type is ignored, the
+	// result of `cmp.Diff` is intentionally not checked.
+	//
+	// When a target contains an ignored field of a `MapValue` type, the resulting
+	// target will contain a zero value, which, because the `elementType` is nil, will
+	// always return `false` from the `Equal` method, even when compared with another
+	// zero value. In practice, this zeroed `MapValue` would be overwritten
+	// by a subsequent step (ie. transparent tagging), and the temporary invalid
+	// state of the zeroed `MapValue` will not appear in the final state.
+	//
+	// Example expected diff:
+	// 	    unexpected diff (+wanted, -got):   &flex.tf01{
+	//                 Field1: s"false",
+	//         -       Tags:   types.MapValueOf[github.com/hashicorp/terraform-plugin-framework/types/basetypes.StringValue]{},
+	//         +       Tags:   types.MapValueOf[github.com/hashicorp/terraform-plugin-framework/types/basetypes.StringValue]{MapValue: basetypes.MapValue{elementType: basetypes.StringType{}}},
+	//           }
+	ctx := context.Background()
+	testCases := autoFlexTestCases{
+		{
+			TestName: "empty source with tags",
+			Source:   &aws01{},
+			Target:   &tf01{},
+			WantTarget: &tf01{
+				Field1: types.BoolValue(false),
+				Tags:   fwtypes.NewMapValueOfNull[types.String](ctx),
+			},
+			WantDiff: true, // Ignored MapValue type, expect diff
+		},
+		{
+			TestName: "ignore tags by default",
+			Source: &aws01{
+				Field1: true,
+				Tags:   map[string]string{"foo": "bar"},
+			},
+			Target: &tf01{},
+			WantTarget: &tf01{
+				Field1: types.BoolValue(true),
+				Tags:   fwtypes.NewMapValueOfNull[types.String](ctx),
+			},
+			WantDiff: true, // Ignored MapValue type, expect diff
+		},
+		{
+			TestName: "include tags with option override",
+			Options: []AutoFlexOptionsFunc{
+				func(opts *AutoFlexOptions) {
+					opts.SetIgnoredFields([]string{})
+				},
+			},
+			Source: &aws01{
+				Field1: true,
+				Tags:   map[string]string{"foo": "bar"},
+			},
+			Target: &tf01{},
+			WantTarget: &tf01{
+				Field1: types.BoolValue(true),
+				Tags: fwtypes.NewMapValueOfMust[types.String](
+					ctx,
+					map[string]attr.Value{
+						"foo": types.StringValue("bar"),
+					},
+				),
+			},
+		},
+		{
+			TestName: "ignore custom field",
+			Options: []AutoFlexOptionsFunc{
+				func(opts *AutoFlexOptions) {
+					opts.SetIgnoredFields([]string{"Field1"})
+				},
+			},
+			Source: &aws01{
+				Field1: true,
+				Tags:   map[string]string{"foo": "bar"},
+			},
+			Target: &tf01{},
+			WantTarget: &tf01{
+				Field1: types.BoolNull(),
+				Tags: fwtypes.NewMapValueOfMust[types.String](
+					ctx,
+					map[string]attr.Value{
+						"foo": types.StringValue("bar"),
+					},
+				),
+			},
+		},
+	}
+	runAutoFlattenTestCases(ctx, t, testCases)
+}
+
 func runAutoFlattenTestCases(ctx context.Context, t *testing.T, testCases autoFlexTestCases) {
 	t.Helper()
 
@@ -1029,7 +1130,7 @@ func runAutoFlattenTestCases(ctx context.Context, t *testing.T, testCases autoFl
 				testCtx = testCase.Context
 			}
 
-			err := Flatten(testCtx, testCase.Source, testCase.Target)
+			err := Flatten(testCtx, testCase.Source, testCase.Target, testCase.Options...)
 			gotErr := err != nil
 
 			if gotErr != testCase.WantErr {
@@ -1043,7 +1144,9 @@ func runAutoFlattenTestCases(ctx context.Context, t *testing.T, testCases autoFl
 					t.Errorf("err = %q", err)
 				}
 			} else if diff := cmp.Diff(testCase.Target, testCase.WantTarget, cmpopts.SortSlices(less)); diff != "" {
-				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+				if !testCase.WantDiff {
+					t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+				}
 			}
 		})
 	}

--- a/internal/framework/flex/autoflex.go
+++ b/internal/framework/flex/autoflex.go
@@ -27,10 +27,47 @@ const (
 // autoFlexer is the interface implemented by an auto-flattener or expander.
 type autoFlexer interface {
 	convert(context.Context, reflect.Value, reflect.Value) diag.Diagnostics
+	getOptions() AutoFlexOptions
 }
 
+// AutoFlexOptions stores configurable options for an auto-flattener or expander.
+type AutoFlexOptions struct {
+	// ignoredFieldNames stores names which expanders and flatteners will
+	// not read from or write to
+	ignoredFieldNames []string
+}
+
+// IsIgnoredField returns true if s is in the list of ignored field names
+func (o *AutoFlexOptions) IsIgnoredField(s string) bool {
+	for _, name := range o.ignoredFieldNames {
+		if s == name {
+			return true
+		}
+	}
+	return false
+}
+
+// AddIgnoredField appends s to the list of ignored field names
+func (o *AutoFlexOptions) AddIgnoredField(s string) {
+	o.ignoredFieldNames = append(o.ignoredFieldNames, s)
+}
+
+// SetIgnoredFields replaces the list of ignored field names
+//
+// To preseve existing items in the list, use the AddIgnoredField
+// method instead.
+func (o *AutoFlexOptions) SetIgnoredFields(fields []string) {
+	o.ignoredFieldNames = fields
+}
+
+var (
+	DefaultIgnoredFieldNames = []string{
+		"Tags", // Resource tags are handled separately.
+	}
+)
+
 // AutoFlexOptionsFunc is a type alias for an autoFlexer functional option.
-type AutoFlexOptionsFunc func(autoFlexer)
+type AutoFlexOptionsFunc func(*AutoFlexOptions)
 
 // autoFlexConvert converts `from` to `to` using the specified auto-flexer.
 func autoFlexConvert(ctx context.Context, from, to any, flexer autoFlexer) diag.Diagnostics {
@@ -86,20 +123,21 @@ func autoFlexConvertStruct(ctx context.Context, from any, to any, flexer autoFle
 		return diags
 	}
 
+	opts := flexer.getOptions()
 	for i, typFrom := 0, valFrom.Type(); i < typFrom.NumField(); i++ {
 		field := typFrom.Field(i)
 		if field.PkgPath != "" {
 			continue // Skip unexported fields.
 		}
 		fieldName := field.Name
-		if fieldName == "Tags" {
-			continue // Resource tags are handled separately.
+		if opts.IsIgnoredField(fieldName) {
+			continue
 		}
 		if fieldName == MapBlockKey {
 			continue
 		}
 
-		toFieldVal := findFieldFuzzy(ctx, fieldName, valTo, valFrom)
+		toFieldVal := findFieldFuzzy(ctx, fieldName, valTo, valFrom, flexer)
 		if !toFieldVal.IsValid() {
 			continue // Corresponding field not found in to.
 		}
@@ -117,7 +155,7 @@ func autoFlexConvertStruct(ctx context.Context, from any, to any, flexer autoFle
 	return diags
 }
 
-func findFieldFuzzy(ctx context.Context, fieldNameFrom string, valTo, valFrom reflect.Value) reflect.Value {
+func findFieldFuzzy(ctx context.Context, fieldNameFrom string, valTo, valFrom reflect.Value, flexer autoFlexer) reflect.Value {
 	// first precedence is exact match (case sensitive)
 	if v := valTo.FieldByName(fieldNameFrom); v.IsValid() {
 		return v
@@ -130,14 +168,15 @@ func findFieldFuzzy(ctx context.Context, fieldNameFrom string, valTo, valFrom re
 	// to make sure fuzzy matches are not in "from".
 
 	// second precedence is exact match (case insensitive)
+	opts := flexer.getOptions()
 	for i, typTo := 0, valTo.Type(); i < typTo.NumField(); i++ {
 		field := typTo.Field(i)
 		if field.PkgPath != "" {
 			continue // Skip unexported fields.
 		}
 		fieldNameTo := field.Name
-		if fieldNameTo == "Tags" {
-			continue // Resource tags are handled separately.
+		if opts.IsIgnoredField(fieldNameTo) {
+			continue
 		}
 		if v := valTo.FieldByName(fieldNameTo); v.IsValid() && strings.EqualFold(fieldNameFrom, fieldNameTo) && !fieldExistsInStruct(fieldNameTo, valFrom) {
 			// probably could assume validity here since reflect gave the field name
@@ -165,9 +204,9 @@ func findFieldFuzzy(ctx context.Context, fieldNameFrom string, valTo, valFrom re
 			// so it will only recurse once
 			ctx = context.WithValue(ctx, ResourcePrefixRecurse, true)
 			if strings.HasPrefix(fieldNameFrom, v) {
-				return findFieldFuzzy(ctx, strings.TrimPrefix(fieldNameFrom, v), valTo, valFrom)
+				return findFieldFuzzy(ctx, strings.TrimPrefix(fieldNameFrom, v), valTo, valFrom, flexer)
 			}
-			return findFieldFuzzy(ctx, v+fieldNameFrom, valTo, valFrom)
+			return findFieldFuzzy(ctx, v+fieldNameFrom, valTo, valFrom, flexer)
 		}
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This change implements AutoFlex options, allowing custom options to be passed to `flex.Expand` or `flex.Flatten`. The changes include:

- Adding a new `AutoFlexOptions` struct, which stores all configurable options
- Embedding the `AutoFlexOptions` struct into the `autoExpand` and `autoFlatten` flexer structs
- Adjusting the `AutoFlexOptionsFunc` signature to accept a pointer to `AutoFlexOptions`

As a first use case, the `IgnoreFieldNames` option was added. This option is a slice of strings, with a default value of `[]string{"Tags"}`. This replaces the previously hardcoded logic which skipped processing of any fields named `Tags`, and instead makes this configurable. Test cases have been added to exercise the behavior with default options and overrides to remove defaults and add custom values.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #36332
Depends on https://github.com/hashicorp/terraform-plugin-framework/pull/961
Depends on #36992

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- AWS SDK for Go V2 retry options, the pattern on which these options are based: https://github.com/aws/aws-sdk-go-v2/blob/main/aws/retry/standard.go


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% go test ./internal/framework/flex/...
ok      github.com/hashicorp/terraform-provider-aws/internal/framework/flex     0.488s
```
