### PR TITLE
feat(datazone): add domain and environment blueprint configuration resources

### DIFF
--- a/internal/service/datazone/domain.go
+++ b/internal/service/datazone/domain.go
@@ -1,0 +1,494 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package datazone
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/datazone"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/datazone/types"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	sdkid "github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// Function annotations are used for resource registration to the Provider. DO NOT EDIT.
+// @FrameworkResource(name="Domain")
+// @Tags(identifierAttribute="arn")
+func newResourceDomain(_ context.Context) (resource.ResourceWithConfigure, error) {
+	r := &resourceDomain{}
+
+	r.SetDefaultCreateTimeout(10 * time.Minute)
+	r.SetDefaultDeleteTimeout(10 * time.Minute)
+
+	return r, nil
+}
+
+const (
+	ResNameDomain            = "Domain"
+	CreateDomainRetryTimeout = 30 * time.Second
+)
+
+type resourceDomain struct {
+	framework.ResourceWithConfigure
+	framework.WithTimeouts
+}
+
+func (r *resourceDomain) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "aws_datazone_domain"
+}
+
+func (r *resourceDomain) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"arn": framework.ARNAttributeComputedOnly(),
+			"description": schema.StringAttribute{
+				Optional: true,
+			},
+			"domain_execution_role": schema.StringAttribute{
+				CustomType: fwtypes.ARNType,
+				Required:   true,
+			},
+			"id": framework.IDAttribute(),
+			"kms_key_identifier": schema.StringAttribute{
+				CustomType: fwtypes.ARNType,
+				Optional:   true,
+			},
+			"name": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"portal_url": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			names.AttrTags:    tftags.TagsAttribute(),
+			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
+		},
+		Blocks: map[string]schema.Block{
+			"single_sign_on": schema.ListNestedBlock{
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.UseStateForUnknown(),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"type": schema.StringAttribute{
+							Optional: true,
+							Computed: true,
+							Validators: []validator.String{
+								enum.FrameworkValidate[awstypes.AuthType](),
+							},
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
+							Default: stringdefault.StaticString("DISABLED"),
+						},
+						"user_assignment": schema.StringAttribute{
+							Optional: true,
+							Validators: []validator.String{
+								enum.FrameworkValidate[awstypes.UserAssignment](),
+							},
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
+						},
+					},
+				},
+			},
+			"timeouts": timeouts.Block(ctx, timeouts.Opts{
+				Create: true,
+				Delete: true,
+			}),
+		},
+	}
+}
+
+func (r *resourceDomain) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().DataZoneClient(ctx)
+
+	var plan domainResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := &datazone.CreateDomainInput{
+		ClientToken:         aws.String(sdkid.UniqueId()),
+		DomainExecutionRole: aws.String(plan.DomainExecutionRole.ValueString()),
+		Name:                aws.String(plan.Name.ValueString()),
+		Tags:                getTagsIn(ctx),
+	}
+
+	if !plan.Description.IsNull() {
+		in.Description = aws.String(plan.Description.ValueString())
+	}
+
+	if !plan.KmsKeyIdentifier.IsNull() {
+		in.KmsKeyIdentifier = aws.String(plan.KmsKeyIdentifier.ValueString())
+	}
+
+	if !plan.SingleSignOn.IsNull() {
+		var tfList []singleSignOnModel
+		resp.Diagnostics.Append(plan.SingleSignOn.ElementsAs(ctx, &tfList, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		in.SingleSignOn = expandSingleSignOn(tfList)
+	}
+
+	outputRaw, err := tfresource.RetryWhenAWSErrCodeContains(ctx, CreateDomainRetryTimeout, func() (interface{}, error) {
+		return conn.CreateDomain(ctx, in)
+	}, ErrorCodeAccessDenied)
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.DataZone, create.ErrActionCreating, ResNameDomain, plan.Name.String(), err),
+			err.Error(),
+		)
+		return
+	}
+	if outputRaw == nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.DataZone, create.ErrActionCreating, ResNameDomain, plan.Name.String(), nil),
+			errors.New("empty output").Error(),
+		)
+		return
+	}
+
+	out := outputRaw.(*datazone.CreateDomainOutput)
+
+	plan.ARN = flex.StringToFramework(ctx, out.Arn)
+	plan.ID = flex.StringToFramework(ctx, out.Id)
+	plan.PortalUrl = flex.StringToFramework(ctx, out.PortalUrl)
+
+	createTimeout := r.CreateTimeout(ctx, plan.Timeouts)
+	_, err = waitDomainCreated(ctx, conn, plan.ID.ValueString(), createTimeout)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.DataZone, create.ErrActionWaitingForCreation, ResNameDomain, plan.Name.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *resourceDomain) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().DataZoneClient(ctx)
+
+	var state domainResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := findDomainByID(ctx, conn, state.ID.ValueString())
+	if tfresource.NotFound(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.DataZone, create.ErrActionSetting, ResNameDomain, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	state.ARN = flex.StringToFramework(ctx, out.Arn)
+	state.Description = flex.StringToFramework(ctx, out.Description)
+	state.DomainExecutionRole = flex.StringToFrameworkARN(ctx, out.DomainExecutionRole)
+	state.ID = flex.StringToFramework(ctx, out.Id)
+	state.KmsKeyIdentifier = flex.StringToFrameworkARN(ctx, out.KmsKeyIdentifier)
+	state.Name = flex.StringToFramework(ctx, out.Name)
+	state.PortalUrl = flex.StringToFramework(ctx, out.PortalUrl)
+
+	if out.SingleSignOn.Type == awstypes.AuthType("DISABLED") && state.SingleSignOn.IsNull() {
+		// Do not set single sign on in state if it was null and response is DISABLED as this is equivalent
+		elemType := fwtypes.NewObjectTypeOf[singleSignOnModel](ctx).ObjectType
+		state.SingleSignOn = types.ListNull(elemType)
+	} else {
+		singleSignOn, d := flattenSingleSignOn(ctx, out.SingleSignOn)
+		resp.Diagnostics.Append(d...)
+		state.SingleSignOn = singleSignOn
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *resourceDomain) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	conn := r.Meta().DataZoneClient(ctx)
+
+	var plan, state domainResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !plan.Description.Equal(state.Description) ||
+		!plan.DomainExecutionRole.Equal(state.DomainExecutionRole) ||
+		!plan.Name.Equal(state.Name) ||
+		!plan.SingleSignOn.Equal(state.SingleSignOn) {
+		in := &datazone.UpdateDomainInput{
+			ClientToken: aws.String(sdkid.UniqueId()),
+			Identifier:  aws.String(plan.ID.ValueString()),
+		}
+
+		if !plan.Description.IsNull() {
+			in.Description = aws.String(plan.Description.ValueString())
+		}
+
+		if !plan.DomainExecutionRole.IsNull() {
+			in.DomainExecutionRole = aws.String(plan.DomainExecutionRole.ValueString())
+		}
+
+		if !plan.Name.IsNull() {
+			in.Name = aws.String(plan.Name.ValueString())
+		}
+
+		if !plan.SingleSignOn.IsNull() {
+			var tfList []singleSignOnModel
+			resp.Diagnostics.Append(plan.SingleSignOn.ElementsAs(ctx, &tfList, false)...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+
+			in.SingleSignOn = expandSingleSignOn(tfList)
+		}
+
+		out, err := conn.UpdateDomain(ctx, in)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.DataZone, create.ErrActionUpdating, ResNameDomain, plan.ID.String(), err),
+				err.Error(),
+			)
+			return
+		}
+		if out == nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.DataZone, create.ErrActionUpdating, ResNameDomain, plan.ID.String(), nil),
+				errors.New("empty output").Error(),
+			)
+			return
+		}
+
+		plan.ID = flex.StringToFramework(ctx, out.Id)
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *resourceDomain) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	conn := r.Meta().DataZoneClient(ctx)
+
+	var state domainResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := &datazone.DeleteDomainInput{
+		ClientToken: aws.String(sdkid.UniqueId()),
+		Identifier:  aws.String(state.ID.ValueString()),
+	}
+
+	_, err := conn.DeleteDomain(ctx, in)
+	if err != nil {
+		if isResourceMissing(err) {
+			return
+		}
+
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.DataZone, create.ErrActionDeleting, ResNameDomain, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	deleteTimeout := r.DeleteTimeout(ctx, state.Timeouts)
+	_, err = waitDomainDeleted(ctx, conn, state.ID.ValueString(), deleteTimeout)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.DataZone, create.ErrActionWaitingForDeletion, ResNameDomain, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+}
+
+func (r *resourceDomain) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func (r *resourceDomain) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	r.SetTagsAll(ctx, req, resp)
+}
+
+func waitDomainCreated(ctx context.Context, conn *datazone.Client, id string, timeout time.Duration) (*datazone.GetDomainOutput, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: enum.Slice(awstypes.DomainStatusCreating),
+		Target:  enum.Slice(awstypes.DomainStatusAvailable),
+		Refresh: statusDomain(ctx, conn, id),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if out, ok := outputRaw.(*datazone.GetDomainOutput); ok {
+		return out, err
+	}
+
+	return nil, err
+}
+
+func waitDomainDeleted(ctx context.Context, conn *datazone.Client, id string, timeout time.Duration) (*datazone.GetDomainOutput, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: enum.Slice(awstypes.DomainStatusAvailable, awstypes.DomainStatusDeleting),
+		Target:  []string{},
+		Refresh: statusDomain(ctx, conn, id),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if out, ok := outputRaw.(*datazone.GetDomainOutput); ok {
+		return out, err
+	}
+
+	return nil, err
+}
+
+func statusDomain(ctx context.Context, conn *datazone.Client, id string) retry.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		out, err := findDomainByID(ctx, conn, id)
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return out, string(out.Status), nil
+	}
+}
+
+func findDomainByID(ctx context.Context, conn *datazone.Client, id string) (*datazone.GetDomainOutput, error) {
+	in := &datazone.GetDomainInput{
+		Identifier: aws.String(id),
+	}
+
+	out, err := conn.GetDomain(ctx, in)
+	if err != nil {
+		if isResourceMissing(err) {
+			return nil, &retry.NotFoundError{
+				LastError:   err,
+				LastRequest: in,
+			}
+		}
+
+		return nil, err
+	}
+
+	if out == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return out, nil
+}
+
+func flattenSingleSignOn(ctx context.Context, apiObject *awstypes.SingleSignOn) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	elemType := types.ObjectType{AttrTypes: singleSignOnAttrTypes}
+
+	if apiObject == nil {
+		return types.ListNull(elemType), diags
+	}
+
+	obj := map[string]attr.Value{
+		"type":            flex.StringValueToFramework(ctx, apiObject.Type),
+		"user_assignment": flex.StringValueToFramework(ctx, apiObject.UserAssignment),
+	}
+	objVal, d := types.ObjectValue(singleSignOnAttrTypes, obj)
+	diags.Append(d...)
+
+	listVal, d := types.ListValue(elemType, []attr.Value{objVal})
+	diags.Append(d...)
+
+	return listVal, diags
+}
+
+func expandSingleSignOn(tfList []singleSignOnModel) *awstypes.SingleSignOn {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	tfObj := tfList[0]
+	apiObject := &awstypes.SingleSignOn{}
+
+	if !tfObj.Type.IsNull() {
+		apiObject.Type = awstypes.AuthType(tfObj.Type.ValueString())
+	}
+
+	if !tfObj.UserAssignment.IsNull() {
+		apiObject.UserAssignment = awstypes.UserAssignment(tfObj.UserAssignment.ValueString())
+	}
+
+	return apiObject
+}
+
+type domainResourceModel struct {
+	ARN                 types.String   `tfsdk:"arn"`
+	Description         types.String   `tfsdk:"description"`
+	DomainExecutionRole fwtypes.ARN    `tfsdk:"domain_execution_role"`
+	ID                  types.String   `tfsdk:"id"`
+	KmsKeyIdentifier    fwtypes.ARN    `tfsdk:"kms_key_identifier"`
+	Name                types.String   `tfsdk:"name"`
+	PortalUrl           types.String   `tfsdk:"portal_url"`
+	SingleSignOn        types.List     `tfsdk:"single_sign_on"`
+	Tags                types.Map      `tfsdk:"tags"`
+	TagsAll             types.Map      `tfsdk:"tags_all"`
+	Timeouts            timeouts.Value `tfsdk:"timeouts"`
+}
+
+type singleSignOnModel struct {
+	Type           types.String `tfsdk:"type"`
+	UserAssignment types.String `tfsdk:"user_assignment"`
+}
+
+var singleSignOnAttrTypes = map[string]attr.Type{
+	"type":            types.StringType,
+	"user_assignment": types.StringType,
+}

