### PR TITLE
fix: Count UTF-8 string length by # of chars vs. bytes in message and subject args for aws_cognito_user_pool

### DIFF
--- a/.changelog/36661.txt
+++ b/.changelog/36661.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_cognito_user_pool: Updated string validation of `*_message` and `*_subject` arguments to count UTF-8 characters properly
+resource/aws_cognito_user_pool: Correct plan-time validation of `email_verification_message`, `email_verification_subject`, `admin_create_user_config.invite_message_template.email_message`, `admin_create_user_config.invite_message_template.email_subject`, `admin_create_user_config.invite_message_template.sms_message`, `sms_authentication_message`, `sms_verification_message`, `verification_message_template.email_message`, `verification_message_template.email_message_by_link`, `verification_message_template.email_subject`, `verification_message_template.email_subject_by_link`, and `verification_message_template.sms_message` to count UTF-8 characters properly
 ```

--- a/.changelog/36661.txt
+++ b/.changelog/36661.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cognito_user_pool: Updated string validation of `*_message` and `*_subject` arguments to count UTF-8 characters properly
+```

--- a/internal/service/cognitoidp/user_pool.go
+++ b/internal/service/cognitoidp/user_pool.go
@@ -2290,7 +2290,7 @@ func flattenUserPoolUserAttributeUpdateSettings(u *cognitoidentityprovider.UserA
 		return nil
 	}
 	// If this setting is enabled then disabled, the API returns a nested empty slice instead of nil
