### PR TITLE
New resource: aws_costoptimizationhub_enrollment_status

### DIFF
--- a/.changelog/36440.txt
+++ b/.changelog/36440.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_costoptimizationhub_enrollment_status
+```

--- a/internal/service/costoptimizationhub/costoptimizationhub_test.go
+++ b/internal/service/costoptimizationhub/costoptimizationhub_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package costoptimizationhub_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccCostOptimizationHub_serial(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]map[string]func(t *testing.T){
+		"EnrollmentStatus": {
+			"basic":                 testAccCostOptimizationHubEnrollmentStatus_basic,
+			"disappears":            testAccCostOptimizationHubEnrollmentStatus_disappears,
+			"includeMemberAccounts": testAccCostOptimizationHubEnrollmentStatus_IncludeMemberAccounts,
+		},
+	}
+
+	acctest.RunSerialTests2Levels(t, testCases, 0)
+}

--- a/internal/service/costoptimizationhub/costoptimizationhub_test.go
+++ b/internal/service/costoptimizationhub/costoptimizationhub_test.go
@@ -14,9 +14,9 @@ func TestAccCostOptimizationHub_serial(t *testing.T) {
 
 	testCases := map[string]map[string]func(t *testing.T){
 		"EnrollmentStatus": {
-			"basic":                 testAccCostOptimizationHubEnrollmentStatus_basic,
-			"disappears":            testAccCostOptimizationHubEnrollmentStatus_disappears,
-			"includeMemberAccounts": testAccCostOptimizationHubEnrollmentStatus_IncludeMemberAccounts,
+			"basic":                 testAccEnrollmentStatus_basic,
+			"disappears":            testAccEnrollmentStatus_disappears,
+			"includeMemberAccounts": testAccEnrollmentStatus_includeMemberAccounts,
 		},
 	}
 

--- a/internal/service/costoptimizationhub/costoptimizationhub_test.go
+++ b/internal/service/costoptimizationhub/costoptimizationhub_test.go
@@ -14,8 +14,8 @@ func TestAccCostOptimizationHub_serial(t *testing.T) {
 
 	testCases := map[string]map[string]func(t *testing.T){
 		"EnrollmentStatus": {
-			acctest.CtBasic:                 testAccEnrollmentStatus_basic,
-			acctest.CtDisappears:            testAccEnrollmentStatus_disappears,
+			acctest.CtBasic:         testAccEnrollmentStatus_basic,
+			acctest.CtDisappears:    testAccEnrollmentStatus_disappears,
 			"includeMemberAccounts": testAccEnrollmentStatus_includeMemberAccounts,
 		},
 	}

--- a/internal/service/costoptimizationhub/costoptimizationhub_test.go
+++ b/internal/service/costoptimizationhub/costoptimizationhub_test.go
@@ -14,8 +14,8 @@ func TestAccCostOptimizationHub_serial(t *testing.T) {
 
 	testCases := map[string]map[string]func(t *testing.T){
 		"EnrollmentStatus": {
-			"basic":                 testAccEnrollmentStatus_basic,
-			"disappears":            testAccEnrollmentStatus_disappears,
+			acctest.CtBasic:                 testAccEnrollmentStatus_basic,
+			acctest.CtDisappears:            testAccEnrollmentStatus_disappears,
 			"includeMemberAccounts": testAccEnrollmentStatus_includeMemberAccounts,
 		},
 	}

--- a/internal/service/costoptimizationhub/enrollment_status.go
+++ b/internal/service/costoptimizationhub/enrollment_status.go
@@ -1,0 +1,819 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package costoptimizationhub
+// **PLEASE DELETE THIS AND ALL TIP COMMENTS BEFORE SUBMITTING A PR FOR REVIEW!**
+//
+// TIP: ==== INTRODUCTION ====
+// Thank you for trying the skaff tool!
+//
+// You have opted to include these helpful comments. They all include "TIP:"
+// to help you find and remove them when you're done with them.
+//
+// While some aspects of this file are customized to your input, the
+// scaffold tool does *not* look at the AWS API and ensure it has correct
+// function, structure, and variable names. It makes guesses based on
+// commonalities. You will need to make significant adjustments.
+//
+// In other words, as generated, this is a rough outline of the work you will
+// need to do. If something doesn't make sense for your situation, get rid of
+// it.
+
+import (
+	// TIP: ==== IMPORTS ====
+	// This is a common set of imports but not customized to your code since
+	// your code hasn't been written yet. Make sure you, your IDE, or
+	// goimports -w <file> fixes these imports.
+	//
+	// The provider linter wants your imports to be in two groups: first,
+	// standard library (i.e., "fmt" or "strings"), second, everything else.
+	//
+	// Also, AWS Go SDK v2 may handle nested structures differently than v1,
+	// using the services/costoptimizationhub/types package. If so, you'll
+	// need to import types and reference the nested types, e.g., as
+	// awstypes.<Type Name>.
+	"context"
+	"errors"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/costoptimizationhub"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/costoptimizationhub/types"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+// TIP: ==== FILE STRUCTURE ====
+// All resources should follow this basic outline. Improve this resource's
+// maintainability by sticking to it.
+//
+// 1. Package declaration
+// 2. Imports
+// 3. Main resource struct with schema method
+// 4. Create, read, update, delete methods (in that order)
+// 5. Other functions (flatteners, expanders, waiters, finders, etc.)
+
+// Function annotations are used for resource registration to the Provider. DO NOT EDIT.
+// @FrameworkResource(name="Enrollment Status")
+func newResourceEnrollmentStatus(_ context.Context) (resource.ResourceWithConfigure, error) {
+	r := &resourceEnrollmentStatus{}
+	
+	// TIP: ==== CONFIGURABLE TIMEOUTS ====
+	// Users can configure timeout lengths but you need to use the times they
+	// provide. Access the timeout they configure (or the defaults) using,
+	// e.g., r.CreateTimeout(ctx, plan.Timeouts) (see below). The times here are
+	// the defaults if they don't configure timeouts.
+	r.SetDefaultCreateTimeout(30 * time.Minute)
+	r.SetDefaultUpdateTimeout(30 * time.Minute)
+	r.SetDefaultDeleteTimeout(30 * time.Minute)
+
+	return r, nil
+}
+
+const (
+	ResNameEnrollmentStatus = "Enrollment Status"
+)
+
+type resourceEnrollmentStatus struct {
+	framework.ResourceWithConfigure
+	framework.WithTimeouts
+}
+
+func (r *resourceEnrollmentStatus) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "aws_costoptimizationhub_enrollment_status"
+}
+
+// TIP: ==== SCHEMA ====
+// In the schema, add each of the attributes in snake case (e.g.,
+// delete_automated_backups).
+//
+// Formatting rules:
+// * Alphabetize attributes to make them easier to find.
+// * Do not add a blank line between attributes.
+//
+// Attribute basics:
+// * If a user can provide a value ("configure a value") for an
+//   attribute (e.g., instances = 5), we call the attribute an
+//   "argument."
+// * You change the way users interact with attributes using:
+//     - Required
+//     - Optional
+//     - Computed
+// * There are only four valid combinations:
+//
+// 1. Required only - the user must provide a value
+// Required: true,
+//
+// 2. Optional only - the user can configure or omit a value; do not
+//    use Default or DefaultFunc
+// Optional: true,
+//
+// 3. Computed only - the provider can provide a value but the user
+//    cannot, i.e., read-only
+// Computed: true,
+//
+// 4. Optional AND Computed - the provider or user can provide a value;
+//    use this combination if you are using Default
+// Optional: true,
+// Computed: true,
+//
+// You will typically find arguments in the input struct
+// (e.g., CreateDBInstanceInput) for the create operation. Sometimes
+// they are only in the input struct (e.g., ModifyDBInstanceInput) for
+// the modify operation.
+//
+// For more about schema options, visit
+// https://developer.hashicorp.com/terraform/plugin/framework/handling-data/schemas?page=schemas
+func (r *resourceEnrollmentStatus) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"arn": framework.ARNAttributeComputedOnly(),
+			"description": schema.StringAttribute{
+				Optional: true,
+			},
+			"id": framework.IDAttribute(),
+			"name": schema.StringAttribute{
+				Required: true,
+				// TIP: ==== PLAN MODIFIERS ====
+				// Plan modifiers were introduced with Plugin-Framework to provide a mechanism
+				// for adjusting planned changes prior to apply. The planmodifier subpackage
+				// provides built-in modifiers for many common use cases such as 
+				// requiring replacement on a value change ("ForceNew: true" in Plugin-SDK 
+				// resources).
+				//
+				// See more:
+				// https://developer.hashicorp.com/terraform/plugin/framework/resources/plan-modification
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"type": schema.StringAttribute{
+				Required: true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"complex_argument": schema.ListNestedBlock{
+				// TIP: ==== LIST VALIDATORS ====
+				// List and set validators take the place of MaxItems and MinItems in 
+				// Plugin-Framework based resources. Use listvalidator.SizeAtLeast(1) to
+				// make a nested object required. Similar to Plugin-SDK, complex objects 
+				// can be represented as lists or sets with listvalidator.SizeAtMost(1).
+				//
+				// For a complete mapping of Plugin-SDK to Plugin-Framework schema fields, 
+				// see:
+				// https://developer.hashicorp.com/terraform/plugin/framework/migrating/attributes-blocks/blocks
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"nested_required": schema.StringAttribute{
+							Required: true,
+						},
+						"nested_computed": schema.StringAttribute{
+							Computed: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
+						},
+					},
+				},
+			},
+			"timeouts": timeouts.Block(ctx, timeouts.Opts{
+				Create: true,
+				Update: true,
+				Delete: true,
+			}),
+		},
+	}
+}
+
+func (r *resourceEnrollmentStatus) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	// TIP: ==== RESOURCE CREATE ====
+	// Generally, the Create function should do the following things. Make
+	// sure there is a good reason if you don't do one of these.
+	//
+	// 1. Get a client connection to the relevant service
+	// 2. Fetch the plan
+	// 3. Populate a create input structure
+	// 4. Call the AWS create/put function
+	// 5. Using the output from the create function, set the minimum arguments
+	//    and attributes for the Read function to work, as well as any computed
+	//    only attributes. 
+	// 6. Use a waiter to wait for create to complete
+	// 7. Save the request plan to response state
+
+	// TIP: -- 1. Get a client connection to the relevant service
+	conn := r.Meta().CostOptimizationHubClient(ctx)
+	
+	// TIP: -- 2. Fetch the plan
+	var plan resourceEnrollmentStatusData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	
+	// TIP: -- 3. Populate a create input structure
+	in := &costoptimizationhub.CreateEnrollmentStatusInput{
+		// TIP: Mandatory or fields that will always be present can be set when
+		// you create the Input structure. (Replace these with real fields.)
+		EnrollmentStatusName: aws.String(plan.Name.ValueString()),
+		EnrollmentStatusType: aws.String(plan.Type.ValueString()),
+	}
+
+	if !plan.Description.IsNull() {
+		// TIP: Optional fields should be set based on whether or not they are
+		// used.
+		in.Description = aws.String(plan.Description.ValueString())
+	}
+	if !plan.ComplexArgument.IsNull() {
+		// TIP: Use an expander to assign a complex argument. The elements must be
+		// deserialized into the appropriate struct before being passed to the expander.
+		var tfList []complexArgumentData
+		resp.Diagnostics.Append(plan.ComplexArgument.ElementsAs(ctx, &tfList, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		in.ComplexArgument = expandComplexArgument(tfList)
+	}
+	
+	// TIP: -- 4. Call the AWS create function
+	out, err := conn.CreateEnrollmentStatus(ctx, in)
+	if err != nil {
+		// TIP: Since ID has not been set yet, you cannot use plan.ID.String()
+		// in error messages at this point.
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.CostOptimizationHub, create.ErrActionCreating, ResNameEnrollmentStatus, plan.Name.String(), err),
+			err.Error(),
+		)
+		return
+	}
+	if out == nil || out.EnrollmentStatus == nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.CostOptimizationHub, create.ErrActionCreating, ResNameEnrollmentStatus, plan.Name.String(), nil),
+			errors.New("empty output").Error(),
+		)
+		return
+	}
+	
+	// TIP: -- 5. Using the output from the create function, set the minimum attributes
+	plan.ARN = flex.StringToFramework(ctx, out.EnrollmentStatus.Arn)
+	plan.ID = flex.StringToFramework(ctx, out.EnrollmentStatus.EnrollmentStatusId)
+	
+	// TIP: -- 6. Use a waiter to wait for create to complete
+	createTimeout := r.CreateTimeout(ctx, plan.Timeouts)
+	_, err = waitEnrollmentStatusCreated(ctx, conn, plan.ID.ValueString(), createTimeout)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.CostOptimizationHub, create.ErrActionWaitingForCreation, ResNameEnrollmentStatus, plan.Name.String(), err),
+			err.Error(),
+		)
+		return
+	}
+	
+	// TIP: -- 7. Save the request plan to response state
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *resourceEnrollmentStatus) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	// TIP: ==== RESOURCE READ ====
+	// Generally, the Read function should do the following things. Make
+	// sure there is a good reason if you don't do one of these.
+	//
+	// 1. Get a client connection to the relevant service
+	// 2. Fetch the state
+	// 3. Get the resource from AWS
+	// 4. Remove resource from state if it is not found
+	// 5. Set the arguments and attributes
+	// 6. Set the state
+
+	// TIP: -- 1. Get a client connection to the relevant service
+	conn := r.Meta().CostOptimizationHubClient(ctx)
+	
+	// TIP: -- 2. Fetch the state
+	var state resourceEnrollmentStatusData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	
+	// TIP: -- 3. Get the resource from AWS using an API Get, List, or Describe-
+	// type function, or, better yet, using a finder.
+	out, err := findEnrollmentStatusByID(ctx, conn, state.ID.ValueString())
+	// TIP: -- 4. Remove resource from state if it is not found
+	if tfresource.NotFound(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.CostOptimizationHub, create.ErrActionSetting, ResNameEnrollmentStatus, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+	
+	// TIP: -- 5. Set the arguments and attributes
+	//
+	// For simple data types (i.e., schema.StringAttribute, schema.BoolAttribute,
+	// schema.Int64Attribute, and schema.Float64Attribue), simply setting the  
+	// appropriate data struct field is sufficient. The flex package implements
+	// helpers for converting between Go and Plugin-Framework types seamlessly. No 
+	// error or nil checking is necessary.
+	//
+	// However, there are some situations where more handling is needed such as
+	// complex data types (e.g., schema.ListAttribute, schema.SetAttribute). In 
+	// these cases the flatten function may have a diagnostics return value, which
+	// should be appended to resp.Diagnostics.
+	state.ARN = flex.StringToFramework(ctx, out.Arn)
+	state.ID = flex.StringToFramework(ctx, out.EnrollmentStatusId)
+	state.Name = flex.StringToFramework(ctx, out.EnrollmentStatusName)
+	state.Type = flex.StringToFramework(ctx, out.EnrollmentStatusType)
+	
+	// TIP: Setting a complex type.
+	complexArgument, d := flattenComplexArgument(ctx, out.ComplexArgument)
+	resp.Diagnostics.Append(d...)
+	state.ComplexArgument = complexArgument
+	
+	// TIP: -- 6. Set the state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *resourceEnrollmentStatus) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// TIP: ==== RESOURCE UPDATE ====
+	// Not all resources have Update functions. There are a few reasons:
+	// a. The AWS API does not support changing a resource
+	// b. All arguments have RequiresReplace() plan modifiers
+	// c. The AWS API uses a create call to modify an existing resource
+	//
+	// In the cases of a. and b., the resource will not have an update method
+	// defined. In the case of c., Update and Create can be refactored to call
+	// the same underlying function.
+	//
+	// The rest of the time, there should be an Update function and it should
+	// do the following things. Make sure there is a good reason if you don't
+	// do one of these.
+	//
+	// 1. Get a client connection to the relevant service
+	// 2. Fetch the plan and state
+	// 3. Populate a modify input structure and check for changes
+	// 4. Call the AWS modify/update function
+	// 5. Use a waiter to wait for update to complete
+	// 6. Save the request plan to response state
+	// TIP: -- 1. Get a client connection to the relevant service
+	conn := r.Meta().CostOptimizationHubClient(ctx)
+	
+	// TIP: -- 2. Fetch the plan
+	var plan, state resourceEnrollmentStatusData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	
+	// TIP: -- 3. Populate a modify input structure and check for changes
+	if !plan.Name.Equal(state.Name) ||
+		!plan.Description.Equal(state.Description) ||
+		!plan.ComplexArgument.Equal(state.ComplexArgument) ||
+		!plan.Type.Equal(state.Type) {
+
+		in := &costoptimizationhub.UpdateEnrollmentStatusInput{
+			// TIP: Mandatory or fields that will always be present can be set when
+			// you create the Input structure. (Replace these with real fields.)
+			EnrollmentStatusId:   aws.String(plan.ID.ValueString()),
+			EnrollmentStatusName: aws.String(plan.Name.ValueString()),
+			EnrollmentStatusType: aws.String(plan.Type.ValueString()),
+		}
+
+		if !plan.Description.IsNull() {
+			// TIP: Optional fields should be set based on whether or not they are
+			// used.
+			in.Description = aws.String(plan.Description.ValueString())
+		}
+		if !plan.ComplexArgument.IsNull() {
+			// TIP: Use an expander to assign a complex argument. The elements must be
+			// deserialized into the appropriate struct before being passed to the expander.
+			var tfList []complexArgumentData
+			resp.Diagnostics.Append(plan.ComplexArgument.ElementsAs(ctx, &tfList, false)...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+
+			in.ComplexArgument = expandComplexArgument(tfList)
+		}
+		
+		// TIP: -- 4. Call the AWS modify/update function
+		out, err := conn.UpdateEnrollmentStatus(ctx, in)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.CostOptimizationHub, create.ErrActionUpdating, ResNameEnrollmentStatus, plan.ID.String(), err),
+				err.Error(),
+			)
+			return
+		}
+		if out == nil || out.EnrollmentStatus == nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.CostOptimizationHub, create.ErrActionUpdating, ResNameEnrollmentStatus, plan.ID.String(), nil),
+				errors.New("empty output").Error(),
+			)
+			return
+		}
+		
+		// TIP: Using the output from the update function, re-set any computed attributes
+		plan.ARN = flex.StringToFramework(ctx, out.EnrollmentStatus.Arn)
+		plan.ID = flex.StringToFramework(ctx, out.EnrollmentStatus.EnrollmentStatusId)
+	}
+
+	
+	// TIP: -- 5. Use a waiter to wait for update to complete
+	updateTimeout := r.UpdateTimeout(ctx, plan.Timeouts)
+	_, err := waitEnrollmentStatusUpdated(ctx, conn, plan.ID.ValueString(), updateTimeout)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.CostOptimizationHub, create.ErrActionWaitingForUpdate, ResNameEnrollmentStatus, plan.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	
+	// TIP: -- 6. Save the request plan to response state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *resourceEnrollmentStatus) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	// TIP: ==== RESOURCE DELETE ====
+	// Most resources have Delete functions. There are rare situations
+	// where you might not need a delete:
+	// a. The AWS API does not provide a way to delete the resource
+	// b. The point of your resource is to perform an action (e.g., reboot a
+	//    server) and deleting serves no purpose.
+	//
+	// The Delete function should do the following things. Make sure there
+	// is a good reason if you don't do one of these.
+	//
+	// 1. Get a client connection to the relevant service
+	// 2. Fetch the state
+	// 3. Populate a delete input structure
+	// 4. Call the AWS delete function
+	// 5. Use a waiter to wait for delete to complete
+	// TIP: -- 1. Get a client connection to the relevant service
+	conn := r.Meta().CostOptimizationHubClient(ctx)
+	
+	// TIP: -- 2. Fetch the state
+	var state resourceEnrollmentStatusData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	
+	// TIP: -- 3. Populate a delete input structure
+	in := &costoptimizationhub.DeleteEnrollmentStatusInput{
+		EnrollmentStatusId: aws.String(state.ID.ValueString()),
+	}
+	
+	// TIP: -- 4. Call the AWS delete function
+	_, err := conn.DeleteEnrollmentStatus(ctx, in)
+	// TIP: On rare occassions, the API returns a not found error after deleting a
+	// resource. If that happens, we don't want it to show up as an error.
+	if err != nil {
+		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+			return
+		}
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.CostOptimizationHub, create.ErrActionDeleting, ResNameEnrollmentStatus, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+	
+	// TIP: -- 5. Use a waiter to wait for delete to complete
+	deleteTimeout := r.DeleteTimeout(ctx, state.Timeouts)
+	_, err = waitEnrollmentStatusDeleted(ctx, conn, state.ID.ValueString(), deleteTimeout)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.CostOptimizationHub, create.ErrActionWaitingForDeletion, ResNameEnrollmentStatus, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+}
+
+// TIP: ==== TERRAFORM IMPORTING ====
+// If Read can get all the information it needs from the Identifier
+// (i.e., path.Root("id")), you can use the PassthroughID importer. Otherwise,
+// you'll need a custom import function.
+//
+// See more:
+// https://developer.hashicorp.com/terraform/plugin/framework/resources/import
+func (r *resourceEnrollmentStatus) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+
+// TIP: ==== STATUS CONSTANTS ====
+// Create constants for states and statuses if the service does not
+// already have suitable constants. We prefer that you use the constants
+// provided in the service if available (e.g., awstypes.StatusInProgress).
+const (
+	statusChangePending = "Pending"
+	statusDeleting      = "Deleting"
+	statusNormal        = "Normal"
+	statusUpdated       = "Updated"
+)
+
+// TIP: ==== WAITERS ====
+// Some resources of some services have waiters provided by the AWS API.
+// Unless they do not work properly, use them rather than defining new ones
+// here.
+//
+// Sometimes we define the wait, status, and find functions in separate
+// files, wait.go, status.go, and find.go. Follow the pattern set out in the
+// service and define these where it makes the most sense.
+//
+// If these functions are used in the _test.go file, they will need to be
+// exported (i.e., capitalized).
+//
+// You will need to adjust the parameters and names to fit the service.
+func waitEnrollmentStatusCreated(ctx context.Context, conn *costoptimizationhub.Client, id string, timeout time.Duration) (*awstypes.EnrollmentStatus, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending:                   []string{},
+		Target:                    []string{statusNormal},
+		Refresh:                   statusEnrollmentStatus(ctx, conn, id),
+		Timeout:                   timeout,
+		NotFoundChecks:            20,
+		ContinuousTargetOccurence: 2,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if out, ok := outputRaw.(*costoptimizationhub.EnrollmentStatus); ok {
+		return out, err
+	}
+
+	return nil, err
+}
+
+// TIP: It is easier to determine whether a resource is updated for some
+// resources than others. The best case is a status flag that tells you when
+// the update has been fully realized. Other times, you can check to see if a
+// key resource argument is updated to a new value or not.
+func waitEnrollmentStatusUpdated(ctx context.Context, conn *costoptimizationhub.Client, id string, timeout time.Duration) (*awstypes.EnrollmentStatus, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending:                   []string{statusChangePending},
+		Target:                    []string{statusUpdated},
+		Refresh:                   statusEnrollmentStatus(ctx, conn, id),
+		Timeout:                   timeout,
+		NotFoundChecks:            20,
+		ContinuousTargetOccurence: 2,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if out, ok := outputRaw.(*costoptimizationhub.EnrollmentStatus); ok {
+		return out, err
+	}
+
+	return nil, err
+}
+
+// TIP: A deleted waiter is almost like a backwards created waiter. There may
+// be additional pending states, however.
+func waitEnrollmentStatusDeleted(ctx context.Context, conn *costoptimizationhub.Client, id string, timeout time.Duration) (*awstypes.EnrollmentStatus, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending:                   []string{statusDeleting, statusNormal},
+		Target:                    []string{},
+		Refresh:                   statusEnrollmentStatus(ctx, conn, id),
+		Timeout:                   timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if out, ok := outputRaw.(*costoptimizationhub.EnrollmentStatus); ok {
+		return out, err
+	}
+
+	return nil, err
+}
+
+// TIP: ==== STATUS ====
+// The status function can return an actual status when that field is
+// available from the API (e.g., out.Status). Otherwise, you can use custom
+// statuses to communicate the states of the resource.
+//
+// Waiters consume the values returned by status functions. Design status so
+// that it can be reused by a create, update, and delete waiter, if possible.
+func statusEnrollmentStatus(ctx context.Context, conn *costoptimizationhub.Client, id string) retry.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		out, err := findEnrollmentStatusByID(ctx, conn, id)
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return out, aws.ToString(out.Status), nil
+	}
+}
+
+// TIP: ==== FINDERS ====
+// The find function is not strictly necessary. You could do the API
+// request from the status function. However, we have found that find often
+// comes in handy in other places besides the status function. As a result, it
+// is good practice to define it separately.
+func findEnrollmentStatusByID(ctx context.Context, conn *costoptimizationhub.Client, id string) (*awstypes.EnrollmentStatus, error) {
+	in := &costoptimizationhub.GetEnrollmentStatusInput{
+		Id: aws.String(id),
+	}
+	
+	out, err := conn.GetEnrollmentStatus(ctx, in)
+	if err != nil {
+		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+			return nil, &retry.NotFoundError{
+				LastError:   err,
+				LastRequest: in,
+			}
+		}
+
+		return nil, err
+	}
+
+	if out == nil || out.EnrollmentStatus == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return out.EnrollmentStatus, nil
+}
+
+// TIP: ==== FLEX ====
+// Flatteners and expanders ("flex" functions) help handle complex data
+// types. Flatteners take an API data type and return the equivalent Plugin-Framework 
+// type. In other words, flatteners translate from AWS -> Terraform.
+//
+// On the other hand, expanders take a Terraform data structure and return
+// something that you can send to the AWS API. In other words, expanders
+// translate from Terraform -> AWS.
+//
+// See more:
+// https://hashicorp.github.io/terraform-provider-aws/data-handling-and-conversion/
+func flattenComplexArgument(ctx context.Context, apiObject *awstypes.ComplexArgument) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	elemType := types.ObjectType{AttrTypes: complexArgumentAttrTypes}
+
+	if apiObject == nil {
+		return types.ListNull(elemType), diags
+	}
+
+	obj := map[string]attr.Value{
+		"nested_required": flex.StringValueToFramework(ctx, apiObject.NestedRequired),
+		"nested_optional": flex.StringValueToFramework(ctx, apiObject.NestedOptional),
+	}
+	objVal, d := types.ObjectValue(complexArgumentAttrTypes, obj)
+	diags.Append(d...)
+
+	listVal, d := types.ListValue(elemType, []attr.Value{objVal})
+	diags.Append(d...)
+
+	return listVal, diags
+}
+
+// TIP: Often the AWS API will return a slice of structures in response to a
+// request for information. Sometimes you will have set criteria (e.g., the ID)
+// that means you'll get back a one-length slice. This plural function works
+// brilliantly for that situation too.
+func flattenComplexArguments(ctx context.Context, apiObjects []*awstypes.ComplexArgument) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	elemType := types.ObjectType{AttrTypes: complexArgumentAttrTypes}
+
+	if len(apiObjects) == 0 {
+		return types.ListNull(elemType), diags
+	}
+
+	elems := []attr.Value{}
+	for _, apiObject := range apiObjects {
+		if apiObject == nil {
+			continue
+		}
+
+		obj := map[string]attr.Value{
+			"nested_required": flex.StringValueToFramework(ctx, apiObject.NestedRequired),
+			"nested_optional": flex.StringValueToFramework(ctx, apiObject.NestedOptional),
+		}
+		objVal, d := types.ObjectValue(complexArgumentAttrTypes, obj)
+		diags.Append(d...)
+
+		elems = append(elems, objVal)
+	}
+
+	listVal, d := types.ListValue(elemType, elems)
+	diags.Append(d...)
+
+	return listVal, diags
+}
+
+// TIP: Remember, as mentioned above, expanders take a Terraform data structure
+// and return something that you can send to the AWS API. In other words,
+// expanders translate from Terraform -> AWS.
+//
+// See more:
+// https://hashicorp.github.io/terraform-provider-aws/data-handling-and-conversion/
+func expandComplexArgument(tfList []complexArgumentData) *awstypes.ComplexArgument {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	tfObj := tfList[0]
+	apiObject := &awstypes.ComplexArgument{
+		NestedRequired: aws.String(tfObj.NestedRequired.ValueString()),
+	}
+	if !tfObj.NestedOptional.IsNull() {
+		apiObject.NestedOptional = aws.String(tfObj.NestedOptional.ValueString())
+	}
+
+	return apiObject
+}
+
+// TIP: Even when you have a list with max length of 1, this plural function
+// works brilliantly. However, if the AWS API takes a structure rather than a
+// slice of structures, you will not need it.
+func expandComplexArguments(tfList []complexArgumentData) []*costoptimizationhub.ComplexArgument {
+	// TIP: The AWS API can be picky about whether you send a nil or zero-
+	// length for an argument that should be cleared. For example, in some
+	// cases, if you send a nil value, the AWS API interprets that as "make no
+	// changes" when what you want to say is "remove everything." Sometimes
+	// using a zero-length list will cause an error.
+	//
+	// As a result, here are two options. Usually, option 1, nil, will work as
+	// expected, clearing the field. But, test going from something to nothing
+	// to make sure it works. If not, try the second option.
+	// TIP: Option 1: Returning nil for zero-length list
+    if len(tfList) == 0 {
+        return nil
+    }
+    var apiObject []*awstypes.ComplexArgument
+	// TIP: Option 2: Return zero-length list for zero-length list. If option 1 does
+	// not work, after testing going from something to nothing (if that is
+	// possible), uncomment out the next line and remove option 1.
+	//
+	// apiObject := make([]*costoptimizationhub.ComplexArgument, 0)
+
+	for _, tfObj := range tfList {
+		item := &costoptimizationhub.ComplexArgument{
+			NestedRequired: aws.String(tfObj.NestedRequired.ValueString()),
+		}
+		if !tfObj.NestedOptional.IsNull() {
+			item.NestedOptional = aws.String(tfObj.NestedOptional.ValueString())
+		}
+
+		apiObject = append(apiObject, item)
+	}
+
+	return apiObject
+}
+
+// TIP: ==== DATA STRUCTURES ====
+// With Terraform Plugin-Framework configurations are deserialized into
+// Go types, providing type safety without the need for type assertions.
+// These structs should match the schema definition exactly, and the `tfsdk`
+// tag value should match the attribute name. 
+//
+// Nested objects are represented in their own data struct. These will 
+// also have a corresponding attribute type mapping for use inside flex
+// functions.
+//
+// See more:
+// https://developer.hashicorp.com/terraform/plugin/framework/handling-data/accessing-values
+type resourceEnrollmentStatusData struct {
+	ARN             types.String   `tfsdk:"arn"`
+	ComplexArgument types.List     `tfsdk:"complex_argument"`
+	Description     types.String   `tfsdk:"description"`
+	ID              types.String   `tfsdk:"id"`
+	Name            types.String   `tfsdk:"name"`
+	Timeouts        timeouts.Value `tfsdk:"timeouts"`
+	Type            types.String   `tfsdk:"type"`
+}
+
+type complexArgumentData struct {
+	NestedRequired types.String `tfsdk:"nested_required"`
+	NestedOptional types.String `tfsdk:"nested_optional"`
+}
+
+var complexArgumentAttrTypes = map[string]attr.Type{
+	"nested_required": types.StringType,
+	"nested_optional": types.StringType,
+}

--- a/internal/service/costoptimizationhub/enrollment_status.go
+++ b/internal/service/costoptimizationhub/enrollment_status.go
@@ -2,82 +2,31 @@
 // SPDX-License-Identifier: MPL-2.0
 
 package costoptimizationhub
-// **PLEASE DELETE THIS AND ALL TIP COMMENTS BEFORE SUBMITTING A PR FOR REVIEW!**
-//
-// TIP: ==== INTRODUCTION ====
-// Thank you for trying the skaff tool!
-//
-// You have opted to include these helpful comments. They all include "TIP:"
-// to help you find and remove them when you're done with them.
-//
-// While some aspects of this file are customized to your input, the
-// scaffold tool does *not* look at the AWS API and ensure it has correct
-// function, structure, and variable names. It makes guesses based on
-// commonalities. You will need to make significant adjustments.
-//
-// In other words, as generated, this is a rough outline of the work you will
-// need to do. If something doesn't make sense for your situation, get rid of
-// it.
 
 import (
-	// TIP: ==== IMPORTS ====
-	// This is a common set of imports but not customized to your code since
-	// your code hasn't been written yet. Make sure you, your IDE, or
-	// goimports -w <file> fixes these imports.
-	//
-	// The provider linter wants your imports to be in two groups: first,
-	// standard library (i.e., "fmt" or "strings"), second, everything else.
-	//
-	// Also, AWS Go SDK v2 may handle nested structures differently than v1,
-	// using the services/costoptimizationhub/types package. If so, you'll
-	// need to import types and reference the nested types, e.g., as
-	// awstypes.<Type Name>.
 	"context"
 	"errors"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/costoptimizationhub"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/costoptimizationhub/types"
-	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
-	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
-	"github.com/hashicorp/terraform-plugin-framework/attr"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
-	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
-// TIP: ==== FILE STRUCTURE ====
-// All resources should follow this basic outline. Improve this resource's
-// maintainability by sticking to it.
-//
-// 1. Package declaration
-// 2. Imports
-// 3. Main resource struct with schema method
-// 4. Create, read, update, delete methods (in that order)
-// 5. Other functions (flatteners, expanders, waiters, finders, etc.)
 
-// Function annotations are used for resource registration to the Provider. DO NOT EDIT.
 // @FrameworkResource(name="Enrollment Status")
 func newResourceEnrollmentStatus(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &resourceEnrollmentStatus{}
-	
-	// TIP: ==== CONFIGURABLE TIMEOUTS ====
-	// Users can configure timeout lengths but you need to use the times they
-	// provide. Access the timeout they configure (or the defaults) using,
-	// e.g., r.CreateTimeout(ctx, plan.Timeouts) (see below). The times here are
-	// the defaults if they don't configure timeouts.
+
 	r.SetDefaultCreateTimeout(30 * time.Minute)
 	r.SetDefaultUpdateTimeout(30 * time.Minute)
 	r.SetDefaultDeleteTimeout(30 * time.Minute)
@@ -92,235 +41,86 @@ const (
 type resourceEnrollmentStatus struct {
 	framework.ResourceWithConfigure
 	framework.WithTimeouts
+	framework.WithImportByID
 }
 
 func (r *resourceEnrollmentStatus) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = "aws_costoptimizationhub_enrollment_status"
 }
 
-// TIP: ==== SCHEMA ====
-// In the schema, add each of the attributes in snake case (e.g.,
-// delete_automated_backups).
-//
-// Formatting rules:
-// * Alphabetize attributes to make them easier to find.
-// * Do not add a blank line between attributes.
-//
-// Attribute basics:
-// * If a user can provide a value ("configure a value") for an
-//   attribute (e.g., instances = 5), we call the attribute an
-//   "argument."
-// * You change the way users interact with attributes using:
-//     - Required
-//     - Optional
-//     - Computed
-// * There are only four valid combinations:
-//
-// 1. Required only - the user must provide a value
-// Required: true,
-//
-// 2. Optional only - the user can configure or omit a value; do not
-//    use Default or DefaultFunc
-// Optional: true,
-//
-// 3. Computed only - the provider can provide a value but the user
-//    cannot, i.e., read-only
-// Computed: true,
-//
-// 4. Optional AND Computed - the provider or user can provide a value;
-//    use this combination if you are using Default
-// Optional: true,
-// Computed: true,
-//
-// You will typically find arguments in the input struct
-// (e.g., CreateDBInstanceInput) for the create operation. Sometimes
-// they are only in the input struct (e.g., ModifyDBInstanceInput) for
-// the modify operation.
-//
-// For more about schema options, visit
-// https://developer.hashicorp.com/terraform/plugin/framework/handling-data/schemas?page=schemas
 func (r *resourceEnrollmentStatus) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			"arn": framework.ARNAttributeComputedOnly(),
-			"description": schema.StringAttribute{
+			"id": framework.IDAttribute(),
+			"status": schema.StringAttribute{
+				Computed: true,
+				Validators: []validator.String{
+					enum.FrameworkValidate[awstypes.EnrollmentStatus](),
+				},
+			},
+			"include_member_accounts": schema.BoolAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  booldefault.StaticBool(false),
+			},
+			"unenroll_on_destroy": schema.BoolAttribute{
 				Optional: true,
 			},
-			"id": framework.IDAttribute(),
-			"name": schema.StringAttribute{
-				Required: true,
-				// TIP: ==== PLAN MODIFIERS ====
-				// Plan modifiers were introduced with Plugin-Framework to provide a mechanism
-				// for adjusting planned changes prior to apply. The planmodifier subpackage
-				// provides built-in modifiers for many common use cases such as 
-				// requiring replacement on a value change ("ForceNew: true" in Plugin-SDK 
-				// resources).
-				//
-				// See more:
-				// https://developer.hashicorp.com/terraform/plugin/framework/resources/plan-modification
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
-			},
-			"type": schema.StringAttribute{
-				Required: true,
-			},
-		},
-		Blocks: map[string]schema.Block{
-			"complex_argument": schema.ListNestedBlock{
-				// TIP: ==== LIST VALIDATORS ====
-				// List and set validators take the place of MaxItems and MinItems in 
-				// Plugin-Framework based resources. Use listvalidator.SizeAtLeast(1) to
-				// make a nested object required. Similar to Plugin-SDK, complex objects 
-				// can be represented as lists or sets with listvalidator.SizeAtMost(1).
-				//
-				// For a complete mapping of Plugin-SDK to Plugin-Framework schema fields, 
-				// see:
-				// https://developer.hashicorp.com/terraform/plugin/framework/migrating/attributes-blocks/blocks
-				Validators: []validator.List{
-					listvalidator.SizeAtMost(1),
-				},
-				NestedObject: schema.NestedBlockObject{
-					Attributes: map[string]schema.Attribute{
-						"nested_required": schema.StringAttribute{
-							Required: true,
-						},
-						"nested_computed": schema.StringAttribute{
-							Computed: true,
-							PlanModifiers: []planmodifier.String{
-								stringplanmodifier.UseStateForUnknown(),
-							},
-						},
-					},
-				},
-			},
-			"timeouts": timeouts.Block(ctx, timeouts.Opts{
-				Create: true,
-				Update: true,
-				Delete: true,
-			}),
 		},
 	}
 }
 
 func (r *resourceEnrollmentStatus) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	// TIP: ==== RESOURCE CREATE ====
-	// Generally, the Create function should do the following things. Make
-	// sure there is a good reason if you don't do one of these.
-	//
-	// 1. Get a client connection to the relevant service
-	// 2. Fetch the plan
-	// 3. Populate a create input structure
-	// 4. Call the AWS create/put function
-	// 5. Using the output from the create function, set the minimum arguments
-	//    and attributes for the Read function to work, as well as any computed
-	//    only attributes. 
-	// 6. Use a waiter to wait for create to complete
-	// 7. Save the request plan to response state
-
-	// TIP: -- 1. Get a client connection to the relevant service
 	conn := r.Meta().CostOptimizationHubClient(ctx)
-	
-	// TIP: -- 2. Fetch the plan
+
 	var plan resourceEnrollmentStatusData
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	
-	// TIP: -- 3. Populate a create input structure
-	in := &costoptimizationhub.CreateEnrollmentStatusInput{
-		// TIP: Mandatory or fields that will always be present can be set when
-		// you create the Input structure. (Replace these with real fields.)
-		EnrollmentStatusName: aws.String(plan.Name.ValueString()),
-		EnrollmentStatusType: aws.String(plan.Type.ValueString()),
+
+	//Input for UpdateEnrollmentStatus
+	in := &costoptimizationhub.UpdateEnrollmentStatusInput{
+		Status: awstypes.EnrollmentStatus("Active"),
 	}
 
-	if !plan.Description.IsNull() {
-		// TIP: Optional fields should be set based on whether or not they are
-		// used.
-		in.Description = aws.String(plan.Description.ValueString())
+	if !plan.IncludeMemberAccounts.IsNull() {
+		in.IncludeMemberAccounts = plan.IncludeMemberAccounts.ValueBoolPointer()
 	}
-	if !plan.ComplexArgument.IsNull() {
-		// TIP: Use an expander to assign a complex argument. The elements must be
-		// deserialized into the appropriate struct before being passed to the expander.
-		var tfList []complexArgumentData
-		resp.Diagnostics.Append(plan.ComplexArgument.ElementsAs(ctx, &tfList, false)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 
-		in.ComplexArgument = expandComplexArgument(tfList)
-	}
-	
-	// TIP: -- 4. Call the AWS create function
-	out, err := conn.CreateEnrollmentStatus(ctx, in)
+	out, err := conn.UpdateEnrollmentStatus(ctx, in)
 	if err != nil {
-		// TIP: Since ID has not been set yet, you cannot use plan.ID.String()
-		// in error messages at this point.
 		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.CostOptimizationHub, create.ErrActionCreating, ResNameEnrollmentStatus, plan.Name.String(), err),
+			create.ProblemStandardMessage(names.CostOptimizationHub, create.ErrActionCreating, ResNameEnrollmentStatus, "UpdateEnrollmentStatus", err),
 			err.Error(),
 		)
 		return
 	}
-	if out == nil || out.EnrollmentStatus == nil {
+	if out == nil {
 		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.CostOptimizationHub, create.ErrActionCreating, ResNameEnrollmentStatus, plan.Name.String(), nil),
-			errors.New("empty output").Error(),
+			create.ProblemStandardMessage(names.CostOptimizationHub, create.ErrActionCreating, ResNameEnrollmentStatus, "UpdateEnrollmentStatus", nil),
+			errors.New("empty out").Error(),
 		)
 		return
 	}
-	
-	// TIP: -- 5. Using the output from the create function, set the minimum attributes
-	plan.ARN = flex.StringToFramework(ctx, out.EnrollmentStatus.Arn)
-	plan.ID = flex.StringToFramework(ctx, out.EnrollmentStatus.EnrollmentStatusId)
-	
-	// TIP: -- 6. Use a waiter to wait for create to complete
-	createTimeout := r.CreateTimeout(ctx, plan.Timeouts)
-	_, err = waitEnrollmentStatusCreated(ctx, conn, plan.ID.ValueString(), createTimeout)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.CostOptimizationHub, create.ErrActionWaitingForCreation, ResNameEnrollmentStatus, plan.Name.String(), err),
-			err.Error(),
-		)
-		return
-	}
-	
-	// TIP: -- 7. Save the request plan to response state
+
+	plan.ID = flex.StringValueToFramework(ctx, r.Meta().AccountID)
+	plan.Status = flex.StringValueToFramework(ctx, *out.Status)
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
 
 func (r *resourceEnrollmentStatus) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	// TIP: ==== RESOURCE READ ====
-	// Generally, the Read function should do the following things. Make
-	// sure there is a good reason if you don't do one of these.
-	//
-	// 1. Get a client connection to the relevant service
-	// 2. Fetch the state
-	// 3. Get the resource from AWS
-	// 4. Remove resource from state if it is not found
-	// 5. Set the arguments and attributes
-	// 6. Set the state
-
-	// TIP: -- 1. Get a client connection to the relevant service
 	conn := r.Meta().CostOptimizationHubClient(ctx)
-	
-	// TIP: -- 2. Fetch the state
+
 	var state resourceEnrollmentStatusData
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	
-	// TIP: -- 3. Get the resource from AWS using an API Get, List, or Describe-
-	// type function, or, better yet, using a finder.
-	out, err := findEnrollmentStatusByID(ctx, conn, state.ID.ValueString())
-	// TIP: -- 4. Remove resource from state if it is not found
-	if tfresource.NotFound(err) {
-		resp.State.RemoveResource(ctx)
-		return
-	}
+
+	out, err := findEnrollmentStatus(ctx, conn)
+
 	if err != nil {
 		resp.Diagnostics.AddError(
 			create.ProblemStandardMessage(names.CostOptimizationHub, create.ErrActionSetting, ResNameEnrollmentStatus, state.ID.String(), err),
@@ -328,492 +128,109 @@ func (r *resourceEnrollmentStatus) Read(ctx context.Context, req resource.ReadRe
 		)
 		return
 	}
-	
-	// TIP: -- 5. Set the arguments and attributes
-	//
-	// For simple data types (i.e., schema.StringAttribute, schema.BoolAttribute,
-	// schema.Int64Attribute, and schema.Float64Attribue), simply setting the  
-	// appropriate data struct field is sufficient. The flex package implements
-	// helpers for converting between Go and Plugin-Framework types seamlessly. No 
-	// error or nil checking is necessary.
-	//
-	// However, there are some situations where more handling is needed such as
-	// complex data types (e.g., schema.ListAttribute, schema.SetAttribute). In 
-	// these cases the flatten function may have a diagnostics return value, which
-	// should be appended to resp.Diagnostics.
-	state.ARN = flex.StringToFramework(ctx, out.Arn)
-	state.ID = flex.StringToFramework(ctx, out.EnrollmentStatusId)
-	state.Name = flex.StringToFramework(ctx, out.EnrollmentStatusName)
-	state.Type = flex.StringToFramework(ctx, out.EnrollmentStatusType)
-	
-	// TIP: Setting a complex type.
-	complexArgument, d := flattenComplexArgument(ctx, out.ComplexArgument)
-	resp.Diagnostics.Append(d...)
-	state.ComplexArgument = complexArgument
-	
-	// TIP: -- 6. Set the state
+
+	//For this Enrollment resource, The non-existence of this resource will mean status will be "Inactive"
+	//So if that is the case, remove the resource from state
+	if out.Items[0].Status == "Inactive" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	state.ID = flex.StringValueToFramework(ctx, r.Meta().AccountID)
+	state.Status = flex.StringValueToFramework(ctx, out.Items[0].Status)
+	state.IncludeMemberAccounts = flex.BoolToFramework(ctx, out.IncludeMemberAccounts)
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
 func (r *resourceEnrollmentStatus) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	// TIP: ==== RESOURCE UPDATE ====
-	// Not all resources have Update functions. There are a few reasons:
-	// a. The AWS API does not support changing a resource
-	// b. All arguments have RequiresReplace() plan modifiers
-	// c. The AWS API uses a create call to modify an existing resource
-	//
-	// In the cases of a. and b., the resource will not have an update method
-	// defined. In the case of c., Update and Create can be refactored to call
-	// the same underlying function.
-	//
-	// The rest of the time, there should be an Update function and it should
-	// do the following things. Make sure there is a good reason if you don't
-	// do one of these.
-	//
-	// 1. Get a client connection to the relevant service
-	// 2. Fetch the plan and state
-	// 3. Populate a modify input structure and check for changes
-	// 4. Call the AWS modify/update function
-	// 5. Use a waiter to wait for update to complete
-	// 6. Save the request plan to response state
-	// TIP: -- 1. Get a client connection to the relevant service
 	conn := r.Meta().CostOptimizationHubClient(ctx)
-	
-	// TIP: -- 2. Fetch the plan
+
 	var plan, state resourceEnrollmentStatusData
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	
-	// TIP: -- 3. Populate a modify input structure and check for changes
-	if !plan.Name.Equal(state.Name) ||
-		!plan.Description.Equal(state.Description) ||
-		!plan.ComplexArgument.Equal(state.ComplexArgument) ||
-		!plan.Type.Equal(state.Type) {
 
+	if !plan.IncludeMemberAccounts.Equal(state.IncludeMemberAccounts) {
 		in := &costoptimizationhub.UpdateEnrollmentStatusInput{
-			// TIP: Mandatory or fields that will always be present can be set when
-			// you create the Input structure. (Replace these with real fields.)
-			EnrollmentStatusId:   aws.String(plan.ID.ValueString()),
-			EnrollmentStatusName: aws.String(plan.Name.ValueString()),
-			EnrollmentStatusType: aws.String(plan.Type.ValueString()),
+			Status:                awstypes.EnrollmentStatus("Active"),
+			IncludeMemberAccounts: plan.IncludeMemberAccounts.ValueBoolPointer(),
 		}
 
-		if !plan.Description.IsNull() {
-			// TIP: Optional fields should be set based on whether or not they are
-			// used.
-			in.Description = aws.String(plan.Description.ValueString())
-		}
-		if !plan.ComplexArgument.IsNull() {
-			// TIP: Use an expander to assign a complex argument. The elements must be
-			// deserialized into the appropriate struct before being passed to the expander.
-			var tfList []complexArgumentData
-			resp.Diagnostics.Append(plan.ComplexArgument.ElementsAs(ctx, &tfList, false)...)
-			if resp.Diagnostics.HasError() {
-				return
-			}
-
-			in.ComplexArgument = expandComplexArgument(tfList)
-		}
-		
-		// TIP: -- 4. Call the AWS modify/update function
 		out, err := conn.UpdateEnrollmentStatus(ctx, in)
 		if err != nil {
 			resp.Diagnostics.AddError(
-				create.ProblemStandardMessage(names.CostOptimizationHub, create.ErrActionUpdating, ResNameEnrollmentStatus, plan.ID.String(), err),
+				create.ProblemStandardMessage(names.CostOptimizationHub, create.ErrActionCreating, ResNameEnrollmentStatus, plan.ID.String(), err),
 				err.Error(),
 			)
 			return
 		}
-		if out == nil || out.EnrollmentStatus == nil {
+		if out == nil {
 			resp.Diagnostics.AddError(
-				create.ProblemStandardMessage(names.CostOptimizationHub, create.ErrActionUpdating, ResNameEnrollmentStatus, plan.ID.String(), nil),
-				errors.New("empty output").Error(),
+				create.ProblemStandardMessage(names.CostOptimizationHub, create.ErrActionCreating, ResNameEnrollmentStatus, plan.ID.String(), nil),
+				errors.New("empty out").Error(),
 			)
 			return
 		}
-		
-		// TIP: Using the output from the update function, re-set any computed attributes
-		plan.ARN = flex.StringToFramework(ctx, out.EnrollmentStatus.Arn)
-		plan.ID = flex.StringToFramework(ctx, out.EnrollmentStatus.EnrollmentStatusId)
+		plan.ID = state.ID
+		plan.Status = flex.StringValueToFramework(ctx, *out.Status)
 	}
 
-	
-	// TIP: -- 5. Use a waiter to wait for update to complete
-	updateTimeout := r.UpdateTimeout(ctx, plan.Timeouts)
-	_, err := waitEnrollmentStatusUpdated(ctx, conn, plan.ID.ValueString(), updateTimeout)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.CostOptimizationHub, create.ErrActionWaitingForUpdate, ResNameEnrollmentStatus, plan.ID.String(), err),
-			err.Error(),
-		)
-		return
-	}
-
-	
-	// TIP: -- 6. Save the request plan to response state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
 func (r *resourceEnrollmentStatus) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	// TIP: ==== RESOURCE DELETE ====
-	// Most resources have Delete functions. There are rare situations
-	// where you might not need a delete:
-	// a. The AWS API does not provide a way to delete the resource
-	// b. The point of your resource is to perform an action (e.g., reboot a
-	//    server) and deleting serves no purpose.
-	//
-	// The Delete function should do the following things. Make sure there
-	// is a good reason if you don't do one of these.
-	//
-	// 1. Get a client connection to the relevant service
-	// 2. Fetch the state
-	// 3. Populate a delete input structure
-	// 4. Call the AWS delete function
-	// 5. Use a waiter to wait for delete to complete
-	// TIP: -- 1. Get a client connection to the relevant service
 	conn := r.Meta().CostOptimizationHubClient(ctx)
-	
-	// TIP: -- 2. Fetch the state
+
 	var state resourceEnrollmentStatusData
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	
-	// TIP: -- 3. Populate a delete input structure
-	in := &costoptimizationhub.DeleteEnrollmentStatusInput{
-		EnrollmentStatusId: aws.String(state.ID.ValueString()),
+
+	in := &costoptimizationhub.UpdateEnrollmentStatusInput{
+		Status: awstypes.EnrollmentStatus("Inactive"),
 	}
-	
-	// TIP: -- 4. Call the AWS delete function
-	_, err := conn.DeleteEnrollmentStatus(ctx, in)
-	// TIP: On rare occassions, the API returns a not found error after deleting a
-	// resource. If that happens, we don't want it to show up as an error.
+
+	out, err := conn.UpdateEnrollmentStatus(ctx, in)
 	if err != nil {
-		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
-			return
-		}
 		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.CostOptimizationHub, create.ErrActionDeleting, ResNameEnrollmentStatus, state.ID.String(), err),
+			create.ProblemStandardMessage(names.CostOptimizationHub, create.ErrActionCreating, ResNameEnrollmentStatus, "UpdateEnrollmentStatus", err),
 			err.Error(),
 		)
 		return
 	}
-	
-	// TIP: -- 5. Use a waiter to wait for delete to complete
-	deleteTimeout := r.DeleteTimeout(ctx, state.Timeouts)
-	_, err = waitEnrollmentStatusDeleted(ctx, conn, state.ID.ValueString(), deleteTimeout)
-	if err != nil {
+	if out == nil || out.Status == nil {
 		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.CostOptimizationHub, create.ErrActionWaitingForDeletion, ResNameEnrollmentStatus, state.ID.String(), err),
-			err.Error(),
+			create.ProblemStandardMessage(names.CostOptimizationHub, create.ErrActionCreating, ResNameEnrollmentStatus, "UpdateEnrollmentStatus", nil),
+			errors.New("empty out").Error(),
 		)
 		return
 	}
 }
 
-// TIP: ==== TERRAFORM IMPORTING ====
-// If Read can get all the information it needs from the Identifier
-// (i.e., path.Root("id")), you can use the PassthroughID importer. Otherwise,
-// you'll need a custom import function.
-//
-// See more:
-// https://developer.hashicorp.com/terraform/plugin/framework/resources/import
+func findEnrollmentStatus(ctx context.Context, conn *costoptimizationhub.Client) (*costoptimizationhub.ListEnrollmentStatusesOutput, error) {
+	in := &costoptimizationhub.ListEnrollmentStatusesInput{
+		IncludeOrganizationInfo: false, //Pass in false to get only this account's status (and not its member accounts)
+	}
+
+	out, err := conn.ListEnrollmentStatuses(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
 func (r *resourceEnrollmentStatus) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
-
-// TIP: ==== STATUS CONSTANTS ====
-// Create constants for states and statuses if the service does not
-// already have suitable constants. We prefer that you use the constants
-// provided in the service if available (e.g., awstypes.StatusInProgress).
-const (
-	statusChangePending = "Pending"
-	statusDeleting      = "Deleting"
-	statusNormal        = "Normal"
-	statusUpdated       = "Updated"
-)
-
-// TIP: ==== WAITERS ====
-// Some resources of some services have waiters provided by the AWS API.
-// Unless they do not work properly, use them rather than defining new ones
-// here.
-//
-// Sometimes we define the wait, status, and find functions in separate
-// files, wait.go, status.go, and find.go. Follow the pattern set out in the
-// service and define these where it makes the most sense.
-//
-// If these functions are used in the _test.go file, they will need to be
-// exported (i.e., capitalized).
-//
-// You will need to adjust the parameters and names to fit the service.
-func waitEnrollmentStatusCreated(ctx context.Context, conn *costoptimizationhub.Client, id string, timeout time.Duration) (*awstypes.EnrollmentStatus, error) {
-	stateConf := &retry.StateChangeConf{
-		Pending:                   []string{},
-		Target:                    []string{statusNormal},
-		Refresh:                   statusEnrollmentStatus(ctx, conn, id),
-		Timeout:                   timeout,
-		NotFoundChecks:            20,
-		ContinuousTargetOccurence: 2,
-	}
-
-	outputRaw, err := stateConf.WaitForStateContext(ctx)
-	if out, ok := outputRaw.(*costoptimizationhub.EnrollmentStatus); ok {
-		return out, err
-	}
-
-	return nil, err
-}
-
-// TIP: It is easier to determine whether a resource is updated for some
-// resources than others. The best case is a status flag that tells you when
-// the update has been fully realized. Other times, you can check to see if a
-// key resource argument is updated to a new value or not.
-func waitEnrollmentStatusUpdated(ctx context.Context, conn *costoptimizationhub.Client, id string, timeout time.Duration) (*awstypes.EnrollmentStatus, error) {
-	stateConf := &retry.StateChangeConf{
-		Pending:                   []string{statusChangePending},
-		Target:                    []string{statusUpdated},
-		Refresh:                   statusEnrollmentStatus(ctx, conn, id),
-		Timeout:                   timeout,
-		NotFoundChecks:            20,
-		ContinuousTargetOccurence: 2,
-	}
-
-	outputRaw, err := stateConf.WaitForStateContext(ctx)
-	if out, ok := outputRaw.(*costoptimizationhub.EnrollmentStatus); ok {
-		return out, err
-	}
-
-	return nil, err
-}
-
-// TIP: A deleted waiter is almost like a backwards created waiter. There may
-// be additional pending states, however.
-func waitEnrollmentStatusDeleted(ctx context.Context, conn *costoptimizationhub.Client, id string, timeout time.Duration) (*awstypes.EnrollmentStatus, error) {
-	stateConf := &retry.StateChangeConf{
-		Pending:                   []string{statusDeleting, statusNormal},
-		Target:                    []string{},
-		Refresh:                   statusEnrollmentStatus(ctx, conn, id),
-		Timeout:                   timeout,
-	}
-
-	outputRaw, err := stateConf.WaitForStateContext(ctx)
-	if out, ok := outputRaw.(*costoptimizationhub.EnrollmentStatus); ok {
-		return out, err
-	}
-
-	return nil, err
-}
-
-// TIP: ==== STATUS ====
-// The status function can return an actual status when that field is
-// available from the API (e.g., out.Status). Otherwise, you can use custom
-// statuses to communicate the states of the resource.
-//
-// Waiters consume the values returned by status functions. Design status so
-// that it can be reused by a create, update, and delete waiter, if possible.
-func statusEnrollmentStatus(ctx context.Context, conn *costoptimizationhub.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		out, err := findEnrollmentStatusByID(ctx, conn, id)
-		if tfresource.NotFound(err) {
-			return nil, "", nil
-		}
-
-		if err != nil {
-			return nil, "", err
-		}
-
-		return out, aws.ToString(out.Status), nil
-	}
-}
-
-// TIP: ==== FINDERS ====
-// The find function is not strictly necessary. You could do the API
-// request from the status function. However, we have found that find often
-// comes in handy in other places besides the status function. As a result, it
-// is good practice to define it separately.
-func findEnrollmentStatusByID(ctx context.Context, conn *costoptimizationhub.Client, id string) (*awstypes.EnrollmentStatus, error) {
-	in := &costoptimizationhub.GetEnrollmentStatusInput{
-		Id: aws.String(id),
-	}
-	
-	out, err := conn.GetEnrollmentStatus(ctx, in)
-	if err != nil {
-		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
-			return nil, &retry.NotFoundError{
-				LastError:   err,
-				LastRequest: in,
-			}
-		}
-
-		return nil, err
-	}
-
-	if out == nil || out.EnrollmentStatus == nil {
-		return nil, tfresource.NewEmptyResultError(in)
-	}
-
-	return out.EnrollmentStatus, nil
-}
-
-// TIP: ==== FLEX ====
-// Flatteners and expanders ("flex" functions) help handle complex data
-// types. Flatteners take an API data type and return the equivalent Plugin-Framework 
-// type. In other words, flatteners translate from AWS -> Terraform.
-//
-// On the other hand, expanders take a Terraform data structure and return
-// something that you can send to the AWS API. In other words, expanders
-// translate from Terraform -> AWS.
-//
-// See more:
-// https://hashicorp.github.io/terraform-provider-aws/data-handling-and-conversion/
-func flattenComplexArgument(ctx context.Context, apiObject *awstypes.ComplexArgument) (types.List, diag.Diagnostics) {
-	var diags diag.Diagnostics
-	elemType := types.ObjectType{AttrTypes: complexArgumentAttrTypes}
-
-	if apiObject == nil {
-		return types.ListNull(elemType), diags
-	}
-
-	obj := map[string]attr.Value{
-		"nested_required": flex.StringValueToFramework(ctx, apiObject.NestedRequired),
-		"nested_optional": flex.StringValueToFramework(ctx, apiObject.NestedOptional),
-	}
-	objVal, d := types.ObjectValue(complexArgumentAttrTypes, obj)
-	diags.Append(d...)
-
-	listVal, d := types.ListValue(elemType, []attr.Value{objVal})
-	diags.Append(d...)
-
-	return listVal, diags
-}
-
-// TIP: Often the AWS API will return a slice of structures in response to a
-// request for information. Sometimes you will have set criteria (e.g., the ID)
-// that means you'll get back a one-length slice. This plural function works
-// brilliantly for that situation too.
-func flattenComplexArguments(ctx context.Context, apiObjects []*awstypes.ComplexArgument) (types.List, diag.Diagnostics) {
-	var diags diag.Diagnostics
-	elemType := types.ObjectType{AttrTypes: complexArgumentAttrTypes}
-
-	if len(apiObjects) == 0 {
-		return types.ListNull(elemType), diags
-	}
-
-	elems := []attr.Value{}
-	for _, apiObject := range apiObjects {
-		if apiObject == nil {
-			continue
-		}
-
-		obj := map[string]attr.Value{
-			"nested_required": flex.StringValueToFramework(ctx, apiObject.NestedRequired),
-			"nested_optional": flex.StringValueToFramework(ctx, apiObject.NestedOptional),
-		}
-		objVal, d := types.ObjectValue(complexArgumentAttrTypes, obj)
-		diags.Append(d...)
-
-		elems = append(elems, objVal)
-	}
-
-	listVal, d := types.ListValue(elemType, elems)
-	diags.Append(d...)
-
-	return listVal, diags
-}
-
-// TIP: Remember, as mentioned above, expanders take a Terraform data structure
-// and return something that you can send to the AWS API. In other words,
-// expanders translate from Terraform -> AWS.
-//
-// See more:
-// https://hashicorp.github.io/terraform-provider-aws/data-handling-and-conversion/
-func expandComplexArgument(tfList []complexArgumentData) *awstypes.ComplexArgument {
-	if len(tfList) == 0 {
-		return nil
-	}
-
-	tfObj := tfList[0]
-	apiObject := &awstypes.ComplexArgument{
-		NestedRequired: aws.String(tfObj.NestedRequired.ValueString()),
-	}
-	if !tfObj.NestedOptional.IsNull() {
-		apiObject.NestedOptional = aws.String(tfObj.NestedOptional.ValueString())
-	}
-
-	return apiObject
-}
-
-// TIP: Even when you have a list with max length of 1, this plural function
-// works brilliantly. However, if the AWS API takes a structure rather than a
-// slice of structures, you will not need it.
-func expandComplexArguments(tfList []complexArgumentData) []*costoptimizationhub.ComplexArgument {
-	// TIP: The AWS API can be picky about whether you send a nil or zero-
-	// length for an argument that should be cleared. For example, in some
-	// cases, if you send a nil value, the AWS API interprets that as "make no
-	// changes" when what you want to say is "remove everything." Sometimes
-	// using a zero-length list will cause an error.
-	//
-	// As a result, here are two options. Usually, option 1, nil, will work as
-	// expected, clearing the field. But, test going from something to nothing
-	// to make sure it works. If not, try the second option.
-	// TIP: Option 1: Returning nil for zero-length list
-    if len(tfList) == 0 {
-        return nil
-    }
-    var apiObject []*awstypes.ComplexArgument
-	// TIP: Option 2: Return zero-length list for zero-length list. If option 1 does
-	// not work, after testing going from something to nothing (if that is
-	// possible), uncomment out the next line and remove option 1.
-	//
-	// apiObject := make([]*costoptimizationhub.ComplexArgument, 0)
-
-	for _, tfObj := range tfList {
-		item := &costoptimizationhub.ComplexArgument{
-			NestedRequired: aws.String(tfObj.NestedRequired.ValueString()),
-		}
-		if !tfObj.NestedOptional.IsNull() {
-			item.NestedOptional = aws.String(tfObj.NestedOptional.ValueString())
-		}
-
-		apiObject = append(apiObject, item)
-	}
-
-	return apiObject
-}
-
-// TIP: ==== DATA STRUCTURES ====
-// With Terraform Plugin-Framework configurations are deserialized into
-// Go types, providing type safety without the need for type assertions.
-// These structs should match the schema definition exactly, and the `tfsdk`
-// tag value should match the attribute name. 
-//
-// Nested objects are represented in their own data struct. These will 
-// also have a corresponding attribute type mapping for use inside flex
-// functions.
-//
-// See more:
-// https://developer.hashicorp.com/terraform/plugin/framework/handling-data/accessing-values
 type resourceEnrollmentStatusData struct {
-	ARN             types.String   `tfsdk:"arn"`
-	ComplexArgument types.List     `tfsdk:"complex_argument"`
-	Description     types.String   `tfsdk:"description"`
-	ID              types.String   `tfsdk:"id"`
-	Name            types.String   `tfsdk:"name"`
-	Timeouts        timeouts.Value `tfsdk:"timeouts"`
-	Type            types.String   `tfsdk:"type"`
-}
-
-type complexArgumentData struct {
-	NestedRequired types.String `tfsdk:"nested_required"`
-	NestedOptional types.String `tfsdk:"nested_optional"`
-}
-
-var complexArgumentAttrTypes = map[string]attr.Type{
-	"nested_required": types.StringType,
-	"nested_optional": types.StringType,
+	ID                    types.String `tfsdk:"id"`
+	Status                types.String `tfsdk:"status"`
+	IncludeMemberAccounts types.Bool   `tfsdk:"include_member_accounts"`
+	UnenrollOnDestroy     types.Bool   `tfsdk:"unenroll_on_destroy"`
 }

--- a/internal/service/costoptimizationhub/enrollment_status.go
+++ b/internal/service/costoptimizationhub/enrollment_status.go
@@ -63,9 +63,6 @@ func (r *resourceEnrollmentStatus) Schema(ctx context.Context, req resource.Sche
 				Computed: true,
 				Default:  booldefault.StaticBool(false),
 			},
-			"unenroll_on_destroy": schema.BoolAttribute{
-				Optional: true,
-			},
 		},
 	}
 }
@@ -232,5 +229,4 @@ type resourceEnrollmentStatusData struct {
 	ID                    types.String `tfsdk:"id"`
 	Status                types.String `tfsdk:"status"`
 	IncludeMemberAccounts types.Bool   `tfsdk:"include_member_accounts"`
-	UnenrollOnDestroy     types.Bool   `tfsdk:"unenroll_on_destroy"`
 }

--- a/internal/service/costoptimizationhub/enrollment_status.go
+++ b/internal/service/costoptimizationhub/enrollment_status.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
-	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -55,8 +54,8 @@ func (r *resourceEnrollmentStatus) Metadata(_ context.Context, request resource.
 func (r *resourceEnrollmentStatus) Schema(ctx context.Context, request resource.SchemaRequest, response *resource.SchemaResponse) {
 	response.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			"id": framework.IDAttribute(),
-			"status": schema.StringAttribute{
+			names.AttrID: framework.IDAttribute(),
+			names.AttrStatus: schema.StringAttribute{
 				Computed: true,
 				Validators: []validator.String{
 					enum.FrameworkValidate[awstypes.EnrollmentStatus](),
@@ -106,8 +105,8 @@ func (r *resourceEnrollmentStatus) Create(ctx context.Context, request resource.
 		return
 	}
 
-	data.ID = flex.StringValueToFramework(ctx, r.Meta().AccountID)
-	data.Status = flex.StringValueToFramework(ctx, aws.ToString(out.Status))
+	data.ID = fwflex.StringValueToFramework(ctx, r.Meta().AccountID)
+	data.Status = fwflex.StringValueToFramework(ctx, aws.ToString(out.Status))
 
 	response.Diagnostics.Append(response.State.Set(ctx, data)...)
 }
@@ -151,7 +150,7 @@ func (r *resourceEnrollmentStatus) Read(ctx context.Context, request resource.Re
 		return
 	}
 
-	data.Status = flex.StringValueToFramework(ctx, out.Items[0].Status)
+	data.Status = fwflex.StringValueToFramework(ctx, out.Items[0].Status)
 
 	// out includes the IncludeMemberAccounts field ATM but it is always nil. Thus, we cannot update state
 	// and drift detection is not possible. (However, we can still update if the configuration changes.)
@@ -159,7 +158,7 @@ func (r *resourceEnrollmentStatus) Read(ctx context.Context, request resource.Re
 
 	// data.IncludeMemberAccounts = types.BoolValue(false)
 	// if out.IncludeMemberAccounts != nil {
-	// 	data.IncludeMemberAccounts = flex.BoolToFramework(ctx, out.IncludeMemberAccounts)
+	// 	data.IncludeMemberAccounts = fwflex.BoolToFramework(ctx, out.IncludeMemberAccounts)
 	// }
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
@@ -201,7 +200,7 @@ func (r *resourceEnrollmentStatus) Update(ctx context.Context, request resource.
 		}
 
 		old.ID = new.ID
-		old.Status = flex.StringValueToFramework(ctx, *out.Status)
+		old.Status = fwflex.StringValueToFramework(ctx, *out.Status)
 	}
 
 	response.Diagnostics.Append(response.State.Set(ctx, &old)...)
@@ -254,7 +253,7 @@ func findEnrollmentStatus(ctx context.Context, conn *costoptimizationhub.Client)
 }
 
 func (r *resourceEnrollmentStatus) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), request, response)
+	resource.ImportStatePassthroughID(ctx, path.Root(names.AttrID), request, response)
 }
 
 type resourceEnrollmentStatusData struct {

--- a/internal/service/costoptimizationhub/enrollment_status_test.go
+++ b/internal/service/costoptimizationhub/enrollment_status_test.go
@@ -1,0 +1,332 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package costoptimizationhub_test
+// **PLEASE DELETE THIS AND ALL TIP COMMENTS BEFORE SUBMITTING A PR FOR REVIEW!**
+//
+// TIP: ==== INTRODUCTION ====
+// Thank you for trying the skaff tool!
+//
+// You have opted to include these helpful comments. They all include "TIP:"
+// to help you find and remove them when you're done with them.
+//
+// While some aspects of this file are customized to your input, the
+// scaffold tool does *not* look at the AWS API and ensure it has correct
+// function, structure, and variable names. It makes guesses based on
+// commonalities. You will need to make significant adjustments.
+//
+// In other words, as generated, this is a rough outline of the work you will
+// need to do. If something doesn't make sense for your situation, get rid of
+// it.
+
+import (
+	// TIP: ==== IMPORTS ====
+	// This is a common set of imports but not customized to your code since
+	// your code hasn't been written yet. Make sure you, your IDE, or
+	// goimports -w <file> fixes these imports.
+	//
+	// The provider linter wants your imports to be in two groups: first,
+	// standard library (i.e., "fmt" or "strings"), second, everything else.
+	//
+	// Also, AWS Go SDK v2 may handle nested structures differently than v1,
+	// using the services/costoptimizationhub/types package. If so, you'll
+	// need to import types and reference the nested types, e.g., as
+	// types.<Type Name>.
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/YakDriver/regexache"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/costoptimizationhub"
+	"github.com/aws/aws-sdk-go-v2/service/costoptimizationhub/types"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/names"
+
+	// TIP: You will often need to import the package that this test file lives
+	// in. Since it is in the "test" context, it must import the package to use
+	// any normal context constants, variables, or functions.
+	tfcostoptimizationhub "github.com/hashicorp/terraform-provider-aws/internal/service/costoptimizationhub"
+)
+
+// TIP: File Structure. The basic outline for all test files should be as
+// follows. Improve this resource's maintainability by following this
+// outline.
+//
+// 1. Package declaration (add "_test" since this is a test file)
+// 2. Imports
+// 3. Unit tests
+// 4. Basic test
+// 5. Disappears test
+// 6. All the other tests
+// 7. Helper functions (exists, destroy, check, etc.)
+// 8. Functions that return Terraform configurations
+
+// TIP: ==== UNIT TESTS ====
+// This is an example of a unit test. Its name is not prefixed with
+// "TestAcc" like an acceptance test.
+//
+// Unlike acceptance tests, unit tests do not access AWS and are focused on a
+// function (or method). Because of this, they are quick and cheap to run.
+//
+// In designing a resource's implementation, isolate complex bits from AWS bits
+// so that they can be tested through a unit test. We encourage more unit tests
+// in the provider.
+//
+// Cut and dry functions using well-used patterns, like typical flatteners and
+// expanders, don't need unit testing. However, if they are complex or
+// intricate, they should be unit tested.
+func TestEnrollmentStatusExampleUnitTest(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		TestName string
+		Input    string
+		Expected string
+		Error    bool
+	}{
+		{
+			TestName: "empty",
+			Input:    "",
+			Expected: "",
+			Error:    true,
+		},
+		{
+			TestName: "descriptive name",
+			Input:    "some input",
+			Expected: "some output",
+			Error:    false,
+		},
+		{
+			TestName: "another descriptive name",
+			Input:    "more input",
+			Expected: "more output",
+			Error:    false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.TestName, func(t *testing.T) {
+			t.Parallel()
+			got, err := tfcostoptimizationhub.FunctionFromResource(testCase.Input)
+
+			if err != nil && !testCase.Error {
+				t.Errorf("got error (%s), expected no error", err)
+			}
+
+			if err == nil && testCase.Error {
+				t.Errorf("got (%s) and no error, expected error", got)
+			}
+
+			if got != testCase.Expected {
+				t.Errorf("got %s, expected %s", got, testCase.Expected)
+			}
+		})
+	}
+}
+
+// TIP: ==== ACCEPTANCE TESTS ====
+// This is an example of a basic acceptance test. This should test as much of
+// standard functionality of the resource as possible, and test importing, if
+// applicable. We prefix its name with "TestAcc", the service, and the
+// resource name.
+//
+// Acceptance test access AWS and cost money to run.
+func TestAccCostOptimizationHubEnrollmentStatus_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	// TIP: This is a long-running test guard for tests that run longer than
+	// 300s (5 min) generally.
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var enrollmentstatus costoptimizationhub.DescribeEnrollmentStatusResponse
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_costoptimizationhub_enrollment_status.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.CostOptimizationHubEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.CostOptimizationHubEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEnrollmentStatusDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnrollmentStatusConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEnrollmentStatusExists(ctx, resourceName, &enrollmentstatus),
+					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "maintenance_window_start_time.0.day_of_week"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
+						"console_access": "false",
+						"groups.#":       "0",
+						"username":       "Test",
+						"password":       "TestTest1234",
+					}),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "costoptimizationhub", regexache.MustCompile(`enrollmentstatus:+.`)),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately", "user"},
+			},
+		},
+	})
+}
+
+func TestAccCostOptimizationHubEnrollmentStatus_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var enrollmentstatus costoptimizationhub.DescribeEnrollmentStatusResponse
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_costoptimizationhub_enrollment_status.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.CostOptimizationHubEndpointID)
+			testAccPreCheck(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.CostOptimizationHubEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEnrollmentStatusDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnrollmentStatusConfig_basic(rName, testAccEnrollmentStatusVersionNewer),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEnrollmentStatusExists(ctx, resourceName, &enrollmentstatus),
+					// TIP: The Plugin-Framework disappears helper is similar to the Plugin-SDK version,
+					// but expects a new resource factory function as the third argument. To expose this
+					// private function to the testing package, you may need to add a line like the following
+					// to exports_test.go:
+					//
+					//   var ResourceEnrollmentStatus = newResourceEnrollmentStatus
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfcostoptimizationhub.ResourceEnrollmentStatus, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckEnrollmentStatusDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).CostOptimizationHubClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_costoptimizationhub_enrollment_status" {
+				continue
+			}
+
+			input := &costoptimizationhub.DescribeEnrollmentStatusInput{
+				EnrollmentStatusId: aws.String(rs.Primary.ID),
+			}
+			_, err := conn.DescribeEnrollmentStatus(ctx, &costoptimizationhub.DescribeEnrollmentStatusInput{
+				EnrollmentStatusId: aws.String(rs.Primary.ID),
+			})
+			if errs.IsA[*types.ResourceNotFoundException](err){
+				return nil
+			}
+			if err != nil {
+			        return create.Error(names.CostOptimizationHub, create.ErrActionCheckingDestroyed, tfcostoptimizationhub.ResNameEnrollmentStatus, rs.Primary.ID, err)
+			}
+
+			return create.Error(names.CostOptimizationHub, create.ErrActionCheckingDestroyed, tfcostoptimizationhub.ResNameEnrollmentStatus, rs.Primary.ID, errors.New("not destroyed"))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckEnrollmentStatusExists(ctx context.Context, name string, enrollmentstatus *costoptimizationhub.DescribeEnrollmentStatusResponse) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.CostOptimizationHub, create.ErrActionCheckingExistence, tfcostoptimizationhub.ResNameEnrollmentStatus, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.CostOptimizationHub, create.ErrActionCheckingExistence, tfcostoptimizationhub.ResNameEnrollmentStatus, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).CostOptimizationHubClient(ctx)
+		resp, err := conn.DescribeEnrollmentStatus(ctx, &costoptimizationhub.DescribeEnrollmentStatusInput{
+			EnrollmentStatusId: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return create.Error(names.CostOptimizationHub, create.ErrActionCheckingExistence, tfcostoptimizationhub.ResNameEnrollmentStatus, rs.Primary.ID, err)
+		}
+
+		*enrollmentstatus = *resp
+
+		return nil
+	}
+}
+
+func testAccPreCheck(ctx context.Context, t *testing.T) {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).CostOptimizationHubClient(ctx)
+
+	input := &costoptimizationhub.ListEnrollmentStatussInput{}
+	_, err := conn.ListEnrollmentStatuss(ctx, input)
+
+	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func testAccCheckEnrollmentStatusNotRecreated(before, after *costoptimizationhub.DescribeEnrollmentStatusResponse) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if before, after := aws.ToString(before.EnrollmentStatusId), aws.ToString(after.EnrollmentStatusId); before != after {
+			return create.Error(names.CostOptimizationHub, create.ErrActionCheckingNotRecreated, tfcostoptimizationhub.ResNameEnrollmentStatus, aws.ToString(before.EnrollmentStatusId), errors.New("recreated"))
+		}
+
+		return nil
+	}
+}
+
+func testAccEnrollmentStatusConfig_basic(rName, version string) string {
+	return fmt.Sprintf(`
+resource "aws_security_group" "test" {
+  name = %[1]q
+}
+
+resource "aws_costoptimizationhub_enrollment_status" "test" {
+  enrollment_status_name             = %[1]q
+  engine_type             = "ActiveCostOptimizationHub"
+  engine_version          = %[2]q
+  host_instance_type      = "costoptimizationhub.t2.micro"
+  security_groups         = [aws_security_group.test.id]
+  authentication_strategy = "simple"
+  storage_type            = "efs"
+
+  logs {
+    general = true
+  }
+
+  user {
+    username = "Test"
+    password = "TestTest1234"
+  }
+}
+`, rName, version)
+}

--- a/internal/service/costoptimizationhub/enrollment_status_test.go
+++ b/internal/service/costoptimizationhub/enrollment_status_test.go
@@ -80,12 +80,8 @@ func TestAccCostOptimizationHubEnrollmentStatus_disappears(t *testing.T) {
 	})
 }
 
-// testAccCheckEnrollmentStatusDestroy verfies ListEnrollmentStatuses does not return an error
-//
-// Since this resource manages enrollment/unenrollment to Cost Optimization Hub, there is nothing
-// to destroy. Additionally, because enrollment may remain active depending on whether
-// the unenroll_on_destroy attribute was set, this function does not check that account
-// enrollment is inactive, simply that the status check returns a valid response.
+// Since this resource manages enrollment/unenrollment destroying the resource
+// only means that account enrollment is inactive.
 func testAccCheckEnrollmentStatusDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).CostOptimizationHubClient(ctx)
@@ -104,7 +100,6 @@ func testAccCheckEnrollmentStatusDestroy(ctx context.Context) resource.TestCheck
 			}
 
 			return fmt.Errorf("Cost Optimization Hub Enrollment Status %s still exists", rs.Primary.ID)
-
 		}
 
 		return nil

--- a/internal/service/costoptimizationhub/enrollment_status_test.go
+++ b/internal/service/costoptimizationhub/enrollment_status_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func testAccCostOptimizationHubEnrollmentStatus_basic(t *testing.T) {
+func testAccEnrollmentStatus_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var les_out costoptimizationhub.ListEnrollmentStatusesOutput
@@ -51,7 +51,7 @@ func testAccCostOptimizationHubEnrollmentStatus_basic(t *testing.T) {
 	})
 }
 
-func testAccCostOptimizationHubEnrollmentStatus_disappears(t *testing.T) {
+func testAccEnrollmentStatus_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName := "aws_costoptimizationhub_enrollment_status.test"
@@ -131,7 +131,7 @@ func testAccCheckEnrollmentStatusIsActive(ctx context.Context, name string) reso
 	}
 }
 
-func testAccCostOptimizationHubEnrollmentStatus_IncludeMemberAccounts(t *testing.T) {
+func testAccEnrollmentStatus_includeMemberAccounts(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var les_out costoptimizationhub.ListEnrollmentStatusesOutput

--- a/internal/service/costoptimizationhub/enrollment_status_test.go
+++ b/internal/service/costoptimizationhub/enrollment_status_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccCostOptimizationHubEnrollmentStatus_basic(t *testing.T) {
+func testAccCostOptimizationHubEnrollmentStatus_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var les_out costoptimizationhub.ListEnrollmentStatusesOutput
@@ -51,7 +51,7 @@ func TestAccCostOptimizationHubEnrollmentStatus_basic(t *testing.T) {
 	})
 }
 
-func TestAccCostOptimizationHubEnrollmentStatus_disappears(t *testing.T) {
+func testAccCostOptimizationHubEnrollmentStatus_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName := "aws_costoptimizationhub_enrollment_status.test"
@@ -131,7 +131,7 @@ func testAccCheckEnrollmentStatusIsActive(ctx context.Context, name string) reso
 	}
 }
 
-func TestAccCostOptimizationHubEnrollmentStatus_IncludeMemberAccounts(t *testing.T) {
+func testAccCostOptimizationHubEnrollmentStatus_IncludeMemberAccounts(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var les_out costoptimizationhub.ListEnrollmentStatusesOutput

--- a/internal/service/costoptimizationhub/enrollment_status_test.go
+++ b/internal/service/costoptimizationhub/enrollment_status_test.go
@@ -2,186 +2,50 @@
 // SPDX-License-Identifier: MPL-2.0
 
 package costoptimizationhub_test
-// **PLEASE DELETE THIS AND ALL TIP COMMENTS BEFORE SUBMITTING A PR FOR REVIEW!**
-//
-// TIP: ==== INTRODUCTION ====
-// Thank you for trying the skaff tool!
-//
-// You have opted to include these helpful comments. They all include "TIP:"
-// to help you find and remove them when you're done with them.
-//
-// While some aspects of this file are customized to your input, the
-// scaffold tool does *not* look at the AWS API and ensure it has correct
-// function, structure, and variable names. It makes guesses based on
-// commonalities. You will need to make significant adjustments.
-//
-// In other words, as generated, this is a rough outline of the work you will
-// need to do. If something doesn't make sense for your situation, get rid of
-// it.
 
 import (
-	// TIP: ==== IMPORTS ====
-	// This is a common set of imports but not customized to your code since
-	// your code hasn't been written yet. Make sure you, your IDE, or
-	// goimports -w <file> fixes these imports.
-	//
-	// The provider linter wants your imports to be in two groups: first,
-	// standard library (i.e., "fmt" or "strings"), second, everything else.
-	//
-	// Also, AWS Go SDK v2 may handle nested structures differently than v1,
-	// using the services/costoptimizationhub/types package. If so, you'll
-	// need to import types and reference the nested types, e.g., as
-	// types.<Type Name>.
 	"context"
 	"errors"
 	"fmt"
 	"testing"
 
-	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/costoptimizationhub"
 	"github.com/aws/aws-sdk-go-v2/service/costoptimizationhub/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
-	"github.com/hashicorp/terraform-provider-aws/internal/errs"
-	"github.com/hashicorp/terraform-provider-aws/names"
-
-	// TIP: You will often need to import the package that this test file lives
-	// in. Since it is in the "test" context, it must import the package to use
-	// any normal context constants, variables, or functions.
 	tfcostoptimizationhub "github.com/hashicorp/terraform-provider-aws/internal/service/costoptimizationhub"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// TIP: File Structure. The basic outline for all test files should be as
-// follows. Improve this resource's maintainability by following this
-// outline.
-//
-// 1. Package declaration (add "_test" since this is a test file)
-// 2. Imports
-// 3. Unit tests
-// 4. Basic test
-// 5. Disappears test
-// 6. All the other tests
-// 7. Helper functions (exists, destroy, check, etc.)
-// 8. Functions that return Terraform configurations
-
-// TIP: ==== UNIT TESTS ====
-// This is an example of a unit test. Its name is not prefixed with
-// "TestAcc" like an acceptance test.
-//
-// Unlike acceptance tests, unit tests do not access AWS and are focused on a
-// function (or method). Because of this, they are quick and cheap to run.
-//
-// In designing a resource's implementation, isolate complex bits from AWS bits
-// so that they can be tested through a unit test. We encourage more unit tests
-// in the provider.
-//
-// Cut and dry functions using well-used patterns, like typical flatteners and
-// expanders, don't need unit testing. However, if they are complex or
-// intricate, they should be unit tested.
-func TestEnrollmentStatusExampleUnitTest(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		TestName string
-		Input    string
-		Expected string
-		Error    bool
-	}{
-		{
-			TestName: "empty",
-			Input:    "",
-			Expected: "",
-			Error:    true,
-		},
-		{
-			TestName: "descriptive name",
-			Input:    "some input",
-			Expected: "some output",
-			Error:    false,
-		},
-		{
-			TestName: "another descriptive name",
-			Input:    "more input",
-			Expected: "more output",
-			Error:    false,
-		},
-	}
-
-	for _, testCase := range testCases {
-		testCase := testCase
-		t.Run(testCase.TestName, func(t *testing.T) {
-			t.Parallel()
-			got, err := tfcostoptimizationhub.FunctionFromResource(testCase.Input)
-
-			if err != nil && !testCase.Error {
-				t.Errorf("got error (%s), expected no error", err)
-			}
-
-			if err == nil && testCase.Error {
-				t.Errorf("got (%s) and no error, expected error", got)
-			}
-
-			if got != testCase.Expected {
-				t.Errorf("got %s, expected %s", got, testCase.Expected)
-			}
-		})
-	}
-}
-
-// TIP: ==== ACCEPTANCE TESTS ====
-// This is an example of a basic acceptance test. This should test as much of
-// standard functionality of the resource as possible, and test importing, if
-// applicable. We prefix its name with "TestAcc", the service, and the
-// resource name.
-//
-// Acceptance test access AWS and cost money to run.
 func TestAccCostOptimizationHubEnrollmentStatus_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	// TIP: This is a long-running test guard for tests that run longer than
-	// 300s (5 min) generally.
-	if testing.Short() {
-		t.Skip("skipping long-running test in short mode")
-	}
 
-	var enrollmentstatus costoptimizationhub.DescribeEnrollmentStatusResponse
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	var les_out costoptimizationhub.ListEnrollmentStatusesOutput
 	resourceName := "aws_costoptimizationhub_enrollment_status.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, names.CostOptimizationHubEndpointID)
-			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, names.CostOptimizationHubEndpointID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.CostOptimizationHub),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckEnrollmentStatusDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEnrollmentStatusConfig_basic(rName),
+				Config: testAccEnrollmentStatusConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEnrollmentStatusExists(ctx, resourceName, &enrollmentstatus),
-					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "false"),
-					resource.TestCheckResourceAttrSet(resourceName, "maintenance_window_start_time.0.day_of_week"),
-					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
-						"console_access": "false",
-						"groups.#":       "0",
-						"username":       "Test",
-						"password":       "TestTest1234",
-					}),
-					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "costoptimizationhub", regexache.MustCompile(`enrollmentstatus:+.`)),
+					testAccCheckEnrollmentStatusExists(ctx, resourceName, &les_out),
+					resource.TestCheckResourceAttr(resourceName, "status", "Active"),
+					resource.TestCheckResourceAttr(resourceName, "include_member_accounts", "false"),
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"apply_immediately", "user"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -189,42 +53,39 @@ func TestAccCostOptimizationHubEnrollmentStatus_basic(t *testing.T) {
 
 func TestAccCostOptimizationHubEnrollmentStatus_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	if testing.Short() {
-		t.Skip("skipping long-running test in short mode")
-	}
 
-	var enrollmentstatus costoptimizationhub.DescribeEnrollmentStatusResponse
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_costoptimizationhub_enrollment_status.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, names.CostOptimizationHubEndpointID)
-			testAccPreCheck(t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, names.CostOptimizationHubEndpointID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.CostOptimizationHub),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckEnrollmentStatusDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEnrollmentStatusConfig_basic(rName, testAccEnrollmentStatusVersionNewer),
+				Config: testAccEnrollmentStatusConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEnrollmentStatusExists(ctx, resourceName, &enrollmentstatus),
-					// TIP: The Plugin-Framework disappears helper is similar to the Plugin-SDK version,
-					// but expects a new resource factory function as the third argument. To expose this
-					// private function to the testing package, you may need to add a line like the following
-					// to exports_test.go:
-					//
-					//   var ResourceEnrollmentStatus = newResourceEnrollmentStatus
+					testAccCheckEnrollmentStatusIsActive(ctx, resourceName),
 					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfcostoptimizationhub.ResourceEnrollmentStatus, resourceName),
 				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				RefreshState:       true,
 				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
 }
 
+// testAccCheckEnrollmentStatusDestroy verfies ListEnrollmentStatuses does not return an error
+//
+// Since this resource manages enrollment/unenrollment to Cost Optimization Hub, there is nothing
+// to destroy. Additionally, because enrollment may remain active depending on whether
+// the unenroll_on_destroy attribute was set, this function does not check that account
+// enrollment is inactive, simply that the status check returns a valid response.
 func testAccCheckEnrollmentStatusDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).CostOptimizationHubClient(ctx)
@@ -234,27 +95,24 @@ func testAccCheckEnrollmentStatusDestroy(ctx context.Context) resource.TestCheck
 				continue
 			}
 
-			input := &costoptimizationhub.DescribeEnrollmentStatusInput{
-				EnrollmentStatusId: aws.String(rs.Primary.ID),
-			}
-			_, err := conn.DescribeEnrollmentStatus(ctx, &costoptimizationhub.DescribeEnrollmentStatusInput{
-				EnrollmentStatusId: aws.String(rs.Primary.ID),
-			})
-			if errs.IsA[*types.ResourceNotFoundException](err){
-				return nil
-			}
+			out, err := conn.ListEnrollmentStatuses(ctx, &costoptimizationhub.ListEnrollmentStatusesInput{})
 			if err != nil {
-			        return create.Error(names.CostOptimizationHub, create.ErrActionCheckingDestroyed, tfcostoptimizationhub.ResNameEnrollmentStatus, rs.Primary.ID, err)
+				return err
+			}
+			if out.Items[0].Status == types.EnrollmentStatusInactive {
+				continue
 			}
 
-			return create.Error(names.CostOptimizationHub, create.ErrActionCheckingDestroyed, tfcostoptimizationhub.ResNameEnrollmentStatus, rs.Primary.ID, errors.New("not destroyed"))
+			return fmt.Errorf("Cost Optimization Hub Enrollment Status %s still exists", rs.Primary.ID)
+
 		}
 
 		return nil
 	}
 }
 
-func testAccCheckEnrollmentStatusExists(ctx context.Context, name string, enrollmentstatus *costoptimizationhub.DescribeEnrollmentStatusResponse) resource.TestCheckFunc {
+// testAccCheckEnrollmentStatusIsActive verifies Cost Optimization Hub is active in the current account/region combination
+func testAccCheckEnrollmentStatusIsActive(ctx context.Context, name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -266,8 +124,63 @@ func testAccCheckEnrollmentStatusExists(ctx context.Context, name string, enroll
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).CostOptimizationHubClient(ctx)
-		resp, err := conn.DescribeEnrollmentStatus(ctx, &costoptimizationhub.DescribeEnrollmentStatusInput{
-			EnrollmentStatusId: aws.String(rs.Primary.ID),
+		out, err := conn.ListEnrollmentStatuses(ctx, &costoptimizationhub.ListEnrollmentStatusesInput{})
+		if err != nil {
+			return create.Error(names.CostOptimizationHub, create.ErrActionCheckingExistence, tfcostoptimizationhub.ResNameEnrollmentStatus, rs.Primary.ID, err)
+		}
+		if out == nil || out.Items[0].Status != "Active" {
+			return create.Error(names.CostOptimizationHub, create.ErrActionCheckingExistence, tfcostoptimizationhub.ResNameEnrollmentStatus, rs.Primary.ID, errors.New("Cost Optimization Hub not active"))
+		}
+
+		return nil
+	}
+}
+
+func TestAccCostOptimizationHubEnrollmentStatus_IncludeMemberAccounts(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var les_out costoptimizationhub.ListEnrollmentStatusesOutput
+	resourceName := "aws_costoptimizationhub_enrollment_status.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.CostOptimizationHub),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEnrollmentStatusDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnrollmentStatusConfig_IncludeMemberAccounts(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEnrollmentStatusExists(ctx, resourceName, &les_out),
+					resource.TestCheckResourceAttr(resourceName, "status", "Active"),
+					resource.TestCheckResourceAttr(resourceName, "include_member_accounts", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckEnrollmentStatusExists(ctx context.Context, name string, enrollmentstatus *costoptimizationhub.ListEnrollmentStatusesOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.CostOptimizationHub, create.ErrActionCheckingExistence, tfcostoptimizationhub.ResNameEnrollmentStatus, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.CostOptimizationHub, create.ErrActionCheckingExistence, tfcostoptimizationhub.ResNameEnrollmentStatus, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).CostOptimizationHubClient(ctx)
+		resp, err := conn.ListEnrollmentStatuses(ctx, &costoptimizationhub.ListEnrollmentStatusesInput{
+			IncludeOrganizationInfo: false,
 		})
 
 		if err != nil {
@@ -280,53 +193,17 @@ func testAccCheckEnrollmentStatusExists(ctx context.Context, name string, enroll
 	}
 }
 
-func testAccPreCheck(ctx context.Context, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).CostOptimizationHubClient(ctx)
-
-	input := &costoptimizationhub.ListEnrollmentStatussInput{}
-	_, err := conn.ListEnrollmentStatuss(ctx, input)
-
-	if acctest.PreCheckSkipError(err) {
-		t.Skipf("skipping acceptance testing: %s", err)
-	}
-	if err != nil {
-		t.Fatalf("unexpected PreCheck error: %s", err)
-	}
-}
-
-func testAccCheckEnrollmentStatusNotRecreated(before, after *costoptimizationhub.DescribeEnrollmentStatusResponse) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if before, after := aws.ToString(before.EnrollmentStatusId), aws.ToString(after.EnrollmentStatusId); before != after {
-			return create.Error(names.CostOptimizationHub, create.ErrActionCheckingNotRecreated, tfcostoptimizationhub.ResNameEnrollmentStatus, aws.ToString(before.EnrollmentStatusId), errors.New("recreated"))
-		}
-
-		return nil
-	}
-}
-
-func testAccEnrollmentStatusConfig_basic(rName, version string) string {
-	return fmt.Sprintf(`
-resource "aws_security_group" "test" {
-  name = %[1]q
-}
-
+func testAccEnrollmentStatusConfig_basic() string {
+	return `
 resource "aws_costoptimizationhub_enrollment_status" "test" {
-  enrollment_status_name             = %[1]q
-  engine_type             = "ActiveCostOptimizationHub"
-  engine_version          = %[2]q
-  host_instance_type      = "costoptimizationhub.t2.micro"
-  security_groups         = [aws_security_group.test.id]
-  authentication_strategy = "simple"
-  storage_type            = "efs"
-
-  logs {
-    general = true
-  }
-
-  user {
-    username = "Test"
-    password = "TestTest1234"
-  }
 }
-`, rName, version)
+`
+}
+
+func testAccEnrollmentStatusConfig_IncludeMemberAccounts() string {
+	return `
+resource "aws_costoptimizationhub_enrollment_status" "test" {
+  include_member_accounts = true
+}
+`
 }

--- a/internal/service/costoptimizationhub/enrollment_status_test.go
+++ b/internal/service/costoptimizationhub/enrollment_status_test.go
@@ -40,8 +40,8 @@ func testAccEnrollmentStatus_basic(t *testing.T) {
 				Config: testAccEnrollmentStatusConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEnrollmentStatusExists(ctx, resourceName, &les),
-					resource.TestCheckResourceAttr(resourceName, "status", "Active"),
-					resource.TestCheckResourceAttr(resourceName, "include_member_accounts", "false"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, "Active"),
+					resource.TestCheckResourceAttr(resourceName, "include_member_accounts", acctest.CtFalse),
 				),
 			},
 			{
@@ -104,16 +104,16 @@ func testAccEnrollmentStatus_includeMemberAccounts(t *testing.T) {
 				Config: testAccEnrollmentStatusConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEnrollmentStatusExists(ctx, resourceName, &les),
-					resource.TestCheckResourceAttr(resourceName, "status", "Active"),
-					resource.TestCheckResourceAttr(resourceName, "include_member_accounts", "false"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, "Active"),
+					resource.TestCheckResourceAttr(resourceName, "include_member_accounts", acctest.CtFalse),
 				),
 			},
 			{
 				Config: testAccEnrollmentStatusConfig_includeMemberAccounts(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEnrollmentStatusExists(ctx, resourceName, &les),
-					resource.TestCheckResourceAttr(resourceName, "status", "Active"),
-					resource.TestCheckResourceAttr(resourceName, "include_member_accounts", "true"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, "Active"),
+					resource.TestCheckResourceAttr(resourceName, "include_member_accounts", acctest.CtTrue),
 				),
 			},
 			{

--- a/internal/service/costoptimizationhub/exports_test.go
+++ b/internal/service/costoptimizationhub/exports_test.go
@@ -1,0 +1,9 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package costoptimizationhub
+
+// Exports for use in tests only.
+var (
+	ResourceEnrollmentStatus = newResourceEnrollmentStatus
+)

--- a/internal/service/costoptimizationhub/service_package_gen.go
+++ b/internal/service/costoptimizationhub/service_package_gen.go
@@ -17,7 +17,12 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.Serv
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.ServicePackageFrameworkResource {
-	return []*types.ServicePackageFrameworkResource{}
+	return []*types.ServicePackageFrameworkResource{
+		{
+			Factory: newResourceEnrollmentStatus,
+			Name:    "Enrollment Status",
+		},
+	}
 }
 
 func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePackageSDKDataSource {

--- a/website/docs/r/costoptimizationhub_enrollment_status.html.markdown
+++ b/website/docs/r/costoptimizationhub_enrollment_status.html.markdown
@@ -23,7 +23,7 @@ resource "aws_costoptimizationhub_enrollment_status" "example" {
 
 ```terraform
 resource "aws_costoptimizationhub_enrollment_status" "example" {
-  include_member_accounts            = true
+  include_member_accounts = true
 }
 ```
 

--- a/website/docs/r/costoptimizationhub_enrollment_status.html.markdown
+++ b/website/docs/r/costoptimizationhub_enrollment_status.html.markdown
@@ -3,19 +3,12 @@ subcategory: "Cost Optimization Hub"
 layout: "aws"
 page_title: "AWS: aws_costoptimizationhub_enrollment_status"
 description: |-
-  Terraform resource for managing an AWS Cost Optimization Hub Enrollment Status.
+  Terraform resource for managing AWS Cost Optimization Hub Enrollment Status.
 ---
-<!---
-TIP: A few guiding principles for writing documentation:
-1. Use simple language while avoiding jargon and figures of speech.
-2. Focus on brevity and clarity to keep a reader's attention.
-3. Use active voice and present tense whenever you can.
-4. Document your feature as it exists now; do not mention the future or past if you can help it.
-5. Use accessible and inclusive language.
---->`
+
 # Resource: aws_costoptimizationhub_enrollment_status
 
