### PR TITLE
feat(datazone): add domain resource

### DIFF
--- a/internal/service/datazone/domain.go
+++ b/internal/service/datazone/domain.go
@@ -1,0 +1,510 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package datazone
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/datazone"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/datazone/types"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	sdkid "github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// Function annotations are used for resource registration to the Provider. DO NOT EDIT.
+// @FrameworkResource(name="Domain")
+// @Tags(identifierAttribute="arn")
+func newResourceDomain(_ context.Context) (resource.ResourceWithConfigure, error) {
+	r := &resourceDomain{}
+
+	r.SetDefaultCreateTimeout(10 * time.Minute)
+	r.SetDefaultDeleteTimeout(10 * time.Minute)
+
+	return r, nil
+}
+
+const (
+	ResNameDomain           = "Domain"
+	CreateNumRetries        = 3
+	CreateRetryDelaySeconds = 2
+)
+
+type resourceDomain struct {
+	framework.ResourceWithConfigure
+	framework.WithTimeouts
+}
+
+func (r *resourceDomain) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "aws_datazone_domain"
+}
+
+func (r *resourceDomain) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"arn": framework.ARNAttributeComputedOnly(),
+			"description": schema.StringAttribute{
+				Optional: true,
+			},
+			"id": framework.IDAttribute(),
+			"name": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"portal_url": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"domain_execution_role": schema.StringAttribute{
+				CustomType: fwtypes.ARNType,
+				Required:   true,
+			},
+			"kms_key_identifier": schema.StringAttribute{
+				CustomType: fwtypes.ARNType,
+				Optional:   true,
+			},
+			names.AttrTags:    tftags.TagsAttribute(),
+			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
+		},
+		Blocks: map[string]schema.Block{
+			"single_sign_on": schema.ListNestedBlock{
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.UseStateForUnknown(),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"type": schema.StringAttribute{
+							Optional: true,
+							Computed: true,
+							Validators: []validator.String{
+								enum.FrameworkValidate[awstypes.AuthType](),
+							},
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
+							Default: stringdefault.StaticString("DISABLED"),
+						},
+						"user_assignment": schema.StringAttribute{
+							Optional: true,
+							Validators: []validator.String{
+								enum.FrameworkValidate[awstypes.UserAssignment](),
+							},
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
+						},
+					},
+				},
+			},
+			"timeouts": timeouts.Block(ctx, timeouts.Opts{
+				Create: true,
+				Delete: true,
+			}),
+		},
+	}
+}
+
+func (r *resourceDomain) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().DataZoneClient(ctx)
+
+	var plan resourceDomainData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := &datazone.CreateDomainInput{
+		Name:                aws.String(plan.Name.ValueString()),
+		DomainExecutionRole: aws.String(plan.DomainExecutionRole.ValueString()),
+		ClientToken:         aws.String(sdkid.UniqueId()),
+		Tags:                getTagsIn(ctx),
+	}
+
+	if !plan.Description.IsNull() {
+		in.Description = aws.String(plan.Description.ValueString())
+	}
+
+	if !plan.KmsKeyIdentifier.IsNull() {
+		in.KmsKeyIdentifier = aws.String(plan.KmsKeyIdentifier.ValueString())
+	}
+
+	if !plan.SingleSignOn.IsNull() {
+		var tfList []singleSignOnData
+		resp.Diagnostics.Append(plan.SingleSignOn.ElementsAs(ctx, &tfList, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		in.SingleSignOn = expandSingleSignOn(tfList)
+	}
+
+	out, err := retryCreateDomain(ctx, conn, in, CreateNumRetries)
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.DataZone, create.ErrActionCreating, ResNameDomain, plan.Name.String(), err),
+			err.Error(),
+		)
+		return
+	}
+	if out == nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.DataZone, create.ErrActionCreating, ResNameDomain, plan.Name.String(), nil),
+			errors.New("empty output").Error(),
+		)
+		return
+	}
+
+	plan.ARN = flex.StringToFramework(ctx, out.Arn)
+	plan.ID = flex.StringToFramework(ctx, out.Id)
+	plan.PortalUrl = flex.StringToFramework(ctx, out.PortalUrl)
+
+	createTimeout := r.CreateTimeout(ctx, plan.Timeouts)
+	_, err = waitDomainCreated(ctx, conn, plan.ID.ValueString(), createTimeout)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.DataZone, create.ErrActionWaitingForCreation, ResNameDomain, plan.Name.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *resourceDomain) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().DataZoneClient(ctx)
+
+	var state resourceDomainData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := findDomainByID(ctx, conn, state.ID.ValueString())
+	if tfresource.NotFound(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.DataZone, create.ErrActionSetting, ResNameDomain, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	state.ARN = flex.StringToFramework(ctx, out.Arn)
+	state.ID = flex.StringToFramework(ctx, out.Id)
+	state.Name = flex.StringToFramework(ctx, out.Name)
+	state.Description = flex.StringToFramework(ctx, out.Description)
+	state.PortalUrl = flex.StringToFramework(ctx, out.PortalUrl)
+	state.KmsKeyIdentifier = flex.StringToFrameworkARN(ctx, out.KmsKeyIdentifier)
+	state.DomainExecutionRole = flex.StringToFrameworkARN(ctx, out.DomainExecutionRole)
+
+	if out.SingleSignOn.Type == awstypes.AuthType("DISABLED") && state.SingleSignOn.IsNull() {
+		// Do not set single sign on in state if it was null and response is DISABLED as this is equivalent
+		elemType := fwtypes.NewObjectTypeOf[singleSignOnData](ctx).ObjectType
+		state.SingleSignOn = types.ListNull(elemType)
+	} else {
+		singleSignOn, d := flattenSingleSignOn(ctx, out.SingleSignOn)
+		resp.Diagnostics.Append(d...)
+		state.SingleSignOn = singleSignOn
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *resourceDomain) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	conn := r.Meta().DataZoneClient(ctx)
+
+	var plan, state resourceDomainData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !plan.Description.Equal(state.Description) ||
+		!plan.DomainExecutionRole.Equal(state.DomainExecutionRole) ||
+		!plan.Name.Equal(state.Name) ||
+		!plan.SingleSignOn.Equal(state.SingleSignOn) {
+		in := &datazone.UpdateDomainInput{
+			Identifier:  aws.String(plan.ID.ValueString()),
+			ClientToken: aws.String(sdkid.UniqueId()),
+		}
+
+		if !plan.Description.IsNull() {
+			in.Description = aws.String(plan.Description.ValueString())
+		}
+
+		if !plan.Name.IsNull() {
+			in.Name = aws.String(plan.Name.ValueString())
+		}
+
+		if !plan.DomainExecutionRole.IsNull() {
+			in.DomainExecutionRole = aws.String(plan.DomainExecutionRole.ValueString())
+		}
+
+		if !plan.SingleSignOn.IsNull() {
+			var tfList []singleSignOnData
+			resp.Diagnostics.Append(plan.SingleSignOn.ElementsAs(ctx, &tfList, false)...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+
+			in.SingleSignOn = expandSingleSignOn(tfList)
+		}
+
+		out, err := conn.UpdateDomain(ctx, in)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.DataZone, create.ErrActionUpdating, ResNameDomain, plan.ID.String(), err),
+				err.Error(),
+			)
+			return
+		}
+		if out == nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.DataZone, create.ErrActionUpdating, ResNameDomain, plan.ID.String(), nil),
+				errors.New("empty output").Error(),
+			)
+			return
+		}
+
+		plan.ID = flex.StringToFramework(ctx, out.Id)
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *resourceDomain) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	conn := r.Meta().DataZoneClient(ctx)
+
+	var state resourceDomainData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := &datazone.DeleteDomainInput{
+		Identifier:  aws.String(state.ID.ValueString()),
+		ClientToken: aws.String(sdkid.UniqueId()),
+	}
+
+	_, err := conn.DeleteDomain(ctx, in)
+	if err != nil {
+		if isResourceMissing(err) {
+			return
+		}
+
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.DataZone, create.ErrActionDeleting, ResNameDomain, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	deleteTimeout := r.DeleteTimeout(ctx, state.Timeouts)
+	_, err = waitDomainDeleted(ctx, conn, state.ID.ValueString(), deleteTimeout)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.DataZone, create.ErrActionWaitingForDeletion, ResNameDomain, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+}
+
+func (r *resourceDomain) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func (r *resourceDomain) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	r.SetTagsAll(ctx, req, resp)
+}
+
+func retryCreateDomain(ctx context.Context, conn *datazone.Client, in *datazone.CreateDomainInput, retries int) (*datazone.CreateDomainOutput, error) {
+	out, err := conn.CreateDomain(ctx, in)
+
+	// Race condition can occur domain execution IAM role is not yet ready to be assumed by datazone
+	if retries > 0 && errs.IsA[*awstypes.AccessDeniedException](err) {
+		time.Sleep(CreateRetryDelaySeconds * time.Second)
+		return retryCreateDomain(ctx, conn, in, retries-1)
+	}
+
+	return out, err
+}
+
+func waitDomainCreated(ctx context.Context, conn *datazone.Client, id string, timeout time.Duration) (*datazone.GetDomainOutput, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: enum.Slice(awstypes.DomainStatusCreating),
+		Target:  enum.Slice(awstypes.DomainStatusAvailable),
+		Refresh: statusDomain(ctx, conn, id),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if out, ok := outputRaw.(*datazone.GetDomainOutput); ok {
+		return out, err
+	}
+
+	return nil, err
+}
+
+func waitDomainDeleted(ctx context.Context, conn *datazone.Client, id string, timeout time.Duration) (*datazone.GetDomainOutput, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: enum.Slice(awstypes.DomainStatusAvailable, awstypes.DomainStatusDeleting),
+		Target:  []string{},
+		Refresh: statusDomain(ctx, conn, id),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if out, ok := outputRaw.(*datazone.GetDomainOutput); ok {
+		return out, err
+	}
+
+	return nil, err
+}
+
+func statusDomain(ctx context.Context, conn *datazone.Client, id string) retry.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		out, err := findDomainByID(ctx, conn, id)
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return out, string(out.Status), nil
+	}
+}
+
+func findDomainByID(ctx context.Context, conn *datazone.Client, id string) (*datazone.GetDomainOutput, error) {
+	in := &datazone.GetDomainInput{
+		Identifier: aws.String(id),
+	}
+
+	out, err := conn.GetDomain(ctx, in)
+	if err != nil {
+		if isResourceMissing(err) {
+			return nil, &retry.NotFoundError{
+				LastError:   err,
+				LastRequest: in,
+			}
+		}
+
+		return nil, err
+	}
+
+	if out == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return out, nil
+}
+
+func isResourceMissing(err error) bool {
+	// DataZone returns a 403 when the domain does not exist
+	// AccessDeniedException: User is not permitted to perform operation: GetDomain
+	return errs.IsA[*awstypes.ResourceNotFoundException](err) || errs.IsAErrorMessageContains[*awstypes.AccessDeniedException](err, "is not permitted to perform")
+}
+
+func flattenSingleSignOn(ctx context.Context, apiObject *awstypes.SingleSignOn) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	elemType := types.ObjectType{AttrTypes: singleSignOnAttrTypes}
+
+	if apiObject == nil {
+		return types.ListNull(elemType), diags
+	}
+
+	obj := map[string]attr.Value{
+		"type":            flex.StringValueToFramework(ctx, apiObject.Type),
+		"user_assignment": flex.StringValueToFramework(ctx, apiObject.UserAssignment),
+	}
+	objVal, d := types.ObjectValue(singleSignOnAttrTypes, obj)
+	diags.Append(d...)
+
+	listVal, d := types.ListValue(elemType, []attr.Value{objVal})
+	diags.Append(d...)
+
+	return listVal, diags
+}
+
+func expandSingleSignOn(tfList []singleSignOnData) *awstypes.SingleSignOn {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	tfObj := tfList[0]
+	apiObject := &awstypes.SingleSignOn{}
+
+	if !tfObj.Type.IsNull() {
+		apiObject.Type = awstypes.AuthType(tfObj.Type.ValueString())
+	}
+
+	if !tfObj.UserAssignment.IsNull() {
+		apiObject.UserAssignment = awstypes.UserAssignment(tfObj.UserAssignment.ValueString())
+	}
+
+	return apiObject
+}
+
+type resourceDomainData struct {
+	ARN                 types.String   `tfsdk:"arn"`
+	SingleSignOn        types.List     `tfsdk:"single_sign_on"`
+	DomainExecutionRole fwtypes.ARN    `tfsdk:"domain_execution_role"`
+	KmsKeyIdentifier    fwtypes.ARN    `tfsdk:"kms_key_identifier"`
+	Description         types.String   `tfsdk:"description"`
+	PortalUrl           types.String   `tfsdk:"portal_url"`
+	ID                  types.String   `tfsdk:"id"`
+	Name                types.String   `tfsdk:"name"`
+	Timeouts            timeouts.Value `tfsdk:"timeouts"`
+	Tags                types.Map      `tfsdk:"tags"`
+	TagsAll             types.Map      `tfsdk:"tags_all"`
+}
+
+type singleSignOnData struct {
+	Type           types.String `tfsdk:"type"`
+	UserAssignment types.String `tfsdk:"user_assignment"`
+}
+
+var singleSignOnAttrTypes = map[string]attr.Type{
+	"type":            types.StringType,
+	"user_assignment": types.StringType,
+}

