### PR TITLE
Update kinesisanalyticsv2_application.html.markdown

### DIFF
--- a/website/docs/r/kinesisanalyticsv2_application.html.markdown
+++ b/website/docs/r/kinesisanalyticsv2_application.html.markdown
@@ -256,7 +256,7 @@ resource "aws_kinesisanalyticsv2_application" "example" {
 This resource supports the following arguments:
 
 * `name` - (Required) The name of the application.
-* `runtime_environment` - (Required) The runtime environment for the application. Valid values: `SQL-1_0`, `FLINK-1_6`, `FLINK-1_8`, `FLINK-1_11`, `FLINK-1_13`, `FLINK-1_15`.
+* `runtime_environment` - (Required) The runtime environment for the application. Valid values: `SQL-1_0`, `FLINK-1_6`, `FLINK-1_8`, `FLINK-1_11`, `FLINK-1_13`, `FLINK-1_15`, `FLINK-1_18`.
 * `service_execution_role` - (Required) The ARN of the [IAM role](/docs/providers/aws/r/iam_role.html) used by the application to access Kinesis data streams, Kinesis Data Firehose delivery streams, Amazon S3 objects, and other external resources.
 * `application_configuration` - (Optional) The application's configuration
 * `cloudwatch_logging_options` - (Optional) A [CloudWatch log stream](/docs/providers/aws/r/cloudwatch_log_stream.html) to monitor application configuration errors.


### PR DESCRIPTION
r/aws_kinesisanalyticsv2_application: Document support for Apache Flink v1.18

Closes #36449.

This value was added in [AWS SDK for Go v1.51.1](https://github.com/aws/aws-sdk-go/releases/tag/v1.51.1), https://github.com/hashicorp/terraform-provider-aws/pull/36435, which was incorporated into [Terraform AWS Provider v5.42.0](https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.42.0).