### PR TITLE
r/aws_redshift_cluster: skip_final_snapshot updates state only

### DIFF
--- a/.changelog/36635.txt
+++ b/.changelog/36635.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_redshift_cluster: Fix `InvalidParameterCombination` errors when updating only `skip_final_snapshot`
+```

--- a/internal/service/redshift/cluster.go
+++ b/internal/service/redshift/cluster.go
@@ -738,7 +738,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RedshiftConn(ctx)
 
-	if d.HasChangesExcept("aqua_configuration_status", "availability_zone", "iam_roles", "logging", "multi_az", "snapshot_copy", "tags", "tags_all") {
+	if d.HasChangesExcept("aqua_configuration_status", "availability_zone", "iam_roles", "logging", "multi_az", "snapshot_copy", "tags", "tags_all", "skip_final_snapshot") {
 		input := &redshift.ModifyClusterInput{
 			ClusterIdentifier: aws.String(d.Id()),
 		}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


Previously an update to `skip_final_snapshot` would trigger a call to the ModifyCluster API, which fails if no other arguments are modified.

Before:

  ```
  Terraform will perform the following actions:

  # aws_redshift_cluster.example will be updated in-place
  ~ resource "aws_redshift_cluster" "example" {
        id                                   = "tf-redshift-cluster"
      ~ skip_final_snapshot                  = false -> true
        tags                                 = {}
        # (38 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
aws_redshift_cluster.example: Modifying... [id=tf-redshift-cluster] ╷
│ Error: modifying Redshift Cluster (tf-redshift-cluster): InvalidParameterCombination: No modifications were requested
│       status code: 400, request id: 0b087c95-ac6b-4ad6-8eed-ded497fb4a2e
│
│   with aws_redshift_cluster.example,
│   on main.tf line 13, in resource "aws_redshift_cluster" "example":
│   13: resource "aws_redshift_cluster" "example" {
│
╵
```

After:

```
Terraform will perform the following actions:

  # aws_redshift_cluster.example will be updated in-place
  ~ resource "aws_redshift_cluster" "example" {
        id                                   = "tf-redshift-cluster"
      ~ skip_final_snapshot                  = false -> true
        tags                                 = {}
        # (38 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
aws_redshift_cluster.example: Modifying... [id=tf-redshift-cluster]
aws_redshift_cluster.example: Modifications complete after 1s [id=tf-redshift-cluster]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #30160

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=redshift TESTS=TestAccRedshiftCluster_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/redshift/... -v -count 1 -parallel 20 -run='TestAccRedshiftCluster_'  -timeout 360m

--- PASS: TestAccRedshiftCluster_changeAvailabilityZone_availabilityZoneRelocationNotSet (363.56s)
=== CONT  TestAccRedshiftCluster_updateNodeCount
--- PASS: TestAccRedshiftCluster_availabilityZoneRelocation_publiclyAccessible (367.74s)
=== CONT  TestAccRedshiftCluster_updateNodeType
--- PASS: TestAccRedshiftCluster_aqua (413.01s)
=== CONT  TestAccRedshiftCluster_iamRoles
--- PASS: TestAccRedshiftCluster_kmsKey (422.21s)
=== CONT  TestAccRedshiftCluster_changeAvailabilityZone
--- PASS: TestAccRedshiftCluster_disappears (423.58s)
=== CONT  TestAccRedshiftCluster_publiclyAccessible
--- PASS: TestAccRedshiftCluster_availabilityZoneRelocation (437.10s)
--- PASS: TestAccRedshiftCluster_tags (445.99s)
--- PASS: TestAccRedshiftCluster_basic (449.41s)
--- PASS: TestAccRedshiftCluster_snapshotCopy (454.19s)
--- PASS: TestAccRedshiftCluster_loggingEnabled (478.74s)
--- PASS: TestAccRedshiftCluster_withFinalSnapshot (479.88s)
--- PASS: TestAccRedshiftCluster_manageMasterPassword (531.65s)
--- PASS: TestAccRedshiftCluster_enhancedVPCRoutingEnabled (663.40s)
--- PASS: TestAccRedshiftCluster_forceNewUsername (797.23s)
--- PASS: TestAccRedshiftCluster_iamRoles (406.81s)
--- PASS: TestAccRedshiftCluster_multiAZ (867.56s)
--- PASS: TestAccRedshiftCluster_changeAvailabilityZoneAndSetAvailabilityZoneRelocation (872.22s)
--- PASS: TestAccRedshiftCluster_publiclyAccessible (452.18s)
--- PASS: TestAccRedshiftCluster_restoreFromSnapshotARN (965.99s)
--- PASS: TestAccRedshiftCluster_restoreFromSnapshot (991.94s)
--- PASS: TestAccRedshiftCluster_changeAvailabilityZone (769.91s)
--- PASS: TestAccRedshiftCluster_changeEncryption1 (1215.88s)
--- PASS: TestAccRedshiftCluster_changeEncryption2 (1360.85s)
--- PASS: TestAccRedshiftCluster_updateNodeType (1281.25s)
--- PASS: TestAccRedshiftCluster_updateNodeCount (1425.33s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/redshift   1794.511s
```