-	if u != nil && len(u.AttributesRequireVerificationBeforeUpdate) == 0 {
+	if len(u.AttributesRequireVerificationBeforeUpdate) == 0 {
 		return nil
 	}
 

--- a/internal/service/cognitoidp/validate.go
+++ b/internal/service/cognitoidp/validate.go
@@ -5,6 +5,7 @@ package cognitoidp
 
 import (
 	"fmt"
+	"unicode/utf8"
 
 	"github.com/YakDriver/regexache"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -44,12 +45,13 @@ func validUserGroupName(v interface{}, k string) (ws []string, es []error) {
 
 func validUserPoolEmailVerificationMessage(v interface{}, k string) (ws []string, es []error) {
 	value := v.(string)
-	if len(value) < 6 {
-		es = append(es, fmt.Errorf("%q cannot be less than 6 characters", k))
+	count := utf8.RuneCountInString(value)
+	if count < 6 {
+		es = append(es, fmt.Errorf("%q cannot be less than 6 UTF-8 characters", k))
 	}
 
-	if len(value) > 20000 {
-		es = append(es, fmt.Errorf("%q cannot be longer than 20000 characters", k))
+	if count > 20000 {
+		es = append(es, fmt.Errorf("%q cannot be longer than 20000 UTF-8 characters", k))
 	}
 
 	if !regexache.MustCompile(`[\p{L}\p{M}\p{S}\p{N}\p{P}\s*]*\{####\}[\p{L}\p{M}\p{S}\p{N}\p{P}\s*]*`).MatchString(value) {
@@ -60,12 +62,13 @@ func validUserPoolEmailVerificationMessage(v interface{}, k string) (ws []string
 
 func validUserPoolEmailVerificationSubject(v interface{}, k string) (ws []string, es []error) {
 	value := v.(string)
-	if len(value) < 6 {
-		es = append(es, fmt.Errorf("%q cannot be less than 6 characters", k))
+	count := utf8.RuneCountInString(value)
+	if count < 1 {
+		es = append(es, fmt.Errorf("%q cannot be less than 1 UTF-8 character", k))
 	}
 
-	if len(value) > 140 {
-		es = append(es, fmt.Errorf("%q cannot be longer than 140 characters", k))
+	if count > 140 {
+		es = append(es, fmt.Errorf("%q cannot be longer than 140 UTF-8 characters", k))
 	}
 
 	if !regexache.MustCompile(`[\p{L}\p{M}\p{S}\p{N}\p{P}\s]+`).MatchString(value) {
@@ -84,12 +87,13 @@ func validUserPoolID(v interface{}, k string) (ws []string, es []error) {
 
 func validUserPoolInviteTemplateEmailMessage(v interface{}, k string) (ws []string, es []error) {
 	value := v.(string)
-	if len(value) < 6 {
-		es = append(es, fmt.Errorf("%q cannot be less than 6 characters", k))
+	count := utf8.RuneCountInString(value)
+	if count < 6 {
+		es = append(es, fmt.Errorf("%q cannot be less than 6 UTF-8 characters", k))
 	}
 
-	if len(value) > 20000 {
-		es = append(es, fmt.Errorf("%q cannot be longer than 20000 characters", k))
+	if count > 20000 {
+		es = append(es, fmt.Errorf("%q cannot be longer than 20000 UTF-8 characters", k))
 	}
 
 	if !regexache.MustCompile(`[\p{L}\p{M}\p{S}\p{N}\p{P}\s*]*\{####\}[\p{L}\p{M}\p{S}\p{N}\p{P}\s*]*`).MatchString(value) {
@@ -104,12 +108,13 @@ func validUserPoolInviteTemplateEmailMessage(v interface{}, k string) (ws []stri
 
 func validUserPoolInviteTemplateSMSMessage(v interface{}, k string) (ws []string, es []error) {
 	value := v.(string)
-	if len(value) < 6 {
-		es = append(es, fmt.Errorf("%q cannot be less than 6 characters", k))
+	count := utf8.RuneCountInString(value)
+	if count < 6 {
+		es = append(es, fmt.Errorf("%q cannot be less than 6 UTF-8 characters", k))
 	}
 
-	if len(value) > 140 {
-		es = append(es, fmt.Errorf("%q cannot be longer than 140 characters", k))
+	if count > 140 {
+		es = append(es, fmt.Errorf("%q cannot be longer than 140 UTF-8 characters", k))
 	}
 
 	if !regexache.MustCompile(`.*\{####\}.*`).MatchString(value) {
@@ -140,12 +145,13 @@ func validUserPoolSchemaName(v interface{}, k string) (ws []string, es []error) 
 
 func validUserPoolSMSAuthenticationMessage(v interface{}, k string) (ws []string, es []error) {
 	value := v.(string)
-	if len(value) < 6 {
-		es = append(es, fmt.Errorf("%q cannot be less than 6 characters", k))
+	count := utf8.RuneCountInString(value)
+	if count < 6 {
+		es = append(es, fmt.Errorf("%q cannot be less than 6 UTF-8 characters", k))
 	}
 
-	if len(value) > 140 {
-		es = append(es, fmt.Errorf("%q cannot be longer than 140 characters", k))
+	if count > 140 {
+		es = append(es, fmt.Errorf("%q cannot be longer than 140 UTF-8 characters", k))
 	}
 
 	if !regexache.MustCompile(`.*\{####\}.*`).MatchString(value) {
@@ -156,12 +162,13 @@ func validUserPoolSMSAuthenticationMessage(v interface{}, k string) (ws []string
 
 func validUserPoolSMSVerificationMessage(v interface{}, k string) (ws []string, es []error) {
 	value := v.(string)
-	if len(value) < 6 {
-		es = append(es, fmt.Errorf("%q cannot be less than 6 characters", k))
+	count := utf8.RuneCountInString(value)
+	if count < 6 {
+		es = append(es, fmt.Errorf("%q cannot be less than 6 UTF-8 characters", k))
 	}
 
-	if len(value) > 140 {
-		es = append(es, fmt.Errorf("%q cannot be longer than 140 characters", k))
+	if count > 140 {
+		es = append(es, fmt.Errorf("%q cannot be longer than 140 UTF-8 characters", k))
 	}
 
 	if !regexache.MustCompile(`.*\{####\}.*`).MatchString(value) {
@@ -172,12 +179,13 @@ func validUserPoolSMSVerificationMessage(v interface{}, k string) (ws []string, 
 
 func validUserPoolTemplateEmailMessage(v interface{}, k string) (ws []string, es []error) {
 	value := v.(string)
-	if len(value) < 6 {
-		es = append(es, fmt.Errorf("%q cannot be less than 6 characters", k))
+	count := utf8.RuneCountInString(value)
+	if count < 6 {
+		es = append(es, fmt.Errorf("%q cannot be less than 6 UTF-8 characters", k))
 	}
 
-	if len(value) > 20000 {
-		es = append(es, fmt.Errorf("%q cannot be longer than 20000 characters", k))
+	if count > 20000 {
+		es = append(es, fmt.Errorf("%q cannot be longer than 20000 UTF-8 characters", k))
 	}
 
 	if !regexache.MustCompile(`[\p{L}\p{M}\p{S}\p{N}\p{P}\s*]*\{####\}[\p{L}\p{M}\p{S}\p{N}\p{P}\s*]*`).MatchString(value) {
@@ -188,12 +196,13 @@ func validUserPoolTemplateEmailMessage(v interface{}, k string) (ws []string, es
 
 func validUserPoolTemplateEmailMessageByLink(v interface{}, k string) (ws []string, es []error) {
 	value := v.(string)
-	if len(value) < 1 {
-		es = append(es, fmt.Errorf("%q cannot be less than 1 character", k))
+	count := utf8.RuneCountInString(value)
+	if count < 6 {
+		es = append(es, fmt.Errorf("%q cannot be less than 6 UTF-8 characters", k))
 	}
 
-	if len(value) > 20000 {
-		es = append(es, fmt.Errorf("%q cannot be longer than 20000 characters", k))
+	if count > 20000 {
+		es = append(es, fmt.Errorf("%q cannot be longer than 20000 UTF-8 characters", k))
 	}
 
 	if !regexache.MustCompile(`[\p{L}\p{M}\p{S}\p{N}\p{P}\s*]*\{##[\p{L}\p{M}\p{S}\p{N}\p{P}\s*]*##\}[\p{L}\p{M}\p{S}\p{N}\p{P}\s*]*`).MatchString(value) {
@@ -204,12 +213,13 @@ func validUserPoolTemplateEmailMessageByLink(v interface{}, k string) (ws []stri
 
 func validUserPoolTemplateEmailSubject(v interface{}, k string) (ws []string, es []error) {
 	value := v.(string)
-	if len(value) < 1 {
-		es = append(es, fmt.Errorf("%q cannot be less than 1 character", k))
+	count := utf8.RuneCountInString(value)
+	if count < 1 {
+		es = append(es, fmt.Errorf("%q cannot be less than 1 UTF-8 character", k))
 	}
 
-	if len(value) > 140 {
-		es = append(es, fmt.Errorf("%q cannot be longer than 140 characters", k))
+	if count > 140 {
+		es = append(es, fmt.Errorf("%q cannot be longer than 140 UTF-8 characters", k))
 	}
 
 	if !regexache.MustCompile(`[\p{L}\p{M}\p{S}\p{N}\p{P}\s]+`).MatchString(value) {
@@ -220,12 +230,13 @@ func validUserPoolTemplateEmailSubject(v interface{}, k string) (ws []string, es
 
 func validUserPoolTemplateEmailSubjectByLink(v interface{}, k string) (ws []string, es []error) {
 	value := v.(string)
-	if len(value) < 1 {
-		es = append(es, fmt.Errorf("%q cannot be less than 1 character", k))
+	count := utf8.RuneCountInString(value)
+	if count < 1 {
+		es = append(es, fmt.Errorf("%q cannot be less than 1 UTF-8 character", k))
 	}
 
-	if len(value) > 140 {
-		es = append(es, fmt.Errorf("%q cannot be longer than 140 characters", k))
+	if count > 140 {
+		es = append(es, fmt.Errorf("%q cannot be longer than 140 UTF-8 characters", k))
 	}
 
 	if !regexache.MustCompile(`[\p{L}\p{M}\p{S}\p{N}\p{P}\s]+`).MatchString(value) {
@@ -236,12 +247,13 @@ func validUserPoolTemplateEmailSubjectByLink(v interface{}, k string) (ws []stri
 
 func validUserPoolTemplateSMSMessage(v interface{}, k string) (ws []string, es []error) {
 	value := v.(string)
-	if len(value) < 6 {
-		es = append(es, fmt.Errorf("%q cannot be less than 6 characters", k))
+	count := utf8.RuneCountInString(value)
+	if count < 6 {
+		es = append(es, fmt.Errorf("%q cannot be less than 6 UTF-8 characters", k))
 	}
 
-	if len(value) > 140 {
-		es = append(es, fmt.Errorf("%q cannot be longer than 140 characters", k))
+	if count > 140 {
+		es = append(es, fmt.Errorf("%q cannot be longer than 140 UTF-8 characters", k))
 	}
 
 	if !regexache.MustCompile(`.*\{####\}.*`).MatchString(value) {

--- a/internal/service/cognitoidp/validate_test.go
+++ b/internal/service/cognitoidp/validate_test.go
@@ -51,6 +51,7 @@ func TestValidUserPoolEmailVerificationMessage(t *testing.T) {
 		"{####} Bar",
 		"AZERTYUIOPQSDFGHJKLMWXCVBN?./+%£*¨°0987654321&é\"'(§è!çà)-@^'{####},=ù`$|´”’[å»ÛÁØ]–Ô¥#‰±•",
 		"{####}" + strings.Repeat("W", 19994), // = 20000
+		"{####}" + strings.Repeat("あ", 19994), // = 20000, UTF-8 (2 bytes/char)
 	}
 
 	for _, s := range validValues {
@@ -62,8 +63,10 @@ func TestValidUserPoolEmailVerificationMessage(t *testing.T) {
 
 	invalidValues := []string{
 		"Foo",
+		"あいうえお",
 		"{###}",
 		"{####}" + strings.Repeat("W", 19995), // > 20000
+		"{####}" + strings.Repeat("あ", 19995), // > 20000, UTF-8 (2 bytes/char)
 	}
 
 	for _, s := range invalidValues {
@@ -82,6 +85,7 @@ func TestValidUserPoolEmailVerificationSubject(t *testing.T) {
 		"AZERTYUIOPQSDFGHJKLMWXCVBN?./+%£*¨°0987654321&é\" '(§è!çà)-@^'{####},=ù`$|´”’[å»ÛÁØ]–Ô¥#‰±•",
 		"Foo Bar", // special whitespace character
 		strings.Repeat("W", 140),
+		strings.Repeat("あ", 140), // UTF-8 (2 bytes/char)
 	}
 
 	for _, s := range validValues {
@@ -92,8 +96,8 @@ func TestValidUserPoolEmailVerificationSubject(t *testing.T) {
 	}
 
 	invalidValues := []string{
-		"Foo",
-		strings.Repeat("W", 141),
+		strings.Repeat("W", 141), // > 140
+		strings.Repeat("あ", 141), // UTF-8 (2 bytes/char)
 	}
 
 	for _, s := range invalidValues {
@@ -143,6 +147,7 @@ func TestValidUserPoolSMSAuthenticationMessage(t *testing.T) {
 		"{####} Bar",
 		"AZERTYUIOPQSDFGHJKLMWXCVBN?./+%£*¨°0987654321&é\"'(§è!çà)-@^'{####},=ù`$|´”’[å»ÛÁØ]–Ô¥#‰±•",
 		"{####}" + strings.Repeat("W", 134), // = 140
+		"{####}" + strings.Repeat("あ", 134), // = 140, UTF-8 (2 bytes/char)
 	}
 
 	for _, s := range validValues {
@@ -154,7 +159,9 @@ func TestValidUserPoolSMSAuthenticationMessage(t *testing.T) {
 
 	invalidValues := []string{
 		"Foo",
-		"{####}" + strings.Repeat("W", 135),
+		"あいうえお",
+		"{####}" + strings.Repeat("W", 135), // > 140
+		"{####}" + strings.Repeat("あ", 135), // > 140, UTF-8 (2 bytes/char)
 	}
 
 	for _, s := range invalidValues {
@@ -174,6 +181,7 @@ func TestValidUserPoolSMSVerificationMessage(t *testing.T) {
 		"{####} Bar",
 		"AZERTYUIOPQSDFGHJKLMWXCVBN?./+%£*¨°0987654321&é\"'(§è!çà)-@^'{####},=ù`$|´”’[å»ÛÁØ]–Ô¥#‰±•",
 		"{####}" + strings.Repeat("W", 134), // = 140
+		"{####}" + strings.Repeat("あ", 134), // = 140, UTF-8 (2 bytes/char)
 	}
 
 	for _, s := range validValues {
@@ -185,7 +193,9 @@ func TestValidUserPoolSMSVerificationMessage(t *testing.T) {
 
 	invalidValues := []string{
 		"Foo",
-		"{####}" + strings.Repeat("W", 135),
+		"あいうえお",
+		"{####}" + strings.Repeat("W", 135), // > 140
+		"{####}" + strings.Repeat("あ", 135), // > 140, UTF-8 (2 bytes/char)
 	}
 
 	for _, s := range invalidValues {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to fix the validation functions of the `*message` and `*subject` arguments in the `aws_cognito_user_pool` resource, which allows UTF-8 characters, so that the # of characters are counted by runes and not by bytes.

**Note:** When I initially added a new test case with max size messages and subjects, the API will fail with a 413 object too large error. I believe this is a bug with the AWS API since the API specs should technically allow messages up to 20000 characters, including UTF-8. To allow the test case to pass, I've reduced the message sizes to 1000 characters. Meanwhile I've opened an AWS support case to see if they can address it. So be aware that even with this fix, you probably can't use very long messages.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #32607

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [CreateUserPool](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateUserPool.html) and [Configuring SMS and email verification messages and user invitation messages](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-message-customizations.html) for the specs.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TESTS=TestValidUserPool PKG=cognitoidp
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cognitoidp/... -v -count 1 -parallel 20 -run='TestValidUserPool'  -timeout 360m
=== RUN   TestValidUserPoolEmailVerificationMessage
=== PAUSE TestValidUserPoolEmailVerificationMessage
=== RUN   TestValidUserPoolEmailVerificationSubject
=== PAUSE TestValidUserPoolEmailVerificationSubject
=== RUN   TestValidUserPoolID
=== PAUSE TestValidUserPoolID
=== RUN   TestValidUserPoolSMSAuthenticationMessage
=== PAUSE TestValidUserPoolSMSAuthenticationMessage
=== RUN   TestValidUserPoolSMSVerificationMessage
=== PAUSE TestValidUserPoolSMSVerificationMessage
=== CONT  TestValidUserPoolEmailVerificationMessage
=== CONT  TestValidUserPoolSMSAuthenticationMessage
=== CONT  TestValidUserPoolID
=== CONT  TestValidUserPoolSMSVerificationMessage
=== CONT  TestValidUserPoolEmailVerificationSubject
--- PASS: TestValidUserPoolID (0.00s)
--- PASS: TestValidUserPoolSMSAuthenticationMessage (0.00s)
--- PASS: TestValidUserPoolSMSVerificationMessage (0.00s)
--- PASS: TestValidUserPoolEmailVerificationSubject (0.00s)
--- PASS: TestValidUserPoolEmailVerificationMessage (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp 0.166s

$
```

```console
$ make testacc TESTS=TestAccCognitoIDPUserPool_ PKG=cognitoidp
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cognitoidp/... -v -count 1 -parallel 20 -run='TestAccCognitoIDPUserPool_'  -timeout 360m
=== RUN   TestAccCognitoIDPUserPool_basic
=== PAUSE TestAccCognitoIDPUserPool_basic
=== RUN   TestAccCognitoIDPUserPool_deletionProtection
=== PAUSE TestAccCognitoIDPUserPool_deletionProtection
=== RUN   TestAccCognitoIDPUserPool_recovery
=== PAUSE TestAccCognitoIDPUserPool_recovery
=== RUN   TestAccCognitoIDPUserPool_withAdminCreateUser
=== PAUSE TestAccCognitoIDPUserPool_withAdminCreateUser
=== RUN   TestAccCognitoIDPUserPool_withAdminCreateUserAndPasswordPolicy
=== PAUSE TestAccCognitoIDPUserPool_withAdminCreateUserAndPasswordPolicy
=== RUN   TestAccCognitoIDPUserPool_withAdvancedSecurityMode
=== PAUSE TestAccCognitoIDPUserPool_withAdvancedSecurityMode
=== RUN   TestAccCognitoIDPUserPool_withDevice
=== PAUSE TestAccCognitoIDPUserPool_withDevice
=== RUN   TestAccCognitoIDPUserPool_withEmailVerificationMessage
=== PAUSE TestAccCognitoIDPUserPool_withEmailVerificationMessage
=== RUN   TestAccCognitoIDPUserPool_MFA_sms
=== PAUSE TestAccCognitoIDPUserPool_MFA_sms
=== RUN   TestAccCognitoIDPUserPool_MFA_smsAndSoftwareTokenMFA
=== PAUSE TestAccCognitoIDPUserPool_MFA_smsAndSoftwareTokenMFA
=== RUN   TestAccCognitoIDPUserPool_MFA_smsToSoftwareTokenMFA
=== PAUSE TestAccCognitoIDPUserPool_MFA_smsToSoftwareTokenMFA
=== RUN   TestAccCognitoIDPUserPool_MFA_softwareTokenMFA
=== PAUSE TestAccCognitoIDPUserPool_MFA_softwareTokenMFA
=== RUN   TestAccCognitoIDPUserPool_MFA_softwareTokenMFAToSMS
=== PAUSE TestAccCognitoIDPUserPool_MFA_softwareTokenMFAToSMS
=== RUN   TestAccCognitoIDPUserPool_smsAuthenticationMessage
=== PAUSE TestAccCognitoIDPUserPool_smsAuthenticationMessage
=== RUN   TestAccCognitoIDPUserPool_sms
=== PAUSE TestAccCognitoIDPUserPool_sms
=== RUN   TestAccCognitoIDPUserPool_SMS_snsRegion
=== PAUSE TestAccCognitoIDPUserPool_SMS_snsRegion
=== RUN   TestAccCognitoIDPUserPool_SMS_externalID
=== PAUSE TestAccCognitoIDPUserPool_SMS_externalID
=== RUN   TestAccCognitoIDPUserPool_SMS_snsCallerARN
=== PAUSE TestAccCognitoIDPUserPool_SMS_snsCallerARN
=== RUN   TestAccCognitoIDPUserPool_smsVerificationMessage
=== PAUSE TestAccCognitoIDPUserPool_smsVerificationMessage
=== RUN   TestAccCognitoIDPUserPool_withEmail
=== PAUSE TestAccCognitoIDPUserPool_withEmail
=== RUN   TestAccCognitoIDPUserPool_withEmailSource
    user_pool_test.go:885: Environment variable TEST_AWS_SES_VERIFIED_EMAIL_ARN is not set, skipping test
--- SKIP: TestAccCognitoIDPUserPool_withEmailSource (0.00s)
=== RUN   TestAccCognitoIDPUserPool_tags
=== PAUSE TestAccCognitoIDPUserPool_tags
=== RUN   TestAccCognitoIDPUserPool_withAliasAttributes
=== PAUSE TestAccCognitoIDPUserPool_withAliasAttributes
=== RUN   TestAccCognitoIDPUserPool_withUsernameAttributes
=== PAUSE TestAccCognitoIDPUserPool_withUsernameAttributes
=== RUN   TestAccCognitoIDPUserPool_withPasswordPolicy
=== PAUSE TestAccCognitoIDPUserPool_withPasswordPolicy
=== RUN   TestAccCognitoIDPUserPool_withUsername
=== PAUSE TestAccCognitoIDPUserPool_withUsername
=== RUN   TestAccCognitoIDPUserPool_withLambda
=== PAUSE TestAccCognitoIDPUserPool_withLambda
=== RUN   TestAccCognitoIDPUserPool_WithLambda_email
=== PAUSE TestAccCognitoIDPUserPool_WithLambda_email
=== RUN   TestAccCognitoIDPUserPool_WithLambda_sms
=== PAUSE TestAccCognitoIDPUserPool_WithLambda_sms
=== RUN   TestAccCognitoIDPUserPool_WithLambda_preGenerationTokenConfig
=== PAUSE TestAccCognitoIDPUserPool_WithLambda_preGenerationTokenConfig
=== RUN   TestAccCognitoIDPUserPool_schemaAttributes
=== PAUSE TestAccCognitoIDPUserPool_schemaAttributes
=== RUN   TestAccCognitoIDPUserPool_schemaAttributesRemoved
=== PAUSE TestAccCognitoIDPUserPool_schemaAttributesRemoved
=== RUN   TestAccCognitoIDPUserPool_schemaAttributesModified
=== PAUSE TestAccCognitoIDPUserPool_schemaAttributesModified
=== RUN   TestAccCognitoIDPUserPool_schemaAttributesStringAttributeConstraints
=== PAUSE TestAccCognitoIDPUserPool_schemaAttributesStringAttributeConstraints
=== RUN   TestAccCognitoIDPUserPool_withVerificationMessageTemplate
=== PAUSE TestAccCognitoIDPUserPool_withVerificationMessageTemplate
=== RUN   TestAccCognitoIDPUserPool_withVerificationMessageTemplateUTF8
=== PAUSE TestAccCognitoIDPUserPool_withVerificationMessageTemplateUTF8
=== RUN   TestAccCognitoIDPUserPool_update
=== PAUSE TestAccCognitoIDPUserPool_update
=== RUN   TestAccCognitoIDPUserPool_disappears
=== PAUSE TestAccCognitoIDPUserPool_disappears
=== RUN   TestAccCognitoIDPUserPool_withUserAttributeUpdateSettings
=== PAUSE TestAccCognitoIDPUserPool_withUserAttributeUpdateSettings
=== CONT  TestAccCognitoIDPUserPool_basic
=== CONT  TestAccCognitoIDPUserPool_withEmail
=== CONT  TestAccCognitoIDPUserPool_schemaAttributes
=== CONT  TestAccCognitoIDPUserPool_withVerificationMessageTemplateUTF8
=== CONT  TestAccCognitoIDPUserPool_disappears
=== CONT  TestAccCognitoIDPUserPool_withUsername
=== CONT  TestAccCognitoIDPUserPool_schemaAttributesStringAttributeConstraints
=== CONT  TestAccCognitoIDPUserPool_withVerificationMessageTemplate
=== CONT  TestAccCognitoIDPUserPool_WithLambda_sms
=== CONT  TestAccCognitoIDPUserPool_WithLambda_preGenerationTokenConfig
=== CONT  TestAccCognitoIDPUserPool_schemaAttributesModified
=== CONT  TestAccCognitoIDPUserPool_withUsernameAttributes
=== CONT  TestAccCognitoIDPUserPool_withPasswordPolicy
=== CONT  TestAccCognitoIDPUserPool_update
=== CONT  TestAccCognitoIDPUserPool_MFA_smsToSoftwareTokenMFA
=== CONT  TestAccCognitoIDPUserPool_smsVerificationMessage
=== CONT  TestAccCognitoIDPUserPool_SMS_snsCallerARN
=== CONT  TestAccCognitoIDPUserPool_SMS_externalID
=== CONT  TestAccCognitoIDPUserPool_SMS_snsRegion
=== CONT  TestAccCognitoIDPUserPool_sms
--- PASS: TestAccCognitoIDPUserPool_disappears (132.71s)
=== CONT  TestAccCognitoIDPUserPool_smsAuthenticationMessage
--- PASS: TestAccCognitoIDPUserPool_withEmail (146.69s)
=== CONT  TestAccCognitoIDPUserPool_MFA_softwareTokenMFAToSMS
--- PASS: TestAccCognitoIDPUserPool_basic (151.13s)
=== CONT  TestAccCognitoIDPUserPool_MFA_softwareTokenMFA
--- PASS: TestAccCognitoIDPUserPool_schemaAttributesStringAttributeConstraints (178.62s)
=== CONT  TestAccCognitoIDPUserPool_WithLambda_email
--- PASS: TestAccCognitoIDPUserPool_schemaAttributesModified (192.96s)
=== CONT  TestAccCognitoIDPUserPool_withAliasAttributes
--- PASS: TestAccCognitoIDPUserPool_withPasswordPolicy (244.53s)
=== CONT  TestAccCognitoIDPUserPool_withUserAttributeUpdateSettings
--- PASS: TestAccCognitoIDPUserPool_withVerificationMessageTemplate (245.32s)
=== CONT  TestAccCognitoIDPUserPool_withLambda
--- PASS: TestAccCognitoIDPUserPool_smsVerificationMessage (249.77s)
=== CONT  TestAccCognitoIDPUserPool_schemaAttributesRemoved
--- PASS: TestAccCognitoIDPUserPool_withVerificationMessageTemplateUTF8 (250.24s)
=== CONT  TestAccCognitoIDPUserPool_tags
--- PASS: TestAccCognitoIDPUserPool_schemaAttributes (255.53s)
=== CONT  TestAccCognitoIDPUserPool_withAdvancedSecurityMode
--- PASS: TestAccCognitoIDPUserPool_withUsername (262.78s)
=== CONT  TestAccCognitoIDPUserPool_MFA_smsAndSoftwareTokenMFA
--- PASS: TestAccCognitoIDPUserPool_withUsernameAttributes (265.03s)
=== CONT  TestAccCognitoIDPUserPool_MFA_sms
--- PASS: TestAccCognitoIDPUserPool_SMS_snsRegion (370.45s)
=== CONT  TestAccCognitoIDPUserPool_withEmailVerificationMessage
--- PASS: TestAccCognitoIDPUserPool_smsAuthenticationMessage (266.71s)
=== CONT  TestAccCognitoIDPUserPool_withDevice
--- PASS: TestAccCognitoIDPUserPool_MFA_smsToSoftwareTokenMFA (411.84s)
=== CONT  TestAccCognitoIDPUserPool_withAdminCreateUser
--- PASS: TestAccCognitoIDPUserPool_schemaAttributesRemoved (192.18s)
=== CONT  TestAccCognitoIDPUserPool_withAdminCreateUserAndPasswordPolicy
--- PASS: TestAccCognitoIDPUserPool_withAliasAttributes (288.79s)
=== CONT  TestAccCognitoIDPUserPool_recovery
--- PASS: TestAccCognitoIDPUserPool_withUserAttributeUpdateSettings (281.21s)
=== CONT  TestAccCognitoIDPUserPool_deletionProtection
--- PASS: TestAccCognitoIDPUserPool_MFA_softwareTokenMFA (395.09s)
--- PASS: TestAccCognitoIDPUserPool_SMS_externalID (565.35s)
--- PASS: TestAccCognitoIDPUserPool_MFA_softwareTokenMFAToSMS (459.64s)
--- PASS: TestAccCognitoIDPUserPool_SMS_snsCallerARN (613.08s)
--- PASS: TestAccCognitoIDPUserPool_withAdminCreateUserAndPasswordPolicy (190.01s)
--- PASS: TestAccCognitoIDPUserPool_tags (389.98s)
--- PASS: TestAccCognitoIDPUserPool_withAdvancedSecurityMode (392.29s)
--- PASS: TestAccCognitoIDPUserPool_sms (666.08s)
--- PASS: TestAccCognitoIDPUserPool_withEmailVerificationMessage (297.58s)
--- PASS: TestAccCognitoIDPUserPool_withDevice (279.41s)
--- PASS: TestAccCognitoIDPUserPool_withAdminCreateUser (270.70s)
--- PASS: TestAccCognitoIDPUserPool_WithLambda_preGenerationTokenConfig (713.60s)
--- PASS: TestAccCognitoIDPUserPool_deletionProtection (201.47s)
--- PASS: TestAccCognitoIDPUserPool_update (747.89s)
--- PASS: TestAccCognitoIDPUserPool_WithLambda_sms (752.08s)
--- PASS: TestAccCognitoIDPUserPool_recovery (272.24s)
--- PASS: TestAccCognitoIDPUserPool_MFA_smsAndSoftwareTokenMFA (508.70s)
--- PASS: TestAccCognitoIDPUserPool_MFA_sms (535.12s)
--- PASS: TestAccCognitoIDPUserPool_WithLambda_email (632.77s)
--- PASS: TestAccCognitoIDPUserPool_withLambda (662.11s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp 907.618s

$
```
