### PR TITLE
Add `key_value_store_associations` to `aws_cloudfront_function`

### DIFF
--- a/.changelog/36228.txt
+++ b/.changelog/36228.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cloudfront_function: Add `key_value_store_associations` argument
+```

--- a/internal/service/cloudfront/function_data_source.go
+++ b/internal/service/cloudfront/function_data_source.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 // @SDKDataSource("aws_cloudfront_function")
@@ -67,6 +68,15 @@ func DataSourceFunction() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"key_value_store_associations": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					// Required:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+			},
 		},
 	}
 }
@@ -96,6 +106,8 @@ func dataSourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta in
 		Name:  aws.String(name),
 		Stage: aws.String(stage),
 	})
+
+	d.Set("key_value_store_associations", flattenKeyValueStoreAssociations(describeFunctionOutput.FunctionSummary.FunctionConfig.KeyValueStoreAssociations))
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "getting CloudFront Function (%s): %s", d.Id(), err)

--- a/internal/service/cloudfront/function_data_source_test.go
+++ b/internal/service/cloudfront/function_data_source_test.go
@@ -19,6 +19,7 @@ func TestAccCloudFrontFunctionDataSource_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_cloudfront_function.test"
 	resourceName := "aws_cloudfront_function.test"
+	keyValueStorerName := "aws_cloudfront_key_value_store.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, cloudfront.EndpointsID) },
@@ -36,6 +37,7 @@ func TestAccCloudFrontFunctionDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "runtime", resourceName, "runtime"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "status", resourceName, "status"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "key_value_store_associations.0", keyValueStorerName, "arn"),
 				),
 			},
 		},
@@ -45,10 +47,11 @@ func TestAccCloudFrontFunctionDataSource_basic(t *testing.T) {
 func testAccFunctionDataSourceConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudfront_function" "test" {
-  name    = %[1]q
-  runtime = "cloudfront-js-1.0"
-  comment = "test"
-  code    = <<-EOT
+  name                         = %[1]q
+  runtime                      = "cloudfront-js-2.0"
+  comment                      = "test"
+  key_value_store_associations = [aws_cloudfront_key_value_store.test.arn]
+  code                         = <<-EOT
 function handler(event) {
 	var response = {
 		statusCode: 302,
@@ -61,6 +64,10 @@ function handler(event) {
 	return response;
 }
 EOT
+}
+
+resource "aws_cloudfront_key_value_store" "test" {
+  name = %[1]q
 }
 
 data "aws_cloudfront_function" "test" {

--- a/website/docs/d/cloudfront_function.html.markdown
+++ b/website/docs/d/cloudfront_function.html.markdown
@@ -37,6 +37,8 @@ This data source exports the following attributes in addition to the arguments a
 * `code` - Source code of the function
 * `comment` - Comment.
 * `etag` - ETag hash of the function
+* `key_value_store_associations` - List of `aws_cloudfront_key_value_store` ARNs associated to the function.
 * `last_modified_time` - When this resource was last modified.
 * `runtime` - Identifier of the function's runtime.
 * `status` - Status of the function. Can be `UNPUBLISHED`, `UNASSOCIATED` or `ASSOCIATED`.
+

--- a/website/docs/r/cloudfront_function.html.markdown
+++ b/website/docs/r/cloudfront_function.html.markdown
@@ -40,7 +40,7 @@ The following arguments are optional:
 
 * `comment` - (Optional) Comment.
 * `publish` - (Optional) Whether to publish creation/change as Live CloudFront Function Version. Defaults to `true`.
-* `key_value_store_associations` - (Optional) List of `aws_cloudfront_key_value_store` ARNs to be associated to the function.
+* `key_value_store_associations` - (Optional) List of `aws_cloudfront_key_value_store` ARNs to be associated to the function. AWS limits associations to on key value store per function.
 
 ## Attribute Reference
 

--- a/website/docs/r/cloudfront_function.html.markdown
+++ b/website/docs/r/cloudfront_function.html.markdown
@@ -40,6 +40,7 @@ The following arguments are optional:
 
 * `comment` - (Optional) Comment.
 * `publish` - (Optional) Whether to publish creation/change as Live CloudFront Function Version. Defaults to `true`.
+* `key_value_store_associations` - (Optional) List of `aws_cloudfront_key_value_store` ARNs to be associated to the function.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR builds on another PR #36228 to add the ability to associate `aws_cloudfront_key_value_store` to an `aws_cloudfront_function` 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #36048
Closes #35889
Closes #36228

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccCloudFrontFunction_' PKG=cloudfront 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudfront/... -v -count 1 -parallel 20  -run=TestAccCloudFrontFunction_ -timeout 360m
=== RUN   TestAccCloudFrontFunction_basic
=== PAUSE TestAccCloudFrontFunction_basic
=== RUN   TestAccCloudFrontFunction_disappears
=== PAUSE TestAccCloudFrontFunction_disappears
=== RUN   TestAccCloudFrontFunction_publish
=== PAUSE TestAccCloudFrontFunction_publish
=== RUN   TestAccCloudFrontFunction_associated
=== PAUSE TestAccCloudFrontFunction_associated
=== RUN   TestAccCloudFrontFunction_Update_code
=== PAUSE TestAccCloudFrontFunction_Update_code
=== RUN   TestAccCloudFrontFunction_UpdateCodeAndPublish
=== PAUSE TestAccCloudFrontFunction_UpdateCodeAndPublish
=== RUN   TestAccCloudFrontFunction_Update_comment
=== PAUSE TestAccCloudFrontFunction_Update_comment
=== RUN   TestAccCloudFrontFunction_KeyValueStoreAssociations
=== PAUSE TestAccCloudFrontFunction_KeyValueStoreAssociations
=== CONT  TestAccCloudFrontFunction_basic
=== CONT  TestAccCloudFrontFunction_Update_code
=== CONT  TestAccCloudFrontFunction_Update_comment
=== CONT  TestAccCloudFrontFunction_KeyValueStoreAssociations
=== CONT  TestAccCloudFrontFunction_associated
=== CONT  TestAccCloudFrontFunction_disappears
=== CONT  TestAccCloudFrontFunction_UpdateCodeAndPublish
=== CONT  TestAccCloudFrontFunction_publish
--- PASS: TestAccCloudFrontFunction_disappears (19.63s)
--- PASS: TestAccCloudFrontFunction_basic (21.87s)
--- PASS: TestAccCloudFrontFunction_UpdateCodeAndPublish (33.33s)
--- PASS: TestAccCloudFrontFunction_publish (33.46s)
--- PASS: TestAccCloudFrontFunction_Update_code (37.44s)
--- PASS: TestAccCloudFrontFunction_Update_comment (47.80s)
--- PASS: TestAccCloudFrontFunction_KeyValueStoreAssociations (88.13s)
--- PASS: TestAccCloudFrontFunction_associated (505.51s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront 510.568s

...
```
