### PR TITLE
docs: add protocol to target_ip object in route53 resolver rule

### DIFF
--- a/website/docs/r/route53_resolver_rule.html.markdown
+++ b/website/docs/r/route53_resolver_rule.html.markdown
@@ -56,7 +56,8 @@ This argument should only be specified for `FORWARD` type rules.
 The `target_ip` object supports the following:
 
 * `ip` - (Required) One IP address that you want to forward DNS queries to. You can specify only IPv4 addresses.
-* `port` - (Optional) The port at `ip` that you want to forward DNS queries to. Default value is `53`
+* `port` - (Optional) The port at `ip` that you want to forward DNS queries to. Default value is `53`.
+* `protocol` - (Optional) The protocol for the resolver endpoint. Valid values are `Do53` and `DoH`. Default value is `Do53`.
 
 ## Attribute Reference
 

--- a/website/docs/r/route53_resolver_rule.html.markdown
+++ b/website/docs/r/route53_resolver_rule.html.markdown
@@ -57,7 +57,7 @@ The `target_ip` object supports the following:
 
 * `ip` - (Required) One IP address that you want to forward DNS queries to. You can specify only IPv4 addresses.
 * `port` - (Optional) The port at `ip` that you want to forward DNS queries to. Default value is `53`.
-* `protocol` - (Optional) The protocol for the resolver endpoint. Valid values are `Do53` and `DoH`. Default value is `Do53`.
+* `protocol` - (Optional) The protocol for the resolver endpoint. Valid values can be found in the [AWS documentation](https://docs.aws.amazon.com/Route53/latest/APIReference/API_route53resolver_TargetAddress.html). Default value is `Do53`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
### Description

The documentation of the [`target_ip`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_rule#target_ip) object of the resource  `aws_route53_resolver_rule` is missing the `protocol` argument.  Based on the existing [implementation](https://github.com/hashicorp/terraform-provider-aws/blob/fb68fa7d9c2a1afc1243902d3a85bcb99cd1e633/internal/service/route53resolver/rule.go#L104) details on the default value have been added.
The valid allowed values have also been added. There is only one unclarity: should we add also `DoH-FIPS`? 

`DoH-FIPS`  is listed as third option in the [AWS SDKv2](https://github.com/aws/aws-sdk-go/blob/90cffbc8aed533a77667a5ee66c3727cb5237b26/service/route53resolver/api.go#L19629) string enum and the `validateFunc` makes use of it.

```go
"protocol": {
  Type:         schema.TypeString,
  Optional:     true,
  Default:      route53resolver.ProtocolDo53,
  validateFunc: validation.StringInSlice( --> route53resolver.Protocol_Values() <-- false),
},
```

Added also a  "." to the `port` explanation to end the sentence.

### Relations

Closes #36439 .

### References

* The support for `protocol` on the resource came in with this  [pull request](https://github.com/hashicorp/terraform-provider-aws/pull/35744).
* In the current code base `protocol` can be found [here](https://github.com/hashicorp/terraform-provider-aws/blob/fb68fa7d9c2a1afc1243902d3a85bcb99cd1e633/internal/service/route53resolver/rule.go#L101).

### Output from Acceptance Testing

No test/ code has been modified.