### PR TITLE
d/aws_redshift_producer_data_shares: new data source

### DIFF
--- a/.changelog/36481.txt
+++ b/.changelog/36481.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_redshift_producer_data_shares
+```

--- a/internal/service/redshift/producer_data_shares_data_source.go
+++ b/internal/service/redshift/producer_data_shares_data_source.go
@@ -1,0 +1,120 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package redshift
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/redshift"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/redshift/types"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource(name="Producer Data Shares")
+func newDataSourceProducerDataShares(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &dataSourceProducerDataShares{}, nil
+}
+
+const (
+	DSNameProducerDataShares = "Producer Data Shares Data Source"
+)
+
+type dataSourceProducerDataShares struct {
+	framework.DataSourceWithConfigure
+}
+
+func (d *dataSourceProducerDataShares) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) { // nosemgrep:ci.meta-in-func-name
+	resp.TypeName = "aws_redshift_producer_data_shares"
+}
+
+func (d *dataSourceProducerDataShares) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": framework.IDAttribute(),
+			"producer_arn": schema.StringAttribute{
+				CustomType: fwtypes.ARNType,
+				Required:   true,
+			},
+			"status": schema.StringAttribute{
+				CustomType: fwtypes.StringEnumType[awstypes.DataShareStatusForProducer](),
+				Optional:   true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"data_shares": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[dataSharesData](ctx),
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"data_share_arn": schema.StringAttribute{
+							Computed: true,
+						},
+						"managed_by": schema.StringAttribute{
+							Computed: true,
+						},
+						"producer_arn": schema.StringAttribute{
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+func (d *dataSourceProducerDataShares) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	conn := d.Meta().RedshiftClient(ctx)
+
+	var data dataSourceProducerDataSharesData
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	data.ID = types.StringValue(data.ProducerARN.ValueString())
+
+	input := &redshift.DescribeDataSharesForProducerInput{
+		ProducerArn: aws.String(data.ProducerARN.ValueString()),
+	}
+	if !data.Status.IsNull() {
+		input.Status = awstypes.DataShareStatusForProducer(data.Status.ValueString())
+	}
+
+	paginator := redshift.NewDescribeDataSharesForProducerPaginator(conn, input)
+
+	var out redshift.DescribeDataSharesForProducerOutput
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.Redshift, create.ErrActionReading, DSNameProducerDataShares, data.ID.String(), err),
+				err.Error(),
+			)
+			return
+		}
+
+		if page != nil && len(page.DataShares) > 0 {
+			out.DataShares = append(out.DataShares, page.DataShares...)
+		}
+	}
+
+	resp.Diagnostics.Append(flex.Flatten(ctx, out, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+type dataSourceProducerDataSharesData struct {
+	DataShares  fwtypes.ListNestedObjectValueOf[dataSharesData]         `tfsdk:"data_shares"`
+	ID          types.String                                            `tfsdk:"id"`
+	Status      fwtypes.StringEnum[awstypes.DataShareStatusForProducer] `tfsdk:"status"`
+	ProducerARN fwtypes.ARN                                             `tfsdk:"producer_arn"`
+}

--- a/internal/service/redshift/producer_data_shares_data_source_test.go
+++ b/internal/service/redshift/producer_data_shares_data_source_test.go
@@ -1,0 +1,92 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package redshift_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/YakDriver/regexache"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccRedshiftProducerDataSharesDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_redshift_producer_data_shares.test"
+	namespaceResourceName := "aws_redshiftserverless_namespace.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.RedshiftEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.RedshiftServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProducerDataSharesDataSourceConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "producer_arn", namespaceResourceName, "arn"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_shares.#"),
+					resource.TestMatchTypeSetElemNestedAttrs(dataSourceName, "data_shares.*", map[string]*regexp.Regexp{
+						"data_share_arn": regexache.MustCompile(`datashare:+.`),
+						"producer_arn":   regexache.MustCompile(`namespace/+.`),
+					}),
+				),
+			},
+		},
+	})
+}
+
+func testAccProducerDataSharesDataSourceConfig_basic(rName string) string {
+	return acctest.ConfigCompose(
+		fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+resource "aws_redshiftserverless_namespace" "test" {
+  namespace_name = %[1]q
+  db_name        = "test"
+}
+
+resource "aws_redshiftserverless_workgroup" "test" {
+  namespace_name = aws_redshiftserverless_namespace.test.namespace_name
+  workgroup_name = %[1]q
+}
+
+resource "aws_redshiftdata_statement" "test_create" {
+  workgroup_name = aws_redshiftserverless_workgroup.test.workgroup_name
+  database       = aws_redshiftserverless_namespace.test.db_name
+  sql            = "CREATE DATASHARE tfacctest;"
+}
+`, rName),
+		// Split this resource into a string literal so the terraform `format` function
+		// interpolates properly.
+		//
+		// Grant statement must be run before the data share will be returned from the
+		// DescribeDataShares API.
+		`
+resource "aws_redshiftdata_statement" "test_grant_usage" {
+  depends_on     = [aws_redshiftdata_statement.test_create]
+  workgroup_name = aws_redshiftserverless_workgroup.test.workgroup_name
+  database       = aws_redshiftserverless_namespace.test.db_name
+  sql            = format("GRANT USAGE ON DATASHARE tfacctest TO ACCOUNT '%s';", data.aws_caller_identity.current.account_id)
+}
+
+data "aws_redshift_producer_data_shares" "test" {
+  depends_on = [aws_redshiftdata_statement.test_grant_usage]
+
+  producer_arn = aws_redshiftserverless_namespace.test.arn
+}
+`)
+}

