### PR TITLE
r/aws_devopsguru_notification_channel: new resource 

### DIFF
--- a/.changelog/36557.txt
+++ b/.changelog/36557.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_devopsguru_notification_channel
+```

--- a/internal/framework/flex/auto_expand.go
+++ b/internal/framework/flex/auto_expand.go
@@ -384,7 +384,13 @@ func (expander autoExpander) listOfString(ctx context.Context, vFrom basetypes.L
 				return diags
 			}
 
-			vTo.Set(reflect.ValueOf(to))
+			// Copy elements individually to enable expansion of lists of
+			// custom string types (AWS enums)
+			vals := reflect.MakeSlice(vTo.Type(), len(to), len(to))
+			for i := 0; i < len(to); i++ {
+				vals.Index(i).SetString(to[i])
+			}
+			vTo.Set(vals)
 			return diags
 
 		case reflect.Ptr:

--- a/internal/service/devopsguru/devopsguru_test.go
+++ b/internal/service/devopsguru/devopsguru_test.go
@@ -17,6 +17,13 @@ func TestAccDevOpsGuru_serial(t *testing.T) {
 			"basic":      testAccEventSourcesConfig_basic,
 			"disappears": testAccEventSourcesConfig_disappears,
 		},
+		// A maxiumum of 2 notification channels can be configured at once, so
+		// serialize tests for safety.
+		"NotificationChannel": {
+			"basic":      testAccNotificationChannel_basic,
+			"disappears": testAccNotificationChannel_disappears,
+			"filters":    testAccNotificationChannel_filters,
+		},
 		"ResourceCollection": {
 			"basic":            testAccResourceCollection_basic,
 			"cloudformation":   testAccResourceCollection_cloudformation,

--- a/internal/service/devopsguru/exports_test.go
+++ b/internal/service/devopsguru/exports_test.go
@@ -5,9 +5,11 @@ package devopsguru
 
 // Exports for use in tests only.
 var (
-	ResourceEventSourcesConfig = newResourceEventSourcesConfig
-	ResourceResourceCollection = newResourceResourceCollection
+	ResourceEventSourcesConfig  = newResourceEventSourcesConfig
+	ResourceNotificationChannel = newResourceNotificationChannel
+	ResourceResourceCollection  = newResourceResourceCollection
 
-	FindEventSourcesConfig     = findEventSourcesConfig
-	FindResourceCollectionByID = findResourceCollectionByID
+	FindEventSourcesConfig      = findEventSourcesConfig
+	FindNotificationChannelByID = findNotificationChannelByID
+	FindResourceCollectionByID  = findResourceCollectionByID
 )

--- a/internal/service/devopsguru/notification_channel.go
+++ b/internal/service/devopsguru/notification_channel.go
@@ -1,0 +1,250 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package devopsguru
+
+import (
+	"context"
+	"errors"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/devopsguru"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/devopsguru/types"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource(name="Notification Channel")
+func newResourceNotificationChannel(_ context.Context) (resource.ResourceWithConfigure, error) {
+	return &resourceNotificationChannel{}, nil
+}
+
+const (
+	ResNameNotificationChannel = "Notification Channel"
+)
+
+type resourceNotificationChannel struct {
+	framework.ResourceWithConfigure
+}
+
+func (r *resourceNotificationChannel) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "aws_devopsguru_notification_channel"
+}
+
+func (r *resourceNotificationChannel) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": framework.IDAttribute(),
+		},
+		Blocks: map[string]schema.Block{
+			"filters": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[filtersData](ctx),
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"message_types": schema.ListAttribute{
+							Optional:    true,
+							CustomType:  fwtypes.ListOfStringType,
+							ElementType: types.StringType,
+							PlanModifiers: []planmodifier.List{
+								listplanmodifier.RequiresReplace(),
+							},
+							Validators: []validator.List{
+								listvalidator.ValueStringsAre(
+									enum.FrameworkValidate[awstypes.NotificationMessageType](),
+								),
+							},
+						},
+						"severities": schema.ListAttribute{
+							Optional:    true,
+							CustomType:  fwtypes.ListOfStringType,
+							ElementType: types.StringType,
+							PlanModifiers: []planmodifier.List{
+								listplanmodifier.RequiresReplace(),
+							},
+							Validators: []validator.List{
+								listvalidator.ValueStringsAre(
+									enum.FrameworkValidate[awstypes.InsightSeverity](),
+								),
+							},
+						},
+					},
+				},
+			},
+			"sns": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[snsData](ctx),
+				Validators: []validator.List{
+					listvalidator.IsRequired(),
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"topic_arn": schema.StringAttribute{
+							Required:   true,
+							CustomType: fwtypes.ARNType,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.RequiresReplace(),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r *resourceNotificationChannel) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().DevOpsGuruClient(ctx)
+
+	var plan resourceNotificationChannelData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	cfg := &awstypes.NotificationChannelConfig{}
+	resp.Diagnostics.Append(flex.Expand(ctx, plan, cfg)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	in := &devopsguru.AddNotificationChannelInput{
+		Config: cfg,
+	}
+
+	out, err := conn.AddNotificationChannel(ctx, in)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.DevOpsGuru, create.ErrActionCreating, ResNameNotificationChannel, "", err),
+			err.Error(),
+		)
+		return
+	}
+	if out == nil || out.Id == nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.DevOpsGuru, create.ErrActionCreating, ResNameNotificationChannel, "", nil),
+			errors.New("empty output").Error(),
+		)
+		return
+	}
+
+	plan.ID = flex.StringToFramework(ctx, out.Id)
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *resourceNotificationChannel) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().DevOpsGuruClient(ctx)
+
+	var state resourceNotificationChannelData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := findNotificationChannelByID(ctx, conn, state.ID.ValueString())
+	if tfresource.NotFound(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.DevOpsGuru, create.ErrActionSetting, ResNameNotificationChannel, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	state.ID = flex.StringToFramework(ctx, out.Id)
+
+	resp.Diagnostics.Append(flex.Flatten(ctx, out.Config, &state)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *resourceNotificationChannel) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// Update is a no-op
+}
+
+func (r *resourceNotificationChannel) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	conn := r.Meta().DevOpsGuruClient(ctx)
+
+	var state resourceNotificationChannelData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := &devopsguru.RemoveNotificationChannelInput{
+		Id: aws.String(state.ID.ValueString()),
+	}
+
+	_, err := conn.RemoveNotificationChannel(ctx, in)
+	if err != nil {
+		if errs.IsA[*retry.NotFoundError](err) {
+			return
+		}
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.DevOpsGuru, create.ErrActionDeleting, ResNameNotificationChannel, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+}
+
+func (r *resourceNotificationChannel) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func findNotificationChannelByID(ctx context.Context, conn *devopsguru.Client, id string) (*awstypes.NotificationChannel, error) {
+	in := &devopsguru.ListNotificationChannelsInput{}
+
+	paginator := devopsguru.NewListNotificationChannelsPaginator(conn, in)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, channel := range page.Channels {
+			if aws.ToString(channel.Id) == id {
+				return &channel, nil
+			}
+		}
+	}
+
+	return nil, &retry.NotFoundError{
+		LastError:   errors.New("not found"),
+		LastRequest: in,
+	}
+}
+
+type resourceNotificationChannelData struct {
+	Filters fwtypes.ListNestedObjectValueOf[filtersData] `tfsdk:"filters"`
+	ID      types.String                                 `tfsdk:"id"`
+	Sns     fwtypes.ListNestedObjectValueOf[snsData]     `tfsdk:"sns"`
+}
+
+type filtersData struct {
+	MessageTypes fwtypes.ListValueOf[types.String] `tfsdk:"message_types"`
+	Severities   fwtypes.ListValueOf[types.String] `tfsdk:"severities"`
+}
+
+type snsData struct {
+	TopicARN fwtypes.ARN `tfsdk:"topic_arn"`
+}

--- a/internal/service/devopsguru/notification_channel_test.go
+++ b/internal/service/devopsguru/notification_channel_test.go
@@ -1,0 +1,204 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package devopsguru_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/devopsguru/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	tfdevopsguru "github.com/hashicorp/terraform-provider-aws/internal/service/devopsguru"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func testAccNotificationChannel_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	var channel types.NotificationChannel
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_devopsguru_notification_channel.test"
+	snsTopicResourceName := "aws_sns_topic.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.DevOpsGuruEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DevOpsGuruServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckNotificationChannelDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNotificationChannelConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNotificationChannelExists(ctx, resourceName, &channel),
+					resource.TestCheckResourceAttr(resourceName, "sns.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "sns.0.topic_arn", snsTopicResourceName, "arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccNotificationChannel_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	var channel types.NotificationChannel
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_devopsguru_notification_channel.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.DevOpsGuruEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DevOpsGuruServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckNotificationChannelDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNotificationChannelConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNotificationChannelExists(ctx, resourceName, &channel),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfdevopsguru.ResourceNotificationChannel, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccNotificationChannel_filters(t *testing.T) {
+	ctx := acctest.Context(t)
+	var channel types.NotificationChannel
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_devopsguru_notification_channel.test"
+	snsTopicResourceName := "aws_sns_topic.test"
+	messageType := string(types.NotificationMessageTypeNewInsight)
+	severity := string(types.InsightSeverityHigh)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.DevOpsGuruEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DevOpsGuruServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckNotificationChannelDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNotificationChannelConfig_filters(rName, messageType, severity),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNotificationChannelExists(ctx, resourceName, &channel),
+					resource.TestCheckResourceAttr(resourceName, "sns.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "sns.0.topic_arn", snsTopicResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "filters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "filters.0.message_types.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "filters.0.message_types.0", messageType),
+					resource.TestCheckResourceAttr(resourceName, "filters.0.severities.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "filters.0.severities.0", severity),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckNotificationChannelDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).DevOpsGuruClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_devopsguru_notification_channel" {
+				continue
+			}
+
+			_, err := tfdevopsguru.FindNotificationChannelByID(ctx, conn, rs.Primary.ID)
+			if errs.IsA[*retry.NotFoundError](err) {
+				return nil
+			}
+			if err != nil {
+				return create.Error(names.DevOpsGuru, create.ErrActionCheckingDestroyed, tfdevopsguru.ResNameNotificationChannel, rs.Primary.ID, err)
+			}
+
+			return create.Error(names.DevOpsGuru, create.ErrActionCheckingDestroyed, tfdevopsguru.ResNameNotificationChannel, rs.Primary.ID, errors.New("not destroyed"))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckNotificationChannelExists(ctx context.Context, name string, channel *types.NotificationChannel) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.DevOpsGuru, create.ErrActionCheckingExistence, tfdevopsguru.ResNameNotificationChannel, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.DevOpsGuru, create.ErrActionCheckingExistence, tfdevopsguru.ResNameNotificationChannel, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).DevOpsGuruClient(ctx)
+
+		resp, err := tfdevopsguru.FindNotificationChannelByID(ctx, conn, rs.Primary.ID)
+		if err != nil {
+			return create.Error(names.DevOpsGuru, create.ErrActionCheckingExistence, tfdevopsguru.ResNameNotificationChannel, rs.Primary.ID, err)
+		}
+
+		*channel = *resp
+
+		return nil
+	}
+}
+
+func testAccNotificationChannelConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_sns_topic" "test" {
+  name = %[1]q
+}
+
+resource "aws_devopsguru_notification_channel" "test" {
+  sns {
+    topic_arn = aws_sns_topic.test.arn
+  }
+}
+`, rName)
+}
+
+func testAccNotificationChannelConfig_filters(rName, messageType, severity string) string {
+	return fmt.Sprintf(`
+resource "aws_sns_topic" "test" {
+  name = %[1]q
+}
+
+resource "aws_devopsguru_notification_channel" "test" {
+  sns {
+    topic_arn = aws_sns_topic.test.arn
+  }
+
+  filters {
+    message_types = [%[2]q]
+    severities    = [%[3]q]
+  }
+}
+`, rName, messageType, severity)
+}

