### PR TITLE
r/aws_devopsguru_event_sources_config: new resource

### DIFF
--- a/.changelog/36485.txt
+++ b/.changelog/36485.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_devopsguru_event_sources_config
+```

--- a/internal/service/devopsguru/devopsguru_test.go
+++ b/internal/service/devopsguru/devopsguru_test.go
@@ -1,0 +1,23 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package devopsguru_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccDevOpsGuru_serial(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]map[string]func(t *testing.T){
+		"EventSourcesConfig": {
+			"basic":      testAccEventSourcesConfig_basic,
+			"disappears": testAccEventSourcesConfig_disappears,
+		},
+	}
+
+	acctest.RunSerialTests2Levels(t, testCases, 0)
+}

--- a/internal/service/devopsguru/event_sources_config.go
+++ b/internal/service/devopsguru/event_sources_config.go
@@ -1,0 +1,196 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package devopsguru
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/devopsguru"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/devopsguru/types"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource(name="Event Sources Config")
+func newResourceEventSourcesConfig(_ context.Context) (resource.ResourceWithConfigure, error) {
+	return &resourceEventSourcesConfig{}, nil
+}
+
+const (
+	ResNameEventSourcesConfig = "Event Sources Config"
+)
+
+type resourceEventSourcesConfig struct {
+	framework.ResourceWithConfigure
+}
+
+func (r *resourceEventSourcesConfig) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "aws_devopsguru_event_sources_config"
+}
+
+func (r *resourceEventSourcesConfig) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": framework.IDAttribute(),
+		},
+		Blocks: map[string]schema.Block{
+			"event_sources": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[eventSourcesData](ctx),
+				Validators: []validator.List{
+					listvalidator.IsRequired(),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Blocks: map[string]schema.Block{
+						"amazon_code_guru_profiler": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[amazonCodeGuruProfilerData](ctx),
+							Validators: []validator.List{
+								listvalidator.IsRequired(),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"status": schema.StringAttribute{
+										CustomType: fwtypes.StringEnumType[awstypes.EventSourceOptInStatus](),
+										Required:   true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.RequiresReplace(),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r *resourceEventSourcesConfig) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().DevOpsGuruClient(ctx)
+
+	var plan resourceEventSourcesConfigData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	plan.ID = types.StringValue(r.Meta().Region)
+
+	in := &devopsguru.UpdateEventSourcesConfigInput{}
+	resp.Diagnostics.Append(flex.Expand(ctx, &plan, in)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	_, err := conn.UpdateEventSourcesConfig(ctx, in)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.DevOpsGuru, create.ErrActionCreating, ResNameEventSourcesConfig, plan.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *resourceEventSourcesConfig) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().DevOpsGuruClient(ctx)
+
+	var state resourceEventSourcesConfigData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := findEventSourcesConfig(ctx, conn)
+	if tfresource.NotFound(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.DevOpsGuru, create.ErrActionSetting, ResNameEventSourcesConfig, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(flex.Flatten(ctx, out, &state)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *resourceEventSourcesConfig) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// Update is a no-op
+}
+
+func (r *resourceEventSourcesConfig) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	conn := r.Meta().DevOpsGuruClient(ctx)
+
+	var state resourceEventSourcesConfigData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := &devopsguru.UpdateEventSourcesConfigInput{
+		EventSources: &awstypes.EventSourcesConfig{
+			AmazonCodeGuruProfiler: &awstypes.AmazonCodeGuruProfilerIntegration{
+				Status: awstypes.EventSourceOptInStatusDisabled,
+			},
+		},
+	}
+
+	_, err := conn.UpdateEventSourcesConfig(ctx, in)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.DevOpsGuru, create.ErrActionDeleting, ResNameEventSourcesConfig, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+}
+
+func (r *resourceEventSourcesConfig) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func findEventSourcesConfig(ctx context.Context, conn *devopsguru.Client) (*devopsguru.DescribeEventSourcesConfigOutput, error) {
+	in := &devopsguru.DescribeEventSourcesConfigInput{}
+
+	out, err := conn.DescribeEventSourcesConfig(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+
+	if out == nil || out.EventSources == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return out, nil
+}
+
+type resourceEventSourcesConfigData struct {
+	EventSources fwtypes.ListNestedObjectValueOf[eventSourcesData] `tfsdk:"event_sources"`
+	ID           types.String                                      `tfsdk:"id"`
+}
+
+type eventSourcesData struct {
+	AmazonCodeGuruProfiler fwtypes.ListNestedObjectValueOf[amazonCodeGuruProfilerData] `tfsdk:"amazon_code_guru_profiler"`
+}
+
+type amazonCodeGuruProfilerData struct {
+	Status fwtypes.StringEnum[awstypes.EventSourceOptInStatus] `tfsdk:"status"`
+}

--- a/internal/service/devopsguru/event_sources_config_test.go
+++ b/internal/service/devopsguru/event_sources_config_test.go
@@ -1,0 +1,141 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package devopsguru_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/devopsguru"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/devopsguru/types"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tfdevopsguru "github.com/hashicorp/terraform-provider-aws/internal/service/devopsguru"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func testAccEventSourcesConfig_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	var cfg devopsguru.DescribeEventSourcesConfigOutput
+	resourceName := "aws_devopsguru_event_sources_config.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.DevOpsGuruEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DevOpsGuruServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEventSourcesConfigDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEventSourcesConfigConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEventSourcesConfigExists(ctx, resourceName, &cfg),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "event_sources.0.amazon_code_guru_profiler.*", map[string]string{
+						"status": "ENABLED",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccEventSourcesConfig_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	var eventsourcesconfig devopsguru.DescribeEventSourcesConfigOutput
+	resourceName := "aws_devopsguru_event_sources_config.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.DevOpsGuruEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DevOpsGuruServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEventSourcesConfigDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEventSourcesConfigConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEventSourcesConfigExists(ctx, resourceName, &eventsourcesconfig),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfdevopsguru.ResourceEventSourcesConfig, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckEventSourcesConfigDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).DevOpsGuruClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_devopsguru_event_sources_config" {
+				continue
+			}
+
+			out, err := tfdevopsguru.FindEventSourcesConfig(ctx, conn)
+			if out.EventSources == nil || out.EventSources.AmazonCodeGuruProfiler == nil {
+				return create.Error(names.DevOpsGuru, create.ErrActionCheckingDestroyed, tfdevopsguru.ResNameEventSourcesConfig, rs.Primary.ID, errors.New("empty output"))
+			}
+			if out.EventSources.AmazonCodeGuruProfiler.Status == awstypes.EventSourceOptInStatusDisabled {
+				return nil
+			}
+
+			if err != nil {
+				return create.Error(names.DevOpsGuru, create.ErrActionCheckingDestroyed, tfdevopsguru.ResNameEventSourcesConfig, rs.Primary.ID, err)
+			}
+			return create.Error(names.DevOpsGuru, create.ErrActionCheckingDestroyed, tfdevopsguru.ResNameEventSourcesConfig, rs.Primary.ID, errors.New("not destroyed"))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckEventSourcesConfigExists(ctx context.Context, name string, cfg *devopsguru.DescribeEventSourcesConfigOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.DevOpsGuru, create.ErrActionCheckingExistence, tfdevopsguru.ResNameEventSourcesConfig, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.DevOpsGuru, create.ErrActionCheckingExistence, tfdevopsguru.ResNameEventSourcesConfig, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).DevOpsGuruClient(ctx)
+
+		out, err := tfdevopsguru.FindEventSourcesConfig(ctx, conn)
+		if err != nil {
+			return create.Error(names.DevOpsGuru, create.ErrActionCheckingExistence, tfdevopsguru.ResNameEventSourcesConfig, rs.Primary.ID, err)
+		}
+
+		*cfg = *out
+
+		return nil
+	}
+}
+
+func testAccEventSourcesConfigConfig_basic() string {
+	return `
+resource "aws_devopsguru_event_sources_config" "test" {
+  event_sources {
+    amazon_code_guru_profiler {
+      status = "ENABLED"
+    }
+  }
+}
+`
+}

--- a/internal/service/devopsguru/exports_test.go
+++ b/internal/service/devopsguru/exports_test.go
@@ -1,0 +1,11 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package devopsguru
+
+// Exports for use in tests only.
+var (
+	ResourceEventSourcesConfig = newResourceEventSourcesConfig
+
+	FindEventSourcesConfig = findEventSourcesConfig
+)

--- a/internal/service/devopsguru/service_package_gen.go
+++ b/internal/service/devopsguru/service_package_gen.go
@@ -19,7 +19,12 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.Serv
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.ServicePackageFrameworkResource {
-	return []*types.ServicePackageFrameworkResource{}
+	return []*types.ServicePackageFrameworkResource{
+		{
+			Factory: newResourceEventSourcesConfig,
+			Name:    "Event Sources Config",
+		},
+	}
 }
 
 func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePackageSDKDataSource {

--- a/names/names.go
+++ b/names/names.go
@@ -43,6 +43,7 @@ const (
 	CognitoIdentityEndpointID            = "cognito-identity"
 	ComprehendEndpointID                 = "comprehend"
 	ConfigServiceEndpointID              = "config"
+	DevOpsGuruEndpointID                 = "devops-guru"
 	ECREndpointID                        = "api.ecr"
 	EKSEndpointID                        = "eks"
 	EMREndpointID                        = "elasticmapreduce"

--- a/website/docs/r/devopsguru_event_sources_config.html.markdown
+++ b/website/docs/r/devopsguru_event_sources_config.html.markdown
@@ -1,0 +1,65 @@
+---
+subcategory: "DevOps Guru"
+layout: "aws"
+page_title: "AWS: aws_devopsguru_event_sources_config"
+description: |-
+  Terraform resource for managing an AWS DevOps Guru Event Sources Config.
+---
+# Resource: aws_devopsguru_event_sources_config
+
+Terraform resource for managing an AWS DevOps Guru Event Sources Config. Currently the only service that can be integrated with DevOps Guru is Amazon CodeGuru Profiler, which can produce proactive recommendations which can be stored and viewed in DevOps Guru.
+
+~> Destruction of this resource will set the CodeGuru profiler status to `DISABLED`. If you wish to preserve an `ENABLED` configuration while removing the Terraform resource, utilize a [`removed` block](https://developer.hashicorp.com/terraform/language/resources/syntax#removing-resources) (available in Terraform 1.7+).
+
+~> Event sources are configured at the account level. To avoid persistent differences, this resource should be defined only once.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_devopsguru_event_sources_config" "example" {
+  event_sources {
+    amazon_code_guru_profiler {
+      status = "ENABLED"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `event_sources` - (Required) Configuration information about the integration of DevOps Guru as the Consumer via EventBridge with another AWS Service. See [`event_sources`](#event_sources-argument-reference) below.
+
+### `event_sources` Argument Reference
+
+* `amazon_code_guru_profiler` - (Required) Stores whether DevOps Guru is configured to consume recommendations which are generated from AWS CodeGuru Profiler. See [`amazon_code_guru_profiler`](#amazon_code_guru_profiler-argument-reference) below.
+
+### `amazon_code_guru_profiler` Argument Reference
+
+* `status` - (Required) Status of the CodeGuru Profiler integration. Valid values are `ENABLED` and `DISABLED`.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `id` - AWS region.
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import DevOps Guru Event Sources Config using the `id`. For example:
+
+```terraform
+import {
+  to = aws_devopsguru_event_sources_config.example
+  id = "us-east-1"
+}
+```
+
+Using `terraform import`, import DevOps Guru Event Sources Config using the `id`. For example:
+
+```console
+% terraform import aws_devopsguru_event_sources_config.example us-east-1
+```


### PR DESCRIPTION



<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This resource will allow practitioners to manage DevOps Guru event sources configurations with Terraform. Event sources are configured at the account level, and therefore should not be included in multiple configurations to avoid persistent differences.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->
Relates #17919
Closes #36333 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/devops-guru/latest/APIReference/API_UpdateEventSourcesConfig.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->


```console
% make testacc PKG=devopsguru TESTS=TestAccDevOpsGuru_serial
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/devopsguru/... -v -count 1 -parallel 20 -run='TestAccDevOpsGuru_serial'  -timeout 360m

--- PASS: TestAccDevOpsGuru_serial (22.05s)
    --- PASS: TestAccDevOpsGuru_serial/EventSourcesConfig (22.05s)
        --- PASS: TestAccDevOpsGuru_serial/EventSourcesConfig/basic (12.86s)
        --- PASS: TestAccDevOpsGuru_serial/EventSourcesConfig/disappears (9.18s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/devopsguru 27.920s
```
