### PR TITLE
fix: Set arn attr of AWS managed documents to proper arn vs. name for aws_ssm_document data source

### DIFF
--- a/.changelog/36665.txt
+++ b/.changelog/36665.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_ssm_document: Set `arn` attribute to proper ARN for AWS managed documents (name starts with `AWS-` or `AWSSSO-`)
+```

--- a/internal/service/ssm/document_data_source.go
+++ b/internal/service/ssm/document_data_source.go
@@ -76,7 +76,15 @@ func dataDocumentRead(ctx context.Context, d *schema.ResourceData, meta interfac
 
 	d.SetId(aws.StringValue(output.Name))
 
-	if !strings.HasPrefix(name, "AWS-") {
+	if strings.HasPrefix(name, "AWS-") || strings.HasPrefix(name, "AWSSSO-") {
+		arn := arn.ARN{
+			Partition: meta.(*conns.AWSClient).Partition,
+			Service:   "ssm",
+			Region:    meta.(*conns.AWSClient).Region,
+			Resource:  fmt.Sprintf("document/%s", name),
+		}.String()
+		d.Set("arn", arn)
+	} else {
 		arn := arn.ARN{
 			Partition: meta.(*conns.AWSClient).Partition,
 			Service:   "ssm",
@@ -85,8 +93,6 @@ func dataDocumentRead(ctx context.Context, d *schema.ResourceData, meta interfac
 			Resource:  fmt.Sprintf("document/%s", name),
 		}.String()
 		d.Set("arn", arn)
-	} else {
-		d.Set("arn", name)
 	}
 	d.Set("content", output.Content)
 	d.Set("document_format", output.DocumentFormat)

--- a/website/docs/d/ssm_document.html.markdown
+++ b/website/docs/d/ssm_document.html.markdown
@@ -46,6 +46,8 @@ This data source supports the following arguments:
 
 This data source exports the following attributes in addition to the arguments above:
 
-* `arn` - ARN of the document. If the document is an AWS managed document, this value will be set to the name of the document instead.
+* `arn` - ARN of the document.
+  
+  **NOTE:** The ARN of an AWS managed document does not have the account ID partition (for example, `arn:aws:ssm:us-east-1::document/AWS-GatherSoftwareInventory`).
 * `content` - Contents of the document.
 * `document_type` - Type of the document.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to set the `arn` attribute to a proper ARN of AWS managed documents in the `aws_ssm_document` data source.

**Note:** I don't know if this change is considered a breaking changing, since I am replacing the name-based value with an ARN. However it didn't work for the `AWSSSO-` case anyway, so perhaps that's OK. If there are additional considerations or changes needed, please let me know.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #33436

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to the **Policy for connecting to EC2 instances with specific tags** example in [Connecting to a Windows Server managed instance using Remote Desktop](https://docs.aws.amazon.com/systems-manager/latest/userguide/fleet-rdp.html#fleet-rdp-iam-policy-examples) for the proper ARN example of AWS managed documents.

However, in another example, the IAM policies include a `*` for the account ID partition in the name. I am not sure whether that is specific to IAM Identity Center users, but I was not able to fetch a document that includes an account ID in Cloud Shell with the `aws ssm get-document` command and ARN in the `--name` argument.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccSSMDocumentDataSource_ PKG=ssm
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ssm/... -v -count 1 -parallel 20 -run='TestAccSSMDocumentDataSource_'  -timeout 360m
=== RUN   TestAccSSMDocumentDataSource_basic
=== PAUSE TestAccSSMDocumentDataSource_basic
=== RUN   TestAccSSMDocumentDataSource_managed
=== PAUSE TestAccSSMDocumentDataSource_managed
=== CONT  TestAccSSMDocumentDataSource_basic
=== CONT  TestAccSSMDocumentDataSource_managed
--- PASS: TestAccSSMDocumentDataSource_managed (43.75s)
--- PASS: TestAccSSMDocumentDataSource_basic (73.14s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssm        73.311s

$
```
