### PR TITLE
New Resource: `aws_cloudfrontkeyvaluestore_key`

### DIFF
--- a/.changelog/36534.txt
+++ b/.changelog/36534.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_cloudfrontkeyvaluestore_key
+```

--- a/.github/labeler-pr-triage.yml
+++ b/.github/labeler-pr-triage.yml
@@ -214,7 +214,7 @@ service/cloudfront:
   - 'website/**/cloudfront_*'
 service/cloudfrontkeyvaluestore:
   - 'internal/service/cloudfrontkeyvaluestore/**/*'
-  - 'website/**/cloudfront_keyvaluestore_*'
+  - 'website/**/cloudfrontkeyvaluestore_*'
 service/cloudhsmv2:
   - 'internal/service/cloudhsmv2/**/*'
   - 'website/**/cloudhsm*'

--- a/internal/errs/fwdiag/diags.go
+++ b/internal/errs/fwdiag/diags.go
@@ -44,3 +44,7 @@ func NewResourceNotFoundWarningDiagnostic(err error) diag.Diagnostic {
 		"Automatically removing from Terraform State instead of returning the error, which may trigger resource recreation. Original error: "+err.Error(),
 	)
 }
+
+func AsErr[T any](x T, diags diag.Diagnostics) (T, error) {
+	return x, DiagnosticsError(diags)
+}

--- a/internal/errs/fwdiag/must.go
+++ b/internal/errs/fwdiag/must.go
@@ -14,5 +14,5 @@ import (
 // [1]: https://pkg.go.dev/text/template#Must
 // [2]: https://pkg.go.dev/regexp#MustCompile
 func Must[T any](x T, diags diag.Diagnostics) T {
-	return errs.Must(x, DiagnosticsError(diags))
+	return errs.Must(AsErr(x, diags))
 }

--- a/internal/service/cloudfrontkeyvaluestore/exports_test.go
+++ b/internal/service/cloudfrontkeyvaluestore/exports_test.go
@@ -1,0 +1,11 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cloudfrontkeyvaluestore
+
+// Exports for use in tests only.
+var (
+	ResourceKey = newKeyResource
+
+	FindKeyByTwoPartKey = findKeyByTwoPartKey
+)

--- a/internal/service/cloudfrontkeyvaluestore/key.go
+++ b/internal/service/cloudfrontkeyvaluestore/key.go
@@ -177,7 +177,6 @@ func (r *resourceKey) Update(ctx context.Context, req resource.UpdateRequest, re
 	}
 
 	if !plan.Value.Equal(state.Value) {
-
 		etag, err := findEtagByARN(ctx, conn, plan.KeyValueStoreARN.ValueString())
 
 		if err != nil {

--- a/internal/service/cloudfrontkeyvaluestore/key.go
+++ b/internal/service/cloudfrontkeyvaluestore/key.go
@@ -1,0 +1,345 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cloudfrontkeyvaluestore
+
+import (
+	"context"
+	"errors"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudfrontkeyvaluestore"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/cloudfrontkeyvaluestore/types"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	intflex "github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+var (
+	ResourceKey = newResourceKey
+)
+
+// @FrameworkResource(name="Key")
+func newResourceKey(_ context.Context) (resource.ResourceWithConfigure, error) {
+	r := &resourceKey{}
+
+	return r, nil
+}
+
+const (
+	ResNameKey        = "Key"
+	ResIDKeyPartCount = 2
+)
+
+type resourceKey struct {
+	framework.ResourceWithConfigure
+}
+
+func (r *resourceKey) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "aws_cloudfrontkeyvaluestore_key"
+}
+
+func (r *resourceKey) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": framework.IDAttribute(),
+			"key": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "The key to put.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"key_value_store_arn": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "The Amazon Resource Name (ARN) of the Key Value Store.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"total_size_in_bytes": schema.Int64Attribute{
+				Computed:            true,
+				MarkdownDescription: "Total size of the Key Value Store in bytes.",
+			},
+			"value": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "The value to put.",
+			},
+		},
+	}
+}
+
+func (r *resourceKey) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().CloudFrontKeyValueStoreClient(ctx)
+
+	var plan resourceKeyData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	etag, err := findEtagByARN(ctx, conn, plan.KeyValueStoreARN.ValueString())
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.CloudFrontKeyValueStore, create.ErrActionCreating, ResNameKey, plan.Key.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	in := &cloudfrontkeyvaluestore.PutKeyInput{
+		IfMatch: etag,
+		Key:     aws.String(plan.Key.ValueString()),
+		KvsARN:  aws.String(plan.KeyValueStoreARN.ValueString()),
+		Value:   aws.String(plan.Value.ValueString()),
+	}
+
+	out, err := conn.PutKey(ctx, in)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.CloudFrontKeyValueStore, create.ErrActionCreating, ResNameKey, plan.Key.String(), err),
+			err.Error(),
+		)
+		return
+	}
+	if out == nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.CloudFrontKeyValueStore, create.ErrActionCreating, ResNameKey, plan.Key.String(), nil),
+			errors.New("empty output").Error(),
+		)
+		return
+	}
+
+	plan.TotalSizeInBytes = flex.Int64ToFramework(ctx, out.TotalSizeInBytes)
+	err = plan.setID(ctx)
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.CloudFrontKeyValueStore, create.ErrActionCreating, ResNameKey, plan.Key.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *resourceKey) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().CloudFrontKeyValueStoreClient(ctx)
+
+	var state resourceKeyData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	kvsARN, out, err := FindKeyByID(ctx, conn, state.ID.ValueString())
+	if tfresource.NotFound(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.CloudFrontKeyValueStore, create.ErrActionSetting, ResNameKey, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	state.Key = flex.StringToFramework(ctx, out.Key)
+	state.KeyValueStoreARN = flex.StringValueToFramework(ctx, kvsARN)
+	state.TotalSizeInBytes = flex.Int64ToFramework(ctx, out.TotalSizeInBytes)
+	state.Value = flex.StringToFramework(ctx, out.Value)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *resourceKey) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	conn := r.Meta().CloudFrontKeyValueStoreClient(ctx)
+
+	var plan, state resourceKeyData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !plan.Value.Equal(state.Value) {
+
+		etag, err := findEtagByARN(ctx, conn, plan.KeyValueStoreARN.ValueString())
+
+		if err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.CloudFrontKeyValueStore, create.ErrActionUpdating, ResNameKey, plan.ID.String(), err),
+				err.Error(),
+			)
+			return
+		}
+
+		in := &cloudfrontkeyvaluestore.PutKeyInput{
+			IfMatch: etag,
+			Key:     aws.String(plan.Key.ValueString()),
+			KvsARN:  aws.String(plan.KeyValueStoreARN.ValueString()),
+			Value:   aws.String(plan.Value.ValueString()),
+		}
+
+		out, err := conn.PutKey(ctx, in)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.CloudFrontKeyValueStore, create.ErrActionUpdating, ResNameKey, plan.ID.String(), err),
+				err.Error(),
+			)
+			return
+		}
+		if out == nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.CloudFrontKeyValueStore, create.ErrActionUpdating, ResNameKey, plan.ID.String(), nil),
+				errors.New("empty output").Error(),
+			)
+			return
+		}
+
+		plan.TotalSizeInBytes = flex.Int64ToFramework(ctx, out.TotalSizeInBytes)
+		err = plan.setID(ctx)
+
+		if err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.CloudFrontKeyValueStore, create.ErrActionUpdating, ResNameKey, plan.ID.String(), err),
+				err.Error(),
+			)
+			return
+		}
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *resourceKey) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	conn := r.Meta().CloudFrontKeyValueStoreClient(ctx)
+
+	var state resourceKeyData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	etag, err := findEtagByARN(ctx, conn, state.KeyValueStoreARN.ValueString())
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.CloudFrontKeyValueStore, create.ErrActionDeleting, ResNameKey, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	in := &cloudfrontkeyvaluestore.DeleteKeyInput{
+		IfMatch: etag,
+		Key:     aws.String(state.Key.ValueString()),
+		KvsARN:  aws.String(state.KeyValueStoreARN.ValueString()),
+	}
+
+	_, err = conn.DeleteKey(ctx, in)
+
+	if err != nil {
+		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+			return
+		}
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.CloudFrontKeyValueStore, create.ErrActionDeleting, ResNameKey, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+}
+
+func (r *resourceKey) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func FindKeyByID(ctx context.Context, conn *cloudfrontkeyvaluestore.Client, id string) (kvsARN string, getKeyOutPut *cloudfrontkeyvaluestore.GetKeyOutput, err error) {
+	parts, err := intflex.ExpandResourceId(id, ResIDKeyPartCount, false)
+
+	if err != nil {
+		return "", nil, err
+	}
+
+	in := &cloudfrontkeyvaluestore.GetKeyInput{
+		KvsARN: aws.String(parts[0]),
+		Key:    aws.String(parts[1]),
+	}
+
+	out, err := conn.GetKey(ctx, in)
+	if err != nil {
+		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+			return "", nil, &retry.NotFoundError{
+				LastError:   err,
+				LastRequest: in,
+			}
+		}
+
+		return "", nil, err
+	}
+
+	if out == nil || out.Key == nil {
+		return "", nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return parts[0], out, nil
+}
+
+func findEtagByARN(ctx context.Context, conn *cloudfrontkeyvaluestore.Client, arn string) (*string, error) {
+	in := &cloudfrontkeyvaluestore.DescribeKeyValueStoreInput{
+		KvsARN: aws.String(arn),
+	}
+
+	out, err := conn.DescribeKeyValueStore(ctx, in)
+	if err != nil {
+		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+			return nil, &retry.NotFoundError{
+				LastError:   err,
+				LastRequest: in,
+			}
+		}
+
+		return nil, err
+	}
+
+	if out == nil || out.ETag == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return out.ETag, nil
+}
+
+type resourceKeyData struct {
+	ID               types.String `tfsdk:"id"`
+	Key              types.String `tfsdk:"key"`
+	KeyValueStoreARN types.String `tfsdk:"key_value_store_arn"`
+	TotalSizeInBytes types.Int64  `tfsdk:"total_size_in_bytes"`
+	Value            types.String `tfsdk:"value"`
+}
+
+func (data *resourceKeyData) setID(ctx context.Context) error {
+	id, err := intflex.FlattenResourceId([]string{data.KeyValueStoreARN.ValueString(), data.Key.ValueString()}, ResIDKeyPartCount, false)
+
+	if err != nil {
+		return err
+	}
+
+	data.ID = flex.StringToFramework(ctx, aws.String(id))
+
+	return nil
+}

--- a/internal/service/cloudfrontkeyvaluestore/key.go
+++ b/internal/service/cloudfrontkeyvaluestore/key.go
@@ -5,55 +5,47 @@ package cloudfrontkeyvaluestore
 
 import (
 	"context"
-	"errors"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudfrontkeyvaluestore"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/cloudfrontkeyvaluestore/types"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
-	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
-	intflex "github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
-	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-var (
-	ResourceKey = newResourceKey
-)
-
 // @FrameworkResource(name="Key")
-func newResourceKey(_ context.Context) (resource.ResourceWithConfigure, error) {
-	r := &resourceKey{}
+func newKeyResource(_ context.Context) (resource.ResourceWithConfigure, error) {
+	r := &keyResource{}
 
 	return r, nil
 }
 
-const (
-	ResNameKey        = "Key"
-	ResIDKeyPartCount = 2
-)
-
-type resourceKey struct {
+type keyResource struct {
 	framework.ResourceWithConfigure
+	framework.WithImportByID
 }
 
-func (r *resourceKey) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = "aws_cloudfrontkeyvaluestore_key"
+func (*keyResource) Metadata(_ context.Context, request resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = "aws_cloudfrontkeyvaluestore_key"
 }
 
-func (r *resourceKey) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
-	resp.Schema = schema.Schema{
+func (r *keyResource) Schema(ctx context.Context, request resource.SchemaRequest, response *resource.SchemaResponse) {
+	response.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			"id": framework.IDAttribute(),
+			names.AttrID: framework.IDAttribute(),
 			"key": schema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "The key to put.",
@@ -62,6 +54,7 @@ func (r *resourceKey) Schema(ctx context.Context, req resource.SchemaRequest, re
 				},
 			},
 			"key_value_store_arn": schema.StringAttribute{
+				CustomType:          fwtypes.ARNType,
 				Required:            true,
 				MarkdownDescription: "The Amazon Resource Name (ARN) of the Key Value Store.",
 				PlanModifiers: []planmodifier.String{
@@ -80,265 +73,247 @@ func (r *resourceKey) Schema(ctx context.Context, req resource.SchemaRequest, re
 	}
 }
 
-func (r *resourceKey) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+func (r *keyResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
+	var data keyResourceModel
+	response.Diagnostics.Append(request.Plan.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
 	conn := r.Meta().CloudFrontKeyValueStoreClient(ctx)
 
-	var plan resourceKeyData
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	etag, err := findEtagByARN(ctx, conn, plan.KeyValueStoreARN.ValueString())
+	etag, err := findETagByARN(ctx, conn, data.KvsARN.ValueString())
 
 	if err != nil {
-		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.CloudFrontKeyValueStore, create.ErrActionCreating, ResNameKey, plan.Key.String(), err),
-			err.Error(),
-		)
+		response.Diagnostics.AddError(fmt.Sprintf("reading CloudFront KeyValueStore ETag (%s)", data.KvsARN.ValueString()), err.Error())
+
 		return
 	}
 
-	in := &cloudfrontkeyvaluestore.PutKeyInput{
-		IfMatch: etag,
-		Key:     aws.String(plan.Key.ValueString()),
-		KvsARN:  aws.String(plan.KeyValueStoreARN.ValueString()),
-		Value:   aws.String(plan.Value.ValueString()),
-	}
-
-	out, err := conn.PutKey(ctx, in)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.CloudFrontKeyValueStore, create.ErrActionCreating, ResNameKey, plan.Key.String(), err),
-			err.Error(),
-		)
-		return
-	}
-	if out == nil {
-		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.CloudFrontKeyValueStore, create.ErrActionCreating, ResNameKey, plan.Key.String(), nil),
-			errors.New("empty output").Error(),
-		)
+	input := &cloudfrontkeyvaluestore.PutKeyInput{}
+	response.Diagnostics.Append(fwflex.Expand(ctx, data, input)...)
+	if response.Diagnostics.HasError() {
 		return
 	}
 
-	plan.TotalSizeInBytes = flex.Int64ToFramework(ctx, out.TotalSizeInBytes)
-	err = plan.setID(ctx)
+	// Additional fields.
+	input.IfMatch = etag
+
+	output, err := conn.PutKey(ctx, input)
 
 	if err != nil {
-		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.CloudFrontKeyValueStore, create.ErrActionCreating, ResNameKey, plan.Key.String(), err),
-			err.Error(),
-		)
+		response.Diagnostics.AddError(fmt.Sprintf("creating CloudFront KeyValueStore (%s) Key (%s)", data.KvsARN.ValueString(), data.Key.ValueString()), err.Error())
+
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+	// Set values for unknowns.
+	data.TotalSizeInBytes = fwflex.Int64ToFramework(ctx, output.TotalSizeInBytes)
+	data.setID()
+
+	response.Diagnostics.Append(response.State.Set(ctx, data)...)
 }
 
-func (r *resourceKey) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	conn := r.Meta().CloudFrontKeyValueStoreClient(ctx)
-
-	var state resourceKeyData
-	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+func (r *keyResource) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
+	var data keyResourceModel
+	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
 		return
 	}
 
-	kvsARN, out, err := FindKeyByID(ctx, conn, state.ID.ValueString())
+	if err := data.InitFromID(); err != nil {
+		response.Diagnostics.AddError("parsing resource ID", err.Error())
+
+		return
+	}
+
+	conn := r.Meta().CloudFrontKeyValueStoreClient(ctx)
+
+	output, err := findKeyByTwoPartKey(ctx, conn, data.KvsARN.ValueString(), data.Key.ValueString())
+
 	if tfresource.NotFound(err) {
-		resp.State.RemoveResource(ctx)
+		response.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
+		response.State.RemoveResource(ctx)
+
 		return
 	}
-	if err != nil {
-		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.CloudFrontKeyValueStore, create.ErrActionSetting, ResNameKey, state.ID.String(), err),
-			err.Error(),
-		)
-		return
-	}
-
-	state.Key = flex.StringToFramework(ctx, out.Key)
-	state.KeyValueStoreARN = flex.StringValueToFramework(ctx, kvsARN)
-	state.TotalSizeInBytes = flex.Int64ToFramework(ctx, out.TotalSizeInBytes)
-	state.Value = flex.StringToFramework(ctx, out.Value)
-
-	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-}
-
-func (r *resourceKey) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	conn := r.Meta().CloudFrontKeyValueStoreClient(ctx)
-
-	var plan, state resourceKeyData
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
-	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	if !plan.Value.Equal(state.Value) {
-		etag, err := findEtagByARN(ctx, conn, plan.KeyValueStoreARN.ValueString())
-
-		if err != nil {
-			resp.Diagnostics.AddError(
-				create.ProblemStandardMessage(names.CloudFrontKeyValueStore, create.ErrActionUpdating, ResNameKey, plan.ID.String(), err),
-				err.Error(),
-			)
-			return
-		}
-
-		in := &cloudfrontkeyvaluestore.PutKeyInput{
-			IfMatch: etag,
-			Key:     aws.String(plan.Key.ValueString()),
-			KvsARN:  aws.String(plan.KeyValueStoreARN.ValueString()),
-			Value:   aws.String(plan.Value.ValueString()),
-		}
-
-		out, err := conn.PutKey(ctx, in)
-		if err != nil {
-			resp.Diagnostics.AddError(
-				create.ProblemStandardMessage(names.CloudFrontKeyValueStore, create.ErrActionUpdating, ResNameKey, plan.ID.String(), err),
-				err.Error(),
-			)
-			return
-		}
-		if out == nil {
-			resp.Diagnostics.AddError(
-				create.ProblemStandardMessage(names.CloudFrontKeyValueStore, create.ErrActionUpdating, ResNameKey, plan.ID.String(), nil),
-				errors.New("empty output").Error(),
-			)
-			return
-		}
-
-		plan.TotalSizeInBytes = flex.Int64ToFramework(ctx, out.TotalSizeInBytes)
-		err = plan.setID(ctx)
-
-		if err != nil {
-			resp.Diagnostics.AddError(
-				create.ProblemStandardMessage(names.CloudFrontKeyValueStore, create.ErrActionUpdating, ResNameKey, plan.ID.String(), err),
-				err.Error(),
-			)
-			return
-		}
-	}
-
-	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-}
-
-func (r *resourceKey) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	conn := r.Meta().CloudFrontKeyValueStoreClient(ctx)
-
-	var state resourceKeyData
-	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	etag, err := findEtagByARN(ctx, conn, state.KeyValueStoreARN.ValueString())
 
 	if err != nil {
-		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.CloudFrontKeyValueStore, create.ErrActionDeleting, ResNameKey, state.ID.String(), err),
-			err.Error(),
-		)
+		response.Diagnostics.AddError(fmt.Sprintf("reading CloudFront KeyValueStore Key (%s)", data.ID.ValueString()), err.Error())
+
 		return
 	}
 
-	in := &cloudfrontkeyvaluestore.DeleteKeyInput{
+	// Set attributes for import.
+	response.Diagnostics.Append(fwflex.Flatten(ctx, output, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
+}
+
+func (r *keyResource) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
+	var old, new keyResourceModel
+	response.Diagnostics.Append(request.State.Get(ctx, &old)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+	response.Diagnostics.Append(request.Plan.Get(ctx, &new)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().CloudFrontKeyValueStoreClient(ctx)
+
+	if !new.Value.Equal(old.Value) {
+		etag, err := findETagByARN(ctx, conn, new.KvsARN.ValueString())
+
+		if err != nil {
+			response.Diagnostics.AddError(fmt.Sprintf("reading CloudFront KeyValueStore ETag (%s)", new.KvsARN.ValueString()), err.Error())
+
+			return
+		}
+
+		input := &cloudfrontkeyvaluestore.PutKeyInput{}
+		response.Diagnostics.Append(fwflex.Expand(ctx, new, input)...)
+		if response.Diagnostics.HasError() {
+			return
+		}
+
+		// Additional fields.
+		input.IfMatch = etag
+
+		output, err := conn.PutKey(ctx, input)
+
+		if err != nil {
+			response.Diagnostics.AddError(fmt.Sprintf("updating CloudFront KeyValueStore (%s) Key (%s)", new.KvsARN.ValueString(), new.Key.ValueString()), err.Error())
+
+			return
+		}
+
+		// Set values for unknowns.
+		new.TotalSizeInBytes = fwflex.Int64ToFramework(ctx, output.TotalSizeInBytes)
+	}
+
+	response.Diagnostics.Append(response.State.Set(ctx, &new)...)
+}
+
+func (r *keyResource) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {
+	var data keyResourceModel
+	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().CloudFrontKeyValueStoreClient(ctx)
+
+	etag, err := findETagByARN(ctx, conn, data.KvsARN.ValueString())
+
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("reading CloudFront KeyValueStore ETag (%s)", data.KvsARN.ValueString()), err.Error())
+
+		return
+	}
+
+	_, err = conn.DeleteKey(ctx, &cloudfrontkeyvaluestore.DeleteKeyInput{
 		IfMatch: etag,
-		Key:     aws.String(state.Key.ValueString()),
-		KvsARN:  aws.String(state.KeyValueStoreARN.ValueString()),
+		Key:     fwflex.StringFromFramework(ctx, data.Key),
+		KvsARN:  fwflex.StringFromFramework(ctx, data.KvsARN),
+	})
+
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return
 	}
 
-	_, err = conn.DeleteKey(ctx, in)
-
 	if err != nil {
-		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
-			return
-		}
-		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.CloudFrontKeyValueStore, create.ErrActionDeleting, ResNameKey, state.ID.String(), err),
-			err.Error(),
-		)
+		response.Diagnostics.AddError(fmt.Sprintf("deleting CloudFront KeyValueStore Key (%s)", data.ID.ValueString()), err.Error())
+
 		return
 	}
 }
 
-func (r *resourceKey) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
-}
-
-func FindKeyByID(ctx context.Context, conn *cloudfrontkeyvaluestore.Client, id string) (kvsARN string, getKeyOutPut *cloudfrontkeyvaluestore.GetKeyOutput, err error) {
-	parts, err := intflex.ExpandResourceId(id, ResIDKeyPartCount, false)
-
-	if err != nil {
-		return "", nil, err
+func findKeyByTwoPartKey(ctx context.Context, conn *cloudfrontkeyvaluestore.Client, kvsARN, key string) (*cloudfrontkeyvaluestore.GetKeyOutput, error) {
+	input := &cloudfrontkeyvaluestore.GetKeyInput{
+		Key:    aws.String(key),
+		KvsARN: aws.String(kvsARN),
 	}
 
-	in := &cloudfrontkeyvaluestore.GetKeyInput{
-		KvsARN: aws.String(parts[0]),
-		Key:    aws.String(parts[1]),
-	}
+	output, err := conn.GetKey(ctx, input)
 
-	out, err := conn.GetKey(ctx, in)
-	if err != nil {
-		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
-			return "", nil, &retry.NotFoundError{
-				LastError:   err,
-				LastRequest: in,
-			}
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
 		}
-
-		return "", nil, err
 	}
 
-	if out == nil || out.Key == nil {
-		return "", nil, tfresource.NewEmptyResultError(in)
-	}
-
-	return parts[0], out, nil
-}
-
-func findEtagByARN(ctx context.Context, conn *cloudfrontkeyvaluestore.Client, arn string) (*string, error) {
-	in := &cloudfrontkeyvaluestore.DescribeKeyValueStoreInput{
-		KvsARN: aws.String(arn),
-	}
-
-	out, err := conn.DescribeKeyValueStore(ctx, in)
 	if err != nil {
-		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
-			return nil, &retry.NotFoundError{
-				LastError:   err,
-				LastRequest: in,
-			}
-		}
-
 		return nil, err
 	}
 
-	if out == nil || out.ETag == nil {
-		return nil, tfresource.NewEmptyResultError(in)
+	if output == nil || output.Key == nil {
+		return nil, tfresource.NewEmptyResultError(input)
 	}
 
-	return out.ETag, nil
+	return output, nil
 }
 
-type resourceKeyData struct {
+func findETagByARN(ctx context.Context, conn *cloudfrontkeyvaluestore.Client, arn string) (*string, error) {
+	input := &cloudfrontkeyvaluestore.DescribeKeyValueStoreInput{
+		KvsARN: aws.String(arn),
+	}
+
+	output, err := conn.DescribeKeyValueStore(ctx, input)
+
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.ETag == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.ETag, nil
+}
+
+type keyResourceModel struct {
 	ID               types.String `tfsdk:"id"`
 	Key              types.String `tfsdk:"key"`
-	KeyValueStoreARN types.String `tfsdk:"key_value_store_arn"`
+	KvsARN           fwtypes.ARN  `tfsdk:"key_value_store_arn"`
 	TotalSizeInBytes types.Int64  `tfsdk:"total_size_in_bytes"`
 	Value            types.String `tfsdk:"value"`
 }
 
-func (data *resourceKeyData) setID(ctx context.Context) error {
-	id, err := intflex.FlattenResourceId([]string{data.KeyValueStoreARN.ValueString(), data.Key.ValueString()}, ResIDKeyPartCount, false)
+const (
+	keyResourceIDPartCount = 2
+)
 
+func (data *keyResourceModel) InitFromID() error {
+	id := data.ID.ValueString()
+	parts, err := flex.ExpandResourceId(id, keyResourceIDPartCount, false)
 	if err != nil {
 		return err
 	}
 
-	data.ID = flex.StringToFramework(ctx, aws.String(id))
+	v, err := fwdiag.AsErr(fwtypes.ARNValue(parts[0]))
+	if err != nil {
+		return err
+	}
+
+	data.KvsARN = v
+	data.Key = types.StringValue(parts[1])
 
 	return nil
+}
+
+func (data *keyResourceModel) setID() {
+	data.ID = types.StringValue(errs.Must(flex.FlattenResourceId([]string{data.KvsARN.ValueString(), data.Key.ValueString()}, keyResourceIDPartCount, false)))
 }

--- a/internal/service/cloudfrontkeyvaluestore/key_test.go
+++ b/internal/service/cloudfrontkeyvaluestore/key_test.go
@@ -1,0 +1,197 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cloudfrontkeyvaluestore_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+
+	tfcloudfrontkeyvaluestore "github.com/hashicorp/terraform-provider-aws/internal/service/cloudfrontkeyvaluestore"
+)
+
+func TestAccCloudFrontKeyValueStoreKey_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	value := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_cloudfrontkeyvaluestore_key.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.CloudFront)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFront),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckKeyDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKeyConfig_basic(rName, value),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeyExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "key", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "key_value_store_arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "total_size_in_bytes"),
+					resource.TestCheckResourceAttr(resourceName, "value", value),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccCloudFrontKeyValueStoreKey_value(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	value1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	value2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resourceName := "aws_cloudfrontkeyvaluestore_key.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.CloudFront)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFront),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckKeyDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKeyConfig_basic(rName, value1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeyExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "key", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "key_value_store_arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "total_size_in_bytes"),
+					resource.TestCheckResourceAttr(resourceName, "value", value1),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccKeyConfig_basic(rName, value2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeyExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "key", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "key_value_store_arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "total_size_in_bytes"),
+					resource.TestCheckResourceAttr(resourceName, "value", value2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudFrontKeyValueStoreKey_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	value := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_cloudfrontkeyvaluestore_key.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.CloudFront)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFront),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckKeyDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKeyConfig_basic(rName, value),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeyExists(ctx, resourceName),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfcloudfrontkeyvaluestore.ResourceKey, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckKeyDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).CloudFrontKeyValueStoreClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_cloudfrontkeyvaluestore_key" {
+				continue
+			}
+
+			_, _, err := tfcloudfrontkeyvaluestore.FindKeyByID(ctx, conn, rs.Primary.ID)
+			if tfresource.NotFound(err) {
+				return nil
+			}
+
+			if err != nil {
+				return create.Error(names.CloudFrontKeyValueStore, create.ErrActionCheckingDestroyed, tfcloudfrontkeyvaluestore.ResNameKey, rs.Primary.ID, err)
+			}
+
+			return create.Error(names.CloudFrontKeyValueStore, create.ErrActionCheckingDestroyed, tfcloudfrontkeyvaluestore.ResNameKey, rs.Primary.ID, errors.New("not destroyed"))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckKeyExists(ctx context.Context, name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.CloudFrontKeyValueStore, create.ErrActionCheckingExistence, tfcloudfrontkeyvaluestore.ResNameKey, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.CloudFrontKeyValueStore, create.ErrActionCheckingExistence, tfcloudfrontkeyvaluestore.ResNameKey, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).CloudFrontKeyValueStoreClient(ctx)
+		_, _, err := tfcloudfrontkeyvaluestore.FindKeyByID(ctx, conn, rs.Primary.ID)
+		if tfresource.NotFound(err) {
+			return create.Error(names.CloudFrontKeyValueStore, create.ErrActionCheckingExistence, tfcloudfrontkeyvaluestore.ResNameKey, rs.Primary.ID, errors.New("Resource Not Found"))
+		}
+
+		if err != nil {
+			return create.Error(names.CloudFrontKeyValueStore, create.ErrActionCheckingExistence, tfcloudfrontkeyvaluestore.ResNameKey, rs.Primary.ID, err)
+		}
+
+		return nil
+	}
+}
+
+func testAccKeyConfig_basic(rName, value string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudfront_key_value_store" "test" {
+  name = %[1]q
+}
+resource "aws_cloudfrontkeyvaluestore_key" "test" {
+  key                 = %[1]q
+  key_value_store_arn = aws_cloudfront_key_value_store.test.arn
+  value               = %[2]q
+}
+`, rName, value)
+}

