### PR TITLE
fix(aws_mq_broker): Do not reboot on changes to `maintenance_window_start_time` or `auto_minor_version_upgrade`

### DIFF
--- a/.changelog/36506.txt
+++ b/.changelog/36506.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_mq_broker: Do not reboot on changes to `maintenance_window_start_time` or `auto_minor_version_upgrade`
+```

--- a/internal/service/mq/broker.go
+++ b/internal/service/mq/broker.go
@@ -615,8 +615,6 @@ func resourceBrokerUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating MQ Broker (%s) auto minor version upgrade: %s", d.Id(), err)
 		}
-
-		requiresReboot = true
 	}
 
 	if d.HasChange("maintenance_window_start_time") {
@@ -630,8 +628,6 @@ func resourceBrokerUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating MQ Broker (%s) maintenance window start time: %s", d.Id(), err)
 		}
-
-		requiresReboot = true
 	}
 
 	if d.HasChange("data_replication_mode") {


### PR DESCRIPTION
### Description
Rebooting the Amazon MQ broker is not necessary for modifications to `maintenance_window_start_time` or to `auto_minor_version_upgrade`. These changes take effect immediately.