### PR TITLE
r/aws_lakeformation_resource_lf_tag: remove unneeded validation

### DIFF
--- a/internal/service/lakeformation/resource_lf_tag.go
+++ b/internal/service/lakeformation/resource_lf_tag.go
@@ -200,12 +200,6 @@ func (r *resourceResourceLFTag) Schema(ctx context.Context, req resource.SchemaR
 						},
 						"name": schema.StringAttribute{
 							Required: true,
-							Validators: []validator.String{
-								stringvalidator.AtLeastOneOf(
-									path.MatchRelative().AtParent().AtName("name"),
-									path.MatchRelative().AtParent().AtName("wildcard"),
-								),
-							},
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.RequiresReplace(),
 								stringplanmodifier.UseStateForUnknown(),


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Relates #36537

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS="-run=TestAccLakeFormation_serial/ResourceLFTag/\$" PKG=lakeformation

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/lakeformation/... -v -count 1 -parallel 20  -run=TestAccLakeFormation_serial/ResourceLFTag/ -timeout 360m
--- PASS: TestAccLakeFormation_serial (184.14s)
    --- PASS: TestAccLakeFormation_serial/ResourceLFTag (49.99s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTag/basic (12.56s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTag/disappears (11.96s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTag/table (12.73s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTag/tableWithColumns (12.73s)
    --- PASS: TestAccLakeFormation_serial/ResourceLFTags (134.15s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/basic (11.48s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/database (20.32s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/databaseMultipleTags (20.00s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/disappears (12.10s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/hierarchy (25.61s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/table (22.59s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/tableWithColumns (22.06s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lakeformation	190.122s
```
