### PR TITLE
ecs/task_definition: Add configuredAtLaunch argument

### DIFF
--- a/.changelog/36533.txt
+++ b/.changelog/36533.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_ecs_task_definition: Add `configured_at_launch` attribute
+```

--- a/internal/service/ecs/task_definition.go
+++ b/internal/service/ecs/task_definition.go
@@ -435,6 +435,12 @@ func ResourceTaskDefinition() *schema.Resource {
 							Required: true,
 							ForceNew: true,
 						},
+						"configured_at_launch": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							ForceNew: false,
+							Default:  false,
+						},
 					},
 				},
 				Set: resourceTaskDefinitionVolumeHash,
@@ -700,6 +706,7 @@ func resourceTaskDefinitionVolumeHash(v interface{}) int {
 	m := v.(map[string]interface{})
 	buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
 	buf.WriteString(fmt.Sprintf("%s-", m["host_path"].(string)))
+	buf.WriteString(fmt.Sprintf("%t-", m["configured_at_launch"].(bool)))
 
 	if v, ok := m["efs_volume_configuration"]; ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 		m := v.([]interface{})[0].(map[string]interface{})
@@ -924,6 +931,9 @@ func expandVolumes(configured []interface{}) []*ecs.Volume {
 			}
 		}
 
+		configuredAtLaunch := data["configured_at_launch"].(bool)
+		l.ConfiguredAtLaunch = aws.Bool(configuredAtLaunch)
+
 		if v, ok := data["docker_volume_configuration"].([]interface{}); ok && len(v) > 0 {
 			l.DockerVolumeConfiguration = expandVolumesDockerVolume(v)
 		}
@@ -1054,6 +1064,10 @@ func flattenVolumes(list []*ecs.Volume) []map[string]interface{} {
 
 		if volume.Host != nil && volume.Host.SourcePath != nil {
 			l["host_path"] = aws.StringValue(volume.Host.SourcePath)
+		}
+
+		if volume.ConfiguredAtLaunch != nil {
+			l["configured_at_launch"] = aws.BoolValue(volume.ConfiguredAtLaunch)
 		}
 
 		if volume.DockerVolumeConfiguration != nil {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR adds the `configuredAtLaunch` argument to the `ecs_task_definition` resource. This does not complete the EBS volume support for ECS Fargate, as this only handles the task definition. However, this feature in isolation does provide stability to the `ecs_task_definition` resource if you are currently configuring that field manually. 

I intend to raise a separate PR for the `ecs_service` side, but that will take longer so I'm separating the PRs. I hope this means we can have a stable release of this `configuredAtLaunch` feature in isolation, as that would be helpful with my use case. 

I worked on this with @chelzackey-els
### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #35279

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Credit to @epiehl-it for commenting the original issue with some starter code: https://github.com/epiehl-it/terraform-provider-aws/commit/4d8f188aaeb3c8d4dcbf740b96c294426eaefb97

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS='TestAccECSTaskDefinition_' PKG=ecs TESTARGS=-short
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSTaskDefinition_' -short -timeout 360m
=== RUN   TestAccECSTaskDefinition_basic
=== PAUSE TestAccECSTaskDefinition_basic
=== RUN   TestAccECSTaskDefinition_scratchVolume
=== PAUSE TestAccECSTaskDefinition_scratchVolume
=== RUN   TestAccECSTaskDefinition_DockerVolume_basic
=== PAUSE TestAccECSTaskDefinition_DockerVolume_basic
=== RUN   TestAccECSTaskDefinition_DockerVolume_minimal
=== PAUSE TestAccECSTaskDefinition_DockerVolume_minimal
=== RUN   TestAccECSTaskDefinition_EBSVolumeConfiguredAtLaunch
=== PAUSE TestAccECSTaskDefinition_EBSVolumeConfiguredAtLaunch
=== RUN   TestAccECSTaskDefinition_runtimePlatform
=== PAUSE TestAccECSTaskDefinition_runtimePlatform
=== RUN   TestAccECSTaskDefinition_Fargate_runtimePlatform
=== PAUSE TestAccECSTaskDefinition_Fargate_runtimePlatform
=== RUN   TestAccECSTaskDefinition_Fargate_runtimePlatformWithoutArch
=== PAUSE TestAccECSTaskDefinition_Fargate_runtimePlatformWithoutArch
=== RUN   TestAccECSTaskDefinition_EFSVolume_minimal
=== PAUSE TestAccECSTaskDefinition_EFSVolume_minimal
=== RUN   TestAccECSTaskDefinition_EFSVolume_basic
=== PAUSE TestAccECSTaskDefinition_EFSVolume_basic
=== RUN   TestAccECSTaskDefinition_EFSVolume_transitEncryptionMinimal
=== PAUSE TestAccECSTaskDefinition_EFSVolume_transitEncryptionMinimal
=== RUN   TestAccECSTaskDefinition_EFSVolume_transitEncryption
=== PAUSE TestAccECSTaskDefinition_EFSVolume_transitEncryption
=== RUN   TestAccECSTaskDefinition_EFSVolume_transitEncryptionDisabled
=== PAUSE TestAccECSTaskDefinition_EFSVolume_transitEncryptionDisabled
=== RUN   TestAccECSTaskDefinition_EFSVolume_accessPoint
=== PAUSE TestAccECSTaskDefinition_EFSVolume_accessPoint
=== RUN   TestAccECSTaskDefinition_fsxWinFileSystem
    task_definition_test.go:586: skipping long-running test in short mode
--- SKIP: TestAccECSTaskDefinition_fsxWinFileSystem (0.00s)
=== RUN   TestAccECSTaskDefinition_DockerVolume_taskScoped
=== PAUSE TestAccECSTaskDefinition_DockerVolume_taskScoped
=== RUN   TestAccECSTaskDefinition_service
=== PAUSE TestAccECSTaskDefinition_service
=== RUN   TestAccECSTaskDefinition_taskRoleARN
=== PAUSE TestAccECSTaskDefinition_taskRoleARN
=== RUN   TestAccECSTaskDefinition_networkMode
=== PAUSE TestAccECSTaskDefinition_networkMode
=== RUN   TestAccECSTaskDefinition_ipcMode
=== PAUSE TestAccECSTaskDefinition_ipcMode
=== RUN   TestAccECSTaskDefinition_pidMode
=== PAUSE TestAccECSTaskDefinition_pidMode
=== RUN   TestAccECSTaskDefinition_constraint
=== PAUSE TestAccECSTaskDefinition_constraint
=== RUN   TestAccECSTaskDefinition_changeVolumesForcesNewResource
=== PAUSE TestAccECSTaskDefinition_changeVolumesForcesNewResource
=== RUN   TestAccECSTaskDefinition_arrays
=== PAUSE TestAccECSTaskDefinition_arrays
=== RUN   TestAccECSTaskDefinition_Fargate_basic
=== PAUSE TestAccECSTaskDefinition_Fargate_basic
=== RUN   TestAccECSTaskDefinition_Fargate_ephemeralStorage
=== PAUSE TestAccECSTaskDefinition_Fargate_ephemeralStorage
=== RUN   TestAccECSTaskDefinition_executionRole
=== PAUSE TestAccECSTaskDefinition_executionRole
=== RUN   TestAccECSTaskDefinition_disappears
=== PAUSE TestAccECSTaskDefinition_disappears
=== RUN   TestAccECSTaskDefinition_tags
=== PAUSE TestAccECSTaskDefinition_tags
=== RUN   TestAccECSTaskDefinition_proxy
=== PAUSE TestAccECSTaskDefinition_proxy
=== RUN   TestAccECSTaskDefinition_inferenceAccelerator
=== PAUSE TestAccECSTaskDefinition_inferenceAccelerator
=== RUN   TestAccECSTaskDefinition_invalidContainerDefinition
=== PAUSE TestAccECSTaskDefinition_invalidContainerDefinition
=== RUN   TestAccECSTaskDefinition_trackLatest
=== PAUSE TestAccECSTaskDefinition_trackLatest
=== CONT  TestAccECSTaskDefinition_basic
=== CONT  TestAccECSTaskDefinition_taskRoleARN
=== CONT  TestAccECSTaskDefinition_inferenceAccelerator
=== CONT  TestAccECSTaskDefinition_EFSVolume_minimal
=== CONT  TestAccECSTaskDefinition_service
=== CONT  TestAccECSTaskDefinition_DockerVolume_taskScoped
=== CONT  TestAccECSTaskDefinition_EFSVolume_accessPoint
=== CONT  TestAccECSTaskDefinition_EFSVolume_transitEncryptionDisabled
=== CONT  TestAccECSTaskDefinition_EFSVolume_transitEncryption
=== CONT  TestAccECSTaskDefinition_EFSVolume_transitEncryptionMinimal
=== CONT  TestAccECSTaskDefinition_EFSVolume_basic
=== CONT  TestAccECSTaskDefinition_EBSVolumeConfiguredAtLaunch
=== CONT  TestAccECSTaskDefinition_Fargate_runtimePlatformWithoutArch
=== CONT  TestAccECSTaskDefinition_Fargate_runtimePlatform
=== CONT  TestAccECSTaskDefinition_runtimePlatform
=== CONT  TestAccECSTaskDefinition_scratchVolume
=== CONT  TestAccECSTaskDefinition_DockerVolume_minimal
=== CONT  TestAccECSTaskDefinition_Fargate_ephemeralStorage
=== CONT  TestAccECSTaskDefinition_trackLatest
=== CONT  TestAccECSTaskDefinition_invalidContainerDefinition
--- PASS: TestAccECSTaskDefinition_invalidContainerDefinition (9.08s)
=== CONT  TestAccECSTaskDefinition_DockerVolume_basic
--- PASS: TestAccECSTaskDefinition_DockerVolume_taskScoped (142.76s)
=== CONT  TestAccECSTaskDefinition_tags
--- PASS: TestAccECSTaskDefinition_Fargate_ephemeralStorage (153.75s)
=== CONT  TestAccECSTaskDefinition_proxy
--- PASS: TestAccECSTaskDefinition_trackLatest (171.31s)
=== CONT  TestAccECSTaskDefinition_disappears
--- PASS: TestAccECSTaskDefinition_inferenceAccelerator (171.32s)
--- PASS: TestAccECSTaskDefinition_runtimePlatform (171.32s)
=== CONT  TestAccECSTaskDefinition_executionRole
=== CONT  TestAccECSTaskDefinition_constraint
--- PASS: TestAccECSTaskDefinition_Fargate_runtimePlatform (171.33s)
=== CONT  TestAccECSTaskDefinition_Fargate_basic
--- PASS: TestAccECSTaskDefinition_EBSVolumeConfiguredAtLaunch (171.33s)
=== CONT  TestAccECSTaskDefinition_arrays
--- PASS: TestAccECSTaskDefinition_Fargate_runtimePlatformWithoutArch (171.33s)
=== CONT  TestAccECSTaskDefinition_changeVolumesForcesNewResource
--- PASS: TestAccECSTaskDefinition_DockerVolume_basic (162.28s)
=== CONT  TestAccECSTaskDefinition_networkMode
--- PASS: TestAccECSTaskDefinition_DockerVolume_minimal (171.49s)
=== CONT  TestAccECSTaskDefinition_pidMode
--- PASS: TestAccECSTaskDefinition_scratchVolume (171.50s)
=== CONT  TestAccECSTaskDefinition_ipcMode
--- PASS: TestAccECSTaskDefinition_EFSVolume_transitEncryptionDisabled (260.41s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_transitEncryptionMinimal (268.14s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_basic (269.20s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_minimal (269.32s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_transitEncryption (270.95s)
--- PASS: TestAccECSTaskDefinition_basic (276.31s)
--- PASS: TestAccECSTaskDefinition_arrays (134.74s)
--- PASS: TestAccECSTaskDefinition_proxy (170.41s)
--- PASS: TestAccECSTaskDefinition_taskRoleARN (325.07s)
--- PASS: TestAccECSTaskDefinition_Fargate_basic (158.77s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_accessPoint (334.76s)
--- PASS: TestAccECSTaskDefinition_disappears (170.68s)
--- PASS: TestAccECSTaskDefinition_changeVolumesForcesNewResource (175.93s)
--- PASS: TestAccECSTaskDefinition_constraint (180.75s)
--- PASS: TestAccECSTaskDefinition_pidMode (198.36s)
--- PASS: TestAccECSTaskDefinition_networkMode (198.82s)
--- PASS: TestAccECSTaskDefinition_executionRole (199.55s)
--- PASS: TestAccECSTaskDefinition_ipcMode (200.54s)
--- PASS: TestAccECSTaskDefinition_tags (237.42s)
--- PASS: TestAccECSTaskDefinition_service (415.04s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	420.152s

...
```