--- a/internal/service/datazone/domain_test.go
+++ b/internal/service/datazone/domain_test.go
@@ -1,0 +1,443 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package datazone_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/datazone"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tfdatazone "github.com/hashicorp/terraform-provider-aws/internal/service/datazone"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccDataZoneDomain_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var domain datazone.GetDomainOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_datazone_domain.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DataZoneServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDomainDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "portal_url"),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately", "user"},
+			},
+		},
+	})
+}
+
+func TestAccDataZoneDomain_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var domain datazone.GetDomainOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_datazone_domain.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DataZoneServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDomainDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName, &domain),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfdatazone.ResourceDomain, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccDataZoneDomain_kms_key_identifier(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var domain datazone.GetDomainOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_datazone_domain.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DataZoneServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDomainDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainConfig_kms_key_identifier(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "kms_key_identifier"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately", "user"},
+			},
+		},
+	})
+}
+
+func TestAccDataZoneDomain_description(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var domain datazone.GetDomainOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_datazone_domain.test"
+	description := "This is a description"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DataZoneServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDomainDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainConfig_description(rName, description),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately", "user"},
+			},
+		},
+	})
+}
+
+func TestAccDataZoneDomain_single_sign_on(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var domain datazone.GetDomainOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_datazone_domain.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DataZoneServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDomainDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainConfig_single_sign_on(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// we do not set single_sign_on if it's the default value
+				ImportStateVerifyIgnore: []string{"single_sign_on"},
+			},
+		},
+	})
+}
+
+func TestAccDataZoneDomain_tags(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var domain datazone.GetDomainOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_datazone_domain.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DataZoneServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDomainDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainConfig_tags(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDomainConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccDomainConfig_tags(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDomainDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).DataZoneClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_datazone_domain" {
+				continue
+			}
+
+			_, err := conn.GetDomain(ctx, &datazone.GetDomainInput{
+				Identifier: aws.String(rs.Primary.ID),
+			})
+
+			if tfdatazone.IsResourceMissing(err) {
+				return nil
+			}
+
+			if err != nil {
+				return create.Error(names.DataZone, create.ErrActionCheckingDestroyed, tfdatazone.ResNameDomain, rs.Primary.ID, err)
+			}
+
+			return create.Error(names.DataZone, create.ErrActionCheckingDestroyed, tfdatazone.ResNameDomain, rs.Primary.ID, errors.New("not destroyed"))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckDomainExists(ctx context.Context, name string, domain *datazone.GetDomainOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.DataZone, create.ErrActionCheckingExistence, tfdatazone.ResNameDomain, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.DataZone, create.ErrActionCheckingExistence, tfdatazone.ResNameDomain, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).DataZoneClient(ctx)
+		resp, err := conn.GetDomain(ctx, &datazone.GetDomainInput{
+			Identifier: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return create.Error(names.DataZone, create.ErrActionCheckingExistence, tfdatazone.ResNameDomain, rs.Primary.ID, err)
+		}
+
+		*domain = *resp
+
+		return nil
+	}
+}
+
+func testAccPreCheck(ctx context.Context, t *testing.T) {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).DataZoneClient(ctx)
+
+	input := &datazone.ListDomainsInput{}
+	_, err := conn.ListDomains(ctx, input)
+
+	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func testAccDomainConfigDomainExecutionRole(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "domain_execution_role" {
+  name = %[1]q
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = ["sts:AssumeRole", "sts:TagSession"]
+        Effect = "Allow"
+        Principal = {
+          Service = "datazone.amazonaws.com"
+        }
+      },
+      {
+        Action = ["sts:AssumeRole", "sts:TagSession"]
+        Effect = "Allow"
+        Principal = {
+          Service = "cloudformation.amazonaws.com"
+        }
+      },
+    ]
+  })
+
+  inline_policy {
+    name = %[1]q
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Action = [
+            "datazone:*",
+            "ram:*",
+            "sso:*",
+            "kms:*",
+          ]
+          Effect   = "Allow"
+          Resource = "*"
+        },
+      ]
+    })
+  }
+}
+`, rName)
+}
+
+func testAccDomainConfig_basic(rName string) string {
+	return acctest.ConfigCompose(
+		testAccDomainConfigDomainExecutionRole(rName),
+		fmt.Sprintf(`
+resource "aws_datazone_domain" "test" {
+  name                  = %[1]q
+  domain_execution_role = aws_iam_role.domain_execution_role.arn
+}
+`, rName),
+	)
+}
+
+func testAccDomainConfig_kms_key_identifier(rName string) string {
+	return acctest.ConfigCompose(
+		testAccDomainConfigDomainExecutionRole(rName),
+		fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  deletion_window_in_days = 7
+}
+
+resource "aws_datazone_domain" "test" {
+  name                  = %[1]q
+  domain_execution_role = aws_iam_role.domain_execution_role.arn
+  kms_key_identifier    = aws_kms_key.test.arn
+}
+`, rName),
+	)
+}
+
+func testAccDomainConfig_description(rName, description string) string {
+	return acctest.ConfigCompose(
+		testAccDomainConfigDomainExecutionRole(rName),
+		fmt.Sprintf(`
+resource "aws_datazone_domain" "test" {
+  name                  = %[1]q
+  domain_execution_role = aws_iam_role.domain_execution_role.arn
+  description           = %[2]q
+}
+`, rName, description),
+	)
+}
+
+func testAccDomainConfig_single_sign_on(rName string) string {
+	return acctest.ConfigCompose(
+		testAccDomainConfigDomainExecutionRole(rName),
+		fmt.Sprintf(`
+resource "aws_datazone_domain" "test" {
+  name                  = %[1]q
+  domain_execution_role = aws_iam_role.domain_execution_role.arn
+  single_sign_on {
+    type = "DISABLED"
+  }
+}
+`, rName),
+	)
+}
+
+func testAccDomainConfig_tags(rName, tagKey, tagValue string) string {
+	return acctest.ConfigCompose(
+		testAccDomainConfigDomainExecutionRole(rName),
+		fmt.Sprintf(`
+resource "aws_datazone_domain" "test" {
+  name                  = %[1]q
+  domain_execution_role = aws_iam_role.domain_execution_role.arn
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey, tagValue),
+	)
+}
+
+func testAccDomainConfig_tags2(rName, tagKey, tagValue, tagKey2, tagValue2 string) string {
+	return acctest.ConfigCompose(
+		testAccDomainConfigDomainExecutionRole(rName),
+		fmt.Sprintf(`
+resource "aws_datazone_domain" "test" {
+  name                  = %[1]q
+  domain_execution_role = aws_iam_role.domain_execution_role.arn
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey, tagValue, tagKey2, tagValue2),
+	)
+}

--- a/internal/service/datazone/environment_blueprint_configuration.go
+++ b/internal/service/datazone/environment_blueprint_configuration.go
@@ -1,0 +1,342 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package datazone
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/datazone"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource(name="Environment Blueprint Configuration")
+func newResourceEnvironmentBlueprintConfiguration(_ context.Context) (resource.ResourceWithConfigure, error) {
+	r := &resourceEnvironmentBlueprintConfiguration{}
+	return r, nil
+}
+
+const (
+	ResNameEnvironmentBlueprintConfiguration = "Environment Blueprint Configuration"
+)
+
+type resourceEnvironmentBlueprintConfiguration struct {
+	framework.ResourceWithConfigure
+}
+
+func (r *resourceEnvironmentBlueprintConfiguration) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "aws_datazone_environment_blueprint_configuration"
+}
+
+func (r *resourceEnvironmentBlueprintConfiguration) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"domain_id": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"enabled_regions": schema.ListAttribute{
+				ElementType: types.StringType,
+				Required:    true,
+			},
+			"environment_blueprint_id": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"manage_access_role_arn": schema.StringAttribute{
+				CustomType: fwtypes.ARNType,
+				Optional:   true,
+			},
+			"provisioning_role_arn": schema.StringAttribute{
+				CustomType: fwtypes.ARNType,
+				Optional:   true,
+			},
+			"regional_parameters": schema.MapAttribute{
+				Optional: true,
+				ElementType: types.MapType{
+					ElemType: types.StringType,
+				},
+			},
+		},
+	}
+}
+
+func (r *resourceEnvironmentBlueprintConfiguration) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().DataZoneClient(ctx)
+
+	var plan environmentBlueprintConfigurationResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := &datazone.PutEnvironmentBlueprintConfigurationInput{
+		DomainIdentifier:               aws.String(plan.DomainId.ValueString()),
+		EnabledRegions:                 flex.ExpandFrameworkStringValueList(ctx, plan.EnabledRegions),
+		EnvironmentBlueprintIdentifier: aws.String(plan.EnvironmentBlueprintId.ValueString()),
+	}
+
+	if !plan.ManageAccessRoleArn.IsNull() {
+		in.ManageAccessRoleArn = aws.String(plan.ManageAccessRoleArn.ValueString())
+	}
+
+	if !plan.ProvisioningRoleArn.IsNull() {
+		in.ProvisioningRoleArn = aws.String(plan.ProvisioningRoleArn.ValueString())
+	}
+
+	if !plan.RegionalParameters.IsNull() {
+		var tfMap map[string]map[string]string
+		resp.Diagnostics.Append(plan.RegionalParameters.ElementsAs(ctx, &tfMap, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		in.RegionalParameters = tfMap
+	}
+
+	out, err := conn.PutEnvironmentBlueprintConfiguration(ctx, in)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.DataZone, create.ErrActionCreating, ResNameEnvironmentBlueprintConfiguration, plan.EnvironmentBlueprintId.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	if out == nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.DataZone, create.ErrActionCreating, ResNameEnvironmentBlueprintConfiguration, plan.EnvironmentBlueprintId.String(), nil),
+			errors.New("empty output").Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *resourceEnvironmentBlueprintConfiguration) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().DataZoneClient(ctx)
+
+	var state environmentBlueprintConfigurationResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := findEnvironmentBlueprintConfigurationByIDs(ctx, conn, state.DomainId.ValueString(), state.EnvironmentBlueprintId.ValueString())
+	if tfresource.NotFound(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.DataZone, create.ErrActionSetting, ResNameEnvironmentBlueprintConfiguration, state.EnvironmentBlueprintId.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	state.DomainId = flex.StringToFramework(ctx, out.DomainId)
+	state.EnabledRegions = flattenEnabledRegions(ctx, out.EnabledRegions)
+	state.EnvironmentBlueprintId = flex.StringToFramework(ctx, out.EnvironmentBlueprintId)
+	state.ManageAccessRoleArn = flex.StringToFrameworkARN(ctx, out.ManageAccessRoleArn)
+	state.ProvisioningRoleArn = flex.StringToFrameworkARN(ctx, out.ProvisioningRoleArn)
+
+	regionalParameters, d := flattenRegionalParameters(ctx, &out.RegionalParameters)
+	resp.Diagnostics.Append(d...)
+	state.RegionalParameters = regionalParameters
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *resourceEnvironmentBlueprintConfiguration) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	conn := r.Meta().DataZoneClient(ctx)
+
+	var plan, state environmentBlueprintConfigurationResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !plan.EnabledRegions.Equal(state.EnabledRegions) ||
+		!plan.ManageAccessRoleArn.Equal(state.ManageAccessRoleArn) ||
+		!plan.ProvisioningRoleArn.Equal(state.ProvisioningRoleArn) ||
+		!plan.RegionalParameters.Equal(state.RegionalParameters) {
+		in := &datazone.PutEnvironmentBlueprintConfigurationInput{
+			DomainIdentifier:               aws.String(plan.DomainId.ValueString()),
+			EnabledRegions:                 flex.ExpandFrameworkStringValueList(ctx, plan.EnabledRegions),
+			EnvironmentBlueprintIdentifier: aws.String(plan.EnvironmentBlueprintId.ValueString()),
+		}
+
+		if !plan.ManageAccessRoleArn.IsNull() {
+			in.ManageAccessRoleArn = aws.String(plan.ManageAccessRoleArn.ValueString())
+		}
+
+		if !plan.ProvisioningRoleArn.IsNull() {
+			in.ProvisioningRoleArn = aws.String(plan.ProvisioningRoleArn.ValueString())
+		}
+
+		if !plan.RegionalParameters.IsNull() {
+			var tfMap map[string]map[string]string
+			resp.Diagnostics.Append(plan.RegionalParameters.ElementsAs(ctx, &tfMap, false)...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+
+			in.RegionalParameters = tfMap
+		}
+
+		out, err := conn.PutEnvironmentBlueprintConfiguration(ctx, in)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.DataZone, create.ErrActionUpdating, ResNameEnvironmentBlueprintConfiguration, plan.EnvironmentBlueprintId.String(), err),
+				err.Error(),
+			)
+			return
+		}
+		if out == nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.DataZone, create.ErrActionUpdating, ResNameEnvironmentBlueprintConfiguration, plan.EnvironmentBlueprintId.String(), nil),
+				errors.New("empty output").Error(),
+			)
+			return
+		}
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *resourceEnvironmentBlueprintConfiguration) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	conn := r.Meta().DataZoneClient(ctx)
+
+	var state environmentBlueprintConfigurationResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := &datazone.DeleteEnvironmentBlueprintConfigurationInput{
+		DomainIdentifier:               aws.String(state.DomainId.ValueString()),
+		EnvironmentBlueprintIdentifier: aws.String(state.EnvironmentBlueprintId.ValueString()),
+	}
+
+	_, err := conn.DeleteEnvironmentBlueprintConfiguration(ctx, in)
+	if err != nil {
+		if isResourceMissing(err) {
+			return
+		}
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.DataZone, create.ErrActionDeleting, ResNameEnvironmentBlueprintConfiguration, state.EnvironmentBlueprintId.String(), err),
+			err.Error(),
+		)
+		return
+	}
+}
+
+func (r *resourceEnvironmentBlueprintConfiguration) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	parts := strings.Split(req.ID, "/")
+	if len(parts) != 2 {
+		resp.Diagnostics.AddError("Resource Import Invalid ID", fmt.Sprintf("Wrong format for import ID (%s), use: 'domain-id/environment-blueprint-id'", req.ID))
+		return
+	}
+	domainId := parts[0]
+	environmentBlueprintId := parts[1]
+
+	environmentBlueprintConfiguration, err := findEnvironmentBlueprintConfigurationByIDs(ctx, r.Meta().DataZoneClient(ctx), domainId, environmentBlueprintId)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Importing Resource",
+			err.Error(),
+		)
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("domain_id"), aws.ToString(environmentBlueprintConfiguration.DomainId))...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("environment_blueprint_id"), aws.ToString(environmentBlueprintConfiguration.EnvironmentBlueprintId))...)
+}
+
+func findEnvironmentBlueprintConfigurationByIDs(ctx context.Context, conn *datazone.Client, domainId, environmentBlueprintId string) (*datazone.GetEnvironmentBlueprintConfigurationOutput, error) {
+	in := &datazone.GetEnvironmentBlueprintConfigurationInput{
+		DomainIdentifier:               aws.String(domainId),
+		EnvironmentBlueprintIdentifier: aws.String(environmentBlueprintId),
+	}
+
+	out, err := conn.GetEnvironmentBlueprintConfiguration(ctx, in)
+	if err != nil {
+		if isResourceMissing(err) {
+			return nil, &retry.NotFoundError{
+				LastError:   err,
+				LastRequest: in,
+			}
+		}
+
+		return nil, err
+	}
+
+	if out == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return out, nil
+}
+
+func flattenRegionalParameters(ctx context.Context, apiObject *map[string]map[string]string) (types.Map, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	elemType := types.MapType{ElemType: types.StringType}
+
+	if apiObject == nil || len(*apiObject) == 0 {
+		return types.MapNull(elemType), diags
+	}
+
+	elements := map[string]types.Map{}
+
+	for k, v := range *apiObject {
+		elements[k] = flex.FlattenFrameworkStringValueMap(ctx, v)
+	}
+
+	mapVal, d := types.MapValueFrom(ctx, types.MapType{ElemType: types.StringType}, elements)
+	diags.Append(d...)
+
+	return mapVal, diags
+}
+
+func flattenEnabledRegions(ctx context.Context, apiList []string) basetypes.ListValue {
+	// When the list returned from the api is empty, return empty list rather than the
+	// default flatten result of null for empty lists.
+	if len(apiList) == 0 {
+		return types.ListValueMust(types.StringType, []attr.Value{})
+	}
+	return flex.FlattenFrameworkStringValueList(ctx, apiList)
+}
+
+type environmentBlueprintConfigurationResourceModel struct {
+	DomainId               types.String `tfsdk:"domain_id"`
+	EnabledRegions         types.List   `tfsdk:"enabled_regions"`
+	EnvironmentBlueprintId types.String `tfsdk:"environment_blueprint_id"`
+	ManageAccessRoleArn    fwtypes.ARN  `tfsdk:"manage_access_role_arn"`
+	ProvisioningRoleArn    fwtypes.ARN  `tfsdk:"provisioning_role_arn"`
+	RegionalParameters     types.Map    `tfsdk:"regional_parameters"`
+}

