### PR TITLE
r/aws_secretsmanager_secret_version: shorten expected error message text

### DIFF
--- a/.changelog/36609.txt
+++ b/.changelog/36609.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_secretsmanager_secret_version: Fix to handle versions deleted out-of-band without raising an `InvalidRequestException`
+```

--- a/internal/service/secretsmanager/secret_version.go
+++ b/internal/service/secretsmanager/secret_version.go
@@ -270,8 +270,8 @@ func resourceSecretVersionDelete(ctx context.Context, d *schema.ResourceData, me
 			_, err := conn.UpdateSecretVersionStage(ctx, input)
 
 			if errs.IsA[*types.ResourceNotFoundException](err) ||
-				errs.IsAErrorMessageContains[*types.InvalidRequestException](err, "You can’t perform this operation on the secret because it was deleted") ||
-				errs.IsAErrorMessageContains[*types.InvalidRequestException](err, "You can't perform this operation on the secret because it was marked for deletion") {
+				errs.IsAErrorMessageContains[*types.InvalidRequestException](err, "because it was deleted") ||
+				errs.IsAErrorMessageContains[*types.InvalidRequestException](err, "because it was marked for deletion") {
 				return diags
 			}
 
@@ -325,8 +325,8 @@ func findSecretVersion(ctx context.Context, conn *secretsmanager.Client, input *
 	output, err := conn.GetSecretValue(ctx, input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) ||
-		errs.IsAErrorMessageContains[*types.InvalidRequestException](err, "You can’t perform this operation on the secret because it was deleted") ||
-		errs.IsAErrorMessageContains[*types.InvalidRequestException](err, "You can't perform this operation on the secret because it was marked for deletion") {
+		errs.IsAErrorMessageContains[*types.InvalidRequestException](err, "because it was deleted") ||
+		errs.IsAErrorMessageContains[*types.InvalidRequestException](err, "because it was marked for deletion") {
 		return nil, &retry.NotFoundError{
 			LastError:   err,
 			LastRequest: input,

--- a/website/docs/r/secretsmanager_secret_version.html.markdown
+++ b/website/docs/r/secretsmanager_secret_version.html.markdown
@@ -60,8 +60,8 @@ output "example" {
 This resource supports the following arguments:
 
 * `secret_id` - (Required) Specifies the secret to which you want to add a new version. You can specify either the Amazon Resource Name (ARN) or the friendly name of the secret. The secret must already exist.
-* `secret_string` - (Optional) Specifies text data that you want to encrypt and store in this version of the secret. This is required if secret_binary is not set.
-* `secret_binary` - (Optional) Specifies binary data that you want to encrypt and store in this version of the secret. This is required if secret_string is not set. Needs to be encoded to base64.
+* `secret_string` - (Optional) Specifies text data that you want to encrypt and store in this version of the secret. This is required if `secret_binary` is not set.
+* `secret_binary` - (Optional) Specifies binary data that you want to encrypt and store in this version of the secret. This is required if `secret_string` is not set. Needs to be encoded to base64.
 * `version_stages` - (Optional) Specifies a list of staging labels that are attached to this version of the secret. A staging label must be unique to a single version of the secret. If you specify a staging label that's already associated with a different version of the same secret then that staging label is automatically removed from the other version and attached to this version. If you do not specify a value, then AWS Secrets Manager automatically moves the staging label `AWSCURRENT` to this new version on creation.
 
 ~> **NOTE:** If `version_stages` is configured, you must include the `AWSCURRENT` staging label if this secret version is the only version or if the label is currently present on this secret version, otherwise Terraform will show a perpetual difference.


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This allows the resource to be removed from state gracefully when either the secret or secret version is deleted.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #36607

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/secretsmanager/latest/userguide/reference_limits.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->


```console
% make testacc PKG=secretsmanager TESTS=TestAccSecretsManagerSecretVersion_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/secretsmanager/... -v -count 1 -parallel 20 -run='TestAccSecretsManagerSecretVersion_'  -timeout 360m

--- PASS: TestAccSecretsManagerSecretVersion_disappears (15.02s)
--- PASS: TestAccSecretsManagerSecretVersion_Disappears_secret (15.74s)
--- PASS: TestAccSecretsManagerSecretVersion_multipleVersions (16.14s)
--- PASS: TestAccSecretsManagerSecretVersion_basicString (17.43s)
--- PASS: TestAccSecretsManagerSecretVersion_base64Binary (17.47s)
--- PASS: TestAccSecretsManagerSecretVersion_versionStagesExternalUpdate (22.68s)
--- PASS: TestAccSecretsManagerSecretVersion_versionStages (32.30s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager     37.964s
```