--- a/internal/service/cloudfrontkeyvaluestore/key_test.go
+++ b/internal/service/cloudfrontkeyvaluestore/key_test.go
@@ -15,10 +15,9 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tfcloudfrontkeyvaluestore "github.com/hashicorp/terraform-provider-aws/internal/service/cloudfrontkeyvaluestore"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
-
-	tfcloudfrontkeyvaluestore "github.com/hashicorp/terraform-provider-aws/internal/service/cloudfrontkeyvaluestore"
 )
 
 func TestAccCloudFrontKeyValueStoreKey_basic(t *testing.T) {

--- a/internal/service/cloudfrontkeyvaluestore/service_package_gen.go
+++ b/internal/service/cloudfrontkeyvaluestore/service_package_gen.go
@@ -19,7 +19,12 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.Serv
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.ServicePackageFrameworkResource {
-	return []*types.ServicePackageFrameworkResource{}
+	return []*types.ServicePackageFrameworkResource{
+		{
+			Factory: newResourceKey,
+			Name:    "Key",
+		},
+	}
 }
 
 func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePackageSDKDataSource {

--- a/internal/service/cloudfrontkeyvaluestore/service_package_gen.go
+++ b/internal/service/cloudfrontkeyvaluestore/service_package_gen.go
@@ -21,7 +21,7 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.Serv
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.ServicePackageFrameworkResource {
 	return []*types.ServicePackageFrameworkResource{
 		{
-			Factory: newResourceKey,
+			Factory: newKeyResource,
 			Name:    "Key",
 		},
 	}

--- a/names/data/names_data.csv
+++ b/names/data/names_data.csv
@@ -62,7 +62,7 @@ servicediscovery,servicediscovery,servicediscovery,servicediscovery,,servicedisc
 cloud9,cloud9,cloud9,cloud9,,cloud9,,,Cloud9,Cloud9,,,2,,aws_cloud9_,,cloud9_,Cloud9,AWS,,,,,,,Cloud9,ListEnvironments,,
 cloudformation,cloudformation,cloudformation,cloudformation,,cloudformation,,,CloudFormation,CloudFormation,,1,,,aws_cloudformation_,,cloudformation_,CloudFormation,AWS,,,,,,,CloudFormation,ListStackInstances,,
 cloudfront,cloudfront,cloudfront,cloudfront,,cloudfront,,,CloudFront,CloudFront,,1,2,,aws_cloudfront_,,cloudfront_,CloudFront,Amazon,,,,,,,CloudFront,ListDistributions,,
-cloudfront-keyvaluestore,cloudfrontkeyvaluestore,,cloudfrontkeyvaluestore,,cloudfrontkeyvaluestore,,,CloudFrontKeyValueStore,CloudFrontKeyValueStore,,,2,,aws_cloudfrontkeyvaluestore_,,cloudfront_keyvaluestore_,CloudFront KeyValueStore,Amazon,,,,,,,CloudFront KeyValueStore,ListKeys,"KvsARN: aws_sdkv2.String(""arn:aws:cloudfront::111122223333:key-value-store/MaxAge"")",
+cloudfront-keyvaluestore,cloudfrontkeyvaluestore,,cloudfrontkeyvaluestore,,cloudfrontkeyvaluestore,,,CloudFrontKeyValueStore,CloudFrontKeyValueStore,,,2,,aws_cloudfrontkeyvaluestore_,,cloudfrontkeyvaluestore_,CloudFront KeyValueStore,Amazon,,,,,,,CloudFront KeyValueStore,ListKeys,"KvsARN: aws_sdkv2.String(""arn:aws:cloudfront::111122223333:key-value-store/MaxAge"")",
 cloudhsm,cloudhsm,cloudhsm,cloudhsm,,,,,,,,,,,,,,CloudHSM,AWS,x,,,,,,,,,Legacy
 cloudhsmv2,cloudhsmv2,cloudhsmv2,cloudhsmv2,,cloudhsmv2,,cloudhsm,CloudHSMV2,CloudHSMV2,x,,2,aws_cloudhsm_v2_,aws_cloudhsmv2_,,cloudhsm,CloudHSM,AWS,,,,,,,CloudHSM V2,DescribeClusters,,
 cloudsearch,cloudsearch,cloudsearch,cloudsearch,,cloudsearch,,,CloudSearch,CloudSearch,,,2,,aws_cloudsearch_,,cloudsearch_,CloudSearch,Amazon,,,,,,,CloudSearch,ListDomainNames,,

--- a/website/docs/r/cloudfrontkeyvaluestore_key.html.markdown
+++ b/website/docs/r/cloudfrontkeyvaluestore_key.html.markdown
@@ -1,0 +1,60 @@
+---
+subcategory: "CloudFront KeyValueStore"
+layout: "aws"
+page_title: "AWS: aws_cloudfrontkeyvaluestore_key"
+description: |-
+  Terraform resource for managing an AWS CloudFront KeyValueStore Key.
+---
+
+# Resource: aws_cloudfrontkeyvaluestore_key
+
+Terraform resource for managing an AWS CloudFront KeyValueStore Key.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_cloudfront_key_value_store" "example" {
+  name    = "ExampleKeyValueStore"
+  comment = "This is an example key value store"
+}
+
+resource "aws_cloudfrontkeyvaluestore_key" "example" {
+  key_value_store_arn = aws_cloudfront_key_value_store.example.arn
+  key                 = "Test Key"
+  value               = "Test Value"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `key` - (Required) Key to put.
+* `key_value_store_arn` - (Required) Amazon Resource Name (ARN) of the Key Value Store.
+* `value` - (Required) Value to put.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `id` - Combination of attributes separated by a `,` to create a unique id: `key_value_store_arn`,`key`
+* `total_size_in_bytes` - Total size of the Key Value Store in bytes.
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import CloudFront KeyValueStore Key using the `example_id_arg`. For example:
+
+```terraform
+import {
+  to = aws_cloudfrontkeyvaluestore_key.example
+  id = "arn:aws:cloudfront::111111111111:key-value-store/8562g61f-caba-2845-9d99-b97diwae5d3c,someKey"
+}
+```
+
+Using `terraform import`, import CloudFront KeyValueStore Key using the `id`. For example:
+
+```console
+% terraform import aws_cloudfrontkeyvaluestore_key.example arn:aws:cloudfront::111111111111:key-value-store/8562g61f-caba-2845-9d99-b97diwae5d3c,someKey
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This pull requests adds the ability to create and manage Cloudfront Key Value Store Keys with terraform utilizing the `aws_cloudfrontkeyvaluestore_key` resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #35793

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccCloudFrontKeyValueStoreKey' PKG=cloudfrontkeyvaluestore
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/cloudfrontkeyvaluestore/... -v -count 1 -parallel 20  -run=TestAccCloudFrontKeyValueStoreKey -timeout 360m
=== RUN   TestAccCloudFrontKeyValueStoreKey_basic
=== PAUSE TestAccCloudFrontKeyValueStoreKey_basic
=== RUN   TestAccCloudFrontKeyValueStoreKey_value
=== PAUSE TestAccCloudFrontKeyValueStoreKey_value
=== RUN   TestAccCloudFrontKeyValueStoreKey_disappears
=== PAUSE TestAccCloudFrontKeyValueStoreKey_disappears
=== CONT  TestAccCloudFrontKeyValueStoreKey_basic
=== CONT  TestAccCloudFrontKeyValueStoreKey_value
=== CONT  TestAccCloudFrontKeyValueStoreKey_disappears
--- PASS: TestAccCloudFrontKeyValueStoreKey_basic (28.79s)
--- PASS: TestAccCloudFrontKeyValueStoreKey_disappears (37.95s)
--- PASS: TestAccCloudFrontKeyValueStoreKey_value (46.48s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudfrontkeyvaluestore    52.515s
...
```