-Terraform resource for managing an AWS Cost Optimization Hub Enrollment Status.
+Terraform resource for managing AWS Cost Optimization Hub Enrollment Status.
 
 ## Example Usage
 
@@ -26,44 +19,40 @@ resource "aws_costoptimizationhub_enrollment_status" "example" {
 }
 ```
 
+### Usage with all the arguments
+
+```terraform
+resource "aws_costoptimizationhub_enrollment_status" "example" {
+  include_member_accounts            = true
+}
+```
+
 ## Argument Reference
-
-The following arguments are required:
-
-* `example_arg` - (Required) Concise argument description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
 
 The following arguments are optional:
 
-* `optional_arg` - (Optional) Concise argument description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+* `include_member_accounts` - (Optional) Flag to enroll member accounts of the organization if the account is the management account. Default value is `false`
 
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `arn` - ARN of the Enrollment Status. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
-* `example_attribute` - Concise description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
-
-## Timeouts
-
-[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
-
-* `create` - (Default `60m`)
-* `update` - (Default `180m`)
-* `delete` - (Default `90m`)
+* `id` - Unique identifier for the enrollment. Since enrollment is for the entire account, this will be the 12-digit account id.
+* `status` - Status of enrollment. When the resource is present in Terraform, it's status will always be `Active`
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Cost Optimization Hub Enrollment Status using the `example_id_arg`. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Cost Optimization Hub Enrollment Status using the `id`. For example:
 
 ```terraform
 import {
   to = aws_costoptimizationhub_enrollment_status.example
-  id = "enrollment_status-id-12345678"
+  id = "111222333444"
 }
 ```
 
-Using `terraform import`, import Cost Optimization Hub Enrollment Status using the `example_id_arg`. For example:
+Using `terraform import`, import Cost Optimization Hub Enrollment Status using the `id`. For example:
 
 ```console
