### PR TITLE
r/aws_applicationinsights_application: ACTIVE is a valid create target status

### DIFF
--- a/.changelog/36615.txt
+++ b/.changelog/36615.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_applicationinsights_application: Make `ACTIVE` a valid create target status
+```

--- a/internal/service/applicationinsights/wait.go
+++ b/internal/service/applicationinsights/wait.go
@@ -20,7 +20,7 @@ const (
 func waitApplicationCreated(ctx context.Context, conn *applicationinsights.ApplicationInsights, name string) (*applicationinsights.ApplicationInfo, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{"CREATING"},
-		Target:  []string{"NOT_CONFIGURED"},
+		Target:  []string{"NOT_CONFIGURED", "ACTIVE"},
 		Refresh: statusApplication(ctx, conn, name),
 		Timeout: ApplicationCreatedTimeout,
 	}


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
In some configurations with `auto_config_enabled = true`, intermittent errors are observed waiting for application creation.

```
│ Error: waiting for ApplicationInsights Application (example) create: unexpected state 'ACTIVE', wanted target 'NOT_CONFIGURED'. last error: %!s(<nil>)
```

The current assumption is that all applications enter a `NOT_CONFIGURED` lifecycle status upon initial creation (which is why this succeeds most of the time in minimal configurations such as our acceptance test), but in some instances can proceed into an `ACTIVE` status before the create waiter has polled for and observed a `NOT_CONFIGURED` status. The AWS documentation on the [LifeCycle argument](https://docs.aws.amazon.com/cloudwatch/latest/APIReference/API_ApplicationInfo.html#appinsights-Type-ApplicationInfo-LifeCycle) is limited, so while we cannot be certain about the expected values in the lifecycle flow, there is enough evidence from issue reports and manual testing to indicate `ACTIVE` should be considered a valid target state.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #27277 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/cloudwatch/latest/APIReference/API_ApplicationInfo.html#appinsights-Type-ApplicationInfo-LifeCycle

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=applicationinsights TESTS=TestAccApplicationInsightsApplication_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/applicationinsights/... -v -count 1 -parallel 20 -run='TestAccApplicationInsightsApplication_'  -timeout 360m

--- PASS: TestAccApplicationInsightsApplication_disappears (22.83s)
--- PASS: TestAccApplicationInsightsApplication_autoConfig (25.47s)
--- PASS: TestAccApplicationInsightsApplication_basic (34.21s)
--- PASS: TestAccApplicationInsightsApplication_tags (43.17s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/applicationinsights        48.867s
```
