### PR TITLE
Fix doc on setting up multiple alb targets

### DIFF
--- a/website/docs/r/lb_target_group_attachment.html.markdown
+++ b/website/docs/r/lb_target_group_attachment.html.markdown
@@ -77,7 +77,7 @@ resource "aws_lb_target_group_attachment" "example" {
   # object as the value.
   for_each = {
     for k, v in aws_instance.example :
-    v.id => v
+    k => v
   }
 
   target_group_arn = aws_lb_target_group.example.arn


### PR DESCRIPTION
### Description

Cannot use dynamic values as map keys, change to static keys to cater for the error thrown.

### Relations

Closes #36541

### References


### Output from Acceptance Testing

Successfully run `terraform apply` with the following:

```hcl
resource "aws_vpc" "example" {
  cidr_block = "172.16.0.0/16"

  tags = {
    Name = "tf-example"
  }
}

resource "aws_subnet" "example" {
  vpc_id            = aws_vpc.example.id
  cidr_block        = "172.16.10.0/24"
  availability_zone = "ap-southeast-1a"

  tags = {
    Name = "tf-example"
  }
}

data "aws_ami" "amzn-linux-2023-ami" {
  most_recent = true
  owners      = ["amazon"]

  filter {
    name   = "name"
    values = ["al2023-ami-2023.*-x86_64"]
  }
}

resource "aws_instance" "example" {
  count         = 3
  ami           = data.aws_ami.amzn-linux-2023-ami.id
  instance_type = "t2.micro"
  subnet_id     = aws_subnet.example.id

  tags = {
    Name = "tf-example"
  }
}

resource "aws_lb_target_group" "example" {
  name     = "tf-example-lb-tg"
  port     = 80
  protocol = "HTTP"
  vpc_id   = aws_vpc.example.id
}

resource "aws_lb_target_group_attachment" "example" {
  # covert a list of instance objects to a map with instance ID as the key, and an instance
  # object as the value.
  for_each = {
    for k, v in aws_instance.example : k => v
  }
  target_group_arn = aws_lb_target_group.example.arn
  target_id        = each.value.id
  port             = 80
}
```