--- a/internal/service/datazone/environment_blueprint_configuration_test.go
+++ b/internal/service/datazone/environment_blueprint_configuration_test.go
@@ -1,0 +1,384 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package datazone_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/datazone"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tfdatazone "github.com/hashicorp/terraform-provider-aws/internal/service/datazone"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccDataZoneEnvironmentBlueprintConfiguration_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var environmentblueprintconfiguration datazone.GetEnvironmentBlueprintConfigurationOutput
+	domainName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_datazone_environment_blueprint_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DataZoneServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEnvironmentBlueprintConfigurationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnvironmentBlueprintConfigurationConfig_basic(domainName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEnvironmentBlueprintConfigurationExists(ctx, resourceName, &environmentblueprintconfiguration),
+					resource.TestCheckResourceAttrSet(resourceName, "environment_blueprint_id"),
+					resource.TestCheckResourceAttr(resourceName, "enabled_regions.#", "0"),
+				),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateIdFunc:                    testAccEnvironmentBlueprintConfigurationImportStateIdFunc(resourceName),
+				ImportStateVerifyIdentifierAttribute: "environment_blueprint_id",
+			},
+		},
+	})
+}
+
+func TestAccDataZoneEnvironmentBlueprintConfiguration_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var environmentblueprintconfiguration datazone.GetEnvironmentBlueprintConfigurationOutput
+	domainName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_datazone_environment_blueprint_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DataZoneServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEnvironmentBlueprintConfigurationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnvironmentBlueprintConfigurationConfig_basic(domainName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEnvironmentBlueprintConfigurationExists(ctx, resourceName, &environmentblueprintconfiguration),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfdatazone.ResourceEnvironmentBlueprintConfiguration, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccDataZoneEnvironmentBlueprintConfiguration_enabled_regions(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var environmentblueprintconfiguration datazone.GetEnvironmentBlueprintConfigurationOutput
+	domainName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_datazone_environment_blueprint_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DataZoneServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEnvironmentBlueprintConfigurationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnvironmentBlueprintConfigurationConfig_enabled_regions(domainName, names.USEast1RegionID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEnvironmentBlueprintConfigurationExists(ctx, resourceName, &environmentblueprintconfiguration),
+					resource.TestCheckResourceAttrSet(resourceName, "environment_blueprint_id"),
+					resource.TestCheckResourceAttr(resourceName, "enabled_regions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "enabled_regions.0", names.USEast1RegionID),
+				),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateIdFunc:                    testAccEnvironmentBlueprintConfigurationImportStateIdFunc(resourceName),
+				ImportStateVerifyIdentifierAttribute: "environment_blueprint_id",
+			},
+			{
+				Config: testAccEnvironmentBlueprintConfigurationConfig_enabled_regions(domainName, names.APSoutheast2RegionID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEnvironmentBlueprintConfigurationExists(ctx, resourceName, &environmentblueprintconfiguration),
+					resource.TestCheckResourceAttrSet(resourceName, "environment_blueprint_id"),
+					resource.TestCheckResourceAttr(resourceName, "enabled_regions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "enabled_regions.0", names.APSoutheast2RegionID),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckEnvironmentBlueprintConfigurationDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).DataZoneClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_datazone_environment_blueprint_configuration" {
+				continue
+			}
+
+			_, err := conn.GetEnvironmentBlueprintConfiguration(ctx, &datazone.GetEnvironmentBlueprintConfigurationInput{
+				DomainIdentifier:               aws.String(rs.Primary.Attributes["domain_id"]),
+				EnvironmentBlueprintIdentifier: aws.String(rs.Primary.Attributes["environment_blueprint_id"]),
+			})
+			if tfdatazone.IsResourceMissing(err) {
+				return nil
+			}
+			if err != nil {
+				return create.Error(names.DataZone, create.ErrActionCheckingDestroyed, tfdatazone.ResNameEnvironmentBlueprintConfiguration, rs.Primary.ID, err)
+			}
+
+			return create.Error(names.DataZone, create.ErrActionCheckingDestroyed, tfdatazone.ResNameEnvironmentBlueprintConfiguration, rs.Primary.ID, errors.New("not destroyed"))
+		}
+
+		return nil
+	}
+}
+
+func TestAccDataZoneEnvironmentBlueprintConfiguration_manage_access_role_arn(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var environmentblueprintconfiguration datazone.GetEnvironmentBlueprintConfigurationOutput
+	domainName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_datazone_environment_blueprint_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DataZoneServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEnvironmentBlueprintConfigurationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnvironmentBlueprintConfigurationConfig_manage_access_role_arn(domainName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEnvironmentBlueprintConfigurationExists(ctx, resourceName, &environmentblueprintconfiguration),
+					resource.TestCheckResourceAttrSet(resourceName, "environment_blueprint_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "manage_access_role_arn"),
+				),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateIdFunc:                    testAccEnvironmentBlueprintConfigurationImportStateIdFunc(resourceName),
+				ImportStateVerifyIdentifierAttribute: "environment_blueprint_id",
+			},
+		},
+	})
+}
+
+func TestAccDataZoneEnvironmentBlueprintConfiguration_provisioning_role_arn(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var environmentblueprintconfiguration datazone.GetEnvironmentBlueprintConfigurationOutput
+	domainName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_datazone_environment_blueprint_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DataZoneServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEnvironmentBlueprintConfigurationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnvironmentBlueprintConfigurationConfig_provisioning_role_arn(domainName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEnvironmentBlueprintConfigurationExists(ctx, resourceName, &environmentblueprintconfiguration),
+					resource.TestCheckResourceAttrSet(resourceName, "environment_blueprint_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "provisioning_role_arn"),
+				),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateIdFunc:                    testAccEnvironmentBlueprintConfigurationImportStateIdFunc(resourceName),
+				ImportStateVerifyIdentifierAttribute: "environment_blueprint_id",
+			},
+		},
+	})
+}
+
+func TestAccDataZoneEnvironmentBlueprintConfiguration_regional_parameters(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var environmentblueprintconfiguration datazone.GetEnvironmentBlueprintConfigurationOutput
+	domainName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_datazone_environment_blueprint_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DataZoneServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEnvironmentBlueprintConfigurationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnvironmentBlueprintConfigurationConfig_regional_parameters(domainName, names.USWest2RegionID, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEnvironmentBlueprintConfigurationExists(ctx, resourceName, &environmentblueprintconfiguration),
+					resource.TestCheckResourceAttrSet(resourceName, "environment_blueprint_id"),
+					resource.TestCheckResourceAttr(resourceName, "regional_parameters.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, fmt.Sprintf("regional_parameters.%s.%%", names.USWest2RegionID), "1"),
+					resource.TestCheckResourceAttr(resourceName, fmt.Sprintf("regional_parameters.%s.key1", names.USWest2RegionID), "value1"),
+				),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateIdFunc:                    testAccEnvironmentBlueprintConfigurationImportStateIdFunc(resourceName),
+				ImportStateVerifyIdentifierAttribute: "environment_blueprint_id",
+			},
+			{
+				Config: testAccEnvironmentBlueprintConfigurationConfig_regional_parameters(domainName, names.USWest2RegionID, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEnvironmentBlueprintConfigurationExists(ctx, resourceName, &environmentblueprintconfiguration),
+					resource.TestCheckResourceAttrSet(resourceName, "environment_blueprint_id"),
+					resource.TestCheckResourceAttr(resourceName, "regional_parameters.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, fmt.Sprintf("regional_parameters.%s.%%", names.USWest2RegionID), "1"),
+					resource.TestCheckResourceAttr(resourceName, fmt.Sprintf("regional_parameters.%s.key2", names.USWest2RegionID), "value2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckEnvironmentBlueprintConfigurationExists(ctx context.Context, name string, environmentblueprintconfiguration *datazone.GetEnvironmentBlueprintConfigurationOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.DataZone, create.ErrActionCheckingExistence, tfdatazone.ResNameEnvironmentBlueprintConfiguration, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.DataZone, create.ErrActionCheckingExistence, tfdatazone.ResNameEnvironmentBlueprintConfiguration, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).DataZoneClient(ctx)
+		resp, err := conn.GetEnvironmentBlueprintConfiguration(ctx, &datazone.GetEnvironmentBlueprintConfigurationInput{
+			DomainIdentifier:               aws.String(rs.Primary.Attributes["domain_id"]),
+			EnvironmentBlueprintIdentifier: aws.String(rs.Primary.Attributes["environment_blueprint_id"]),
+		})
+
+		if err != nil {
+			return create.Error(names.DataZone, create.ErrActionCheckingExistence, tfdatazone.ResNameEnvironmentBlueprintConfiguration, rs.Primary.ID, err)
+		}
+
+		*environmentblueprintconfiguration = *resp
+
+		return nil
+	}
+}
+
+func testAccEnvironmentBlueprintConfigurationImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["domain_id"], rs.Primary.Attributes["environment_blueprint_id"]), nil
+	}
+}
+
+func testAccEnvironmentBlueprintConfigurationConfig_basic(domainName string) string {
+	return acctest.ConfigCompose(
+		testAccEnvironmentBlueprintDataSourceConfig_basic(domainName),
+		`
+resource "aws_datazone_environment_blueprint_configuration" "test" {
+  domain_id                = aws_datazone_domain.test.id
+  environment_blueprint_id = data.aws_datazone_environment_blueprint.test.id
+  enabled_regions          = []
+}
+`,
+	)
+}
+
+func testAccEnvironmentBlueprintConfigurationConfig_enabled_regions(domainName, enabledRegion string) string {
+	return acctest.ConfigCompose(
+		testAccEnvironmentBlueprintDataSourceConfig_basic(domainName),
+		fmt.Sprintf(`
+resource "aws_datazone_environment_blueprint_configuration" "test" {
+  domain_id                = aws_datazone_domain.test.id
+  environment_blueprint_id = data.aws_datazone_environment_blueprint.test.id
+  enabled_regions          = [%[1]q]
+}
+`, enabledRegion),
+	)
+}
+
+func testAccEnvironmentBlueprintConfigurationConfig_manage_access_role_arn(domainName string) string {
+	return acctest.ConfigCompose(
+		testAccEnvironmentBlueprintDataSourceConfig_basic(domainName),
+		`
+resource "aws_datazone_environment_blueprint_configuration" "test" {
+  domain_id                = aws_datazone_domain.test.id
+  environment_blueprint_id = data.aws_datazone_environment_blueprint.test.id
+  manage_access_role_arn   = aws_iam_role.domain_execution_role.arn
+  enabled_regions          = []
+}
+`,
+	)
+}
+
+func testAccEnvironmentBlueprintConfigurationConfig_provisioning_role_arn(domainName string) string {
+	return acctest.ConfigCompose(
+		testAccEnvironmentBlueprintDataSourceConfig_basic(domainName),
+		`
+resource "aws_datazone_environment_blueprint_configuration" "test" {
+  domain_id                = aws_datazone_domain.test.id
+  environment_blueprint_id = data.aws_datazone_environment_blueprint.test.id
+  provisioning_role_arn    = aws_iam_role.domain_execution_role.arn
+  enabled_regions          = []
+}
+`,
+	)
+}
+
+func testAccEnvironmentBlueprintConfigurationConfig_regional_parameters(domainName, region, key, value string) string {
+	return acctest.ConfigCompose(
+		testAccEnvironmentBlueprintDataSourceConfig_basic(domainName),
+		fmt.Sprintf(`
+resource "aws_datazone_environment_blueprint_configuration" "test" {
+  domain_id                = aws_datazone_domain.test.id
+  environment_blueprint_id = data.aws_datazone_environment_blueprint.test.id
+  enabled_regions          = []
+  regional_parameters = {
+    %[1]q = {
+      %[2]q = %[3]q
+    }
+  }
+}
+`, region, key, value),
+	)
+}

