### PR TITLE
r/aws_opensearch_domain_policy: handle domain update propagation delays

### DIFF
--- a/.changelog/36592.txt
+++ b/.changelog/36592.txt
@@ -1,0 +1,6 @@
+```release-note:bug
+resource/aws_elasticsearch_domain_policy: Handle delayed domain status propagation, preventing a `ValidationException`.
+```
+```release-note:bug
+resource/aws_opensearch_domain_policy: Handle delayed domain status propagation, preventing a `ValidationException`.
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This change adds logic to retry ValidationExceptions which indicate a domain change is in-progress. When a domain policy change immediately follows domain creation or modification, delays in propagation of the ACTIVE status can cause intermittent ValidationExceptions. These errors are now retried for a short interval (2 minutes), which should allow configurations pairing domain and domain policy resources to complete successfully on the first apply.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #35811

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=elasticsearch TESTS=TestAccElasticsearchDomainPolicy_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/elasticsearch/... -v -count 1 -parallel 20 -run='TestAccElasticsearchDomainPolicy_'  -timeout 360m

--- PASS: TestAccElasticsearchDomainPolicy_basic (1956.43s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticsearch      1962.012s
```

```console
% make testacc PKG=opensearch TESTS=TestAccOpenSearchDomainPolicy_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/opensearch/... -v -count 1 -parallel 20 -run='TestAccOpenSearchDomainPolicy_'  -timeout 360m

--- PASS: TestAccOpenSearchDomainPolicy_basic (2148.30s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/opensearch 2153.767
```
