### PR TITLE
aws_transfer_ssh_key: Fix typos in error messages

### DIFF
--- a/internal/service/transfer/ssh_key_test.go
+++ b/internal/service/transfer/ssh_key_test.go
@@ -64,7 +64,7 @@ func testAccCheckSSHKeyExists(ctx context.Context, n string, res *transfer.SshPu
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No Transfer Ssh Public Key ID is set")
+			return fmt.Errorf("Transfer SSH Public Key ID not set")
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).TransferConn(ctx)
@@ -89,7 +89,7 @@ func testAccCheckSSHKeyExists(ctx context.Context, n string, res *transfer.SshPu
 			}
 		}
 
-		return fmt.Errorf("Transfer Ssh Public Key doesn't exists.")
+		return fmt.Errorf("Transfer SSH Public Key does not exist")
 	}
 }
 

--- a/website/docs/r/transfer_ssh_key.html.markdown
+++ b/website/docs/r/transfer_ssh_key.html.markdown
@@ -13,10 +13,15 @@ Provides a AWS Transfer User SSH Key resource.
 ## Example Usage
 
 ```terraform
+resource "tls_private_key" "example" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
 resource "aws_transfer_ssh_key" "example" {
   server_id = aws_transfer_server.example.id
   user_name = aws_transfer_user.example.user_name
-  body      = "... SSH key ..."
+  body      = trimspace(tls_private_key.example.public_key_openssh)
 }
 
 resource "aws_transfer_server" "example" {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
- Fix a couple typos and grammar errors in the acceptance test suite for `aws_transfer_ssh_key`
- Update the example in the `aws_transfer_ssh_key` docs to use [tls_private_key](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key#public_key_openssh) in OpenSSH format and with the `trimspace()` function

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.
---->
N/A


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
N/A

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

N/A
