### PR TITLE
resource/aws_db_instance: Adds warning when setting `character_set_name` on replica- or restore-type resources

### DIFF
--- a/.changelog/36518.txt
+++ b/.changelog/36518.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_db_instance: Adds warning when setting `character_set_name` when `replicate_source_db`, `restore_to_point_in_time`, or `snapshot_identifier` is set
+```

--- a/internal/errs/diag.go
+++ b/internal/errs/diag.go
@@ -74,6 +74,21 @@ func withPath(d diag.Diagnostic, path cty.Path) diag.Diagnostic {
 	return d
 }
 
+// newAttributeConflictsError is included for use with NewAttributeConflictsWillBeError.
+// The typical behavior is covered using the schema ConflictsWith parameter.
+func newAttributeConflictsError(path, otherPath cty.Path) diag.Diagnostic {
+	return NewAttributeErrorDiagnostic(
+		path,
+		"Invalid Attribute Combination",
+		fmt.Sprintf("Attribute %q cannot be specified when %q is specified.",
+			PathString(path),
+			PathString(otherPath),
+		),
+	)
+}
+
+// NewAttributeConflictsWhenError returns an error diagnostic indicating that the attribute at the given path cannot be
+// specified when the attribute at otherPath has the given value.
 func NewAttributeConflictsWhenError(path, otherPath cty.Path, otherValue string) diag.Diagnostic {
 	return NewAttributeErrorDiagnostic(
 		path,
@@ -86,18 +101,32 @@ func NewAttributeConflictsWhenError(path, otherPath cty.Path, otherValue string)
 	)
 }
 
-func NewAttributeRequiredWhenError(neededPath, path cty.Path, value string) diag.Diagnostic {
+// NewAttributeRequiredWhenError returns an error diagnostic indicating that the attribute at neededPath is required when the
+// attribute at otherPath has the given value.
+func NewAttributeRequiredWhenError(neededPath, otherPath cty.Path, value string) diag.Diagnostic {
 	return NewAttributeErrorDiagnostic(
-		path,
+		otherPath,
 		"Invalid Attribute Combination",
 		fmt.Sprintf("Attribute %q must be specified when %q is %q.",
 			PathString(neededPath),
-			PathString(path),
+			PathString(otherPath),
 			value,
 		),
 	)
 }
 
+// NewAttributeConflictsWillBeError returns a warning diagnostic indicating that the attribute at the given path cannot be
+// specified when the attribute at otherPath is set.
+// This is intended to be used for situations where the conflict will become an error in a future release.
+func NewAttributeConflictsWillBeError(path, otherPath cty.Path) diag.Diagnostic {
+	return willBeError(
+		newAttributeConflictsError(path, otherPath),
+	)
+}
+
+// NewAttributeConflictsWhenWillBeError returns a warning diagnostic indicating that the attribute at the given path cannot be
+// specified when the attribute at otherPath has the given value.
+// This is intended to be used for situations where the conflict will become an error in a future release.
 func NewAttributeConflictsWhenWillBeError(path, otherPath cty.Path, otherValue string) diag.Diagnostic {
 	return willBeError(
 		NewAttributeConflictsWhenError(path, otherPath, otherValue),

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -152,6 +152,9 @@ func ResourceInstance() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.StringInSlice(backupTarget_Values(), false),
+				ConflictsWith: []string{
+					"s3_import",
+				},
 			},
 			"backup_window": {
 				Type:         schema.TypeString,
@@ -182,6 +185,9 @@ func ResourceInstance() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
+				ConflictsWith: []string{
+					"s3_import",
+				},
 			},
 			"copy_tags_to_snapshot": {
 				Type:     schema.TypeBool,
@@ -628,6 +634,9 @@ func ResourceInstance() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
+				ConflictsWith: []string{
+					"s3_import",
+				},
 			},
 			"username": {
 				Type:          schema.TypeString,
@@ -901,15 +910,6 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 		if _, ok := d.GetOk("username"); !ok {
 			diags = sdkdiag.AppendErrorf(diags, `"username": required field is not set`)
-		}
-		if _, ok := d.GetOk("character_set_name"); ok {
-			diags = sdkdiag.AppendErrorf(diags, `"character_set_name" doesn't work with restores"`)
-		}
-		if _, ok := d.GetOk("timezone"); ok {
-			diags = sdkdiag.AppendErrorf(diags, `"timezone" doesn't work with restores"`)
-		}
-		if _, ok := d.GetOk("backup_target"); ok {
-			diags = sdkdiag.AppendErrorf(diags, `"backup_target" doesn't work with restores"`)
 		}
 		if diags.HasError() {
 			return diags

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -9743,11 +9743,11 @@ func testAccInstanceConfig_ReplicateSourceDB_characterSet_Source(rName string) s
 		testAccInstanceConfig_orderableClassOracleEnterprise(),
 		fmt.Sprintf(`
 resource "aws_db_instance" "test" {
-  identifier           = %[1]q
-  replicate_source_db  = aws_db_instance.source.identifier
-  instance_class       = data.aws_rds_orderable_db_instance.test.instance_class
-  skip_final_snapshot  = true
-  apply_immediately    = true
+  identifier          = %[1]q
+  replicate_source_db = aws_db_instance.source.identifier
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
+  skip_final_snapshot = true
+  apply_immediately   = true
 }
 
 resource "aws_db_instance" "source" {
@@ -9774,11 +9774,11 @@ func testAccInstanceConfig_ReplicateSourceDB_characterSet_Replica(rName string) 
 		testAccInstanceConfig_orderableClassOracleEnterprise(),
 		fmt.Sprintf(`
 resource "aws_db_instance" "test" {
-  identifier           = %[1]q
-  replicate_source_db  = aws_db_instance.source.identifier
-  instance_class       = data.aws_rds_orderable_db_instance.test.instance_class
-  skip_final_snapshot  = true
-  apply_immediately    = true
+  identifier          = %[1]q
+  replicate_source_db = aws_db_instance.source.identifier
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
+  skip_final_snapshot = true
+  apply_immediately   = true
 
   character_set_name = "NE8ISO8859P10"
 }
@@ -9986,11 +9986,11 @@ func testAccInstanceConfig_ReplicateSourceDB_CrossRegion_CharacterSet(rName stri
 resource "aws_db_instance" "test" {
   provider = "aws"
 
-  identifier           = %[1]q
-  replicate_source_db  = aws_db_instance.source.arn
-  instance_class       = data.aws_rds_orderable_db_instance.test.instance_class
-  skip_final_snapshot  = true
-  apply_immediately    = true
+  identifier          = %[1]q
+  replicate_source_db = aws_db_instance.source.arn
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
+  skip_final_snapshot = true
+  apply_immediately   = true
 }
 
 resource "aws_db_instance" "source" {

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -2116,18 +2116,6 @@ func TestAccRDSInstance_ReplicateSourceDB_characterSet_Replica(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "replicate_source_db", sourceResourceName, "identifier"),
 					resource.TestCheckResourceAttr(resourceName, "character_set_name", "WE8ISO8859P15"),
 				),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
-					},
-					PostApplyPreRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
-					},
-					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
-					},
-				},
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -2044,6 +2044,95 @@ func TestAccRDSInstance_ReplicateSourceDB_caCertificateIdentifier(t *testing.T) 
 	})
 }
 
