### PR TITLE
chore: allow a minimum of 1 worker for a Glue Job

### DIFF
--- a/.changelog/36458.txt
+++ b/.changelog/36458.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_glue_job: Set the `number_of_workers` to a minimum of 1.
+resource/aws_glue_job: Adjust `number_of_workers` minimum value to `1`
 ```

--- a/.changelog/36458.txt
+++ b/.changelog/36458.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_glue_job: Set the `number_of_workers` to a minimum of 1.
+```

--- a/internal/service/glue/job.go
+++ b/internal/service/glue/job.go
@@ -154,7 +154,7 @@ func ResourceJob() *schema.Resource {
 				Type:          schema.TypeInt,
 				Optional:      true,
 				ConflictsWith: []string{"max_capacity"},
-				ValidateFunc:  validation.IntAtLeast(2),
+				ValidateFunc:  validation.IntAtLeast(1),
 			},
 			"role_arn": {
 				Type:         schema.TypeString,

--- a/internal/service/glue/job_test.go
+++ b/internal/service/glue/job_test.go
@@ -994,7 +994,7 @@ func testAccJobConfig_executionClass(rName, executionClass string) string {
 resource "aws_glue_job" "test" {
   execution_class   = %[2]q
   name              = %[1]q
-  number_of_workers = 1
+  number_of_workers = 2
   role_arn          = aws_iam_role.test.arn
   worker_type       = "G.1X"
   glue_version      = "3.0"

--- a/internal/service/glue/job_test.go
+++ b/internal/service/glue/job_test.go
@@ -976,7 +976,7 @@ func testAccJobConfig_versionNumberOfWorkers(rName, glueVersion string) string {
 resource "aws_glue_job" "test" {
   glue_version      = %[1]q
   name              = %[2]q
-  number_of_workers = 2
+  number_of_workers = 1
   role_arn          = aws_iam_role.test.arn
   worker_type       = "Standard"
 
@@ -994,7 +994,7 @@ func testAccJobConfig_executionClass(rName, executionClass string) string {
 resource "aws_glue_job" "test" {
   execution_class   = %[2]q
   name              = %[1]q
-  number_of_workers = 2
+  number_of_workers = 1
   role_arn          = aws_iam_role.test.arn
   worker_type       = "G.1X"
   glue_version      = "3.0"
@@ -1102,7 +1102,7 @@ func testAccJobConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(testAccJobConfig_base(rName), fmt.Sprintf(`
 resource "aws_glue_job" "test" {
   name              = %[1]q
-  number_of_workers = 2
+  number_of_workers = 1
   role_arn          = aws_iam_role.test.arn
   worker_type       = "Standard"
 
@@ -1123,7 +1123,7 @@ func testAccJobConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string
 	return acctest.ConfigCompose(testAccJobConfig_base(rName), fmt.Sprintf(`
 resource "aws_glue_job" "test" {
   name              = %[1]q
-  number_of_workers = 2
+  number_of_workers = 1
   role_arn          = aws_iam_role.test.arn
   worker_type       = "Standard"
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Lower the minimum of `number_of_workers` to 1


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #23372

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
make testacc TESTS=TestAccGlueJob_ PKG=glue
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/glue/... -v -count 1 -parallel 20 -run='TestAccGlueJob_'  -timeout 360m
=== RUN   TestAccGlueJob_basic
=== PAUSE TestAccGlueJob_basic
=== RUN   TestAccGlueJob_disappears
=== PAUSE TestAccGlueJob_disappears
=== RUN   TestAccGlueJob_basicStreaming
=== PAUSE TestAccGlueJob_basicStreaming
=== RUN   TestAccGlueJob_command
=== PAUSE TestAccGlueJob_command
=== RUN   TestAccGlueJob_defaultArguments
=== PAUSE TestAccGlueJob_defaultArguments
=== RUN   TestAccGlueJob_nonOverridableArguments
=== PAUSE TestAccGlueJob_nonOverridableArguments
=== RUN   TestAccGlueJob_description
=== PAUSE TestAccGlueJob_description
=== RUN   TestAccGlueJob_glueVersion
=== PAUSE TestAccGlueJob_glueVersion
=== RUN   TestAccGlueJob_executionClass
=== PAUSE TestAccGlueJob_executionClass
=== RUN   TestAccGlueJob_executionProperty
=== PAUSE TestAccGlueJob_executionProperty
=== RUN   TestAccGlueJob_maxRetries
=== PAUSE TestAccGlueJob_maxRetries
=== RUN   TestAccGlueJob_notificationProperty
=== PAUSE TestAccGlueJob_notificationProperty
=== RUN   TestAccGlueJob_tags
=== PAUSE TestAccGlueJob_tags
=== RUN   TestAccGlueJob_streamingTimeout
=== PAUSE TestAccGlueJob_streamingTimeout
=== RUN   TestAccGlueJob_timeout
=== PAUSE TestAccGlueJob_timeout
=== RUN   TestAccGlueJob_security
=== PAUSE TestAccGlueJob_security
=== RUN   TestAccGlueJob_workerType
=== PAUSE TestAccGlueJob_workerType
=== RUN   TestAccGlueJob_pythonShell
=== PAUSE TestAccGlueJob_pythonShell
=== RUN   TestAccGlueJob_rayJob
=== PAUSE TestAccGlueJob_rayJob
=== RUN   TestAccGlueJob_maxCapacity
=== PAUSE TestAccGlueJob_maxCapacity
=== CONT  TestAccGlueJob_basic
=== CONT  TestAccGlueJob_maxRetries
=== CONT  TestAccGlueJob_security
=== CONT  TestAccGlueJob_nonOverridableArguments
=== CONT  TestAccGlueJob_executionProperty
=== CONT  TestAccGlueJob_executionClass
=== CONT  TestAccGlueJob_glueVersion
=== CONT  TestAccGlueJob_description
=== CONT  TestAccGlueJob_streamingTimeout
=== CONT  TestAccGlueJob_timeout
=== CONT  TestAccGlueJob_tags
=== CONT  TestAccGlueJob_rayJob
=== CONT  TestAccGlueJob_maxCapacity
=== CONT  TestAccGlueJob_command
=== CONT  TestAccGlueJob_defaultArguments
=== CONT  TestAccGlueJob_basicStreaming
=== CONT  TestAccGlueJob_disappears
=== CONT  TestAccGlueJob_notificationProperty
=== CONT  TestAccGlueJob_pythonShell
=== CONT  TestAccGlueJob_workerType
=== NAME  TestAccGlueJob_basicStreaming
    job_test.go:92: Step 1/2 error: Error running apply: exit status 1

        Error: creating Glue Job (tf-acc-test-4945447631411293439): InvalidInputException: Glue version null is not supported for this region
        {
          RespMetadata: {
            StatusCode: 400,
            RequestID: "676a9b1b-0069-4536-b50d-834ef1375533"
          },
          Message_: "Glue version null is not supported for this region"
        }

          with aws_glue_job.test,
          on terraform_plugin_test.tf line 43, in resource "aws_glue_job" "test":
          43: resource "aws_glue_job" "test" {

--- FAIL: TestAccGlueJob_basicStreaming (20.52s)
--- PASS: TestAccGlueJob_rayJob (35.85s)
--- PASS: TestAccGlueJob_basic (36.40s)
--- PASS: TestAccGlueJob_security (56.16s)
--- PASS: TestAccGlueJob_executionClass (56.42s)
--- PASS: TestAccGlueJob_command (56.57s)
--- PASS: TestAccGlueJob_streamingTimeout (56.94s)
--- PASS: TestAccGlueJob_timeout (56.94s)
--- PASS: TestAccGlueJob_description (56.97s)
--- PASS: TestAccGlueJob_maxCapacity (57.10s)
--- PASS: TestAccGlueJob_nonOverridableArguments (58.09s)
--- PASS: TestAccGlueJob_notificationProperty (58.21s)
--- PASS: TestAccGlueJob_defaultArguments (58.81s)
--- PASS: TestAccGlueJob_executionProperty (59.42s)
--- PASS: TestAccGlueJob_maxRetries (59.92s)
--- PASS: TestAccGlueJob_disappears (60.32s)
--- PASS: TestAccGlueJob_tags (69.22s)
--- PASS: TestAccGlueJob_glueVersion (70.31s)
--- PASS: TestAccGlueJob_workerType (70.86s)
--- PASS: TestAccGlueJob_pythonShell (86.53s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/glue       90.286s
FAIL
make: *** [testacc] Error 1
```
