### PR TITLE
Fix custom payload typo

### DIFF
--- a/.changelog/36488.txt
+++ b/.changelog/36488.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lexv2models_slot: Fix custom_payload typo
+```

--- a/internal/service/lexv2models/slot.go
+++ b/internal/service/lexv2models/slot.go
@@ -111,7 +111,7 @@ func (r *resourceSlot) Schema(ctx context.Context, req resource.SchemaRequest, r
 
 	messageNBO := schema.NestedBlockObject{
 		Blocks: map[string]schema.Block{
-			"custom_playload": schema.ListNestedBlock{
+			"custom_payload": schema.ListNestedBlock{
 				Validators: []validator.List{
 					listvalidator.SizeAtMost(1),
 				},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Fixes a typo which causes plan to fail.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #35670

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
> make testacc TESTS=TestAccLexV2ModelsSlot_ PKG=lexv2models
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/lexv2models/... -v -count 1 -parallel 20 -run='TestAccLexV2ModelsSlot_'  -timeout 360m
=== RUN   TestAccLexV2ModelsSlot_basic
=== PAUSE TestAccLexV2ModelsSlot_basic
=== RUN   TestAccLexV2ModelsSlot_updateMultipleValuesSetting
=== PAUSE TestAccLexV2ModelsSlot_updateMultipleValuesSetting
=== RUN   TestAccLexV2ModelsSlot_ObfuscationSetting
=== PAUSE TestAccLexV2ModelsSlot_ObfuscationSetting
=== RUN   TestAccLexV2ModelsSlot_disappears
=== PAUSE TestAccLexV2ModelsSlot_disappears
=== CONT  TestAccLexV2ModelsSlot_basic
=== CONT  TestAccLexV2ModelsSlot_ObfuscationSetting
=== CONT  TestAccLexV2ModelsSlot_updateMultipleValuesSetting
=== CONT  TestAccLexV2ModelsSlot_disappears
--- PASS: TestAccLexV2ModelsSlot_disappears (40.94s)
--- PASS: TestAccLexV2ModelsSlot_ObfuscationSetting (47.35s)
--- PASS: TestAccLexV2ModelsSlot_basic (49.56s)
--- PASS: TestAccLexV2ModelsSlot_updateMultipleValuesSetting (57.93s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lexv2models        63.662s

...
```
