### PR TITLE
New resource: aws_ec2_instance_metadata_defaults

### DIFF
--- a/.changelog/36589.txt
+++ b/.changelog/36589.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_ec2_instance_metadata_defaults
+```

--- a/internal/service/ec2/ec2_instance_metadata_defaults.go
+++ b/internal/service/ec2/ec2_instance_metadata_defaults.go
@@ -122,7 +122,7 @@ func (r *resourceEC2InstanceMetadataDefaults) Create(ctx context.Context, req re
 		)
 		return
 	}
-	if out == nil || out.Return == nil || *out.Return == false {
+	if out == nil || aws.ToBool(out.Return) == false {
 		resp.Diagnostics.AddError(
 			create.ProblemStandardMessage(names.EC2, create.ErrActionCreating, ResNameInstanceMetadataDefaults, meta.Region, nil),
 			errors.New("empty output").Error(),
@@ -244,7 +244,7 @@ func (r *resourceEC2InstanceMetadataDefaults) Delete(ctx context.Context, req re
 		)
 		return
 	}
-	if out == nil || out.Return == nil || *out.Return == false {
+	if out == nil || aws.ToBool(out.Return) == false {
 		resp.Diagnostics.AddError(
 			create.ProblemStandardMessage(names.EC2, create.ErrActionCreating, ResNameInstanceMetadataDefaults, meta.Region, nil),
 			errors.New("empty output").Error(),

--- a/internal/service/ec2/ec2_instance_metadata_defaults.go
+++ b/internal/service/ec2/ec2_instance_metadata_defaults.go
@@ -153,7 +153,6 @@ func (r *resourceEC2InstanceMetadataDefaults) Delete(ctx context.Context, req re
 	if err := r.updateDefaultInstanceMetadataDefaults(ctx, in, create.ErrActionDeleting); err != nil {
 		resp.Diagnostics.AddError(err.Error(), "")
 	}
-
 }
 
 // utility function to avoid duplicating code, since Create, Update and Delete all use the same AWS API call ModifyInstanceMetadataDefaults
@@ -166,7 +165,7 @@ func (r *resourceEC2InstanceMetadataDefaults) updateDefaultInstanceMetadataDefau
 	if err != nil {
 		return errors.New(create.ProblemStandardMessage(names.EC2, action, ResNameInstanceMetadataDefaults, region, err))
 	}
-	if out == nil || aws.ToBool(out.Return) == false {
+	if out == nil || !aws.ToBool(out.Return) {
 		return errors.New(create.ProblemStandardMessage(names.EC2, action, ResNameInstanceMetadataDefaults, region, errors.New("empty output")))
 	}
 	return nil

--- a/internal/service/ec2/ec2_instance_metadata_defaults.go
+++ b/internal/service/ec2/ec2_instance_metadata_defaults.go
@@ -1,0 +1,266 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ec2
+
+import (
+	// TIP: ==== IMPORTS ====
+	// This is a common set of imports but not customized to your code since
+	// your code hasn't been written yet. Make sure you, your IDE, or
+	// goimports -w <file> fixes these imports.
+	//
+	// The provider linter wants your imports to be in two groups: first,
+	// standard library (i.e., "fmt" or "strings"), second, everything else.
+	//
+	// Also, AWS Go SDK v2 may handle nested structures differently than v1,
+	// using the services/ec2/types package. If so, you'll
+	// need to import types and reference the nested types, e.g., as
+	// awstypes.<Type Name>.
+	"context"
+	"errors"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource(name="Instance Metadata Defaults")
+func newResourceEC2InstanceMetadataDefaults(_ context.Context) (resource.ResourceWithConfigure, error) {
+	r := &resourceEC2InstanceMetadataDefaults{}
+
+	r.SetDefaultCreateTimeout(10 * time.Minute)
+	r.SetDefaultUpdateTimeout(10 * time.Minute)
+	r.SetDefaultDeleteTimeout(10 * time.Minute)
+
+	return r, nil
+}
+
+const (
+	ResNameEC2InstanceMetadataDefaults = "EC2 Instance Metadata Defaults"
+)
+
+type resourceEC2InstanceMetadataDefaults struct {
+	framework.ResourceWithConfigure
+	framework.WithTimeouts
+}
+
+type resourceEC2InstanceMetadataDefaultsData struct {
+	HttpEndpoint            types.String `tfsdk:"http_endpoint"`
+	HttpPutResponseHopLimit types.Int64  `tfsdk:"http_put_response_hop_limit"`
+	HttpTokens              types.String `tfsdk:"http_tokens"`
+	InstanceMetadataTags    types.String `tfsdk:"instance_metadata_tags"`
+}
+
+func (r *resourceEC2InstanceMetadataDefaults) Metadata(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "aws_ec2_instance_metadata_defaults"
+}
+
+func (r *resourceEC2InstanceMetadataDefaults) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"http_endpoint": schema.StringAttribute{
+				Optional: true,
+				Validators: []validator.String{
+					enum.FrameworkValidate[awstypes.DefaultInstanceMetadataEndpointState](),
+				},
+			},
+			"http_put_response_hop_limit": schema.Int64Attribute{
+				Optional: true,
+				Validators: []validator.Int64{
+					int64validator.Between(-1, 64),
+				},
+			},
+			"http_tokens": schema.StringAttribute{
+				Optional: true,
+				Validators: []validator.String{
+					enum.FrameworkValidate[awstypes.MetadataDefaultHttpTokensState](),
+				},
+			},
+			"instance_metadata_tags": schema.StringAttribute{
+				Optional: true,
+				Validators: []validator.String{
+					enum.FrameworkValidate[awstypes.DefaultInstanceMetadataTagsState](),
+				},
+			},
+		},
+		Blocks: map[string]schema.Block{},
+	}
+}
+
+func (r *resourceEC2InstanceMetadataDefaults) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	meta := r.Meta()
+	conn := meta.EC2Client(ctx)
+
+	var plan resourceEC2InstanceMetadataDefaultsData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := &ec2.ModifyInstanceMetadataDefaultsInput{}
+
+	if !plan.HttpEndpoint.IsNull() {
+		in.HttpEndpoint = awstypes.DefaultInstanceMetadataEndpointState(plan.HttpEndpoint.ValueString())
+	}
+	if !plan.HttpPutResponseHopLimit.IsNull() {
+		// When the value is -1, it means "no preference"
+		// In which case we don't set the argument and leave it to null
+		if httpPutResponseHopLimit := int32(plan.HttpPutResponseHopLimit.ValueInt64()); httpPutResponseHopLimit != -1 {
+			in.HttpPutResponseHopLimit = aws.Int32(httpPutResponseHopLimit)
+		}
+	}
+	if !plan.HttpTokens.IsNull() {
+		in.HttpTokens = awstypes.MetadataDefaultHttpTokensState(plan.HttpTokens.ValueString())
+	}
+	if !plan.InstanceMetadataTags.IsNull() {
+		in.InstanceMetadataTags = awstypes.DefaultInstanceMetadataTagsState(plan.InstanceMetadataTags.ValueString())
+	}
+
+	out, err := conn.ModifyInstanceMetadataDefaults(ctx, in)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.EC2, create.ErrActionCreating, ResNameEC2InstanceMetadataDefaults, meta.Region, err),
+			err.Error(),
+		)
+		return
+	}
+	if out == nil || out.Return == nil || *out.Return == false {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.EC2, create.ErrActionCreating, ResNameEC2InstanceMetadataDefaults, meta.Region, nil),
+			errors.New("empty output").Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *resourceEC2InstanceMetadataDefaults) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	meta := r.Meta()
+	conn := meta.EC2Client(ctx)
+
+	var state resourceEC2InstanceMetadataDefaultsData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := conn.GetInstanceMetadataDefaults(ctx, &ec2.GetInstanceMetadataDefaultsInput{})
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.EC2, create.ErrActionSetting, ResNameEC2InstanceMetadataDefaults, meta.Region, err),
+			err.Error(),
+		)
+		return
+	}
+
+	if out.AccountLevel.HttpEndpoint != "" {
+		state.HttpEndpoint = types.StringValue(string(out.AccountLevel.HttpEndpoint))
+	}
+
+	if out.AccountLevel.HttpPutResponseHopLimit == nil {
+		state.HttpPutResponseHopLimit = types.Int64Value(-1)
+	} else {
+		state.HttpPutResponseHopLimit = types.Int64Value(int64(*out.AccountLevel.HttpPutResponseHopLimit))
+	}
+
+	if out.AccountLevel.HttpTokens != "" {
+		state.HttpTokens = types.StringValue(string(out.AccountLevel.HttpTokens))
+	}
+
+	if out.AccountLevel.InstanceMetadataTags != "" {
+		state.InstanceMetadataTags = types.StringValue(string(out.AccountLevel.InstanceMetadataTags))
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *resourceEC2InstanceMetadataDefaults) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan, state resourceEC2InstanceMetadataDefaultsData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+
+	// TODO: deduplicate
+	meta := r.Meta()
+	conn := meta.EC2Client(ctx)
+
+	in := &ec2.ModifyInstanceMetadataDefaultsInput{}
+
+	if !plan.HttpEndpoint.IsNull() {
+		in.HttpEndpoint = awstypes.DefaultInstanceMetadataEndpointState(plan.HttpEndpoint.ValueString())
+	}
+
+	if plan.HttpPutResponseHopLimit.IsNull() {
+		in.HttpPutResponseHopLimit = aws.Int32(-1)
+	} else {
+		in.HttpPutResponseHopLimit = aws.Int32(int32(plan.HttpPutResponseHopLimit.ValueInt64()))
+	}
+
+	if !plan.HttpTokens.IsNull() {
+		in.HttpTokens = awstypes.MetadataDefaultHttpTokensState(plan.HttpTokens.ValueString())
+	}
+
+	if !plan.InstanceMetadataTags.IsNull() {
+		in.InstanceMetadataTags = awstypes.DefaultInstanceMetadataTagsState(plan.InstanceMetadataTags.ValueString())
+	}
+
+	out, err := conn.ModifyInstanceMetadataDefaults(ctx, in)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.EC2, create.ErrActionCreating, ResNameEC2InstanceMetadataDefaults, meta.Region, err),
+			err.Error(),
+		)
+		return
+	}
+	if out == nil || out.Return == nil || *out.Return == false {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.EC2, create.ErrActionCreating, ResNameEC2InstanceMetadataDefaults, meta.Region, nil),
+			errors.New("empty output").Error(),
+		)
+		return
+	}
+
+	// END todo
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *resourceEC2InstanceMetadataDefaults) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	meta := r.Meta()
+	conn := meta.EC2Client(ctx)
+
+	var state resourceEC2InstanceMetadataDefaultsData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+
+	out, err := conn.ModifyInstanceMetadataDefaults(context.Background(), &ec2.ModifyInstanceMetadataDefaultsInput{
+		HttpEndpoint:            awstypes.DefaultInstanceMetadataEndpointStateNoPreference,
+		HttpPutResponseHopLimit: aws.Int32(-1), // -1 means "no preference"
+		HttpTokens:              awstypes.MetadataDefaultHttpTokensStateNoPreference,
+		InstanceMetadataTags:    awstypes.DefaultInstanceMetadataTagsStateNoPreference,
+	})
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.EC2, create.ErrActionDeleting, ResNameEC2InstanceMetadataDefaults, meta.Region, err),
+			err.Error(),
+		)
+		return
+	}
+	if out == nil || out.Return == nil || *out.Return == false {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.EC2, create.ErrActionCreating, ResNameEC2InstanceMetadataDefaults, meta.Region, nil),
+			errors.New("empty output").Error(),
+		)
+		return
+	}
+}

--- a/internal/service/ec2/ec2_instance_metadata_defaults.go
+++ b/internal/service/ec2/ec2_instance_metadata_defaults.go
@@ -4,32 +4,20 @@
 package ec2
 
 import (
-	// TIP: ==== IMPORTS ====
-	// This is a common set of imports but not customized to your code since
-	// your code hasn't been written yet. Make sure you, your IDE, or
-	// goimports -w <file> fixes these imports.
-	//
-	// The provider linter wants your imports to be in two groups: first,
-	// standard library (i.e., "fmt" or "strings"), second, everything else.
-	//
-	// Also, AWS Go SDK v2 may handle nested structures differently than v1,
-	// using the services/ec2/types package. If so, you'll
-	// need to import types and reference the nested types, e.g., as
-	// awstypes.<Type Name>.
 	"context"
 	"errors"
-	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
-	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -223,7 +211,7 @@ func (r *resourceEC2InstanceMetadataDefaults) Update(ctx context.Context, req re
 		)
 		return
 	}
-	if out == nil || out.Return == nil || *out.Return == false {
+	if out == nil || aws.ToBool(out.Return) == false {
 		resp.Diagnostics.AddError(
 			create.ProblemStandardMessage(names.EC2, create.ErrActionCreating, ResNameEC2InstanceMetadataDefaults, meta.Region, nil),
 			errors.New("empty output").Error(),
@@ -242,7 +230,7 @@ func (r *resourceEC2InstanceMetadataDefaults) Delete(ctx context.Context, req re
 	var state resourceEC2InstanceMetadataDefaultsData
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 
-	out, err := conn.ModifyInstanceMetadataDefaults(context.Background(), &ec2.ModifyInstanceMetadataDefaultsInput{
+	out, err := conn.ModifyInstanceMetadataDefaults(ctx, &ec2.ModifyInstanceMetadataDefaultsInput{
 		HttpEndpoint:            awstypes.DefaultInstanceMetadataEndpointStateNoPreference,
 		HttpPutResponseHopLimit: aws.Int32(-1), // -1 means "no preference"
 		HttpTokens:              awstypes.MetadataDefaultHttpTokensStateNoPreference,
@@ -256,7 +244,7 @@ func (r *resourceEC2InstanceMetadataDefaults) Delete(ctx context.Context, req re
 		)
 		return
 	}
-	if out == nil || out.Return == nil || *out.Return == false {
+	if out == nil || aws.ToBool(out.Return) == false {
 		resp.Diagnostics.AddError(
 			create.ProblemStandardMessage(names.EC2, create.ErrActionCreating, ResNameEC2InstanceMetadataDefaults, meta.Region, nil),
 			errors.New("empty output").Error(),

--- a/internal/service/ec2/ec2_instance_metadata_defaults.go
+++ b/internal/service/ec2/ec2_instance_metadata_defaults.go
@@ -23,7 +23,7 @@ import (
 )
 
 // @FrameworkResource(name="Instance Metadata Defaults")
-func newResourceEC2InstanceMetadataDefaults(_ context.Context) (resource.ResourceWithConfigure, error) {
+func newResourceInstanceMetadataDefaults(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &resourceEC2InstanceMetadataDefaults{}
 
 	r.SetDefaultCreateTimeout(10 * time.Minute)
@@ -34,7 +34,7 @@ func newResourceEC2InstanceMetadataDefaults(_ context.Context) (resource.Resourc
 }
 
 const (
-	ResNameEC2InstanceMetadataDefaults = "EC2 Instance Metadata Defaults"
+	ResNameInstanceMetadataDefaults = "EC2 Instance Metadata Defaults"
 )
 
 type resourceEC2InstanceMetadataDefaults struct {
@@ -117,14 +117,14 @@ func (r *resourceEC2InstanceMetadataDefaults) Create(ctx context.Context, req re
 	out, err := conn.ModifyInstanceMetadataDefaults(ctx, in)
 	if err != nil {
 		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.EC2, create.ErrActionCreating, ResNameEC2InstanceMetadataDefaults, meta.Region, err),
+			create.ProblemStandardMessage(names.EC2, create.ErrActionCreating, ResNameInstanceMetadataDefaults, meta.Region, err),
 			err.Error(),
 		)
 		return
 	}
 	if out == nil || out.Return == nil || *out.Return == false {
 		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.EC2, create.ErrActionCreating, ResNameEC2InstanceMetadataDefaults, meta.Region, nil),
+			create.ProblemStandardMessage(names.EC2, create.ErrActionCreating, ResNameInstanceMetadataDefaults, meta.Region, nil),
 			errors.New("empty output").Error(),
 		)
 		return
@@ -147,7 +147,7 @@ func (r *resourceEC2InstanceMetadataDefaults) Read(ctx context.Context, req reso
 
 	if err != nil {
 		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.EC2, create.ErrActionSetting, ResNameEC2InstanceMetadataDefaults, meta.Region, err),
+			create.ProblemStandardMessage(names.EC2, create.ErrActionSetting, ResNameInstanceMetadataDefaults, meta.Region, err),
 			err.Error(),
 		)
 		return
@@ -206,14 +206,14 @@ func (r *resourceEC2InstanceMetadataDefaults) Update(ctx context.Context, req re
 	out, err := conn.ModifyInstanceMetadataDefaults(ctx, in)
 	if err != nil {
 		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.EC2, create.ErrActionCreating, ResNameEC2InstanceMetadataDefaults, meta.Region, err),
+			create.ProblemStandardMessage(names.EC2, create.ErrActionCreating, ResNameInstanceMetadataDefaults, meta.Region, err),
 			err.Error(),
 		)
 		return
 	}
 	if out == nil || aws.ToBool(out.Return) == false {
 		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.EC2, create.ErrActionCreating, ResNameEC2InstanceMetadataDefaults, meta.Region, nil),
+			create.ProblemStandardMessage(names.EC2, create.ErrActionCreating, ResNameInstanceMetadataDefaults, meta.Region, nil),
 			errors.New("empty output").Error(),
 		)
 		return
@@ -239,14 +239,14 @@ func (r *resourceEC2InstanceMetadataDefaults) Delete(ctx context.Context, req re
 
 	if err != nil {
 		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.EC2, create.ErrActionDeleting, ResNameEC2InstanceMetadataDefaults, meta.Region, err),
+			create.ProblemStandardMessage(names.EC2, create.ErrActionDeleting, ResNameInstanceMetadataDefaults, meta.Region, err),
 			err.Error(),
 		)
 		return
 	}
-	if out == nil || aws.ToBool(out.Return) == false {
+	if out == nil || out.Return == nil || *out.Return == false {
 		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.EC2, create.ErrActionCreating, ResNameEC2InstanceMetadataDefaults, meta.Region, nil),
+			create.ProblemStandardMessage(names.EC2, create.ErrActionCreating, ResNameInstanceMetadataDefaults, meta.Region, nil),
 			errors.New("empty output").Error(),
 		)
 		return

--- a/internal/service/ec2/ec2_instance_metadata_defaults_test.go
+++ b/internal/service/ec2/ec2_instance_metadata_defaults_test.go
@@ -4,46 +4,30 @@
 package ec2_test
 
 import (
-	// TIP: ==== IMPORTS ====
-	// This is a common set of imports but not customized to your code since
-	// your code hasn't been written yet. Make sure you, your IDE, or
-	// goimports -w <file> fixes these imports.
-	//
-	// The provider linter wants your imports to be in two groups: first,
-	// standard library (i.e., "fmt" or "strings"), second, everything else.
-	//
-	// Also, AWS Go SDK v2 may handle nested structures differently than v1,
-	// using the services/ec2/types package. If so, you'll
-	// need to import types and reference the nested types, e.g., as
-	// types.<Type Name>.
 	"context"
 	"errors"
 	"fmt"
-	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	"github.com/aws/aws-sdk-go/aws"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
-	"github.com/hashicorp/terraform-provider-aws/names"
-
-	// TIP: You will often need to import the package that this test file lives
-	// in. Since it is in the "test" context, it must import the package to use
-	// any normal context constants, variables, or functions.
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func testAccInstanceMetadataDefaultsConfig_basic() string {
 	return fmt.Sprintf(`
 resource "aws_ec2_instance_metadata_defaults" "test" {
-  http_tokens                   = "required" # non-default
-  instance_metadata_tags        = "disabled" 
-  http_endpoint                 = "enabled"
-  http_put_response_hop_limit   = 1
+  http_tokens                 = "required" # non-default
+  instance_metadata_tags      = "disabled"
+  http_endpoint               = "enabled"
+  http_put_response_hop_limit = 1
 }
 `)
 }
@@ -51,8 +35,8 @@ resource "aws_ec2_instance_metadata_defaults" "test" {
 func testAccInstanceMetadataDefaultsConfig_partial() string {
 	return fmt.Sprintf(`
 resource "aws_ec2_instance_metadata_defaults" "test-partial" {
-  http_tokens                   = "required" # non-default
-  http_put_response_hop_limit   = 2 # non-default
+  http_tokens                 = "required" # non-default
+  http_put_response_hop_limit = 2          # non-default
 }
 `)
 }
@@ -164,8 +148,8 @@ func testAccCheckInstanceMetadataDefaultsExists(ctx context.Context, name string
 		if resp.AccountLevel.HttpTokens != expectations.HttpTokens {
 			return fmt.Errorf("expected HttpTokens to be '%s', got '%s'", expectations.HttpTokens, resp.AccountLevel.HttpTokens)
 		}
-		if aws.Int32Value(resp.AccountLevel.HttpPutResponseHopLimit) != aws.Int32Value(expectations.HttpPutResponseHopLimit) {
-			return fmt.Errorf("expected HttpPutResponseHopLimit to be '%d', got '%d'", aws.Int32Value(expectations.HttpPutResponseHopLimit), aws.Int32Value(resp.AccountLevel.HttpPutResponseHopLimit))
+		if *resp.AccountLevel.HttpPutResponseHopLimit != *expectations.HttpPutResponseHopLimit {
+			return fmt.Errorf("expected HttpPutResponseHopLimit to be '%d', got '%d'", *expectations.HttpPutResponseHopLimit, *resp.AccountLevel.HttpPutResponseHopLimit)
 		}
 		if resp.AccountLevel.HttpEndpoint != expectations.HttpEndpoint {
 			return fmt.Errorf("expected HttpEndpoint to be '%s', got '%s'", expectations.HttpEndpoint, resp.AccountLevel.HttpEndpoint)

--- a/internal/service/ec2/ec2_instance_metadata_defaults_test.go
+++ b/internal/service/ec2/ec2_instance_metadata_defaults_test.go
@@ -41,6 +41,9 @@ resource "aws_ec2_instance_metadata_defaults" "test-partial" {
 `)
 }
 
