### PR TITLE
r/aws_route53_zone: prevent re-creation with uppercase name

### DIFF
--- a/.changelog/36563.txt
+++ b/.changelog/36563.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_route53_zone: Prevent re-creation when `name` casing changes
+```

--- a/internal/service/route53/zone_data_source.go
+++ b/internal/service/route53/zone_data_source.go
@@ -123,7 +123,7 @@ func dataSourceZoneRead(ctx context.Context, d *schema.ResourceData, meta interf
 				hostedZoneFound = hostedZone
 				break
 				// we check if the name is the same as requested and if private zone field is the same as requested or if there is a vpc_id
-			} else if (TrimTrailingPeriod(aws.StringValue(hostedZone.Name)) == TrimTrailingPeriod(name)) && (aws.BoolValue(hostedZone.Config.PrivateZone) == d.Get("private_zone").(bool) || (aws.BoolValue(hostedZone.Config.PrivateZone) && vpcIdExists)) {
+			} else if (NormalizeZoneName(aws.StringValue(hostedZone.Name)) == NormalizeZoneName(name)) && (aws.BoolValue(hostedZone.Config.PrivateZone) == d.Get("private_zone").(bool) || (aws.BoolValue(hostedZone.Config.PrivateZone) && vpcIdExists)) {
 				matchingVPC := false
 				if vpcIdExists {
 					reqHostedZone := &route53.GetHostedZoneInput{}
@@ -178,7 +178,7 @@ func dataSourceZoneRead(ctx context.Context, d *schema.ResourceData, meta interf
 	d.Set("zone_id", idHostedZone)
 	// To be consistent with other AWS services (e.g. ACM) that do not accept a trailing period,
 	// we remove the suffix from the Hosted Zone Name returned from the API
-	d.Set("name", TrimTrailingPeriod(aws.StringValue(hostedZoneFound.Name)))
+	d.Set("name", NormalizeZoneName(aws.StringValue(hostedZoneFound.Name)))
 	d.Set("comment", hostedZoneFound.Config.Comment)
 	d.Set("private_zone", hostedZoneFound.Config.PrivateZone)
 	d.Set("caller_reference", hostedZoneFound.CallerReference)

--- a/internal/service/route53/zone_test.go
+++ b/internal/service/route53/zone_test.go
@@ -60,7 +60,7 @@ func TestCleanChangeID(t *testing.T) {
 	}
 }
 
-func TestTrimTrailingPeriod(t *testing.T) {
+func TestNormalizeZoneName(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -70,17 +70,22 @@ func TestTrimTrailingPeriod(t *testing.T) {
 		{"example.com", "example.com"},
 		{"example.com.", "example.com"},
 		{"www.example.com.", "www.example.com"},
+		{"www.ExAmPlE.COM.", "www.example.com"},
 		{"", ""},
 		{".", "."},
 		{aws.String("example.com"), "example.com"},
 		{aws.String("example.com."), "example.com"},
+		{aws.String("www.example.com."), "www.example.com"},
+		{aws.String("www.ExAmPlE.COM."), "www.example.com"},
+		{aws.String(""), ""},
+		{aws.String("."), "."},
 		{(*string)(nil), ""},
 		{42, ""},
 		{nil, ""},
 	}
 
 	for _, tc := range cases {
-		actual := tfroute53.TrimTrailingPeriod(tc.Input)
+		actual := tfroute53.NormalizeZoneName(tc.Input)
 		if actual != tc.Output {
 			t.Fatalf("input: %s\noutput: %s", tc.Input, actual)
 		}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This change handles normalizing the `name` argument such that the value returned from the Route53 API matches what is stored in state. Previously, if the `name` argument included an uppercase letter a persistent difference would be present, causing the resource to be re-created.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #35022 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/Route53/latest/APIReference/API_CreateHostedZone.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=route53 TESTS=TestAccRoute53Zone_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/route53/... -v -count 1 -parallel 20 -run='TestAccRoute53Zone_'  -timeout 360m

--- PASS: TestAccRoute53Zone_disappears (57.95s)
--- PASS: TestAccRoute53Zone_delegationSetID (65.40s)
--- PASS: TestAccRoute53Zone_basic (66.34s)
--- PASS: TestAccRoute53Zone_VPC_single (70.98s)
--- PASS: TestAccRoute53Zone_comment (71.97s)
--- PASS: TestAccRoute53Zone_multiple (74.73s)
--- PASS: TestAccRoute53Zone_tags (76.63s)
--- PASS: TestAccRoute53Zone_VPC_multiple (143.04s)
--- PASS: TestAccRoute53Zone_VPC_single_forceDestroy (190.01s)
--- PASS: TestAccRoute53Zone_VPC_updates (212.37s)
--- PASS: TestAccRoute53Zone_forceDestroy (258.91s)
--- PASS: TestAccRoute53Zone_ForceDestroy_trailingPeriod (274.02s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53    279.439
```

```console
% make testacc PKG=route53 TESTS=TestAccRoute53ZoneDataSource_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/route53/... -v -count 1 -parallel 20 -run='TestAccRoute53ZoneDataSource_'  -timeout 360m

--- PASS: TestAccRoute53ZoneDataSource_id (45.26s)
--- PASS: TestAccRoute53ZoneDataSource_name (48.35s)
--- PASS: TestAccRoute53ZoneDataSource_tags (65.21s)
--- PASS: TestAccRoute53ZoneDataSource_vpc (83.68s)
--- PASS: TestAccRoute53ZoneDataSource_serviceDiscovery (102.34s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53    107.890s
```