### PR TITLE
ec2/instance: Replace instance when architecture changes

### DIFF
--- a/.changelog/36590.txt
+++ b/.changelog/36590.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_instance: Replace an instance when an `instance_type` change also requires an architecture change, such as x86_64 to arm64
+```

--- a/internal/service/ec2/ec2_instance_test.go
+++ b/internal/service/ec2/ec2_instance_test.go
@@ -2259,7 +2259,7 @@ func TestAccEC2Instance_changeInstanceType(t *testing.T) {
 		CheckDestroy:             testAccCheckInstanceDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_smallType(rName),
+				Config: testAccInstanceConfig_type(rName, "t2.medium"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(ctx, resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "instance_type", "t2.medium"),
@@ -2272,11 +2272,43 @@ func TestAccEC2Instance_changeInstanceType(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"user_data_replace_on_change"},
 			},
 			{
-				Config: testAccInstanceConfig_updateType(rName),
+				Config: testAccInstanceConfig_type(rName, "t2.large"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(ctx, resourceName, &after),
 					testAccCheckInstanceNotRecreated(&before, &after),
 					resource.TestCheckResourceAttr(resourceName, "instance_type", "t2.large"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEC2Instance_changeInstanceTypeReplace(t *testing.T) {
+	ctx := acctest.Context(t)
+	var before ec2.Instance
+	var after ec2.Instance
+	resourceName := "aws_instance.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInstanceDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_typeReplace(rName, "m5.2xlarge"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(ctx, resourceName, &before),
+					resource.TestCheckResourceAttr(resourceName, "instance_type", "m5.2xlarge"),
+				),
+			},
+			{
+				Config: testAccInstanceConfig_typeReplace(rName, "m6g.2xlarge"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(ctx, resourceName, &after),
+					testAccCheckInstanceRecreated(&before, &after),
+					resource.TestCheckResourceAttr(resourceName, "instance_type", "m6g.2xlarge"),
 				),
 			},
 		},
@@ -6195,7 +6227,7 @@ resource "aws_instance" "test" {
 `, rName, filename))
 }
 
-func testAccInstanceConfig_smallType(rName string) string {
+func testAccInstanceConfig_type(rName, instanceType string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinux2HVMEBSX8664AMI(),
 		testAccInstanceVPCConfig(rName, false, 0),
@@ -6204,31 +6236,41 @@ resource "aws_instance" "test" {
   ami       = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.id
   subnet_id = aws_subnet.test.id
 
-  instance_type = "t2.medium"
+  instance_type = %[1]q
 
   tags = {
-    Name = %[1]q
+    Name = %[2]q
   }
 }
-`, rName))
+`, instanceType, rName))
 }
 
-func testAccInstanceConfig_updateType(rName string) string {
+func testAccInstanceConfig_typeReplace(rName, instanceType string) string {
+	arch := acctest.ConfigLatestAmazonLinux2HVMEBSX8664AMI()
+	archs := "x86_64"
+	if strings.HasPrefix(instanceType, "m6g.") {
+		arch = acctest.ConfigLatestAmazonLinux2HVMEBSARM64AMI()
+		archs = "arm64"
+	}
 	return acctest.ConfigCompose(
-		acctest.ConfigLatestAmazonLinux2HVMEBSX8664AMI(),
+		arch,
 		testAccInstanceVPCConfig(rName, false, 0),
 		fmt.Sprintf(`
 resource "aws_instance" "test" {
-  ami       = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.id
+  ami       = data.aws_ami.amzn2-ami-minimal-hvm-ebs-%[3]s.id
   subnet_id = aws_subnet.test.id
 
-  instance_type = "t2.large"
+  instance_type = %[1]q
 
   tags = {
-    Name = %[1]q
+    Name = %[2]q
+  }
+
+  lifecycle {
+    ignore_changes = [ami]
   }
 }
-`, rName))
+`, instanceType, rName, archs))
 }
 
 func testAccInstanceConfig_typeAndUserData(rName, instanceType, userData string) string {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #36376

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccEC2Instance_changeInstanceType K=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2Instance_changeInstanceType'  -timeout 360m
=== RUN   TestAccEC2Instance_changeInstanceType
=== PAUSE TestAccEC2Instance_changeInstanceType
=== RUN   TestAccEC2Instance_changeInstanceTypeReplace
=== PAUSE TestAccEC2Instance_changeInstanceTypeReplace
=== RUN   TestAccEC2Instance_changeInstanceTypeAndUserData
=== PAUSE TestAccEC2Instance_changeInstanceTypeAndUserData
=== RUN   TestAccEC2Instance_changeInstanceTypeAndUserDataBase64
=== PAUSE TestAccEC2Instance_changeInstanceTypeAndUserDataBase64
=== CONT  TestAccEC2Instance_changeInstanceType
=== CONT  TestAccEC2Instance_changeInstanceTypeAndUserData
=== CONT  TestAccEC2Instance_changeInstanceTypeReplace
=== CONT  TestAccEC2Instance_changeInstanceTypeAndUserDataBase64
--- PASS: TestAccEC2Instance_changeInstanceType (192.27s)
--- PASS: TestAccEC2Instance_changeInstanceTypeAndUserDataBase64 (335.55s)
--- PASS: TestAccEC2Instance_changeInstanceTypeAndUserData (345.81s)
--- PASS: TestAccEC2Instance_changeInstanceTypeReplace (646.57s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	649.046s
```
