### PR TITLE
r/aws_route53_record(fix): correctly interpret wildcard record names

### DIFF
--- a/.changelog/36699.txt
+++ b/.changelog/36699.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+r/aws_route53_record: Fix to correctly interpret alias names with wildcards
+```

--- a/internal/service/route53/record.go
+++ b/internal/service/route53/record.go
@@ -1038,7 +1038,7 @@ func nilString(s string) *string {
 
 func NormalizeAliasName(alias interface{}) string {
 	output := strings.ToLower(alias.(string))
-	return strings.TrimSuffix(output, ".")
+	return CleanRecordName(strings.TrimSuffix(output, "."))
 }
 
 func ParseRecordID(id string) [4]string {

--- a/internal/service/route53/record_test.go
+++ b/internal/service/route53/record_test.go
@@ -85,6 +85,7 @@ func TestNormalizeAliasName(t *testing.T) {
 		{"ipv6.name-123456789.region.elb.amazonaws.com", "ipv6.name-123456789.region.elb.amazonaws.com"},
 		{"NAME-123456789.region.elb.amazonaws.com", "name-123456789.region.elb.amazonaws.com"},
 		{"name-123456789.region.elb.amazonaws.com", "name-123456789.region.elb.amazonaws.com"},
+		{"\\052.example.com", "*.example.com"},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

The response for ListResourceRecordSet encodes special characters like `*` as octal escape sequences. This causes plans to see drift in the alias records where none actually exists.

### References

* https://github.com/hashicorp/terraform/issues/501

### Output from Acceptance Testing

This seems unnecessarily involved and expensive for what this PR is trying to accomplish.