### PR TITLE
ASG check instance protection

### DIFF
--- a/.changelog/36586.txt
+++ b/.changelog/36586.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_autoscaling_group: Don't attempt to remove scale-in protection from instances that don't have the feature enabled
+```


### PR DESCRIPTION
See #36584

Fix regression on ASG destruction. Only call SetInstanceProtection on instances that are protected.

### Description

Re-incorporate logic from #23187


### Relations

Closes #36584

### References

#23187

