### PR TITLE
Simplify creation of AWS SDK for Go v1 API clients for alternate AWS Regions

### DIFF
--- a/internal/conns/awsclient.go
+++ b/internal/conns/awsclient.go
@@ -329,7 +329,7 @@ func resolveServiceBaseEndpoint(ctx context.Context, sdkID string, configs []any
 
 // conn returns the AWS SDK for Go v1 API client for the specified service.
 // The default service client (`extra` is empty) is cached. In this case the AWSClient lock is held.
-// This function is not a method on `AWSClient` as methods can't be parameterize (https://go.googlesource.com/proposal/+/refs/heads/master/design/43651-type-parameters.md#no-parameterized-methods).
+// This function is not a method on `AWSClient` as methods can't be parameterized (https://go.googlesource.com/proposal/+/refs/heads/master/design/43651-type-parameters.md#no-parameterized-methods).
 func conn[T any](ctx context.Context, c *AWSClient, servicePackageName string, extra map[string]any) (T, error) {
 	isDefault := len(extra) == 0
 	// Default service client is cached.
@@ -389,7 +389,7 @@ func conn[T any](ctx context.Context, c *AWSClient, servicePackageName string, e
 
 // client returns the AWS SDK for Go v2 API client for the specified service.
 // The default service client (`extra` is empty) is cached. In this case the AWSClient lock is held.
-// This function is not a method on `AWSClient` as methods can't be parameterize (https://go.googlesource.com/proposal/+/refs/heads/master/design/43651-type-parameters.md#no-parameterized-methods).
+// This function is not a method on `AWSClient` as methods can't be parameterized (https://go.googlesource.com/proposal/+/refs/heads/master/design/43651-type-parameters.md#no-parameterized-methods).
 func client[T any](ctx context.Context, c *AWSClient, servicePackageName string, extra map[string]any) (T, error) {
 	isDefault := len(extra) == 0
 	// Default service client is cached.

--- a/internal/conns/awsclient.go
+++ b/internal/conns/awsclient.go
@@ -17,6 +17,11 @@ import (
 	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
 	session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
 	apigatewayv2_sdkv1 "github.com/aws/aws-sdk-go/service/apigatewayv2"
+	directoryservice_sdkv1 "github.com/aws/aws-sdk-go/service/directoryservice"
+	dynamodb_sdkv1 "github.com/aws/aws-sdk-go/service/dynamodb"
+	efs_sdkv1 "github.com/aws/aws-sdk-go/service/efs"
+	kms_sdkv1 "github.com/aws/aws-sdk-go/service/kms"
+	opsworks_sdkv1 "github.com/aws/aws-sdk-go/service/opsworks"
 	rds_sdkv1 "github.com/aws/aws-sdk-go/service/rds"
 	baselogging "github.com/hashicorp/aws-sdk-go-base/v2/logging"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -31,7 +36,6 @@ type AWSClient struct {
 	Partition         string
 	Region            string
 	ServicePackages   map[string]ServicePackage
-	TerraformVersion  string
 
 	awsConfig                 *aws_sdkv2.Config
 	clients                   map[string]any
@@ -58,6 +62,56 @@ func (c *AWSClient) CredentialsProvider(context.Context) aws_sdkv2.CredentialsPr
 
 func (c *AWSClient) AwsConfig(context.Context) aws_sdkv2.Config { // nosemgrep:ci.aws-in-func-name
 	return c.awsConfig.Copy()
+}
+
+// DynamoDBConnForRegion returns an AWS SDK For Go v1 DynamoDB API client for the specified AWS Region.
+// If the specified region is not the default a new "simple" client is created.
+// This new client does not use any configured endpoint override.
+func (c *AWSClient) DynamoDBConnForRegion(ctx context.Context, region string) *dynamodb_sdkv1.DynamoDB {
+	if region == c.Region {
+		return c.DynamoDBConn(ctx)
+	}
+	return dynamodb_sdkv1.New(c.session, aws_sdkv1.NewConfig().WithRegion(region))
+}
+
+// DSConnForRegion returns an AWS SDK For Go v1 DS API client for the specified AWS Region.
+// If the specified region is not the default a new "simple" client is created.
+// This new client does not use any configured endpoint override.
+func (c *AWSClient) DSConnForRegion(ctx context.Context, region string) *directoryservice_sdkv1.DirectoryService {
+	if region == c.Region {
+		return c.DSConn(ctx)
+	}
+	return directoryservice_sdkv1.New(c.session, aws_sdkv1.NewConfig().WithRegion(region))
+}
+
+// EFSConnForRegion returns an AWS SDK For Go v1 EFS API client for the specified AWS Region.
+// If the specified region is not the default a new "simple" client is created.
+// This new client does not use any configured endpoint override.
+func (c *AWSClient) EFSConnForRegion(ctx context.Context, region string) *efs_sdkv1.EFS {
+	if region == c.Region {
+		return c.EFSConn(ctx)
+	}
+	return efs_sdkv1.New(c.session, aws_sdkv1.NewConfig().WithRegion(region))
+}
+
+// KMSConnForRegion returns an AWS SDK For Go v1 KMS API client for the specified AWS Region.
+// If the specified region is not the default a new "simple" client is created.
+// This new client does not use any configured endpoint override.
+func (c *AWSClient) KMSConnForRegion(ctx context.Context, region string) *kms_sdkv1.KMS {
+	if region == c.Region {
+		return c.KMSConn(ctx)
+	}
+	return kms_sdkv1.New(c.session, aws_sdkv1.NewConfig().WithRegion(region))
+}
+
+// KMSConnForRegion returns an AWS SDK For Go v1 OpsWorks API client for the specified AWS Region.
+// If the specified region is not the default a new "simple" client is created.
+// This new client does not use any configured endpoint override.
+func (c *AWSClient) OpsWorksConnForRegion(ctx context.Context, region string) *opsworks_sdkv1.OpsWorks {
+	if region == c.Region {
+		return c.OpsWorksConn(ctx)
+	}
+	return opsworks_sdkv1.New(c.session, aws_sdkv1.NewConfig().WithRegion(region))
 }
 
 // PartitionHostname returns a hostname with the provider domain suffix for the partition

--- a/internal/conns/awsclient.go
+++ b/internal/conns/awsclient.go
@@ -15,9 +15,9 @@ import (
 	config_sdkv2 "github.com/aws/aws-sdk-go-v2/config"
 	s3_sdkv2 "github.com/aws/aws-sdk-go-v2/service/s3"
 	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
-	client_sdkv1 "github.com/aws/aws-sdk-go/aws/client"
 	session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
 	apigatewayv2_sdkv1 "github.com/aws/aws-sdk-go/service/apigatewayv2"
+	rds_sdkv1 "github.com/aws/aws-sdk-go/service/rds"
 	baselogging "github.com/hashicorp/aws-sdk-go-base/v2/logging"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
@@ -74,7 +74,17 @@ func (c *AWSClient) RegionalHostname(ctx context.Context, prefix string) string 
 	return fmt.Sprintf("%s.%s.%s", prefix, c.Region, c.DNSSuffix(ctx))
 }
 
-// S3ExpressClient returns an S3 API client suitable for use with S3 Express (directory buckets).
+// RDSConnForRegion returns an AWS SDK For Go v1 RDS API client for the specified AWS Region.
+// If the specified region is not the default a new "simple" client is created.
+// This new client does not use any configured endpoint override.
+func (c *AWSClient) RDSConnForRegion(ctx context.Context, region string) *rds_sdkv1.RDS {
+	if region == c.Region {
+		return c.RDSConn(ctx)
+	}
+	return rds_sdkv1.New(c.session, aws_sdkv1.NewConfig().WithRegion(region))
+}
+
+// S3ExpressClient returns an AWS SDK for Go v2 S3 API client suitable for use with S3 Express (directory buckets).
 // This client differs from the standard S3 API client only in us-east-1 if the global S3 endpoint is used.
 // In that case the returned client uses the regional S3 endpoint.
 func (c *AWSClient) S3ExpressClient(ctx context.Context) *s3_sdkv2.Client {
@@ -261,10 +271,6 @@ func resolveServiceBaseEndpoint(ctx context.Context, sdkID string, configs []any
 		}
 	}
 	return
-}
-
-func NewConnForRegion[T any](ctx context.Context, c *AWSClient, region string, f func(client_sdkv1.ConfigProvider, ...*aws_sdkv1.Config) T) T {
-	return f(c.session, aws_sdkv1.NewConfig().WithRegion(region))
 }
 
 // conn returns the AWS SDK for Go v1 API client for the specified service.

--- a/internal/conns/config.go
+++ b/internal/conns/config.go
@@ -156,7 +156,7 @@ func (c *Config) ConfigureProvider(ctx context.Context, client *AWSClient) (*AWS
 	awsbaseConfig.SkipCredsValidation = skipCredsValidation
 
 	tflog.Debug(ctx, "Creating AWS SDK v1 session")
-	sess, awsDiags := awsbasev1.GetSession(ctx, &cfg, &awsbaseConfig)
+	session, awsDiags := awsbasev1.GetSession(ctx, &cfg, &awsbaseConfig)
 
 	for _, d := range awsDiags {
 		diags = append(diags, diag.Diagnostic{
@@ -202,8 +202,8 @@ func (c *Config) ConfigureProvider(ctx context.Context, client *AWSClient) (*AWS
 	client.IgnoreTagsConfig = c.IgnoreTagsConfig
 	client.Partition = partition
 	client.Region = c.Region
-	client.SetHTTPClient(ctx, sess.Config.HTTPClient) // Must be called while client.Session is nil.
-	client.Session = sess
+	client.SetHTTPClient(ctx, session.Config.HTTPClient) // Must be called while client.Session is nil.
+	client.session = session
 	client.TerraformVersion = c.TerraformVersion
 
 	// Used for lazy-loading AWS API clients.

--- a/internal/conns/config.go
+++ b/internal/conns/config.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/names"
+	"github.com/hashicorp/terraform-provider-aws/version"
 )
 
 type Config struct {
@@ -69,9 +70,15 @@ func (c *Config) ConfigureProvider(ctx context.Context, client *AWSClient) (*AWS
 	ctx, logger := logging.NewTfLogger(ctx)
 
 	awsbaseConfig := awsbase.Config{
-		AccessKey:                      c.AccessKey,
-		AllowedAccountIds:              c.AllowedAccountIds,
-		APNInfo:                        StdUserAgentProducts(c.TerraformVersion),
+		AccessKey:         c.AccessKey,
+		AllowedAccountIds: c.AllowedAccountIds,
+		APNInfo: &awsbase.APNInfo{
+			PartnerName: "HashiCorp",
+			Products: []awsbase.UserAgentProduct{
+				{Name: "Terraform", Version: c.TerraformVersion, Comment: "+https://www.terraform.io"},
+				{Name: "terraform-provider-aws", Version: version.ProviderVersion, Comment: "+https://registry.terraform.io/providers/hashicorp/aws"},
+			},
+		},
 		AssumeRoleWithWebIdentity:      c.AssumeRoleWithWebIdentity,
 		CallerDocumentationURL:         "https://registry.terraform.io/providers/hashicorp/aws",
 		CallerName:                     "Terraform AWS Provider",
@@ -204,7 +211,6 @@ func (c *Config) ConfigureProvider(ctx context.Context, client *AWSClient) (*AWS
 	client.Region = c.Region
 	client.SetHTTPClient(ctx, session.Config.HTTPClient) // Must be called while client.Session is nil.
 	client.session = session
-	client.TerraformVersion = c.TerraformVersion
 
 	// Used for lazy-loading AWS API clients.
 	client.awsConfig = &cfg

--- a/internal/conns/conns.go
+++ b/internal/conns/conns.go
@@ -5,14 +5,8 @@ package conns
 
 import (
 	"context"
-	"strings"
 
-	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
-	session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
-	awsbase "github.com/hashicorp/aws-sdk-go-base/v2"
-	awsbasev1 "github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2"
 	"github.com/hashicorp/terraform-provider-aws/internal/types"
-	"github.com/hashicorp/terraform-provider-aws/version"
 )
 
 // ServicePackage is the minimal interface exported from each AWS service package.
@@ -62,39 +56,4 @@ func NewResourceContext(ctx context.Context, servicePackageName, resourceName st
 func FromContext(ctx context.Context) (*InContext, bool) {
 	v, ok := ctx.Value(contextKey).(*InContext)
 	return v, ok
-}
-
-func NewSessionForRegion(cfg *aws_sdkv1.Config, region, terraformVersion string) (*session_sdkv1.Session, error) {
-	session, err := session_sdkv1.NewSession(cfg)
-
-	if err != nil {
-		return nil, err
-	}
-
-	apnInfo := StdUserAgentProducts(terraformVersion)
-
-	awsbasev1.SetSessionUserAgent(session, apnInfo, awsbase.UserAgentProducts{})
-
-	return session.Copy(&aws_sdkv1.Config{Region: aws_sdkv1.String(region)}), nil
-}
-
-func StdUserAgentProducts(terraformVersion string) *awsbase.APNInfo {
-	return &awsbase.APNInfo{
-		PartnerName: "HashiCorp",
-		Products: []awsbase.UserAgentProduct{
-			{Name: "Terraform", Version: terraformVersion, Comment: "+https://www.terraform.io"},
-			{Name: "terraform-provider-aws", Version: version.ProviderVersion, Comment: "+https://registry.terraform.io/providers/hashicorp/aws"},
-		},
-	}
-}
-
-// ReverseDNS switches a DNS hostname to reverse DNS and vice-versa.
-func ReverseDNS(hostname string) string {
-	parts := strings.Split(hostname, ".")
-
-	for i, j := 0, len(parts)-1; i < j; i, j = i+1, j-1 {
-		parts[i], parts[j] = parts[j], parts[i]
-	}
-
-	return strings.Join(parts, ".")
 }

--- a/internal/service/ds/region.go
+++ b/internal/service/ds/region.go
@@ -119,11 +119,7 @@ func resourceRegionCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		return sdkdiag.AppendErrorf(diags, "waiting for Directory Service Region (%s) create: %s", d.Id(), err)
 	}
 
-	regionConn, err := regionalConn(ctx, meta.(*conns.AWSClient), regionName)
-
-	if err != nil {
-		return sdkdiag.AppendFromErr(diags, err)
-	}
+	regionConn := meta.(*conns.AWSClient).DSConnForRegion(ctx, regionName)
 
 	if tags := getTagsIn(ctx); len(tags) > 0 {
 		if err := createTags(ctx, regionConn, directoryID, tags); err != nil {
@@ -174,11 +170,7 @@ func resourceRegionRead(ctx context.Context, d *schema.ResourceData, meta interf
 		d.Set("vpc_settings", nil)
 	}
 
-	regionConn, err := regionalConn(ctx, meta.(*conns.AWSClient), regionName)
-
-	if err != nil {
-		return sdkdiag.AppendFromErr(diags, err)
-	}
+	regionConn := meta.(*conns.AWSClient).DSConnForRegion(ctx, regionName)
 
 	tags, err := listTags(ctx, regionConn, directoryID)
 
@@ -200,11 +192,7 @@ func resourceRegionUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	conn, err := regionalConn(ctx, meta.(*conns.AWSClient), regionName)
-
-	if err != nil {
-		return sdkdiag.AppendFromErr(diags, err)
-	}
+	conn := meta.(*conns.AWSClient).DSConnForRegion(ctx, regionName)
 
 	if d.HasChange("desired_number_of_domain_controllers") {
 		if err := updateNumberOfDomainControllers(ctx, conn, directoryID, d.Get("desired_number_of_domain_controllers").(int), d.Timeout(schema.TimeoutUpdate)); err != nil {
@@ -233,11 +221,7 @@ func resourceRegionDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	// The Region must be removed using a client in the region.
-	conn, err := regionalConn(ctx, meta.(*conns.AWSClient), regionName)
-
-	if err != nil {
-		return sdkdiag.AppendFromErr(diags, err)
-	}
+	conn := meta.(*conns.AWSClient).DSConnForRegion(ctx, regionName)
 
 	_, err = conn.RemoveRegionWithContext(ctx, &directoryservice.RemoveRegionInput{
 		DirectoryId: aws.String(directoryID),
@@ -256,16 +240,6 @@ func resourceRegionDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	return diags
-}
-
-func regionalConn(ctx context.Context, client *conns.AWSClient, regionName string) (*directoryservice.DirectoryService, error) {
-	sess, err := conns.NewSessionForRegion(&client.DSConn(ctx).Config, regionName, client.TerraformVersion)
-
-	if err != nil {
-		return nil, fmt.Errorf("creating AWS session (%s): %w", regionName, err)
-	}
-
-	return directoryservice.New(sess), nil
 }
 
 const regionIDSeparator = "," // nosemgrep:ci.ds-in-const-name,ci.ds-in-var-name

--- a/internal/service/dynamodb/table_replica.go
+++ b/internal/service/dynamodb/table_replica.go
@@ -109,12 +109,8 @@ func resourceTableReplicaCreate(ctx context.Context, d *schema.ResourceData, met
 		return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionCreating, ResNameTableReplica, d.Get("global_table_arn").(string), errors.New("replica cannot be in same region as main table"))
 	}
 
-	session, err := conns.NewSessionForRegion(&conn.Config, mainRegion, meta.(*conns.AWSClient).TerraformVersion)
-	if err != nil {
-		return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionCreating, ResNameTableReplica, d.Get("global_table_arn").(string), fmt.Errorf("region %s: %w", mainRegion, err))
-	}
-
-	conn = dynamodb.New(session) // now main table region
+	// now main table region
+	conn = meta.(*conns.AWSClient).DynamoDBConnForRegion(ctx, mainRegion)
 
 	var replicaInput = &dynamodb.CreateReplicationGroupMemberAction{}
 
@@ -214,12 +210,8 @@ func resourceTableReplicaRead(ctx context.Context, d *schema.ResourceData, meta 
 		return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionReading, ResNameTableReplica, d.Id(), errors.New("replica cannot be in same region as main table"))
 	}
 
-	session, err := conns.NewSessionForRegion(&conn.Config, mainRegion, meta.(*conns.AWSClient).TerraformVersion)
-	if err != nil {
-		return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionReading, ResNameTableReplica, d.Id(), fmt.Errorf("region %s: %w", mainRegion, err))
-	}
-
-	conn = dynamodb.New(session) // now main table region
+	// now main table region
+	conn = meta.(*conns.AWSClient).DynamoDBConnForRegion(ctx, mainRegion)
 
 	result, err := conn.DescribeTableWithContext(ctx, &dynamodb.DescribeTableInput{
 		TableName: aws.String(tableName),
@@ -255,7 +247,7 @@ func resourceTableReplicaRead(ctx context.Context, d *schema.ResourceData, meta 
 		return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionReading, ResNameTableReplica, d.Id(), err)
 	}
 
-	dk, err := kms.FindDefaultKey(ctx, "dynamodb", replicaRegion, meta)
+	dk, err := kms.FindDefaultKey(ctx, meta.(*conns.AWSClient), "dynamodb", replicaRegion)
 	if err != nil {
 		return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionReading, ResNameTableReplica, d.Id(), err)
 	}
@@ -362,12 +354,8 @@ func resourceTableReplicaUpdate(ctx context.Context, d *schema.ResourceData, met
 		return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionUpdating, ResNameTableReplica, d.Id(), errors.New("replica cannot be in same region as main table"))
 	}
 
-	session, err := conns.NewSessionForRegion(&repConn.Config, mainRegion, meta.(*conns.AWSClient).TerraformVersion)
-	if err != nil {
-		return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionUpdating, ResNameTableReplica, d.Id(), fmt.Errorf("region %s: %w", mainRegion, err))
-	}
-
-	tabConn := dynamodb.New(session) // now main table region
+	// now main table region
+	tabConn := meta.(*conns.AWSClient).DynamoDBConnForRegion(ctx, mainRegion)
 
 	viaMainChanges := false
 	viaMainInput := &dynamodb.UpdateReplicationGroupMemberAction{
@@ -375,7 +363,7 @@ func resourceTableReplicaUpdate(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	if d.HasChange(names.AttrKMSKeyARN) && !d.IsNewResource() { // create ends with update and sets kms_key_arn causing change that is not
-		dk, err := kms.FindDefaultKey(ctx, "dynamodb", replicaRegion, meta)
+		dk, err := kms.FindDefaultKey(ctx, meta.(*conns.AWSClient), "dynamodb", replicaRegion)
 		if err != nil {
 			return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionUpdating, ResNameTableReplica, d.Id(), fmt.Errorf("region %s: %w", replicaRegion, err))
 		}
@@ -437,7 +425,7 @@ func resourceTableReplicaUpdate(ctx context.Context, d *schema.ResourceData, met
 		}
 
 		if d.HasChange("point_in_time_recovery") {
-			if err := updatePITR(ctx, repConn, tableName, d.Get("point_in_time_recovery").(bool), replicaRegion, meta.(*conns.AWSClient).TerraformVersion, d.Timeout(schema.TimeoutUpdate)); err != nil {
+			if err := updatePITR(ctx, meta.(*conns.AWSClient), tableName, d.Get("point_in_time_recovery").(bool), replicaRegion, d.Timeout(schema.TimeoutUpdate)); err != nil {
 				return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionUpdating, ResNameTableReplica, d.Id(), err)
 			}
 		}
@@ -463,12 +451,8 @@ func resourceTableReplicaDelete(ctx context.Context, d *schema.ResourceData, met
 
 	replicaRegion := aws.StringValue(conn.Config.Region)
 
-	session, err := conns.NewSessionForRegion(&conn.Config, mainRegion, meta.(*conns.AWSClient).TerraformVersion)
-	if err != nil {
-		return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionDeleting, ResNameTableReplica, d.Id(), fmt.Errorf("region %s: %w", mainRegion, err))
-	}
-
-	conn = dynamodb.New(session) // now main table region
+	// now main table region.
+	conn = meta.(*conns.AWSClient).DynamoDBConnForRegion(ctx, mainRegion)
 
 	input := &dynamodb.UpdateTableInput{
 		TableName: aws.String(tableName),

--- a/internal/service/dynamodb/table_replica_test.go
+++ b/internal/service/dynamodb/table_replica_test.go
@@ -367,12 +367,7 @@ func testAccCheckTableReplicaDestroy(ctx context.Context) resource.TestCheckFunc
 				return create.Error(names.DynamoDB, create.ErrActionCheckingDestroyed, tfdynamodb.ResNameTableReplica, rs.Primary.ID, err)
 			}
 
-			session, err := conns.NewSessionForRegion(&conn.Config, mainRegion, acctest.Provider.Meta().(*conns.AWSClient).TerraformVersion)
-			if err != nil {
-				return create.Error(names.DynamoDB, create.ErrActionCheckingDestroyed, tfdynamodb.ResNameTableReplica, rs.Primary.ID, fmt.Errorf("region %s: %w", mainRegion, err))
-			}
-
-			conn = dynamodb.New(session) // now global table region
+			conn := acctest.Provider.Meta().(*conns.AWSClient).DynamoDBConnForRegion(ctx, mainRegion)
 
 			params := &dynamodb.DescribeTableInput{
 				TableName: aws.String(tableName),
@@ -415,19 +410,12 @@ func testAccCheckTableReplicaExists(ctx context.Context, n string) resource.Test
 			return create.Error(names.DynamoDB, create.ErrActionCheckingExistence, tfdynamodb.ResNameTableReplica, rs.Primary.ID, errors.New("no ID"))
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).DynamoDBConn(ctx)
-
 		tableName, mainRegion, err := tfdynamodb.TableReplicaParseID(rs.Primary.ID)
 		if err != nil {
 			return create.Error(names.DynamoDB, create.ErrActionCheckingExistence, tfdynamodb.ResNameTableReplica, rs.Primary.ID, err)
 		}
 
-		session, err := conns.NewSessionForRegion(&conn.Config, mainRegion, acctest.Provider.Meta().(*conns.AWSClient).TerraformVersion)
-		if err != nil {
-			return create.Error(names.DynamoDB, create.ErrActionCheckingExistence, tfdynamodb.ResNameTableReplica, rs.Primary.ID, fmt.Errorf("region %s: %w", mainRegion, err))
-		}
-
-		conn = dynamodb.New(session) // now global table region
+		conn := acctest.Provider.Meta().(*conns.AWSClient).DynamoDBConnForRegion(ctx, mainRegion)
 
 		params := &dynamodb.DescribeTableInput{
 			TableName: aws.String(tableName),

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -2663,17 +2663,7 @@ func testAccCheckReplicaExists(ctx context.Context, n string, region string, v *
 			return fmt.Errorf("no DynamoDB table name specified!")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).DynamoDBConn(ctx)
-		terraformVersion := acctest.Provider.Meta().(*conns.AWSClient).TerraformVersion
-
-		if aws.StringValue(conn.Config.Region) != region {
-			session, err := conns.NewSessionForRegion(&conn.Config, region, terraformVersion)
-			if err != nil {
-				return create.Error(names.DynamoDB, create.ErrActionChecking, tfdynamodb.ResNameTable, rs.Primary.ID, err)
-			}
-
-			conn = dynamodb.New(session)
-		}
+		conn := acctest.Provider.Meta().(*conns.AWSClient).DynamoDBConnForRegion(ctx, region)
 
 		output, err := tfdynamodb.FindTableByName(ctx, conn, rs.Primary.ID)
 
@@ -2698,17 +2688,7 @@ func testAccCheckReplicaHasTags(ctx context.Context, n string, region string, co
 			return fmt.Errorf("no DynamoDB table name specified!")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).DynamoDBConn(ctx)
-		terraformVersion := acctest.Provider.Meta().(*conns.AWSClient).TerraformVersion
-
-		if aws.StringValue(conn.Config.Region) != region {
-			session, err := conns.NewSessionForRegion(&conn.Config, region, terraformVersion)
-			if err != nil {
-				return create.Error(names.DynamoDB, create.ErrActionChecking, tfdynamodb.ResNameTable, rs.Primary.ID, err)
-			}
-
-			conn = dynamodb.New(session)
-		}
+		conn := acctest.Provider.Meta().(*conns.AWSClient).DynamoDBConnForRegion(ctx, region)
 
 		newARN, err := tfdynamodb.ARNForNewRegion(rs.Primary.Attributes[names.AttrARN], region)
 

--- a/internal/service/dynamodb/wait.go
+++ b/internal/service/dynamodb/wait.go
@@ -228,12 +228,8 @@ func waitSSEUpdated(ctx context.Context, conn *dynamodb.DynamoDB, tableName stri
 }
 
 func waitReplicaSSEUpdated(ctx context.Context, client *conns.AWSClient, region string, tableName string, timeout time.Duration) (*dynamodb.TableDescription, error) {
-	sess, err := conns.NewSessionForRegion(&client.DynamoDBConn(ctx).Config, region, client.TerraformVersion)
-	if err != nil {
-		return nil, fmt.Errorf("creating session for region %q: %w", region, err)
-	}
+	conn := client.DynamoDBConnForRegion(ctx, region)
 
-	conn := dynamodb.New(sess)
 	stateConf := &retry.StateChangeConf{
 		Delay:   30 * time.Second,
 		Pending: []string{dynamodb.SSEStatusDisabling, dynamodb.SSEStatusEnabling, dynamodb.SSEStatusUpdating},

--- a/internal/service/kms/exports.go
+++ b/internal/service/kms/exports.go
@@ -1,0 +1,9 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package kms
+
+// Exports for use in other modules.
+var (
+	FindDefaultKey = findDefaultKey
+)

--- a/internal/service/kms/find.go
+++ b/internal/service/kms/find.go
@@ -101,17 +101,8 @@ func FindKeyByID(ctx context.Context, conn *kms.KMS, id string) (*kms.KeyMetadat
 	return keyMetadata, nil
 }
 
-func FindDefaultKey(ctx context.Context, service, region string, meta interface{}) (string, error) {
-	conn := meta.(*conns.AWSClient).KMSConn(ctx)
-
-	if aws.StringValue(conn.Config.Region) != region {
-		session, err := conns.NewSessionForRegion(&conn.Config, region, meta.(*conns.AWSClient).TerraformVersion)
-		if err != nil {
-			return "", fmt.Errorf("finding default key, getting connection for %s: %w", region, err)
-		}
-
-		conn = kms.New(session)
-	}
+func findDefaultKey(ctx context.Context, client *conns.AWSClient, service, region string) (string, error) {
+	conn := client.KMSConnForRegion(ctx, region)
 
 	k, err := FindKeyByID(ctx, conn, fmt.Sprintf("alias/aws/%s", service)) //default key
 	if err != nil {

--- a/internal/service/kms/replica_external_key.go
+++ b/internal/service/kms/replica_external_key.go
@@ -143,13 +143,7 @@ func resourceReplicaExternalKeyCreate(ctx context.Context, d *schema.ResourceDat
 	}
 
 	// Replication is initiated in the primary key's region.
-	session, err := conns.NewSessionForRegion(&conn.Config, primaryKeyARN.Region, meta.(*conns.AWSClient).TerraformVersion)
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "creating AWS session: %s", err)
-	}
-
-	replicateConn := kms.New(session)
+	replicateConn := meta.(*conns.AWSClient).KMSConnForRegion(ctx, primaryKeyARN.Region)
 
 	output, err := WaitIAMPropagation(ctx, propagationTimeout, func() (*kms.ReplicateKeyOutput, error) {
 		return replicateConn.ReplicateKeyWithContext(ctx, input)

--- a/internal/service/kms/replica_key.go
+++ b/internal/service/kms/replica_key.go
@@ -131,13 +131,7 @@ func resourceReplicaKeyCreate(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	// Replication is initiated in the primary key's region.
-	session, err := conns.NewSessionForRegion(&conn.Config, primaryKeyARN.Region, meta.(*conns.AWSClient).TerraformVersion)
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "creating AWS session: %s", err)
-	}
-
-	replicateConn := kms.New(session)
+	replicateConn := meta.(*conns.AWSClient).KMSConnForRegion(ctx, primaryKeyARN.Region)
 
 	output, err := WaitIAMPropagation(ctx, propagationTimeout, func() (*kms.ReplicateKeyOutput, error) {
 		return replicateConn.ReplicateKeyWithContext(ctx, input)

--- a/internal/service/opsworks/stack.go
+++ b/internal/service/opsworks/stack.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/opsworks"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -325,11 +324,7 @@ func resourceStackRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	conn := meta.(*conns.AWSClient).OpsWorksConn(ctx)
 
 	if v, ok := d.GetOk("stack_endpoint"); ok {
-		log.Printf(`[DEBUG] overriding region using "stack_endpoint": %s`, v)
-		conn, err = regionalConn(ctx, meta.(*conns.AWSClient), v.(string))
-		if err != nil {
-			return sdkdiag.AppendErrorf(diags, `reading OpsWorks Stack (%s): creating client for "stack_endpoint" (%s): %s`, d.Id(), v, err)
-		}
+		conn = meta.(*conns.AWSClient).OpsWorksConnForRegion(ctx, v.(string))
 	}
 
 	stack, err := FindStackByID(ctx, conn, d.Id())
@@ -338,12 +333,7 @@ func resourceStackRead(ctx context.Context, d *schema.ResourceData, meta interfa
 		// If it's not found in the default region we're in, we check us-east-1
 		// in the event this stack was created with Terraform before version 0.9.
 		// See https://github.com/hashicorp/terraform/issues/12842.
-		v := endpoints.UsEast1RegionID
-		log.Printf(`[DEBUG] overriding region using legacy region: %s`, v)
-		conn, err = regionalConn(ctx, meta.(*conns.AWSClient), v)
-		if err != nil {
-			return sdkdiag.AppendErrorf(diags, `reading OpsWorks Stack (%s): creating client for legacy region (%s): %s`, d.Id(), v, err)
-		}
+		conn = meta.(*conns.AWSClient).OpsWorksConnForRegion(ctx, names.USEast1RegionID)
 
 		stack, err = FindStackByID(ctx, conn, d.Id())
 	}
@@ -431,10 +421,7 @@ func resourceStackUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 	conn := meta.(*conns.AWSClient).OpsWorksConn(ctx)
 
 	if v, ok := d.GetOk("stack_endpoint"); ok {
-		conn, err = regionalConn(ctx, meta.(*conns.AWSClient), v.(string))
-		if err != nil {
-			return sdkdiag.AppendErrorf(diags, `updating OpsWorks Stack (%s): creating client for "stack_endpoint" (%s): %s`, d.Id(), v, err)
-		}
+		conn = meta.(*conns.AWSClient).OpsWorksConnForRegion(ctx, v.(string))
 	}
 
 	if d.HasChangesExcept("tags", "tags_all") {
@@ -547,10 +534,7 @@ func resourceStackDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	conn := meta.(*conns.AWSClient).OpsWorksConn(ctx)
 
 	if v, ok := d.GetOk("stack_endpoint"); ok {
-		conn, err = regionalConn(ctx, meta.(*conns.AWSClient), v.(string))
-		if err != nil {
-			return sdkdiag.AppendErrorf(diags, `deleting OpsWorks Stack (%s): creating client for "stack_endpoint" (%s): %s`, d.Id(), v, err)
-		}
+		conn = meta.(*conns.AWSClient).OpsWorksConnForRegion(ctx, v.(string))
 	}
 
 	log.Printf("[DEBUG] Deleting OpsWorks Stack: %s", d.Id())
@@ -680,28 +664,4 @@ func flattenSource(apiObject *opsworks.Source) map[string]interface{} {
 	}
 
 	return tfMap
-}
-
-// opsworksConn will return a connection for the stack_endpoint in the
-// configuration. Stacks can only be accessed or managed within the endpoint
-// in which they are created, so we allow users to specify an original endpoint
-// for Stacks created before multiple endpoints were offered (Terraform v0.9.0).
-// See:
-//   - https://github.com/hashicorp/terraform/pull/12688
-//   - https://github.com/hashicorp/terraform/issues/12842
-func regionalConn(ctx context.Context, client *conns.AWSClient, regionName string) (*opsworks.OpsWorks, error) {
-	conn := client.OpsWorksConn(ctx)
-
-	// Regions are the same, no need to reconfigure.
-	if aws.StringValue(conn.Config.Region) == regionName {
-		return conn, nil
-	}
-
-	sess, err := conns.NewSessionForRegion(&conn.Config, regionName, client.TerraformVersion)
-
-	if err != nil {
-		return nil, fmt.Errorf("creating AWS session (%s): %w", regionName, err)
-	}
-
-	return opsworks.New(sess), nil
 }

--- a/internal/service/opsworks/stack_test.go
+++ b/internal/service/opsworks/stack_test.go
@@ -455,13 +455,13 @@ func TestAccOpsWorksStack_windows(t *testing.T) {
 		CheckDestroy:             testAccCheckStackDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccStackConfig_windows(rName, "Microsoft Windows Server 2012 R2 Base"),
+				Config: testAccStackConfig_windows(rName, "Microsoft Windows Server 2019 Base"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStackExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttrSet(resourceName, "agent_version"),
 					resource.TestCheckResourceAttr(resourceName, "configuration_manager_name", "Chef"),
 					resource.TestCheckResourceAttr(resourceName, "configuration_manager_version", "12.2"),
-					resource.TestCheckResourceAttr(resourceName, "default_os", "Microsoft Windows Server 2012 R2 Base"),
+					resource.TestCheckResourceAttr(resourceName, "default_os", "Microsoft Windows Server 2019 Base"),
 				),
 			},
 			{
@@ -470,13 +470,13 @@ func TestAccOpsWorksStack_windows(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccStackConfig_windows(rName, "Microsoft Windows Server 2012 R2 with SQL Server Standard"),
+				Config: testAccStackConfig_windows(rName, "Microsoft Windows Server 2022 Base"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStackExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttrSet(resourceName, "agent_version"),
 					resource.TestCheckResourceAttr(resourceName, "configuration_manager_name", "Chef"),
 					resource.TestCheckResourceAttr(resourceName, "configuration_manager_version", "12.2"),
-					resource.TestCheckResourceAttr(resourceName, "default_os", "Microsoft Windows Server 2012 R2 with SQL Server Standard"),
+					resource.TestCheckResourceAttr(resourceName, "default_os", "Microsoft Windows Server 2022 Base"),
 				),
 			},
 		},
@@ -504,10 +504,6 @@ func testAccCheckStackExists(ctx context.Context, n string, v *opsworks.Stack) r
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No OpsWorks Stack ID is set")
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).OpsWorksConn(ctx)

--- a/internal/service/rds/custom_db_engine_version.go
+++ b/internal/service/rds/custom_db_engine_version.go
@@ -215,10 +215,6 @@ func resourceCustomDBEngineVersionCreate(ctx context.Context, d *schema.Resource
 		return append(diags, create.DiagError(names.RDS, create.ErrActionCreating, ResNameCustomDBEngineVersion, fmt.Sprintf("%s:%s", aws.StringValue(output.Engine), aws.StringValue(output.EngineVersion)), err)...)
 	}
 
-	if output == nil {
-		return append(diags, create.DiagError(names.RDS, create.ErrActionCreating, ResNameCustomDBEngineVersion, fmt.Sprintf("%s:%s", aws.StringValue(output.Engine), aws.StringValue(output.EngineVersion)), errors.New("empty output"))...)
-	}
-
 	d.SetId(fmt.Sprintf("%s:%s", aws.StringValue(output.Engine), aws.StringValue(output.EngineVersion)))
 
 	if _, err := waitCustomDBEngineVersionCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {

--- a/internal/service/rds/global_cluster.go
+++ b/internal/service/rds/global_cluster.go
@@ -636,7 +636,7 @@ func globalClusterUpgradeMajorEngineVersion(ctx context.Context, meta interface{
 		useConn := conn // clusters may not all be in the same region
 
 		if clusterRegion != meta.(*conns.AWSClient).Region {
-			useConn = rds.New(meta.(*conns.AWSClient).Session, aws.NewConfig().WithRegion(clusterRegion))
+			useConn = rds.New(meta.(*conns.AWSClient).Session(ctx), aws.NewConfig().WithRegion(clusterRegion))
 		}
 
 		if err := WaitForClusterUpdate(ctx, useConn, dbi, timeout); err != nil {
@@ -677,7 +677,7 @@ func globalClusterUpgradeMinorEngineVersion(ctx context.Context, meta interface{
 		useConn := conn
 
 		if clusterRegion != meta.(*conns.AWSClient).Region {
-			useConn = rds.New(meta.(*conns.AWSClient).Session, aws.NewConfig().WithRegion(clusterRegion))
+			useConn = rds.New(meta.(*conns.AWSClient).Session(ctx), aws.NewConfig().WithRegion(clusterRegion))
 		}
 
 		// pre-wait for the cluster to be in a state where it can be updated

--- a/internal/service/rds/global_cluster.go
+++ b/internal/service/rds/global_cluster.go
@@ -633,11 +633,8 @@ func globalClusterUpgradeMajorEngineVersion(ctx context.Context, meta interface{
 			continue
 		}
 
-		useConn := conn // clusters may not all be in the same region
-
-		if clusterRegion != meta.(*conns.AWSClient).Region {
-			useConn = conns.NewConnForRegion(ctx, meta.(*conns.AWSClient), clusterRegion, rds.New)
-		}
+		// Clusters may not all be in the same region.
+		useConn := meta.(*conns.AWSClient).RDSConnForRegion(ctx, clusterRegion)
 
 		if err := WaitForClusterUpdate(ctx, useConn, dbi, timeout); err != nil {
 			return fmt.Errorf("failed to update engine_version, waiting for RDS Global Cluster (%s) to update: %s", dbi, err)
@@ -674,11 +671,7 @@ func globalClusterUpgradeMinorEngineVersion(ctx context.Context, meta interface{
 			continue
 		}
 
-		useConn := conn
-
-		if clusterRegion != meta.(*conns.AWSClient).Region {
-			useConn = conns.NewConnForRegion(ctx, meta.(*conns.AWSClient), clusterRegion, rds.New)
-		}
+		useConn := meta.(*conns.AWSClient).RDSConnForRegion(ctx, clusterRegion)
 
 		// pre-wait for the cluster to be in a state where it can be updated
 		if err := WaitForClusterUpdate(ctx, useConn, dbi, timeout); err != nil {

--- a/internal/service/rds/global_cluster.go
+++ b/internal/service/rds/global_cluster.go
@@ -636,7 +636,7 @@ func globalClusterUpgradeMajorEngineVersion(ctx context.Context, meta interface{
 		useConn := conn // clusters may not all be in the same region
 
 		if clusterRegion != meta.(*conns.AWSClient).Region {
-			useConn = rds.New(meta.(*conns.AWSClient).Session(ctx), aws.NewConfig().WithRegion(clusterRegion))
+			useConn = conns.NewConnForRegion(ctx, meta.(*conns.AWSClient), clusterRegion, rds.New)
 		}
 
 		if err := WaitForClusterUpdate(ctx, useConn, dbi, timeout); err != nil {
@@ -677,7 +677,7 @@ func globalClusterUpgradeMinorEngineVersion(ctx context.Context, meta interface{
 		useConn := conn
 
 		if clusterRegion != meta.(*conns.AWSClient).Region {
-			useConn = rds.New(meta.(*conns.AWSClient).Session(ctx), aws.NewConfig().WithRegion(clusterRegion))
+			useConn = conns.NewConnForRegion(ctx, meta.(*conns.AWSClient), clusterRegion, rds.New)
 		}
 
 		// pre-wait for the cluster to be in a state where it can be updated

--- a/internal/service/rds/instance_automated_backups_replication.go
+++ b/internal/service/rds/instance_automated_backups_replication.go
@@ -169,10 +169,7 @@ func resourceInstanceAutomatedBackupsReplicationDelete(ctx context.Context, d *s
 	}
 
 	// Create a new client to the source region.
-	sourceDatabaseConn := conn
-	if sourceDatabaseARN.Region != meta.(*conns.AWSClient).Region {
-		sourceDatabaseConn = conns.NewConnForRegion(ctx, meta.(*conns.AWSClient), sourceDatabaseARN.Region, rds.New)
-	}
+	sourceDatabaseConn := meta.(*conns.AWSClient).RDSConnForRegion(ctx, sourceDatabaseARN.Region)
 
 	if _, err := waitDBInstanceAutomatedBackupDeleted(ctx, sourceDatabaseConn, dbInstanceID, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for DB instance automated backup (%s) delete: %s", d.Id(), err)

--- a/internal/service/rds/instance_automated_backups_replication.go
+++ b/internal/service/rds/instance_automated_backups_replication.go
@@ -171,7 +171,7 @@ func resourceInstanceAutomatedBackupsReplicationDelete(ctx context.Context, d *s
 	// Create a new client to the source region.
 	sourceDatabaseConn := conn
 	if sourceDatabaseARN.Region != meta.(*conns.AWSClient).Region {
-		sourceDatabaseConn = rds.New(meta.(*conns.AWSClient).Session(ctx), aws.NewConfig().WithRegion(sourceDatabaseARN.Region))
+		sourceDatabaseConn = conns.NewConnForRegion(ctx, meta.(*conns.AWSClient), sourceDatabaseARN.Region, rds.New)
 	}
 
 	if _, err := waitDBInstanceAutomatedBackupDeleted(ctx, sourceDatabaseConn, dbInstanceID, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {

--- a/internal/service/rds/instance_automated_backups_replication.go
+++ b/internal/service/rds/instance_automated_backups_replication.go
@@ -171,7 +171,7 @@ func resourceInstanceAutomatedBackupsReplicationDelete(ctx context.Context, d *s
 	// Create a new client to the source region.
 	sourceDatabaseConn := conn
 	if sourceDatabaseARN.Region != meta.(*conns.AWSClient).Region {
-		sourceDatabaseConn = rds.New(meta.(*conns.AWSClient).Session, aws.NewConfig().WithRegion(sourceDatabaseARN.Region))
+		sourceDatabaseConn = rds.New(meta.(*conns.AWSClient).Session(ctx), aws.NewConfig().WithRegion(sourceDatabaseARN.Region))
 	}
 
 	if _, err := waitDBInstanceAutomatedBackupDeleted(ctx, sourceDatabaseConn, dbInstanceID, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/23694.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccRDSInstanceAutomatedBackupsReplication_basic' PKG=rds ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/rds/... -v -count 1 -parallel 2  -run=TestAccRDSInstanceAutomatedBackupsReplication_basic -timeout 360m
=== RUN   TestAccRDSInstanceAutomatedBackupsReplication_basic
=== PAUSE TestAccRDSInstanceAutomatedBackupsReplication_basic
=== CONT  TestAccRDSInstanceAutomatedBackupsReplication_basic
--- PASS: TestAccRDSInstanceAutomatedBackupsReplication_basic (1288.35s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	1299.277s
```
```console
% make testacc TESTARGS='-run=TestAccEFSReplicationConfiguration_' PKG=efs ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/efs/... -v -count 1 -parallel 2  -run=TestAccEFSReplicationConfiguration_ -timeout 360m
=== RUN   TestAccEFSReplicationConfiguration_basic
=== PAUSE TestAccEFSReplicationConfiguration_basic
=== RUN   TestAccEFSReplicationConfiguration_disappears
=== PAUSE TestAccEFSReplicationConfiguration_disappears
=== RUN   TestAccEFSReplicationConfiguration_allAttributes
=== PAUSE TestAccEFSReplicationConfiguration_allAttributes
=== RUN   TestAccEFSReplicationConfiguration_existingDestination
=== PAUSE TestAccEFSReplicationConfiguration_existingDestination
=== CONT  TestAccEFSReplicationConfiguration_basic
=== CONT  TestAccEFSReplicationConfiguration_allAttributes
--- PASS: TestAccEFSReplicationConfiguration_basic (535.88s)
=== CONT  TestAccEFSReplicationConfiguration_disappears
--- PASS: TestAccEFSReplicationConfiguration_allAttributes (542.56s)
=== CONT  TestAccEFSReplicationConfiguration_existingDestination
--- PASS: TestAccEFSReplicationConfiguration_disappears (537.08s)
--- PASS: TestAccEFSReplicationConfiguration_existingDestination (1442.61s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/efs	1996.278s
```
```console
% make testacc TESTARGS='-run=TestAccOpsWorksStack_' PKG=opsworks ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/opsworks/... -v -count 1 -parallel 2  -run=TestAccOpsWorksStack_ -timeout 360m
=== RUN   TestAccOpsWorksStack_basic
=== PAUSE TestAccOpsWorksStack_basic
=== RUN   TestAccOpsWorksStack_disappears
=== PAUSE TestAccOpsWorksStack_disappears
=== RUN   TestAccOpsWorksStack_noVPC_basic
=== PAUSE TestAccOpsWorksStack_noVPC_basic
=== RUN   TestAccOpsWorksStack_noVPC_defaultAZ
=== PAUSE TestAccOpsWorksStack_noVPC_defaultAZ
=== RUN   TestAccOpsWorksStack_tags
=== PAUSE TestAccOpsWorksStack_tags
=== RUN   TestAccOpsWorksStack_tagsAlternateRegion
=== PAUSE TestAccOpsWorksStack_tagsAlternateRegion
=== RUN   TestAccOpsWorksStack_allAttributes
=== PAUSE TestAccOpsWorksStack_allAttributes
=== RUN   TestAccOpsWorksStack_windows
=== PAUSE TestAccOpsWorksStack_windows
=== CONT  TestAccOpsWorksStack_basic
=== CONT  TestAccOpsWorksStack_tags
--- PASS: TestAccOpsWorksStack_basic (71.43s)
=== CONT  TestAccOpsWorksStack_allAttributes
--- PASS: TestAccOpsWorksStack_tags (166.75s)
=== CONT  TestAccOpsWorksStack_windows
--- PASS: TestAccOpsWorksStack_allAttributes (185.67s)
=== CONT  TestAccOpsWorksStack_noVPC_basic
--- PASS: TestAccOpsWorksStack_windows (129.37s)
=== CONT  TestAccOpsWorksStack_noVPC_defaultAZ
--- PASS: TestAccOpsWorksStack_noVPC_basic (46.95s)
=== CONT  TestAccOpsWorksStack_tagsAlternateRegion
    stack_test.go:248: skipping tests; AWS_DEFAULT_REGION (us-west-2) not supported. Supported: [us-east-1]
--- SKIP: TestAccOpsWorksStack_tagsAlternateRegion (0.13s)
=== CONT  TestAccOpsWorksStack_disappears
--- PASS: TestAccOpsWorksStack_disappears (68.43s)
--- PASS: TestAccOpsWorksStack_noVPC_defaultAZ (80.36s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/opsworks	387.250s
% AWS_ALTERNATE_REGION=us-west-1 AWS_DEFAULT_REGION=us-east-1 make testacc TESTARGS='-run=TestAccOpsWorksStack_tagsAlternateRegion' PKG=opsworks ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/opsworks/... -v -count 1 -parallel 2  -run=TestAccOpsWorksStack_tagsAlternateRegion -timeout 360m
=== RUN   TestAccOpsWorksStack_tagsAlternateRegion
=== PAUSE TestAccOpsWorksStack_tagsAlternateRegion
=== CONT  TestAccOpsWorksStack_tagsAlternateRegion
--- PASS: TestAccOpsWorksStack_tagsAlternateRegion (88.61s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/opsworks	100.598s
```
```console
% make testacc TESTARGS='-run=TestAccKMSReplicaKey_\|TestAccKMSReplicaExternalKey_' PKG=kms ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/kms/... -v -count 1 -parallel 3  -run=TestAccKMSReplicaKey_\|TestAccKMSReplicaExternalKey_ -timeout 360m
=== RUN   TestAccKMSReplicaExternalKey_basic
=== PAUSE TestAccKMSReplicaExternalKey_basic
=== RUN   TestAccKMSReplicaExternalKey_descriptionAndEnabled
=== PAUSE TestAccKMSReplicaExternalKey_descriptionAndEnabled
=== RUN   TestAccKMSReplicaExternalKey_policy
=== PAUSE TestAccKMSReplicaExternalKey_policy
=== RUN   TestAccKMSReplicaExternalKey_tags
=== PAUSE TestAccKMSReplicaExternalKey_tags
=== RUN   TestAccKMSReplicaKey_basic
=== PAUSE TestAccKMSReplicaKey_basic
=== RUN   TestAccKMSReplicaKey_disappears
=== PAUSE TestAccKMSReplicaKey_disappears
=== RUN   TestAccKMSReplicaKey_descriptionAndEnabled
=== PAUSE TestAccKMSReplicaKey_descriptionAndEnabled
=== RUN   TestAccKMSReplicaKey_policy
=== PAUSE TestAccKMSReplicaKey_policy
=== RUN   TestAccKMSReplicaKey_tags
=== PAUSE TestAccKMSReplicaKey_tags
=== RUN   TestAccKMSReplicaKey_twoReplicas
=== PAUSE TestAccKMSReplicaKey_twoReplicas
=== CONT  TestAccKMSReplicaExternalKey_basic
=== CONT  TestAccKMSReplicaKey_disappears
=== CONT  TestAccKMSReplicaKey_twoReplicas
--- PASS: TestAccKMSReplicaKey_disappears (73.22s)
=== CONT  TestAccKMSReplicaExternalKey_tags
--- PASS: TestAccKMSReplicaKey_twoReplicas (92.17s)
=== CONT  TestAccKMSReplicaKey_basic
--- PASS: TestAccKMSReplicaExternalKey_basic (105.04s)
=== CONT  TestAccKMSReplicaExternalKey_policy
--- PASS: TestAccKMSReplicaKey_basic (94.37s)
=== CONT  TestAccKMSReplicaExternalKey_descriptionAndEnabled
--- PASS: TestAccKMSReplicaExternalKey_policy (139.82s)
=== CONT  TestAccKMSReplicaKey_policy
--- PASS: TestAccKMSReplicaExternalKey_tags (216.76s)
=== CONT  TestAccKMSReplicaKey_tags
--- PASS: TestAccKMSReplicaKey_policy (81.50s)
=== CONT  TestAccKMSReplicaKey_descriptionAndEnabled
--- PASS: TestAccKMSReplicaExternalKey_descriptionAndEnabled (227.38s)
--- PASS: TestAccKMSReplicaKey_tags (144.14s)
--- PASS: TestAccKMSReplicaKey_descriptionAndEnabled (198.14s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kms	537.352s
```
```console
% make testacc TESTARGS='-run=TestAccDSRegion_' PKG=ds ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/ds/... -v -count 1 -parallel 2  -run=TestAccDSRegion_ -timeout 360m
=== RUN   TestAccDSRegion_basic
=== PAUSE TestAccDSRegion_basic
=== RUN   TestAccDSRegion_disappears
=== PAUSE TestAccDSRegion_disappears
=== RUN   TestAccDSRegion_tags
=== PAUSE TestAccDSRegion_tags
=== RUN   TestAccDSRegion_desiredNumberOfDomainControllers
=== PAUSE TestAccDSRegion_desiredNumberOfDomainControllers
=== CONT  TestAccDSRegion_basic
=== CONT  TestAccDSRegion_tags
--- PASS: TestAccDSRegion_tags (8303.47s)
=== CONT  TestAccDSRegion_desiredNumberOfDomainControllers
--- PASS: TestAccDSRegion_basic (9129.27s)
=== CONT  TestAccDSRegion_disappears
--- PASS: TestAccDSRegion_disappears (8233.58s)
--- PASS: TestAccDSRegion_desiredNumberOfDomainControllers (11190.43s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ds	19505.290s
```
```console
% make testacc TESTARGS='-run=TestAccDynamoDBTableReplica_\|TestAccDynamoDBTable_' PKG=dynamodb ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/dynamodb/... -v -count 1 -parallel 3  -run=TestAccDynamoDBTableReplica_\|TestAccDynamoDBTable_ -timeout 360m
=== RUN   TestAccDynamoDBTableReplica_basic
=== PAUSE TestAccDynamoDBTableReplica_basic
=== RUN   TestAccDynamoDBTableReplica_disappears
=== PAUSE TestAccDynamoDBTableReplica_disappears
=== RUN   TestAccDynamoDBTableReplica_pitr
=== PAUSE TestAccDynamoDBTableReplica_pitr
=== RUN   TestAccDynamoDBTableReplica_pitrKMS
=== PAUSE TestAccDynamoDBTableReplica_pitrKMS
=== RUN   TestAccDynamoDBTableReplica_pitrDefault
=== PAUSE TestAccDynamoDBTableReplica_pitrDefault
=== RUN   TestAccDynamoDBTableReplica_tags
=== PAUSE TestAccDynamoDBTableReplica_tags
=== RUN   TestAccDynamoDBTableReplica_tableClass
=== PAUSE TestAccDynamoDBTableReplica_tableClass
=== RUN   TestAccDynamoDBTableReplica_keys
=== PAUSE TestAccDynamoDBTableReplica_keys
=== RUN   TestAccDynamoDBTable_basic
=== PAUSE TestAccDynamoDBTable_basic
=== RUN   TestAccDynamoDBTable_deletion_protection
=== PAUSE TestAccDynamoDBTable_deletion_protection
=== RUN   TestAccDynamoDBTable_disappears
=== PAUSE TestAccDynamoDBTable_disappears
=== RUN   TestAccDynamoDBTable_Disappears_payPerRequestWithGSI
=== PAUSE TestAccDynamoDBTable_Disappears_payPerRequestWithGSI
=== RUN   TestAccDynamoDBTable_extended
=== PAUSE TestAccDynamoDBTable_extended
=== RUN   TestAccDynamoDBTable_enablePITR
=== PAUSE TestAccDynamoDBTable_enablePITR
=== RUN   TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned
=== PAUSE TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned
=== RUN   TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges
=== PAUSE TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges
=== RUN   TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest
=== PAUSE TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest
=== RUN   TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges
=== PAUSE TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges
=== RUN   TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned
=== PAUSE TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned
=== RUN   TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest
=== PAUSE TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest
=== RUN   TestAccDynamoDBTable_streamSpecification
=== PAUSE TestAccDynamoDBTable_streamSpecification
=== RUN   TestAccDynamoDBTable_streamSpecificationDiffs
=== PAUSE TestAccDynamoDBTable_streamSpecificationDiffs
=== RUN   TestAccDynamoDBTable_streamSpecificationValidation
=== PAUSE TestAccDynamoDBTable_streamSpecificationValidation
=== RUN   TestAccDynamoDBTable_tags
=== PAUSE TestAccDynamoDBTable_tags
=== RUN   TestAccDynamoDBTable_gsiUpdateCapacity
=== PAUSE TestAccDynamoDBTable_gsiUpdateCapacity
=== RUN   TestAccDynamoDBTable_gsiUpdateOtherAttributes
=== PAUSE TestAccDynamoDBTable_gsiUpdateOtherAttributes
=== RUN   TestAccDynamoDBTable_lsiNonKeyAttributes
=== PAUSE TestAccDynamoDBTable_lsiNonKeyAttributes
=== RUN   TestAccDynamoDBTable_gsiUpdateNonKeyAttributes
=== PAUSE TestAccDynamoDBTable_gsiUpdateNonKeyAttributes
=== RUN   TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan
=== PAUSE TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan
=== RUN   TestAccDynamoDBTable_TTL_enabled
=== PAUSE TestAccDynamoDBTable_TTL_enabled
=== RUN   TestAccDynamoDBTable_TTL_disabled
=== PAUSE TestAccDynamoDBTable_TTL_disabled
=== RUN   TestAccDynamoDBTable_attributeUpdate
=== PAUSE TestAccDynamoDBTable_attributeUpdate
=== RUN   TestAccDynamoDBTable_lsiUpdate
=== PAUSE TestAccDynamoDBTable_lsiUpdate
=== RUN   TestAccDynamoDBTable_attributeUpdateValidation
=== PAUSE TestAccDynamoDBTable_attributeUpdateValidation
=== RUN   TestAccDynamoDBTable_encryption
=== PAUSE TestAccDynamoDBTable_encryption
=== RUN   TestAccDynamoDBTable_Replica_multiple
=== PAUSE TestAccDynamoDBTable_Replica_multiple
=== RUN   TestAccDynamoDBTable_Replica_single
=== PAUSE TestAccDynamoDBTable_Replica_single
=== RUN   TestAccDynamoDBTable_Replica_singleStreamSpecification
=== PAUSE TestAccDynamoDBTable_Replica_singleStreamSpecification
=== RUN   TestAccDynamoDBTable_Replica_singleDefaultKeyEncrypted
=== PAUSE TestAccDynamoDBTable_Replica_singleDefaultKeyEncrypted
=== RUN   TestAccDynamoDBTable_Replica_singleCMK
=== PAUSE TestAccDynamoDBTable_Replica_singleCMK
=== RUN   TestAccDynamoDBTable_Replica_doubleAddCMK
=== PAUSE TestAccDynamoDBTable_Replica_doubleAddCMK
=== RUN   TestAccDynamoDBTable_Replica_pitr
=== PAUSE TestAccDynamoDBTable_Replica_pitr
=== RUN   TestAccDynamoDBTable_Replica_pitrKMS
=== PAUSE TestAccDynamoDBTable_Replica_pitrKMS
=== RUN   TestAccDynamoDBTable_Replica_tagsOneOfTwo
=== PAUSE TestAccDynamoDBTable_Replica_tagsOneOfTwo
=== RUN   TestAccDynamoDBTable_Replica_tagsTwoOfTwo
=== PAUSE TestAccDynamoDBTable_Replica_tagsTwoOfTwo
=== RUN   TestAccDynamoDBTable_Replica_tagsNext
=== PAUSE TestAccDynamoDBTable_Replica_tagsNext
=== RUN   TestAccDynamoDBTable_Replica_tagsUpdate
=== PAUSE TestAccDynamoDBTable_Replica_tagsUpdate
=== RUN   TestAccDynamoDBTable_tableClassInfrequentAccess
=== PAUSE TestAccDynamoDBTable_tableClassInfrequentAccess
=== RUN   TestAccDynamoDBTable_tableClassExplicitDefault
=== PAUSE TestAccDynamoDBTable_tableClassExplicitDefault
=== RUN   TestAccDynamoDBTable_tableClass_ConcurrentModification
=== PAUSE TestAccDynamoDBTable_tableClass_ConcurrentModification
=== RUN   TestAccDynamoDBTable_tableClass_migrate
=== PAUSE TestAccDynamoDBTable_tableClass_migrate
=== RUN   TestAccDynamoDBTable_backupEncryption
=== PAUSE TestAccDynamoDBTable_backupEncryption
=== RUN   TestAccDynamoDBTable_backup_overrideEncryption
=== PAUSE TestAccDynamoDBTable_backup_overrideEncryption
=== RUN   TestAccDynamoDBTable_importTable
=== PAUSE TestAccDynamoDBTable_importTable
=== CONT  TestAccDynamoDBTableReplica_basic
=== CONT  TestAccDynamoDBTable_gsiUpdateNonKeyAttributes
=== CONT  TestAccDynamoDBTable_Replica_pitr
--- PASS: TestAccDynamoDBTable_gsiUpdateNonKeyAttributes (299.36s)
=== CONT  TestAccDynamoDBTable_importTable
--- PASS: TestAccDynamoDBTableReplica_basic (322.41s)
=== CONT  TestAccDynamoDBTable_backup_overrideEncryption
--- PASS: TestAccDynamoDBTable_Replica_pitr (353.14s)
=== CONT  TestAccDynamoDBTable_backupEncryption
--- PASS: TestAccDynamoDBTable_importTable (161.46s)
=== CONT  TestAccDynamoDBTable_tableClass_migrate
--- PASS: TestAccDynamoDBTable_tableClass_migrate (198.98s)
=== CONT  TestAccDynamoDBTable_tableClass_ConcurrentModification
--- PASS: TestAccDynamoDBTable_tableClass_ConcurrentModification (47.73s)
=== CONT  TestAccDynamoDBTable_tableClassExplicitDefault
--- PASS: TestAccDynamoDBTable_tableClassExplicitDefault (37.45s)
=== CONT  TestAccDynamoDBTable_tableClassInfrequentAccess
--- PASS: TestAccDynamoDBTable_tableClassInfrequentAccess (48.07s)
=== CONT  TestAccDynamoDBTable_Replica_tagsUpdate
--- PASS: TestAccDynamoDBTable_Replica_tagsUpdate (457.26s)
=== CONT  TestAccDynamoDBTable_Replica_tagsNext
--- PASS: TestAccDynamoDBTable_backup_overrideEncryption (801.59s)
=== CONT  TestAccDynamoDBTable_Replica_tagsTwoOfTwo
--- PASS: TestAccDynamoDBTable_backupEncryption (800.39s)
=== CONT  TestAccDynamoDBTable_Replica_tagsOneOfTwo
--- PASS: TestAccDynamoDBTable_Replica_tagsTwoOfTwo (317.06s)
=== CONT  TestAccDynamoDBTable_Replica_pitrKMS
--- PASS: TestAccDynamoDBTable_Replica_tagsOneOfTwo (296.62s)
=== CONT  TestAccDynamoDBTable_encryption
--- PASS: TestAccDynamoDBTable_Replica_tagsNext (493.29s)
=== CONT  TestAccDynamoDBTable_Replica_doubleAddCMK
--- PASS: TestAccDynamoDBTable_encryption (122.76s)
=== CONT  TestAccDynamoDBTable_Replica_singleCMK
--- PASS: TestAccDynamoDBTable_Replica_singleCMK (218.01s)
=== CONT  TestAccDynamoDBTable_Replica_singleDefaultKeyEncrypted
--- PASS: TestAccDynamoDBTable_Replica_pitrKMS (468.27s)
=== CONT  TestAccDynamoDBTable_Replica_singleStreamSpecification
--- PASS: TestAccDynamoDBTable_Replica_singleDefaultKeyEncrypted (255.24s)
=== CONT  TestAccDynamoDBTable_Replica_single
--- PASS: TestAccDynamoDBTable_Replica_singleStreamSpecification (254.59s)
=== CONT  TestAccDynamoDBTable_Replica_multiple
--- PASS: TestAccDynamoDBTable_Replica_single (348.07s)
=== CONT  TestAccDynamoDBTable_attributeUpdateValidation
--- PASS: TestAccDynamoDBTable_attributeUpdateValidation (7.03s)
=== CONT  TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned
--- PASS: TestAccDynamoDBTable_Replica_doubleAddCMK (845.83s)
=== CONT  TestAccDynamoDBTable_lsiNonKeyAttributes
--- PASS: TestAccDynamoDBTable_lsiNonKeyAttributes (33.69s)
=== CONT  TestAccDynamoDBTable_attributeUpdate
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned (54.86s)
=== CONT  TestAccDynamoDBTable_gsiUpdateOtherAttributes
--- PASS: TestAccDynamoDBTable_Replica_multiple (579.02s)
=== CONT  TestAccDynamoDBTable_gsiUpdateCapacity
--- PASS: TestAccDynamoDBTable_gsiUpdateCapacity (67.48s)
=== CONT  TestAccDynamoDBTable_lsiUpdate
--- PASS: TestAccDynamoDBTable_lsiUpdate (64.43s)
=== CONT  TestAccDynamoDBTable_tags
--- PASS: TestAccDynamoDBTable_tags (45.25s)
=== CONT  TestAccDynamoDBTableReplica_keys
--- PASS: TestAccDynamoDBTableReplica_keys (274.62s)
=== CONT  TestAccDynamoDBTable_streamSpecificationValidation
--- PASS: TestAccDynamoDBTable_streamSpecificationValidation (2.94s)
=== CONT  TestAccDynamoDBTable_enablePITR
--- PASS: TestAccDynamoDBTable_enablePITR (70.92s)
=== CONT  TestAccDynamoDBTable_extended
--- PASS: TestAccDynamoDBTable_gsiUpdateOtherAttributes (832.19s)
=== CONT  TestAccDynamoDBTable_Disappears_payPerRequestWithGSI
--- PASS: TestAccDynamoDBTable_attributeUpdate (857.85s)
=== CONT  TestAccDynamoDBTable_disappears
--- PASS: TestAccDynamoDBTable_disappears (29.15s)
=== CONT  TestAccDynamoDBTable_streamSpecificationDiffs
--- PASS: TestAccDynamoDBTable_Disappears_payPerRequestWithGSI (92.09s)
=== CONT  TestAccDynamoDBTable_deletion_protection
--- PASS: TestAccDynamoDBTable_deletion_protection (45.77s)
=== CONT  TestAccDynamoDBTable_streamSpecification
--- PASS: TestAccDynamoDBTable_streamSpecificationDiffs (148.09s)
=== CONT  TestAccDynamoDBTable_basic
--- PASS: TestAccDynamoDBTable_streamSpecification (76.36s)
=== CONT  TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest
--- PASS: TestAccDynamoDBTable_basic (30.48s)
=== CONT  TestAccDynamoDBTable_TTL_enabled
--- PASS: TestAccDynamoDBTable_TTL_enabled (27.49s)
=== CONT  TestAccDynamoDBTable_TTL_disabled
--- PASS: TestAccDynamoDBTable_TTL_disabled (44.44s)
=== CONT  TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned
--- PASS: TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned (63.55s)
=== CONT  TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest
--- PASS: TestAccDynamoDBTable_extended (442.06s)
=== CONT  TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges (379.92s)
=== CONT  TestAccDynamoDBTableReplica_pitrDefault
--- PASS: TestAccDynamoDBTableReplica_pitrDefault (215.75s)
=== CONT  TestAccDynamoDBTableReplica_tableClass
--- PASS: TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest (1113.31s)
=== CONT  TestAccDynamoDBTableReplica_tags
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest (855.55s)
=== CONT  TestAccDynamoDBTableReplica_pitr
--- PASS: TestAccDynamoDBTableReplica_tableClass (330.70s)
=== CONT  TestAccDynamoDBTableReplica_pitrKMS
--- PASS: TestAccDynamoDBTableReplica_tags (233.46s)
=== CONT  TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges
--- PASS: TestAccDynamoDBTableReplica_pitr (176.50s)
=== CONT  TestAccDynamoDBTableReplica_disappears
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges (74.79s)
=== CONT  TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan
--- PASS: TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan (61.61s)
--- PASS: TestAccDynamoDBTableReplica_disappears (245.08s)
--- PASS: TestAccDynamoDBTableReplica_pitrKMS (279.48s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb	4928.121s
```