### PR TITLE
[36384] Add job state time limit actions to batch queue

### DIFF
--- a/.changelog/36658.txt
+++ b/.changelog/36658.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_batch_job_queue: Add `job_state_time_limit_action` argument
+```
+
+```release-note:enhancement
+data-source/aws_batch_job_queue: Add `job_state_time_limit_action` attribute
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,6 @@ BUG FIXES:
 
 * resource/aws_iam_user: When `force_destroy` is used and there are inline or attached policies, allow resource to be destroyed ([#36640](https://github.com/hashicorp/terraform-provider-aws/issues/36640))
 
-ENHANCEMENTS:
-
-* data-source/aws_batch_job_queue: Add `job_state_time_limit_action` attribute ([#36384](https://github.com/hashicorp/terraform-provider-aws/issues/36384))
-* resource/aws_batch_job_queue: Add `job_state_time_limit_action` attribute ([#36384](https://github.com/hashicorp/terraform-provider-aws/issues/36384))
-
 ## 5.43.0 (March 28, 2024)
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ BUG FIXES:
 
 * resource/aws_iam_user: When `force_destroy` is used and there are inline or attached policies, allow resource to be destroyed ([#36640](https://github.com/hashicorp/terraform-provider-aws/issues/36640))
 
+ENHANCEMENTS:
+
+* data-source/aws_batch_job_queue: Add `job_state_time_limit_action` attribute ([#36384](https://github.com/hashicorp/terraform-provider-aws/issues/36384))
+* resource/aws_batch_job_queue: Add `job_state_time_limit_action` attribute ([#36384](https://github.com/hashicorp/terraform-provider-aws/issues/36384))
+
 ## 5.43.0 (March 28, 2024)
 
 FEATURES:

--- a/internal/service/batch/job_queue.go
+++ b/internal/service/batch/job_queue.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/batch"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -139,18 +140,24 @@ func (r *resourceJobQueue) Schema(ctx context.Context, request resource.SchemaRe
 				Attributes: map[string]schema.Attribute{
 					"action": schema.StringAttribute{
 						Required: true,
-						ValidateFunc: validation.StringInSlice(ec2.JobStateTimeLimitActionsAction_Values(), false),
+						Validators: []validator.String{
+							stringvalidator.OneOf(batch.JobStateTimeLimitActionsAction_Values()...),
+						},
 					},
 					"max_time_seconds": schema.Int64Attribute{
 						Required: true,
-						ValidateFunc: validation.IntBetween(600, 86400),
+						Validators: []validator.Int64{
+							int64validator.Between(600, 86400),
+						},
 					},
 					"reason": schema.StringAttribute{
 						Required: true,
 					},
 					"state": schema.StringAttribute{
 						Required: true,
-						ValidateFunc: validation.StringInSlice(ec2.JobStateTimeLimitActionsState_Values(), false),
+						Validators: []validator.String{
+							stringvalidator.OneOf(batch.JobStateTimeLimitActionsState_Values()...),
+						},
 					},
 				},
 			},

--- a/internal/service/batch/job_queue.go
+++ b/internal/service/batch/job_queue.go
@@ -139,15 +139,18 @@ func (r *resourceJobQueue) Schema(ctx context.Context, request resource.SchemaRe
 				Attributes: map[string]schema.Attribute{
 					"action": schema.StringAttribute{
 						Required: true,
+						ValidateFunc: validation.StringInSlice(ec2.JobStateTimeLimitActionsAction_Values(), false),
 					},
 					"max_time_seconds": schema.Int64Attribute{
 						Required: true,
+						ValidateFunc: validation.IntBetween(600, 86400),
 					},
 					"reason": schema.StringAttribute{
 						Required: true,
 					},
 					"state": schema.StringAttribute{
 						Required: true,
+						ValidateFunc: validation.StringInSlice(ec2.JobStateTimeLimitActionsState_Values(), false),
 					},
 				},
 			},

--- a/internal/service/batch/job_queue_data_source.go
+++ b/internal/service/batch/job_queue_data_source.go
@@ -75,6 +75,31 @@ func DataSourceJobQueue() *schema.Resource {
 					},
 				},
 			},
+
+			"job_state_time_limit_action": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"action": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"max_time_seconds": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"reason": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"state": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -119,6 +144,19 @@ func dataSourceJobQueueRead(ctx context.Context, d *schema.ResourceData, meta in
 	}
 	if err := d.Set("compute_environment_order", ceos); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting compute_environment_order: %s", err)
+	}
+
+	jobStateTimeLimitActions := make([]map[string]interface{}, 0)
+	for _, v := range jobQueue.JobStateTimeLimitActions {
+		jobStateTimeLimitAction := map[string]interface{}{}
+		jobStateTimeLimitAction["action"] = aws.StringValue(v.Action)
+		jobStateTimeLimitAction["max_time_seconds"] = aws.Int64Value(v.MaxTimeSeconds)
+		jobStateTimeLimitAction["reason"] = aws.StringValue(v.Reason)
+		jobStateTimeLimitAction["state"] = aws.StringValue(v.State)
+		jobStateTimeLimitActions = append(jobStateTimeLimitActions, jobStateTimeLimitAction)
+	}
+	if err := d.Set("job_state_time_limit_action", jobStateTimeLimitActions); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting job_state_time_limit_action: %s", err)
 	}
 
 	if err := d.Set("tags", KeyValueTags(ctx, jobQueue.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {

--- a/internal/service/batch/job_queue_data_source_test.go
+++ b/internal/service/batch/job_queue_data_source_test.go
@@ -29,6 +29,7 @@ func TestAccBatchJobQueueDataSource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(datasourceName, "compute_environment_order.#", resourceName, "compute_environments.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "job_state_time_limit_action.#", resourceName, "job_state_time_limit_action.#"),
 					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(datasourceName, "priority", resourceName, "priority"),
 					resource.TestCheckResourceAttrPair(datasourceName, "scheduling_policy_arn", resourceName, "scheduling_policy_arn"),
@@ -177,6 +178,13 @@ resource "aws_batch_job_queue" "test" {
   state                = "ENABLED"
   priority             = 1
   compute_environments = [aws_batch_compute_environment.sample.arn]
+
+  job_state_time_limit_action {
+    action           = "CANCEL"
+    max_time_seconds = 123
+    reason           = "foobar"
+    state            = "RUNNABLE"
+  }
 }
 
 resource "aws_batch_job_queue" "wrong" {

--- a/internal/service/batch/job_queue_schema.go
+++ b/internal/service/batch/job_queue_schema.go
@@ -91,6 +91,7 @@ func upgradeJobQueueResourceStateV0toV1(ctx context.Context, req resource.Upgrad
 		return
 	}
 	ceo := fwtypes.NewListNestedObjectValueOfNull[computeEnvironmentOrder](ctx)
+	jobStateTimeLimitActions := fwtypes.NewListNestedObjectValueOfNull[jobStateTimeLimitAction](ctx)
 
 	jobQueueDataV2 := resourceJobQueueData{
 		ComputeEnvironments:     jobQueueDataV0.ComputeEnvironments,
@@ -99,6 +100,7 @@ func upgradeJobQueueResourceStateV0toV1(ctx context.Context, req resource.Upgrad
 		JobQueueName:            jobQueueDataV0.Name,
 		Priority:                jobQueueDataV0.Priority,
 		State:                   jobQueueDataV0.State,
+		JobStateTimeLimitAction: jobStateTimeLimitActions,
 		Tags:                    jobQueueDataV0.Tags,
 		TagsAll:                 jobQueueDataV0.TagsAll,
 		Timeouts:                jobQueueDataV0.Timeouts,

--- a/internal/service/batch/job_queue_test.go
+++ b/internal/service/batch/job_queue_test.go
@@ -730,7 +730,7 @@ resource "aws_batch_compute_environment" "test" {
 
 func testAccJobQueueConfig_priority(rName string, priority int) string {
 	return acctest.ConfigCompose(
-		testAccJobQueueConfigBase(rName),
+		testAccJobQueueConfig_Base(rName),
 		fmt.Sprintf(`
 resource "aws_batch_job_queue" "test" {
   compute_environments = [aws_batch_compute_environment.test.arn]
@@ -775,7 +775,7 @@ resource "aws_batch_scheduling_policy" "test2" {
 
 func testAccJobQueueConfig_schedulingPolicy(rName string, schedulingPolicyName1 string, schedulingPolicyName2 string, selectSchedulingPolicy string) string {
 	return acctest.ConfigCompose(
-		testAccJobQueueConfigBase(rName),
+		testAccJobQueueConfig_Base(rName),
 		testAccJobQueueSchedulingPolicy(schedulingPolicyName1, schedulingPolicyName2),
 		fmt.Sprintf(`
 locals {
@@ -794,7 +794,7 @@ resource "aws_batch_job_queue" "test" {
 
 func testAccJobQueueConfig_state(rName string, state string) string {
 	return acctest.ConfigCompose(
-		testAccJobQueueConfigBase(rName),
+		testAccJobQueueConfig_Base(rName),
 		fmt.Sprintf(`
 resource "aws_batch_job_queue" "test" {
   compute_environments = [aws_batch_compute_environment.test.arn]
@@ -808,7 +808,7 @@ resource "aws_batch_job_queue" "test" {
 
 func testAccJobQueueConfig_stateCEO(rName string, state string) string {
 	return acctest.ConfigCompose(
-		testAccJobQueueConfigBase(rName),
+		testAccJobQueueConfig_Base(rName),
 		fmt.Sprintf(`
 resource "aws_batch_job_queue" "test" {
   compute_environment_order {
@@ -825,7 +825,7 @@ resource "aws_batch_job_queue" "test" {
 
 func testAccJobQueueConfig_ComputeEnvironments_multiple(rName string, state string) string {
 	return acctest.ConfigCompose(
-		testAccJobQueueConfigBase(rName),
+		testAccJobQueueConfig_Base(rName),
 		fmt.Sprintf(`
 resource "aws_batch_job_queue" "test" {
   compute_environments = concat(
@@ -861,7 +861,7 @@ resource "aws_batch_compute_environment" "more" {
 
 func testAccJobQueueConfig_ComputeEnvironmentOrder_multiple(rName string, state string, o1 int, o2 int, o3 int) string {
 	return acctest.ConfigCompose(
-		testAccJobQueueConfigBase(rName),
+		testAccJobQueueConfig_Base(rName),
 		fmt.Sprintf(`
 resource "aws_batch_job_queue" "test" {
   compute_environment_order {
@@ -908,7 +908,7 @@ resource "aws_batch_compute_environment" "more" {
 
 func testAccJobQueueConfig_ComputeEnvironments_multipleReorder(rName string, state string) string {
 	return acctest.ConfigCompose(
-		testAccJobQueueConfigBase(rName),
+		testAccJobQueueConfig_Base(rName),
 		fmt.Sprintf(`
 resource "aws_batch_job_queue" "test" {
   compute_environments = [
@@ -945,7 +945,7 @@ resource "aws_batch_compute_environment" "more" {
 
 func testAccJobQueueConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(
-		testAccJobQueueConfigBase(rName),
+		testAccJobQueueConfig_Base(rName),
 		fmt.Sprintf(`
 resource "aws_batch_job_queue" "test" {
   compute_environments = [aws_batch_compute_environment.test.arn]
@@ -962,7 +962,7 @@ resource "aws_batch_job_queue" "test" {
 
 func testAccJobQueueConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return acctest.ConfigCompose(
-		testAccJobQueueConfigBase(rName),
+		testAccJobQueueConfig_Base(rName),
 		fmt.Sprintf(`
 resource "aws_batch_job_queue" "test" {
   compute_environments = [aws_batch_compute_environment.test.arn]

--- a/internal/service/batch/job_queue_test.go
+++ b/internal/service/batch/job_queue_test.go
@@ -453,6 +453,38 @@ func TestAccBatchJobQueue_tags(t *testing.T) {
 	})
 }
 
+func TestAccBatchJobQueue_JobStateTimeLimitActions(t *testing.T) {
+	ctx := acctest.Context(t)
+	var jobQueue1 batch.JobQueueDetail
+	resourceName := "aws_batch_job_queue.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckJobQueueDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccJobQueueConfig_jobStateTimeLimitAction(rName, "CANCEL", 123, "foobar", "RUNNABLE"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckJobQueueExists(ctx, resourceName, &jobQueue1),
+					resource.TestCheckResourceAttr(resourceName, "job_state_time_limit_action.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "job_state_time_limit_action.0", "job_state_time_limit_action.action", "CANCEL"),
+					resource.TestCheckResourceAttrPair(resourceName, "job_state_time_limit_action.0", "job_state_time_limit_action.max_time_seconds", "123"),
+					resource.TestCheckResourceAttrPair(resourceName, "job_state_time_limit_action.0", "job_state_time_limit_action.reason", "foobar"),
+					resource.TestCheckResourceAttrPair(resourceName, "job_state_time_limit_action.0", "job_state_time_limit_action.state", "RUNNABLE"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckJobQueueExists(ctx context.Context, n string, jq *batch.JobQueueDetail) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -844,6 +876,32 @@ resource "aws_batch_compute_environment" "more" {
   depends_on = [aws_iam_role_policy_attachment.test]
 }
 `, rName, state))
+}
+
+func testAccJobQueueConfig_jobStateTimeLimitAction(
+	rName string,
+	action string,
+	maxTimeSeconds uint64,
+	reason string,
+	state string,
+) string {
+	return acctest.ConfigCompose(
+		testAccJobQueueConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_batch_job_queue" "test" {
+  compute_environments = [aws_batch_compute_environment.test.arn]
+  name                 = %[1]q
+  priority             = 1
+  state                = "DISABLED"
+
+  job_state_time_limit_action {
+    action           = %[2]q
+    max_time_seconds = %[3]q
+    reason           = %[4]q
+    state            = %[5]q
+  }
+}
+`, rName, action, maxTimeSeconds, reason, state))
 }
 
 func testAccJobQueueConfig_tags1(rName, tagKey1, tagValue1 string) string {

--- a/internal/service/batch/job_queue_test.go
+++ b/internal/service/batch/job_queue_test.go
@@ -520,7 +520,7 @@ resource "aws_batch_job_queue" "test" {
 
   job_state_time_limit_action {
     action           = "CANCEL"
-    max_time_seconds = 600
+    max_time_seconds = 610
     reason           = "MISCONFIGURATION:JOB_RESOURCE_REQUIREMENT"
     state            = "RUNNABLE"
   }
@@ -537,7 +537,7 @@ resource "aws_batch_job_queue" "test" {
 					testAccCheckJobQueueExists(ctx, resourceName, &jobQueue1),
 					resource.TestCheckResourceAttr(resourceName, "job_state_time_limit_action.#", "2"),
 					resource.TestCheckResourceAttrPair(resourceName, "job_state_time_limit_action.0", "job_state_time_limit_action.action", "CANCEL"),
-					resource.TestCheckResourceAttrPair(resourceName, "job_state_time_limit_action.0", "job_state_time_limit_action.max_time_seconds", "600"),
+					resource.TestCheckResourceAttrPair(resourceName, "job_state_time_limit_action.0", "job_state_time_limit_action.max_time_seconds", "610"),
 					resource.TestCheckResourceAttrPair(resourceName, "job_state_time_limit_action.0", "job_state_time_limit_action.reason", "MISCONFIGURATION:JOB_RESOURCE_REQUIREMENT"),
 					resource.TestCheckResourceAttrPair(resourceName, "job_state_time_limit_action.0", "job_state_time_limit_action.state", "RUNNABLE"),
 					resource.TestCheckResourceAttrPair(resourceName, "job_state_time_limit_action.1", "job_state_time_limit_action.action", "CANCEL"),

--- a/internal/service/batch/job_queue_test.go
+++ b/internal/service/batch/job_queue_test.go
@@ -467,7 +467,7 @@ func TestAccBatchJobQueue_JobStateTimeLimitActionsMultiple(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acctest.ConfigCompose(
-					testAccJobQueueConfigBase(rName),
+					testAccJobQueueConfig_Base(rName),
 					fmt.Sprintf(`
 resource "aws_batch_job_queue" "test" {
   compute_environments = [aws_batch_compute_environment.test.arn]
@@ -510,7 +510,7 @@ resource "aws_batch_job_queue" "test" {
 			},
 			{
 				Config: acctest.ConfigCompose(
-					testAccJobQueueConfigBase(rName),
+					testAccJobQueueConfig_Base(rName),
 					fmt.Sprintf(`
 resource "aws_batch_job_queue" "test" {
   compute_environments = [aws_batch_compute_environment.test.arn]

--- a/internal/service/batch/job_queue_test.go
+++ b/internal/service/batch/job_queue_test.go
@@ -630,7 +630,7 @@ func testAccCheckJobQueueComputeEnvironmentOrderUpdate(ctx context.Context, jobQ
 	}
 }
 
-func testAccJobQueueConfigBase(rName string) string {
+func testAccJobQueueConfig_Base(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 

--- a/website/docs/d/batch_job_queue.html.markdown
+++ b/website/docs/d/batch_job_queue.html.markdown
@@ -42,3 +42,8 @@ This data source exports the following attributes in addition to the arguments a
     which job placement is preferred. Compute environments are selected for job placement in ascending order.
     * `compute_environment_order.#.order` - The order of the compute environment.
     * `compute_environment_order.#.compute_environment` - The ARN of the compute environment.
+* `job_state_time_limit_action` - Specifies an action that AWS Batch will take after the job has remained at the head of the queue in the specified state for longer than the specified time.
+    * `job_state_time_limit_action.#.action` - The action to take when a job is at the head of the job queue in the specified state for the specified period of time.
+    * `job_state_time_limit_action.#.max_time_seconds` - The approximate amount of time, in seconds, that must pass with the job in the specified state before the action is taken.
+    * `job_state_time_limit_action.#.reason` - The reason to log for the action being taken.
+    * `job_state_time_limit_action.#.state` - The state of the job needed to trigger the action.

--- a/website/docs/r/batch_job_queue.html.markdown
+++ b/website/docs/r/batch_job_queue.html.markdown
@@ -75,6 +75,7 @@ This resource supports the following arguments:
 * `name` - (Required) Specifies the name of the job queue.
 * `compute_environments` - (Deprecated) (Optional) This parameter is deprecated, please use `compute_environment_order` instead. List of compute environment ARNs mapped to a job queue. The position of the compute environments in the list will dictate the order. When importing a AWS Batch Job Queue, the parameter `compute_environments` will always be used over `compute_environment_order`. Please adjust your HCL accordingly.
 * `compute_environment_order` - (Optional) The set of compute environments mapped to a job queue and their order relative to each other. The job scheduler uses this parameter to determine which compute environment runs a specific job. Compute environments must be in the VALID state before you can associate them with a job queue. You can associate up to three compute environments with a job queue.  
+* `job_state_time_limit_action` - (Optional) The set of job state time limit actions mapped to a job queue. Specifies an action that AWS Batch will take after the job has remained at the head of the queue in the specified state for longer than the specified time.
 * `priority` - (Required) The priority of the job queue. Job queues with a higher priority
     are evaluated first when associated with the same compute environment.
 * `scheduling_policy_arn` - (Optional) The ARN of the fair share scheduling policy. If this parameter is specified, the job queue uses a fair share scheduling policy. If this parameter isn't specified, the job queue uses a first in, first out (FIFO) scheduling policy. After a job queue is created, you can replace but can't remove the fair share scheduling policy.
@@ -85,6 +86,13 @@ This resource supports the following arguments:
 
 * `compute_environment` - (Required) The Amazon Resource Name (ARN) of the compute environment.
 * `order` - (Required) The order of the compute environment. Compute environments are tried in ascending order. For example, if two compute environments are associated with a job queue, the compute environment with a lower order integer value is tried for job placement first.
+
+### job_state_time_limit_action
+
+* `action` - (Required) The action to take when a job is at the head of the job queue in the specified state for the specified period of time.
+* `max_time_seconds` - (Required) The approximate amount of time, in seconds, that must pass with the job in the specified state before the action is taken.
+* `reason` - (Required) The reason to log for the action being taken.
+* `state` - (Required) The state of the job needed to trigger the action.
 
 ## Attribute Reference
 

--- a/website/docs/r/batch_job_queue.html.markdown
+++ b/website/docs/r/batch_job_queue.html.markdown
@@ -89,10 +89,10 @@ This resource supports the following arguments:
 
 ### job_state_time_limit_action
 
-* `action` - (Required) The action to take when a job is at the head of the job queue in the specified state for the specified period of time.
-* `max_time_seconds` - (Required) The approximate amount of time, in seconds, that must pass with the job in the specified state before the action is taken.
+* `action` - (Required) The action to take when a job is at the head of the job queue in the specified state for the specified period of time. Valid values include `"CANCEL"`
+    * `job_state_time_limit_action.#.max_time_seconds` - The approximate amount of time, in seconds, that must pass with the job in the specified state before the action is taken. Valid values include integers between `600` & `86400`
 * `reason` - (Required) The reason to log for the action being taken.
-* `state` - (Required) The state of the job needed to trigger the action.
+* `state` - (Required) The state of the job needed to trigger the action. Valid values include `"RUNNABLE"`.
 
 ## Attribute Reference
 


### PR DESCRIPTION

### Description
A new option has been added to batch job queues: https://aws.amazon.com/about-aws/whats-new/2024/03/aws-batch-alerts-detect-jobs-runnable-state/

This PR just adds support for the new API fields to the batch queue terraform resource.


### Relations

Closes #36384

### References

API reference: https://docs.aws.amazon.com/batch/latest/APIReference/API_JobStateTimeLimitAction.html


### Output from Acceptance Testing

I didn't run acceptance tests to avoid dangling resources in my account.

I did however use this to update job queues and it worked.