### PR TITLE
Bugfix: Resource aws_eks_access_entry only updates group OR username

### DIFF
--- a/.changelog/36484.txt
+++ b/.changelog/36484.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_eks_access_entry: Always send `kubernetes_groups` and `username` values on update when configured
+resource/aws_eks_access_entry: Always send `kubernetes_groups` and `user_name` values on update when configured
 ```

--- a/.changelog/36484.txt
+++ b/.changelog/36484.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_eks_access_entry: Fix partial updates to only kubernetes_groups or username reverting values to defaults.
+```

--- a/.changelog/36484.txt
+++ b/.changelog/36484.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_eks_access_entry: Fix partial updates to only kubernetes_groups or username reverting values to defaults.
+resource/aws_eks_access_entry: Always send `kubernetes_groups` and `username` values on update when configured
 ```

--- a/internal/service/eks/access_entry.go
+++ b/internal/service/eks/access_entry.go
@@ -183,13 +183,8 @@ func resourceAccessEntryUpdate(ctx context.Context, d *schema.ResourceData, meta
 			PrincipalArn: aws.String(principalARN),
 		}
 
-		if d.HasChange("kubernetes_groups") {
-			input.KubernetesGroups = flex.ExpandStringValueSet(d.Get("kubernetes_groups").(*schema.Set))
-		}
-
-		if d.HasChange("user_name") {
-			input.Username = aws.String(d.Get("user_name").(string))
-		}
+		input.KubernetesGroups = flex.ExpandStringValueSet(d.Get("kubernetes_groups").(*schema.Set))
+		input.Username = aws.String(d.Get("user_name").(string))
 
 		_, err = conn.UpdateAccessEntry(ctx, input)
 

--- a/internal/service/eks/access_entry_test.go
+++ b/internal/service/eks/access_entry_test.go
@@ -236,6 +236,8 @@ func TestAccEKSAccessEntry_username(t *testing.T) {
 				Config: testAccAccessEntryConfig_username(rName, "user1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAccessEntryExists(ctx, resourceName, &accessentry),
+					resource.TestCheckResourceAttr(resourceName, "kubernetes_groups.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "kubernetes_groups.*", "ae-test"),
 					resource.TestCheckResourceAttr(resourceName, "type", "STANDARD"),
 					resource.TestCheckResourceAttr(resourceName, "user_name", "user1"),
 				),
@@ -249,6 +251,8 @@ func TestAccEKSAccessEntry_username(t *testing.T) {
 				Config: testAccAccessEntryConfig_username(rName, "user2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAccessEntryExists(ctx, resourceName, &accessentry),
+					resource.TestCheckResourceAttr(resourceName, "kubernetes_groups.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "kubernetes_groups.*", "ae-test"),
 					resource.TestCheckResourceAttr(resourceName, "type", "STANDARD"),
 					resource.TestCheckResourceAttr(resourceName, "user_name", "user2"),
 				),
@@ -528,6 +532,8 @@ resource "aws_eks_access_entry" "test" {
 
   type      = "STANDARD"
   user_name = %[2]q
+
+  kubernetes_groups = ["ae-test"]
 }
 `, rName, username))
 }


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The problematic behavior is pretty well explained in https://github.com/hashicorp/terraform-provider-aws/issues/36480 so I'm not going to repeat that here, but there is a problem with updating an aws_eks_access_entry where omitting certain fields will not keep them as-is, but replace it with the default that AWS has. So this is consistent AWS API behavior that is currently not modeled correctly in the AWS provider.

After implementing this fix, the behavior is correct and you can update only the username or kubernetes_groups without impacting the other.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #36480
