### PR TITLE
iam/user: Force destroy with policies

### DIFF
--- a/.changelog/36640.txt
+++ b/.changelog/36640.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_iam_user: When `force_destroy` is used and there are inline or attached policies, allow resource to be destroyed
+```

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -381,7 +381,7 @@ sweep: prereq-go ## Run sweepers
 
 sweeper: prereq-go ## Run sweepers with failures allowed
 	@echo "WARNING: This will destroy infrastructure. Use only in development accounts."
-	$(GO_VER) test $(SWEEP_DIR) -v -tags=sweep -sweep=$(SWEEP) -sweep-allow-failures -timeout $(SWEEP_TIMEOUT)
+	$(GO_VER) test $(SWEEP_DIR) -v -sweep=$(SWEEP) -sweep-allow-failures -timeout $(SWEEP_TIMEOUT)
 
 t: prereq-go fmtcheck
 	TF_ACC=1 $(GO_VER) test ./$(PKG_NAME)/... -v -count $(TEST_COUNT) -parallel $(ACCTEST_PARALLELISM) $(RUNARGS) $(TESTARGS) -timeout $(ACCTEST_TIMEOUT)

--- a/internal/service/iam/exports.go
+++ b/internal/service/iam/exports.go
@@ -10,4 +10,5 @@ var (
 	DeleteServiceLinkedRole = deleteServiceLinkedRole
 	FindRoleByName          = findRoleByName
 	ListGroupsForUserPages  = listGroupsForUserPages
+	AttachPolicyToUser      = attachPolicyToUser
 )

--- a/internal/service/iam/user_test.go
+++ b/internal/service/iam/user_test.go
@@ -290,7 +290,7 @@ func TestAccIAMUser_ForceDestroy_policyAttached(t *testing.T) {
 				Config: testAccUserConfig_forceDestroy(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(ctx, resourceName, &user),
-					testAccCheckUserAttachPolicy(ctx, t, &user),
+					testAccCheckUserAttachPolicy(ctx, t, &user), // externally attach a policy
 				),
 			},
 		},
@@ -314,7 +314,7 @@ func TestAccIAMUser_ForceDestroy_policyInline(t *testing.T) {
 				Config: testAccUserConfig_forceDestroy(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(ctx, resourceName, &user),
-					testAccCheckUserInlinePolicy(ctx, t, &user),
+					testAccCheckUserInlinePolicy(ctx, t, &user), // externally put an inline policy
 				),
 			},
 		},
@@ -338,8 +338,8 @@ func TestAccIAMUser_ForceDestroy_policyInlineAttached(t *testing.T) {
 				Config: testAccUserConfig_forceDestroy(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(ctx, resourceName, &user),
-					testAccCheckUserInlinePolicy(ctx, t, &user),
-					testAccCheckUserAttachPolicy(ctx, t, &user),
+					testAccCheckUserInlinePolicy(ctx, t, &user), // externally put an inline policy
+					testAccCheckUserAttachPolicy(ctx, t, &user), // externally attach a policy
 				),
 			},
 		},

--- a/internal/service/iam/user_test.go
+++ b/internal/service/iam/user_test.go
@@ -290,7 +290,7 @@ func TestAccIAMUser_ForceDestroy_policyAttached(t *testing.T) {
 				Config: testAccUserConfig_forceDestroy(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(ctx, resourceName, &user),
-					testAccCheckUserAttachPolicy(ctx, t, &user), // externally attach a policy
+					testAccCheckUserAttachPolicy(ctx, &user), // externally attach a policy
 				),
 			},
 		},
@@ -314,7 +314,7 @@ func TestAccIAMUser_ForceDestroy_policyInline(t *testing.T) {
 				Config: testAccUserConfig_forceDestroy(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(ctx, resourceName, &user),
-					testAccCheckUserInlinePolicy(ctx, t, &user), // externally put an inline policy
+					testAccCheckUserInlinePolicy(ctx, &user), // externally put an inline policy
 				),
 			},
 		},
@@ -338,8 +338,8 @@ func TestAccIAMUser_ForceDestroy_policyInlineAttached(t *testing.T) {
 				Config: testAccUserConfig_forceDestroy(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(ctx, resourceName, &user),
-					testAccCheckUserInlinePolicy(ctx, t, &user), // externally put an inline policy
-					testAccCheckUserAttachPolicy(ctx, t, &user), // externally attach a policy
+					testAccCheckUserInlinePolicy(ctx, &user), // externally put an inline policy
+					testAccCheckUserAttachPolicy(ctx, &user), // externally attach a policy
 				),
 			},
 		},
@@ -741,7 +741,7 @@ func testAccCheckUserUploadSigningCertificate(ctx context.Context, t *testing.T,
 	}
 }
 
-func testAccCheckUserAttachPolicy(ctx context.Context, t *testing.T, user *awstypes.User) resource.TestCheckFunc {
+func testAccCheckUserAttachPolicy(ctx context.Context, user *awstypes.User) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
 
@@ -772,7 +772,7 @@ func testAccCheckUserAttachPolicy(ctx context.Context, t *testing.T, user *awsty
 	}
 }
 
-func testAccCheckUserInlinePolicy(ctx context.Context, t *testing.T, user *awstypes.User) resource.TestCheckFunc {
+func testAccCheckUserInlinePolicy(ctx context.Context, user *awstypes.User) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #12903

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing


```console
% make t T=TestAccIAMUser K=iam P=12                       
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/iam/... -v -count 1 -parallel 12 -run='TestAccIAMUser'  -timeout 360m
=== RUN   TestAccIAMUserDataSource_basic
=== PAUSE TestAccIAMUserDataSource_basic
=== RUN   TestAccIAMUserDataSource_tags
=== PAUSE TestAccIAMUserDataSource_tags
=== RUN   TestAccIAMUserGroupMembership_basic
=== PAUSE TestAccIAMUserGroupMembership_basic
=== RUN   TestAccIAMUserLoginProfile_basic
=== PAUSE TestAccIAMUserLoginProfile_basic
=== RUN   TestAccIAMUserLoginProfile_keybase
=== PAUSE TestAccIAMUserLoginProfile_keybase
=== RUN   TestAccIAMUserLoginProfile_keybaseDoesntExist
=== PAUSE TestAccIAMUserLoginProfile_keybaseDoesntExist
=== RUN   TestAccIAMUserLoginProfile_notAKey
=== PAUSE TestAccIAMUserLoginProfile_notAKey
=== RUN   TestAccIAMUserLoginProfile_passwordLength
=== PAUSE TestAccIAMUserLoginProfile_passwordLength
=== RUN   TestAccIAMUserLoginProfile_nogpg
=== PAUSE TestAccIAMUserLoginProfile_nogpg
=== RUN   TestAccIAMUserLoginProfile_disappears
=== PAUSE TestAccIAMUserLoginProfile_disappears
=== RUN   TestAccIAMUserPolicyAttachment_basic
=== PAUSE TestAccIAMUserPolicyAttachment_basic
=== RUN   TestAccIAMUserPolicyAttachment_disappears
=== PAUSE TestAccIAMUserPolicyAttachment_disappears
=== RUN   TestAccIAMUserPolicy_basic
=== PAUSE TestAccIAMUserPolicy_basic
=== RUN   TestAccIAMUserPolicy_disappears
=== PAUSE TestAccIAMUserPolicy_disappears
=== RUN   TestAccIAMUserPolicy_nameGenerated
=== PAUSE TestAccIAMUserPolicy_nameGenerated
=== RUN   TestAccIAMUserPolicy_namePrefix
=== PAUSE TestAccIAMUserPolicy_namePrefix
=== RUN   TestAccIAMUserPolicy_multiplePolicies
=== PAUSE TestAccIAMUserPolicy_multiplePolicies
=== RUN   TestAccIAMUserPolicy_policyOrder
=== PAUSE TestAccIAMUserPolicy_policyOrder
=== RUN   TestAccIAMUserSSHKeyDataSource_basic
=== PAUSE TestAccIAMUserSSHKeyDataSource_basic
=== RUN   TestAccIAMUserSSHKey_basic
=== PAUSE TestAccIAMUserSSHKey_basic
=== RUN   TestAccIAMUserSSHKey_disappears
=== PAUSE TestAccIAMUserSSHKey_disappears
=== RUN   TestAccIAMUserSSHKey_pemEncoding
=== PAUSE TestAccIAMUserSSHKey_pemEncoding
=== RUN   TestAccIAMUser_tags
=== PAUSE TestAccIAMUser_tags
=== RUN   TestAccIAMUser_tags_null
=== PAUSE TestAccIAMUser_tags_null
=== RUN   TestAccIAMUser_tags_AddOnUpdate
=== PAUSE TestAccIAMUser_tags_AddOnUpdate
=== RUN   TestAccIAMUser_tags_EmptyTag_OnCreate
=== PAUSE TestAccIAMUser_tags_EmptyTag_OnCreate
=== RUN   TestAccIAMUser_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccIAMUser_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccIAMUser_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccIAMUser_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccIAMUser_tags_DefaultTags_providerOnly
=== PAUSE TestAccIAMUser_tags_DefaultTags_providerOnly
=== RUN   TestAccIAMUser_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccIAMUser_tags_DefaultTags_nonOverlapping
=== RUN   TestAccIAMUser_tags_DefaultTags_overlapping
=== PAUSE TestAccIAMUser_tags_DefaultTags_overlapping
=== RUN   TestAccIAMUser_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccIAMUser_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccIAMUser_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccIAMUser_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccIAMUser_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccIAMUser_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccIAMUser_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccIAMUser_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccIAMUser_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccIAMUser_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccIAMUser_basic
=== PAUSE TestAccIAMUser_basic
=== RUN   TestAccIAMUser_disappears
=== PAUSE TestAccIAMUser_disappears
=== RUN   TestAccIAMUser_ForceDestroy_accessKey
=== PAUSE TestAccIAMUser_ForceDestroy_accessKey
=== RUN   TestAccIAMUser_ForceDestroy_loginProfile
=== PAUSE TestAccIAMUser_ForceDestroy_loginProfile
=== RUN   TestAccIAMUser_ForceDestroy_mfaDevice
=== PAUSE TestAccIAMUser_ForceDestroy_mfaDevice
=== RUN   TestAccIAMUser_ForceDestroy_sshKey
=== PAUSE TestAccIAMUser_ForceDestroy_sshKey
=== RUN   TestAccIAMUser_ForceDestroy_serviceSpecificCred
=== PAUSE TestAccIAMUser_ForceDestroy_serviceSpecificCred
=== RUN   TestAccIAMUser_ForceDestroy_signingCertificate
=== PAUSE TestAccIAMUser_ForceDestroy_signingCertificate
=== RUN   TestAccIAMUser_ForceDestroy_policyAttached
=== PAUSE TestAccIAMUser_ForceDestroy_policyAttached
=== RUN   TestAccIAMUser_ForceDestroy_policyInline
=== PAUSE TestAccIAMUser_ForceDestroy_policyInline
=== RUN   TestAccIAMUser_ForceDestroy_policyInlineAttached
=== PAUSE TestAccIAMUser_ForceDestroy_policyInlineAttached
=== RUN   TestAccIAMUser_nameChange
=== PAUSE TestAccIAMUser_nameChange
=== RUN   TestAccIAMUser_pathChange
=== PAUSE TestAccIAMUser_pathChange
=== RUN   TestAccIAMUser_permissionsBoundary
=== PAUSE TestAccIAMUser_permissionsBoundary
=== RUN   TestAccIAMUsersDataSource_nameRegex
=== PAUSE TestAccIAMUsersDataSource_nameRegex
=== RUN   TestAccIAMUsersDataSource_pathPrefix
=== PAUSE TestAccIAMUsersDataSource_pathPrefix
=== RUN   TestAccIAMUsersDataSource_nonExistentNameRegex
=== PAUSE TestAccIAMUsersDataSource_nonExistentNameRegex
=== RUN   TestAccIAMUsersDataSource_nonExistentPathPrefix
=== PAUSE TestAccIAMUsersDataSource_nonExistentPathPrefix
=== CONT  TestAccIAMUserDataSource_basic
=== CONT  TestAccIAMUser_tags_EmptyTag_OnUpdate_Replace
=== CONT  TestAccIAMUserPolicy_nameGenerated
=== CONT  TestAccIAMUserLoginProfile_passwordLength
=== CONT  TestAccIAMUserLoginProfile_keybase
=== CONT  TestAccIAMUserLoginProfile_basic
=== CONT  TestAccIAMUserPolicyAttachment_disappears
=== CONT  TestAccIAMUsersDataSource_nonExistentPathPrefix
=== CONT  TestAccIAMUserDataSource_tags
=== CONT  TestAccIAMUserPolicy_disappears
=== CONT  TestAccIAMUserGroupMembership_basic
=== CONT  TestAccIAMUserLoginProfile_notAKey
--- PASS: TestAccIAMUserLoginProfile_notAKey (16.84s)
=== CONT  TestAccIAMUserPolicy_basic
--- PASS: TestAccIAMUsersDataSource_nonExistentPathPrefix (20.24s)
=== CONT  TestAccIAMUser_ForceDestroy_mfaDevice
--- PASS: TestAccIAMUserDataSource_tags (25.26s)
=== CONT  TestAccIAMUsersDataSource_nonExistentNameRegex
--- PASS: TestAccIAMUserDataSource_basic (27.70s)
=== CONT  TestAccIAMUsersDataSource_pathPrefix
--- PASS: TestAccIAMUserPolicy_disappears (29.84s)
=== CONT  TestAccIAMUsersDataSource_nameRegex
--- PASS: TestAccIAMUserPolicyAttachment_disappears (30.06s)
=== CONT  TestAccIAMUser_permissionsBoundary
--- PASS: TestAccIAMUserPolicy_nameGenerated (36.13s)
=== CONT  TestAccIAMUser_pathChange
--- PASS: TestAccIAMUserLoginProfile_keybase (36.90s)
=== CONT  TestAccIAMUser_nameChange
--- PASS: TestAccIAMUserLoginProfile_passwordLength (36.94s)
=== CONT  TestAccIAMUser_ForceDestroy_loginProfile
--- PASS: TestAccIAMUserLoginProfile_basic (46.13s)
=== CONT  TestAccIAMUser_ForceDestroy_accessKey
--- PASS: TestAccIAMUsersDataSource_nonExistentNameRegex (24.56s)
=== CONT  TestAccIAMUser_disappears
--- PASS: TestAccIAMUsersDataSource_pathPrefix (27.54s)
=== CONT  TestAccIAMUserLoginProfile_keybaseDoesntExist
--- PASS: TestAccIAMUser_tags_EmptyTag_OnUpdate_Replace (57.48s)
=== CONT  TestAccIAMUser_basic
--- PASS: TestAccIAMUsersDataSource_nameRegex (29.24s)
=== CONT  TestAccIAMUser_tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccIAMUser_ForceDestroy_mfaDevice (39.13s)
=== CONT  TestAccIAMUser_tags_AddOnUpdate
--- PASS: TestAccIAMUserLoginProfile_keybaseDoesntExist (18.04s)
=== CONT  TestAccIAMUser_tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccIAMUser_ForceDestroy_loginProfile (39.58s)
=== CONT  TestAccIAMUser_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccIAMUserPolicy_basic (62.87s)
=== CONT  TestAccIAMUserPolicyAttachment_basic
--- PASS: TestAccIAMUser_disappears (31.61s)
=== CONT  TestAccIAMUserLoginProfile_disappears
--- PASS: TestAccIAMUser_ForceDestroy_accessKey (38.16s)
=== CONT  TestAccIAMUserLoginProfile_nogpg
--- PASS: TestAccIAMUser_tags_DefaultTags_nullNonOverlappingResourceTag (35.78s)
=== CONT  TestAccIAMUserSSHKey_pemEncoding
--- PASS: TestAccIAMUser_nameChange (59.30s)
=== CONT  TestAccIAMUser_tags_EmptyTag_OnCreate
--- PASS: TestAccIAMUser_pathChange (60.14s)
=== CONT  TestAccIAMUserSSHKeyDataSource_basic
--- PASS: TestAccIAMUser_tags_DefaultTags_nullOverlappingResourceTag (33.64s)
=== CONT  TestAccIAMUser_tags_null
--- PASS: TestAccIAMUser_basic (58.20s)
=== CONT  TestAccIAMUserSSHKey_disappears
--- PASS: TestAccIAMUser_tags_AddOnUpdate (58.74s)
=== CONT  TestAccIAMUser_tags_DefaultTags_overlapping
--- PASS: TestAccIAMUserLoginProfile_nogpg (36.78s)
=== CONT  TestAccIAMUserSSHKey_basic
--- PASS: TestAccIAMUserLoginProfile_disappears (42.09s)
=== CONT  TestAccIAMUser_tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccIAMUserSSHKeyDataSource_basic (30.44s)
=== CONT  TestAccIAMUser_tags_DefaultTags_emptyResourceTag
--- PASS: TestAccIAMUserSSHKey_pemEncoding (37.42s)
=== CONT  TestAccIAMUserPolicy_multiplePolicies
--- PASS: TestAccIAMUserPolicyAttachment_basic (58.76s)
=== CONT  TestAccIAMUser_ForceDestroy_policyInlineAttached
--- PASS: TestAccIAMUserSSHKey_disappears (32.53s)
=== CONT  TestAccIAMUser_tags_DefaultTags_nonOverlapping
=== CONT  TestAccIAMUser_ForceDestroy_serviceSpecificCred
--- PASS: TestAccIAMUserGroupMembership_basic (157.02s)
--- PASS: TestAccIAMUser_tags_null (52.26s)
=== CONT  TestAccIAMUser_tags_DefaultTags_providerOnly
--- PASS: TestAccIAMUserSSHKey_basic (40.64s)
=== CONT  TestAccIAMUser_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccIAMUser_tags_DefaultTags_emptyResourceTag (36.90s)
=== CONT  TestAccIAMUser_ForceDestroy_policyInline
--- PASS: TestAccIAMUser_tags_EmptyTag_OnUpdate_Add (89.88s)
=== CONT  TestAccIAMUser_ForceDestroy_signingCertificate
--- PASS: TestAccIAMUser_tags_EmptyTag_OnCreate (70.26s)
=== CONT  TestAccIAMUser_ForceDestroy_policyAttached
--- PASS: TestAccIAMUser_ForceDestroy_policyInlineAttached (32.22s)
=== CONT  TestAccIAMUser_ForceDestroy_sshKey
--- PASS: TestAccIAMUser_tags_DefaultTags_updateToResourceOnly (57.65s)
=== CONT  TestAccIAMUserPolicy_namePrefix
--- PASS: TestAccIAMUserPolicy_multiplePolicies (55.59s)
=== CONT  TestAccIAMUser_tags
--- PASS: TestAccIAMUser_permissionsBoundary (159.11s)
=== CONT  TestAccIAMUserPolicy_policyOrder
--- PASS: TestAccIAMUser_ForceDestroy_policyInline (30.29s)
--- PASS: TestAccIAMUser_ForceDestroy_serviceSpecificCred (38.77s)
--- PASS: TestAccIAMUser_ForceDestroy_policyAttached (31.09s)
--- PASS: TestAccIAMUser_ForceDestroy_signingCertificate (37.92s)
--- PASS: TestAccIAMUser_ForceDestroy_sshKey (36.20s)
--- PASS: TestAccIAMUser_tags_DefaultTags_overlapping (92.32s)
--- PASS: TestAccIAMUserPolicy_namePrefix (32.42s)
--- PASS: TestAccIAMUser_tags_DefaultTags_updateToProviderOnly (52.24s)
--- PASS: TestAccIAMUserPolicy_policyOrder (30.39s)
--- PASS: TestAccIAMUser_tags_DefaultTags_nonOverlapping (76.56s)
--- PASS: TestAccIAMUser_tags_DefaultTags_providerOnly (79.84s)
--- PASS: TestAccIAMUser_tags (66.70s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	257.311s
```