### PR TITLE
fix: Add '.' to name regex in ami_distribution_configuration block for aws_imagebuilder_distribution_configuration

### DIFF
--- a/.changelog/36659.txt
+++ b/.changelog/36659.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_imagebuilder_distribution_configuration: Fix validation regex for `ami_distribution_configuration.name`
+```

--- a/internal/service/imagebuilder/distribution_configuration.go
+++ b/internal/service/imagebuilder/distribution_configuration.go
@@ -121,7 +121,7 @@ func ResourceDistributionConfiguration() *schema.Resource {
 										Optional: true,
 										ValidateFunc: validation.All(
 											validation.StringLenBetween(0, 127),
-											validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_{-][0-9A-Za-z_\s:{}-]+[0-9A-Za-z_}-]$`), "must contain only alphanumeric characters, underscores, and hyphens"),
+											validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_{-][0-9A-Za-z_\.\s:{}-]+[0-9A-Za-z_}-]$`), "must be a valid output AMI name"),
 										),
 									},
 									"target_account_ids": {

--- a/internal/service/imagebuilder/distribution_configuration_test.go
+++ b/internal/service/imagebuilder/distribution_configuration_test.go
@@ -447,6 +447,18 @@ func TestAccImageBuilderDistributionConfiguration_DistributionAMIDistribution_na
 					}),
 				),
 			},
+			{
+				Config: testAccDistributionConfigurationConfig_amiName(rName, "AmazonLinux2-EKS-1.27-{{ imagebuilder:buildDate }}"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDistributionConfigurationExists(ctx, resourceName),
+					acctest.CheckResourceAttrRFC3339(resourceName, "date_updated"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "distribution.*", map[string]string{
+						"ami_distribution_configuration.#":      "1",
+						"ami_distribution_configuration.0.name": "AmazonLinux2-EKS-1.27-{{ imagebuilder:buildDate }}",
+					}),
+				),
+			},
 		},
 	})
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to fix the regular expression in the validation function for the `name` arg of the `ami_distribution_configuration` configuration block for the `aws_imagebuilder_distribution_configuration` resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #36610

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [AmiDistributionConfiguration](https://docs.aws.amazon.com/imagebuilder/latest/APIReference/API_AmiDistributionConfiguration.html) for the correct regular expression.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccImageBuilderDistributionConfiguration_DistributionAMIDistribution_name PKG=imagebuilder
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/imagebuilder/... -v -count 1 -parallel 20 -run='TestAccImageBuilderDistributionConfiguration_DistributionAMIDistribution_name'  -timeout 360m
=== RUN   TestAccImageBuilderDistributionConfiguration_DistributionAMIDistribution_name
=== PAUSE TestAccImageBuilderDistributionConfiguration_DistributionAMIDistribution_name
=== CONT  TestAccImageBuilderDistributionConfiguration_DistributionAMIDistribution_name
--- PASS: TestAccImageBuilderDistributionConfiguration_DistributionAMIDistribution_name (110.44s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder       110.625s

$
```
