### PR TITLE
ECS Service Alarm Config read uses wrong key

### DIFF
--- a/.changelog/36691.txt
+++ b/.changelog/36691.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ecs_service: Correctly set `alarms.rollback` on resource Create and Update
+```

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -1156,7 +1156,7 @@ func expandAlarms(tfMap map[string]interface{}) *ecs.DeploymentAlarms {
 		apiObject.Enable = aws.Bool(v)
 	}
 
-	if v, ok := tfMap["enable"].(bool); ok {
+	if v, ok := tfMap["rollback"].(bool); ok {
 		apiObject.Rollback = aws.Bool(v)
 	}
 


### PR DESCRIPTION
When you configure
```HCL
resource "aws_ecs_service" "ext" {
...

  alarms {
    enable   = true
    rollback = false
    alarm_names = [
      "xyz"
    ]
  }
}
```

The `rollback` flag is always set to true. Even though it gets detected as it should be set to false.

Truth be told, the setting also doesn't seem to do anything meaningful on the AWS side with that parameter combination. While it's not documented to not be meaningful.

Still you can configure it as such with the AWS console or API, so given line is a bug none the less.

(I have not touched or run acceptance test, I hope that can be taken care of by the receiving end of this PR)