### PR TITLE
docs: cleanup developer reference section

### DIFF
--- a/docs/aws-go-sdk-base.md
+++ b/docs/aws-go-sdk-base.md
@@ -1,7 +1,0 @@
-# aws-go-sdk-base
-
-[https://github.com/hashicorp/aws-sdk-go-base](https://github.com/hashicorp/aws-sdk-go-base)
-
-This is a base library used by the [AWS Provider](https://github.com/hashicorp/terraform-provider-aws), [AWSCC Provider](https://github.com/hashicorp/terraform-provider-awscc) and the [Terraform S3 Backend](https://github.com/hashicorp/terraform/tree/main/internal/backend/remote-state/s3) to allow them to handle authentication and other non-service level AWS interactions consistently.
-
-Typically this changes infrequently and changes are normally performed by HashiCorp maintainers. It should not be necessary to change this library for the majority of provider contributions.

--- a/docs/aws-sdk-go-base.md
+++ b/docs/aws-sdk-go-base.md
@@ -1,0 +1,6 @@
+# AWS SDK Go Base
+
+[AWS SDK Go Base](https://github.com/hashicorp/aws-sdk-go-base) is a shared library used by the [AWS Provider](https://github.com/hashicorp/terraform-provider-aws), [AWSCC Provider](https://github.com/hashicorp/terraform-provider-awscc) and the [Terraform S3 Backend](https://github.com/hashicorp/terraform/tree/main/internal/backend/remote-state/s3) to handle authentication and other non-service level AWS interactions consistently.
+
+Changes are infrequent and normally performed by HashiCorp maintainers.
+It should not be necessary to change this library for the majority of provider contributions.

--- a/docs/terraform-plugin-migrations.md
+++ b/docs/terraform-plugin-migrations.md
@@ -1,4 +1,4 @@
-# Migrating from Terraform SDKv2 to Framework
+# Terraform Plugin Migrations
 
 With the introduction of [Terraform Plugin Framework](https://developer.hashicorp.com/terraform/plugin/framework) it will become necessary to migrate existing resources from SDKv2. The Provider currently implements both plugins so migration can be done at a resource level.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,7 +37,7 @@ nav:
       - AWS SDK for Go Migrations: aws-go-sdk-migrations.md
       - Terraform Plugin Development Packages: terraform-plugin-development-packages.md
       - Terraform Plugin Migrations: terraform-plugin-migrations.md
-      - AWS Go SDK Base: aws-go-sdk-base.md
+      - AWS SDK Go Base: aws-sdk-go-base.md
       - Error Handling: error-handling.md
       - Provider Design: provider-design.md
       - Provider Scaffolding (skaff): skaff.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,21 +29,21 @@ nav:
       - How We Prioritize: prioritization.md
   - Developer Reference:
       - Acceptance Test Environment Variables: acc-test-environment-variables.md
-      - Data Handling and Conversion: data-handling-and-conversion.md
-      - Debugging: debugging.md
-      - Design Decision Log: design-decision-log.md
-      - Dependency Updates: dependency-updates.md
       - AWS SDK for Go Versions: aws-go-sdk-versions.md
       - AWS SDK for Go Migrations: aws-go-sdk-migrations.md
-      - Terraform Plugin Development Packages: terraform-plugin-development-packages.md
-      - Terraform Plugin Migrations: terraform-plugin-migrations.md
       - AWS SDK Go Base: aws-sdk-go-base.md
+      - Data Handling and Conversion: data-handling-and-conversion.md
+      - Debugging: debugging.md
+      - Dependency Updates: dependency-updates.md
+      - Design Decision Log: design-decision-log.md
       - Error Handling: error-handling.md
+      - Naming Standards: naming.md
       - Provider Design: provider-design.md
       - Provider Scaffolding (skaff): skaff.md
-      - Naming Standards: naming.md
-      - Retries and Waiters: retries-and-waiters.md
       - Regular Expressions: regular-expressions.md
+      - Retries and Waiters: retries-and-waiters.md
+      - Terraform Plugin Development Packages: terraform-plugin-development-packages.md
+      - Terraform Plugin Migrations: terraform-plugin-migrations.md
   - Submit an Issue: issue-reporting-and-lifecycle.md
   - FAQ: faq.md
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,7 +27,6 @@ nav:
       - Changelog Process: changelog-process.md
       - Raising a Pull Request: raising-a-pull-request.md
       - How We Prioritize: prioritization.md
-      - Migrating from SDKv2 to Framework: migrate-from-sdk-to-framework.md
   - Developer Reference:
       - Acceptance Test Environment Variables: acc-test-environment-variables.md
       - Data Handling and Conversion: data-handling-and-conversion.md
@@ -37,6 +36,7 @@ nav:
       - AWS SDK for Go Versions: aws-go-sdk-versions.md
       - AWS SDK for Go Migrations: aws-go-sdk-migrations.md
       - Terraform Plugin Development Packages: terraform-plugin-development-packages.md
+      - Terraform Plugin Migrations: terraform-plugin-migrations.md
       - AWS Go SDK Base: aws-go-sdk-base.md
       - Error Handling: error-handling.md
       - Provider Design: provider-design.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ nav:
       - AWS SDK for Go Versions: aws-go-sdk-versions.md
       - AWS SDK for Go Migrations: aws-go-sdk-migrations.md
       - AWS SDK Go Base: aws-sdk-go-base.md
+      - Core Services: core-services.md
       - Data Handling and Conversion: data-handling-and-conversion.md
       - Debugging: debugging.md
       - Dependency Updates: dependency-updates.md


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Miscellaneous cleanup of the developer reference section of the contributor guide, including:
- Moving the `Terraform Plugin Migration` document from the `Contribute` section to `Developer Reference` for consistency with the `AWS SDK for Go Migration` documentation.
- Fixing naming of the `AWS SDK Go Base` and minor cleanup.
- Alphabetizing the developer reference navbar.