-% terraform import aws_costoptimizationhub_enrollment_status.example enrollment_status-id-12345678
+% terraform import aws_costoptimizationhub_enrollment_status.example 111222333444
 ```

--- a/website/docs/r/costoptimizationhub_enrollment_status.html.markdown
+++ b/website/docs/r/costoptimizationhub_enrollment_status.html.markdown
@@ -1,0 +1,69 @@
+---
+subcategory: "Cost Optimization Hub"
+layout: "aws"
+page_title: "AWS: aws_costoptimizationhub_enrollment_status"
+description: |-
+  Terraform resource for managing an AWS Cost Optimization Hub Enrollment Status.
+---
+<!---
+TIP: A few guiding principles for writing documentation:
+1. Use simple language while avoiding jargon and figures of speech.
+2. Focus on brevity and clarity to keep a reader's attention.
+3. Use active voice and present tense whenever you can.
+4. Document your feature as it exists now; do not mention the future or past if you can help it.
+5. Use accessible and inclusive language.
+--->`
+# Resource: aws_costoptimizationhub_enrollment_status
+
+Terraform resource for managing an AWS Cost Optimization Hub Enrollment Status.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_costoptimizationhub_enrollment_status" "example" {
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `example_arg` - (Required) Concise argument description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+
+The following arguments are optional:
+
+* `optional_arg` - (Optional) Concise argument description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `arn` - ARN of the Enrollment Status. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+* `example_attribute` - Concise description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+* `create` - (Default `60m`)
+* `update` - (Default `180m`)
+* `delete` - (Default `90m`)
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Cost Optimization Hub Enrollment Status using the `example_id_arg`. For example:
+
+```terraform
+import {
+  to = aws_costoptimizationhub_enrollment_status.example
+  id = "enrollment_status-id-12345678"
+}
+```
+
+Using `terraform import`, import Cost Optimization Hub Enrollment Status using the `example_id_arg`. For example:
+
+```console
+% terraform import aws_costoptimizationhub_enrollment_status.example enrollment_status-id-12345678
+```

