### PR TITLE
resource/aws_athena_database: Add  argument

### DIFF
--- a/internal/service/athena/database.go
+++ b/internal/service/athena/database.go
@@ -107,6 +107,12 @@ func resourceDatabase() *schema.Resource {
 				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"workgroup": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "primary",
+				ForceNew: false,
+			},
 		},
 	}
 }
@@ -141,6 +147,7 @@ func resourceDatabaseCreate(ctx context.Context, d *schema.ResourceData, meta in
 	input := &athena.StartQueryExecutionInput{
 		QueryString:         aws.String(queryString.String()),
 		ResultConfiguration: expandResultConfiguration(d),
+		WorkGroup:           aws.String(d.Get("workgroup").(string)),
 	}
 
 	output, err := conn.StartQueryExecution(ctx, input)
@@ -194,6 +201,7 @@ func resourceDatabaseDelete(ctx context.Context, d *schema.ResourceData, meta in
 	input := &athena.StartQueryExecutionInput{
 		QueryString:         aws.String(queryString),
 		ResultConfiguration: expandResultConfiguration(d),
+		WorkGroup:           aws.String(d.Get("workgroup").(string)),
 	}
 
 	output, err := conn.StartQueryExecution(ctx, input)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Add `workgroup` argument to `aws_athena_database` resource.
It ensures that the database is created with the given workgroup. That allows primary workgroup to be deactivated.

### Relations

Closes #36621  

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
No references


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccAthenaDatabase_withWorkgroup PKG=athena                        
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/athena/... -v -count 1 -parallel 20 -run='TestAccAthenaDatabase_withWorkgroup'  -timeout 360m
=== RUN   TestAccAthenaDatabase_withWorkgroup
=== PAUSE TestAccAthenaDatabase_withWorkgroup
=== CONT  TestAccAthenaDatabase_withWorkgroup
--- PASS: TestAccAthenaDatabase_withWorkgroup (24.49s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/athena     30.335s
```
