### PR TITLE
iam/instance_profile: Clarify docs

### DIFF
--- a/internal/service/iam/instance_profile_test.go
+++ b/internal/service/iam/instance_profile_test.go
@@ -185,6 +185,82 @@ func TestAccIAMInstanceProfile_Disappears_role(t *testing.T) {
 	})
 }
 
+func TestAccIAMInstanceProfile_launchConfiguration(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf iam.InstanceProfile
+	resourceName := "aws_iam_instance_profile.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceProfileConfig_launchConfiguration(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceProfileExists(ctx, resourceName, &conf),
+					acctest.CheckResourceAttrGlobalARN(resourceName, "arn", "iam", fmt.Sprintf("instance-profile/%s", rName)),
+					resource.TestCheckResourceAttrPair(resourceName, "role", "aws_iam_role.test", "name"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccInstanceProfileConfig_launchConfiguration(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceProfileExists(ctx, resourceName, &conf),
+					acctest.CheckResourceAttrGlobalARN(resourceName, "arn", "iam", fmt.Sprintf("instance-profile/%s", rName)),
+					resource.TestCheckResourceAttrPair(resourceName, "role", "aws_iam_role.test", "name"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+				),
+			},
+			{
+				Config: testAccInstanceProfileConfig_launchConfiguration(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceProfileExists(ctx, resourceName, &conf),
+					acctest.CheckResourceAttrGlobalARN(resourceName, "arn", "iam", fmt.Sprintf("instance-profile/%s", rName)),
+					resource.TestCheckResourceAttrPair(resourceName, "role", "aws_iam_role.test", "name"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+				),
+			},
+			{
+				Config: testAccInstanceProfileConfig_launchConfiguration(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceProfileExists(ctx, resourceName, &conf),
+					acctest.CheckResourceAttrGlobalARN(resourceName, "arn", "iam", fmt.Sprintf("instance-profile/%s", rName)),
+					resource.TestCheckResourceAttrPair(resourceName, "role", "aws_iam_role.test", "name"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccInstanceProfileConfig_launchConfiguration(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceProfileExists(ctx, resourceName, &conf),
+					acctest.CheckResourceAttrGlobalARN(resourceName, "arn", "iam", fmt.Sprintf("instance-profile/%s", rName)),
+					resource.TestCheckResourceAttrPair(resourceName, "role", "aws_iam_role.test", "name"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckInstanceProfileDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMConn(ctx)
@@ -344,4 +420,27 @@ resource "aws_iam_instance_profile" "test" {
   }
 }
 `, rName, tagKey1))
+}
+
+func testAccInstanceProfileConfig_launchConfiguration(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigLatestAmazonLinux2HVMEBSX8664AMI(),
+		testAccInstanceProfileConfig_base(rName),
+		fmt.Sprintf(`
+resource "aws_launch_configuration" "test" {
+  name                 = %[1]q
+  iam_instance_profile = aws_iam_instance_profile.test.name
+  image_id             = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.id
+  instance_type        = "t2.micro"
+}
+
+resource "aws_iam_instance_profile" "test" {
+  name = %[1]q
+  role = aws_iam_role.test.name
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName))
 }

--- a/website/docs/r/iam_instance_profile.html.markdown
+++ b/website/docs/r/iam_instance_profile.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides an IAM instance profile.
 
+~> **NOTE:** When managing instance profiles, remember that the `name` attribute must always be unique. This means that even if you have different `role` or `path` values, duplicating an existing instance profile `name` will lead to an `EntityAlreadyExists` error.
+
 ## Example Usage
 
 ```terraform
@@ -42,7 +44,7 @@ resource "aws_iam_role" "role" {
 
 The following arguments are optional:
 
-* `name` - (Optional, Forces new resource) Name of the instance profile. If omitted, Terraform will assign a random, unique name. Conflicts with `name_prefix`. Can be a string of characters consisting of upper and lowercase alphanumeric characters and these special characters: `_`, `+`, `=`, `,`, `.`, `@`, `-`. Spaces are not allowed.
+* `name` - (Optional, Forces new resource) Name of the instance profile. If omitted, Terraform will assign a random, unique name. Conflicts with `name_prefix`. Can be a string of characters consisting of upper and lowercase alphanumeric characters and these special characters: `_`, `+`, `=`, `,`, `.`, `@`, `-`. Spaces are not allowed. The `name` must be unique, regardless of the `path` or `role`. In other words, if there are different `role` or `path` values but the same `name` as an existing instance profile, it will still cause an `EntityAlreadyExists` error.
 * `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `path` - (Optional, default "/") Path to the instance profile. For more information about paths, see [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) in the IAM User Guide. Can be a string of characters consisting of either a forward slash (`/`) by itself or a string that must begin and end with forward slashes. Can include any ASCII character from the ! (\u0021) through the DEL character (\u007F), including most punctuation characters, digits, and upper and lowercase letters.
 * `role` - (Optional) Name of the role to add to the profile.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #8041

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccIAMInstanceProfile_ K=iam
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMInstanceProfile_'  -timeout 360m
=== RUN   TestAccIAMInstanceProfile_tags
=== PAUSE TestAccIAMInstanceProfile_tags
=== RUN   TestAccIAMInstanceProfile_tags_null
=== PAUSE TestAccIAMInstanceProfile_tags_null
=== RUN   TestAccIAMInstanceProfile_tags_AddOnUpdate
=== PAUSE TestAccIAMInstanceProfile_tags_AddOnUpdate
=== RUN   TestAccIAMInstanceProfile_tags_EmptyTag_OnCreate
=== PAUSE TestAccIAMInstanceProfile_tags_EmptyTag_OnCreate
=== RUN   TestAccIAMInstanceProfile_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccIAMInstanceProfile_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccIAMInstanceProfile_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccIAMInstanceProfile_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccIAMInstanceProfile_tags_DefaultTags_providerOnly
=== PAUSE TestAccIAMInstanceProfile_tags_DefaultTags_providerOnly
=== RUN   TestAccIAMInstanceProfile_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccIAMInstanceProfile_tags_DefaultTags_nonOverlapping
=== RUN   TestAccIAMInstanceProfile_tags_DefaultTags_overlapping
=== PAUSE TestAccIAMInstanceProfile_tags_DefaultTags_overlapping
=== RUN   TestAccIAMInstanceProfile_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccIAMInstanceProfile_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccIAMInstanceProfile_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccIAMInstanceProfile_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccIAMInstanceProfile_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccIAMInstanceProfile_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccIAMInstanceProfile_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccIAMInstanceProfile_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccIAMInstanceProfile_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccIAMInstanceProfile_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccIAMInstanceProfile_basic
=== PAUSE TestAccIAMInstanceProfile_basic
=== RUN   TestAccIAMInstanceProfile_withoutRole
=== PAUSE TestAccIAMInstanceProfile_withoutRole
=== RUN   TestAccIAMInstanceProfile_nameGenerated
=== PAUSE TestAccIAMInstanceProfile_nameGenerated
=== RUN   TestAccIAMInstanceProfile_namePrefix
=== PAUSE TestAccIAMInstanceProfile_namePrefix
=== RUN   TestAccIAMInstanceProfile_disappears
=== PAUSE TestAccIAMInstanceProfile_disappears
=== RUN   TestAccIAMInstanceProfile_Disappears_role
=== PAUSE TestAccIAMInstanceProfile_Disappears_role
=== RUN   TestAccIAMInstanceProfile_launchConfiguration
=== PAUSE TestAccIAMInstanceProfile_launchConfiguration
=== CONT  TestAccIAMInstanceProfile_tags
=== CONT  TestAccIAMInstanceProfile_tags_DefaultTags_emptyResourceTag
=== CONT  TestAccIAMInstanceProfile_tags_DefaultTags_providerOnly
=== CONT  TestAccIAMInstanceProfile_tags_EmptyTag_OnCreate
=== CONT  TestAccIAMInstanceProfile_nameGenerated
=== CONT  TestAccIAMInstanceProfile_tags_DefaultTags_updateToResourceOnly
=== CONT  TestAccIAMInstanceProfile_launchConfiguration
=== CONT  TestAccIAMInstanceProfile_tags_EmptyTag_OnUpdate_Add
=== CONT  TestAccIAMInstanceProfile_tags_DefaultTags_overlapping
=== CONT  TestAccIAMInstanceProfile_namePrefix
=== CONT  TestAccIAMInstanceProfile_tags_AddOnUpdate
=== CONT  TestAccIAMInstanceProfile_tags_DefaultTags_nullNonOverlappingResourceTag
=== CONT  TestAccIAMInstanceProfile_tags_DefaultTags_updateToProviderOnly
=== CONT  TestAccIAMInstanceProfile_tags_null
=== CONT  TestAccIAMInstanceProfile_tags_EmptyTag_OnUpdate_Replace
=== CONT  TestAccIAMInstanceProfile_basic
=== CONT  TestAccIAMInstanceProfile_withoutRole
=== CONT  TestAccIAMInstanceProfile_tags_DefaultTags_nonOverlapping
=== CONT  TestAccIAMInstanceProfile_disappears
=== CONT  TestAccIAMInstanceProfile_Disappears_role
--- PASS: TestAccIAMInstanceProfile_disappears (49.43s)
=== CONT  TestAccIAMInstanceProfile_tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccIAMInstanceProfile_tags_DefaultTags_nullNonOverlappingResourceTag (49.71s)
--- PASS: TestAccIAMInstanceProfile_tags_DefaultTags_emptyResourceTag (49.72s)
--- PASS: TestAccIAMInstanceProfile_withoutRole (50.11s)
--- PASS: TestAccIAMInstanceProfile_Disappears_role (52.40s)
--- PASS: TestAccIAMInstanceProfile_namePrefix (56.88s)
--- PASS: TestAccIAMInstanceProfile_nameGenerated (59.36s)
--- PASS: TestAccIAMInstanceProfile_basic (59.93s)
--- PASS: TestAccIAMInstanceProfile_tags_null (68.37s)
--- PASS: TestAccIAMInstanceProfile_tags_DefaultTags_updateToResourceOnly (75.18s)
--- PASS: TestAccIAMInstanceProfile_tags_DefaultTags_updateToProviderOnly (81.71s)
--- PASS: TestAccIAMInstanceProfile_tags_EmptyTag_OnUpdate_Replace (82.45s)
--- PASS: TestAccIAMInstanceProfile_tags_AddOnUpdate (82.51s)
--- PASS: TestAccIAMInstanceProfile_tags_DefaultTags_nullOverlappingResourceTag (36.04s)
--- PASS: TestAccIAMInstanceProfile_tags_EmptyTag_OnCreate (86.17s)
--- PASS: TestAccIAMInstanceProfile_tags_DefaultTags_overlapping (99.74s)
--- PASS: TestAccIAMInstanceProfile_tags_EmptyTag_OnUpdate_Add (99.92s)
--- PASS: TestAccIAMInstanceProfile_tags_DefaultTags_nonOverlapping (102.00s)
--- PASS: TestAccIAMInstanceProfile_tags_DefaultTags_providerOnly (114.33s)
--- PASS: TestAccIAMInstanceProfile_tags (114.97s)
--- PASS: TestAccIAMInstanceProfile_launchConfiguration (124.74s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	127.234s
```