--- a/internal/service/datazone/environment_blueprint_data_source.go
+++ b/internal/service/datazone/environment_blueprint_data_source.go
@@ -1,0 +1,132 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package datazone
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/datazone"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/datazone/types"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource(name="Environment Blueprint")
+func newDataSourceEnvironmentBlueprint(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &dataSourceEnvironmentBlueprint{}, nil
+}
+
+const (
+	DSNameEnvironmentBlueprint = "Environment Blueprint Data Source"
+)
+
+type dataSourceEnvironmentBlueprint struct {
+	framework.DataSourceWithConfigure
+}
+
+func (d *dataSourceEnvironmentBlueprint) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) { // nosemgrep:ci.meta-in-func-name
+	resp.TypeName = "aws_datazone_environment_blueprint"
+}
+
+func (d *dataSourceEnvironmentBlueprint) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"blueprint_provider": schema.StringAttribute{
+				Computed: true,
+			},
+			"description": schema.StringAttribute{
+				Computed: true,
+			},
+			"domain_id": schema.StringAttribute{
+				Required: true,
+			},
+			"id": framework.IDAttribute(),
+			"managed": schema.BoolAttribute{
+				Required: true,
+			},
+			"name": schema.StringAttribute{
+				Required: true,
+			},
+		},
+	}
+}
+
+func (d *dataSourceEnvironmentBlueprint) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	conn := d.Meta().DataZoneClient(ctx)
+
+	var data environmentBlueprintDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := findEnvironmentBlueprintByName(ctx, conn, data.DomainId.ValueString(), data.Name.ValueString(), data.Managed.ValueBool())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.DataZone, create.ErrActionReading, DSNameEnvironmentBlueprint, data.Name.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	data.BlueprintProvider = flex.StringToFramework(ctx, out.Provider)
+	data.Description = flex.StringToFramework(ctx, out.Description)
+	data.ID = flex.StringToFramework(ctx, out.Id)
+	data.Name = flex.StringToFramework(ctx, out.Name)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func findEnvironmentBlueprintByName(ctx context.Context, conn *datazone.Client, domainId, name string, managed bool) (*awstypes.EnvironmentBlueprintSummary, error) {
+	return _findEnvironmentBlueprintByName(ctx, conn, domainId, name, managed, nil)
+}
+
+func _findEnvironmentBlueprintByName(ctx context.Context, conn *datazone.Client, domainId, name string, managed bool, nextToken *string) (*awstypes.EnvironmentBlueprintSummary, error) {
+	in := &datazone.ListEnvironmentBlueprintsInput{
+		DomainIdentifier: aws.String(domainId),
+		Managed:          aws.Bool(managed),
+	}
+
+	if nextToken != nil {
+		in.NextToken = aws.String(*nextToken)
+	}
+
+	out, err := conn.ListEnvironmentBlueprints(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+
+	if out == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	for i := range out.Items {
+		blueprint := out.Items[i]
+		if name == aws.ToString(blueprint.Name) {
+			return &blueprint, nil
+		}
+	}
+
+	if out.NextToken == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return _findEnvironmentBlueprintByName(ctx, conn, domainId, name, managed, out.NextToken)
+}
+
+type environmentBlueprintDataSourceModel struct {
+	BlueprintProvider types.String `tfsdk:"blueprint_provider"`
+	Description       types.String `tfsdk:"description"`
+	DomainId          types.String `tfsdk:"domain_id"`
+	ID                types.String `tfsdk:"id"`
+	Managed           types.Bool   `tfsdk:"managed"`
+	Name              types.String `tfsdk:"name"`
+}

--- a/internal/service/datazone/environment_blueprint_data_source_test.go
+++ b/internal/service/datazone/environment_blueprint_data_source_test.go
@@ -1,0 +1,116 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package datazone_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/datazone"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tfdatazone "github.com/hashicorp/terraform-provider-aws/internal/service/datazone"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccDataZoneEnvironmentBlueprintDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var environmentblueprint datazone.GetEnvironmentBlueprintOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_datazone_environment_blueprint.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DataZoneServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEnvironmentBlueprintDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnvironmentBlueprintDataSourceConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEnvironmentBlueprintExists(ctx, dataSourceName, &environmentblueprint),
+					resource.TestCheckResourceAttrSet(dataSourceName, "id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "blueprint_provider"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckEnvironmentBlueprintExists(ctx context.Context, name string, environmentblueprint *datazone.GetEnvironmentBlueprintOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.DataZone, create.ErrActionCheckingExistence, tfdatazone.DSNameEnvironmentBlueprint, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.DataZone, create.ErrActionCheckingExistence, tfdatazone.DSNameEnvironmentBlueprint, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).DataZoneClient(ctx)
+		resp, err := conn.GetEnvironmentBlueprint(ctx, &datazone.GetEnvironmentBlueprintInput{
+			DomainIdentifier: aws.String(rs.Primary.Attributes["domain_id"]),
+			Identifier:       aws.String(rs.Primary.Attributes["id"]),
+		})
+
+		if err != nil {
+			return create.Error(names.DataZone, create.ErrActionCheckingExistence, tfdatazone.DSNameEnvironmentBlueprint, rs.Primary.ID, err)
+		}
+
+		*environmentblueprint = *resp
+
+		return nil
+	}
+}
+
+func testAccCheckEnvironmentBlueprintDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).DataZoneClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_datazone_environment_blueprint" {
+				continue
+			}
+
+			_, err := conn.GetEnvironmentBlueprint(ctx, &datazone.GetEnvironmentBlueprintInput{
+				DomainIdentifier: aws.String(rs.Primary.Attributes["domain_id"]),
+				Identifier:       aws.String(rs.Primary.Attributes["id"]),
+			})
+			if tfdatazone.IsResourceMissing(err) {
+				return nil
+			}
+			if err != nil {
+				return create.Error(names.DataZone, create.ErrActionCheckingDestroyed, tfdatazone.ResNameEnvironmentBlueprintConfiguration, rs.Primary.ID, err)
+			}
+
+			return create.Error(names.DataZone, create.ErrActionCheckingDestroyed, tfdatazone.ResNameEnvironmentBlueprintConfiguration, rs.Primary.ID, errors.New("not destroyed"))
+		}
+
+		return nil
+	}
+}
+
+func testAccEnvironmentBlueprintDataSourceConfig_basic(rName string) string {
+	return acctest.ConfigCompose(
+		testAccDomainConfig_basic(rName),
+		`
+data "aws_datazone_environment_blueprint" "test" {
+  domain_id = aws_datazone_domain.test.id
+  name      = "DefaultDataLake"
+  managed   = true
+}
+`,
+	)
+}

