### PR TITLE
iam/policy: Allow IAM policy leading whitespace

### DIFF
--- a/.changelog/36597.txt
+++ b/.changelog/36597.txt
@@ -1,0 +1,39 @@
+```release-note:enhancement
+resource/aws_glacier_vault_lock: Allow `policy` to have leading whitespace
+```
+
+```release-note:enhancement
+resource/aws_iam_group_policy: Allow `policy` to have leading whitespace
+```
+
+```release-note:enhancement
+resource/aws_iam_policy: Allow `policy` to have leading whitespace
+```
+
+```release-note:enhancement
+resource/aws_iam_role_policy: Allow `policy` to have leading whitespace
+```
+
+```release-note:enhancement
+resource/aws_iam_role: Allow `assume_role_policy` and `inline_policy.*.policy` to have leading whitespace
+```
+
+```release-note:enhancement
+resource/aws_iam_user_policy: Allow `policy` to have leading whitespace
+```
+
+```release-note:enhancement
+resource/aws_media_store_container_policy: Allow `policy` to have leading whitespace
+```
+
+```release-note:enhancement
+resource/aws_ssoadmin_permission_set_inline_policy: Allow `inline_policy` to have leading whitespace
+```
+
+```release-note:enhancement
+resource/aws_transfer_access: Allow `policy` to have leading whitespace
+```
+
+```release-note:enhancement
+resource/aws_transfer_user: Allow `policy` to have leading whitespace
+```

--- a/internal/service/iam/policy_test.go
+++ b/internal/service/iam/policy_test.go
@@ -83,6 +83,44 @@ func TestAccIAMPolicy_description(t *testing.T) {
 	})
 }
 