--- a/website/docs/r/costoptimizationhub_enrollment_status.html.markdown
+++ b/website/docs/r/costoptimizationhub_enrollment_status.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Terraform resource for managing AWS Cost Optimization Hub Enrollment Status.
 
+-> **TIP:** The Cost Optimization Hub only has a `us-east-1` endpoint. However, you can access the service globally with the AWS Provider from other regions. Other tools, such as the [AWS CLI](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cost-optimization-hub/index.html), may require you to specify the `us-east-1` region when using the service.
+
 ## Example Usage
 
 ### Basic Usage
@@ -31,18 +33,17 @@ resource "aws_costoptimizationhub_enrollment_status" "example" {
 
 The following arguments are optional:
 
-* `include_member_accounts` - (Optional) Flag to enroll member accounts of the organization if the account is the management account. Default value is `false`
+* `include_member_accounts` - (Optional) Flag to enroll member accounts of the organization if the account is the management account. No drift detection is currently supported for this argument. Default value is `false`. 
 
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `id` - Unique identifier for the enrollment. Since enrollment is for the entire account, this will be the 12-digit account id.
-* `status` - Status of enrollment. When the resource is present in Terraform, it's status will always be `Active`
+* `status` - Status of enrollment. When the resource is present in Terraform, its status will always be `Active`.
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Cost Optimization Hub Enrollment Status using the `id`. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Cost Optimization Hub Enrollment Status using your AWS account ID. For example:
 
 ```terraform
 import {
@@ -51,7 +52,7 @@ import {
 }
 ```
 
-Using `terraform import`, import Cost Optimization Hub Enrollment Status using the `id`. For example:
+Using `terraform import`, import Cost Optimization Hub Enrollment Status using your AWS account ID. For example:
 
 ```console
 % terraform import aws_costoptimizationhub_enrollment_status.example 111222333444

--- a/website/docs/r/costoptimizationhub_enrollment_status.html.markdown
+++ b/website/docs/r/costoptimizationhub_enrollment_status.html.markdown
@@ -33,7 +33,7 @@ resource "aws_costoptimizationhub_enrollment_status" "example" {
 
 The following arguments are optional:
 
-* `include_member_accounts` - (Optional) Flag to enroll member accounts of the organization if the account is the management account. No drift detection is currently supported for this argument. Default value is `false`. 
+* `include_member_accounts` - (Optional) Flag to enroll member accounts of the organization if the account is the management account. No drift detection is currently supported for this argument. Default value is `false`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This change adds a new resource to Cost Optimization Hub

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Related #34588

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/costoptimizationhub
https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_Operations_Cost_Optimization_Hub.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
bash-3.2$ make testacc PKG=costoptimizationhub
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/costoptimizationhub/... -v -count 1 -parallel 20   -timeout 360m
=== RUN   TestAccCostOptimizationHub_serial
=== PAUSE TestAccCostOptimizationHub_serial
=== RUN   TestEndpointConfiguration
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_service_config_file
=== RUN   TestEndpointConfiguration/service_aws_envvar_overrides_service_config_file
=== RUN   TestEndpointConfiguration/service_config_file
=== RUN   TestEndpointConfiguration/package_name_endpoint_config
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_aws_service_envvar
=== RUN   TestEndpointConfiguration/base_endpoint_envvar_overrides_base_config_file
=== RUN   TestEndpointConfiguration/service_config_file_overrides_base_config_file
=== RUN   TestEndpointConfiguration/no_config
=== RUN   TestEndpointConfiguration/service_aws_envvar_overrides_base_envvar
=== RUN   TestEndpointConfiguration/base_endpoint_envvar
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_base_config_file
=== RUN   TestEndpointConfiguration/service_aws_envvar
=== RUN   TestEndpointConfiguration/service_aws_envvar_overrides_base_config_file
=== RUN   TestEndpointConfiguration/base_endpoint_envvar_overrides_service_config_file
=== RUN   TestEndpointConfiguration/base_endpoint_config_file
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_base_envvar
--- PASS: TestEndpointConfiguration (0.71s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_service_config_file (0.06s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar_overrides_service_config_file (0.04s)
    --- PASS: TestEndpointConfiguration/service_config_file (0.04s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config (0.09s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_aws_service_envvar (0.05s)
    --- PASS: TestEndpointConfiguration/base_endpoint_envvar_overrides_base_config_file (0.03s)
    --- PASS: TestEndpointConfiguration/service_config_file_overrides_base_config_file (0.03s)
    --- PASS: TestEndpointConfiguration/no_config (0.03s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar_overrides_base_envvar (0.04s)
    --- PASS: TestEndpointConfiguration/base_endpoint_envvar (0.04s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_base_config_file (0.05s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar (0.03s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar_overrides_base_config_file (0.04s)
    --- PASS: TestEndpointConfiguration/base_endpoint_envvar_overrides_service_config_file (0.04s)
    --- PASS: TestEndpointConfiguration/base_endpoint_config_file (0.04s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_base_envvar (0.06s)
=== CONT  TestAccCostOptimizationHub_serial
=== RUN   TestAccCostOptimizationHub_serial/EnrollmentStatus
=== RUN   TestAccCostOptimizationHub_serial/EnrollmentStatus/basic
=== RUN   TestAccCostOptimizationHub_serial/EnrollmentStatus/disappears
=== RUN   TestAccCostOptimizationHub_serial/EnrollmentStatus/includeMemberAccounts
--- PASS: TestAccCostOptimizationHub_serial (42.65s)
    --- PASS: TestAccCostOptimizationHub_serial/EnrollmentStatus (42.65s)
        --- PASS: TestAccCostOptimizationHub_serial/EnrollmentStatus/basic (15.21s)
        --- PASS: TestAccCostOptimizationHub_serial/EnrollmentStatus/disappears (13.73s)
        --- PASS: TestAccCostOptimizationHub_serial/EnrollmentStatus/includeMemberAccounts (13.71s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/costoptimizationhub        48.111s
```
