### PR TITLE
[docs] Fix terraform-provider-aws documentation typos, misspellings

### DIFF
--- a/docs/acc-test-environment-variables.md
+++ b/docs/acc-test-environment-variables.md
@@ -5,10 +5,10 @@ Environment variables (beyond standard AWS Go SDK ones) used by acceptance testi
 | Variable | Description |
 |----------|-------------|
 | `ACM_CERTIFICATE_ROOT_DOMAIN` | Root domain name to use with ACM Certificate testing. |
-| `ACM_CERTIFICATE_MULTIPLE_ISSUED_DOMAIN` | Domain name of ACM Certificate with a multiple issued certificates. **DEPRECATED:** Should be replaced with `aws_acm_certficate` resource usage in tests. |
-| `ACM_CERTIFICATE_MULTIPLE_ISSUED_MOST_RECENT_ARN` | Amazon Resource Name of most recent ACM Certificate with a multiple issued certificates. **DEPRECATED:** Should be replaced with `aws_acm_certficate` resource usage in tests. |
-| `ACM_CERTIFICATE_SINGLE_ISSUED_DOMAIN` | Domain name of ACM Certificate with a single issued certificate. **DEPRECATED:** Should be replaced with `aws_acm_certficate` resource usage in tests. |
-| `ACM_CERTIFICATE_SINGLE_ISSUED_MOST_RECENT_ARN` | Amazon Resource Name of most recent ACM Certificate with a single issued certificate. **DEPRECATED:** Should be replaced with `aws_acm_certficate` resource usage in tests. |
+| `ACM_CERTIFICATE_MULTIPLE_ISSUED_DOMAIN` | Domain name of ACM Certificate with multiple issued certificates. **DEPRECATED:** Should be replaced with `aws_acm_certificate` resource usage in tests. |
+| `ACM_CERTIFICATE_MULTIPLE_ISSUED_MOST_RECENT_ARN` | Amazon Resource Name of most recent ACM Certificate with multiple issued certificates. **DEPRECATED:** Should be replaced with `aws_acm_certificate` resource usage in tests. |
+| `ACM_CERTIFICATE_SINGLE_ISSUED_DOMAIN` | Domain name of ACM Certificate with a single issued certificate. **DEPRECATED:** Should be replaced with `aws_acm_certificate` resource usage in tests. |
+| `ACM_CERTIFICATE_SINGLE_ISSUED_MOST_RECENT_ARN` | Amazon Resource Name of most recent ACM Certificate with a single issued certificate. **DEPRECATED:** Should be replaced with `aws_acm_certificate` resource usage in tests. |
 | `ADM_CLIENT_ID` | Identifier for Amazon Device Manager Client in Pinpoint testing. |
 | `AMPLIFY_DOMAIN_NAME` | Domain name to use for Amplify domain association testing. |
 | `AMPLIFY_GITHUB_ACCESS_TOKEN` | GitHub access token used for AWS Amplify testing. |
@@ -23,7 +23,7 @@ Environment variables (beyond standard AWS Go SDK ones) used by acceptance testi
 | `APNS_SANDBOX_CREDENTIAL` | Credential contents for Sandbox Apple Push Notification Service in SNS Application Platform testing. Conflicts with `APNS_SANDBOX_CREDENTIAL_PATH`. |
 | `APNS_SANDBOX_CREDENTIAL_PATH` | Path to credential for Sandbox Apple Push Notification Service in SNS Application Platform testing. Conflicts with `APNS_SANDBOX_CREDENTIAL`. |
 | `APNS_SANDBOX_PRINCIPAL` | Principal contents for Sandbox Apple Push Notification Service in SNS Application Platform testing. Conflicts with `APNS_SANDBOX_PRINCIPAL_PATH`. |
-| `APNS_SANDBOX_PRINCIPAL_PATH` | Path to principal for Sandbox Apple Push Notification Service in SNS Application Platform testing. Conflicts with `APNS_SANDBOX_PRINCIPAL`. |
+| `APNS_SANDBOX_PRINCIPAL_PATH` | Path to the principal for Sandbox Apple Push Notification Service in SNS Application Platform testing. Conflicts with `APNS_SANDBOX_PRINCIPAL`. |
 | `APNS_SANDBOX_TEAM_ID` | Identifier for Sandbox Apple Push Notification Service Team in Pinpoint testing. |
 | `APNS_SANDBOX_TOKEN_KEY` | Token key file content (.p8 format) for Sandbox Apple Push Notification Service in Pinpoint testing. |
 | `APNS_SANDBOX_TOKEN_KEY_ID` | Identifier for Sandbox Apple Push Notification Service Token Key in Pinpoint testing. |