+// Note: these acceptance tests cannot run in parallel using `resource.ParallelTest` because the
+// `aws_ec2_instance_metadata_defaults` resource is regional
+
 func TestAccEC2InstanceMetadataDefaults_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -49,7 +52,7 @@ func TestAccEC2InstanceMetadataDefaults_basic(t *testing.T) {
 
 	resourceName := "aws_ec2_instance_metadata_defaults.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, "ec2")
@@ -86,7 +89,7 @@ func TestAccEC2InstanceMetadataDefaults_partial(t *testing.T) {
 
 	resourceName := "aws_ec2_instance_metadata_defaults.test-partial"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, "ec2")

--- a/internal/service/ec2/ec2_instance_metadata_defaults_test.go
+++ b/internal/service/ec2/ec2_instance_metadata_defaults_test.go
@@ -130,18 +130,18 @@ func testAccCheckInstanceMetadataDefaultsExists(ctx context.Context, name string
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
-			return create.Error(names.EC2, create.ErrActionCheckingExistence, tfec2.ResNameEC2InstanceMetadataDefaults, name, errors.New("not found"))
+			return create.Error(names.EC2, create.ErrActionCheckingExistence, tfec2.ResNameInstanceMetadataDefaults, name, errors.New("not found"))
 		}
 
 		if rs.Primary.ID == "" {
-			return create.Error(names.EC2, create.ErrActionCheckingExistence, tfec2.ResNameEC2InstanceMetadataDefaults, name, errors.New("not set"))
+			return create.Error(names.EC2, create.ErrActionCheckingExistence, tfec2.ResNameInstanceMetadataDefaults, name, errors.New("not set"))
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Client(ctx)
 		resp, err := conn.GetInstanceMetadataDefaults(ctx, &ec2.GetInstanceMetadataDefaultsInput{})
 
 		if err != nil {
-			return create.Error(names.EC2, create.ErrActionCheckingExistence, tfec2.ResNameEC2InstanceMetadataDefaults, rs.Primary.ID, err)
+			return create.Error(names.EC2, create.ErrActionCheckingExistence, tfec2.ResNameInstanceMetadataDefaults, rs.Primary.ID, err)
 		}
 
 		// check assertions

--- a/internal/service/ec2/ec2_instance_metadata_defaults_test.go
+++ b/internal/service/ec2/ec2_instance_metadata_defaults_test.go
@@ -22,23 +22,23 @@ import (
 )
 
 func testAccInstanceMetadataDefaultsConfig_basic() string {
-	return fmt.Sprintf(`
+	return `
 resource "aws_ec2_instance_metadata_defaults" "test" {
   http_tokens                 = "required" # non-default
   instance_metadata_tags      = "disabled"
   http_endpoint               = "enabled"
   http_put_response_hop_limit = 1
 }
-`)
+`
 }
 
 func testAccInstanceMetadataDefaultsConfig_partial() string {
-	return fmt.Sprintf(`
+	return `
 resource "aws_ec2_instance_metadata_defaults" "test-partial" {
   http_tokens                 = "required" # non-default
   http_put_response_hop_limit = 2          # non-default
 }
-`)
+`
 }
 
 // Note: these acceptance tests cannot run in parallel using `resource.ParallelTest` because the

--- a/internal/service/ec2/ec2_instance_metadata_defaults_test.go
+++ b/internal/service/ec2/ec2_instance_metadata_defaults_test.go
@@ -1,0 +1,191 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ec2_test
+
+import (
+	// TIP: ==== IMPORTS ====
+	// This is a common set of imports but not customized to your code since
+	// your code hasn't been written yet. Make sure you, your IDE, or
+	// goimports -w <file> fixes these imports.
+	//
+	// The provider linter wants your imports to be in two groups: first,
+	// standard library (i.e., "fmt" or "strings"), second, everything else.
+	//
+	// Also, AWS Go SDK v2 may handle nested structures differently than v1,
+	// using the services/ec2/types package. If so, you'll
+	// need to import types and reference the nested types, e.g., as
+	// types.<Type Name>.
+	"context"
+	"errors"
+	"fmt"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go/aws"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/names"
+
+	// TIP: You will often need to import the package that this test file lives
+	// in. Since it is in the "test" context, it must import the package to use
+	// any normal context constants, variables, or functions.
+	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
+)
+
+func testAccInstanceMetadataDefaultsConfig_basic() string {
+	return fmt.Sprintf(`
+resource "aws_ec2_instance_metadata_defaults" "test" {
+  http_tokens                   = "required" # non-default
+  instance_metadata_tags        = "disabled" 
+  http_endpoint                 = "enabled"
+  http_put_response_hop_limit   = 1
+}
+`)
+}
+
+func testAccInstanceMetadataDefaultsConfig_partial() string {
+	return fmt.Sprintf(`
+resource "aws_ec2_instance_metadata_defaults" "test-partial" {
+  http_tokens                   = "required" # non-default
+  http_put_response_hop_limit   = 2 # non-default
+}
+`)
+}
+
+func TestAccEC2InstanceMetadataDefaults_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	resourceName := "aws_ec2_instance_metadata_defaults.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, "ec2")
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInstanceMetadataDefaultsDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceMetadataDefaultsConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceMetadataDefaultsExists(ctx, resourceName, &awstypes.InstanceMetadataDefaultsResponse{
+						HttpTokens:              awstypes.HttpTokensState(awstypes.MetadataDefaultHttpTokensStateRequired),
+						HttpPutResponseHopLimit: aws.Int32(1),
+						HttpEndpoint:            awstypes.InstanceMetadataEndpointStateEnabled,
+						InstanceMetadataTags:    awstypes.InstanceMetadataTagsStateDisabled,
+					}),
+					resource.TestCheckResourceAttr(resourceName, "http_tokens", "required"),
+					resource.TestCheckResourceAttr(resourceName, "instance_metadata_tags", "disabled"),
+					resource.TestCheckResourceAttr(resourceName, "http_endpoint", "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "http_put_response_hop_limit", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEC2InstanceMetadataDefaults_partial(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	resourceName := "aws_ec2_instance_metadata_defaults.test-partial"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, "ec2")
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInstanceMetadataDefaultsDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceMetadataDefaultsConfig_partial(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceMetadataDefaultsExists(ctx, resourceName, &awstypes.InstanceMetadataDefaultsResponse{
+						HttpTokens:              awstypes.HttpTokensState(awstypes.MetadataDefaultHttpTokensStateRequired),
+						HttpPutResponseHopLimit: aws.Int32(2),
+						HttpEndpoint:            "",
+						InstanceMetadataTags:    "",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "http_tokens", "required"),
+					resource.TestCheckResourceAttr(resourceName, "http_put_response_hop_limit", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckInstanceMetadataDefaultsDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		result, err := acctest.Provider.Meta().(*conns.AWSClient).EC2Client(ctx).GetInstanceMetadataDefaults(ctx, &ec2.GetInstanceMetadataDefaultsInput{})
+		if err != nil {
+			return fmt.Errorf("unable to describe instance metadata defaults: %w", err)
+		}
+		if string(result.AccountLevel.HttpEndpoint) != "" || string(result.AccountLevel.HttpTokens) != "" || result.AccountLevel.HttpPutResponseHopLimit != nil || string(result.AccountLevel.InstanceMetadataTags) != "" {
+			return errors.New("expected instance metadata defaults to be reset")
+		}
+		return nil
+	}
+}
+
+func testAccCheckInstanceMetadataDefaultsExists(ctx context.Context, name string, expectations *awstypes.InstanceMetadataDefaultsResponse) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.EC2, create.ErrActionCheckingExistence, tfec2.ResNameEC2InstanceMetadataDefaults, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.EC2, create.ErrActionCheckingExistence, tfec2.ResNameEC2InstanceMetadataDefaults, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Client(ctx)
+		resp, err := conn.GetInstanceMetadataDefaults(ctx, &ec2.GetInstanceMetadataDefaultsInput{})
+
+		if err != nil {
+			return create.Error(names.EC2, create.ErrActionCheckingExistence, tfec2.ResNameEC2InstanceMetadataDefaults, rs.Primary.ID, err)
+		}
+
+		// check assertions
+		if resp.AccountLevel.HttpTokens != expectations.HttpTokens {
+			return fmt.Errorf("expected HttpTokens to be '%s', got '%s'", expectations.HttpTokens, resp.AccountLevel.HttpTokens)
+		}
+		if aws.Int32Value(resp.AccountLevel.HttpPutResponseHopLimit) != aws.Int32Value(expectations.HttpPutResponseHopLimit) {
+			return fmt.Errorf("expected HttpPutResponseHopLimit to be '%d', got '%d'", aws.Int32Value(expectations.HttpPutResponseHopLimit), aws.Int32Value(resp.AccountLevel.HttpPutResponseHopLimit))
+		}
+		if resp.AccountLevel.HttpEndpoint != expectations.HttpEndpoint {
+			return fmt.Errorf("expected HttpEndpoint to be '%s', got '%s'", expectations.HttpEndpoint, resp.AccountLevel.HttpEndpoint)
+		}
+		if resp.AccountLevel.InstanceMetadataTags != expectations.InstanceMetadataTags {
+			return fmt.Errorf("expected InstanceMetadataTags to be '%s', got '%s'", expectations.InstanceMetadataTags, resp.AccountLevel.InstanceMetadataTags)
+		}
+
+		return nil
+	}
+}
+func testAccPreCheck(ctx context.Context, t *testing.T) {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Client(ctx)
+
+	_, err := conn.GetInstanceMetadataDefaults(ctx, &ec2.GetInstanceMetadataDefaultsInput{})
+
+	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}

--- a/internal/service/ec2/exports_test.go
+++ b/internal/service/ec2/exports_test.go
@@ -10,6 +10,7 @@ var (
 	ResourceDefaultRouteTable               = resourceDefaultRouteTable
 	ResourceEBSFastSnapshotRestore          = newResourceEBSFastSnapshotRestore
 	ResourceInstanceConnectEndpoint         = newResourceInstanceConnectEndpoint
+	ResourceInstanceMetadataDefaults        = newInstanceMetadataDefaultsResource
 	ResourceNetworkACL                      = resourceNetworkACL
 	ResourceNetworkACLRule                  = resourceNetworkACLRule
 	ResourceRoute                           = resourceRoute
@@ -26,6 +27,7 @@ var (
 
 	CustomFiltersSchema            = customFiltersSchema
 	FindEBSFastSnapshotRestoreByID = findEBSFastSnapshotRestoreByID
+	FindInstanceMetadataDefaults   = findInstanceMetadataDefaults
 	FindNetworkACLByIDV2           = findNetworkACLByIDV2
 	NewAttributeFilterList         = newAttributeFilterList
 	NewCustomFilterList            = newCustomFilterList

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -35,7 +35,7 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 			Name:    "EBS Fast Snapshot Restore",
 		},
 		{
-			Factory: newResourceEC2InstanceMetadataDefaults,
+			Factory: newResourceInstanceMetadataDefaults,
 			Name:    "Instance Metadata Defaults",
 		},
 		{

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -31,6 +31,10 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.Serv
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.ServicePackageFrameworkResource {
 	return []*types.ServicePackageFrameworkResource{
 		{
+			Factory: newInstanceMetadataDefaultsResource,
+			Name:    "Instance Metadata Defaults",
+		},
+		{
 			Factory: newResourceEBSFastSnapshotRestore,
 			Name:    "EBS Fast Snapshot Restore",
 		},
@@ -40,10 +44,6 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 			Tags: &types.ServicePackageResourceTags{
 				IdentifierAttribute: "id",
 			},
-		},
-		{
-			Factory: newResourceInstanceMetadataDefaults,
-			Name:    "Instance Metadata Defaults",
 		},
 		{
 			Factory: newResourceSecurityGroupEgressRule,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -35,6 +35,10 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 			Name:    "EBS Fast Snapshot Restore",
 		},
 		{
+			Factory: newResourceEC2InstanceMetadataDefaults,
+			Name:    "Instance Metadata Defaults",
+		},
+		{
 			Factory: newResourceInstanceConnectEndpoint,
 			Name:    "Instance Connect Endpoint",
 			Tags: &types.ServicePackageResourceTags{

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -35,15 +35,15 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 			Name:    "EBS Fast Snapshot Restore",
 		},
 		{
-			Factory: newResourceInstanceMetadataDefaults,
-			Name:    "Instance Metadata Defaults",
-		},
-		{
 			Factory: newResourceInstanceConnectEndpoint,
 			Name:    "Instance Connect Endpoint",
 			Tags: &types.ServicePackageResourceTags{
 				IdentifierAttribute: "id",
 			},
+		},
+		{
+			Factory: newResourceInstanceMetadataDefaults,
+			Name:    "Instance Metadata Defaults",
 		},
 		{
 			Factory: newResourceSecurityGroupEgressRule,

--- a/website/docs/r/ec2_instance_metadata_defaults.html.markdown
+++ b/website/docs/r/ec2_instance_metadata_defaults.html.markdown
@@ -24,10 +24,10 @@ resource "aws_ec2_instance_metadata_defaults" "enforce-imdsv2" {
 
 This resource supports the following arguments.
 
-* `http_endpoint` - (Optional) Whether the metadata service is available. Can be `"enabled"` or `"disabled"`.
-* `http_tokens` - (Optional) Whether the metadata service requires session tokens, also referred to as _Instance Metadata Service Version 2 (IMDSv2)_. Can be `"optional"` or `"required"`.
-* `http_put_response_hop_limit` - (Optional) The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. Can be an integer from `1` to `64`.
-* `instance_metadata_tags` - (Optional) Enables or disables access to instance tags from the instance metadata service. Can be `"enabled"` or `"disabled"`.
+* `http_endpoint` - (Optional) Whether the metadata service is available. Can be `"enabled"`, `"disabled"`, or `"no-preference"`. Default: `"no-preference"`.
+* `http_tokens` - (Optional) Whether the metadata service requires session tokens, also referred to as _Instance Metadata Service Version 2 (IMDSv2)_. Can be `"optional"`, `"required"`, or `"no-preference"`. Default: `"no-preference"`.
+* `http_put_response_hop_limit` - (Optional) The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. Can be an integer from `1` to `64`, or `-1` to indicate no preference. Default: `-1`.
+* `instance_metadata_tags` - (Optional) Enables or disables access to instance tags from the instance metadata service. Can be `"enabled"`, `"disabled"`, or `"no-preference"`. Default: `"no-preference"`.
 
 ## Attribute Reference
 

--- a/website/docs/r/ec2_instance_metadata_defaults.html.markdown
+++ b/website/docs/r/ec2_instance_metadata_defaults.html.markdown
@@ -1,0 +1,38 @@
+---
+subcategory: "EC2 (Elastic Compute Cloud)"
+layout: "aws"
+page_title: "AWS: aws_ec2_instance_metadata_defaults"
+description: |-
+  Manages regional EC2 instance metadata default settings.
+---
+
+# Resource: aws_ec2_instance_metadata_defaults
+
+Manages regional EC2 instance metadata default settings.
+More information can be found in the [Configure instance metadata options for new instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-IMDS-new-instances.html) user guide.
+
+## Example Usage
+
+```terraform
+resource "aws_ec2_instance_metadata_defaults" "enforce-imdsv2" {
+  http_tokens                 = "required"
+  http_put_response_hop_limit = 1
+}
+```
+
+## Argument Reference
+
+This resource supports the following arguments.
+
+* `http_endpoint` - (Optional) Whether the metadata service is available. Can be `"enabled"` or `"disabled"`.
+* `http_tokens` - (Optional) Whether the metadata service requires session tokens, also referred to as _Instance Metadata Service Version 2 (IMDSv2)_. Can be `"optional"` or `"required"`.
+* `http_put_response_hop_limit` - (Optional) The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. Can be an integer from `1` to `64`.
+* `instance_metadata_tags` - (Optional) Enables or disables access to instance tags from the instance metadata service. Can be `"enabled"` or `"disabled"`.
+
+## Attribute Reference
+
+This data source exports no additional attributes.
+
+## Import
+
+You cannot import this resource.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

AWS recently released a new API to set the default IMDS behavior globally at the region level, instead of at the EC2 instance level as before. This is extremely useful for practitioners who wish to use "secure defaults" to ensure that instances launched in that region enforce IMDSv2, which is a strongly recommended security practice.

Sample usage:

```hcl
resource "aws_ec2_instance_metadata_defaults" "test" {
  http_tokens                 = "required" # non-default
  instance_metadata_tags      = "disabled"
  http_endpoint               = "enabled"
  http_put_response_hop_limit = 1
}
```

I had to bump the AWS SDK v2 version to get support for `GetInstanceMetadataDefaults` / `ModifyInstanceMetadataDefaults`. In addition to acceptance tests, I have also tested this implementation locally with a few scenarios and it worked as expected.

### Relations

Closes #36577 

### References

[User Guide](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-IMDS-new-instances.html#set-imdsv2-account-defaults)
[Announcement](https://aws.amazon.com/about-aws/whats-new/2024/03/set-imdsv2-default-new-instance-launches/)
https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifyInstanceMetadataDefaults.html
https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_GetInstanceMetadataDefaults.html

### Output from Acceptance Testing

```console
$ make testacc TESTS=TestAccEC2InstanceMetadataDefaults PKG=ec2
=== RUN   TestAccEC2InstanceMetadataDefaults_basic
--- PASS: TestAccEC2InstanceMetadataDefaults_basic (16.44s)
=== RUN   TestAccEC2InstanceMetadataDefaults_partial
--- PASS: TestAccEC2InstanceMetadataDefaults_partial (13.80s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	35.422s
...
```