+func TestAccIAMPolicy_whitespace(t *testing.T) {
+	ctx := acctest.Context(t)
+	var out iam.Policy
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_iam_policy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPolicyDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPolicyConfig_whitespace(rName, "", "", ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPolicyExists(ctx, resourceName, &out),
+				),
+			},
+			{
+				Config:   testAccPolicyConfig_whitespace(rName, " ", "", ""),
+				PlanOnly: true,
+			},
+			{
+				Config:   testAccPolicyConfig_whitespace(rName, " ", "\n", ""),
+				PlanOnly: true,
+			},
+			{
+				Config:   testAccPolicyConfig_whitespace(rName, " ", "\n", " "),
+				PlanOnly: true,
+			},
+			{
+				Config:   testAccPolicyConfig_whitespace(rName, " \n", "\n", "\t "),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func TestAccIAMPolicy_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var out iam.Policy
@@ -406,6 +444,29 @@ resource "aws_iam_policy" "test" {
 EOF
 }
 `, rName)
+}
+
+func testAccPolicyConfig_whitespace(rName, ws1, ws2, ws3 string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_policy" "test" {
+  name = %[1]q
+
+  policy = <<EOF
+%[2]s{
+  "Version": "2012-10-17",%[3]s
+  "Statement": [
+    {
+      "Action": [
+        "ec2:Describe*"
+      ],
+      "Effect": %[3]s"Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+`, rName, ws1, ws2, ws3)
 }
 
 func testAccPolicyConfig_namePrefix(namePrefix string) string {

--- a/internal/verify/validate.go
+++ b/internal/verify/validate.go
@@ -168,7 +168,7 @@ func ValidIAMPolicyJSON(v interface{}, k string) (ws []string, errors []error) {
 	value = strings.TrimSpace(value)
 	if len(value) < 1 {
 		errors = append(errors, fmt.Errorf("%q is an empty string, which is not a valid JSON value", k))
-		return
+		return //nolint:nakedret // Naked return due to legacy, non-idiomatic Go function, error handling
 	}
 
 	if first := value[:1]; first != "{" {
@@ -197,7 +197,7 @@ func ValidIAMPolicyJSON(v interface{}, k string) (ws []string, errors []error) {
 			// Generic error for if we didn't find something more specific to say.
 			errors = append(errors, fmt.Errorf("%q contains an invalid JSON policy: not a JSON object", k))
 		}
-		return
+		return //nolint:nakedret // Naked return due to legacy, non-idiomatic Go function, error handling
 	}
 
 	if _, err := structure.NormalizeJsonString(v); err != nil {
@@ -206,12 +206,12 @@ func ValidIAMPolicyJSON(v interface{}, k string) (ws []string, errors []error) {
 			errStr = fmt.Sprintf("%s, at byte offset %d", errStr, err.Offset)
 		}
 		errors = append(errors, fmt.Errorf("%q contains an invalid JSON policy: %s", k, errStr))
-		return
+		return //nolint:nakedret // Naked return due to legacy, non-idiomatic Go function, error handling
 	}
 
 	if err := basevalidation.JSONNoDuplicateKeys(value); err != nil {
 		errors = append(errors, fmt.Errorf("%q contains duplicate JSON keys: %s", k, err))
-		return
+		return //nolint:nakedret // Naked return due to legacy, non-idiomatic Go function, error handling
 	}
 
 	return //nolint:nakedret // Just a long function.

--- a/internal/verify/validate.go
+++ b/internal/verify/validate.go
@@ -165,9 +165,13 @@ func ValidCIDRNetworkAddress(v interface{}, k string) (ws []string, errors []err
 func ValidIAMPolicyJSON(v interface{}, k string) (ws []string, errors []error) {
 	// IAM Policy documents need to be valid JSON, and pass legacy parsing
 	value := v.(string)
+	value = strings.TrimSpace(value)
 	if len(value) < 1 {
 		errors = append(errors, fmt.Errorf("%q is an empty string, which is not a valid JSON value", k))
-	} else if first := value[:1]; first != "{" {
+		return
+	}
+
+	if first := value[:1]; first != "{" {
 		switch value[:1] {
 		case " ", "\t", "\r", "\n":
 			errors = append(errors, fmt.Errorf("%q contains an invalid JSON policy: leading space characters are not allowed", k))
@@ -193,14 +197,21 @@ func ValidIAMPolicyJSON(v interface{}, k string) (ws []string, errors []error) {
 			// Generic error for if we didn't find something more specific to say.
 			errors = append(errors, fmt.Errorf("%q contains an invalid JSON policy: not a JSON object", k))
 		}
-	} else if _, err := structure.NormalizeJsonString(v); err != nil {
+		return
+	}
+
+	if _, err := structure.NormalizeJsonString(v); err != nil {
 		errStr := err.Error()
 		if err, ok := errs.As[*json.SyntaxError](err); ok {
 			errStr = fmt.Sprintf("%s, at byte offset %d", errStr, err.Offset)
 		}
 		errors = append(errors, fmt.Errorf("%q contains an invalid JSON policy: %s", k, errStr))
-	} else if err := basevalidation.JSONNoDuplicateKeys(value); err != nil {
+		return
+	}
+
+	if err := basevalidation.JSONNoDuplicateKeys(value); err != nil {
 		errors = append(errors, fmt.Errorf("%q contains duplicate JSON keys: %s", k, err))
+		return
 	}
 
 	return //nolint:nakedret // Just a long function.

--- a/internal/verify/validate_test.go
+++ b/internal/verify/validate_test.go
@@ -392,10 +392,6 @@ func TestValidIAMPolicyJSONString(t *testing.T) {
 			WantError: `"json" is an empty string, which is not a valid JSON value`,
 		},
 		{
-			Value:     `    {"xyz": "foo"}`,
-			WantError: `"json" contains an invalid JSON policy: leading space characters are not allowed`,
-		},
-		{
 			Value:     `"blub"`,
 			WantError: `"json" contains an invalid JSON policy: contains a JSON-encoded string, not a JSON-encoded object`,
 		},

--- a/website/docs/r/glacier_vault_lock.html.markdown
+++ b/website/docs/r/glacier_vault_lock.html.markdown
@@ -12,6 +12,8 @@ Manages a Glacier Vault Lock. You can refer to the [Glacier Developer Guide](htt
 
 ~> **NOTE:** This resource allows you to test Glacier Vault Lock policies by setting the `complete_lock` argument to `false`. When testing policies in this manner, the Glacier Vault Lock automatically expires after 24 hours and Terraform will show this resource as needing recreation after that time. To permanently apply the policy, set the `complete_lock` argument to `true`. When changing `complete_lock` to `true`, it is expected the resource will show as recreating.
 
+~> **NOTE:** We suggest using [`jsonencode()`](https://developer.hashicorp.com/terraform/language/functions/jsonencode) or [`aws_iam_policy_document`](/docs/providers/aws/d/iam_policy_document.html) when assigning a value to `policy`. They seamlessly translate Terraform language into JSON, enabling you to maintain consistency within your configuration without the need for context switches. Also, you can sidestep potential complications arising from formatting discrepancies, whitespace inconsistencies, and other nuances inherent to JSON.
+
 !> **WARNING:** Once a Glacier Vault Lock is completed, it is immutable. The deletion of the Glacier Vault Lock is not be possible and attempting to remove it from Terraform will return an error. Set the `ignore_deletion_error` argument to `true` and apply this configuration before attempting to delete this resource via Terraform or use `terraform state rm` to remove this resource from Terraform management.
 
 ## Example Usage

--- a/website/docs/r/iam_group_policy.html.markdown
+++ b/website/docs/r/iam_group_policy.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides an IAM policy attached to a group.
 
+~> **NOTE:** We suggest using [`jsonencode()`](https://developer.hashicorp.com/terraform/language/functions/jsonencode) or [`aws_iam_policy_document`](/docs/providers/aws/d/iam_policy_document.html) when assigning a value to `policy`. They seamlessly translate Terraform language into JSON, enabling you to maintain consistency within your configuration without the need for context switches. Also, you can sidestep potential complications arising from formatting discrepancies, whitespace inconsistencies, and other nuances inherent to JSON.
+
 ## Example Usage
 
 ```terraform

--- a/website/docs/r/iam_policy.html.markdown
+++ b/website/docs/r/iam_policy.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Provides an IAM policy.
 
-~> **NOTE:** We suggest using [`jsonencode()`](https://developer.hashicorp.com/terraform/language/functions/jsonencode) when assigning a value to `policy`. This function seamlessly translates Terraform language into JSON, enabling you to maintain consistency within your configuration without the need for context switches. By employing `jsonencode()`, you can sidestep potential complications arising from formatting discrepancies, whitespace inconsistencies, and other nuances inherent to JSON.
+~> **NOTE:** We suggest using [`jsonencode()`](https://developer.hashicorp.com/terraform/language/functions/jsonencode) or [`aws_iam_policy_document`](/docs/providers/aws/d/iam_policy_document.html) when assigning a value to `policy`. They seamlessly translate Terraform language into JSON, enabling you to maintain consistency within your configuration without the need for context switches. Also, you can sidestep potential complications arising from formatting discrepancies, whitespace inconsistencies, and other nuances inherent to JSON.
 
 ## Example Usage
 

--- a/website/docs/r/iam_policy.html.markdown
+++ b/website/docs/r/iam_policy.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides an IAM policy.
 
+~> **NOTE:** We suggest using [`jsonencode()`](https://developer.hashicorp.com/terraform/language/functions/jsonencode) when assigning a value to `policy`. This function seamlessly translates Terraform language into JSON, enabling you to maintain consistency within your configuration without the need for context switches. By employing `jsonencode()`, you can sidestep potential complications arising from formatting discrepancies, whitespace inconsistencies, and other nuances inherent to JSON.
+
 ## Example Usage
 
 ```terraform
@@ -40,24 +42,19 @@ resource "aws_iam_policy" "policy" {
 This resource supports the following arguments:
 
 * `description` - (Optional, Forces new resource) Description of the IAM policy.
-* `name` - (Optional, Forces new resource) The name of the policy. If omitted, Terraform will assign a random, unique name.
 * `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
-* `path` - (Optional, default "/") Path in which to create the policy.
-  See [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) for more information.
-* `policy` - (Required) The policy document. This is a JSON formatted string. For more information about building AWS IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](https://learn.hashicorp.com/terraform/aws/iam-policy)
+* `name` - (Optional, Forces new resource) Name of the policy. If omitted, Terraform will assign a random, unique name.
+* `path` - (Optional, default "/") Path in which to create the policy. See [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) for more information.
+* `policy` - (Required) Policy document. This is a JSON formatted string. For more information about building AWS IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](https://learn.hashicorp.com/terraform/aws/iam-policy)
 * `tags` - (Optional) Map of resource tags for the IAM Policy. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `id` - The ARN assigned by AWS to this policy.
-* `arn` - The ARN assigned by AWS to this policy.
-* `description` - The description of the policy.
-* `name` - The name of the policy.
-* `path` - The path of the policy in IAM.
-* `policy` - The policy document.
-* `policy_id` - The policy's ID.
+* `arn` - ARN assigned by AWS to this policy.
+* `id` - ARN assigned by AWS to this policy.
+* `policy_id` - Policy's ID.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Import

--- a/website/docs/r/iam_role.html.markdown
+++ b/website/docs/r/iam_role.html.markdown
@@ -14,6 +14,8 @@ Provides an IAM role.
 
 ~> **NOTE:** If you use this resource's `managed_policy_arns` argument or `inline_policy` configuration blocks, this resource will take over exclusive management of the role's respective policy types (e.g., both policy types if both arguments are used). These arguments are incompatible with other ways of managing a role's policies, such as [`aws_iam_policy_attachment`](/docs/providers/aws/r/iam_policy_attachment.html), [`aws_iam_role_policy_attachment`](/docs/providers/aws/r/iam_role_policy_attachment.html), and [`aws_iam_role_policy`](/docs/providers/aws/r/iam_role_policy.html). If you attempt to manage a role's policies by multiple means, you will get resource cycling and/or errors.
 
+~> **NOTE:** We suggest using [`jsonencode()`](https://developer.hashicorp.com/terraform/language/functions/jsonencode) or [`aws_iam_policy_document`](/docs/providers/aws/d/iam_policy_document.html) when assigning a value to `assume_role_policy` or `inline_policy.*.policy`. They seamlessly translate Terraform language into JSON, enabling you to maintain consistency within your configuration without the need for context switches. Also, you can sidestep potential complications arising from formatting discrepancies, whitespace inconsistencies, and other nuances inherent to JSON.
+
 ## Example Usage
 
 ### Basic Example

--- a/website/docs/r/iam_role_policy.html.markdown
+++ b/website/docs/r/iam_role_policy.html.markdown
@@ -12,6 +12,8 @@ Provides an IAM role inline policy.
 
 ~> **NOTE:** For a given role, this resource is incompatible with using the [`aws_iam_role` resource](/docs/providers/aws/r/iam_role.html) `inline_policy` argument. When using that argument and this resource, both will attempt to manage the role's inline policies and Terraform will show a permanent difference.
 
+~> **NOTE:** We suggest using [`jsonencode()`](https://developer.hashicorp.com/terraform/language/functions/jsonencode) or [`aws_iam_policy_document`](/docs/providers/aws/d/iam_policy_document.html) when assigning a value to `policy`. They seamlessly translate Terraform language into JSON, enabling you to maintain consistency within your configuration without the need for context switches. Also, you can sidestep potential complications arising from formatting discrepancies, whitespace inconsistencies, and other nuances inherent to JSON.
+
 ## Example Usage
 
 ```terraform

--- a/website/docs/r/iam_user_policy.html.markdown
+++ b/website/docs/r/iam_user_policy.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides an IAM policy attached to a user.
 
+~> **NOTE:** We suggest using [`jsonencode()`](https://developer.hashicorp.com/terraform/language/functions/jsonencode) or [`aws_iam_policy_document`](/docs/providers/aws/d/iam_policy_document.html) when assigning a value to `policy`. They seamlessly translate Terraform language into JSON, enabling you to maintain consistency within your configuration without the need for context switches. Also, you can sidestep potential complications arising from formatting discrepancies, whitespace inconsistencies, and other nuances inherent to JSON.
+
 ## Example Usage
 
 ```terraform

--- a/website/docs/r/media_store_container_policy.html.markdown
+++ b/website/docs/r/media_store_container_policy.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides a MediaStore Container Policy.
 
+~> **NOTE:** We suggest using [`jsonencode()`](https://developer.hashicorp.com/terraform/language/functions/jsonencode) or [`aws_iam_policy_document`](/docs/providers/aws/d/iam_policy_document.html) when assigning a value to `policy`. They seamlessly translate Terraform language into JSON, enabling you to maintain consistency within your configuration without the need for context switches. Also, you can sidestep potential complications arising from formatting discrepancies, whitespace inconsistencies, and other nuances inherent to JSON.
+
 ## Example Usage
 
 ```terraform

--- a/website/docs/r/ssoadmin_permission_set_inline_policy.html.markdown
+++ b/website/docs/r/ssoadmin_permission_set_inline_policy.html.markdown
@@ -13,6 +13,8 @@ Provides an IAM inline policy for a Single Sign-On (SSO) Permission Set resource
 ~> **NOTE:** AWS Single Sign-On (SSO) only supports one IAM inline policy per [`aws_ssoadmin_permission_set`](ssoadmin_permission_set.html) resource.
 Creating or updating this resource will automatically [Provision the Permission Set](https://docs.aws.amazon.com/singlesignon/latest/APIReference/API_ProvisionPermissionSet.html) to apply the corresponding updates to all assigned accounts.
 
+~> **NOTE:** We suggest using [`jsonencode()`](https://developer.hashicorp.com/terraform/language/functions/jsonencode) or [`aws_iam_policy_document`](/docs/providers/aws/d/iam_policy_document.html) when assigning a value to `inline_policy`. They seamlessly translate Terraform language into JSON, enabling you to maintain consistency within your configuration without the need for context switches. Also, you can sidestep potential complications arising from formatting discrepancies, whitespace inconsistencies, and other nuances inherent to JSON.
+
 ## Example Usage
 
 ```terraform

--- a/website/docs/r/transfer_access.html.markdown
+++ b/website/docs/r/transfer_access.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides a AWS Transfer Access resource.
 
+~> **NOTE:** We suggest using [`jsonencode()`](https://developer.hashicorp.com/terraform/language/functions/jsonencode) or [`aws_iam_policy_document`](/docs/providers/aws/d/iam_policy_document.html) when assigning a value to `policy`. They seamlessly translate Terraform language into JSON, enabling you to maintain consistency within your configuration without the need for context switches. Also, you can sidestep potential complications arising from formatting discrepancies, whitespace inconsistencies, and other nuances inherent to JSON.
+
 ## Example Usage
 
 ### Basic S3

--- a/website/docs/r/transfer_user.html.markdown
+++ b/website/docs/r/transfer_user.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides a AWS Transfer User resource. Managing SSH keys can be accomplished with the [`aws_transfer_ssh_key` resource](/docs/providers/aws/r/transfer_ssh_key.html).
 
+~> **NOTE:** We suggest using [`jsonencode()`](https://developer.hashicorp.com/terraform/language/functions/jsonencode) or [`aws_iam_policy_document`](/docs/providers/aws/d/iam_policy_document.html) when assigning a value to `policy`. They seamlessly translate Terraform language into JSON, enabling you to maintain consistency within your configuration without the need for context switches. Also, you can sidestep potential complications arising from formatting discrepancies, whitespace inconsistencies, and other nuances inherent to JSON.
+
 ## Example Usage
 
 ```terraform


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This issue has persisted for quite some time and requires resolution.

One factor contributing to the delay in addressing it is the historical issue where leading whitespace would create complications during JSON normalization. However, significant improvements have been made since then, particularly with the enhancement brought by #22067 to our normalization and difference detection processes. As a result, leading whitespace no longer poses a problem, and we have decided to permit it. Given the potential ramifications of this decision, we will carefully monitor for any unforeseen consequences.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #1873
Closes #5887
Closes #21016 (fixed by #22067)
Closes #438 (fixed by #22067)
Relates #21968 
Relates #22048

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccIAMPolicy K=iam           
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMPolicy'  -timeout 360m
=== RUN   TestAccIAMPolicyAttachment_basic
=== PAUSE TestAccIAMPolicyAttachment_basic
=== RUN   TestAccIAMPolicyAttachment_disappears
=== PAUSE TestAccIAMPolicyAttachment_disappears
=== RUN   TestAccIAMPolicyAttachment_paginatedEntities
=== PAUSE TestAccIAMPolicyAttachment_paginatedEntities
=== RUN   TestAccIAMPolicyDataSource_arn
=== PAUSE TestAccIAMPolicyDataSource_arn
=== RUN   TestAccIAMPolicyDataSource_arnTags
=== PAUSE TestAccIAMPolicyDataSource_arnTags
=== RUN   TestAccIAMPolicyDataSource_name
=== PAUSE TestAccIAMPolicyDataSource_name
=== RUN   TestAccIAMPolicyDataSource_nameTags
=== PAUSE TestAccIAMPolicyDataSource_nameTags
=== RUN   TestAccIAMPolicyDataSource_nameAndPathPrefix
=== PAUSE TestAccIAMPolicyDataSource_nameAndPathPrefix
=== RUN   TestAccIAMPolicyDataSource_nameAndPathPrefixTags
=== PAUSE TestAccIAMPolicyDataSource_nameAndPathPrefixTags
=== RUN   TestAccIAMPolicyDataSource_nonExistent
=== PAUSE TestAccIAMPolicyDataSource_nonExistent
=== RUN   TestAccIAMPolicyDocumentDataSource_basic
=== PAUSE TestAccIAMPolicyDocumentDataSource_basic
=== RUN   TestAccIAMPolicyDocumentDataSource_singleConditionValue
=== PAUSE TestAccIAMPolicyDocumentDataSource_singleConditionValue
=== RUN   TestAccIAMPolicyDocumentDataSource_multipleConditionKeys
=== PAUSE TestAccIAMPolicyDocumentDataSource_multipleConditionKeys
=== RUN   TestAccIAMPolicyDocumentDataSource_duplicateConditionKeys
=== PAUSE TestAccIAMPolicyDocumentDataSource_duplicateConditionKeys
=== RUN   TestAccIAMPolicyDocumentDataSource_conditionWithBoolValue
=== PAUSE TestAccIAMPolicyDocumentDataSource_conditionWithBoolValue
=== RUN   TestAccIAMPolicyDocumentDataSource_source
=== PAUSE TestAccIAMPolicyDocumentDataSource_source
=== RUN   TestAccIAMPolicyDocumentDataSource_sourceList
=== PAUSE TestAccIAMPolicyDocumentDataSource_sourceList
=== RUN   TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== PAUSE TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== RUN   TestAccIAMPolicyDocumentDataSource_sourceListConflicting
=== PAUSE TestAccIAMPolicyDocumentDataSource_sourceListConflicting
=== RUN   TestAccIAMPolicyDocumentDataSource_override
=== PAUSE TestAccIAMPolicyDocumentDataSource_override
=== RUN   TestAccIAMPolicyDocumentDataSource_overrideList
=== PAUSE TestAccIAMPolicyDocumentDataSource_overrideList
=== RUN   TestAccIAMPolicyDocumentDataSource_noStatementMerge
=== PAUSE TestAccIAMPolicyDocumentDataSource_noStatementMerge
=== RUN   TestAccIAMPolicyDocumentDataSource_noStatementOverride
=== PAUSE TestAccIAMPolicyDocumentDataSource_noStatementOverride
=== RUN   TestAccIAMPolicyDocumentDataSource_duplicateSid
=== PAUSE TestAccIAMPolicyDocumentDataSource_duplicateSid
=== RUN   TestAccIAMPolicyDocumentDataSource_sourcePolicyValidJSON
=== PAUSE TestAccIAMPolicyDocumentDataSource_sourcePolicyValidJSON
=== RUN   TestAccIAMPolicyDocumentDataSource_overridePolicyDocumentValidJSON
=== PAUSE TestAccIAMPolicyDocumentDataSource_overridePolicyDocumentValidJSON
=== RUN   TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_stringAndSlice
=== PAUSE TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_stringAndSlice
=== RUN   TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePrincipals
=== PAUSE TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePrincipals
=== RUN   TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePrincipalsGov
=== PAUSE TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePrincipalsGov
=== RUN   TestAccIAMPolicyDocumentDataSource_version20081017
=== PAUSE TestAccIAMPolicyDocumentDataSource_version20081017
=== RUN   TestAccIAMPolicy_tags
=== PAUSE TestAccIAMPolicy_tags
=== RUN   TestAccIAMPolicy_tags_null
=== PAUSE TestAccIAMPolicy_tags_null
=== RUN   TestAccIAMPolicy_tags_AddOnUpdate
=== PAUSE TestAccIAMPolicy_tags_AddOnUpdate
=== RUN   TestAccIAMPolicy_tags_EmptyTag_OnCreate
=== PAUSE TestAccIAMPolicy_tags_EmptyTag_OnCreate
=== RUN   TestAccIAMPolicy_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccIAMPolicy_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccIAMPolicy_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccIAMPolicy_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccIAMPolicy_tags_DefaultTags_providerOnly
=== PAUSE TestAccIAMPolicy_tags_DefaultTags_providerOnly
=== RUN   TestAccIAMPolicy_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccIAMPolicy_tags_DefaultTags_nonOverlapping
=== RUN   TestAccIAMPolicy_tags_DefaultTags_overlapping
=== PAUSE TestAccIAMPolicy_tags_DefaultTags_overlapping
=== RUN   TestAccIAMPolicy_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccIAMPolicy_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccIAMPolicy_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccIAMPolicy_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccIAMPolicy_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccIAMPolicy_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccIAMPolicy_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccIAMPolicy_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccIAMPolicy_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccIAMPolicy_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccIAMPolicy_basic
=== PAUSE TestAccIAMPolicy_basic
=== RUN   TestAccIAMPolicy_description
=== PAUSE TestAccIAMPolicy_description
=== RUN   TestAccIAMPolicy_whitespace
=== PAUSE TestAccIAMPolicy_whitespace
=== RUN   TestAccIAMPolicy_disappears
=== PAUSE TestAccIAMPolicy_disappears
=== RUN   TestAccIAMPolicy_namePrefix
=== PAUSE TestAccIAMPolicy_namePrefix
=== RUN   TestAccIAMPolicy_path
=== PAUSE TestAccIAMPolicy_path
=== RUN   TestAccIAMPolicy_policy
=== PAUSE TestAccIAMPolicy_policy
=== RUN   TestAccIAMPolicy_diffs
=== PAUSE TestAccIAMPolicy_diffs
=== RUN   TestAccIAMPolicy_policyDuplicateKeys
=== PAUSE TestAccIAMPolicy_policyDuplicateKeys
=== CONT  TestAccIAMPolicyAttachment_basic
=== CONT  TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePrincipals
=== CONT  TestAccIAMPolicy_tags_DefaultTags_emptyResourceTag
=== CONT  TestAccIAMPolicy_tags_EmptyTag_OnUpdate_Add
=== CONT  TestAccIAMPolicy_tags_DefaultTags_nonOverlapping
=== CONT  TestAccIAMPolicy_tags_DefaultTags_updateToProviderOnly
=== CONT  TestAccIAMPolicy_tags_EmptyTag_OnCreate
=== CONT  TestAccIAMPolicy_policyDuplicateKeys
=== CONT  TestAccIAMPolicy_policy
=== CONT  TestAccIAMPolicy_tags_DefaultTags_updateToResourceOnly
=== CONT  TestAccIAMPolicy_path
=== CONT  TestAccIAMPolicy_namePrefix
=== CONT  TestAccIAMPolicy_whitespace
=== CONT  TestAccIAMPolicy_description
=== CONT  TestAccIAMPolicy_basic
=== CONT  TestAccIAMPolicy_tags_DefaultTags_nullNonOverlappingResourceTag
=== CONT  TestAccIAMPolicy_tags_DefaultTags_nullOverlappingResourceTag
=== CONT  TestAccIAMPolicy_tags_AddOnUpdate
=== CONT  TestAccIAMPolicy_diffs
=== CONT  TestAccIAMPolicy_disappears
--- PASS: TestAccIAMPolicy_policyDuplicateKeys (5.13s)
=== CONT  TestAccIAMPolicy_tags_null
--- PASS: TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePrincipals (33.70s)
=== CONT  TestAccIAMPolicy_tags
--- PASS: TestAccIAMPolicy_disappears (44.47s)
=== CONT  TestAccIAMPolicyDocumentDataSource_version20081017
--- PASS: TestAccIAMPolicy_tags_DefaultTags_emptyResourceTag (50.12s)
=== CONT  TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePrincipalsGov
    policy_document_data_source_test.go:388: skipping tests; current partition (aws) does not equal aws-us-gov
--- SKIP: TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePrincipalsGov (0.00s)
=== CONT  TestAccIAMPolicy_tags_DefaultTags_overlapping
--- PASS: TestAccIAMPolicy_tags_DefaultTags_nullNonOverlappingResourceTag (53.36s)
=== CONT  TestAccIAMPolicyDocumentDataSource_conditionWithBoolValue
--- PASS: TestAccIAMPolicy_tags_DefaultTags_nullOverlappingResourceTag (53.45s)
=== CONT  TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_stringAndSlice
--- PASS: TestAccIAMPolicy_namePrefix (53.48s)
=== CONT  TestAccIAMPolicyDocumentDataSource_overridePolicyDocumentValidJSON
--- PASS: TestAccIAMPolicy_description (54.17s)
=== CONT  TestAccIAMPolicyDocumentDataSource_sourcePolicyValidJSON
--- PASS: TestAccIAMPolicy_path (54.23s)
=== CONT  TestAccIAMPolicyDocumentDataSource_duplicateSid
--- PASS: TestAccIAMPolicy_basic (54.23s)
=== CONT  TestAccIAMPolicyDocumentDataSource_noStatementOverride
--- PASS: TestAccIAMPolicy_tags_null (65.83s)
=== CONT  TestAccIAMPolicyDocumentDataSource_noStatementMerge
--- PASS: TestAccIAMPolicy_tags_DefaultTags_updateToResourceOnly (80.39s)
=== CONT  TestAccIAMPolicyDocumentDataSource_overrideList
--- PASS: TestAccIAMPolicyAttachment_basic (80.56s)
=== CONT  TestAccIAMPolicyDocumentDataSource_override
--- PASS: TestAccIAMPolicy_tags_DefaultTags_updateToProviderOnly (87.87s)
=== CONT  TestAccIAMPolicyDocumentDataSource_sourceListConflicting
--- PASS: TestAccIAMPolicy_tags_AddOnUpdate (88.63s)
=== CONT  TestAccIAMPolicyDocumentDataSource_sourceConflicting
--- PASS: TestAccIAMPolicyDocumentDataSource_conditionWithBoolValue (36.66s)
=== CONT  TestAccIAMPolicyDocumentDataSource_sourceList
--- PASS: TestAccIAMPolicyDocumentDataSource_noStatementOverride (36.08s)
=== CONT  TestAccIAMPolicyDocumentDataSource_source
--- PASS: TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_stringAndSlice (37.38s)
=== CONT  TestAccIAMPolicyDataSource_nameTags
--- PASS: TestAccIAMPolicy_policy (92.53s)
=== CONT  TestAccIAMPolicyDocumentDataSource_duplicateConditionKeys
--- PASS: TestAccIAMPolicyDocumentDataSource_overridePolicyDocumentValidJSON (40.68s)
=== CONT  TestAccIAMPolicyDocumentDataSource_multipleConditionKeys
=== CONT  TestAccIAMPolicyDocumentDataSource_singleConditionValue
--- PASS: TestAccIAMPolicyDocumentDataSource_sourcePolicyValidJSON (40.09s)
--- PASS: TestAccIAMPolicyDocumentDataSource_sourceListConflicting (7.12s)
=== CONT  TestAccIAMPolicyDocumentDataSource_basic
--- PASS: TestAccIAMPolicyDocumentDataSource_duplicateSid (42.34s)
=== CONT  TestAccIAMPolicyDataSource_nonExistent
--- PASS: TestAccIAMPolicy_tags_EmptyTag_OnCreate (97.15s)
=== CONT  TestAccIAMPolicyDataSource_nameAndPathPrefixTags
--- PASS: TestAccIAMPolicyDocumentDataSource_version20081017 (64.23s)
=== CONT  TestAccIAMPolicyDataSource_nameAndPathPrefix
--- PASS: TestAccIAMPolicyDocumentDataSource_noStatementMerge (37.80s)
=== CONT  TestAccIAMPolicyAttachment_paginatedEntities
--- PASS: TestAccIAMPolicy_whitespace (110.30s)
=== CONT  TestAccIAMPolicyDataSource_name
--- PASS: TestAccIAMPolicyDocumentDataSource_overrideList (40.84s)
=== CONT  TestAccIAMPolicyDataSource_arnTags
--- PASS: TestAccIAMPolicyDocumentDataSource_override (40.75s)
=== CONT  TestAccIAMPolicyDataSource_arn
--- PASS: TestAccIAMPolicyDocumentDataSource_sourceConflicting (36.40s)
=== CONT  TestAccIAMPolicy_tags_DefaultTags_providerOnly
--- PASS: TestAccIAMPolicyDocumentDataSource_sourceList (37.58s)
=== CONT  TestAccIAMPolicyAttachment_disappears
--- PASS: TestAccIAMPolicyDocumentDataSource_duplicateConditionKeys (35.11s)
=== CONT  TestAccIAMPolicy_tags_EmptyTag_OnUpdate_Replace
--- PASS: TestAccIAMPolicyDocumentDataSource_multipleConditionKeys (36.03s)
--- PASS: TestAccIAMPolicyDocumentDataSource_basic (35.86s)
--- PASS: TestAccIAMPolicyDocumentDataSource_singleConditionValue (36.61s)
--- PASS: TestAccIAMPolicy_tags_EmptyTag_OnUpdate_Add (133.95s)
--- PASS: TestAccIAMPolicyDataSource_nameTags (45.87s)
--- PASS: TestAccIAMPolicyDataSource_nameAndPathPrefixTags (40.87s)
--- PASS: TestAccIAMPolicy_tags_DefaultTags_nonOverlapping (141.06s)
--- PASS: TestAccIAMPolicyDataSource_nameAndPathPrefix (36.37s)
--- PASS: TestAccIAMPolicyDocumentDataSource_source (55.58s)
--- PASS: TestAccIAMPolicyDataSource_name (38.01s)
--- PASS: TestAccIAMPolicyDataSource_arn (29.74s)
--- PASS: TestAccIAMPolicyDataSource_arnTags (29.87s)
--- PASS: TestAccIAMPolicyAttachment_disappears (28.71s)
--- PASS: TestAccIAMPolicy_tags_DefaultTags_overlapping (111.54s)
--- PASS: TestAccIAMPolicy_tags_EmptyTag_OnUpdate_Replace (43.17s)
--- PASS: TestAccIAMPolicy_tags (140.73s)
--- PASS: TestAccIAMPolicyAttachment_paginatedEntities (73.75s)
--- PASS: TestAccIAMPolicy_tags_DefaultTags_providerOnly (68.38s)
--- PASS: TestAccIAMPolicy_diffs (194.24s)
--- PASS: TestAccIAMPolicyDataSource_nonExistent (126.23s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	225.142s
% make t T=TestAccIAMGroupPolicy_ K=iam
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMGroupPolicy_'  -timeout 360m
=== RUN   TestAccIAMGroupPolicy_basic
=== PAUSE TestAccIAMGroupPolicy_basic
=== RUN   TestAccIAMGroupPolicy_disappears
=== PAUSE TestAccIAMGroupPolicy_disappears
=== RUN   TestAccIAMGroupPolicy_nameGenerated
=== PAUSE TestAccIAMGroupPolicy_nameGenerated
=== RUN   TestAccIAMGroupPolicy_namePrefix
=== PAUSE TestAccIAMGroupPolicy_namePrefix
=== RUN   TestAccIAMGroupPolicy_unknownsInPolicy
=== PAUSE TestAccIAMGroupPolicy_unknownsInPolicy
=== RUN   TestAccIAMGroupPolicy_update
=== PAUSE TestAccIAMGroupPolicy_update
=== CONT  TestAccIAMGroupPolicy_basic
=== CONT  TestAccIAMGroupPolicy_namePrefix
=== CONT  TestAccIAMGroupPolicy_nameGenerated
=== CONT  TestAccIAMGroupPolicy_disappears
=== CONT  TestAccIAMGroupPolicy_unknownsInPolicy
=== CONT  TestAccIAMGroupPolicy_update
--- PASS: TestAccIAMGroupPolicy_disappears (16.96s)
--- PASS: TestAccIAMGroupPolicy_basic (19.79s)
--- PASS: TestAccIAMGroupPolicy_nameGenerated (19.84s)
--- PASS: TestAccIAMGroupPolicy_namePrefix (19.85s)
--- PASS: TestAccIAMGroupPolicy_unknownsInPolicy (20.94s)
--- PASS: TestAccIAMGroupPolicy_update (25.22s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	27.463s
% make t T=TestAccIAMRolePolicy_ K=iam
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMRolePolicy_'  -timeout 360m
=== RUN   TestAccIAMRolePolicy_basic
=== PAUSE TestAccIAMRolePolicy_basic
=== RUN   TestAccIAMRolePolicy_disappears
=== PAUSE TestAccIAMRolePolicy_disappears
=== RUN   TestAccIAMRolePolicy_nameGenerated
=== PAUSE TestAccIAMRolePolicy_nameGenerated
=== RUN   TestAccIAMRolePolicy_namePrefix
=== PAUSE TestAccIAMRolePolicy_namePrefix
=== RUN   TestAccIAMRolePolicy_policyOrder
=== PAUSE TestAccIAMRolePolicy_policyOrder
=== RUN   TestAccIAMRolePolicy_invalidJSON
=== PAUSE TestAccIAMRolePolicy_invalidJSON
=== RUN   TestAccIAMRolePolicy_Policy_invalidResource
=== PAUSE TestAccIAMRolePolicy_Policy_invalidResource
=== RUN   TestAccIAMRolePolicy_unknownsInPolicy
=== PAUSE TestAccIAMRolePolicy_unknownsInPolicy
=== CONT  TestAccIAMRolePolicy_basic
=== CONT  TestAccIAMRolePolicy_policyOrder
=== CONT  TestAccIAMRolePolicy_namePrefix
=== CONT  TestAccIAMRolePolicy_disappears
=== CONT  TestAccIAMRolePolicy_Policy_invalidResource
=== CONT  TestAccIAMRolePolicy_invalidJSON
=== CONT  TestAccIAMRolePolicy_unknownsInPolicy
=== CONT  TestAccIAMRolePolicy_nameGenerated
--- PASS: TestAccIAMRolePolicy_invalidJSON (2.33s)
--- PASS: TestAccIAMRolePolicy_Policy_invalidResource (9.56s)
--- PASS: TestAccIAMRolePolicy_disappears (18.33s)
--- PASS: TestAccIAMRolePolicy_unknownsInPolicy (20.89s)
--- PASS: TestAccIAMRolePolicy_namePrefix (21.14s)
--- PASS: TestAccIAMRolePolicy_nameGenerated (21.17s)
--- PASS: TestAccIAMRolePolicy_basic (21.19s)
--- PASS: TestAccIAMRolePolicy_policyOrder (22.33s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	24.605s
% make t T=TestAccIAMRole_ K=iam      
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMRole_'  -timeout 360m
=== RUN   TestAccIAMRole_tags
=== PAUSE TestAccIAMRole_tags
=== RUN   TestAccIAMRole_tags_null
=== PAUSE TestAccIAMRole_tags_null
=== RUN   TestAccIAMRole_tags_AddOnUpdate
=== PAUSE TestAccIAMRole_tags_AddOnUpdate
=== RUN   TestAccIAMRole_tags_EmptyTag_OnCreate
=== PAUSE TestAccIAMRole_tags_EmptyTag_OnCreate
=== RUN   TestAccIAMRole_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccIAMRole_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccIAMRole_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccIAMRole_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccIAMRole_tags_DefaultTags_providerOnly
=== PAUSE TestAccIAMRole_tags_DefaultTags_providerOnly
=== RUN   TestAccIAMRole_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccIAMRole_tags_DefaultTags_nonOverlapping
=== RUN   TestAccIAMRole_tags_DefaultTags_overlapping
=== PAUSE TestAccIAMRole_tags_DefaultTags_overlapping
=== RUN   TestAccIAMRole_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccIAMRole_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccIAMRole_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccIAMRole_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccIAMRole_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccIAMRole_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccIAMRole_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccIAMRole_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccIAMRole_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccIAMRole_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccIAMRole_basic
=== PAUSE TestAccIAMRole_basic
=== RUN   TestAccIAMRole_description
=== PAUSE TestAccIAMRole_description
=== RUN   TestAccIAMRole_nameGenerated
=== PAUSE TestAccIAMRole_nameGenerated
=== RUN   TestAccIAMRole_namePrefix
=== PAUSE TestAccIAMRole_namePrefix
=== RUN   TestAccIAMRole_testNameChange
=== PAUSE TestAccIAMRole_testNameChange
=== RUN   TestAccIAMRole_diffs
=== PAUSE TestAccIAMRole_diffs
=== RUN   TestAccIAMRole_diffsCondition
=== PAUSE TestAccIAMRole_diffsCondition
=== RUN   TestAccIAMRole_badJSON
=== PAUSE TestAccIAMRole_badJSON
=== RUN   TestAccIAMRole_disappears
=== PAUSE TestAccIAMRole_disappears
=== RUN   TestAccIAMRole_policiesForceDetach
=== PAUSE TestAccIAMRole_policiesForceDetach
=== RUN   TestAccIAMRole_maxSessionDuration
=== PAUSE TestAccIAMRole_maxSessionDuration
=== RUN   TestAccIAMRole_permissionsBoundary
=== PAUSE TestAccIAMRole_permissionsBoundary
=== RUN   TestAccIAMRole_InlinePolicy_basic
=== PAUSE TestAccIAMRole_InlinePolicy_basic
=== RUN   TestAccIAMRole_InlinePolicy_ignoreOrder
=== PAUSE TestAccIAMRole_InlinePolicy_ignoreOrder
=== RUN   TestAccIAMRole_InlinePolicy_empty
=== PAUSE TestAccIAMRole_InlinePolicy_empty
=== RUN   TestAccIAMRole_ManagedPolicy_basic
=== PAUSE TestAccIAMRole_ManagedPolicy_basic
=== RUN   TestAccIAMRole_ManagedPolicy_outOfBandRemovalAddedBack
=== PAUSE TestAccIAMRole_ManagedPolicy_outOfBandRemovalAddedBack
=== RUN   TestAccIAMRole_InlinePolicy_outOfBandRemovalAddedBack
=== PAUSE TestAccIAMRole_InlinePolicy_outOfBandRemovalAddedBack
=== RUN   TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemoved
=== PAUSE TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemoved
=== RUN   TestAccIAMRole_InlinePolicy_outOfBandAdditionRemoved
=== PAUSE TestAccIAMRole_InlinePolicy_outOfBandAdditionRemoved
=== RUN   TestAccIAMRole_InlinePolicy_outOfBandAdditionIgnored
=== PAUSE TestAccIAMRole_InlinePolicy_outOfBandAdditionIgnored
=== RUN   TestAccIAMRole_ManagedPolicy_outOfBandAdditionIgnored
=== PAUSE TestAccIAMRole_ManagedPolicy_outOfBandAdditionIgnored
=== RUN   TestAccIAMRole_InlinePolicy_outOfBandAdditionRemovedEmpty
=== PAUSE TestAccIAMRole_InlinePolicy_outOfBandAdditionRemovedEmpty
=== RUN   TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemovedEmpty
=== PAUSE TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemovedEmpty
=== CONT  TestAccIAMRole_tags
=== CONT  TestAccIAMRole_diffs
=== CONT  TestAccIAMRole_tags_DefaultTags_updateToResourceOnly
=== CONT  TestAccIAMRole_description
=== CONT  TestAccIAMRole_tags_EmptyTag_OnUpdate_Replace
=== CONT  TestAccIAMRole_tags_EmptyTag_OnCreate
=== CONT  TestAccIAMRole_ManagedPolicy_basic
=== CONT  TestAccIAMRole_tags_EmptyTag_OnUpdate_Add
=== CONT  TestAccIAMRole_maxSessionDuration
=== CONT  TestAccIAMRole_nameGenerated
=== CONT  TestAccIAMRole_badJSON
=== CONT  TestAccIAMRole_InlinePolicy_basic
=== CONT  TestAccIAMRole_disappears
=== CONT  TestAccIAMRole_policiesForceDetach
=== CONT  TestAccIAMRole_InlinePolicy_ignoreOrder
=== CONT  TestAccIAMRole_tags_AddOnUpdate
=== CONT  TestAccIAMRole_testNameChange
=== CONT  TestAccIAMRole_namePrefix
=== CONT  TestAccIAMRole_InlinePolicy_empty
=== CONT  TestAccIAMRole_tags_null
--- PASS: TestAccIAMRole_badJSON (7.05s)
=== CONT  TestAccIAMRole_permissionsBoundary
--- PASS: TestAccIAMRole_InlinePolicy_empty (47.53s)
=== CONT  TestAccIAMRole_diffsCondition
--- PASS: TestAccIAMRole_disappears (52.51s)
=== CONT  TestAccIAMRole_tags_DefaultTags_overlapping
--- PASS: TestAccIAMRole_nameGenerated (62.38s)
=== CONT  TestAccIAMRole_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccIAMRole_namePrefix (63.04s)
=== CONT  TestAccIAMRole_InlinePolicy_outOfBandAdditionIgnored
--- PASS: TestAccIAMRole_policiesForceDetach (66.61s)
=== CONT  TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemovedEmpty
--- PASS: TestAccIAMRole_tags_null (80.86s)
=== CONT  TestAccIAMRole_InlinePolicy_outOfBandAdditionRemovedEmpty
--- PASS: TestAccIAMRole_tags_DefaultTags_updateToResourceOnly (92.51s)
=== CONT  TestAccIAMRole_ManagedPolicy_outOfBandAdditionIgnored
--- PASS: TestAccIAMRole_tags_AddOnUpdate (98.13s)
=== CONT  TestAccIAMRole_tags_DefaultTags_nonOverlapping
--- PASS: TestAccIAMRole_testNameChange (100.59s)
=== CONT  TestAccIAMRole_tags_DefaultTags_emptyResourceTag
--- PASS: TestAccIAMRole_tags_EmptyTag_OnUpdate_Replace (101.71s)
=== CONT  TestAccIAMRole_basic
--- PASS: TestAccIAMRole_tags_EmptyTag_OnCreate (111.22s)
=== CONT  TestAccIAMRole_tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccIAMRole_InlinePolicy_ignoreOrder (111.39s)
=== CONT  TestAccIAMRole_tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccIAMRole_maxSessionDuration (125.07s)
=== CONT  TestAccIAMRole_tags_DefaultTags_providerOnly
--- PASS: TestAccIAMRole_description (137.48s)
=== CONT  TestAccIAMRole_InlinePolicy_outOfBandAdditionRemoved
--- PASS: TestAccIAMRole_InlinePolicy_basic (137.68s)
=== CONT  TestAccIAMRole_InlinePolicy_outOfBandRemovalAddedBack
--- PASS: TestAccIAMRole_ManagedPolicy_basic (138.14s)
=== CONT  TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemoved
--- PASS: TestAccIAMRole_tags_EmptyTag_OnUpdate_Add (148.52s)
=== CONT  TestAccIAMRole_ManagedPolicy_outOfBandRemovalAddedBack
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemovedEmpty (91.50s)
--- PASS: TestAccIAMRole_tags_DefaultTags_updateToProviderOnly (99.98s)
--- PASS: TestAccIAMRole_tags_DefaultTags_emptyResourceTag (61.77s)
--- PASS: TestAccIAMRole_basic (63.07s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionRemovedEmpty (89.42s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionIgnored (77.85s)
--- PASS: TestAccIAMRole_tags_DefaultTags_nullNonOverlappingResourceTag (60.04s)
--- PASS: TestAccIAMRole_tags_DefaultTags_nullOverlappingResourceTag (59.92s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionIgnored (111.15s)
--- PASS: TestAccIAMRole_tags_DefaultTags_overlapping (141.93s)
--- PASS: TestAccIAMRole_tags (195.24s)
--- PASS: TestAccIAMRole_diffsCondition (152.86s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandRemovalAddedBack (63.82s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionRemoved (64.09s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemoved (63.69s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandRemovalAddedBack (57.59s)
--- PASS: TestAccIAMRole_permissionsBoundary (203.89s)
--- PASS: TestAccIAMRole_tags_DefaultTags_nonOverlapping (112.85s)
--- PASS: TestAccIAMRole_tags_DefaultTags_providerOnly (104.28s)
--- PASS: TestAccIAMRole_diffs (305.70s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	308.257s
```