### PR TITLE
generate/tags: Fix a couple of bugs with AWS SDKv2 gen

### DIFF
--- a/internal/generate/tags/templates/v2/list_tags_body.tmpl
+++ b/internal/generate/tags/templates/v2/list_tags_body.tmpl
@@ -4,10 +4,10 @@
 func {{ .ListTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier{{ if .TagResTypeElem }}, resourceType{{ end }} string, optFns ...func(*{{ .AWSService }}.Options)) (tftags.KeyValueTags, error) {
 	input := &{{ .TagPackage  }}.{{ .ListTagsOp }}Input{
 		{{- if .ListTagsInFiltIDName }}
-		Filters: []*{{ .AWSService  }}.Filter{
+		Filters: []awstypes.Filter{
 			{
 				Name:   aws.String("{{ .ListTagsInFiltIDName }}"),
-				Values: []*string{aws.String(identifier)},
+				Values: []string{identifier},
 			},
 		},
 		{{- else }}

--- a/internal/generate/tags/templates/v2/service_tags_slice_body.tmpl
+++ b/internal/generate/tags/templates/v2/service_tags_slice_body.tmpl
@@ -164,7 +164,7 @@ func {{ .KeyValueTagsFunc }}(ctx context.Context, tags any{{ if .TagTypeIDElem }
 		return tftags.New(ctx, m)
 	{{- if .TagTypeAddBoolElem }}
 	case *schema.Set:
-		return {{ .KeyValueTagsFunc }}(tags.List(){{ if .TagTypeIDElem }}, identifier{{ if .TagResTypeElem }}, resourceType{{ end }}{{ end }})
+		return {{ .KeyValueTagsFunc }}(ctx, tags.List(){{ if .TagTypeIDElem }}, identifier{{ if .TagResTypeElem }}, resourceType{{ end }}{{ end }})
 	case []any:
 		result := make(map[string]*tftags.TagData)
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
These were spotted during an attempt to migrate `autoscaling` to AWS SDK v2. That service has quite a complex set of tag gen parameters which happened to hit these code paths.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