+func TestAccRDSInstance_ReplicateSourceDB_characterSet_Source(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var dbInstance, sourceDbInstance rds.DBInstance
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	sourceResourceName := "aws_db_instance.source"
+	resourceName := "aws_db_instance.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInstanceDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_ReplicateSourceDB_characterSet_Source(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInstanceExists(ctx, sourceResourceName, &sourceDbInstance),
+					resource.TestCheckResourceAttr(sourceResourceName, "character_set_name", "WE8ISO8859P15"),
+					testAccCheckInstanceExists(ctx, resourceName, &dbInstance),
+					resource.TestCheckResourceAttrPair(resourceName, "replicate_source_db", sourceResourceName, "identifier"),
+					resource.TestCheckResourceAttr(resourceName, "character_set_name", "WE8ISO8859P15"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"final_snapshot_identifier",
+					"password",
+					"manage_master_user_password",
+					"skip_final_snapshot",
+					"delete_automated_backups",
+				},
+			},
+		},
+	})
+}
+
+func TestAccRDSInstance_ReplicateSourceDB_characterSet_Replica(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var dbInstance, sourceDbInstance rds.DBInstance
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	sourceResourceName := "aws_db_instance.source"
+	resourceName := "aws_db_instance.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInstanceDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_ReplicateSourceDB_characterSet_Replica(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInstanceExists(ctx, sourceResourceName, &sourceDbInstance),
+					resource.TestCheckResourceAttr(sourceResourceName, "character_set_name", "WE8ISO8859P15"),
+					testAccCheckInstanceExists(ctx, resourceName, &dbInstance),
+					resource.TestCheckResourceAttrPair(resourceName, "replicate_source_db", sourceResourceName, "identifier"),
+					resource.TestCheckResourceAttr(resourceName, "character_set_name", "WE8ISO8859P15"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+					},
+				},
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccRDSInstance_ReplicateSourceDB_replicaMode(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -2176,6 +2265,49 @@ func TestAccRDSInstance_ReplicateSourceDB_CrossRegion_parameterGroupNameEquivale
 					resource.TestCheckResourceAttrPair(resourceName, "parameter_group_name", "aws_db_parameter_group.test", "name"),
 					testAccCheckInstanceParameterApplyStatusInSync(&dbInstance),
 					testAccCheckInstanceParameterApplyStatusInSync(&sourceDbInstance),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"password",
+				},
+			},
+		},
+	})
+}
+
+func TestAccRDSInstance_ReplicateSourceDB_CrossRegion_characterSet(t *testing.T) {
+	t.Skip("Skipping due to upstream error")
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var dbInstance, sourceDbInstance rds.DBInstance
+	var providers []*schema.Provider
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	sourceResourceName := "aws_db_instance.source"
+	resourceName := "aws_db_instance.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesPlusProvidersAlternate(ctx, t, &providers),
+		CheckDestroy:             testAccCheckInstanceDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_ReplicateSourceDB_CrossRegion_CharacterSet(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInstanceExistsWithProvider(ctx, sourceResourceName, &sourceDbInstance, acctest.RegionProviderFunc(acctest.AlternateRegion(), &providers)),
+					resource.TestCheckResourceAttr(sourceResourceName, "character_set_name", "WE8ISO8859P15"),
+					testAccCheckInstanceExistsWithProvider(ctx, resourceName, &dbInstance, acctest.RegionProviderFunc(acctest.Region(), &providers)),
+					resource.TestCheckResourceAttrPair(resourceName, "replicate_source_db", sourceResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "character_set_name", "WE8ISO8859P15"),
 				),
 			},
 			{
@@ -6402,6 +6534,23 @@ func testAccInstanceConfig_orderableClassCustomSQLServerWeb() string {
 	return testAccInstanceConfig_orderableClass("custom-sqlserver-web", "", "gp2")
 }
 
+func testAccInstanceConfig_orderableClassOracleEnterprise() string {
+	return fmt.Sprintf(`
+data "aws_rds_engine_version" "default" {
+  engine = %[1]q
+}
+
+data "aws_rds_orderable_db_instance" "test" {
+  engine         = data.aws_rds_engine_version.default.engine
+  engine_version = data.aws_rds_engine_version.default.version
+  license_model  = %[2]q
+  storage_type   = %[3]q
+
+  preferred_instance_classes = [%[4]s]
+}
+`, tfrds.InstanceEngineOracleEnterprise, "bring-your-own-license", "gp2", strings.Replace(mainInstanceClasses, "db.t3.small", "frodo", 1))
+}
+
 func testAccInstanceConfig_basic(rName string) string {
 	return acctest.ConfigCompose(
 		testAccInstanceConfig_orderableClassMySQL(),
@@ -6970,6 +7119,8 @@ resource "aws_db_instance" "test" {
   password                   = "avoid-plaintext-passwords"
   username                   = "tfacctest"
   backup_retention_period    = 0
+
+  character_set_name = "WE8ISO8859P15"
 
   parameter_group_name = "default.${data.aws_rds_engine_version.default.parameter_group_family}"
   skip_final_snapshot  = true
@@ -9599,6 +9750,70 @@ resource "aws_db_instance" "test" {
 `, rName))
 }
 
+func testAccInstanceConfig_ReplicateSourceDB_characterSet_Source(rName string) string {
+	return acctest.ConfigCompose(
+		testAccInstanceConfig_orderableClassOracleEnterprise(),
+		fmt.Sprintf(`
+resource "aws_db_instance" "test" {
+  identifier           = %[1]q
+  replicate_source_db  = aws_db_instance.source.identifier
+  instance_class       = data.aws_rds_orderable_db_instance.test.instance_class
+  skip_final_snapshot  = true
+  apply_immediately    = true
+}
+
+resource "aws_db_instance" "source" {
+  identifier              = "%[1]s-source"
+  allocated_storage       = 20
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
+  engine_version          = data.aws_rds_orderable_db_instance.test.engine_version
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
+  storage_type            = data.aws_rds_orderable_db_instance.test.storage_type
+  db_name                 = "MAINDB"
+  username                = "oadmin"
+  password                = "avoid-plaintext-passwords"
+  skip_final_snapshot     = true
+  apply_immediately       = true
+  backup_retention_period = 1
+
+  character_set_name = "WE8ISO8859P15"
+}
+`, rName))
+}
+
+func testAccInstanceConfig_ReplicateSourceDB_characterSet_Replica(rName string) string {
+	return acctest.ConfigCompose(
+		testAccInstanceConfig_orderableClassOracleEnterprise(),
+		fmt.Sprintf(`
+resource "aws_db_instance" "test" {
+  identifier           = %[1]q
+  replicate_source_db  = aws_db_instance.source.identifier
+  instance_class       = data.aws_rds_orderable_db_instance.test.instance_class
+  skip_final_snapshot  = true
+  apply_immediately    = true
+
+  character_set_name = "NE8ISO8859P10"
+}
+
+resource "aws_db_instance" "source" {
+  identifier              = "%[1]s-source"
+  allocated_storage       = 20
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
+  engine_version          = data.aws_rds_orderable_db_instance.test.engine_version
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
+  storage_type            = data.aws_rds_orderable_db_instance.test.storage_type
+  db_name                 = "MAINDB"
+  username                = "oadmin"
+  password                = "avoid-plaintext-passwords"
+  skip_final_snapshot     = true
+  apply_immediately       = true
+  backup_retention_period = 1
+
+  character_set_name = "WE8ISO8859P15"
+}
+`, rName))
+}
+
 func testAccInstanceConfig_ReplicateSourceDB_replicaMode(rName, replicaMode string) string {
 	return fmt.Sprintf(`
 data "aws_rds_engine_version" "default" {
@@ -9774,6 +9989,41 @@ data "aws_rds_orderable_db_instance" "test" {
   preferred_instance_classes = [%[3]s]
 }
 `, rName, tfrds.InstanceEngineOracleEnterprise, strings.Replace(mainInstanceClasses, "db.t3.small", "frodo", 1), parameters))
+}
+
+func testAccInstanceConfig_ReplicateSourceDB_CrossRegion_CharacterSet(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigMultipleRegionProvider(2),
+		testAccInstanceConfig_orderableClassOracleEnterprise(), fmt.Sprintf(`
+resource "aws_db_instance" "test" {
+  provider = "aws"
+
+  identifier           = %[1]q
+  replicate_source_db  = aws_db_instance.source.arn
+  instance_class       = data.aws_rds_orderable_db_instance.test.instance_class
+  skip_final_snapshot  = true
+  apply_immediately    = true
+}
+
+resource "aws_db_instance" "source" {
+  provider = "awsalternate"
+
+  identifier              = "%[1]s-source"
+  allocated_storage       = 20
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
+  engine_version          = data.aws_rds_orderable_db_instance.test.engine_version
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
+  storage_type            = data.aws_rds_orderable_db_instance.test.storage_type
+  db_name                 = "MAINDB"
+  username                = "oadmin"
+  password                = "avoid-plaintext-passwords"
+  skip_final_snapshot     = true
+  apply_immediately       = true
+  backup_retention_period = 1
+
+  character_set_name = "WE8ISO8859P15"
+}
+`, rName))
 }
 
 func testAccInstanceConfig_baseMonitoringRole(rName string) string {

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -303,10 +303,11 @@ Defaults to true.
 * `blue_green_update` - (Optional) Enables low-downtime updates using [RDS Blue/Green deployments][blue-green].
   See [`blue_green_update`](#blue_green_update) below.
 * `ca_cert_identifier` - (Optional) The identifier of the CA certificate for the DB instance.
-* `character_set_name` - (Optional) The character set name to use for DB
-encoding in Oracle and Microsoft SQL instances (collation). This can't be changed. See [Oracle Character Sets
-Supported in Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.OracleCharacterSets.html)
-or [Server-Level Collation for Microsoft SQL Server](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.SQLServer.CommonDBATasks.Collation.html) for more information.
+* `character_set_name` - (Optional) The character set name to use for DB encoding in Oracle and Microsoft SQL instances (collation).
+  This can't be changed.
+  See [Oracle Character Sets Supported in Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.OracleCharacterSets.html) or
+  [Server-Level Collation for Microsoft SQL Server](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.SQLServer.CommonDBATasks.Collation.html) for more information.
+  Cannot be set  with `replicate_source_db`, `restore_to_point_in_time`, `s3_import`, or `snapshot_identifier`.
 * `copy_tags_to_snapshot` – (Optional, boolean) Copy all Instance `tags` to snapshots. Default is `false`.
 * `custom_iam_instance_profile` - (Optional) The instance profile associated with the underlying Amazon EC2 instance of an RDS Custom DB instance.
 * `db_name` - (Optional) The name of the database to create when the DB instance is created. If this parameter is not specified, no database is created in the DB instance. Note that this does not apply for Oracle or SQL Server engines. See the [AWS documentation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/create-db-instance.html) for more details on what applies for those engines. If you are providing an Oracle db name, it needs to be in all upper case. Cannot be specified for a replica.


### PR DESCRIPTION
### Description

The `character_set_name` parameter can only be set when creating a new DB instance. Adds a conflict warning when setting it when `replicate_source_db`, `restore_to_point_in_time`, or `snapshot_identifier` is set. It was already an error when setting it with `s3_import`.

### Relations

Relates ##20379

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=rds TESTS='TestAccRDSInstance_\w*characterSet'

    instance_test.go:2284: Skipping due to upstream error
--- SKIP: TestAccRDSInstance_ReplicateSourceDB_CrossRegion_characterSet (0.00s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_characterSet_Replica (2379.74s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_characterSet_Source (2422.93s)
```
