### PR TITLE
Add `tier` argument to `aws_vpc_ipam` resource

### DIFF
--- a/internal/service/ec2/ipam_.go
+++ b/internal/service/ec2/ipam_.go
@@ -89,6 +89,10 @@ func ResourceIPAM() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+			"tier": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
@@ -126,6 +130,10 @@ func resourceIPAMCreate(ctx context.Context, d *schema.ResourceData, meta interf
 
 	if v, ok := d.GetOk("description"); ok {
 		input.Description = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("tier"); ok {
+		input.Tier = aws.String(v.(string))
 	}
 
 	output, err := conn.CreateIpamWithContext(ctx, input)
@@ -209,6 +217,10 @@ func resourceIPAMUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 			if len(operatingRegionUpdateRemove) != 0 {
 				input.RemoveOperatingRegions = operatingRegionUpdateRemove
 			}
+		}
+
+		if d.HasChange("tier") {
+			input.Tier = aws.String(d.Get("tier").(string))
 		}
 
 		_, err := conn.ModifyIpamWithContext(ctx, input)

--- a/internal/service/ec2/ipam_test.go
+++ b/internal/service/ec2/ipam_test.go
@@ -182,6 +182,35 @@ func TestAccIPAM_cascade(t *testing.T) {
 	})
 }
 
+func TestAccIPAM_tier(t *testing.T) {
+	ctx := acctest.Context(t)
+	var ipam ec2.Ipam
+	resourceName := "aws_vpc_ipam.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckIPAMDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIPAMConfig_tier("free"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIPAMExists(ctx, resourceName, &ipam),
+					resource.TestCheckResourceAttr(resourceName, "tier", "free"),
+				),
+			},
+			{
+				Config: testAccIPAMConfig_tier("advanced"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIPAMExists(ctx, resourceName, &ipam),
+					resource.TestCheckResourceAttr(resourceName, "tier", "advanced"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccIPAM_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var ipam ec2.Ipam
@@ -377,4 +406,17 @@ resource "aws_vpc_ipam" "test" {
   }
 }
 `, tagKey1, tagValue1, tagKey2, tagValue2)
+}
+
+func testAccIPAMConfig_tier(tier string) string {
+	return fmt.Sprintf(`
+data "aws_region" "current" {}
+
+resource "aws_vpc_ipam" "test" {
+  operating_regions {
+    region_name = data.aws_region.current.name
+  }
+  tier = "%s"
+}
+`, tier)
 }

--- a/website/docs/r/vpc_ipam.html.markdown
+++ b/website/docs/r/vpc_ipam.html.markdown
@@ -59,10 +59,11 @@ locals {
 
 This resource supports the following arguments:
 
+* `cascade` - (Optional) Enables you to quickly delete an IPAM, private scopes, pools in private scopes, and any allocations in the pools in private scopes.
 * `description` - (Optional) A description for the IPAM.
 * `operating_regions` - (Required) Determines which locales can be chosen when you create pools. Locale is the Region where you want to make an IPAM pool available for allocations. You can only create pools with locales that match the operating Regions of the IPAM. You can only create VPCs from a pool whose locale matches the VPC's Region. You specify a region using the [region_name](#operating_regions) parameter. You **must** set your provider block region as an operating_region.
+* `tier` - (Optional) specifies the IPAM tier.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
-* `cascade` - (Optional) Enables you to quickly delete an IPAM, private scopes, pools in private scopes, and any allocations in the pools in private scopes.
 
 ### operating_regions
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds the `tier` argument to the `aws_vpc_ipam` resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #34616

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
make testacc TESTS=TestAccIPAM_tiers PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccIPAM_tiers'  -timeout 360m
=== RUN   TestAccIPAM_tiers
=== PAUSE TestAccIPAM_tiers
=== CONT  TestAccIPAM_tiers
--- PASS: TestAccIPAM_tiers (52.72s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	56.261s
```