### PR TITLE
Fix/Enhancement: Add application_tag attribute to aws_servicecatalogappregistry_application

### DIFF
--- a/.changelog/36647.txt
+++ b/.changelog/36647.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_servicecatalogappregistry_application: Add `application_tag` attribute
+```
+
+```release-note:enhancement
+data-source//aws_servicecatalogappregistry_application: Add `application_tag` attribute
+```

--- a/internal/service/servicecatalogappregistry/application.go
+++ b/internal/service/servicecatalogappregistry/application.go
@@ -59,6 +59,10 @@ func (r *resourceApplication) Schema(ctx context.Context, req resource.SchemaReq
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
+			"application_tag": schema.MapAttribute{
+				ElementType: types.StringType,
+				Computed:    true,
+			},
 		},
 	}
 }
@@ -219,8 +223,9 @@ func findApplicationByID(ctx context.Context, conn *servicecatalogappregistry.Cl
 }
 
 type resourceApplicationData struct {
-	ARN         types.String `tfsdk:"arn"`
-	Description types.String `tfsdk:"description"`
-	ID          types.String `tfsdk:"id"`
-	Name        types.String `tfsdk:"name"`
+	ARN            types.String `tfsdk:"arn"`
+	Description    types.String `tfsdk:"description"`
+	ID             types.String `tfsdk:"id"`
+	Name           types.String `tfsdk:"name"`
+	ApplicationTag types.Map    `tfsdk:"application_tag"`
 }

--- a/internal/service/servicecatalogappregistry/application_data_source.go
+++ b/internal/service/servicecatalogappregistry/application_data_source.go
@@ -45,6 +45,10 @@ func (d *dataSourceApplication) Schema(ctx context.Context, req datasource.Schem
 			"name": schema.StringAttribute{
 				Computed: true,
 			},
+			"application_tag": schema.MapAttribute{
+				ElementType: types.StringType,
+				Computed:    true,
+			},
 		},
 	}
 }
@@ -71,8 +75,9 @@ func (d *dataSourceApplication) Read(ctx context.Context, req datasource.ReadReq
 }
 
 type dataSourceApplicationData struct {
-	ARN         types.String `tfsdk:"arn"`
-	Description types.String `tfsdk:"description"`
-	ID          types.String `tfsdk:"id"`
-	Name        types.String `tfsdk:"name"`
+	ARN            types.String `tfsdk:"arn"`
+	Description    types.String `tfsdk:"description"`
+	ID             types.String `tfsdk:"id"`
+	Name           types.String `tfsdk:"name"`
+	ApplicationTag types.Map    `tfsdk:"application_tag"`
 }

--- a/internal/service/servicecatalogappregistry/application_data_source_test.go
+++ b/internal/service/servicecatalogappregistry/application_data_source_test.go
@@ -50,5 +50,12 @@ resource "aws_servicecatalogappregistry_application" "test" {
 data "aws_servicecatalogappregistry_application" "test" {
   id = aws_servicecatalogappregistry_application.test.id
 }
+
+resource "aws_ssm_parameter" "test" {
+	name  = %[1]q
+	type  = "String"
+	value = "test"
+	tags  = data.aws_servicecatalogappregistry_application.test.application_tag
+  }
 `, rName)
 }

--- a/internal/service/servicecatalogappregistry/application_data_source_test.go
+++ b/internal/service/servicecatalogappregistry/application_data_source_test.go
@@ -52,10 +52,10 @@ data "aws_servicecatalogappregistry_application" "test" {
 }
 
 resource "aws_ssm_parameter" "test" {
-	name  = %[1]q
-	type  = "String"
-	value = "test"
-	tags  = data.aws_servicecatalogappregistry_application.test.application_tag
-  }
+  name  = %[1]q
+  type  = "String"
+  value = "test"
+  tags  = data.aws_servicecatalogappregistry_application.test.application_tag
+}
 `, rName)
 }

--- a/internal/service/servicecatalogappregistry/application_test.go
+++ b/internal/service/servicecatalogappregistry/application_test.go
@@ -177,6 +177,13 @@ func testAccApplicationConfig_basic(name string) string {
 resource "aws_servicecatalogappregistry_application" "test" {
   name = %[1]q
 }
+
+resource "aws_ssm_parameter" "test" {
+  name  = %[1]q
+  type  = "String"
+  value = "test"
+  tags  = aws_servicecatalogappregistry_application.test.application_tag
+}
 `, name)
 }
 