--- a/internal/service/redshift/service_package_gen.go
+++ b/internal/service/redshift/service_package_gen.go
@@ -23,6 +23,10 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.Serv
 			Factory: newDataSourceDataShares,
 			Name:    "Data Shares",
 		},
+		{
+			Factory: newDataSourceProducerDataShares,
+			Name:    "Producer Data Shares",
+		},
 	}
 }
 

--- a/website/docs/d/redshift_producer_data_shares.html.markdown
+++ b/website/docs/d/redshift_producer_data_shares.html.markdown
@@ -1,0 +1,44 @@
+---
+subcategory: "Redshift"
+layout: "aws"
+page_title: "AWS: aws_redshift_producer_data_shares"
+description: |-
+  Terraform data source for managing AWS Redshift Producer Data Shares.
+---
+
+# Data Source: aws_redshift_producer_data_shares
+
+Terraform data source for managing AWS Redshift Producer Data Shares.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_redshift_producer_data_shares" "example" {
+  producer_arn = ""
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `producer_arn` - (Required) Amazon Resource Name (ARN) of the producer namespace that returns in the list of datashares.
+
+The following arguments are optional:
+
+* `status` - (Optional) Status of a datashare in the producer. Valid values are `ACTIVE`, `AUTHORIZED`, `PENDING_AUTHORIZATION`, `DEAUTHORIZED`, and `REJECTED`. Omit this argument to return all statuses.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `id` - Producer ARN.
+* `data_shares` - An array of all data shares in the producer. See [`data_shares`](#data_shares-attribute-reference) below.
+
+### `data_shares` Attribute Reference
+
+* `data_share_arn` - ARN (Amazon Resource Name) of the data share.
+* `managed_by` - Identifier of a datashare to show its managing entity.
+* `producer_arn` - ARN (Amazon Resource Name) of the producer.


### PR DESCRIPTION



<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This data source will allow practitioners to list existing Redshift data shares in a given producer.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #35916

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/redshift/latest/APIReference/API_DescribeDataSharesForProducer.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->


```console
% make testacc PKG=redshift TESTS=TestAccRedshiftProducerDataSharesDataSource_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/redshift/... -v -count 1 -parallel 20 -run='TestAccRedshiftProducerDataSharesDataSource_'  -timeout 360m

--- PASS: TestAccRedshiftProducerDataSharesDataSource_basic (487.34s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/redshift   491.714s
```
