### PR TITLE
New Datasource Resource Explorer2 Search

### DIFF
--- a/.changelog/36560.txt
+++ b/.changelog/36560.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_resourceexplorer2_search
+```

--- a/docs/acc-test-environment-variables.md
+++ b/docs/acc-test-environment-variables.md
@@ -79,6 +79,7 @@ Environment variables (beyond standard AWS Go SDK ones) used by acceptance testi
 | `QUICKSIGHT_NAMESPACE` | QuickSight namespace name for testing. |
 | `QUICKSIGHT_ATHENA_TESTING_ENABLED` | Enable QuickSight tests dependent on Amazon Athena resources. |
 | `ROUTE53DOMAINS_DOMAIN_NAME` | Registered domain for Route 53 Domains testing. |
+| `RESOURCEEXPLORER_INDEX_TYPE` | Index Type for Resource Explorer 2 Search datasource testing. |
 | `SAGEMAKER_IMAGE_VERSION_BASE_IMAGE` | SageMaker base image to use for tests. |
 | `SERVICEQUOTAS_INCREASE_ON_CREATE_QUOTA_CODE` | Quota Code for Service Quotas testing (submits support case). |
 | `SERVICEQUOTAS_INCREASE_ON_CREATE_SERVICE_CODE` | Service Code for Service Quotas testing (submits support case). |

--- a/internal/service/resourceexplorer2/resourceexplorer2_test.go
+++ b/internal/service/resourceexplorer2/resourceexplorer2_test.go
@@ -26,6 +26,10 @@ func TestAccResourceExplorer2_serial(t *testing.T) {
 			"filter":      testAccView_filter,
 			"tags":        testAccView_tags,
 		},
+		"SearchDataSource": {
+			"basic":     testAccSearchDataSource_basic,
+			"indexType": testAccSearchDataSource_IndexType,
+		},
 	}
 
 	acctest.RunSerialTests2Levels(t, testCases, 0)

--- a/internal/service/resourceexplorer2/search_data_source.go
+++ b/internal/service/resourceexplorer2/search_data_source.go
@@ -5,7 +5,6 @@ package resourceexplorer2
 
 import (
 	"context"
-	"log"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/resourceexplorer2"
@@ -65,65 +64,65 @@ func (d *dataSourceSearch) Schema(ctx context.Context, req datasource.SchemaRequ
 				},
 			},
 		},
-		// Blocks: map[string]schema.Block{
-		// 	"rsc_count": schema.ListNestedBlock{
-		// 		CustomType: fwtypes.NewListNestedObjectTypeOf[countData](ctx),
-		// 		NestedObject: schema.NestedBlockObject{
-		// 			Attributes: map[string]schema.Attribute{
-		// 				"complete": schema.BoolAttribute{
-		// 					Computed: true,
-		// 				},
-		// 				"total_resources": schema.Int64Attribute{
-		// 					Computed: true,
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// 	"resources": schema.ListNestedBlock{
-		// 		CustomType: fwtypes.NewListNestedObjectTypeOf[resourcesData](ctx),
-		// 		NestedObject: schema.NestedBlockObject{
-		// 			Attributes: map[string]schema.Attribute{
-		// 				"arn": schema.StringAttribute{
-		// 					Computed: true,
-		// 				},
-		// 				"last_reported_at": schema.StringAttribute{
-		// 					Computed: true,
-		// 				},
-		// 				"owning_account_id": schema.StringAttribute{
-		// 					Computed: true,
-		// 				},
-		// 				"region": schema.StringAttribute{
-		// 					Computed: true,
-		// 				},
-		// 				"resource_type": schema.StringAttribute{
-		// 					Computed: true,
-		// 				},
-		// 				"service": schema.StringAttribute{
-		// 					Computed: true,
-		// 				},
-		// 			},
-		// 			Blocks: map[string]schema.Block{
-		// 				"resource_property": schema.ListNestedBlock{
-		// 					CustomType: fwtypes.NewListNestedObjectTypeOf[resourcePropertyData](ctx),
-		// 					NestedObject: schema.NestedBlockObject{
-		// 						Attributes: map[string]schema.Attribute{
-		// 							"data": schema.StringAttribute{
-		// 								Computed: true,
-		// 								// Validators: jsonvalidator.JSON(),
-		// 							},
-		// 							"last_reported_at": schema.StringAttribute{
-		// 								Computed: true,
-		// 							},
-		// 							"name": schema.StringAttribute{
-		// 								Computed: true,
-		// 							},
-		// 						},
-		// 					},
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// },
+		Blocks: map[string]schema.Block{
+			"resource_count": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[countData](ctx),
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"complete": schema.BoolAttribute{
+							Computed: true,
+						},
+						"total_resources": schema.Int64Attribute{
+							Computed: true,
+						},
+					},
+				},
+			},
+			"resources": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[resourcesData](ctx),
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"arn": schema.StringAttribute{
+							Computed: true,
+						},
+						"last_reported_at": schema.StringAttribute{
+							Computed: true,
+						},
+						"owning_account_id": schema.StringAttribute{
+							Computed: true,
+						},
+						"region": schema.StringAttribute{
+							Computed: true,
+						},
+						"resource_type": schema.StringAttribute{
+							Computed: true,
+						},
+						"service": schema.StringAttribute{
+							Computed: true,
+						},
+					},
+					Blocks: map[string]schema.Block{
+						"resource_property": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[resourcePropertyData](ctx),
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"data": schema.StringAttribute{
+										Computed: true,
+										// Validators: jsonvalidator.JSON(),
+									},
+									"last_reported_at": schema.StringAttribute{
+										Computed: true,
+									},
+									"name": schema.StringAttribute{
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 }
 
@@ -139,11 +138,8 @@ func (d *dataSourceSearch) Read(ctx context.Context, req datasource.ReadRequest,
 	data.ID = types.StringValue(data.ViewArn.ValueString())
 
 	input := &resourceexplorer2.SearchInput{
-		// ViewArn:     aws.String(data.ViewArn.ValueString()),
 		QueryString: aws.String(data.QueryString.ValueString()),
 	}
-
-	log.Printf("[WARN] VIEWARN: %s", data.ViewArn.ValueString())
 
 	paginator := resourceexplorer2.NewSearchPaginator(conn, input)
 
@@ -167,34 +163,16 @@ func (d *dataSourceSearch) Read(ctx context.Context, req datasource.ReadRequest,
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	// out, err := findSearchByName(ctx, conn, data.Name.ValueString())
-	// if err != nil {
-	// 	resp.Diagnostics.AddError(
-	// 		create.ProblemStandardMessage(names.ResourceExplorer2, create.ErrActionReading, DSNameSearch, data.Name.String(), err),
-	// 		err.Error(),
-	// 	)
-	// 	return
-	// }
-
-	// data.ARN = flex.StringToFramework(ctx, out.Arn)
-	// data.ID = flex.StringToFramework(ctx, out.SearchId)
-	// data.Name = flex.StringToFramework(ctx, out.SearchName)
-	// data.Type = flex.StringToFramework(ctx, out.SearchType)
-	// complexArgument, diag := flattenComplexArgument(ctx, out.ComplexArgument)
-	// resp.Diagnostics.Append(diag...)
-	// data.ComplexArgument = complexArgument
-
-	// resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
 type dataSourceSearchData struct {
-	// Count       fwtypes.ListNestedObjectValueOf[countData] `tfsdk:"rsc_count"`
-	MaxResults  types.Int64  `tfsdk:"max_results"`
-	ID          types.String `tfsdk:"id"`
-	NextToken   types.String `tfsdk:"next_token"`
-	ViewArn     types.String `tfsdk:"view_arn"`
-	QueryString types.String `tfsdk:"query_string"`
+	ResourceCount fwtypes.ListNestedObjectValueOf[countData]     `tfsdk:"resource_count"`
+	Resources     fwtypes.ListNestedObjectValueOf[resourcesData] `tfsdk:"resources"`
+	MaxResults    types.Int64                                    `tfsdk:"max_results"`
+	ID            types.String                                   `tfsdk:"id"`
+	NextToken     types.String                                   `tfsdk:"next_token"`
+	ViewArn       types.String                                   `tfsdk:"view_arn"`
+	QueryString   types.String                                   `tfsdk:"query_string"`
 }
 
 type countData struct {

--- a/internal/service/resourceexplorer2/search_data_source.go
+++ b/internal/service/resourceexplorer2/search_data_source.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/resourceexplorer2"
-	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -45,18 +44,6 @@ func (d *dataSourceSearch) Schema(ctx context.Context, req datasource.SchemaRequ
 				Required: true,
 			},
 			"id": framework.IDAttribute(),
-			"max_results": schema.Int64Attribute{
-				Optional: true,
-				Validators: []validator.Int64{
-					int64validator.Between(1, 1000),
-				},
-			},
-			"next_token": schema.StringAttribute{
-				Computed: true,
-				Validators: []validator.String{
-					stringvalidator.LengthBetween(1, 2048),
-				},
-			},
 			"view_arn": schema.StringAttribute{
 				Optional: true,
 				Validators: []validator.String{

--- a/internal/service/resourceexplorer2/search_data_source.go
+++ b/internal/service/resourceexplorer2/search_data_source.go
@@ -95,7 +95,6 @@ func (d *dataSourceSearch) Schema(ctx context.Context, req datasource.SchemaRequ
 								Attributes: map[string]schema.Attribute{
 									"data": schema.StringAttribute{
 										Computed: true,
-										// Validators: jsonvalidator.JSON(),
 									},
 									"last_reported_at": schema.StringAttribute{
 										Computed: true,
@@ -122,7 +121,7 @@ func (d *dataSourceSearch) Read(ctx context.Context, req datasource.ReadRequest,
 		return
 	}
 
-	data.ID = types.StringValue(data.ViewArn.ValueString())
+	data.ID = types.StringValue(data.QueryString.ValueString())
 
 	input := &resourceexplorer2.SearchInput{
 		QueryString: aws.String(data.QueryString.ValueString()),
@@ -155,9 +154,7 @@ func (d *dataSourceSearch) Read(ctx context.Context, req datasource.ReadRequest,
 type dataSourceSearchData struct {
 	ResourceCount fwtypes.ListNestedObjectValueOf[countData]     `tfsdk:"resource_count"`
 	Resources     fwtypes.ListNestedObjectValueOf[resourcesData] `tfsdk:"resources"`
-	MaxResults    types.Int64                                    `tfsdk:"max_results"`
 	ID            types.String                                   `tfsdk:"id"`
-	NextToken     types.String                                   `tfsdk:"next_token"`
 	ViewArn       types.String                                   `tfsdk:"view_arn"`
 	QueryString   types.String                                   `tfsdk:"query_string"`
 }

--- a/internal/service/resourceexplorer2/search_data_source.go
+++ b/internal/service/resourceexplorer2/search_data_source.go
@@ -1,0 +1,219 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package resourceexplorer2
+
+import (
+	"context"
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/resourceexplorer2"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource(name="Search")
+func newDataSourceSearch(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &dataSourceSearch{}, nil
+}
+
+const (
+	DSNameSearch = "Search Data Source"
+)
+
+type dataSourceSearch struct {
+	framework.DataSourceWithConfigure
+}
+
+func (d *dataSourceSearch) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) { // nosemgrep:ci.meta-in-func-name
+	resp.TypeName = "aws_resourceexplorer2_search"
+}
+
+func (d *dataSourceSearch) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"query_string": schema.StringAttribute{
+				Required: true,
+			},
+			"id": framework.IDAttribute(),
+			"max_results": schema.Int64Attribute{
+				Optional: true,
+				Validators: []validator.Int64{
+					int64validator.Between(1, 1000),
+				},
+			},
+			"next_token": schema.StringAttribute{
+				Computed: true,
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 2048),
+				},
+			},
+			"view_arn": schema.StringAttribute{
+				Optional: true,
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(0, 1011),
+				},
+			},
+		},
+		// Blocks: map[string]schema.Block{
+		// 	"rsc_count": schema.ListNestedBlock{
+		// 		CustomType: fwtypes.NewListNestedObjectTypeOf[countData](ctx),
+		// 		NestedObject: schema.NestedBlockObject{
+		// 			Attributes: map[string]schema.Attribute{
+		// 				"complete": schema.BoolAttribute{
+		// 					Computed: true,
+		// 				},
+		// 				"total_resources": schema.Int64Attribute{
+		// 					Computed: true,
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// 	"resources": schema.ListNestedBlock{
+		// 		CustomType: fwtypes.NewListNestedObjectTypeOf[resourcesData](ctx),
+		// 		NestedObject: schema.NestedBlockObject{
+		// 			Attributes: map[string]schema.Attribute{
+		// 				"arn": schema.StringAttribute{
+		// 					Computed: true,
+		// 				},
+		// 				"last_reported_at": schema.StringAttribute{
+		// 					Computed: true,
+		// 				},
+		// 				"owning_account_id": schema.StringAttribute{
+		// 					Computed: true,
+		// 				},
+		// 				"region": schema.StringAttribute{
+		// 					Computed: true,
+		// 				},
+		// 				"resource_type": schema.StringAttribute{
+		// 					Computed: true,
+		// 				},
+		// 				"service": schema.StringAttribute{
+		// 					Computed: true,
+		// 				},
+		// 			},
+		// 			Blocks: map[string]schema.Block{
+		// 				"resource_property": schema.ListNestedBlock{
+		// 					CustomType: fwtypes.NewListNestedObjectTypeOf[resourcePropertyData](ctx),
+		// 					NestedObject: schema.NestedBlockObject{
+		// 						Attributes: map[string]schema.Attribute{
+		// 							"data": schema.StringAttribute{
+		// 								Computed: true,
+		// 								// Validators: jsonvalidator.JSON(),
+		// 							},
+		// 							"last_reported_at": schema.StringAttribute{
+		// 								Computed: true,
+		// 							},
+		// 							"name": schema.StringAttribute{
+		// 								Computed: true,
+		// 							},
+		// 						},
+		// 					},
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// },
+	}
+}
+
+func (d *dataSourceSearch) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	conn := d.Meta().ResourceExplorer2Client(ctx)
+
+	var data dataSourceSearchData
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.ID = types.StringValue(data.ViewArn.ValueString())
+
+	input := &resourceexplorer2.SearchInput{
+		// ViewArn:     aws.String(data.ViewArn.ValueString()),
+		QueryString: aws.String(data.QueryString.ValueString()),
+	}
+
+	log.Printf("[WARN] VIEWARN: %s", data.ViewArn.ValueString())
+
+	paginator := resourceexplorer2.NewSearchPaginator(conn, input)
+
+	var out resourceexplorer2.SearchOutput
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.ResourceExplorer2, create.ErrActionReading, DSNameSearch, data.ID.String(), err),
+				err.Error(),
+			)
+			return
+		}
+
+		if page != nil && len(page.Resources) > 0 {
+			out.Resources = append(out.Resources, page.Resources...)
+		}
+	}
+
+	resp.Diagnostics.Append(flex.Flatten(ctx, out, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// out, err := findSearchByName(ctx, conn, data.Name.ValueString())
+	// if err != nil {
+	// 	resp.Diagnostics.AddError(
+	// 		create.ProblemStandardMessage(names.ResourceExplorer2, create.ErrActionReading, DSNameSearch, data.Name.String(), err),
+	// 		err.Error(),
+	// 	)
+	// 	return
+	// }
+
+	// data.ARN = flex.StringToFramework(ctx, out.Arn)
+	// data.ID = flex.StringToFramework(ctx, out.SearchId)
+	// data.Name = flex.StringToFramework(ctx, out.SearchName)
+	// data.Type = flex.StringToFramework(ctx, out.SearchType)
+	// complexArgument, diag := flattenComplexArgument(ctx, out.ComplexArgument)
+	// resp.Diagnostics.Append(diag...)
+	// data.ComplexArgument = complexArgument
+
+	// resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+type dataSourceSearchData struct {
+	// Count       fwtypes.ListNestedObjectValueOf[countData] `tfsdk:"rsc_count"`
+	MaxResults  types.Int64  `tfsdk:"max_results"`
+	ID          types.String `tfsdk:"id"`
+	NextToken   types.String `tfsdk:"next_token"`
+	ViewArn     types.String `tfsdk:"view_arn"`
+	QueryString types.String `tfsdk:"query_string"`
+}
+
+type countData struct {
+	Completed      types.Bool  `tfsdk:"completed"`
+	TotalResources types.Int64 `tfsdk:"total_resources"`
+}
+
+type resourcesData struct {
+	ARN              types.String                                          `tfsdk:"arn"`
+	LastReportedAt   types.String                                          `tfsdk:"last_reported_at"`
+	OwningAccountID  types.String                                          `tfsdk:"owning_account_id"`
+	Region           types.String                                          `tfsdk:"region"`
+	ResourceProperty fwtypes.ListNestedObjectValueOf[resourcePropertyData] `tfsdk:"resource_property"`
+	ResourceType     types.String                                          `tfsdk:"resource_type"`
+	Service          types.String                                          `tfsdk:"service"`
+}
+
+type resourcePropertyData struct {
+	Data           types.String `tfsdk:"data"`
+	LastReportedAt types.String `tfsdk:"last_reported_at"`
+	Name           types.String `tfsdk:"name"`
+}

--- a/internal/service/resourceexplorer2/search_data_source_test.go
+++ b/internal/service/resourceexplorer2/search_data_source_test.go
@@ -44,6 +44,7 @@ func testAccSearchDataSource_basic(t *testing.T) {
 	})
 }
 
+// Can only be run once a day as changing the index type has a 24 hr cooldown
 func testAccSearchDataSource_IndexType(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -86,17 +87,17 @@ resource "aws_resourceexplorer2_index" "test" {
 }
 
 resource "aws_resourceexplorer2_view" "test" {
+  depends_on = [aws_resourceexplorer2_index.test]
+
   name         = %[1]q
   default_view = true
-
-  depends_on = [aws_resourceexplorer2_index.test]
 }
 
 data "aws_resourceexplorer2_search" "test" {
+  depends_on = [aws_resourceexplorer2_view.test]
+
   query_string = "region:global"
   view_arn     = aws_resourceexplorer2_view.test.arn
-
-  depends_on = [aws_resourceexplorer2_view.test]
 }
 `, rName, indexType)
 }