--- a/website/docs/d/servicecatalogappregistry_application.html.markdown
+++ b/website/docs/d/servicecatalogappregistry_application.html.markdown
@@ -30,7 +30,7 @@ The following arguments are required:
 
 This data source exports the following attributes in addition to the arguments above:
 
+* `application_tag` - A map with a single tag key-value pair used to associate resources with the application.
 * `arn` - ARN (Amazon Resource Name) of the application.
 * `description` - Description of the application.
 * `name` - Name of the application.
-* `application_tag` - A map of tags containing the tags to assigned to resources that should be connected to the application

--- a/website/docs/d/servicecatalogappregistry_application.html.markdown
+++ b/website/docs/d/servicecatalogappregistry_application.html.markdown
@@ -33,3 +33,4 @@ This data source exports the following attributes in addition to the arguments a
 * `arn` - ARN (Amazon Resource Name) of the application.
 * `description` - Description of the application.
 * `name` - Name of the application.
+* `application_tag` - A map of tags containing the tags to assigned to resources that should be connected to the application

--- a/website/docs/r/servicecatalogappregistry_application.html.markdown
+++ b/website/docs/r/servicecatalogappregistry_application.html.markdown
@@ -31,9 +31,7 @@ resource "aws_servicecatalogappregistry_application" "example" {
 resource "aws_s3_bucket" "bucket" {
   bucket = "example-bucket"
 
-  tags = {
-    awsApplication = aws_servicecatalogappregistry_application.example.arn
-  }
+  tags = aws_servicecatalogappregistry_application.example.application_tag
 }
 ```
 
@@ -53,6 +51,7 @@ This resource exports the following attributes in addition to the arguments abov
 
 * `arn` - ARN (Amazon Resource Name) of the application.
 * `id` - Identifier of the application.
+* `application_tag` - A map of tags to assign to resources that should be connected to the application
 
 ## Import
 

--- a/website/docs/r/servicecatalogappregistry_application.html.markdown
+++ b/website/docs/r/servicecatalogappregistry_application.html.markdown
@@ -49,9 +49,9 @@ The following arguments are optional:
 
 This resource exports the following attributes in addition to the arguments above:
 
+* `application_tag` - A map with a single tag key-value pair used to associate resources with the application. This attribute can be passed directly into the `tags` argument of another resource, or merged into a map of existing tags.
 * `arn` - ARN (Amazon Resource Name) of the application.
 * `id` - Identifier of the application.
-* `application_tag` - A map of tags to assign to resources that should be connected to the application
 
 ## Import
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

This PR adds the `application_tag` attribute to the `aws_servicecatalogappregistry_application` resource. There is a design flaw in the new resource. It's not the Application's ARN that has to be assigned to the resource.

The actual tag(s) (key and name) are available in the SDK so just needs to be added.

This PR adds the new attribute and updates the documentation. Also implemented this in the tests

<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccServiceCatalogAppRegistryApplication PKG=servicecatalogappregistry
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/servicecatalogappregistry/... -v -count 1 -parallel 20 -run='TestAccServiceCatalogAppRegistryApplication'  -timeout 360m
=== RUN   TestAccServiceCatalogAppRegistryApplicationDataSource_basic
=== PAUSE TestAccServiceCatalogAppRegistryApplicationDataSource_basic
=== RUN   TestAccServiceCatalogAppRegistryApplication_basic
=== PAUSE TestAccServiceCatalogAppRegistryApplication_basic
=== RUN   TestAccServiceCatalogAppRegistryApplication_disappears
=== PAUSE TestAccServiceCatalogAppRegistryApplication_disappears
=== RUN   TestAccServiceCatalogAppRegistryApplication_update
=== PAUSE TestAccServiceCatalogAppRegistryApplication_update
=== CONT  TestAccServiceCatalogAppRegistryApplicationDataSource_basic
=== CONT  TestAccServiceCatalogAppRegistryApplication_disappears
=== CONT  TestAccServiceCatalogAppRegistryApplication_update
=== CONT  TestAccServiceCatalogAppRegistryApplication_basic
--- PASS: TestAccServiceCatalogAppRegistryApplicationDataSource_basic (8.73s)
--- PASS: TestAccServiceCatalogAppRegistryApplication_disappears (8.97s)
--- PASS: TestAccServiceCatalogAppRegistryApplication_basic (10.32s)
--- PASS: TestAccServiceCatalogAppRegistryApplication_update (19.59s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/servicecatalogappregistry  24.110s
...
```