--- a/internal/service/datazone/errors.go
+++ b/internal/service/datazone/errors.go
@@ -1,0 +1,19 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package datazone
+
+import (
+	awstypes "github.com/aws/aws-sdk-go-v2/service/datazone/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+)
+
+const (
+	ErrorCodeAccessDenied = "AccessDeniedException"
+)
+
+func isResourceMissing(err error) bool {
+	// DataZone returns a 403 when the domain does not exist
+	// AccessDeniedException: User is not permitted to perform operation: GetDomain
+	return errs.IsA[*awstypes.ResourceNotFoundException](err) || errs.IsAErrorMessageContains[*awstypes.AccessDeniedException](err, "is not permitted to perform")
+}

--- a/internal/service/datazone/exports_test.go
+++ b/internal/service/datazone/exports_test.go
@@ -1,0 +1,11 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package datazone
+
+// Exports for use in tests only.
+var (
+	ResourceDomain                            = newResourceDomain
+	ResourceEnvironmentBlueprintConfiguration = newResourceEnvironmentBlueprintConfiguration
+	IsResourceMissing                         = isResourceMissing
+)

--- a/internal/service/datazone/service_package_gen.go
+++ b/internal/service/datazone/service_package_gen.go
@@ -15,11 +15,28 @@ import (
 type servicePackage struct{}
 
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.ServicePackageFrameworkDataSource {
-	return []*types.ServicePackageFrameworkDataSource{}
+	return []*types.ServicePackageFrameworkDataSource{
+		{
+			Factory: newDataSourceEnvironmentBlueprint,
+			Name:    "Environment Blueprint",
+		},
+	}
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.ServicePackageFrameworkResource {
-	return []*types.ServicePackageFrameworkResource{}
+	return []*types.ServicePackageFrameworkResource{
+		{
+			Factory: newResourceDomain,
+			Name:    "Domain",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
+		},
+		{
+			Factory: newResourceEnvironmentBlueprintConfiguration,
+			Name:    "Environment Blueprint Configuration",
+		},
+	}
 }
 
 func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePackageSDKDataSource {

--- a/website/docs/d/datazone_environment_blueprint.html.markdown
+++ b/website/docs/d/datazone_environment_blueprint.html.markdown
@@ -1,0 +1,44 @@
+---
+subcategory: "DataZone"
+layout: "aws"
+page_title: "AWS: aws_datazone_environment_blueprint"
+description: |-
+  Terraform data source for managing an AWS DataZone Environment Blueprint.
+---
+
+# Data Source: aws_datazone_environment_blueprint
+
+Terraform data source for managing an AWS DataZone Environment Blueprint.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_datazone_domain" "example" {
+  name                  = "example_domain"
+  domain_execution_role = aws_iam_role.domain_execution_role.arn
+}
+
+data "aws_datazone_environment_blueprint" "example" {
+  domain_id = aws_datazone_domain.example.id
+  name      = "DefaultDataLake"
+  managed   = true
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `domain_id` - (Required) ID of the domain.
+* `name` - (Required) Name of the blueprint.
+* `managed` (Required) Whether the blueprint is managed by Amazon DataZone.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `id` - ID of the environment blueprint
+* `description` - Description of the blueprint
+* `blueprint_provider` - Provider of the blueprint

--- a/website/docs/r/datazone_domain.html.markdown
+++ b/website/docs/r/datazone_domain.html.markdown
@@ -1,0 +1,111 @@
+---
+subcategory: "DataZone"
+layout: "aws"
+page_title: "AWS: aws_datazone_domain"
+description: |-
+  Terraform resource for managing an AWS DataZone Domain.
+---
+
+# Resource: aws_datazone_domain
+
+Terraform resource for managing an AWS DataZone Domain.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_iam_role" "domain_execution_role" {
+  name = "my_domain_execution_role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = ["sts:AssumeRole", "sts:TagSession"]
+        Effect = "Allow"
+        Principal = {
+          Service = "datazone.amazonaws.com"
+        }
+      },
+      {
+        Action = ["sts:AssumeRole", "sts:TagSession"]
+        Effect = "Allow"
+        Principal = {
+          Service = "cloudformation.amazonaws.com"
+        }
+      },
+    ]
+  })
+
+  inline_policy {
+    name = "domain_execution_policy"
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          # Consider scoping down
+          Action = [
+            "datazone:*",
+            "ram:*",
+            "sso:*",
+            "kms:*",
+          ]
+          Effect   = "Allow"
+          Resource = "*"
+        },
+      ]
+    })
+  }
+}
+
+resource "aws_datazone_domain" "example" {
+  name                  = "example"
+  domain_execution_role = aws_iam_role.domain_execution_role.arn
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `name` - (Required) Name of the Domain.
+* `domain_execution_role` - (Required) ARN of the role used by DataZone to configure the Domain.
+
+The following arguments are optional:
+
+* `description` - (Optional) Description of the Domain.
+* `kms_key_identifier` - (Optional) ARN of the KMS key used to encrypt the Amazon DataZone domain, metadata and reporting data.
+* `single_sign_on` - (Optional) Single sign on options, used to [enable AWS IAM Identity Center](https://docs.aws.amazon.com/datazone/latest/userguide/enable-IAM-identity-center-for-datazone.html) for DataZone.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `arn` - ARN of the Domain.
+* `id` - ID of the Domain.
+* `portal_url` - URL of the data portal for the Domain.
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
+
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+* `create` - (Default `10m`)
+* `delete` - (Default `10m`)
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import DataZone Domain using the `domain_id`. For example:
+
+```terraform
+import {
+  to = aws_datazone_domain.example
+  id = "domain-id-12345678"
+}
+```
+
+Using `terraform import`, import DataZone Domain using the `domain_id`. For example:
+
+```console
+% terraform import aws_datazone_domain.example domain-id-12345678
+```

--- a/website/docs/r/datazone_environment_blueprint_configuration.html.markdown
+++ b/website/docs/r/datazone_environment_blueprint_configuration.html.markdown
@@ -1,0 +1,75 @@
+---
+subcategory: "DataZone"
+layout: "aws"
+page_title: "AWS: aws_datazone_environment_blueprint_configuration"
+description: |-
+  Terraform resource for managing an AWS DataZone Environment Blueprint Configuration.
+---
+
+# Resource: aws_datazone_environment_blueprint_configuration
+
+Terraform resource for managing an AWS DataZone Environment Blueprint Configuration.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_datazone_domain" "example" {
+  name                  = "example_domain"
+  domain_execution_role = aws_iam_role.domain_execution_role.arn
+}
+
+data "aws_datazone_environment_blueprint" "default_data_lake" {
+  domain_id = aws_datazone_domain.example.id
+  name      = "DefaultDataLake"
+  managed   = true
+}
+
+resource "aws_datazone_environment_blueprint_configuration" "example" {
+  domain_id                = aws_datazone_domain.example.id
+  environment_blueprint_id = data.aws_datazone_environment_blueprint.default_data_lake.id
+  enabled_regions          = ["us-east-1"]
+
+  regional_parameters = {
+    us-east-1 = {
+      S3Location = "s3://my-amazon-datazone-bucket"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `domain_id` - (Required) ID of the Domain.
+* `environment_blueprint_id` - (Required) ID of the Environment Blueprint
+* `enabled_regions` (Required) - Regions in which the blueprint is enabled
+
+The following arguments are optional:
+
+* `manage_access_role_arn` - (Optional) ARN of the manage access role with which this blueprint is created.
+* `provisioning_role_arn` - (Optional) ARN of the provisioning role with which this blueprint is created.
+* `regional_parameters` - (Optional) Parameters for each region in which the blueprint is enabled
+
+## Attribute Reference
+
+This resource exports no additional attributes.
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import DataZone Environment Blueprint Configuration using the `domain_id` and `environment_blueprint_id`, separated by a `/`. For example:
+
+```terraform
+import {
+  to = aws_datazone_environment_blueprint_configuration.example
+  id = "domain-id-12345/environment-blueprint-id-54321"
+}
+```
+
+Using `terraform import`, import DataZone Environment Blueprint Configuration using the `domain_id` and `environment_blueprint_id`, separated by a `/`. For example:
+
+```console
+% terraform import aws_datazone_environment_blueprint_configuration.example domain-id-12345/environment-blueprint-id-54321
+```


### PR DESCRIPTION
### Description
Add resources for DataZone:

- Domain
- Environment Blueprint Configuration

Additionally add a data source for Environment Blueprints in order to retrieve the IDs of managed blueprints without hardcoding.

### Relations

Relates #33792

### References

https://docs.aws.amazon.com/datazone/latest/userguide/datazone-concepts.html

### Output from Acceptance Testing

```console
$ AWS_REGION=ap-southeast-2 AWS_PROFILE=default make testacc TESTS=TestAccDataZone PKG=datazone
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/datazone/... -v -count 1 -parallel 20 -run='TestAccDataZone'  -timeout 360m
=== RUN   TestAccDataZoneDomain_basic
=== PAUSE TestAccDataZoneDomain_basic
=== RUN   TestAccDataZoneDomain_disappears
=== PAUSE TestAccDataZoneDomain_disappears
=== RUN   TestAccDataZoneDomain_kms_key_identifier
=== PAUSE TestAccDataZoneDomain_kms_key_identifier
=== RUN   TestAccDataZoneDomain_description
=== PAUSE TestAccDataZoneDomain_description
=== RUN   TestAccDataZoneDomain_single_sign_on
=== PAUSE TestAccDataZoneDomain_single_sign_on
=== RUN   TestAccDataZoneDomain_tags
=== PAUSE TestAccDataZoneDomain_tags
=== RUN   TestAccDataZoneEnvironmentBlueprintConfiguration_basic
=== PAUSE TestAccDataZoneEnvironmentBlueprintConfiguration_basic
=== RUN   TestAccDataZoneEnvironmentBlueprintConfiguration_disappears
=== PAUSE TestAccDataZoneEnvironmentBlueprintConfiguration_disappears
=== RUN   TestAccDataZoneEnvironmentBlueprintConfiguration_enabled_regions
=== PAUSE TestAccDataZoneEnvironmentBlueprintConfiguration_enabled_regions
=== RUN   TestAccDataZoneEnvironmentBlueprintConfiguration_manage_access_role_arn
=== PAUSE TestAccDataZoneEnvironmentBlueprintConfiguration_manage_access_role_arn
=== RUN   TestAccDataZoneEnvironmentBlueprintConfiguration_provisioning_role_arn
=== PAUSE TestAccDataZoneEnvironmentBlueprintConfiguration_provisioning_role_arn
=== RUN   TestAccDataZoneEnvironmentBlueprintConfiguration_regional_parameters
=== PAUSE TestAccDataZoneEnvironmentBlueprintConfiguration_regional_parameters
=== RUN   TestAccDataZoneEnvironmentBlueprintDataSource_basic
=== PAUSE TestAccDataZoneEnvironmentBlueprintDataSource_basic
=== CONT  TestAccDataZoneDomain_basic
=== CONT  TestAccDataZoneEnvironmentBlueprintConfiguration_disappears
=== CONT  TestAccDataZoneDomain_single_sign_on
=== CONT  TestAccDataZoneDomain_kms_key_identifier
=== CONT  TestAccDataZoneEnvironmentBlueprintConfiguration_regional_parameters
=== CONT  TestAccDataZoneDomain_tags
=== CONT  TestAccDataZoneDomain_description
=== CONT  TestAccDataZoneEnvironmentBlueprintConfiguration_manage_access_role_arn
=== CONT  TestAccDataZoneEnvironmentBlueprintConfiguration_enabled_regions
=== CONT  TestAccDataZoneDomain_disappears
=== CONT  TestAccDataZoneEnvironmentBlueprintConfiguration_basic
=== CONT  TestAccDataZoneEnvironmentBlueprintConfiguration_provisioning_role_arn
=== CONT  TestAccDataZoneEnvironmentBlueprintDataSource_basic
--- PASS: TestAccDataZoneDomain_basic (137.87s)
--- PASS: TestAccDataZoneDomain_single_sign_on (139.36s)
--- PASS: TestAccDataZoneDomain_disappears (139.67s)
--- PASS: TestAccDataZoneDomain_description (141.29s)
--- PASS: TestAccDataZoneEnvironmentBlueprintDataSource_basic (164.53s)
--- PASS: TestAccDataZoneDomain_kms_key_identifier (171.80s)
--- PASS: TestAccDataZoneEnvironmentBlueprintConfiguration_disappears (207.23s)
--- PASS: TestAccDataZoneEnvironmentBlueprintConfiguration_basic (210.45s)
--- PASS: TestAccDataZoneEnvironmentBlueprintConfiguration_provisioning_role_arn (220.59s)
--- PASS: TestAccDataZoneEnvironmentBlueprintConfiguration_manage_access_role_arn (220.66s)
--- PASS: TestAccDataZoneDomain_tags (233.04s)
--- PASS: TestAccDataZoneEnvironmentBlueprintConfiguration_enabled_regions (269.25s)
--- PASS: TestAccDataZoneEnvironmentBlueprintConfiguration_regional_parameters (269.30s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/datazone   275.038s
```
