### PR TITLE
r/lakeformation_permissions: use flex functions to flatten/expand permissions

### DIFF
--- a/internal/flex/flex.go
+++ b/internal/flex/flex.go
@@ -127,6 +127,14 @@ func FlattenStringValueList(list []string) []interface{} {
 	return vs
 }
 
+func FlattenStringyValueList[E ~string](configured []E) []any {
+	vs := make([]interface{}, 0, len(configured))
+	for _, v := range configured {
+		vs = append(vs, string(v))
+	}
+	return vs
+}
+
 // Expands a map of string to interface to a map of string to int32
 func ExpandInt32Map(m map[string]interface{}) map[string]int32 {
 	return tfmaps.ApplyToAllValues(m, func(v any) int32 {
@@ -205,6 +213,10 @@ func FlattenStringSet(list []*string) *schema.Set {
 
 func FlattenStringValueSet(list []string) *schema.Set {
 	return schema.NewSet(schema.HashString, FlattenStringValueList(list)) // nosemgrep: helper-schema-Set-extraneous-NewSet-with-FlattenStringList
+}
+
+func FlattenStringyValueSet[E ~string](list []E) *schema.Set {
+	return schema.NewSet(schema.HashString, FlattenStringyValueList[E](list))
 }
 
 func FlattenStringMap(m map[string]*string) map[string]interface{} {

--- a/internal/service/lakeformation/data_lake_settings.go
+++ b/internal/service/lakeformation/data_lake_settings.go
@@ -308,7 +308,7 @@ func expandDataLakeSettingsCreateDefaultPermissions(tfMaps []interface{}) []awst
 
 func expandDataLakeSettingsCreateDefaultPermission(tfMap map[string]interface{}) awstypes.PrincipalPermissions {
 	apiObject := awstypes.PrincipalPermissions{
-		Permissions: expandPermissions(tfMap["permissions"].(*schema.Set).List()),
+		Permissions: flex.ExpandStringyValueList[awstypes.Permission](tfMap["permissions"].(*schema.Set).List()),
 		Principal: &awstypes.DataLakePrincipal{
 			DataLakePrincipalIdentifier: aws.String(tfMap["principal"].(string)),
 		},
@@ -338,7 +338,8 @@ func flattenDataLakeSettingsCreateDefaultPermission(apiObject awstypes.Principal
 	}
 
 	if apiObject.Permissions != nil {
-		tfMap["permissions"] = flex.FlattenStringValueSet(flattenPermissions(apiObject.Permissions))
+		// tfMap["permissions"] = flex.FlattenStringValueSet(flattenPermissions(apiObject.Permissions))
+		tfMap["permissions"] = flex.FlattenStringyValueSet(apiObject.Permissions)
 	}
 
 	if v := aws.ToString(apiObject.Principal.DataLakePrincipalIdentifier); v != "" {
@@ -346,33 +347,6 @@ func flattenDataLakeSettingsCreateDefaultPermission(apiObject awstypes.Principal
 	}
 
 	return tfMap
-}
-
-func expandPermissions(in []interface{}) []awstypes.Permission {
-	if len(in) == 0 {
-		return nil
-	}
-
-	var out []awstypes.Permission
-
-	for _, v := range in {
-		out = append(out, awstypes.Permission(v.(string)))
-	}
-
-	return out
-}
-
-func flattenPermissions(apiObjects []awstypes.Permission) []string {
-	if len(apiObjects) == 0 {
-		return nil
-	}
-
-	var out []string
-	for _, apiObject := range apiObjects {
-		out = append(out, string(apiObject))
-	}
-
-	return out
 }
 
 func expandDataLakeSettingsAdmins(tfSet *schema.Set) []awstypes.DataLakePrincipal {

--- a/internal/service/lakeformation/permissions.go
+++ b/internal/service/lakeformation/permissions.go
@@ -420,7 +420,7 @@ func resourcePermissionsCreate(ctx context.Context, d *schema.ResourceData, meta
 	conn := meta.(*conns.AWSClient).LakeFormationClient(ctx)
 
 	input := &lakeformation.GrantPermissionsInput{
-		Permissions: expandPermissions(d.Get("permissions").([]interface{})),
+		Permissions: flex.ExpandStringyValueList[awstypes.Permission](d.Get("permissions").([]interface{})),
 		Principal: &awstypes.DataLakePrincipal{
 			DataLakePrincipalIdentifier: aws.String(d.Get("principal").(string)),
 		},
@@ -436,7 +436,7 @@ func resourcePermissionsCreate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if v, ok := d.GetOk("permissions_with_grant_option"); ok {
-		input.PermissionsWithGrantOption = expandPermissions(v.([]interface{}))
+		input.PermissionsWithGrantOption = flex.ExpandStringyValueList[awstypes.Permission](v.([]interface{}))
 	}
 
 	if _, ok := d.GetOk("catalog_resource"); ok {
@@ -739,8 +739,8 @@ func resourcePermissionsDelete(ctx context.Context, d *schema.ResourceData, meta
 	conn := meta.(*conns.AWSClient).LakeFormationClient(ctx)
 
 	input := &lakeformation.RevokePermissionsInput{
-		Permissions:                expandPermissions(d.Get("permissions").([]interface{})),
-		PermissionsWithGrantOption: expandPermissions(d.Get("permissions_with_grant_option").([]interface{})),
+		Permissions:                flex.ExpandStringyValueList[awstypes.Permission](d.Get("permissions").([]interface{})),
+		PermissionsWithGrantOption: flex.ExpandStringyValueList[awstypes.Permission](d.Get("permissions_with_grant_option").([]interface{})),
 		Principal: &awstypes.DataLakePrincipal{
 			DataLakePrincipalIdentifier: aws.String(d.Get("principal").(string)),
 		},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:
--->


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS="-run=TestAccLakeFormation_serial/DataLakeSettings\|TestAccLakeFormation_serial/Permissions" PKG=lakeformation

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/lakeformation/... -v -count 1 -parallel 20  -run=TestAccLakeFormation_serial/DataLakeSettings\|TestAccLakeFormation_serial/Permissions -timeout 360m
--- PASS: TestAccLakeFormation_serial (818.66s)
    --- PASS: TestAccLakeFormation_serial/PermissionsDataSource (163.71s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/dataCellsFilter (22.72s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/database (20.52s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/dataLocation (18.53s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/lfTag (19.48s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/lfTagPolicy (19.44s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/table (22.20s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/tableWithColumns (21.81s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/basic (19.01s)
    --- PASS: TestAccLakeFormation_serial/DataLakeSettingsDataSource (19.95s)
        --- PASS: TestAccLakeFormation_serial/DataLakeSettingsDataSource/basic (10.07s)
        --- PASS: TestAccLakeFormation_serial/DataLakeSettingsDataSource/readOnlyAdmins (9.88s)
    --- PASS: TestAccLakeFormation_serial/PermissionsTable (199.64s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/iamAllowed (42.49s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/multipleRoles (21.17s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/selectPlus (21.08s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/wildcardSelectOnly (20.72s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/basic (16.98s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/implicit (20.14s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/selectOnly (17.10s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/wildcardNoSelect (19.33s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/wildcardSelectPlus (20.63s)
    --- PASS: TestAccLakeFormation_serial/PermissionsTableWithColumns (125.73s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTableWithColumns/wildcardExcludedColumns (21.09s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTableWithColumns/wildcardSelectOnly (21.27s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTableWithColumns/wildcardSelectPlus (17.06s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTableWithColumns/basic (46.08s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTableWithColumns/implicit (20.23s)
    --- PASS: TestAccLakeFormation_serial/DataLakeSettings (38.25s)
        --- PASS: TestAccLakeFormation_serial/DataLakeSettings/basic (9.31s)
        --- PASS: TestAccLakeFormation_serial/DataLakeSettings/disappears (10.19s)
        --- PASS: TestAccLakeFormation_serial/DataLakeSettings/withoutCatalogId (9.42s)
        --- PASS: TestAccLakeFormation_serial/DataLakeSettings/readOnlyAdmins (9.33s)
    --- PASS: TestAccLakeFormation_serial/PermissionsBasic (271.38s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/basic (18.20s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/databaseIAMAllowed (40.96s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/dataCellsFilter (16.97s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/dataLocation (17.74s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/lfTagPolicyMultiple (18.83s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/database (19.37s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/databaseMultiple (19.68s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/disappears (81.99s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/lfTag (18.71s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/lfTagPolicy (18.93s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lakeformation	824.380s
```