--- a/internal/service/resourceexplorer2/search_data_source_test.go
+++ b/internal/service/resourceexplorer2/search_data_source_test.go
@@ -5,6 +5,7 @@ package resourceexplorer2_test
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -47,6 +48,9 @@ func testAccSearchDataSource_basic(t *testing.T) {
 // Can only be run once a day as changing the index type has a 24 hr cooldown
 func testAccSearchDataSource_IndexType(t *testing.T) {
 	ctx := acctest.Context(t)
+	if os.Getenv("RESOURCEEXPLORER_INDEX_TYPE") != "AGGREGATOR" {
+		t.Skip("Environment variable RESOURCEEXPLORER_INDEX_TYPE is not set to AGGREGATOR. Before setting this environment variable and running this test, ensure no tests with a LOCAL index type also need to run. Changing the index type will trigger a cool down period of 24 hours.")
+	}
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}

--- a/internal/service/resourceexplorer2/search_data_source_test.go
+++ b/internal/service/resourceexplorer2/search_data_source_test.go
@@ -28,7 +28,7 @@ func testAccSearchDataSource_basic(t *testing.T) {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, names.ResourceExplorer2EndpointID)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, names.ResourceExplorer2EndpointID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ResourceExplorer2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             nil,
 		Steps: []resource.TestStep{
@@ -59,7 +59,7 @@ func testAccSearchDataSource_IndexType(t *testing.T) {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, names.ResourceExplorer2EndpointID)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, names.ResourceExplorer2EndpointID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.ResourceExplorer2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             nil,
 		Steps: []resource.TestStep{
@@ -94,7 +94,7 @@ resource "aws_resourceexplorer2_view" "test" {
 
 data "aws_resourceexplorer2_search" "test" {
   query_string = "region:global"
-  view_arn = aws_resourceexplorer2_view.test.arn
+  view_arn     = aws_resourceexplorer2_view.test.arn
 
   depends_on = [aws_resourceexplorer2_view.test]
 }

--- a/internal/service/resourceexplorer2/search_data_source_test.go
+++ b/internal/service/resourceexplorer2/search_data_source_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package resourceexplorer2_test
+
+import (
+	"fmt"
+	"testing"
+
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccResourceExplorer2SearchDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_resourceexplorer2_search.test"
+	viewResourceName := "aws_resourceexplorer2_view.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.ResourceExplorer2EndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ResourceExplorer2EndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSearchDataSourceConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					// testAccCheckSearchExists(ctx, dataSourceName, &search),
+					resource.TestCheckResourceAttrPair(dataSourceName, "view_arn", viewResourceName, "arn"),
+					// resource.TestCheckResourceAttrSet(dataSourceName, "count.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccSearchDataSourceConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_resourceexplorer2_index" "test" {
+  type = "AGGREGATOR"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_resourceexplorer2_view" "test" {
+  name         = %[1]q
+
+  depends_on = [aws_resourceexplorer2_index.test]
+}
+
+data "aws_resourceexplorer2_search" "test" {
+  query_string = "region:us-west-2"
+  view_arn = aws_resourceexplorer2_index.test.arn
+}
+`, rName)
+}

--- a/internal/service/resourceexplorer2/service_package_gen.go
+++ b/internal/service/resourceexplorer2/service_package_gen.go
@@ -15,7 +15,12 @@ import (
 type servicePackage struct{}
 
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.ServicePackageFrameworkDataSource {
-	return []*types.ServicePackageFrameworkDataSource{}
+	return []*types.ServicePackageFrameworkDataSource{
+		{
+			Factory: newDataSourceSearch,
+			Name:    "Search",
+		},
+	}
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.ServicePackageFrameworkResource {

--- a/website/docs/d/resourceexplorer2_search.html.markdown
+++ b/website/docs/d/resourceexplorer2_search.html.markdown
@@ -1,0 +1,35 @@
+---
+subcategory: "Resource Explorer"
+layout: "aws"
+page_title: "AWS: aws_resourceexplorer2_search"
+description: |-
+  Terraform data source for managing an AWS Resource Explorer Search.
+---
+# Data Source: aws_resourceexplorer2_search
+
+Terraform data source for managing an AWS Resource Explorer Search.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_resourceexplorer2_search" "example" {
+  query_string = "region:us-west-2"
+  view_arn = aws_resourceexplorer2_index.test.arn
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `query_string` - (Required) String that includes keywords and filters that specify the resources that you want to include in the results. For the complete syntax supported by the QueryString parameter, see Search query syntax reference for Resource Explorer (https://docs.aws.amazon.com/resource-explorer/latest/userguide/using-search-query-syntax.html). The search is completely case insensitive. You can specify an empty string to return all results up to the limit of 1,000 total results. The operation can return only the first 1,000 results. If the resource you want is not included, then use a different value for QueryString to refine the results.
+
+The following arguments are optional:
+
+* `max_results` - (Optional) Maximum number of results that you want included on each page of the response. If you do not include this parameter, it defaults to a value appropriate to the operation.
+
+* `next_token` - (Optional) Parameter for receiving additional results if you receive a `NextToken` response in a previous request. A NextToken response indicates that more output is available.
+
+* `view_arn` - (Optional) Specifies the Amazon resource name (ARN) of the view to use for the query. If you don't specify a value for this parameter, then the operation automatically uses the default view for the AWS Region in which you called this operation. If the Region either doesn't have a default view or if you don't have permission to use the default view, then the operation fails with a `401 Unauthorized` exception.

--- a/website/docs/d/resourceexplorer2_search.html.markdown
+++ b/website/docs/d/resourceexplorer2_search.html.markdown
@@ -24,12 +24,36 @@ data "aws_resourceexplorer2_search" "example" {
 
 The following arguments are required:
 
-* `query_string` - (Required) String that includes keywords and filters that specify the resources that you want to include in the results. For the complete syntax supported by the QueryString parameter, see Search query syntax reference for Resource Explorer (https://docs.aws.amazon.com/resource-explorer/latest/userguide/using-search-query-syntax.html). The search is completely case insensitive. You can specify an empty string to return all results up to the limit of 1,000 total results. The operation can return only the first 1,000 results. If the resource you want is not included, then use a different value for QueryString to refine the results.
+* `query_string` - (Required) String that includes keywords and filters that specify the resources that you want to include in the results. For the complete syntax supported by the QueryString parameter, see Search query syntax reference for [Resource Explorer](https://docs.aws.amazon.com/resource-explorer/latest/userguide/using-search-query-syntax.html). The search is completely case insensitive. You can specify an empty string to return all results up to the limit of 1,000 total results. The operation can return only the first 1,000 results. If the resource you want is not included, then use a different value for QueryString to refine the results.
 
 The following arguments are optional:
 
-* `max_results` - (Optional) Maximum number of results that you want included on each page of the response. If you do not include this parameter, it defaults to a value appropriate to the operation.
-
-* `next_token` - (Optional) Parameter for receiving additional results if you receive a `NextToken` response in a previous request. A NextToken response indicates that more output is available.
-
 * `view_arn` - (Optional) Specifies the Amazon resource name (ARN) of the view to use for the query. If you don't specify a value for this parameter, then the operation automatically uses the default view for the AWS Region in which you called this operation. If the Region either doesn't have a default view or if you don't have permission to use the default view, then the operation fails with a `401 Unauthorized` exception.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `resource_count` - Number of resources that match the query. See [`resource_count`](#resource_count-attribute-reference) below.
+* `resources` - List of structures that describe the resources that match the query. See [`resources`](#resources-attribute-reference) below.
+
+### `resource_count` Attribute Reference
+
+* `complete` - Indicates whether the TotalResources value represents an exhaustive count of search results. If True, it indicates that the search was exhaustive. Every resource that matches the query was counted. If False, then the search reached the limit of 1,000 matching results, and stopped counting.
+* `total_resources` - Number of resources that match the search query. This value can't exceed 1,000. If there are more than 1,000 resources that match the query, then only 1,000 are counted and the Complete field is set to false. We recommend that you refine your query to return a smaller number of results.
+
+### `resources` Attribute Reference
+
+* `arn` - Amazon resource name of resource
+* `last_reported_at` - Date and time that Resource Explorer last queried this resource and updated the index with the latest information about the resource.
+* `owning_account_id` - Amazon Web Services account that owns the resource.
+* `resource_property` - Structure with additional type-specific details about the resource.  See [`resource_property`](#resource_property-attribute-reference) below.
+* `region` - Amazon Web Services Region in which the resource was created and exists.
+* `resource_type` - Type of the resource.
+* `service` - Amazon Web Service that owns the resource and is responsible for creating and updating it.
+
+### `resource_property` Attribute Reference
+
+* `data` - Details about this property. The content of this field is a JSON object that varies based on the resource type.
+* `last_reported_at` - The date and time that the information about this resource property was last updated.
+* `name` - Name of this property of the resource

--- a/website/docs/d/resourceexplorer2_search.html.markdown
+++ b/website/docs/d/resourceexplorer2_search.html.markdown
@@ -36,6 +36,7 @@ This data source exports the following attributes in addition to the arguments a
 
 * `resource_count` - Number of resources that match the query. See [`resource_count`](#resource_count-attribute-reference) below.
 * `resources` - List of structures that describe the resources that match the query. See [`resources`](#resources-attribute-reference) below.
+* `id` - Query String
 
 ### `resource_count` Attribute Reference
 

--- a/website/docs/d/resourceexplorer2_search.html.markdown
+++ b/website/docs/d/resourceexplorer2_search.html.markdown
@@ -16,7 +16,7 @@ Terraform data source for managing an AWS Resource Explorer Search.
 ```terraform
 data "aws_resourceexplorer2_search" "example" {
   query_string = "region:us-west-2"
-  view_arn = aws_resourceexplorer2_index.test.arn
+  view_arn     = aws_resourceexplorer2_index.test.arn
 }
 ```
 

--- a/website/docs/d/resourceexplorer2_search.html.markdown
+++ b/website/docs/d/resourceexplorer2_search.html.markdown
@@ -36,7 +36,7 @@ This data source exports the following attributes in addition to the arguments a
 
 * `resource_count` - Number of resources that match the query. See [`resource_count`](#resource_count-attribute-reference) below.
 * `resources` - List of structures that describe the resources that match the query. See [`resources`](#resources-attribute-reference) below.
-* `id` - Query String
+* `id` - Query String.
 
 ### `resource_count` Attribute Reference
 
@@ -45,7 +45,7 @@ This data source exports the following attributes in addition to the arguments a
 
 ### `resources` Attribute Reference
 
-* `arn` - Amazon resource name of resource
+* `arn` - Amazon resource name of resource.
 * `last_reported_at` - Date and time that Resource Explorer last queried this resource and updated the index with the latest information about the resource.
 * `owning_account_id` - Amazon Web Services account that owns the resource.
 * `resource_property` - Structure with additional type-specific details about the resource.  See [`resource_property`](#resource_property-attribute-reference) below.
@@ -57,4 +57,4 @@ This data source exports the following attributes in addition to the arguments a
 
 * `data` - Details about this property. The content of this field is a JSON object that varies based on the resource type.
 * `last_reported_at` - The date and time that the information about this resource property was last updated.
-* `name` - Name of this property of the resource
+* `name` - Name of this property of the resource.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
New datasource Search for Resource Explorer 2

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #36033

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
> make testacc TESTARGS="-run=TestAccResourceExplorer2_serial/SearchDataSource" PKG=resourceexplorer2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/resourceexplorer2/... -v -count 1 -parallel 20  -run=TestAccResourceExplorer2_serial/SearchDataSource -timeout 360m
=== RUN   TestAccResourceExplorer2_serial
=== PAUSE TestAccResourceExplorer2_serial
=== CONT  TestAccResourceExplorer2_serial
=== RUN   TestAccResourceExplorer2_serial/SearchDataSource
=== RUN   TestAccResourceExplorer2_serial/SearchDataSource/basic
=== RUN   TestAccResourceExplorer2_serial/SearchDataSource/indexType
--- PASS: TestAccResourceExplorer2_serial (30.28s)
    --- PASS: TestAccResourceExplorer2_serial/SearchDataSource (30.28s)
        --- PASS: TestAccResourceExplorer2_serial/SearchDataSource/basic (14.03s)
        --- PASS: TestAccResourceExplorer2_serial/SearchDataSource/indexType (16.25s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/resourceexplorer2  36.584s

...
```