--- a/internal/service/datazone/domain_test.go
+++ b/internal/service/datazone/domain_test.go
@@ -1,0 +1,443 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package datazone_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/datazone"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tfdatazone "github.com/hashicorp/terraform-provider-aws/internal/service/datazone"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccDataZoneDomain_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var domain datazone.GetDomainOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_datazone_domain.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DataZoneServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDomainDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "portal_url"),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately", "user"},
+			},
+		},
+	})
+}
+
+func TestAccDataZoneDomain_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var domain datazone.GetDomainOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_datazone_domain.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DataZoneServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDomainDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName, &domain),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfdatazone.ResourceDomain, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccDataZoneDomain_kms_key_identifier(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var domain datazone.GetDomainOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_datazone_domain.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DataZoneServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDomainDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainConfig_kms_key_identifier(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "kms_key_identifier"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately", "user"},
+			},
+		},
+	})
+}
+
+func TestAccDataZoneDomain_description(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var domain datazone.GetDomainOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_datazone_domain.test"
+	description := "This is a description"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DataZoneServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDomainDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainConfig_description(rName, description),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately", "user"},
+			},
+		},
+	})
+}
+
+func TestAccDataZoneDomain_single_sign_on(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var domain datazone.GetDomainOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_datazone_domain.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DataZoneServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDomainDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainConfig_single_sign_on(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// we do not set single_sign_on if it's the default value
+				ImportStateVerifyIgnore: []string{"single_sign_on"},
+			},
+		},
+	})
+}
+
+func TestAccDataZoneDomain_tags(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var domain datazone.GetDomainOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_datazone_domain.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DataZoneServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDomainDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainConfig_tags(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDomainConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccDomainConfig_tags(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDomainDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).DataZoneClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_datazone_domain" {
+				continue
+			}
+
+			_, err := conn.GetDomain(ctx, &datazone.GetDomainInput{
+				Identifier: aws.String(rs.Primary.ID),
+			})
+
+			if tfdatazone.IsResourceMissing(err) {
+				return nil
+			}
+
+			if err != nil {
+				return create.Error(names.DataZone, create.ErrActionCheckingDestroyed, tfdatazone.ResNameDomain, rs.Primary.ID, err)
+			}
+
+			return create.Error(names.DataZone, create.ErrActionCheckingDestroyed, tfdatazone.ResNameDomain, rs.Primary.ID, errors.New("not destroyed"))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckDomainExists(ctx context.Context, name string, domain *datazone.GetDomainOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.DataZone, create.ErrActionCheckingExistence, tfdatazone.ResNameDomain, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.DataZone, create.ErrActionCheckingExistence, tfdatazone.ResNameDomain, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).DataZoneClient(ctx)
+		resp, err := conn.GetDomain(ctx, &datazone.GetDomainInput{
+			Identifier: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return create.Error(names.DataZone, create.ErrActionCheckingExistence, tfdatazone.ResNameDomain, rs.Primary.ID, err)
+		}
+
+		*domain = *resp
+
+		return nil
+	}
+}
+
+func testAccPreCheck(ctx context.Context, t *testing.T) {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).DataZoneClient(ctx)
+
+	input := &datazone.ListDomainsInput{}
+	_, err := conn.ListDomains(ctx, input)
+
+	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func testAccDomainConfigDomainExecutionRole(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "domain_execution_role" {
+  name = %[1]q
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = ["sts:AssumeRole", "sts:TagSession"]
+        Effect = "Allow"
+        Principal = {
+          Service = "datazone.amazonaws.com"
+        }
+      },
+      {
+        Action = ["sts:AssumeRole", "sts:TagSession"]
+        Effect = "Allow"
+        Principal = {
+          Service = "cloudformation.amazonaws.com"
+        }
+      },
+    ]
+  })
+
+  inline_policy {
+    name = %[1]q
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Action = [
+            "datazone:*",
+            "ram:*",
+            "sso:*",
+            "kms:*",
+          ]
+          Effect   = "Allow"
+          Resource = "*"
+        },
+      ]
+    })
+  }
+}
+`, rName)
+}
+
+func testAccDomainConfig_basic(rName string) string {
+	return acctest.ConfigCompose(
+		testAccDomainConfigDomainExecutionRole(rName),
+		fmt.Sprintf(`
+resource "aws_datazone_domain" "test" {
+  name                  = %[1]q
+  domain_execution_role = aws_iam_role.domain_execution_role.arn
+}
+`, rName),
+	)
+}
+
+func testAccDomainConfig_kms_key_identifier(rName string) string {
+	return acctest.ConfigCompose(
+		testAccDomainConfigDomainExecutionRole(rName),
+		fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  deletion_window_in_days = 7
+}
+
+resource "aws_datazone_domain" "test" {
+  name                  = %[1]q
+  domain_execution_role = aws_iam_role.domain_execution_role.arn
+  kms_key_identifier    = aws_kms_key.test.arn
+}
+`, rName),
+	)
+}
+
+func testAccDomainConfig_description(rName, description string) string {
+	return acctest.ConfigCompose(
+		testAccDomainConfigDomainExecutionRole(rName),
+		fmt.Sprintf(`
+resource "aws_datazone_domain" "test" {
+  name                  = %[1]q
+  domain_execution_role = aws_iam_role.domain_execution_role.arn
+  description           = %[2]q
+}
+`, rName, description),
+	)
+}
+
+func testAccDomainConfig_single_sign_on(rName string) string {
+	return acctest.ConfigCompose(
+		testAccDomainConfigDomainExecutionRole(rName),
+		fmt.Sprintf(`
+resource "aws_datazone_domain" "test" {
+  name                  = %[1]q
+  domain_execution_role = aws_iam_role.domain_execution_role.arn
+  single_sign_on {
+    type = "DISABLED"
+  }
+}
+`, rName),
+	)
+}
+
+func testAccDomainConfig_tags(rName, tagKey, tagValue string) string {
+	return acctest.ConfigCompose(
+		testAccDomainConfigDomainExecutionRole(rName),
+		fmt.Sprintf(`
+resource "aws_datazone_domain" "test" {
+  name                  = %[1]q
+  domain_execution_role = aws_iam_role.domain_execution_role.arn
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey, tagValue),
+	)
+}
+
+func testAccDomainConfig_tags2(rName, tagKey, tagValue, tagKey2, tagValue2 string) string {
+	return acctest.ConfigCompose(
+		testAccDomainConfigDomainExecutionRole(rName),
+		fmt.Sprintf(`
+resource "aws_datazone_domain" "test" {
+  name                  = %[1]q
+  domain_execution_role = aws_iam_role.domain_execution_role.arn
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey, tagValue, tagKey2, tagValue2),
+	)
+}

--- a/internal/service/datazone/exports_test.go
+++ b/internal/service/datazone/exports_test.go
@@ -1,0 +1,10 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package datazone
+
+// Exports for use in tests only.
+var (
+	ResourceDomain    = newResourceDomain
+	IsResourceMissing = isResourceMissing
+)

--- a/internal/service/datazone/service_package_gen.go
+++ b/internal/service/datazone/service_package_gen.go
@@ -19,7 +19,15 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.Serv
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.ServicePackageFrameworkResource {
-	return []*types.ServicePackageFrameworkResource{}
+	return []*types.ServicePackageFrameworkResource{
+		{
+			Factory: newResourceDomain,
+			Name:    "Domain",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
+		},
+	}
 }
 
 func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePackageSDKDataSource {

--- a/website/docs/r/datazone_domain.html.markdown
+++ b/website/docs/r/datazone_domain.html.markdown
@@ -1,0 +1,111 @@
+---
+subcategory: "DataZone"
+layout: "aws"
+page_title: "AWS: aws_datazone_domain"
+description: |-
+  Terraform resource for managing an AWS DataZone Domain.
+---
+
+# Resource: aws_datazone_domain
+
+Terraform resource for managing an AWS DataZone Domain.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_iam_role" "domain_execution_role" {
+  name = "my_domain_execution_role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = ["sts:AssumeRole", "sts:TagSession"]
+        Effect = "Allow"
+        Principal = {
+          Service = "datazone.amazonaws.com"
+        }
+      },
+      {
+        Action = ["sts:AssumeRole", "sts:TagSession"]
+        Effect = "Allow"
+        Principal = {
+          Service = "cloudformation.amazonaws.com"
+        }
+      },
+    ]
+  })
+
+  inline_policy {
+    name = "domain_execution_policy"
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          # Consider scoping down
+          Action = [
+            "datazone:*",
+            "ram:*",
+            "sso:*",
+            "kms:*",
+          ]
+          Effect   = "Allow"
+          Resource = "*"
+        },
+      ]
+    })
+  }
+}
+
+resource "aws_datazone_domain" "example" {
+  name                  = "example"
+  domain_execution_role = aws_iam_role.domain_execution_role.arn
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `name` - (Required) Name of the Domain.
+* `domain_execution_role` - (Required) ARN of the role used by DataZone to configure the Domain.
+
+The following arguments are optional:
+
+* `description` - (Optional) Description of the Domain.
+* `kms_key_identifier` - (Optional) ARN of the KMS key used to encrypt the Amazon DataZone domain, metadata and reporting data.
+* `single_sign_on` - (Optional) Single sign on options, used to [enable AWS IAM Identity Center](https://docs.aws.amazon.com/datazone/latest/userguide/enable-IAM-identity-center-for-datazone.html) for DataZone.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `arn` - ARN of the Domain.
+* `id` - ID of the Domain.
+* `portal_url` - URL of the data portal for the Domain.
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
+
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+* `create` - (Default `10m`)
+* `delete` - (Default `10m`)
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import DataZone Domain using the `domain_id`. For example:
+
+```terraform
+import {
+  to = aws_datazone_domain.example
+  id = "domain-id-12345678"
+}
+```
+
+Using `terraform import`, import DataZone Domain using the `domain_id`. For example:
+
+```console
+% terraform import aws_datazone_domain.example domain-id-12345678
+```


### PR DESCRIPTION
### Description

Add a resource for managing DataZone Domains.

### Relations

Relates #33792

### References
https://docs.aws.amazon.com/datazone/latest/userguide/datazone-concepts.html#what-are-domains

### Output from Acceptance Testing

```console
$ AWS_PROFILE=default make testacc TESTS=TestAccDataZoneDomain PKG=datazone
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/datazone/... -v -count 1 -parallel 20 -run='TestAccDataZoneDomain'  -timeout 360m
=== RUN   TestAccDataZoneDomain_basic
=== PAUSE TestAccDataZoneDomain_basic
=== RUN   TestAccDataZoneDomain_disappears
=== PAUSE TestAccDataZoneDomain_disappears
=== RUN   TestAccDataZoneDomain_kms_key_identifier
=== PAUSE TestAccDataZoneDomain_kms_key_identifier
=== RUN   TestAccDataZoneDomain_description
=== PAUSE TestAccDataZoneDomain_description
=== RUN   TestAccDataZoneDomain_single_sign_on
=== PAUSE TestAccDataZoneDomain_single_sign_on
=== RUN   TestAccDataZoneDomain_tags
=== PAUSE TestAccDataZoneDomain_tags
=== CONT  TestAccDataZoneDomain_basic
=== CONT  TestAccDataZoneDomain_description
=== CONT  TestAccDataZoneDomain_tags
=== CONT  TestAccDataZoneDomain_kms_key_identifier
=== CONT  TestAccDataZoneDomain_disappears
=== CONT  TestAccDataZoneDomain_single_sign_on
--- PASS: TestAccDataZoneDomain_disappears (74.08s)
--- PASS: TestAccDataZoneDomain_basic (74.46s)
--- PASS: TestAccDataZoneDomain_description (77.21s)
--- PASS: TestAccDataZoneDomain_single_sign_on (77.74s)
--- PASS: TestAccDataZoneDomain_kms_key_identifier (88.08s)
--- PASS: TestAccDataZoneDomain_tags (138.71s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/datazone   144.433s
```
