### PR TITLE
flex: Add helpers for AWS SDK v2

### DIFF
--- a/internal/flex/flex_test.go
+++ b/internal/flex/flex_test.go
@@ -370,3 +370,99 @@ func TestDiffStringMaps(t *testing.T) {
 		}
 	}
 }
+
+func TestDiffStringValueMaps(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Old, New                  map[string]interface{}
+		Create, Remove, Unchanged map[string]string
+	}{
+		// Add
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"foo": "bar",
+				"bar": "baz",
+			},
+			Create: map[string]string{
+				"bar": "baz",
+			},
+			Remove: map[string]string{},
+			Unchanged: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Modify
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"foo": "baz",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+			Unchanged: map[string]string{},
+		},
+
+		// Overlap
+		{
+			Old: map[string]interface{}{
+				"foo":   "bar",
+				"hello": "world",
+			},
+			New: map[string]interface{}{
+				"foo":   "baz",
+				"hello": "world",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+			Unchanged: map[string]string{
+				"hello": "world",
+			},
+		},
+
+		// Remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+				"bar": "baz",
+			},
+			New: map[string]interface{}{
+				"foo": "bar",
+			},
+			Create: map[string]string{},
+			Remove: map[string]string{
+				"bar": "baz",
+			},
+			Unchanged: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		c, r, u := DiffStringValueMaps(tc.Old, tc.New)
+		if diff := cmp.Diff(c, tc.Create); diff != "" {
+			t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+		}
+		if diff := cmp.Diff(r, tc.Remove); diff != "" {
+			t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+		}
+		if diff := cmp.Diff(u, tc.Unchanged); diff != "" {
+			t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+		}
+	}
+}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
When migrating `apigateway` and `apigatewayv2` I came across a couple of conversions that would be useful to have in `flex`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make test
==> Checking that code complies with gofmt requirements...
go1.21.8 test ./...  -timeout=5m
?   	github.com/hashicorp/terraform-provider-aws	[no test files]
?   	github.com/hashicorp/terraform-provider-aws/internal/attrmap	[no test files]
ok  	github.com/hashicorp/terraform-provider-aws/internal/acctest	(cached)
ok  	github.com/hashicorp/terraform-provider-aws/internal/conns	(cached)
ok  	github.com/hashicorp/terraform-provider-aws/internal/create	(cached)
ok  	github.com/hashicorp/terraform-provider-aws/internal/enum	(cached)
ok  	github.com/hashicorp/terraform-provider-aws/internal/envvar	(cached)
ok  	github.com/hashicorp/terraform-provider-aws/internal/errs	(cached)
ok  	github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag	(cached)
ok  	github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag	(cached)
?   	github.com/hashicorp/terraform-provider-aws/internal/experimental/sync	[no test files]
ok  	github.com/hashicorp/terraform-provider-aws/internal/experimental/depgraph	(cached)
?   	github.com/hashicorp/terraform-provider-aws/internal/framework	[no test files]
ok  	github.com/hashicorp/terraform-provider-aws/internal/flex	0.009s
...
```