--- a/internal/service/devopsguru/service_package_gen.go
+++ b/internal/service/devopsguru/service_package_gen.go
@@ -25,6 +25,10 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 			Name:    "Event Sources Config",
 		},
 		{
+			Factory: newResourceNotificationChannel,
+			Name:    "Notification Channel",
+		},
+		{
 			Factory: newResourceResourceCollection,
 			Name:    "Resource Collection",
 		},

--- a/website/docs/r/devopsguru_notification_channel.html.markdown
+++ b/website/docs/r/devopsguru_notification_channel.html.markdown
@@ -1,0 +1,79 @@
+---
+subcategory: "DevOps Guru"
+layout: "aws"
+page_title: "AWS: aws_devopsguru_notification_channel"
+description: |-
+  Terraform resource for managing an AWS DevOps Guru Notification Channel.
+---
+# Resource: aws_devopsguru_notification_channel
+
+Terraform resource for managing an AWS DevOps Guru Notification Channel.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_devopsguru_notification_channel" "example" {
+  sns {
+    topic_arn = aws_sns_topic.example.arn
+  }
+}
+```
+
+### Filters
+
+```terraform
+resource "aws_devopsguru_notification_channel" "example" {
+  sns {
+    topic_arn = aws_sns_topic.example.arn
+  }
+
+  filters {
+    message_types = ["NEW_INSIGHT"]
+    severities    = ["HIGH"]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `sns` - (Required) SNS noficiation channel configurations. See the [`sns` argument reference](#sns-argument-reference) below.
+
+The following arguments are optional:
+
+* `filters` - (Optional) Filter configurations for the Amazon SNS notification topic  See the [`filters` argument reference](#filters-argument-reference) below.
+
+### `sns` Argument Reference
+
+* `topic_arn` - (Required)
+
+### `filters` Argument Reference
+
+* `message_types` - (Optional) Events to receive notifications for. Valid values are `NEW_INSIGHT`, `CLOSED_INSIGHT`, `NEW_ASSOCIATION`, `SEVERITY_UPGRADED`, and `NEW_RECOMMENDATION`.
+* `severities` - (Optional) Severity levels to receive notifications for. Valid values are `LOW`, `MEDIUM`, and `HIGH`.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `id` - Unique identifier for the notification channel.
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import DevOps Guru Notification Channel using the `id`. For example:
+
+```terraform
+import {
+  to = aws_devopsguru_notification_channel.example
+  id = "id-12345678"
+}
+```
+
+Using `terraform import`, import DevOps Guru Notification Channel using the `id`. For example:
+
+```console
+% terraform import aws_devopsguru_notification_channel.example id-12345678
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This resource will allow practitioners to manage AWS DevOps Guru notification channels with Terraform.

Thing change also adds AutoFlex support for "list of enum" fields.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->
Relates #17919 
Closes #36334 

Closes #36556


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/devops-guru/latest/APIReference/API_AddNotificationChannel.html
- https://docs.aws.amazon.com/devops-guru/latest/APIReference/API_ListNotificationChannels.html
- https://docs.aws.amazon.com/devops-guru/latest/APIReference/API_RemoveNotificationChannel.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=devopsguru TESTS=TestAccDevOpsGuru_serial/NotificationChannel
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/devopsguru/... -v -count 1 -parallel 20 -run='TestAccDevOpsGuru_serial/NotificationChannel'  -timeout 360m

--- PASS: TestAccDevOpsGuru_serial (38.51s)
    --- PASS: TestAccDevOpsGuru_serial/NotificationChannel (38.51s)
        --- PASS: TestAccDevOpsGuru_serial/NotificationChannel/basic (14.01s)
        --- PASS: TestAccDevOpsGuru_serial/NotificationChannel/disappears (11.41s)
        --- PASS: TestAccDevOpsGuru_serial/NotificationChannel/filters (13.09s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/devopsguru 43.970s
```
