### PR TITLE
Add missing description for dhcp_options_id

### DIFF
--- a/website/docs/r/vpc.html.markdown
+++ b/website/docs/r/vpc.html.markdown
@@ -89,6 +89,7 @@ This resource exports the following attributes in addition to the arguments abov
 * `arn` - Amazon Resource Name (ARN) of VPC
 * `id` - The ID of the VPC
 * `instance_tenancy` - Tenancy of instances spin up within VPC
+* `dhcp_options_id` - DHCP options id of the desired VPC.
 * `enable_dns_support` - Whether or not the VPC has DNS support
 * `enable_network_address_usage_metrics` - Whether Network Address Usage metrics are enabled for the VPC
 * `enable_dns_hostnames` - Whether or not the VPC has DNS hostname support


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

This pull request adds the missing description for `dhcp_options_id`, which [is a Computed field](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/ec2/vpc_.go#L94) on `aws_vpc`.


### Output from Acceptance Testing

I'm not sure this change needs an acceptance test but I may be unaware of automation surrounding the any documentation updates.