@@ -57,9 +57,9 @@ Environment variables (beyond standard AWS Go SDK ones) used by acceptance testi
 | `AWS_EC2_VERIFIED_ACCESS_INSTANCE_LIMIT` | Concurrency limit for Verified Access acceptance tests. [Default is 5](https://docs.aws.amazon.com/verified-access/latest/ug/verified-access-quotas.html) if not specified. |
 | `AWS_GUARDDUTY_MEMBER_ACCOUNT_ID` | Identifier of AWS Account for GuardDuty Member testing. **DEPRECATED:** Should be replaced with standard alternate account handling for tests. |
 | `AWS_GUARDDUTY_MEMBER_EMAIL` | Email address for GuardDuty Member testing. **DEPRECATED:** It may be possible to use a placeholder email address instead. |
-| `AWS_LAMBDA_IMAGE_LATEST_ID` | ECR repository image URI (tagged as `latest`) for Lambda container image acceptance tests.
-| `AWS_LAMBDA_IMAGE_V1_ID` | ECR repository image URI (tagged as `v1`) for Lambda container image acceptance tests.
-| `AWS_LAMBDA_IMAGE_V2_ID` | ECR repository image URI (tagged as `v2`) for Lambda container image acceptance tests.
+| `AWS_LAMBDA_IMAGE_LATEST_ID` | ECR repository image URI (tagged as `latest`) for Lambda container image acceptance tests. |
+| `AWS_LAMBDA_IMAGE_V1_ID` | ECR repository image URI (tagged as `v1`) for Lambda container image acceptance tests. |
+| `AWS_LAMBDA_IMAGE_V2_ID` | ECR repository image URI (tagged as `v2`) for Lambda container image acceptance tests. |
 | `AWS_THIRD_ACCESS_KEY_ID` | AWS access key ID with access to a third AWS account for tests requiring multiple accounts. Requires `AWS_THIRD_SECRET_ACCESS_KEY`. Conflicts with `AWS_THIRD_PROFILE`. |
 | `AWS_THIRD_SECRET_ACCESS_KEY` | AWS secret access key with access to a third AWS account for tests requiring multiple accounts. Requires `AWS_THIRD_ACCESS_KEY_ID`. Conflicts with `AWS_THIRD_PROFILE`. |
 | `AWS_THIRD_PROFILE` | AWS profile with access to a third AWS account for tests requiring multiple accounts. Conflicts with `AWS_THIRD_ACCESS_KEY_ID` and `AWS_THIRD_SECRET_ACCESS_KEY`. |

--- a/docs/add-a-new-datasource.md
+++ b/docs/add-a-new-datasource.md
@@ -21,13 +21,13 @@ For a new data source use a branch named `f-{datasource name}` for example: `f-e
 
 See the [Naming Guide](naming.md#resources-and-data-sources) for details on how to name the new resource and the resource file. Not following the naming standards will cause extra delay as maintainers request that you make changes.
 
-Use the [skaff](skaff.md) provider scaffolding tool to generate new resource and test templates using your chosen name ensuring you provide the `v1` flag if you are targeting version 1 of the `aws-go-sdk`. Doing so will ensure that any boilerplate code, structural best practices and repetitive naming is done for you and always represents our most current standards.
+Use the [skaff](skaff.md) provider scaffolding tool to generate new resource and test templates using your chosen name ensuring you provide the `v1` flag if you are targeting version 1 of the `aws-go-sdk`. Doing so will ensure that any boilerplate code, structural best practices and repetitive naming are done for you and always represent our most current standards.
 
 ### Fill out the Data Source Schema
 
 In the `internal/service/<service>/<service>_data_source.go` file you will see a `Schema` property which exists as a map of `Schema` objects. This relates the AWS API data model with the Terraform resource itself. For each property you want to make available in Terraform, you will need to add it as an attribute, and choose the correct data type.
 
-Attribute names are to specified in `snake_case` as opposed to the AWS API which is `CamelCase`
+Attribute names are to be specified in `snake_case`` as opposed to the AWS API which is `CamelCase`
 
 ### Implement Read Handler
 
@@ -35,7 +35,7 @@ These will map the AWS API response to the data source schema. You will also nee
 
 ### Register Data Source to the provider
 
-Data Sources use a self registration process that adds them to the provider using the `@SDKDataSource()` annotation in the datasource's comments. Run `make gen` to register the datasource. This will add an entry to the `service_package_gen.go` file located in the service package folder.
+Data Sources use a self-registration process that adds them to the provider using the `@SDKDataSource()` annotation in the data source's comments. Run `make gen` to register the data source. This will add an entry to the `service_package_gen.go` file located in the service package folder.
 
 === "Terraform Plugin Framework (Preferred)"
 
@@ -78,13 +78,13 @@ Data Sources use a self registration process that adds them to the provider usin
 
 ### Write Passing Acceptance Tests
 
-In order to adequately test the data source we will need to write a complete set of Acceptance Tests. You will need an AWS account for this which allows the provider to read to state of the associated resource. See [Writing Acceptance Tests](running-and-writing-acceptance-tests.md) for a detailed guide on how to approach these.
+To adequately test the data source we will need to write a complete set of Acceptance Tests. You will need an AWS account for this which allows the provider to read to state of the associated resource. See [Writing Acceptance Tests](running-and-writing-acceptance-tests.md) for a detailed guide on how to approach these.
 
-You will need at minimum:
+You will need at a minimum:
 
 - Basic Test - Tests full lifecycle (CRUD + Import) of a minimal configuration (all required fields, no optional).
 - Disappears Test - Tests what Terraform does if a resource it is tracking can no longer be found.
-- Per Attribute Tests - For each attribute a test should exists which tests that particular attribute in isolation alongside any required fields.
+- Per Attribute Tests - For each attribute a test should exist which tests that particular attribute in isolation alongside any required fields.
 
 ### Create Documentation for the Data Source
 

--- a/docs/add-a-new-datasource.md
+++ b/docs/add-a-new-datasource.md
@@ -27,7 +27,7 @@ Use the [skaff](skaff.md) provider scaffolding tool to generate new resource and
 
 In the `internal/service/<service>/<service>_data_source.go` file you will see a `Schema` property which exists as a map of `Schema` objects. This relates the AWS API data model with the Terraform resource itself. For each property you want to make available in Terraform, you will need to add it as an attribute, and choose the correct data type.
 
-Attribute names are to be specified in `snake_case`` as opposed to the AWS API which is `CamelCase`
+Attribute names are to be specified in `snake_case` as opposed to the AWS API which is `CamelCase`
 
 ### Implement Read Handler
 

--- a/docs/add-a-new-function.md
+++ b/docs/add-a-new-function.md
@@ -2,6 +2,7 @@
 
 !!! tip
     Provider-defined function support is in technical preview and offered without compatibility promises until Terraform 1.8 is generally available.
+
 Provider-defined functions were introduced with Terraform 1.8, enabling provider developers to expose functions specific to a given cloud provider or use case.
 Functions in the AWS provider provide a utility that is valuable when paired with AWS resources.
 
@@ -18,7 +19,7 @@ Data manipulation tasks tend to be the most common use cases.
 
 ### Fork the provider and create a feature branch
 
-For a new function use a branch named `f-{function name}, for example, `f-arn_parse`.
+For a new function use a branch named `f-{function name}`, for example, `f-arn_parse`.
 See [Raising a Pull Request](raising-a-pull-request.md) for more details.
 
 ### Create and name the function

--- a/docs/add-a-new-function.md
+++ b/docs/add-a-new-function.md
@@ -2,15 +2,14 @@
 
 !!! tip
     Provider-defined function support is in technical preview and offered without compatibility promises until Terraform 1.8 is generally available.
-
-Provider defined functions were introduced with Terraform 1.8, enabling provider developers to expose functions specific to a given cloud provider or use case.
-Functions in the AWS provider provide utility that is valuable when paired with AWS resources.
+Provider-defined functions were introduced with Terraform 1.8, enabling provider developers to expose functions specific to a given cloud provider or use case.
+Functions in the AWS provider provide a utility that is valuable when paired with AWS resources.
 
 See the Terraform Plugin Framework [Function documentation](https://developer.hashicorp.com/terraform/plugin/framework/functions) for additional details.
 
 ## Prerequisites
 
-The only prerequisite for creating a function is ensuring the desired functionality is appropriate for a provider defined function.
+The only prerequisite for creating a function is ensuring the desired functionality is appropriate for a provider-defined function.
 Functions must be reproducible across executions ("pure" functions), where the same input always results in the same output.
 This requirement precludes the use of network calls, so operations requiring an AWS API call should instead consider utilizing a [data source](add-a-new-datasource.md).
 Data manipulation tasks tend to be the most common use cases.
@@ -19,15 +18,15 @@ Data manipulation tasks tend to be the most common use cases.
 
 ### Fork the provider and create a feature branch
 
-For a new function use a branch named `f-{function name}`, for example `f-arn_parse`.
+For a new function use a branch named `f-{function name}, for example, `f-arn_parse`.
 See [Raising a Pull Request](raising-a-pull-request.md) for more details.
 
 ### Create and name the function
 
-The function name should be descriptive of it's functionality and succinct.
+The function name should be descriptive of its functionality and succinct.
 Existing examples include `arn_parse` for decomposing ARN strings and `arn_build` for constructing them.
 
-At this time [skaff](skaff.md) does not support creation of new functions.
+At this time [skaff](skaff.md) does not support the creation of new functions.
 New functions can be created by copying the format of an existing function inside `internal/functions`.
 
 ### Fill out the function parameter(s) and return value
@@ -69,7 +68,7 @@ func (f exampleFunction) Run(ctx context.Context, req function.RunRequest, resp 
 ### Register function to the provider
 
 Once the function is implemented, it must be registered to the provider to be used.
-As only Terraform Plugin Framework supports provider defined functions, registration occurs on the Plugin Framework provider inside `internal/provider/fwprovider/provider.go`.
+As only Terraform Plugin Framework supports provider-defined functions, registration occurs on the Plugin Framework provider inside `internal/provider/fwprovider/provider.go`.
 Add the `New*` factory function in the `Functions` method to register it.
 
 ```go

--- a/docs/add-a-new-region.md
+++ b/docs/add-a-new-region.md
@@ -3,7 +3,7 @@
 New regions can typically be used immediately with the provider, with two important caveats:
 
 - Regions often need to be explicitly enabled via the AWS console. See [ap-east-1 launch blog](https://aws.amazon.com/blogs/aws/now-open-aws-asia-pacific-hong-kong-region/) for an example of how to enable a new region for use.
-- Until the provider is aware of the new region, automatic region validation will fail. In order to use the region before validation support is added to the provider you will need to disable region validation by doing the following:
+- Until the provider is aware of the new region, automatic region validation will fail. To use the region before validation support is added to the provider you will need to disable region validation by doing the following:
 
 ```terraform
 provider "aws" {
@@ -16,7 +16,7 @@ provider "aws" {
 
 ## Enabling Region Validation
 
-Support for region validation requires that the provider has an updated AWS Go SDK dependency that includes the new region. These are added to the AWS Go SDK `aws/endpoints/defaults.go` file and generally noted in the AWS Go SDK `CHANGELOG` as `aws/endpoints: Updated Regions`. This also needs to be done in the core Terraform binary itself to enable it for the S3 backend. The provider currently takes a dependency on both v1 AND v2 of the AWS Go SDK, as we start to base new (and migrate) resources on v2. Many of the authentication and provider level configuration interactions are also located in the aws-go-sdk-base library. As all of these things take direct dependencies and as a result there ends up being quite a few places these dependency updates need to be made.
+Support for region validation requires that the provider has an updated AWS Go SDK dependency that includes the new region. These are added to the AWS Go SDK `aws/endpoints/defaults.go` file and generally noted in the AWS Go SDK `CHANGELOG` as `aws/endpoints: Updated Regions`. This also needs to be done in the core Terraform binary itself to enable it for the S3 backend. The provider currently takes a dependency on both v1 AND v2 of the AWS Go SDK, as we start to base new (and migrate) resources on v2. Many of the authentication and provider-level configuration interactions are also located in the aws-go-sdk-base library. As all of these things take direct dependencies and as a result there end up being quite a few places where these dependency updates need to be made.
 
 ### Update aws-go-sdk-base
 

--- a/docs/add-a-new-resource.md
+++ b/docs/add-a-new-resource.md
@@ -14,30 +14,29 @@ Determine which version of the AWS SDK for Go the resource will be built upon. F
 ## Steps to Add a Resource
 
 ### Fork the provider and create a feature branch
-
-For a new resources use a branch named `f-{resource name}` for example: `f-ec2-vpc`. See [Raising a Pull Request](raising-a-pull-request.md) for more details.
+For new resources use a branch named `f-{resource name}` for example: `f-ec2-vpc`. See [Raising a Pull Request](raising-a-pull-request.md) for more details.
 
 ### Create and Name the Resource
 
 See the [Naming Guide](naming.md#resources-and-data-sources) for details on how to name the new resource and the resource file. Not following the naming standards will cause extra delay as maintainers request that you make changes.
 
-Use the [skaff](skaff.md) provider scaffolding tool to generate new resource and test templates using your chosen name ensuring you provide the `v1` flag if you are targeting version 1 of the `aws-go-sdk`. Doing so will ensure that any boilerplate code, structural best practices and repetitive naming is done for you and always represents our most current standards.
+Use the [skaff](skaff.md) provider scaffolding tool to generate new resource and test templates using your chosen name ensuring you provide the `v1` flag if you are targeting version 1 of the `aws-go-sdk`. Doing so will ensure that any boilerplate code, structural best practices and repetitive naming are done for you and always represent our most current standards.
 
 ### Fill out the Resource Schema
 
-In the `internal/service/<service>/<service>.go` file you will see a `Schema` property which exists as a map of `Schema` objects. This relates the AWS API data model with the Terraform resource itself. For each property you want to make available in Terraform, you will need to add it as an attribute, choose the correct data type and supply the correct [Schema Behaviors](https://www.terraform.io/plugin/sdkv2/schemas/schema-behaviors) in order to ensure Terraform knows how to correctly handle the value.
+In the `internal/service/<service>/<service>.go` file you will see a `Schema` property which exists as a map of `Schema` objects. This relates the AWS API data model with the Terraform resource itself. For each property you want to make available in Terraform, you will need to add it as an attribute, choose the correct data type and supply the correct [Schema Behaviors](https://www.terraform.io/plugin/sdkv2/schemas/schema-behaviors) to ensure Terraform knows how to correctly handle the value.
 
-Typically you will add arguments to represent the values that are under control by Terraform, and attributes in order to supply read-only values as references for Terraform. These are distinguished by Schema Behavior.
+Typically you will add arguments to represent the values that are under control by Terraform, and attributes to supply read-only values as references for Terraform. These are distinguished by Schema Behavior.
 
-Attribute names are to specified in `camel_case` as opposed to the AWS API which is `CamelCase`
+Attribute names are to be specified in `camel_case`` as opposed to the AWS API which is `CamelCase`
 
 ### Implement CRUD handlers
 
-These will map planned Terraform state to the AWS API call, or an AWS API response to an applied Terraform state. You will also need to handle different response types (including errors correctly). For complex attributes you will need to implement Flattener or Expander functions. The [Data Handling and Conversion Guide](data-handling-and-conversion.md) covers everything you need to know for mapping AWS API responses to Terraform State and vice-versa. The [Error Handling Guide](error-handling.md) covers everything you need to know about handling AWS API responses consistently.
+These will map the planned Terraform state to the AWS API call, or an AWS API response to an applied Terraform state. You will also need to handle different response types (including errors correctly). For complex attributes, you will need to implement Flattener or Expander functions. The [Data Handling and Conversion Guide](data-handling-and-conversion.md) covers everything you need to know for mapping AWS API responses to Terraform State and vice-versa. The [Error Handling Guide](error-handling.md) covers everything you need to know about handling AWS API responses consistently.
 
 ### Register Resource to the provider
 
-Resources use a self registration process that adds them to the provider using the `@FrameworkResource()` or `@SDKResource()` annotation in the resource's comments. Run `make gen` to register the resource. This will add an entry to the `service_package_gen.go` file located in the service package folder.
+Resources use a self-registration process that adds them to the provider using the `@FrameworkResource()` or `@SDKResource()` annotation in the resource's comments. Run `make gen` to register the resource. This will add an entry to the `service_package_gen.go` file located in the service package folder.
 
 === "Terraform Plugin Framework (Preferred)"
 
@@ -80,9 +79,9 @@ Resources use a self registration process that adds them to the provider using t
 
 ### Write passing Acceptance Tests
 
-In order to adequately test the resource we will need to write a complete set of Acceptance Tests. You will need an AWS account for this which allows the creation of that resource. See [Writing Acceptance Tests](running-and-writing-acceptance-tests.md) for a detailed guide on how to approach these.
+To adequately test the resource we will need to write a complete set of Acceptance Tests. You will need an AWS account for this which allows the creation of that resource. See [Writing Acceptance Tests](running-and-writing-acceptance-tests.md) for a detailed guide on how to approach these.
 
-You will need at minimum:
+You will need at a minimum:
 
 - Basic Test - Tests full lifecycle (CRUD + Import) of a minimal configuration (all required fields, no optional).
 - Disappears Test - Tests what Terraform does if a resource it is tracking can no longer be found.

--- a/docs/add-a-new-resource.md
+++ b/docs/add-a-new-resource.md
@@ -28,7 +28,7 @@ In the `internal/service/<service>/<service>.go` file you will see a `Schema` pr
 
 Typically you will add arguments to represent the values that are under control by Terraform, and attributes to supply read-only values as references for Terraform. These are distinguished by Schema Behavior.
 
-Attribute names are to be specified in `camel_case`` as opposed to the AWS API which is `CamelCase`
+Attribute names are to be specified in `camel_case` as opposed to the AWS API which is `CamelCase`.
 
 ### Implement CRUD handlers
 

--- a/docs/add-a-new-resource.md
+++ b/docs/add-a-new-resource.md
@@ -14,6 +14,7 @@ Determine which version of the AWS SDK for Go the resource will be built upon. F
 ## Steps to Add a Resource
 
 ### Fork the provider and create a feature branch
+
 For new resources use a branch named `f-{resource name}` for example: `f-ec2-vpc`. See [Raising a Pull Request](raising-a-pull-request.md) for more details.
 
 ### Create and Name the Resource

--- a/docs/add-a-new-service.md
+++ b/docs/add-a-new-service.md
@@ -53,6 +53,7 @@ package <service>
 ```
 
 Next, generate the client and ensure all dependencies are fetched.
+
 ```console
 make gen
 ```
@@ -60,6 +61,7 @@ make gen
 ```console
 go mod tidy
 ```
+
 At this point a pull request with the re-generated files and new service client can be submitted.
 
 Once the service client has been added, implement the first [resource](./add-a-new-resource.md) or [data source](./add-a-new-datasource.md) in a separate PR.

--- a/docs/add-a-new-service.md
+++ b/docs/add-a-new-service.md
@@ -5,11 +5,11 @@ AWS frequently launches new services, and Terraform support is frequently desire
 
 ## Perform Service Design
 
-Before adding a new service to the provider its a good idea to familiarize yourself with the primary workflows practitioners are likely to want to accomplish with the provider to ensure the provider design can solve for this. Its not always necessary to cover 100% of the AWS service offering to unblock most workflows.
+Before adding a new service to the provider it's a good idea to familiarize yourself with the primary workflows practitioners are likely to want to accomplish with the provider to ensure the provider design can solve this. It's not always necessary to cover 100% of the AWS service offering to unblock most workflows.
 
-You should have an idea of what resources and data sources should be added, their dependencies and relative importance in relation to the workflow. This should give you an idea of the order in which resources to be added. It's important to note that generally, we like to review and merge resources in isolation, and avoid combining multiple new resources in one Pull Request.
+You should have an idea of what resources and data sources should be added, their dependencies and relative importance concerning the workflow. This should give you an idea of the order in which resources are to be added. It's important to note that generally, we like to review and merge resources in isolation, and avoid combining multiple new resources in one Pull Request.
 
-Using the AWS API documentation as a reference, identify the various API's which correspond to the CRUD operations which consist of the management surface for that resource. These will be the set of API's called from the new resource. The API's model attributes will correspond to your resource schema.
+Using the AWS API documentation as a reference, identify the various APIs that correspond to the CRUD operations which consist of the management surface for that resource. These will be the set of APIs called from the new resource. The API's model attributes will correspond to your resource schema.
 
 From there begin to map out the list of resources you would like to implement, and note your plan on the GitHub issue relating to the service (or create one if one does not exist) for the community and maintainers to feedback.
 
@@ -53,7 +53,6 @@ package <service>
 ```
 
 Next, generate the client and ensure all dependencies are fetched.
-
 ```console
 make gen
 ```
@@ -61,14 +60,13 @@ make gen
 ```console
 go mod tidy
 ```
-
 At this point a pull request with the re-generated files and new service client can be submitted.
 
 Once the service client has been added, implement the first [resource](./add-a-new-resource.md) or [data source](./add-a-new-datasource.md) in a separate PR.
 
 ## Adding a Custom Service Client
 
-If an AWS service must be created in a non-standard way, for example the service API's endpoint must be accessed via a single AWS Region, then:
+If an AWS service must be created in a non-standard way, for example, the service API's endpoint must be accessed via a single AWS Region, then:
 
 1. Add an `x` in the **SkipClientGenerate** column for the service in [`names/data/names_data.csv`](https://github.com/hashicorp/terraform-provider-aws/blob/main/names/README.md)
 
@@ -134,7 +132,7 @@ If an AWS service must be created in a non-standard way, for example the service
 
 ## Customizing a new Service Client
 
-If an AWS service must be customized after creation, for example retry handling must be changed, then:
+If an AWS service must be customized after creation, for example, retry handling must be changed, then:
 
 1. Add a file `internal/<service>/service_package.go` that contains an API client customization function, for example:
 
@@ -156,7 +154,7 @@ If an AWS service must be customized after creation, for example retry handling 
     func (p *servicePackage) CustomizeConn(ctx context.Context, conn *chime_sdkv1.Chime) (*chime_sdkv1.Chime, error) {
     	conn.Handlers.Retry.PushBack(func(r *request_sdkv1.Request) {
     		// When calling CreateVoiceConnector across multiple resources,
-    		// the API can randomly return a BadRequestException without explanation
+    		// the API can randomly return a BadRequestException without an explanation
     		if r.Operation.Name == "CreateVoiceConnector" {
     			if tfawserr.ErrMessageContains(r.Error, chime_sdkv1.ErrCodeBadRequestException, "Service received a bad request") {
     				r.Retryable = aws_sdkv1.Bool(true)

--- a/docs/aws-go-sdk-migrations.md
+++ b/docs/aws-go-sdk-migrations.md
@@ -23,7 +23,7 @@ go generate ./internal/conns/...
 ### Add an `EndpointID` Constant
 
 When a service is first migrated, a `{ServiceName}EndpointID` constant must be added to [`names/names.go`](https://github.com/hashicorp/terraform-provider-aws/blob/main/names/names.go) manually.
-Be sure to preserve alphabetical order. 
+Be sure to preserve alphabetical order.
 
 The AWS SDK for Go V1 previously exposed these as constants, but V2 does not.
 This constant is used in common acceptance testing pre-checks, such as `acctest.PreCheckPartitionHasService`.

--- a/docs/aws-go-sdk-migrations.md
+++ b/docs/aws-go-sdk-migrations.md
@@ -184,7 +184,7 @@ Individual services vary in which types are moved into the dedicated subpackage,
 ### Enum Types
 
 Enums are now represented with custom types, rather than as strings.
-Because of this type of change, it may be necessary to convert from or to string values depending on the direction in which data is being exchanged.
+Because of this type change it may be necessary to convert from or to string values depending on the direction in which data is being exchanged.
 
 #### Input Structs
 

--- a/docs/aws-go-sdk-migrations.md
+++ b/docs/aws-go-sdk-migrations.md
@@ -1,10 +1,10 @@
 # AWS SDK For Go Migration Guide
 
-AWS has [announced](https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-go-v1-on-july-31-2025/) that V1 of the SDK for Go will enter maintenance mode on July 31, 2024 and reach end-of-life July 31, 2025.
+AWS has [announced](https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-go-v1-on-july-31-2025/) that V1 of the SDK for Go will enter maintenance mode on July 31, 2024 and reach end-of-life on July 31, 2025.
 While the AWS Terraform provider already [requires all net-new services](./aws-go-sdk-versions.md) to use AWS SDK V2 service clients, there remains a substantial number of existing services utilizing V1.
 
 Over time maintainers will be migrating impacted services to adopt AWS SDK for Go V2.
-For community members interested in contributoring to this effort, this guide documents the common patterns required to migrate a service.
+For community members interested in contributing to this effort, this guide documents the common patterns required to migrate a service.
 
 !!! tip
     The list of remaining services which require migration can be found in [this meta issue](https://github.com/hashicorp/terraform-provider-aws/issues/32976).
@@ -23,7 +23,7 @@ go generate ./internal/conns/...
 ### Add an `EndpointID` Constant
 
 When a service is first migrated, a `{ServiceName}EndpointID` constant must be added to [`names/names.go`](https://github.com/hashicorp/terraform-provider-aws/blob/main/names/names.go) manually.
-Be sure to preseve alphabetical order.
+Be sure to preserve alphabetical order. 
 
 The AWS SDK for Go V1 previously exposed these as constants, but V2 does not.
 This constant is used in common acceptance testing pre-checks, such as `acctest.PreCheckPartitionHasService`.
@@ -179,12 +179,12 @@ As a starting point, any type reference which isn’t an Input/Output struct can
 awstypes.StatusInProgress
 ```
 
-Individual services vary in which types are moved into the dedicated subpackage, so a programatic replacement of all occurrences may require some manual adjustment afterward.
+Individual services vary in which types are moved into the dedicated subpackage, so a programmatic replacement of all occurrences may require some manual adjustment afterward.
 
 ### Enum Types
 
 Enums are now represented with custom types, rather than as strings.
-Because of this type change it may be necessary to convert from or to string values depending on the direction in which data is being exchanged.
+Because of this type of change, it may be necessary to convert from or to string values depending on the direction in which data is being exchanged.
 
 #### Input Structs
 

--- a/docs/aws-go-sdk-versions.md
+++ b/docs/aws-go-sdk-versions.md
@@ -1,13 +1,13 @@
 # AWS Go SDK Versions
 
-The Terraform AWS Provider relies on the [AWS SDK for Go](https://aws.amazon.com/sdk-for-go/) which is maintained and published by AWS to allow us to safely and securely interact with AWS API's in a consistent fashion.
+The Terraform AWS Provider relies on the [AWS SDK for Go](https://aws.amazon.com/sdk-for-go/) which is maintained and published by AWS to allow us to safely and securely interact with AWS APIs consistently.
 There are two versions of this API, both of which are considered Generally Available and fully supported by AWS at present.
 
 - [AWS SDKs and Tools maintenance policy](https://docs.aws.amazon.com/sdkref/latest/guide/maint-policy.html)
 - [AWS SDKs and Tools version support matrix](https://docs.aws.amazon.com/sdkref/latest/guide/version-support-matrix.html)
 
 Each Terraform provider implementation for an AWS service relies on a service client, which in turn is constructed based on a specific SDK version.
-While the vast majority of the provider is based on the [AWS SDK for Go v1](https://github.com/aws/aws-sdk-go), the provider also allows the use of the [AWS SDK for Go v2](https://github.com/aws/aws-sdk-go-v2).
+While the vast majority of the providers are based on the [AWS SDK for Go v1](https://github.com/aws/aws-sdk-go), the provider also allows the use of the [AWS SDK for Go v2](https://github.com/aws/aws-sdk-go-v2).
 
 ## Which SDK Version should I use?
 
@@ -34,12 +34,12 @@ The AWS SDKs also automatically retry several common failure cases, such as netw
 
 The AWS SDK for Go v1.0.0 was released in late 2015, when the current version of Go was v1.5.
 The Go language has evolved significantly since then.
-Many currently-recommended practices were not possible at that time,
+Many currently recommended practices were not possible at that time,
 including the use of the `context` package, introduced in Go v1.7,
 and error wrapping, introduced in Go v1.13.
 
 The AWS SDK for Go v2 uses a modern Go style
-and has also been modularized, so that individual services are packaged and imported separately.
+and has also been modularized so that individual services are packaged and imported separately.
 
 For details on the specific changes to the AWS SDK for Go v2,
 see [Migrating to the AWS SDK for Go v2](https://aws.github.io/aws-sdk-go-v2/docs/migrating/),

--- a/docs/aws-go-sdk-versions.md
+++ b/docs/aws-go-sdk-versions.md
@@ -7,7 +7,7 @@ There are two versions of this API, both of which are considered Generally Avail
 - [AWS SDKs and Tools version support matrix](https://docs.aws.amazon.com/sdkref/latest/guide/version-support-matrix.html)
 
 Each Terraform provider implementation for an AWS service relies on a service client, which in turn is constructed based on a specific SDK version.
-While the vast majority of the providers are based on the [AWS SDK for Go v1](https://github.com/aws/aws-sdk-go), the provider also allows the use of the [AWS SDK for Go v2](https://github.com/aws/aws-sdk-go-v2).
+While the vast majority of the provider is based on the [AWS SDK for Go v1](https://github.com/aws/aws-sdk-go), the provider also allows the use of the [AWS SDK for Go v2](https://github.com/aws/aws-sdk-go-v2).
 
 ## Which SDK Version should I use?
 

--- a/docs/changelog-process.md
+++ b/docs/changelog-process.md
@@ -55,6 +55,7 @@ aws_workspaces_workspace
 ``````
 
 #### New full-length documentation guides (e.g., EKS Getting Started Guide, IAM Policy Documents with Terraform)
+
 A new full-length documentation entry gives the title of the documentation added, using the `release-note:new-guide` header.
 
 ``````

--- a/docs/changelog-process.md
+++ b/docs/changelog-process.md
@@ -1,6 +1,6 @@
 # Changelog Process
 
-HashiCorp’s open-source projects have always maintained user-friendly, readable `CHANGELOG.md` that allow users to tell at a glance whether a release should have any effect on them, and to gauge the risk of an upgrade.
+HashiCorp’s open-source projects have always maintained user-friendly, readable `CHANGELOG.md` that allows users to tell at a glance whether a release should have any effect on them, and to gauge the risk of an upgrade.
 
 We use [go-changelog](https://github.com/hashicorp/go-changelog) to generate the changelog from files created in the `.changelog/` directory.
 It is important that when you raise your pull request, there is a changelog entry which describes the changes your contribution makes.
@@ -55,8 +55,7 @@ aws_workspaces_workspace
 ``````
 
 #### New full-length documentation guides (e.g., EKS Getting Started Guide, IAM Policy Documents with Terraform)
-
-A new full length documentation entry gives the title of the documentation added, using the `release-note:new-guide` header.
+A new full-length documentation entry gives the title of the documentation added, using the `release-note:new-guide` header.
 
 ``````
 ```release-note:new-guide
@@ -66,7 +65,7 @@ Custom Service Endpoint Configuration
 
 #### Resource and provider bug fixes
 
-A new bug entry should use the `release-note:bug` header and have a prefix indicating the resource or data source it corresponds to, a colon, then followed by a brief summary. Use a `provider` prefix for provider level fixes.
+A new bug entry should use the `release-note:bug` header and have a prefix indicating the resource or data source it corresponds to, a colon, then followed by a brief summary. Use a `provider` prefix for provider-level fixes.
 
 ``````
 ```release-note:bug
@@ -76,7 +75,7 @@ resource/aws_glue_classifier: Fix quote_symbol being optional
 
 #### Resource and provider enhancements
 
-A new enhancement entry should use the `release-note:enhancement` header and have a prefix indicating the resource or data source it corresponds to, a colon, then followed by a brief summary. Use a `provider` prefix for provider level enhancements.
+A new enhancement entry should use the `release-note:enhancement` header and have a prefix indicating the resource or data source it corresponds to, a colon, then followed by a brief summary. Use a `provider` prefix for provider-level enhancements.
 
 ``````
 ```release-note:enhancement
@@ -86,7 +85,7 @@ resource/aws_eip: Add network_border_group argument
 
 #### Deprecations
 
-A deprecation entry should use the `release-note:note` header and have a prefix indicating the resource or data source it corresponds to, a colon, then followed by a brief summary. Use a `provider` prefix for provider level changes.
+A deprecation entry should use the `release-note:note` header and have a prefix indicating the resource or data source it corresponds to, a colon, then followed by a brief summary. Use a `provider` prefix for provider-level changes.
 
 ``````
 ```release-note:note
@@ -96,7 +95,7 @@ resource/aws_dx_gateway_association: The vpn_gateway_id attribute is being depre
 
 #### Breaking changes and removals
 
-A breaking-change entry should use the `release-note:breaking-change` header and have a prefix indicating the resource or data source it corresponds to, a colon, then followed by a brief summary. Use a `provider` prefix for provider level changes.
+A breaking-change entry should use the `release-note:breaking-change` header and have a prefix indicating the resource or data source it corresponds to, a colon, then followed by a brief summary. Use a `provider` prefix for provider-level changes.
 
 ``````
 ```release-note:breaking-change

--- a/docs/data-handling-and-conversion.md
+++ b/docs/data-handling-and-conversion.md
@@ -18,7 +18,7 @@ As a generic walkthrough, the following data handling occurs when creating a Ter
 - Terraform CLI sends a Terraform Plugin Protocol request to create the new resource with its planned new state data
 - If the Terraform Plugin is using a higher-level library, such as the Terraform Plugin Framework, that library receives the request and translates the Terraform Plugin Protocol data types into the expected library types
 - Terraform Plugin invokes the resource creation function with the planned new state data
-    - **The planned new state data is converted into a remote system request** (e.g., API creation request) that is invoked**
+    - **The planned new state data is converted into a remote system request (e.g., API creation request) that is invoked**
     - **The remote system response is received and the data is converted into an applied new state**
 - If the Terraform Plugin is using a higher-level library, such as the Terraform Plugin Framework, that library translates the library types back into Terraform Plugin Protocol data types
 - Terraform Plugin responds to Terraform Plugin Protocol request with the new state data

--- a/docs/data-handling-and-conversion.md
+++ b/docs/data-handling-and-conversion.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-configure-file { "code-block-style": false } -->
 # Data Handling and Conversion
 
-The Terraform AWS Provider codebase bridges the implementation of a [Terraform Plugin](https://www.terraform.io/plugin/how-terraform-works) and an AWS API client to support AWS operations and data types as Terraform Resources. Data handling and conversion is a large portion of resource implementation given the domain specific implementations of each side of the provider. The first where Terraform is a generic infrastructure as code tool with a generic data model and the other where the details are driven by AWS API data modeling concepts. This guide is intended to explain and show preferred Terraform AWS Provider code implementations required to successfully translate data between these two systems.
+The Terraform AWS Provider codebase bridges the implementation of a [Terraform Plugin](https://www.terraform.io/plugin/how-terraform-works) and an AWS API client to support AWS operations and data types as Terraform Resources. Data handling and conversion is a large portion of resource implementation given the domain-specific implementations of each side of the provider. The first is where Terraform is a generic infrastructure as code tool with a generic data model and the other is where the details are driven by AWS API data modeling concepts. This guide is intended to explain and show preferred Terraform AWS Provider code implementations required to successfully translate data between these two systems.
 
 At the bottom of this documentation is a [Glossary section](#glossary), which may be a helpful reference while reading the other sections.
 
@@ -9,18 +9,18 @@ At the bottom of this documentation is a [Glossary section](#glossary), which ma
 
 Before getting into highly specific documentation about the Terraform AWS Provider handling of data, it may be helpful to briefly highlight how Terraform Plugins (Terraform Providers in this case) interact with Terraform CLI and the Terraform State in general and where this documentation fits into the whole process.
 
-There are two primary data flows that are typically handled by resources within a Terraform Provider. Data is either being converted from a planned new Terraform State into making a remote system request or a remote system response is being converted into a applied new Terraform State. The semantics of how the data of the planned new Terraform State is surfaced to the resource implementation is determined by where a resource is in its lifecycle and mainly handled by Terraform CLI. This concept can be explored further in the [Terraform Resource Instance Change Lifecycle documentation](https://github.com/hashicorp/terraform/blob/main/docs/resource-instance-change-lifecycle.md), with the caveat that some additional behaviors occur within the Terraform Plugin SDK as well (if the Terraform Plugin uses that implementation detail).
+There are two primary data flows that are typically handled by resources within a Terraform Provider. Data is either being converted from a planned new Terraform State into making a remote system request or a remote system response is being converted into an applied new Terraform State. The semantics of how the data of the planned new Terraform State is surfaced to the resource implementation is determined by where a resource is in its lifecycle and is mainly handled by Terraform CLI. This concept can be explored further in the [Terraform Resource Instance Change Lifecycle documentation](https://github.com/hashicorp/terraform/blob/main/docs/resource-instance-change-lifecycle.md), with the caveat that some additional behaviors occur within the Terraform Plugin SDK as well (if the Terraform Plugin uses that implementation detail).
 
 As a generic walkthrough, the following data handling occurs when creating a Terraform Resource:
 
 - An operator creates a Terraform configuration with a new resource defined and runs `terraform apply`
 - Terraform CLI merges an empty prior state for the resource, along with the given configuration state, to create a planned new state for the resource
 - Terraform CLI sends a Terraform Plugin Protocol request to create the new resource with its planned new state data
-- If the Terraform Plugin is using a higher level library, such as the Terraform Plugin Framework, that library receives the request and translates the Terraform Plugin Protocol data types into the expected library types
+- If the Terraform Plugin is using a higher-level library, such as the Terraform Plugin Framework, that library receives the request and translates the Terraform Plugin Protocol data types into the expected library types
 - Terraform Plugin invokes the resource creation function with the planned new state data
-    - **The planned new state data is converted into an remote system request (e.g., API creation request) that is invoked**
+    - **The planned new state data is converted into a remote system request** (e.g., API creation request) that is invoked**
     - **The remote system response is received and the data is converted into an applied new state**
-- If the Terraform Plugin is using a higher level library, such as the Terraform Plugin Framework, that library translates the library types back into Terraform Plugin Protocol data types
+- If the Terraform Plugin is using a higher-level library, such as the Terraform Plugin Framework, that library translates the library types back into Terraform Plugin Protocol data types
 - Terraform Plugin responds to Terraform Plugin Protocol request with the new state data
 - Terraform CLI verifies and stores the new state
 
@@ -36,7 +36,7 @@ Given a resource with a writeable root attribute named `not_set_attr` that never
 - If the Terraform configuration is updated to `not_set_attr = "updated"`, the Terraform State contains `not_set_attr` equal to `"updated"` after apply.
 - If the attribute was meant to be associated with a remote system value, it will never update the Terraform State on plan or apply with the remote value. Effectively, it cannot perform drift detection with the remote value.
 
-This however does _not_ apply for nested attributes and blocks if the parent block is refreshed.
+This however does _not_ apply to nested attributes and blocks if the parent block is refreshed.
 Given a resource with a root block named `parent`, with nested child attributes `set_attr` and `not_set_attr`, a read operation which updates the value of `parent` (and the nested `set_attr` attribute) will not copy the Terraform State for the nested `not_set_attr` attribute.
 
 There are valid use cases for passthrough attribute values such as these (see the [Virtual Attributes section](#virtual-attributes)), however the behavior can be confusing or incorrect for operators if the drift detection is expected.
@@ -46,7 +46,7 @@ Typically these types of drift detection issues can be discovered by implementin
 
 Perhaps the most distinct difference between [Terraform Plugin Framework](https://developer.hashicorp.com/terraform/plugin/framework) and [Terraform Plugin SDKv2](https://developer.hashicorp.com/terraform/plugin/sdkv2) is data handling.
 With Terraform Plugin Framework state data is strongly typed, while Plugin SDK V2 based resources represent state data generically (each attribute is an `interface{}`) and types must be asserted at runtime.
-Strongly typed data eliminates an entire class of runtime bugs and crashes, but does require compile type type declarations and a slightly different approach to reading and writing data.
+Strongly typed data eliminates an entire class of runtime bugs and crashes, but does require compile type declarations and a slightly different approach to reading and writing data.
 The sections below contain examples for both plugin libraries, but Terraform Plugin Framework should be preferred whenever possible.
 
 ## Data Conversions in the Terraform AWS Provider
@@ -110,21 +110,21 @@ To further understand the necessary data conversions used throughout the Terrafo
 
     <!-- markdownlint-enable no-inline-html --->
 
-    You may notice there are type encoding differences the AWS Go SDK and Terraform Plugin SDK:
+    You may notice there are type encoding differences between the AWS Go SDK and Terraform Plugin SDK:
 
     - AWS Go SDK types are all Go pointer types, while Terraform Plugin SDK types are not.
     - AWS Go SDK structures are the Go `struct` type, while there is no semantically equivalent Terraform Plugin SDK type. Instead they are represented as a slice of interfaces with an underlying map of interfaces.
     - AWS Go SDK types are all Go concrete types, while the Terraform Plugin SDK types for collections and maps are interfaces.
     - AWS Go SDK whole numeric type is always 64-bit, while the Terraform Plugin SDK type is implementation-specific.
 
-    Conceptually, the first and second items above the most problematic in the Terraform AWS Provider codebase. The first item because non-pointer types in Go cannot implement the concept of no value (`nil`). The [Zero Value Mapping section](#zero-value-mapping) will go into more details about the implications of this limitation. The second item because it can be confusing to always handle a structure ("object") type as a list.
+    Conceptually, the first and second items above are the most problematic in the Terraform AWS Provider codebase. The first item because non-pointer types in Go cannot implement the concept of no value (`nil`). The [Zero Value Mapping section](#zero-value-mapping) will go into more detail about the implications of this limitation. The second item because it can be confusing to always handle a structure ("object") type as a list.
 
 ### Zero Value Mapping
 
 !!! note
     This section only applies to Plugin SDK V2 based resources. Terraform Plugin Framework based resources will handle null and unknown values distinctly from zero values.
 
-As mentioned in the [Type Mapping section](#type-mapping) for Terraform Plugin SDK V2, there is a discrepancy with how the Terraform Plugin SDK represents values and the reality that a Terraform State may not configure an Attribute.
+As mentioned in the [Type Mapping section](#type-mapping) for Terraform Plugin SDK V2, there is a discrepancy between how the Terraform Plugin SDK represents values and the reality that a Terraform State may not configure an Attribute.
 These values will default to the matching underlying Go type "zero value" if not set:
 
 | Terraform Plugin SDK | Go Type | Zero Value |
@@ -141,7 +141,7 @@ The semantics of the API and its meaning of the zero value will determine whethe
 - If it is used/needed, whether:
     - A value can always be set and it is safe to always send to the API. Generally, boolean values fall into this category.
     - A different default/sentinel value must be used as the "unset" value so it can either match the default of the API or be ignored when sending to the API.
-    - A special type implementation is required within the schema to workaround the limitation.
+    - A special type implementation is required within the schema to work around the limitation.
 
 The maintainers can provide guidance on appropriate solutions for cases not mentioned in the [Recommended Implementation section](#recommended-implementations).
 
@@ -1543,29 +1543,29 @@ Attribute values may be very lengthy or potentially contain [Sensitive Values](#
 
 - Terraform expects any planned values to match applied values. Ensuring proper handling during the various Terraform operations such as difference planning and Terraform State storage can be a burden.
 - Hashed values are generally unusable in downstream attribute references. If a value is hashed, it cannot be successfully used in another resource or provider configuration that expects the real value.
-- Terraform plan differences are meant to be human readable. If a value is hashed, operators will only see the relatively unhelpful hash differences `abc123 -> def456` in plans.
+- Terraform plan differences are meant to be human-readable. If a value is hashed, operators will only see the relatively unhelpful hash differences `abc123 -> def456` in plans.
 
 Any value hashing implementation will not be accepted. An exception to this guidance is if the remote system explicitly provides a separate hash value in responses, in which a resource can provide a separate attribute with that hashed value.
 
 ### Sensitive Values
 
-Marking an Attribute in the Terraform Plugin Framework Schema with `Sensitive` has the following real world implications:
+Marking an Attribute in the Terraform Plugin Framework Schema with `Sensitive` has the following real-world implications:
 
 - All occurrences of the Attribute will have the value hidden in plan difference output. In the context of an Attribute within a Block, all Blocks will hide all values of the Attribute.
-- In Terraform CLI 0.14 (with the `provider_sensitive_attrs` experiment enabled) and later, any downstream references to the value in other configuration will hide the value in plan difference output.
+- In Terraform CLI 0.14 (with the `provider_sensitive_attrs` experiment enabled) and later, any downstream references to the value in other configurations will hide the value in plan difference output.
 
 The value is either always hidden or not as the Terraform Plugin Framework does not currently implement conditional support for this functionality. Since Terraform Configurations have no control over the behavior, hiding values from the plan difference can incur a potentially undesirable user experience cost for operators.
 
 Given that and especially with the improvements in Terraform CLI 0.14, the Terraform AWS Provider maintainers guiding principles for determining whether an Attribute should be marked as `Sensitive` is if an Attribute value:
 
-- Objectively will always contain a credential, password, or other secret material. Operators can have differing opinions on what constitutes secret material and the maintainers will make best effort determinations, if necessary consulting with the HashiCorp Security team.
-- If the Attribute is within a Block, that all occurrences of the Attribute value will objectively contain secret material. Some APIs (and therefore the Terraform AWS Provider resources) implement generic "setting" and "value" structures which likely will contain a mixture of secret and non-secret material. These will generally not be accepted for marking as `Sensitive`.
+- Objectively will always contain a credential, password, or other secret material. Operators can have differing opinions on what constitutes secret material and the maintainers will make best-effort determinations, if necessary consulting with the HashiCorp Security team.
+- If the Attribute is within a Block, all occurrences of the Attribute value will objectively contain secret material. Some APIs (and therefore the Terraform AWS Provider resources) implement generic "setting" and "value" structures which likely will contain a mixture of secret and non-secret material. These will generally not be accepted for marking as `Sensitive`.
 
 If you are unsatisfied with sensitive value handling, the maintainers can recommend ensuring there is a covering issue in the Terraform CLI and/or Terraform Plugin Framework projects explaining the use case. Ultimately, Terraform Plugins including the Terraform AWS Provider cannot implement their own sensitive value abilities if the upstream projects do not implement the appropriate functionality.
 
 ### Virtual Attributes
 
-Attributes which only exist within Terraform and not the remote system are typically referred as virtual attributes. Especially in the case of [Destroy State Values](#destroy-state-values), these attributes rely on the [Implicit State Passthrough](#implicit-state-passthrough) behavior of values in Terraform to be available in resource logic. A fictitous example of one of these may be a resource attribute such as a `skip_waiting` flag, which is used only in the resource logic to skip the typical behavior of waiting for operations to complete.
+Attributes which only exist within Terraform and not the remote system are typically referred to as virtual attributes. Especially in the case of [Destroy State Values](#destroy-state-values), these attributes rely on the [Implicit State Passthrough](#implicit-state-passthrough) behavior of values in Terraform to be available in resource logic. A fictitious example of one of these may be a resource attribute such as a `skip_waiting` flag, which is used only in the resource logic to skip the typical behavior of waiting for operations to complete.
 
 If a virtual attribute has a default value that does not match the [Zero Value Mapping](#zero-value-mapping) for the type, it is recommended to explicitly call `d.Set()` with the default value in the `schema.Resource` `Importer` `State` function, for example:
 
@@ -1611,7 +1611,7 @@ This list is not exhaustive of all concepts of Terraform Plugins, the Terraform 
 - **Terraform Plugin Go**: Low-level library that converts Go code into Terraform Plugin Protocol compatible operations and data types. Not currently implemented in the Terraform AWS Provider. [Project](https://github.com/hashicorp/terraform-plugin-go).
 - **Terraform Plugin Framework**: High-level library that converts Go code into Terraform Plugin Protocol compatible operations and data types. This library replaces Plugin SDK V2. See [Terraform Plugin Development Packages](terraform-plugin-development-packages.md) for more information. [Project](https://github.com/hashicorp/terraform-plugin-framework).
 - **Terraform Plugin SDK V2**: High-level library that converts Go code into Terraform Plugin Protocol compatible operations and data types. This library is replaced by Plugin Framework. See [Terraform Plugin Development Packages](terraform-plugin-development-packages.md) for more information. [Project](https://github.com/hashicorp/terraform-plugin-sdk).
-- **Terraform Plugin Schema**: Declarative description of types and domain specific behaviors for a Terraform provider, including resources and attributes. [Framework Documentation](https://developer.hashicorp.com/terraform/plugin/framework/handling-data/schemas). [SDK V2 Documentation](https://www.terraform.io/plugin/sdkv2/schemas).
+- **Terraform Plugin Schema**: Declarative description of types and domain-specific behaviors for a Terraform provider, including resources and attributes. [Framework Documentation](https://developer.hashicorp.com/terraform/plugin/framework/handling-data/schemas). [SDK V2 Documentation](https://www.terraform.io/plugin/sdkv2/schemas).
 - **Terraform State**: Bindings between objects in a remote system (e.g., an EC2 VPC) and a Terraform configuration (e.g., an `aws_vpc` resource configuration). [Full Documentation](https://www.terraform.io/language/state).
 
 AWS Service API Models use specific terminology to describe data and types:
@@ -1650,7 +1650,7 @@ Terraform Plugin Framework Schemas use the following terminology to describe dat
     - **Bool**: Boolean value.
     - **Float64**: Fractional numeric value.
     - **Int64**: Whole numeric value.
-    - **List**: Ordered collection of values or Blocks.
+    - **List**: An ordered collection of values or Blocks.
     - **Map**: Grouping of key Type to value Type.
     - **Set**: Unordered collection of values or Blocks.
     - **String**: Sequence of characters value.
@@ -1660,7 +1660,7 @@ Terraform Plugin SDK Schemas use the following terminology to describe data and 
 - **Behaviors**: [Full Documentation](https://www.terraform.io/plugin/sdkv2/schemas/schema-behaviors).
     - **Sensitive**: Whether the value should be hidden from user interface output.
     - **StateFunc**: Conversion function between the value set by the Terraform Plugin and the value seen by Terraform Plugin SDK (and ultimately the Terraform State).
-- **Element**: Underylying value type for a collection or grouping Schema.
+- **Element**: Underlying value type for a collection or grouping Schema.
 - **Resource Data**: Data representation of a Resource Schema. Translation layer between the Schema and Go code of a Terraform Plugin. In the Terraform Plugin SDK, the `ResourceData` Go type.
 - **Resource Schema**: Grouping of Schema that represents a Terraform Resource.
 - **Schema**: Represents an Attribute or Block. Has a Type and Behavior(s).
@@ -1681,6 +1681,6 @@ Some other terms that may be used:
 - **NullableTypeBool**: (SDK V2 Only) Workaround "schema type" created to accept a boolean value that is not configured in addition to true and false. Not implemented in the Terraform Plugin SDK, but uses `TypeString` (where `""` represents not configured) and additional validation.
 - **NullableTypeFloat**: (SDK V2 Only) Workaround "schema type" created to accept a fractional numeric value that is not configured in addition to `0.0`. Not implemented in the Terraform Plugin SDK, but uses `TypeString` (where `""` represents not configured) and additional validation.
 - **NullableTypeInt**: (SDK V2 Only) Workaround "schema type" created to accept a whole numeric value that is not configured in addition to `0`. Not implemented in the Terraform Plugin SDK, but uses `TypeString` (where `""` represents not configured) and additional validation.
-- **Root Attribute**: Resource top level Attribute or Block.
+- **Root Attribute: Resource top-level Attribute or Block.
 
 For additional reference, the Terraform documentation also includes a [full glossary of terminology](https://www.terraform.io/docs/glossary.html).

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -40,9 +40,9 @@ Creating a minimal reproduction of a bug can be a time-consuming process, but it
 
 1. **Start with a simple test case**: Start with a simple configuration that causes the bug.
 2. **Remove any extraneous configuration**: Remove as many resources, dependencies, and arguments as possible to simplify, while still maintaining [test independence](running-and-writing-acceptance-tests.md#test-configuration-independence).
-3. **Verify that the configuration still reproduces the bug**: After removing configuration, make sure that the configuration still causes the bug. If the bug no longer occurs, you may have removed too much. In this case, add back configuration until the bug reappears.
+3. **Verify that the configuration still reproduces the bug**: After removing the configuration, make sure that the configuration still causes the bug. If the bug no longer occurs, you may have removed too much. In this case, add back configuration until the bug reappears.
 
-_A minimal configuration is worth its weight in gold._ If you're only able to make it this far in the debugging process, create a new issue with your minimal configuration or add it to an existing issue. A minimal configuration is a great way to give some else a jump start in looking at the problem.
+_A minimal configuration is worth its weight in gold._ If you're only able to make it this far in the debugging process, create a new issue with your minimal configuration or add it to an existing issue. A minimal configuration is a great way to give someone else a jump start in looking at the problem.
 
 ## 3. Create A New Acceptance Test
 
@@ -184,7 +184,7 @@ This will make the rest of debugging a lot more straightforward.
 
 If you aren't able to figure out a bug or delving into code is not your thing, open a pull request to [contribute just the test](running-and-writing-acceptance-tests.md#writing-an-acceptance-test) that highlights the bug. This is a valuable starting point for future work!
 
-We ask that you make the test "PASS," but use code comments and a GitHub issue to explain what is wrong. With nearly 7,000 acceptance tests, there are always a certain percentage that inexplicably fail. Since we know that the new test we're adding highlights a known bug, we don't want the failure to be lost in the tally of inexplicable failures.
+We ask that you make the test "PASS," but use code comments and a GitHub issue to explain what is wrong. With nearly 7,000 acceptance tests, there is always a certain percentage that inexplicably fails. Since we know that the new test we're adding highlights a known bug, we don't want the failure to be lost in the tally of inexplicable failures.
 
 #### Failing Test Contribution Example: Errors
 
@@ -265,7 +265,7 @@ resource "aws_flow_log" "test" {
 
 Now that we can easily reproduce a bug with a test and we have a minimal configuration, we can look more closely at why the bug is happening.
 
-There are several approaches to looking at what is happening in the AWS provider. You might find that some bugs lend themselves to one approach while others are more easily evaluated with another. Also, you might start with one approach and then find you need to move to another, _e.g._, starting by adding a few `fmt.Printf()` statements and then moving to an IDE debugger.
+There are several approaches to looking at what is happening in the AWS provider. You might find that some bugs lend themselves to one approach while others are more easily evaluated with another. Also, you might start with one approach and then find you need to move to another, _e.g._, starting by adding a few `fmt.Printf()` statements and then move to an IDE debugger.
 
 ### Use `fmt.Printf()`
 
@@ -333,13 +333,13 @@ reached point 4, with output: {
 
 ### Use Visual Studio Code Debugging
 
-Using debugging from within VS Code provides extra benefits but also an extra challenge. The extra benefits include the ability to set break points, step over and into code, and seeing the values of variables. The extra challenge is getting your debug environment properly set up to include access to your AWS credentials and environment variables used for testing.
+Using debugging from within VS Code provides extra benefits but also an extra challenge. The extra benefits include the ability to set breakpoints, step over and into code, and see the values of variables. The extra challenge is getting your debug environment properly set up to include access to your AWS credentials and environment variables used for testing.
 
 Special thanks to Drew Mullen for [his work on debugging the AWS provider in VS Code](https://dev.to/drewmullen/vscode-terraform-provider-development-setup-debugging-6bn).
 
 #### Set up `launch.json`
 
-VS Code uses a hidden directory called `.vscode` in the root of your project for configuration files. This directory and files it contains are ignored by Git using the `.gitignore` file included with the AWS provider. This allows you to have your own local configuration without concerns that it will be uploaded to or overwritten by the AWS provider repository.
+VS Code uses a hidden directory called `.vscode` in the root of your project for configuration files. This directory and the files it contains are ignored by Git using the `.gitignore` file included with the AWS provider. This allows you to have your own local configuration without concerns that it will be uploaded to or overwritten by the AWS provider repository.
 
 As shown below, use VS Code to create two files in the `.vscode` directory: `launch.json` and `private.env`.
 
@@ -408,7 +408,7 @@ With the environment and VS Code GUI set up, you are ready to run and debug.
 
 Depending on where you suspect the problems are occurring, you can set breakpoints on the resource's Create, Read, Update, Delete, or other functions. The debugger will stop at the first breakpoint it encounters.
 
-Setting breakpoints is built into VS Code and easy. Hover to the left of a line number and you'll see a faded red dot. Click on the faded red dot to turn it into a breakpoint, as shown below.
+Setting breakpoints is built into VS Code and is easy. Hover to the left of a line number and you'll see a faded red dot. Click on the faded red dot to turn it into a breakpoint, as shown below.
 
 You can see a list of breakpoints throughout the codebase at the bottom of the Run and Debug panel, as shown below.
 

--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -1,6 +1,5 @@
 # Dependency Updates
-
-Generally dependency updates are handled by maintainers.
+Generally, dependency updates are handled by maintainers.
 
 ## Go Default Version Update
 
@@ -28,7 +27,7 @@ Almost exclusively, `github.com/aws/aws-sdk-go` and `github.com/aws/aws-sdk-go-v
 
 Occasionally, there will be changes listed in the authentication pieces of the AWS Go SDK codebase, e.g., changes to `aws/session`. The AWS Go SDK `CHANGELOG` should include a relevant description of these changes under a heading such as `SDK Enhancements` or `SDK Bug Fixes`. If they seem worthy of a callout in the Terraform AWS Provider `CHANGELOG`, then upon merging we should include a similar message prefixed with the `provider` subsystem, e.g., `* provider: ...`.
 
-Additionally, if a `CHANGELOG` addition seemed appropriate, this dependency and version should also be updated in the Terraform S3 Backend, which currently lives in Terraform Core. An example of this can be found with https://github.com/hashicorp/terraform-provider-aws/pull/9305 and https://github.com/hashicorp/terraform/pull/22055.
+Additionally, if a `CHANGELOG` addition seemed appropriate, this dependency and version should also be updated in the Terraform S3 Backend, which currently lives in Terraform Core. An example of this can be found at https://github.com/hashicorp/terraform-provider-aws/pull/9305 and https://github.com/hashicorp/terraform/pull/22055.
 
 ### CloudFront changes
 

--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -1,4 +1,5 @@
 # Dependency Updates
+
 Generally, dependency updates are handled by maintainers.
 
 ## Go Default Version Update

--- a/docs/design-decisions/rds-bluegreen-deployments.md
+++ b/docs/design-decisions/rds-bluegreen-deployments.md
@@ -13,17 +13,17 @@ Due to Terraform's resource model and how RDS implements Blue/Green Deployments,
 
 ## Background
 
-Terraform treats each resource as a persistent, self-contained object that can be created, modified, and deleted without interacting with other objects, other that having parameter value dependencies on other resources.
+Terraform treats each resource as a persistent, self-contained object that can be created, modified, and deleted without interacting with other objects, other than having parameter value dependencies on other resources.
 In most cases, this more or less corresponds to how objects within AWS interrelate.
 
-RDS Blue/Green Deployments are implemented using a temporary Blue/Green Deployment orchestation object, which manages both the old and new RDS Instances, data synchronization, switchover, and deletion of the old Instances. The orchestation object is typically deleted after switchover, though it can be retained to, for example, review the operation logs for the deployment.
+RDS Blue/Green Deployments are implemented using a temporary Blue/Green Deployment orchestration object, which manages both the old and new RDS Instances, data synchronization, switchover, and deletion of the old Instances. The orchestration object is typically deleted after switchover, though it can be retained to, for example, review the operation logs for the deployment.
 
 ## Implementations
 
 ### `aws_db_instance`
 
 Because the `aws_db_instance` resource type represents a single, self-contained object, we are able to fit within the Terraform resource model while using an RDS Blue/Green Deployment to reduce downtime for many Instance updates.
-For instance, changing the backing EC2 instance type or the engine version in-place can cause downtimes of over 15 minutes.
+For instance, changing the backing EC2 instance type or the engine version in place can cause downtimes of over 15 minutes.
 When the `blue_green_update.enabled` parameter is set, the AWS Provider will use a Blue/Green Deployment internally to perform the update, so that the downtime is only the length of the switchover.
 According to [AWS documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/blue-green-deployments-overview.html), "switchover typically takes under a minute".
 
@@ -31,7 +31,7 @@ The update takes place in a single `terraform apply`, and the Blue/Green Deploym
 
 ### `aws_db_instance` Replicas
 
-Creating replica RDS DB Instance involves one source `aws_db_instance` resource and one or more replica `aws_db_instance` resources.
+Creating a replica RDS DB Instance involves one source `aws_db_instance` resource and one or more replica `aws_db_instance` resources.
 Because multiple resources are involved, Terraform cannot treat the source Instance and its replicas as a single unit.
 Therefore, Terraform cannot use a Blue/Green Deployment for updating an Instance and its replicas.
 
@@ -44,7 +44,7 @@ If, at some point, Blue/Green Deployments are supported, multi-AZ clusters may b
 However, the multi-AZ cluster already performs a rolling update of the individual instances, so there may be no benefit to using a Blue/Green Deployment for updates.
 
 Aurora clusters do support Blue/Green Deployments.
-However, neither the AWS APIs nor the provider treat an Aurora cluster as a self-contained object:
+However, neither the AWS APIs nor the provider treats an Aurora cluster as a self-contained object:
 A cluster consists of a containing `aws_rds_cluster` resource and one or more `aws_rds_cluster_instance` resources.
 Because of this, a Blue/Green Deployment cannot be used for most updates on an Aurora cluster.
 
@@ -55,13 +55,13 @@ When it is created, it first creates replicas of any existing RDS Instances, con
 Once these operations are complete, any additional updates are performed on the new (or "Green") instances.
 After these updates are complete, the Green instances can be promoted to be the live instances.
 
-Using a stand-alone Blue/Green Deployment resource would require multiple iterations of editing the Terraform configuration, applying the configuration, or importing resources.
+Using a standalone Blue/Green Deployment resource would require multiple iterations of editing the Terraform configuration, applying the configuration, or importing resources.
 This isn't a good fit for Terraform.
 
 The following example shows the steps that would be needed to use a standalone Blue/Green Deployment resource with a single RDS Instance (`aws_db_instance`).
 Using it with an Aurora cluster would be similar, but require changes to all of the resources making up the cluster.
 
-We start with the an RDS Instance with the name `example-db`.
+We start with an RDS Instance with the name `example-db`.
 
 ```terraform
 resource "aws_db_instance" "example" {

--- a/docs/design-decisions/relationship-resource-design-standards.md
+++ b/docs/design-decisions/relationship-resource-design-standards.md
@@ -5,13 +5,13 @@
 
 ---
 
-The goal of this document is to assess the design of existing "relationship" resources in the Terraform AWS Provider and determine if a consistent set of rules can be defined for implementing them. For the purpose of this document, a "relationship" resource is defined as a resource which manages either a direct relationship between two standalone resources ("one-to-one", ie. [`aws_ssoadmin_permission_boundary_attachment`](https://registry.terraform.io/providers/-/aws/latest/docs/resources/ssoadmin_permissions_boundary_attachment)), or a variable number of child relationships to a parent resource ("one-to-many", ie. [`aws_iam_role_policy_attachment`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment)). Resources and AWS API’s with this function will often contain suffixes like "attachment", "assignment", "registration", or "rule".
+The goal of this document is to assess the design of existing "relationship" resources in the Terraform AWS Provider and determine if a consistent set of rules can be defined for implementing them. For the purpose of this document, a "relationship" resource is defined as a resource which manages either a direct relationship between two standalone resources ("one-to-one", ie. [`aws_ssoadmin_permission_boundary_attachment`](https://registry.terraform.io/providers/-/aws/latest/docs/resources/ssoadmin_permissions_boundary_attachment)), or a variable number of child relationships to a parent resource ("one-to-many", ie. [`aws_iam_role_policy_attachment`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment)). Resources and AWS APIs with this function will often contain suffixes like "attachment", "assignment", "registration", or "rule".
 
 A documented standard for implementing relationship-styled resources will inform how new resources are written, and provide guidelines to refer back to when the community requests features which may not align with internal best practices.
 
 ## Background
 
-The first form of relationship resources ("one-to-one") typically have a straightforward, singular API design and provider implementation given only a single relationship exists. The second form of resources ("one-to-many") often have to balance two provider design principles:
+The first form of relationship resources ("one-to-one") typically have a straightforward, singular API design and provider implementation given only a single relationship exists. The second form of resources ("one-to-many") often has to balance two provider design principles:
 
 * [Resources should represent a single API object](https://developer.hashicorp.com/terraform/plugin/best-practices/hashicorp-provider-design-principles#resources-should-represent-a-single-api-object)
 * [Resource and attribute schema should closely match the underlying API](https://developer.hashicorp.com/terraform/plugin/best-practices/hashicorp-provider-design-principles#resource-and-attribute-schema-should-closely-match-the-underlying-api)
@@ -68,11 +68,11 @@ An analysis of existing resources can inform which of these principles maintaine
 | [aws_vpn_gateway_attachment](https://registry.terraform.io/providers/-/aws/latest/docs/resources/vpn_gateway_attachment) | One-to-one| [Singular](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AttachVpnGateway.html)| [Singular](https://github.com/hashicorp/terraform-provider-aws/blob/v5.7.0/internal/service/ec2/vpnsite_gateway_attachment.go#L48-L51) |
 
 [^1]: Due to the volume of resources with "rule" in the name (~70), only the prominent security group rule resources were included in the analysis above. While "rule" resources often follow the same relationship-style design, the ~40 examples above provided enough initial data to inform design standards.
-[^2]: Structure of this API precludes it from being implemented in a singular fashion.
+[^2]: The structure of this API precludes it from being implemented in a singular fashion.
 [^3]: Creates exclusive attachments.
 [^4]: Creates exclusive rules.
 
-Of the 44 resources documented above, 29 are of the "one-to-many" form and 17 have "plural" AWS APIs (ie. accepts a list of child resources to be attached to a single parent). Of these 17, 13 resources (76%) use a "singular" Terraform implementation, where a list with one item is sent to the Create/Read/Update API, rather than allowing a single resource to manage multiple relationships. Of the remaining 4 with "plural" Terraform implementations, 2 do so in order to exclusively manage child relationships (`aws_security_group` Ingress/Egress variants), and one requires a "plural" implementation simply because of API limitations.
+Of the 44 resources documented above, 29 are of the "one-to-many" form and 17 have "plural" AWS APIs (ie. accept a list of child resources to be attached to a single parent). Of these 17, 13 resources (76%) use a "singular" Terraform implementation, where a list with one item is sent to the Create/Read/Update API, rather than allowing a single resource to manage multiple relationships. Of the remaining 4 with "plural" Terraform implementations, 2 do so to exclusively manage child relationships (`aws_security_group` Ingress/Egress variants), and one requires a "plural" implementation simply because of API limitations.
 
 These metrics indicate a strong historical preference for representing a single API object over aligning the schema to the underlying AWS API. The primary exceptions to this are when exclusive management of all child resources is desired, such as [security group ingress/egress rules](https://registry.terraform.io/providers/-/aws/latest/docs/resources/security_group), or [IAM policy attachments](https://registry.terraform.io/providers/-/aws/latest/docs/resources/iam_policy_attachment).
 

--- a/docs/documentation-changes.md
+++ b/docs/documentation-changes.md
@@ -1,6 +1,5 @@
 # End User Documentation Changes
-
-All practitioner focused documentation is found in the `/website` folder of the repository.
+All practitioner-focused documentation is found in the `/website` folder of the repository.
 
 ```
 ├── website/docs
@@ -17,7 +16,7 @@ All practitioner focused documentation is found in the `/website` folder of the 
 
 For any documentation change please raise a pull request including and adhering to the following:
 
-- __Reasoning for Change__: Documentation updates should include an explanation for why the update is needed. If the change is a correction which is an alignment to AWS behavior, please include a link to the AWS Documentation in the PR.
+- __Reasoning for Change__: Documentation updates should include an explanation for why the update is needed. If the change is a correction that aligns with AWS behavior, please include a link to the AWS Documentation in the PR.
 - __Prefer AWS Documentation__: Documentation about AWS service features and valid argument values that are likely to update over time should link to AWS service user guides and API references where possible.
 - __Large Example Configurations__: Example Terraform configuration that includes multiple resource definitions should be added to the repository `examples` directory instead of an individual resource documentation page. Each directory under `examples` should be self-contained to call `terraform apply` without special configuration.
 - __Avoid Terraform Configuration Language Features__: Individual resource documentation pages and examples should refrain from highlighting particular Terraform configuration language syntax workarounds or features such as `variable`, `local`, `count`, and built-in functions.

--- a/docs/documentation-changes.md
+++ b/docs/documentation-changes.md
@@ -1,4 +1,5 @@
 # End User Documentation Changes
+
 All practitioner-focused documentation is found in the `/website` folder of the repository.
 
 ```

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -33,12 +33,12 @@ if err != nil {
 // all good!
 ```
 
-This is in preference of some other styles of error checking, such as `switch` conditionals without a condition.
+This is in preference to some other styles of error checking, such as `switch` conditionals without a condition.
 
 ### Wrap Errors
 
 Go implements error wrapping, which means that a deeply nested function call can return a particular error type, while each function up the stack can provide additional error message context without losing the ability to determine the original error.
-Additional information about this concept can be found on the [Go blog entry titled Working with Errors in Go 1.13](https://blog.golang.org/go1.13-errors).
+Additional information about this concept can be found in the [Go blog entry titled Working with Errors in Go 1.13](https://blog.golang.org/go1.13-errors).
 
 For most use cases in this codebase, this means if code is receiving an error and needs to return it, it should implement [`fmt.Errorf()`](https://pkg.go.dev/fmt#Errorf) and the `%w` verb, e.g.
 
@@ -59,7 +59,7 @@ The sections below contain documentation for both SDKs. See [AWS Go SDK Versions
 === "AWS Go SDK V2 (Preferred)"
     The [AWS SDK for Go v2 documentation](https://aws.github.io/aws-sdk-go-v2/docs/) includes a [section on handling errors](https://aws.github.io/aws-sdk-go-v2/docs/handling-errors/), which is recommended reading.
 
-    For the purposes of this documentation, the most important concepts with handling these errors are:
+    For the purposes of this documentation, the most important concepts in handling these errors are:
 
     - The SDK wraps all errors returned by service clients with the [`smithy.OperationError`](https://pkg.go.dev/github.com/aws/smithy-go/#OperationError) type.
     - [`errors.As`](https://golang.org/pkg/errors#As) should be used to unwrap errors when inspecting for a specific error type (e.g, a `BucketAlreadyExists` error from the S3 API).
@@ -67,7 +67,7 @@ The sections below contain documentation for both SDKs. See [AWS Go SDK Versions
 === "AWS Go SDK V1"
     The [AWS SDK for Go v1 documentation](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/welcome.html) includes a [section on handling errors](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/handling-errors.html), which is recommended reading.
 
-    For the purposes of this documentation, the most important concepts with handling these errors are:
+    For the purposes of this documentation, the most important concepts in handling these errors are:
 
     - Each response error (which eventually implements `awserr.Error`) has a `string` error code (`Code`) and `string` error message (`Message`). When printed as a string, they format as: `Code: Message`, e.g., `InvalidParameterValueException: IAM Role arn:aws:iam::123456789012:role/XXX cannot be assumed by AWS Backup`.
     - Error handling is almost exclusively done via those `string` fields and not other response information, such as HTTP Status Codes.
@@ -166,7 +166,7 @@ For Terraform Plugin SDK V2 based resources, creation is implemented on the `Cre
 #### Creation Error Message Context
 
 === "Terraform Plugin Framework (Preferred)"
-    Errors enountered during creation should include additional messaging about the location or cause of the error for operators and code maintainers.
+    Errors encountered during creation should include additional messaging about the location or cause of the error for operators and code maintainers.
     Plugin Framework based resources will append error [diagnostics](https://developer.hashicorp.com/terraform/plugin/framework/diagnostics) to the `resource.CreateResponse` `Diagnostics` field.
     The `create.ProblemStandardMessage` helper function can be used for constructing the appropriate context to accompany the error.
 
@@ -207,7 +207,7 @@ For Terraform Plugin SDK V2 based resources, creation is implemented on the `Cre
     ```
 
 === "Terraform Plugin SDK V2"
-    Errors enountered during creation should include additional messaging about the location or cause of the error for operators and code maintainers.
+    Errors encountered during creation should include additional messaging about the location or cause of the error for operators and code maintainers.
     The `create.AppendDiagError` helper function can be used to convert a native error into a [diagnostic](https://developer.hashicorp.com/terraform/plugin/framework/diagnostics), which is the method for surfacing warnings and errors in Terraform providers.
 
     ```go
@@ -296,7 +296,7 @@ For Terraform Plugin SDK V2 based resources, read is implemented on the `ReadWit
 #### Read Error Message Context
 
 === "Terraform Plugin Framework (Preferred)"
-    Errors enountered during read should include the resource identifier (for managed resources) and additional messaging about the location or cause of the error for operators and code maintainers.
+    Errors encountered during read should include the resource identifier (for managed resources) and additional messaging about the location or cause of the error for operators and code maintainers.
     Plugin Framework based resources will append error [diagnostics](https://developer.hashicorp.com/terraform/plugin/framework/diagnostics) to the `resource.ReadResponse` `Diagnostics` field.
     The `create.ProblemStandardMessage` helper function can be used for constructing the appropriate context to accompany the error.
 
@@ -323,7 +323,7 @@ For Terraform Plugin SDK V2 based resources, read is implemented on the `ReadWit
     ```
 
 === "Terraform Plugin SDK V2"
-    Errors enountered during read should include the resource identifier (for managed resources) and additional messaging about the location or cause of the error for operators and code maintainers.
+    Errors encountered during read should include the resource identifier (for managed resources) and additional messaging about the location or cause of the error for operators and code maintainers.
     The `create.AppendDiagError` helper function can be used to convert a native error into a [diagnostic](https://developer.hashicorp.com/terraform/plugin/framework/diagnostics), which is the method for surfacing warnings and errors in Terraform providers.
 
     ```go
@@ -350,7 +350,7 @@ In addition to remote operation and data handling errors, errors should also be 
 - Multiple results are found.
 
 For remote operations that are designed to return an error when the remote resource is not found, this error is typically just passed through similar to other remote operation errors.
-For remote operations that are designed to return a successful result whether there is zero, one, or multiple multiple results the error must be generated.
+For remote operations that are designed to return a successful result whether there are zero, one, or multiple results, the error must be generated.
 
 For example in pseudo-code:
 
@@ -372,7 +372,7 @@ if len(output.Results) > 1 {
 
 #### Plural Data Source Errors
 
-An emergent concept is a data source that returns multiple results, acting similar to listing functionality from the remote system.
+An emergent concept is a data source that returns multiple results, acting similarly to listing functionality from the remote system.
 These types of data sources should return _not_ return errors if:
 
 - Zero results are found.
@@ -388,7 +388,7 @@ For Terraform Plugin SDK V2 based resources, update is implemented on the `Updat
 #### Update Error Message Context
 
 === "Terraform Plugin Framework (Preferred)"
-    Errors enountered during update should include the resource identifier and additional messaging about the location or cause of the error for operators and code maintainers.
+    Errors ecnountered during update should include the resource identifier and additional messaging about the location or cause of the error for operators and code maintainers.
     Plugin Framework based resources will append error [diagnostics](https://developer.hashicorp.com/terraform/plugin/framework/diagnostics) to the `resource.UpdateResponse` `Diagnostics` field.
     The `create.ProblemStandardMessage` helper function can be used for constructing the appropriate context to accompany the error.
 
@@ -429,7 +429,7 @@ For Terraform Plugin SDK V2 based resources, update is implemented on the `Updat
     ```
 
 === "Terraform Plugin SDK V2"
-    Errors enountered during update should include the resource identifier and additional messaging about the location or cause of the error for operators and code maintainers.
+    Errors encountered during update should include the resource identifier and additional messaging about the location or cause of the error for operators and code maintainers.
     The `create.AppendDiagError` helper function can be used to convert a native error into a [diagnostic](https://developer.hashicorp.com/terraform/plugin/framework/diagnostics), which is the method for surfacing warnings and errors in Terraform providers.
 
     ```go
@@ -462,7 +462,7 @@ For Terraform Plugin SDK V2 based resources, deletion is implemented on the `Del
 #### Deletion Error Message Context
 
 === "Terraform Plugin Framework (Preferred)"
-    Errors enountered during deletion should include the resource identifier and additional messaging about the location or cause of the error for operators and code maintainers.
+    Errors encountered during deletion should include the resource identifier and additional messaging about the location or cause of the error for operators and code maintainers.
     Plugin Framework based resources will append error [diagnostics](https://developer.hashicorp.com/terraform/plugin/framework/diagnostics) to the `resource.DeleteResponse` `Diagnostics` field.
     The `create.ProblemStandardMessage` helper function can be used for constructing the appropriate context to accompany the error.
 
@@ -503,7 +503,7 @@ For Terraform Plugin SDK V2 based resources, deletion is implemented on the `Del
     ```
 
 === "Terraform Plugin SDK V2"
-    Errors enountered during deletion should include the resource identifier and additional messaging about the location or cause of the error for operators and code maintainers.
+    Errors encountered during deletion should include the resource identifier and additional messaging about the location or cause of the error for operators and code maintainers.
     The `create.AppendDiagError` helper function can be used to convert a native error into a [diagnostic](https://developer.hashicorp.com/terraform/plugin/framework/diagnostics), which is the method for surfacing warnings and errors in Terraform providers.
 
     ```go

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -23,13 +23,13 @@ Unfortunately, due to the volume of issues and new pull requests we receive, we 
 
 ## How do you decide what gets merged for each release?
 
-We have a large backlog of pull requests to get through and the team are moving through them as quick as we can. All pull requests must be reviewed by a HashiCorp engineer before inclusion. This is to ensure that the design of the addition fits with what provider users have come to expect, and to ensure that testing and best practices are adhered to. This is particularly important for such a large codebase, to ensure that we sustain its maintainability as its grows.
+We have a large backlog of pull requests to get through and the team is moving through them as quickly as we can. All pull requests must be reviewed by a HashiCorp engineer before inclusion. This is to ensure that the design of the addition fits with what provider users have come to expect, and to ensure that testing and best practices are adhered to. This is particularly important for such a large codebase, to ensure that we sustain its maintainability as it grows.
 
-The number one factor we look at when deciding what issues to look at are your 👍 [reactions](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue/PR description as these can be [easily discovered](https://github.com/hashicorp/terraform-provider-aws/issues?q=is%3Aopen+sort%3Areactions-%2B1-desc). Comments that further explain desired use cases or poor user experience are also heavily factored. The items with the most support are always on our radar, and we commit to keep the community updated on their status and potential timelines.
+The number one factor we look at when deciding what issues to look at are your 👍 [reactions](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue/PR description as these can be [easily discovered](https://github.com/hashicorp/terraform-provider-aws/issues?q=is%3Aopen+sort%3Areactions-%2B1-desc). Comments that further explain desired use cases or poor user experience are also heavily factored in. The items with the most support are always on our radar, and we commit to keeping the community updated on their status and potential timelines.
 
 We publish a [roadmap](https://github.com/hashicorp/terraform-provider-aws/blob/main/ROADMAP.md) every quarter which describes major themes or specific product areas of focus. What is excluded from the public roadmap is work performed under NDA with AWS on new services, and any ad-hoc work we pick up during the quarter. This ad-hoc work can be responding to bugs, gardening day activity, customer prioritization, and technical debt items.
 
-We also are investing time to improve the contributing experience by improving documentation, adding more linter coverage to ensure that incoming PR's can be in as good shape as possible. This will allow us to get through them quicker.
+We also are investing time to improve the contributing experience by improving documentation, adding more linter coverage to ensure that incoming PRs can be in as good shape as possible. This will allow us to get through them quicker.
 
 ## My PR hasn't been merged and it now has merge conflicts/failed checks, should I keep it up to date?
 
@@ -43,15 +43,15 @@ We release weekly on Thursday. We release often to ensure we can bring value to 
 
 Our policy is described on the Terraform website [here](https://www.terraform.io/plugin/sdkv2/best-practices/versioning). While we do our best to prevent breaking changes until major version releases of the provider, it is generally recommended to [pin the provider version in your configuration](https://www.terraform.io/language/providers/configuration#provider-versions).
 
-Due to the constant release pace of AWS and the relatively infrequent major version releases of the provider, there can be cases where a minor version update may contain unexpected changes depending on your configuration or environment. These may include items such as a resource requiring additional IAM permissions to support newer functionality. We typically base these decisions on a pragmatic compromise between introducing a relatively minor one-time inconvenience for a subset of the community versus better overall user experience for the entire community.
+Due to the constant release pace of AWS and the relatively infrequent major version releases of the provider, there can be cases where a minor version update may contain unexpected changes depending on your configuration or environment. These may include items such as a resource requiring additional IAM permissions to support newer functionality. We typically base these decisions on a pragmatic compromise between introducing a relatively minor one-time inconvenience for a subset of the community versus a better overall user experience for the entire community.
 
 ## Once a major release is published, will new features and fixes be backported to previous versions?
 
-Generally new features and fixes will only be added to the most recent major version. Due to the high touch nature of provider development and the extensive regression testing required to ensure stability, maintaining multiple versions of the provider is not sustainable at this time. An exception to this could be a discovered security vulnerability for which backporting may be the most reasonable course of action. These would be reviewed on a case by case basis.
+Generally, new features and fixes will only be added to the most recent major version. Due to the high-touch nature of provider development and the extensive regression testing required to ensure stability, maintaining multiple versions of the provider is not sustainable at this time. An exception to this could be a discovered security vulnerability for which backporting may be the most reasonable course of action. These would be reviewed on a case-by-case basis.
 
-## AWS just announced a new region, when will I see it in the provider.
+## AWS just announced a new region, when will I see it in the provider?
 
-Normally pretty quickly. We usually see the region appear within the `aws-go-sdk` within a couple days of the announcement. Depending on when it lands, we can often get it out within the current or following weekly release. Comparatively, adding support for a new  region in the S3 backend can take a little longer, as it is shipped as part of Terraform Core and not via the AWS Provider.
+Normally pretty quickly. We usually see the region appear within the `aws-go-sdk` within a couple of days of the announcement. Depending on when it lands, we can often get it out within the current or following weekly release. Comparatively, adding support for a new region in the S3 backend can take a little longer, as it is shipped as part of Terraform Core and not via the AWS Provider.
 
 Please note that this new region requires a manual process to enable in your account. Once enabled in the console, it takes a few minutes for everything to work properly.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,7 +47,7 @@ HashiCorp's open-source projects have always maintained a user-friendly, readabl
 
 When your contribution is ready, Create a [Pull Request](raising-a-pull-request.md) in the AWS provider repository.
 
-Pull requests are usually triaged within a few days of creation and are prioritized based on community reactions. Our [Prioritization Guides](prioritization.md) provides more details about the process.
+Pull requests are usually triaged within a few days of creation and are prioritized based on community reactions. Our [Prioritization Guide](prioritization.md) provides more details about the process.
 
 ## Submit an Issue
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,7 +47,7 @@ HashiCorp's open-source projects have always maintained a user-friendly, readabl
 
 When your contribution is ready, Create a [Pull Request](raising-a-pull-request.md) in the AWS provider repository.
 
-Pull requests are usually triaged within a few days of creation and are prioritized based on community reactions. Our [Prioritization Guide](prioritization.md) provides more details about the process.
+Pull requests are usually triaged within a few days of creation and are prioritized based on community reactions. Our [Prioritization Guides](prioritization.md) provide more details about the process.
 
 ## Submit an Issue
 

--- a/docs/issue-reporting-and-lifecycle.md
+++ b/docs/issue-reporting-and-lifecycle.md
@@ -10,7 +10,7 @@ We encourage opening new issues rather than commenting on closed issues if a pro
 
 ### [Bug Reports](https://github.com/hashicorp/terraform-provider-aws/issues/new?template=Bug_Report.md)
 
-- __Test against latest release__: Make sure you test against the latest
+- __Test against the latest release__: Make sure you test against the latest
    released version. It is possible we already fixed the bug you're experiencing.
 
 - __Search for possible duplicate reports__: It's helpful to keep bug
@@ -24,7 +24,7 @@ We encourage opening new issues rather than commenting on closed issues if a pro
 
 - __For panics, include `crash.log`__: If you experienced a panic, please
    create a [gist](https://gist.github.com) of the *entire* generated crash log
-   for us to look at. Double check no sensitive items were in the log.
+   for us to look at. Double-check check no sensitive items were in the log.
 
 ### [Feature Requests](https://github.com/hashicorp/terraform-provider-aws/issues/new?labels=enhancement&template=Feature_Request.md)
 

--- a/docs/naming.md
+++ b/docs/naming.md
@@ -2,7 +2,7 @@
 
 ## Service Identifier
 
-In the AWS Provider, a service identifier should consistently identify an AWS service from code to documentation to provider use by a practitioner. Prominent places you will see service identifiers:
+In the AWS Provider, a service identifier should consistently identify an AWS service from code to documentation to provider used by a practitioner. Prominent places you will see service identifiers:
 
 * The package name (e.g., `internal/service/<serviceidentifier>`)
 * In resource and data source names (e.g., `aws_<serviceidentifier>_thing`)
@@ -51,8 +51,8 @@ When creating a new resource or data source, it is important to get names right.
 1. Follow the [AWS SDK for Go v2](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2). Almost always, the API operations make determining the name simple. For example, the [Amazon CloudWatch Evidently](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/evidently) service includes `CreateExperiment`, `GetExperiment`, `UpdateExperiment`, and `DeleteExperiment`. Thus, the resource (or data source) name is "Experiment."
 2. Give a resource its Terraform configuration (i.e., HCL) name (e.g., `aws_imagebuilder_image_pipeline`) by joining these three parts with underscores:
     * `aws` prefix
-    * [Service identifier](#service-identifier) (service identifiers do not include underscores), all lower case (e.g., `imagebuilder`)
-    * Resource (or data source) name in snake case (spaces replaced with underscores, if any), all lower case (e.g., `image_pipeline`)
+    * [Service identifier](#service-identifier) (service identifiers do not include underscores), all lowercase (e.g., `imagebuilder`)
+    * Resource (or data source) name in snake case (spaces replaced with underscores, if any), all lowercase (e.g., `image_pipeline`)
 3. Name the main resource function `Resource<ResourceName>()`, with the resource name in [MixedCaps](#mixedcaps). Do not include the service name or identifier. For example, define `ResourceImagePipeline()` in a file called `internal/service/imagebuilder/image_pipeline.go`.
 4. Similarly, name the main data source function `DataSource<ResourceName>()`, with the data source name in [MixedCaps](#mixedcaps). Do not include the service name or identifier. For example, define `DataSourceImagePipeline()` in a file called `internal/service/imagebuilder/image_pipeline_data_source.go`.
 
@@ -88,7 +88,7 @@ For more details on capitalizations we enforce with CI Semgrep tests, see the [C
 
 Initialisms and other abbreviations are a key difference between many camel/Pascal case interpretations and mixedCaps. **Abbreviations in mixedCaps should be the correct, human-readable case.** After all, names in code _are for humans_. (The mixedCaps convention aligns with HashiCorp's emphasis on pragmatism and beauty.)
 
-For example, an initialism such as "VPC" should either be all capitalized ("VPC") or all lower case ("vpc"), never "Vpc" or "vPC." Similarly, in mixedCaps, "DynamoDB" should either be "DynamoDB" or "dynamoDB", depending on whether an initial cap is needed or not, and never "dynamoDb" or "DynamoDb."
+For example, an initialism such as "VPC" should either be all capitalized ("VPC") or all lowercase ("vpc"), never "Vpc" or "vPC." Similarly, in mixedCaps, "DynamoDB" should either be "DynamoDB" or "dynamoDB", depending on whether an initial cap is needed or not, and never "dynamoDb" or "DynamoDb."
 
 ### Rule
 
@@ -139,14 +139,14 @@ Acceptance test names have a minimum of two (e.g., `TestAccBackupPlan_tags`) or 
 
 ### Serialized Acceptance Test Rule
 
-The names of serialized acceptance tests follow the regular [acceptance test name rule](#acceptance-test-rule) **_except_** serialized acceptance test names:
+The names of serialized acceptance tests follow the regular [acceptance test name rule](#acceptance-test-rule) **_except_** for serialized acceptance test names:
 
 1. Start with `testAcc` instead of `TestAcc`
 2. Do not include the name of the service (e.g., a serialized acceptance test would be called `testAccApp_basic` not `testAccAmplifyApp_basic`).
 
 ### Unit Test Rule
 
-Unit test names follow the same [rule](#acceptance-test-rule) as acceptance test names except unit test names:
+Unit test names follow the same [rule](#acceptance-test-rule) as acceptance test names except for unit test names:
 
 1. Start with `Test`, not `TestAcc`
 2. Do not include the name of the service

--- a/docs/prioritization.md
+++ b/docs/prioritization.md
@@ -8,27 +8,27 @@ This document describes how we handle prioritization of work from a variety of i
 
 ### What this document is not
 
-Due to the variety of input sources, the scale of the provider, and resource constraints, it is impossible to give a hard number on how each of the factors outlined in this document are weighted. Instead, the goal of the document is to give a transparent, but generalized assessment of each of the sources of input so that the community has a better idea of why things are prioritized the way they are. Additional information may be found in the [FAQ](faq.md#how-do-you-decide-what-gets-merged-for-each-release).
+Due to the variety of input sources, the scale of the provider, and resource constraints, it is impossible to give a hard number on how each of the factors outlined in this document is weighted. Instead, the goal of the document is to give a transparent, but generalized assessment of each of the sources of input so that the community has a better idea of why things are prioritized the way they are. Additional information may be found in the [FAQ](faq.md#how-do-you-decide-what-gets-merged-for-each-release).
 
 ## Prioritization
 
-We prioritze work based on a number of factors, including community feedback, issue/PR reactions, as well as the source of the request. While community feedback is heavily weighted, there are times where other factors take precedence. By their nature, some factors are less visible to the community, and so are outlined here as a way to be as transparent as possible. Each of the sources of input are detailed below.
+We prioritize work based on a number of factors, including community feedback, issue/PR reactions, as well as the source of the request. While community feedback is heavily weighted, there are times when other factors take precedence. By their nature, some factors are less visible to the community, and so are outlined here as a way to be as transparent as possible. Each of the sources of input is detailed below.
 
 ### Community
 
-Our large community of practitioners are vocal and immensely productive in contributing to the provider codebase. Unfortunately our current team capacity means that we are unable to give every issue or pull request the same level of attention. This means we need to prioritize the issues that provide the most value to the greatest number of practitioners.
+Our large community of practitioners is vocal and immensely productive in contributing to the provider codebase. Unfortunately, our current team capacity means that we are unable to give every issue or pull request the same level of attention. This means we need to prioritize the issues that provide the most value to the greatest number of practitioners.
 
-We will always focus on the issues which have the most attention. The main rubric we have for assessing community wants is GitHub reactions. In addition to reactions, we look at comments, reactions to comments, and links to additional issues and PRs to help get a more holistic view of where the community stands. We try to ensure that for the issues where we have the most community support, we are responsive to that support and attempt to give timelines where-ever possible.
+We will always focus on the issues which have the most attention. The main rubric we have for assessing community wants is GitHub reactions. In addition to reactions, we look at comments, reactions to comments, and links to additional issues and PRs to help get a more holistic view of where the community stands. We try to ensure that for the issues where we have the most community support, we are responsive to that support and attempt to give timelines wherever possible.
 
 ### Customer
 
-Another source of work that must be weighted are escalations around particular feature requests and bugs from HashiCorp and AWS customers. Escalations typically come via several routes:
+Another source of work that must be weighted is escalations around particular feature requests and bugs from HashiCorp and AWS customers. Escalations typically come via several routes:
 
 - Customer Support
 - Sales Engineering
 - AWS Solutions Architects contacting us on behalf of their clients.
 
-These reports flow into an internal board and are triaged on a weekly basis to determine whether the escalation request should be prioritized for an upcoming release or added to the backlog to monitor for additional community support. During triage, we verify whether a GitHub issue or PR exists for the request and will create one if it does not exist. In this way, these requests are visible to the community to some degree. An escalation coming from a customer does not necessarily guarantee that it will be prioritized over requests made by the community. Instead, we assess them based on the following rubric:
+These reports flow into an internal board and are triaged weekly to determine whether the escalation request should be prioritized for an upcoming release or added to the backlog to monitor for additional community support. During triage, we verify whether a GitHub issue or PR exists for the request and will create one if it does not exist. In this way, these requests are visible to the community to some degree. An escalation coming from a customer does not necessarily guarantee that it will be prioritized over requests made by the community. Instead, we assess them based on the following rubric:
 
 - Does the issue have considerable community support?
 - Does the issue pertain to one of our [Core Services](core-services.md)?
@@ -49,7 +49,7 @@ We endeavor to keep in step with all minor SDK releases, so these are automatica
 
 #### Technical Debt
 
-We always include capacity for technical debt work in every iteration, but engineers are free to include minor tech debt work on their own recognizance. For larger items, these are discussed and prioritized in an internal meeting aimed at reviewing technical debt.
+We always include capacity for technical debt work in every iteration, but engineers are free to include minor tech debt work on their own recognizance. Larger items are discussed and prioritized in an internal meeting aimed at reviewing technical debt.
 
 #### Adverse User Experience or Security Vulnerabilities
 

--- a/docs/provider-design.md
+++ b/docs/provider-design.md
@@ -10,12 +10,12 @@ Some examples of functionality that is not expected in this provider:
 
 * Raw HTTP(S) handling. See the [Terraform HTTP Provider](https://registry.terraform.io/providers/hashicorp/http/latest) and [Terraform TLS Provider](https://registry.terraform.io/providers/hashicorp/tls/latest) instead.
 * Kubernetes resource management beyond the EKS service APIs. See the [Terraform Kubernetes Provider](https://registry.terraform.io/providers/hashicorp/kubernetes/latest) instead.
-* Active Directory or other protocol clients. See the [Terraform Active Directory Provider](https://registry.terraform.io/providers/hashicorp/ad/latest/docs) and other available provider instead.
+* Active Directory or other protocol clients. See the [Terraform Active Directory Provider](https://registry.terraform.io/providers/hashicorp/ad/latest/docs) and other available providers instead.
 * Functionality that requires additional software beyond the Terraform AWS Provider to be installed on the host executing Terraform. This currently includes the AWS CLI. See the [Terraform External Provider](https://registry.terraform.io/providers/hashicorp/external/latest) and other available providers instead.
 
 ## Infrastructure as Code Suitability
 
-The provider maintainers' design goal is to cover as much of the AWS API as pragmatically possible. However, not every aspect of the API is compatible with an infrastructure-as-code (IaC) conception. Specifically: IaC is best suited for [immutable rather than mutable infrastrcture](https://www.hashicorp.com/resources/what-is-mutable-vs-immutable-infrastructure) -- i.e. for resources with a single desired state described in its entirety, as opposed to resources defined via a dynamic process.
+The provider maintainers' design goal is to cover as much of the AWS API as pragmatically possible. However, not every aspect of the API is compatible with an infrastructure-as-code (IaC) conception. Specifically: IaC is best suited for [immutable rather than mutable infrastructure](https://www.hashicorp.com/resources/what-is-mutable-vs-immutable-infrastructure) -- i.e. for resources with a single desired state described in its entirety, as opposed to resources defined via a dynamic process.
 
 If such limits affect you, we recommend that you open an AWS Support case and encourage others to do the same. Request that AWS components be made more self-contained and compatible with IaC. These AWS Support cases can also yield insights into the AWS service and API that are not well documented.
 
@@ -23,9 +23,9 @@ If such limits affect you, we recommend that you open an AWS Support case and en
 
 Terraform resources work best as the smallest infrastructure blocks on which practitioners can build more complex configurations and abstractions, such as [Terraform Modules](https://www.terraform.io/language/modules). The general heuristic guiding when to implement a new Terraform resource for an aspect of AWS is whether the AWS service API provides create, read, update, and delete (CRUD) operations. However, not all AWS service API functionality falls cleanly into CRUD lifecycle management. In these situations, there is extra consideration necessary for properly mapping API operations to Terraform resources.
 
-This section highlights design patterns when to consider an implementation within a singular Terraform resource or as separate Terraform resources.
+This section highlights design patterns when considering an implementation within a singular Terraform resource or as separate Terraform resources.
 
-Please note: the overall design and implementation across all AWS functionality is federated: individual services may implement concepts and use terminology differently. As such, this guide is not exhaustive. The aim is to provide general concepts and basic terminology that points contributors in the right direction, especially in understanding previous implementations.
+Please note: the overall design and implementation across all AWS functionality is federated: individual services may implement concepts and use terminology differently. As such, this guide is not exhaustive. The aim is to provide general concepts and basic terminology that point contributors in the right direction, especially in understanding previous implementations.
 
 ### Authorization and Acceptance Resources
 
@@ -45,7 +45,7 @@ To model creating an association using an invitation or proposal, follow these g
 * For the originating account, create an "invitation" or "proposal" resource. Make sure that the AWS service API has operations for creating and reading invitations.
 * For the responding account, create an "accepter" resource. Ensure that the API has operations for accepting, reading, and rejecting invitations in the responding account. Map the operations as follows:
     * Create: Accepts the invitation.
-    * Read: Reads the invitation to determine its status. Note that in some APIs, invitations expire and disappear, complicating associations. If a resource does not find an invitation, the developer should implement a fall back to read the API resource associated with the invitation/proposal.
+    * Read: Reads the invitation to determine its status. Note that in some APIs, invitations expire and disappear, complicating associations. If a resource does not find an invitation, the developer should implement a fallback to read the API resource associated with the invitation/proposal.
     * Delete: Rejects or otherwise deletes the invitation.
 
 To model the second type of association, implicit associations, create an "association" resource and, optionally, an "authorization" resource. Map create, read, and delete to the corresponding operations in the AWS service API.
@@ -67,7 +67,7 @@ The rationale behind this design decision includes the following:
 * Needing extra and unexpected API endpoints configuration for organizations using custom endpoints, such as VPC endpoints.
 * Unexpected changes to the AWS service internals for the cross-service implementations. Given that this functionality is not part of the primary service API, these details can change over time and may not be considered as a breaking change by the service team for an API upgrade.
 
-A poignant real-world example of the last point involved a Lambda resource. The resource helped clean up extra resources (ENIs) due to a common misconfiguration. Practitioners found the functionality helpful since the issue was hard to diagnose. Years later, AWS updated the Lambda API. Immediately, practitioners reported that Terraform executions were failing. Downgrading the provider was not possible since many configurations depended on recent releases. For environments running many versions behind, forcing an upgrade with the fix would likely cause unrelated and unexpected changes. In the end, HashiCorp and AWS performed a large-scale outreach to help upgrade and fixing the misconfigurations. Provider maintainers and practitioners lost considerable time.
+A poignant real-world example of the last point involved a Lambda resource. The resource helped clean up extra resources (ENIs) due to a common misconfiguration. Practitioners found the functionality helpful since the issue was hard to diagnose. Years later, AWS updated the Lambda API. Immediately, practitioners reported that Terraform executions were failing. Downgrading the provider was not possible since many configurations depended on recent releases. For environments running many versions behind, forcing an upgrade with the fix would likely cause unrelated and unexpected changes. In the end, HashiCorp and AWS performed a large-scale outreach to help upgrade and fix the misconfigurations. Provider maintainers and practitioners lost considerable time.
 
 ### Data Sources
 
@@ -95,7 +95,7 @@ Provider developers should implement this capability in a new resource rather th
 
 * Many of the policies must include the ARN of the resource. Working around this requirement with custom difference handling within a self-contained resource is unnecessarily cumbersome.
 * Some policies involving multiple resources need to cross-reference each other's ARNs. Without a separate resource, this introduces a configuration cycle.
-* Splitting the resources allows operators to logically split their configurations into purely operational and security boundaries. This allows environments to have distinct practitioners roles and permissions for IAM versus infrastructure changes.
+* Splitting the resources allows operators to logically split their configurations into purely operational and security boundaries. This allows environments to have distinct practitioner roles and permissions for IAM versus infrastructure changes.
 
 One rare exception to this guideline is where the policy is _required_ during resource creation.
 
@@ -134,15 +134,15 @@ In general, provider developers should create a separate resource to represent a
 In deciding when to create a separate resource, follow these guidelines:
 
 * If AWS necessarily creates a version when you make a new AWS component, include version handling in the same Terraform resource. Creating an AWS component with one Terraform resource and later using a different resource for updates is confusing.
-* If the AWS service API allows deleting versions and practitioners will want to delete versions, provider developers should implement a separate version resource.
+* If the AWS service API allows deleting versions and practitioners want to delete versions, provider developers should implement a separate version resource.
 * If the API only supports publishing new versions, either method is acceptable, however most current implementations are self-contained. Terraform's current configuration language does not natively support triggering resource updates or recreation across resources without a state value change. This can make the implementation more difficult for practitioners without special resource and configuration workarounds, such as a `triggers` attribute. If this changes in the future, then this guidance may be updated towards separate resources, following the [Task Execution and Waiter Resources](#task-execution-and-waiter-resources) guidance.
 
 ## Other Considerations
 
 ### AWS Credential Exfiltration
 
-In the interest of security, the maintainers will not approve data sources that provide the ability to reference or export the AWS credentials of the running provider. There are valid use cases for this information, such as to execute AWS CLI calls as part of the same Terraform configuration. However, this mechanism may allow credentials to be discovered and used outside of Terraform. Some specific concerns include:
+In the interest of security, the maintainers will not approve data sources that provide the ability to reference or export the AWS credentials of the running provider. There are valid use cases for this information, such as executing AWS CLI calls as part of the same Terraform configuration. However, this mechanism may allow credentials to be discovered and used outside of Terraform. Some specific concerns include:
 
-* The values may be visible in Terraform user interface output or logging, allowing anyone with user interface or log access to see the credentials.
+* The values may be visible in Terraform user interface output or logging, allowing anyone with a user interface or log access to see the credentials.
 * The values are currently stored in plaintext in the Terraform state, allowing anyone with access to the state file or another Terraform configuration that references the state access to the credentials.
 * Any new related functionality, while opt-in to implement, is also opt-in to prevent via security controls or policies. Adopting a weaker default security posture requires advance notice and prevents organizations that implement those controls from updating to a version with any such functionality.

--- a/docs/raising-a-pull-request.md
+++ b/docs/raising-a-pull-request.md
@@ -15,7 +15,7 @@
 
 1. Make the changes you would like to include in the provider, add new tests as required, and make sure that all relevant existing tests are passing.
 
-1. [Create a pull request](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork). Please ensure (if possible)   the 'Allow edits from maintainers' checkbox is checked. This will allow the maintainers to make changes and merge the PR without requiring action from the contributor.
+1. [Create a pull request](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork). Please ensure (if possible) that the 'Allow edits from maintainers' checkbox is checked. This will allow the maintainers to make changes and merge the PR without requiring action from the contributor.
    You are welcome to submit your pull request for commentary or review before
    it is fully completed by creating a [draft pull request](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests).
    Please include specific questions or items you'd like feedback on.
@@ -31,7 +31,7 @@
 
 1. One of Terraform's provider team members will look over your contribution and
    either approve it or provide comments letting you know if there is anything
-   left to do. We'll try give you the opportunity to make the required changes yourself, but in some cases we may perform the changes ourselves if it makes sense to (minor changes, or for urgent issues).  We do our best to keep up with the volume of PRs waiting for review, but it may take some time depending on the complexity of the work.
+   left to do. We'll try to give you the opportunity to make the required changes yourself, but in some cases, we may perform the changes ourselves if it makes sense to (minor changes, or for urgent issues).  We do our best to keep up with the volume of PRs waiting for review, but it may take some time depending on the complexity of the work.
 
 1. Once all outstanding comments and checklist items have been addressed, your
    contribution will be merged! Merged PRs will be included in the next
@@ -75,7 +75,7 @@ make fmt
 
 The import statement in a Go file follows these rules (see [#15903](https://github.com/hashicorp/terraform-provider-aws/issues/15903)):
 
-1. Import declarations are grouped into a maximum of three groups with the following order:
+1. Import declarations are grouped into a maximum of three groups in the following order:
     - Standard packages (also called short import path or built-in packages)
     - Third-party packages (also called long import path packages)
     - Local packages
@@ -162,7 +162,7 @@ The below are style-based items that _may_ be noted during review and are recomm
 
   When the `arn` attribute is synthesized this way, add the resource to the [list](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#skip_requesting_account_id) of those affected by the provider's `skip_requesting_account_id` attribute.
 
-- __Implements Warning Logging With Resource State Removal__: If a resource is removed outside of Terraform (e.g., via different tool, API, or web UI), `d.SetId("")` and `return nil` can be used in the resource `Read` function to trigger resource recreation. When this occurs, a warning log message should be printed beforehand: `log.Printf("[WARN] {SERVICE} {THING} (%s) not found, removing from state", d.Id())`
+- __Implements Warning Logging With Resource State Removal__: If a resource is removed outside of Terraform (e.g., via a different tool, API, or web UI), `d.SetId("")` and `return nil` can be used in the resource `Read` function to trigger resource recreation. When this occurs, a warning log message should be printed beforehand: `log.Printf("[WARN] {SERVICE} {THING} (%s) not found, removing from state", d.Id())`
 - __Uses American English for Attribute Naming__: For any ambiguity with attribute naming, prefer American English over British English. e.g., `color` instead of `colour`.
 - __Skips Timestamp Attributes__: Generally, creation and modification dates from the API should be omitted from the schema.
 - __Uses Paginated AWS Go SDK Functions When Iterating Over a Collection of Objects__: When the API for listing a collection of objects provides a paginated function, use it instead of looping until the next page token is not set. For example, with the EC2 API, [`DescribeInstancesPages`](https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#EC2.DescribeInstancesPages) should be used instead of [`DescribeInstances`](https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#EC2.DescribeInstances) when more than one result is expected.

--- a/docs/resource-filtering.md
+++ b/docs/resource-filtering.md
@@ -39,7 +39,7 @@ Add the AWS Go SDK service name (e.g., `rds`) to `sliceServiceNames` in `interna
     filters := namevaluesfilters.New(map[string]string{
     	"internet-gateway-id": d.Get("internet_gateway_id").(string),
     })
-    // Add filters based on keyvalue tags (N.B. Not applicable to all AWS services that support filtering)
+    // Add filters based on key-value tags (N.B. Not applicable to all AWS services that support filtering)
     filters.Add(namevaluesfilters.EC2Tags(keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()))
     // Add filters based on the custom filtering "filter" attribute.
     filters.Add(d.Get("filter").(*schema.Set))

--- a/docs/resource-name-generation.md
+++ b/docs/resource-name-generation.md
@@ -12,7 +12,7 @@ Implementing name generation requires modifying the following:
 ## Resource Code
 
 - In the resource file (e.g., `internal/service/{service}/{thing}.go`), add the following import: `"github.com/hashicorp/terraform-provider-aws/internal/create"`.
-- Inside the resource schema, add the new `name_prefix` attribute and adjust the `name` attribute to be `Optional`, `Computed`, and conflict with the `name_prefix` attribute. Be sure to keep any existing validation functions already present on `name`.
+- Inside the resource schema, add the new `name_prefix` attribute and adjust the `name` attribute to be `Optional`, `Computed`, and conflict with the `name_prefix` attribute. Be sure to keep any existing validation functions already present on the `name`.
 
 === "Terraform Plugin Framework (Preferred)"
     ```go
@@ -91,7 +91,7 @@ Implementing name generation requires modifying the following:
 ## Resource Acceptance Tests
 
 - In the resource test file (e.g., `internal/service/{service}/{thing}_test.go`), add the following import: `"github.com/hashicorp/terraform-provider-aws/internal/create"`.
-- Implement two new tests named `_nameGenerated` and `_namePrefix` which verify creation of the resource without `name` and `name_prefix` arguments, and with only the `name_prefix` argument, respectively.
+- Implement two new tests named `_nameGenerated` and `_namePrefix` which verify the creation of the resource without `name` and `name_prefix` arguments, and with only the `name_prefix` argument, respectively.
 
 ```go
 func TestAccServiceThing_nameGenerated(t *testing.T) {
@@ -179,7 +179,7 @@ resource "aws_service_thing" "test" {
 * `name_prefix` - (Optional) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 ```
 
-- Adjust the existing `name` argument description to ensure its denoted as `Optional`, mention that it can be generated, and that it conflicts with `name_prefix`.
+- Adjust the existing `name` argument description to ensure it is denoted as `Optional`, mention that it can be generated and that it conflicts with `name_prefix`.
 
 ```markdown
 * `name` - (Optional) Name of the thing. If omitted, Terraform will assign a random, unique name. Conflicts with `name_prefix`.

--- a/docs/resource-tagging.md
+++ b/docs/resource-tagging.md
@@ -144,7 +144,7 @@ imports (
 
 Add the `tags` parameter and `tags_all` attribute to the schema, using constants defined in the `names` package.
 The `tags` parameter contains the tags set directly on the resource.
-The `tags_all` attribute contains union of the tags set directly on the resource and default tags configured on the provider.
+The `tags_all` attribute contains a union of the tags set directly on the resource and default tags configured on the provider.
 
 === "Terraform Plugin Framework (Preferred)"
     ```go
@@ -280,11 +280,11 @@ In the resource `Read` operation, use the `setTagsOut` function to signal to the
     setTagsOut(ctx, out.Tags)
     ```
 
-If the service API does not return the tags directly from reading the resource and requires use of the generated `listTags` function, do nothing and the transparent tagging mechanism will make the `listTags` call and save any tags into Terraform state.
+If the service API does not return the tags directly from reading the resource and requires use of the generated `listTags` function, do nothing and the transparent tagging mechanism will make the `listTags` call and save any tags into the Terraform state.
 
 #### Resource Update Operation
 
-In the resource `Update` operation, only non-`tags` updates need be done as the transparent tagging mechanism makes the `updateTags` call.
+In the resource `Update` operation, only non-`tags` updates need to be done as the transparent tagging mechanism makes the `updateTags` call.
 
 === "Terraform Plugin Framework (Preferred)"
     ```go
@@ -304,7 +304,7 @@ In the resource `Update` operation, only non-`tags` updates need be done as the 
     }
     ```
 
-For Terraform Plugin SDK V2 based resources, ensure that the `Update` operation always calls the resource `Read` operation before returning so that the transparent tagging mechanism correctly saves any tags into Terraform state.
+For Terraform Plugin SDK V2 based resources, ensure that the `Update` operation always calls the resource `Read` operation before returning so that the transparent tagging mechanism correctly saves any tags into the Terraform state.
 
 === "Terraform Plugin SDK V2"
     ```go
@@ -344,7 +344,7 @@ implement the logic to convert the configuration tags into the service tags, e.g
     }
     ```
 
-If the service API does not allow passing an empty list, the logic can be adjusted similar to:
+If the service API does not allow passing an empty list, the logic can be adjusted similarly to:
 
 === "Terraform Plugin SDK V2"
     ```go

--- a/docs/retries-and-waiters.md
+++ b/docs/retries-and-waiters.md
@@ -11,7 +11,7 @@ This guide describes the behavior of the Terraform AWS Provider and provides cod
 
 !!! note
     The helper functions detailed below **are** compatible with Terraform Plugin Framework based resources (the required library for net-new resources).
-    While these functions currently reside the in the legacy Terraform Plugin SDK repository, they are not directly tied to functionality exclusive to this library, and likely will be moved to a standalone library or into the AWS provider itself in the future.
+    While these functions currently reside in the legacy Terraform Plugin SDK repository, they are not directly tied to functionality exclusive to this library, and likely will be moved to a standalone library or into the AWS provider itself in the future.
 
 ## Terraform Plugin SDK Functionality
 
@@ -369,7 +369,7 @@ Depending on the service and general AWS load, these errors can be frequent or r
 In order to avoid this issue, identify operations that make changes.
 Then, when calling any other operations that rely on the changes, account for the possibility that the AWS service has not yet fully realized them.
 
-Handling eventual consistency looks slightly different for Terraform Plugin Framework based resources versus Plugin SDK V2. For Terraform Framework based resources, a `Get`/`Describe` API call should be made after the create request completes, all within the `Create` method. For Terraform Plugin SDK V2 resources, the `Create` function should return by calling the `Read` function. Both approaches fill in computed attributes and ensures that the AWS service applied the configuration correctly. Add retry logic to the `Get`/`Describe` API call (Plugin Framework) or `Read` function (Plugin SDK V2) to overcome the temporary condition on resource creation.
+Handling eventual consistency looks slightly different for Terraform Plugin Framework based resources versus Plugin SDK V2. For Terraform Framework based resources, a `Get`/`Describe` API call should be made after the create request completes, all within the `Create` method. For Terraform Plugin SDK V2 resources, the `Create` function should return by calling the `Read` function. Both approaches fill in computed attributes and ensure that the AWS service applied the configuration correctly. Add retry logic to the `Get`/`Describe` API call (Plugin Framework) or `Read` function (Plugin SDK V2) to overcome the temporary condition on resource creation.
 
 !!! note
     For eventually consistent resources, "not found" errors can still occur in the `Read` function even after implementing [Resource Lifecycle Waiters](#resource-lifecycle-waiters).
@@ -505,7 +505,7 @@ const (
 
 ### Resource Attribute Value Waiters
 
-An emergent solution for handling eventual consistency with attribute values on updates is to introduce a custom `retry.StateChangeConf` and `resource.RefreshStateFunc` handlers. For example, the waiting logic can be implemeted as:
+An emergent solution for handling eventual consistency with attribute values on updates is to introduce a custom `retry.StateChangeConf` and `resource.RefreshStateFunc` handlers. For example, the waiting logic can be implemented as:
 
 === "AWS SDK Go V2 (Preferred)"
     ```go
@@ -650,7 +650,7 @@ If it is necessary to customize the timeouts and polling, we generally prefer us
 
 ### Resource Lifecycle Waiters
 
-Most of the codebase uses `retry.StateChangeConf` and `retry.StateRefreshFunc` handlers for tracking either component level status fields or explicit tracking identifiers.
+Most of the codebase uses `retry.StateChangeConf` and `retry.StateRefreshFunc` handlers for tracking either component-level status fields or explicit tracking identifiers.
 These should be placed in the `internal/service/{SERVICE}` package and split into separate functions. For example:
 
 === "AWS SDK Go V2 (Preferred)"

--- a/docs/running-and-writing-acceptance-tests.md
+++ b/docs/running-and-writing-acceptance-tests.md
@@ -6,12 +6,12 @@ Terraform Providers, see the [SDKv2 documentation](https://www.terraform.io/plug
 
 ## Acceptance Tests Often Cost Money to Run
 
-Our acceptance test suite creates real resources, and as a result they cost real money to run.
+Our acceptance test suite creates real resources, and as a result, they cost real money to run.
 Because the resources only exist for a short period of time, the total amount
-of money required is usually a relatively small amount. That said there are particular services
-which are very expensive to run and its important to be prepared for those costs.
+of money required is usually relatively small. That said there are particular services
+which are very expensive to run and it's important to be prepared for those costs.
 
-Some services which can be cost prohibitive include (among others):
+Some services which can be cost-prohibitive include (among others):
 
 - WorkSpaces
 - Glue
@@ -154,7 +154,7 @@ export AWS_THIRD_REGION=...
 
 Some tests have been manually marked as long-running (longer than 300 seconds) and can be skipped using the `-short` flag. However, we are adding long-running guards little by little and many services have no guarded tests.
 
-Where guards have been implemented, do not always skip long-running tests. However, for intermediate test runs during development, or to verify functionality unrelated to the specific long-running tests, skipping long-running tests makes work more efficient. We recommend that for the final test run before submitting a PR that you run affected tests without the `-short` flag.
+Where guards have been implemented, do not always skip long-running tests. However, for intermediate test runs during development, or to verify functionality unrelated to the specific long-running tests, skipping long-running tests makes work more efficient. We recommend that for the final test run before submitting a PR you run affected tests without the `-short` flag.
 
 If you want to run only short-running tests, you can use either one of these equivalent statements. Note the use of `-short`.
 
@@ -226,7 +226,7 @@ When executing the test, the following steps are taken for each `TestStep`:
 
 1. The Terraform configuration required for the test is applied. This is
    responsible for configuring the resource under test, and any dependencies it
-   may have. For example, to test the `aws_cloudwatch_dashboard` resource, a valid configuration with the requisite fields is required. This results in configuration which looks like this:
+   may have. For example, to test the `aws_cloudwatch_dashboard` resource, a valid configuration with the requisite fields is required. This results in a configuration which looks like this:
 
     ```terraform
     resource "aws_cloudwatch_dashboard" "foobar" {
@@ -281,7 +281,7 @@ When executing the test, the following steps are taken for each `TestStep`:
    Notice that the only information used from the Terraform state is the ID of
    the resource. For computed properties, we instead assert that the value saved in the Terraform state was the
    expected value if possible. The testing framework provides helper functions
-   for several common types of check - for example:
+   for several common types of checks - for example:
 
    ```go
    resource.TestCheckResourceAttr("aws_cloudwatch_dashboard.foobar", "dashboard_name", testAccDashboardName(rInt)),
@@ -373,7 +373,7 @@ Please also note that the newline on the first line of the configuration (before
 
 #### Test Configuration Independence
 
-_Across the entire provider_, all test configurations should be as indepedent from each other as possible. For example, a common place this concept comes up is with the default VPC. Since we have tests that reconfigure the default VPC, if your configuration requires a VPC, it should not rely on the default VPC. Instead, include a VPC that will be created and destroyed as part of the test.
+_Across the entire provider_, all test configurations should be as independent of each other as possible. For example, a common place this concept comes up is with the default VPC. Since we have tests that reconfigure the default VPC, if your configuration requires a VPC, it should not rely on the default VPC. Instead, include a VPC that will be created and destroyed as part of the test.
 
 Make sure that your test configuration:
 
@@ -382,7 +382,7 @@ Make sure that your test configuration:
 
 #### Combining Test Configurations
 
-We include a helper function, `acctest.ConfigCompose()` for iteratively building and chaining test configurations together. It accepts any number of configurations to combine them. This simplifies a single resource's testing by allowing the creation of a "base" test configuration for all the other test configurations (if necessary) and also allows the maintainers to curate common configurations. Each of these is described in more detail in below sections.
+We include a helper function, `acctest.ConfigCompose()` for iteratively building and chaining test configurations together. It accepts any number of configurations to combine them. This simplifies a single resource's testing by allowing the creation of a "base" test configuration for all the other test configurations (if necessary) and also allows the maintainers to curate common configurations. Each of these is described in more detail in the below sections.
 
 Please note that we do discourage _excessive_ chaining of configurations such as implementing multiple layers of "base" configurations. Usually these configurations are harder for maintainers and other future readers to understand due to the multiple levels of indirection.
 
@@ -425,7 +425,7 @@ These test configurations are typical implementations we have found or allow tes
 
 #### Randomized Naming
 
-For AWS resources that require unique naming, the tests should implement a randomized name, typically coded as a `rName` variable in the test and passed as a parameter to creating the test configuration.
+For AWS resources that require unique naming, the tests should implement a randomized name, typically coded as a `rName` variable in the test and passed as a parameter to create the test configuration.
 
 For example:
 
@@ -678,7 +678,7 @@ However, some services have special conditions that aren't caught by the common 
 
 To add a service-specific ErrorCheck, follow these steps:
 
-1. Make sure there is not already an ErrorCheck for the service you have in mind. For example, search the codebase for `acctest.RegisterServiceErrorCheckFunc(names.ExampleServiceID` replacing "service" with the package name of the service you're working on (e.g., `ec2`). If there is already an ErrorCheck for the service, add to the existing service-specific ErrorCheck.
+1. Make sure there is not already an ErrorCheck for the service you have in mind. For example, search the codebase for `acctest.RegisterServiceErrorCheckFunc(names.ExampleServiceID` replacing "service" with the package name of the service you're working on (e.g., `ec2`). If there is already an ErrorCheck for the service, add it to the existing service-specific ErrorCheck.
 2. Create the service-specific ErrorCheck in an `_test.go` file for the service. See the example below.
 3. Register the new service-specific ErrorCheck in the `init()` at the top of the `_test.go` file. See the example below.
 
@@ -721,12 +721,11 @@ func TestAccExampleThing_longRunningTest(t *testing.T) {
   })
 }
 ```
-
-When running acceptances tests, tests with these guards can be skipped using the Go `-short` flag. See [Running Only Short Tests](#running-only-short-tests) for examples.
+When running acceptance tests, tests with these guards can be skipped using the Go `-short` flag. See [Running Only Short Tests](#running-only-short-tests) for examples.
 
 #### Disappears Acceptance Tests
 
-This test is generally implemented second. It is straightforward to setup once the basic test is passing since it can reuse that test configuration. It prevents a common bug report with Terraform resources that error when they can not be found (e.g., deleted outside Terraform).
+This test is generally implemented second. It is straightforward to set up once the basic test is passing since it can reuse that test configuration. It prevents a common bug report with Terraform resources that error when they can not be found (e.g., deleted outside Terraform).
 
 These are typically named `TestAcc{SERVICE}{THING}_disappears`, e.g., `TestAccCloudWatchDashboard_disappears`
 
@@ -865,6 +864,7 @@ When testing requires AWS infrastructure in a second AWS account, the below chan
 
 An example acceptance test implementation can be seen below:
 
+
 ```go
 func TestAccExample_basic(t *testing.T) {
   ctx := acctest.Context(t)
@@ -916,7 +916,7 @@ resource "aws_example" "test" {
 }
 ```
 
-Searching for usage of `acctest.PreCheckOrganizationsAccount` in the codebase will yield real world examples of this setup in action.
+Searching for the usage of `acctest`.PreCheckOrganizationsAccount` in the codebase will yield real-world examples of this setup in action.
 
 #### Cross-Region Acceptance Tests
 
@@ -981,19 +981,19 @@ resource "aws_example" "test" {
 }
 ```
 
-Searching for usage of `acctest.PreCheckMultipleRegion` in the codebase will yield real world examples of this setup in action.
+Searching for the usage of `acctest.PreCheckMultipleRegion` in the codebase will yield real-world examples of this setup in action.
 
 #### Acceptance Test Concurrency
 
 Certain AWS service APIs allow a limited number of a certain component, while the acceptance testing runs at a default concurrency of twenty tests at a time. For example as of this writing, the SageMaker service only allows one SageMaker Domain per AWS Region. Running the tests with the default concurrency will fail with API errors relating to the component quota being exceeded.
 
-When encountering these types of components, the acceptance testing can be setup to limit the available concurrency of that particular component. When limited to one component at a time, this may also be referred to as serializing the acceptance tests.
+When encountering these types of components, acceptance testing can be set up to limit the available concurrency of that particular component. When limited to one component at a time, this may also be referred to as serializing the acceptance tests.
 
 To convert to serialized (one test at a time) acceptance testing:
 
 - Convert all existing capital `T` test functions with the limited component to begin with a lowercase `t`, e.g., `TestAccSageMakerDomain_basic` becomes `testDomain_basic`. This will prevent the test framework from executing these tests directly as the prefix `Test` is required.
     - In each of these test functions, convert `resource.ParallelTest` to `resource.Test`
-- Create a capital `T` `TestAcc{Service}{Thing}_serial` test function that then references all the lowercase `t` test functions. If multiple test files are referenced, this new test be created in a new shared file such as `internal/service/{SERVICE}/{SERVICE}_test.go`. The contents of this test can be setup like the following:
+- Create a capital `T` `TestAcc{Service}{Thing}_serial` test function that then references all the lowercase `t` test functions. If multiple test files are referenced, this new test be created in a new shared file such as `internal/service/{SERVICE}/{SERVICE}_test.go`. The contents of this test can be set like the following:
 
 ```go
 func TestAccExampleThing_serial(t *testing.T) {
@@ -1074,7 +1074,7 @@ data "aws_example_thing" "test" {
 
 ## Acceptance Test Sweepers
 
-When running the acceptance tests, especially when developing or troubleshooting Terraform resources, its possible for code bugs or other issues to prevent the proper destruction of AWS infrastructure. To prevent lingering resources from consuming quota or causing unexpected billing, the Terraform Plugin SDK supports the test sweeper framework to clear out an AWS region of all resources. This section is meant to augment the [SDKv2 documentation on test sweepers](https://www.terraform.io/plugin/sdkv2/testing/acceptance-tests/sweepers) with Terraform AWS Provider specific details.
+When running the acceptance tests, especially when developing or troubleshooting Terraform resources, it's possible for code bugs or other issues to prevent the proper destruction of AWS infrastructure. To prevent lingering resources from consuming quota or causing unexpected billing, the Terraform Plugin SDK supports the test sweeper framework to clear out an AWS region of all resources. This section is meant to augment the [SDKv2 documentation on test sweepers](https://www.terraform.io/plugin/sdkv2/testing/acceptance-tests/sweepers) with Terraform AWS Provider specific details.
 
 ### Running Test Sweepers
 
@@ -1275,19 +1275,19 @@ These are basic principles to help guide the creation of acceptance tests.
 
 ### Test Implementation
 
-The below are required items that will be noted during submission review and prevent immediate merging:
+Below are the required items that will be noted during the submission review and prevent immediate merging:
 
 - __Implements CheckDestroy__: Resource testing should include a `CheckDestroy` function (typically named `testAccCheck{SERVICE}{RESOURCE}Destroy`) that calls the API to verify that the Terraform resource has been deleted or disassociated as appropriate. More information about `CheckDestroy` functions can be found in the [SDKv2 TestCase documentation](https://www.terraform.io/plugin/sdkv2/testing/acceptance-tests/testcase#checkdestroy).
 - __Implements Exists Check Function__: Resource testing should include a `TestCheckFunc` function (typically named `testAccCheck{SERVICE}{RESOURCE}Exists`) that calls the API to verify that the Terraform resource has been created or associated as appropriate. Preferably, this function will also accept a pointer to an API object representing the Terraform resource from the API response that can be set for potential usage in later `TestCheckFunc`. More information about these functions can be found in the [SDKv2 Custom Check Functions documentation](https://www.terraform.io/plugin/sdkv2/testing/acceptance-tests/teststep#custom-check-functions).
 - __Excludes Provider Declarations__: Test configurations should not include `provider "aws" {...}` declarations. If necessary, only the provider declarations in `acctest.go` should be used for multiple account/region or otherwise specialized testing.
-- __Passes in us-west-2 Region__: Tests default to running in `us-west-2` and at a minimum should pass in that region or include necessary `PreCheck` functions to skip the test when ran outside an expected environment.
+- __Passes in us-west-2 Region__: Tests default to running in `us-west-2` and at a minimum should pass in that region or include necessary `PreCheck` functions to skip the test when run outside an expected environment.
 - __Includes ErrorCheck__: All acceptance tests should include a call to the common ErrorCheck (`ErrorCheck:   acctest.ErrorCheck(t, names.ExampleServiceID),`).
 - __Uses resource.ParallelTest__: Tests should use [`resource.ParallelTest()`](https://godoc.org/github.com/hashicorp/terraform/helper/resource#ParallelTest) instead of [`resource.Test()`](https://godoc.org/github.com/hashicorp/terraform/helper/resource#Test) except where serialized testing is absolutely required.
-- [ ] __Uses fmt.Sprintf()__: Test configurations preferably should to be separated into their own functions (typically named `testAcc{SERVICE}{RESOURCE}Config{PURPOSE}`) that call [`fmt.Sprintf()`](https://golang.org/pkg/fmt/#Sprintf) for variable injection or a string `const` for completely static configurations. Test configurations should avoid `var` or other variable injection functionality such as [`text/template`](https://golang.org/pkg/text/template/).
+- [ ] __Uses fmt.Sprintf()__: Test configurations preferably should be separated into their own functions (typically named `testAcc{SERVICE}{RESOURCE}Config{PURPOSE}`) that call [`fmt.Sprintf()`](https://golang.org/pkg/fmt/#Sprintf) for variable injection or a string `const` for completely static configurations. Test configurations should avoid `var` or other variable injection functionality such as [`text/template`](https://golang.org/pkg/text/template/).
 - __Uses Randomized Infrastructure Naming__: Test configurations that use resources where a unique name is required should generate a random name. Typically this is created via `rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)` in the acceptance test function before generating the configuration.
 - __Prevents S3 Bucket Deletion Errors__: Test configurations that use `aws_s3_bucket` resources as a logging destination should include the `force_destroy = true` configuration. This is to prevent race conditions where logging objects may be written during the testing duration which will cause `BucketNotEmpty` errors during deletion.
 
-For resources that support import, the additional item below is required that will be noted during submission review and prevent immediate merging:
+For resources that support import, the additional item below is required that will be noted during the submission review and prevent immediate merging:
 
 - __Implements ImportState Testing__: Tests should include an additional `TestStep` configuration that verifies resource import via `ImportState: true` and `ImportStateVerify: true`. This `TestStep` should be added to all possible tests for the resource to ensure that all infrastructure configurations are properly imported into Terraform.
 
@@ -1372,7 +1372,7 @@ resource "aws_subnet" "test" {
 
 #### Hardcoded Database Versions
 
-- __Uses Database Version Data Sources__: Hardcoded database versions, e.g., RDS MySQL Engine Version `5.7.42`, should be removed (which means the AWS-defined default version will be used) or replaced with a list of preferred versions using a data source. Because versions change over times and version offerings vary from region to region and partition to partition, using the default version or providing a list of preferences ensures a version will be available. Depending on the situation, there are several data sources for versions, including:
+- __Uses Database Version Data Sources__: Hardcoded database versions, e.g., RDS MySQL Engine Version `5.7.42`, should be removed (which means the AWS-defined default version will be used) or replaced with a list of preferred versions using a data source. Because versions change over time and version offerings vary from region to region and partition to partition, using the default version or providing a list of preferences ensures a version will be available. Depending on the situation, there are several data sources for versions, including:
     - [`aws_rds_engine_version` data source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/rds_engine_version),
     - [`aws_docdb_engine_version` data source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/docdb_engine_version), and
     - [`aws_neptune_engine_version` data source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/neptune_engine_version).
@@ -1497,10 +1497,10 @@ POLICY
     - `acctest.MatchResourceAttrRegionalARN()` verifies that an ARN matches the account ID and region of the test execution with a regular expression of the resource value
     - `acctest.CheckResourceAttrGlobalARN()` verifies that an ARN matches the account ID of the test execution with an exact resource value
     - `acctest.MatchResourceAttrGlobalARN()` verifies that an ARN matches the account ID of the test execution with a regular expression of the resource value
-    - `acctest.CheckResourceAttrRegionalARNNoAccount()` verifies than an ARN has no account ID and matches the current region of the test execution with an exact resource value
-    - `acctest.CheckResourceAttrGlobalARNNoAccount()` verifies than an ARN has no account ID and matches an exact resource value
-    - `acctest.CheckResourceAttrRegionalARNAccountID()` verifies than an ARN matches a specific account ID and the current region of the test execution with an exact resource value
-    - `acctest.CheckResourceAttrGlobalARNAccountID()` verifies than an ARN matches a specific account ID with an exact resource value
+    - `acctest.CheckResourceAttrRegionalARNNoAccount()` verifies that an ARN has no account ID and matches the current region of the test execution with an exact resource value
+    - `acctest.CheckResourceAttrGlobalARNNoAccount()` verifies that an ARN has no account ID and matches an exact resource value
+    - `acctest.CheckResourceAttrRegionalARNAccountID()` verifies that an ARN matches a specific account ID and the current region of the test execution with an exact resource value
+    - `acctest.CheckResourceAttrGlobalARNAccountID()` verifies that an ARN matches a specific account ID with an exact resource value
 
 Here's an example of using `aws_partition` and `data.aws_partition.current.partition`:
 

--- a/docs/running-and-writing-acceptance-tests.md
+++ b/docs/running-and-writing-acceptance-tests.md
@@ -916,7 +916,7 @@ resource "aws_example" "test" {
 }
 ```
 
-Searching for the usage of `acctest`.PreCheckOrganizationsAccount` in the codebase will yield real-world examples of this setup in action.
+Searching for the usage of `acctest.PreCheckOrganizationsAccount` in the codebase will yield real-world examples of this setup in action.
 
 #### Cross-Region Acceptance Tests
 

--- a/docs/running-and-writing-acceptance-tests.md
+++ b/docs/running-and-writing-acceptance-tests.md
@@ -721,6 +721,7 @@ func TestAccExampleThing_longRunningTest(t *testing.T) {
   })
 }
 ```
+
 When running acceptance tests, tests with these guards can be skipped using the Go `-short` flag. See [Running Only Short Tests](#running-only-short-tests) for examples.
 
 #### Disappears Acceptance Tests
@@ -863,7 +864,6 @@ When testing requires AWS infrastructure in a second AWS account, the below chan
 - For any `TestStep` that includes `ImportState: true`, add the `Config` that matches the previous `TestStep` `Config`
 
 An example acceptance test implementation can be seen below:
-
 
 ```go
 func TestAccExample_basic(t *testing.T) {

--- a/docs/skaff.md
+++ b/docs/skaff.md
@@ -1,6 +1,6 @@
 # Provider Scaffolding (skaff)
 
-`skaff` is a Terraform AWS Provider scaffolding command line tool. It generates resource/data source files and accompanying test files which adhere to the latest best practice. These files are heavily commented with instructions so serve as the best way to get started with provider development.
+`skaff` is a Terraform AWS Provider scaffolding command line tool. It generates resource/data source files and accompanying test files which adhere to the latest best practices. These files are heavily commented with instructions so serve as the best way to get started with provider development.
 
 ## Overview workflow steps
 
@@ -14,12 +14,12 @@
 1. Go through the generated code completing code and customizing for the AWS Go SDK API
 1. Run, test, refine
 1. Remove "TIP" comments
-1. Submit code in pull request
+1. Submit code in the pull request
 
 ## Running `skaff`
 
 1. Clone the [Terraform AWS Provider](https://github.com/hashicorp/terraform-provider-aws) repository.
-1. Install skaff
+1. Install `skaff`
 
     ```sh
     make skaff
@@ -54,7 +54,7 @@ Flags:
 
 ### Autocompletion
 
-Generate the autocompletion script for skaff for the specified shell
+Generate the autocompletion script for `skaff` for the specified shell
 
 ```console
 skaff completion --help

--- a/docs/terraform-plugin-migrations.md
+++ b/docs/terraform-plugin-migrations.md
@@ -30,7 +30,7 @@ When done creating the resource using the Framework run `make gen` to remove the
 
 Terraform Plugin Framework introduced `null` values, which differ from `zero` values. Since the Plugin SDKv2 marked both `null` and `zero` values as the same, it will be necessary to use the [State Upgrader](https://developer.hashicorp.com/terraform/plugin/framework/migrating/resources/state-upgrade).
 
-An example to a resource with an upgraded stated, while migrating, can be found [here](https://github.com/hashicorp/terraform-provider-aws/blob/88447d09f85dc737597243b31c5d0c8e212d055b/internal/service/batch/job_queue.go#L330).
+An example of a resource with an upgraded state, while migrating, can be found [here](https://github.com/hashicorp/terraform-provider-aws/blob/88447d09f85dc737597243b31c5d0c8e212d055b/internal/service/batch/job_queue.go#L330).
 
 ### Custom Types
 
@@ -98,7 +98,7 @@ func newResourceExampleResrouce(_ context.Context) (resource.ResourceWithConfigu
 
 ## Testing
 
-It is important to not cause any state diffs that result in breaking changes. Testing will check that the diff before, and after, the migration present no changes.
+It is important to not cause any state diffs that result in breaking changes. Testing will check that the diff before and after the migration presents no changes.
 
 !!! tip
     `VersionConstraint` should be set to the most recently published version of the AWS Provider.


### PR DESCRIPTION
### Description

This PR aims to improve the quality of **terraform-provider-aws** documentation by addressing various grammar errors, typos, misspellings, and inconsistencies. The goal is to have clear and concise documentation that adheres to standard grammar rules so that users can access accurate information without encountering linguistic hurdles.

**Key changes:**
- typo and misspelling corrections - to prevent confusion among users and enhance the professionalism of the documentation,
- grammar corrections - ensuring proper subject-verb agreement and fixing article usage,
- enhanced readability - by adding missing verbs, prepositions or punctuation marks,
- consistency in terminology.

### Relations
N/A, docs

### References
N/A, docs

### Output from Acceptance Testing
N/A