### PR TITLE
r/aws_kinesis_firehose_delivery_stream fix broken link

### DIFF
--- a/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
+++ b/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
@@ -915,7 +915,7 @@ The `output_format_configuration` configuration block supports the following arg
 The `serializer` configuration block supports the following arguments:
 
 * `orc_ser_de` - (Optional) Specifies converting data to the ORC format before storing it in Amazon S3. For more information, see [Apache ORC](https://orc.apache.org/docs/). See [`orc_ser_de` block](#orc_ser_de-block) below for details.
-* `parquet_ser_de` - (Optional) Specifies converting data to the Parquet format before storing it in Amazon S3. For more information, see [Apache Parquet](https://parquet.apache.org/documentation/latest/). More details below.
+* `parquet_ser_de` - (Optional) Specifies converting data to the Parquet format before storing it in Amazon S3. For more information, see [Apache Parquet](https://parquet.apache.org/docs/). More details below.
 
 #### `orc_ser_de` block
 


### PR DESCRIPTION
### Description
This PR addresses a broken link issue in the documentation for `aws_kinesis_firehose_delivery_stream` resource, regarding the `parquet_ser_de` argument. The link pointing to the Apache Parquet documentation was broken, preventing users from accessing relevant information about Apache Parquet. 

### Relations
N/A

### References

Documentation: [https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kinesis_firehose_delivery_stream.html#parquet_ser_de](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kinesis_firehose_delivery_stream.html#parquet_ser_de)

