### PR TITLE
d/aws_devopsguru_notification_channel: new data source

### DIFF
--- a/.changelog/36656.txt
+++ b/.changelog/36656.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_devopsguru_notification_channel
+```

--- a/internal/service/devopsguru/devopsguru_test.go
+++ b/internal/service/devopsguru/devopsguru_test.go
@@ -24,6 +24,9 @@ func TestAccDevOpsGuru_serial(t *testing.T) {
 			"disappears": testAccNotificationChannel_disappears,
 			"filters":    testAccNotificationChannel_filters,
 		},
+		"NotificationChannelDataSource": {
+			"basic": testAccNotificationChannelDataSource_basic,
+		},
 		"ResourceCollection": {
 			"basic":            testAccResourceCollection_basic,
 			"cloudformation":   testAccResourceCollection_cloudformation,

--- a/internal/service/devopsguru/notification_channel_data_source.go
+++ b/internal/service/devopsguru/notification_channel_data_source.go
@@ -1,0 +1,101 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package devopsguru
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource(name="Notification Channel")
+func newDataSourceNotificationChannel(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &dataSourceNotificationChannel{}, nil
+}
+
+const (
+	DSNameNotificationChannel = "Notification Channel Data Source"
+)
+
+type dataSourceNotificationChannel struct {
+	framework.DataSourceWithConfigure
+}
+
+func (d *dataSourceNotificationChannel) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) { // nosemgrep:ci.meta-in-func-name
+	resp.TypeName = "aws_devopsguru_notification_channel"
+}
+
+func (d *dataSourceNotificationChannel) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Required: true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"filters": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[filtersData](ctx),
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"message_types": schema.ListAttribute{
+							Computed:    true,
+							CustomType:  fwtypes.ListOfStringType,
+							ElementType: types.StringType,
+						},
+						"severities": schema.ListAttribute{
+							Computed:    true,
+							CustomType:  fwtypes.ListOfStringType,
+							ElementType: types.StringType,
+						},
+					},
+				},
+			},
+			"sns": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[snsData](ctx),
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"topic_arn": schema.StringAttribute{
+							Computed:   true,
+							CustomType: fwtypes.ARNType,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+func (d *dataSourceNotificationChannel) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	conn := d.Meta().DevOpsGuruClient(ctx)
+
+	var data dataSourceNotificationChannelData
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := findNotificationChannelByID(ctx, conn, data.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.DevOpsGuru, create.ErrActionReading, DSNameNotificationChannel, data.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(flex.Flatten(ctx, out.Config, &data)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+type dataSourceNotificationChannelData struct {
+	Filters fwtypes.ListNestedObjectValueOf[filtersData] `tfsdk:"filters"`
+	ID      types.String                                 `tfsdk:"id"`
+	Sns     fwtypes.ListNestedObjectValueOf[snsData]     `tfsdk:"sns"`
+}

--- a/internal/service/devopsguru/notification_channel_data_source_test.go
+++ b/internal/service/devopsguru/notification_channel_data_source_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package devopsguru_test
+
+import (
+	"fmt"
+	"testing"
+
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func testAccNotificationChannelDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_devopsguru_notification_channel.test"
+	notificationChannelResourceName := "aws_devopsguru_notification_channel.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.DevOpsGuruEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DevOpsGuruServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckNotificationChannelDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNotificationChannelDataSourceConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "id", notificationChannelResourceName, "id"),
+					resource.TestCheckResourceAttr(dataSourceName, "sns.#", "1"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "sns.0.topic_name", notificationChannelResourceName, "sns.0.topic_name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNotificationChannelDataSourceConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_sns_topic" "test" {
+  name = %[1]q
+}
+
+resource "aws_devopsguru_notification_channel" "test" {
+  sns {
+    topic_arn = aws_sns_topic.test.arn
+  }
+}
+
+data "aws_devopsguru_notification_channel" "test" {
+  id = aws_devopsguru_notification_channel.test.id
+}
+`, rName)
+}

--- a/internal/service/devopsguru/service_package_gen.go
+++ b/internal/service/devopsguru/service_package_gen.go
@@ -15,7 +15,12 @@ import (
 type servicePackage struct{}
 
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.ServicePackageFrameworkDataSource {
-	return []*types.ServicePackageFrameworkDataSource{}
+	return []*types.ServicePackageFrameworkDataSource{
+		{
+			Factory: newDataSourceNotificationChannel,
+			Name:    "Notification Channel",
+		},
+	}
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.ServicePackageFrameworkResource {

--- a/website/docs/d/devopsguru_notification_channel.html.markdown
+++ b/website/docs/d/devopsguru_notification_channel.html.markdown
@@ -1,0 +1,43 @@
+---
+subcategory: "DevOps Guru"
+layout: "aws"
+page_title: "AWS: aws_devopsguru_notification_channel"
+description: |-
+  Terraform data source for managing an AWS DevOps Guru Notification Channel.
+---
+
+# Data Source: aws_devopsguru_notification_channel
+
+Terraform data source for managing an AWS DevOps Guru Notification Channel.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_devopsguru_notification_channel" "example" {
+  id = "channel-1234"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `id` - (Required) Unique identifier for the notification channel.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `filters` - Filter configurations for the Amazon SNS notification topic. See the [`filters` attribute reference](#filters-attribute-reference) below.
+* `sns` - SNS noficiation channel configurations. See the [`sns` attribute reference](#sns-attribute-reference) below.
+
+### `sns` Attribute Reference
+
+* `topic_arn` - Amazon Resource Name (ARN) of an Amazon Simple Notification Service topic.
+
+### `filters` Attribute Reference
+
+* `message_types` - Events to receive notifications for.
+* `severities` - Severity levels to receive notifications for.

--- a/website/docs/r/devopsguru_notification_channel.html.markdown
+++ b/website/docs/r/devopsguru_notification_channel.html.markdown
@@ -44,11 +44,11 @@ The following arguments are required:
 
 The following arguments are optional:
 
-* `filters` - (Optional) Filter configurations for the Amazon SNS notification topic  See the [`filters` argument reference](#filters-argument-reference) below.
+* `filters` - (Optional) Filter configurations for the Amazon SNS notification topic. See the [`filters` argument reference](#filters-argument-reference) below.
 
 ### `sns` Argument Reference
 
-* `topic_arn` - (Required)
+* `topic_arn` - (Required) Amazon Resource Name (ARN) of an Amazon Simple Notification Service topic.
 
 ### `filters` Argument Reference
 


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This data source will allow practitioners to read AWS DevOps Guru notification channel data with Terraform.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->
- Relates #17919 
- Closes #36354 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/devops-guru/latest/APIReference/API_ListNotificationChannels.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->


```console
% make testacc PKG=devopsguru TESTS=TestAccDevOpsGuru_serial/NotificationChannelDataSource/
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/devopsguru/... -v -count 1 -parallel 20 -run='TestAccDevOpsGuru_serial/NotificationChannelDataSource/'  -timeout 360m
=== RUN   TestAccDevOpsGuru_serial
=== PAUSE TestAccDevOpsGuru_serial
=== CONT  TestAccDevOpsGuru_serial
=== RUN   TestAccDevOpsGuru_serial/NotificationChannelDataSource
=== RUN   TestAccDevOpsGuru_serial/NotificationChannelDataSource/basic
--- PASS: TestAccDevOpsGuru_serial (12.09s)
    --- PASS: TestAccDevOpsGuru_serial/NotificationChannelDataSource (12.09s)
        --- PASS: TestAccDevOpsGuru_serial/NotificationChannelDataSource/basic (12.09s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/devopsguru 17.651s
```
