### PR TITLE
Add catalog_encryption_service_role to aws_glue_data_catalog_encryption_settings

### DIFF
--- a/.changelog/35978.txt
+++ b/.changelog/35978.txt
@@ -1,4 +1,7 @@
 ```release-note:enhancement
-resource/aws_glue_data_catalog_encryption_settings: Add `catalog_encryption_service_role` configuration
-data/aws_glue_data_catalog_encryption_settings: Add `catalog_encryption_service_role` attribute
+resource/aws_glue_data_catalog_encryption_settings: Add `data_catalog_encryption_settings.encryption_at_rest.catalog_encryption_service_role` argument
+```
+
+```release-note:enhancement
+data/aws_glue_data_catalog_encryption_settings: Add `data_catalog_encryption_settings.encryption_at_rest.catalog_encryption_service_role` attribute
 ```

--- a/.changelog/35978.txt
+++ b/.changelog/35978.txt
@@ -1,0 +1,4 @@
+```release-note:enhancement
+resource/aws_glue_data_catalog_encryption_settings: Add `catalog_encryption_service_role` configuration
+data/aws_glue_data_catalog_encryption_settings: Add `catalog_encryption_service_role` attribute
+```

--- a/internal/service/glue/data_catalog_encryption_settings.go
+++ b/internal/service/glue/data_catalog_encryption_settings.go
@@ -70,6 +70,11 @@ func ResourceDataCatalogEncryptionSettings() *schema.Resource {
 										Required:     true,
 										ValidateFunc: validation.StringInSlice(glue.CatalogEncryptionMode_Values(), false),
 									},
+									"catalog_encryption_service_role": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: verify.ValidARN,
+									},
 									"sse_aws_kms_key_id": {
 										Type:         schema.TypeString,
 										Optional:     true,
@@ -200,6 +205,10 @@ func expandEncryptionAtRest(tfMap map[string]interface{}) *glue.EncryptionAtRest
 		apiObject.CatalogEncryptionMode = aws.String(v)
 	}
 
+	if v, ok := tfMap["catalog_encryption_service_role"].(string); ok && v != "" {
+		apiObject.CatalogEncryptionServiceRole = aws.String(v)
+	}
+
 	if v, ok := tfMap["sse_aws_kms_key_id"].(string); ok && v != "" {
 		apiObject.SseAwsKmsKeyId = aws.String(v)
 	}
@@ -252,6 +261,10 @@ func flattenEncryptionAtRest(apiObject *glue.EncryptionAtRest) map[string]interf
 
 	if v := apiObject.CatalogEncryptionMode; v != nil {
 		tfMap["catalog_encryption_mode"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.CatalogEncryptionServiceRole; v != nil {
+		tfMap["catalog_encryption_service_role"] = aws.StringValue(v)
 	}
 
 	if v := apiObject.SseAwsKmsKeyId; v != nil {

--- a/internal/service/glue/data_catalog_encryption_settings_data_source.go
+++ b/internal/service/glue/data_catalog_encryption_settings_data_source.go
@@ -53,6 +53,10 @@ func DataSourceDataCatalogEncryptionSettings() *schema.Resource {
 										Type:     schema.TypeString,
 										Computed: true,
 									},
+									"catalog_encryption_service_role": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
 									"sse_aws_kms_key_id": {
 										Type:     schema.TypeString,
 										Computed: true,

--- a/internal/service/glue/data_catalog_encryption_settings_test.go
+++ b/internal/service/glue/data_catalog_encryption_settings_test.go
@@ -28,6 +28,7 @@ func testAccDataCatalogEncryptionSettings_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_glue_data_catalog_encryption_settings.test"
 	keyResourceName := "aws_kms_key.test"
+	roleResourceName := "aws_iam_role.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -45,6 +46,7 @@ func testAccDataCatalogEncryptionSettings_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "data_catalog_encryption_settings.0.connection_password_encryption.0.aws_kms_key_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "data_catalog_encryption_settings.0.encryption_at_rest.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "data_catalog_encryption_settings.0.encryption_at_rest.0.catalog_encryption_mode", "DISABLED"),
+					resource.TestCheckResourceAttr(resourceName, "data_catalog_encryption_settings.0.encryption_at_rest.0.catalog_encryption_service_role", "DISABLED"),
 					resource.TestCheckResourceAttr(resourceName, "data_catalog_encryption_settings.0.encryption_at_rest.0.sse_aws_kms_key_id", ""),
 				),
 			},
@@ -63,6 +65,21 @@ func testAccDataCatalogEncryptionSettings_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "data_catalog_encryption_settings.0.connection_password_encryption.0.aws_kms_key_id", keyResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "data_catalog_encryption_settings.0.encryption_at_rest.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "data_catalog_encryption_settings.0.encryption_at_rest.0.catalog_encryption_mode", "SSE-KMS"),
+					resource.TestCheckResourceAttr(resourceName, "data_catalog_encryption_settings.0.encryption_at_rest.0.catalog_encryption_service_role", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "data_catalog_encryption_settings.0.encryption_at_rest.0.sse_aws_kms_key_id", keyResourceName, "arn"),
+				),
+			},
+			{
+				Config: testAccDataCatalogEncryptionSettingsConfig_encrypted_with_catalog_encryption_service_role(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataCatalogEncryptionSettingsExists(ctx, resourceName, &settings),
+					resource.TestCheckResourceAttr(resourceName, "data_catalog_encryption_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "data_catalog_encryption_settings.0.connection_password_encryption.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "data_catalog_encryption_settings.0.connection_password_encryption.0.return_connection_password_encrypted", "true"),
+					resource.TestCheckResourceAttrPair(resourceName, "data_catalog_encryption_settings.0.connection_password_encryption.0.aws_kms_key_id", keyResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "data_catalog_encryption_settings.0.encryption_at_rest.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "data_catalog_encryption_settings.0.encryption_at_rest.0.catalog_encryption_mode", "SSE-KMS"),
+					resource.TestCheckResourceAttrPair(resourceName, "data_catalog_encryption_settings.0.encryption_at_rest.0.catalog_encryption_service_role", roleResourceName, "arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "data_catalog_encryption_settings.0.encryption_at_rest.0.sse_aws_kms_key_id", keyResourceName, "arn"),
 				),
 			},
@@ -76,6 +93,7 @@ func testAccDataCatalogEncryptionSettings_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "data_catalog_encryption_settings.0.connection_password_encryption.0.aws_kms_key_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "data_catalog_encryption_settings.0.encryption_at_rest.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "data_catalog_encryption_settings.0.encryption_at_rest.0.catalog_encryption_mode", "DISABLED"),
+					resource.TestCheckResourceAttr(resourceName, "data_catalog_encryption_settings.0.encryption_at_rest.0.catalog_encryption_service_role", ""),
 					resource.TestCheckResourceAttr(resourceName, "data_catalog_encryption_settings.0.encryption_at_rest.0.sse_aws_kms_key_id", ""),
 				),
 			},
@@ -143,6 +161,63 @@ resource "aws_glue_data_catalog_encryption_settings" "test" {
     encryption_at_rest {
       catalog_encryption_mode = "SSE-KMS"
       sse_aws_kms_key_id      = aws_kms_key.test.arn
+    }
+  }
+}
+`, rName)
+}
+
+func testAccDataCatalogEncryptionSettingsConfig_encrypted_with_catalog_encryption_service_role(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  description = %[1]q
+  policy      = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Id": "kms-tf-1",
+  "Statement": [
+    {
+      "Sid": "Enable IAM User Permissions",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "kms:*",
+      "Resource": "*"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role" "test" {
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "glue.amazonaws.com"
+      },
+      "Action": ["sts:AssumeRole"],
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_glue_data_catalog_encryption_settings" "test" {
+  data_catalog_encryption_settings {
+    connection_password_encryption {
+      aws_kms_key_id                       = aws_kms_key.test.arn
+      return_connection_password_encrypted = true
+    }
+
+    encryption_at_rest {
+      catalog_encryption_mode         = "SSE-KMS"
+      catalog_encryption_service_role = aws_iam_role.test.arn
+      sse_aws_kms_key_id              = aws_kms_key.test.arn
     }
   }
 }

--- a/website/docs/cdktf/python/d/glue_data_catalog_encryption_settings.html.markdown
+++ b/website/docs/cdktf/python/d/glue_data_catalog_encryption_settings.html.markdown
@@ -56,6 +56,7 @@ This data source exports the following attributes in addition to the arguments a
 ### encryption_at_rest
 
 * `catalog_encryption_mode` - The encryption-at-rest mode for encrypting Data Catalog data.
+* `catalog_encryption_service_role` - The ARN of the AWS IAM role used for accessing encrypted Data Catalog data.
 * `sse_aws_kms_key_id` - ARN of the AWS KMS key to use for encryption at rest.
 
 <!-- cache-key: cdktf-0.20.1 input-e959f72d2bff30ad397e7c3f8e5c026335f7731049187b56bb28d0f687ba62fd -->

--- a/website/docs/d/glue_data_catalog_encryption_settings.html.markdown
+++ b/website/docs/d/glue_data_catalog_encryption_settings.html.markdown
@@ -42,4 +42,5 @@ This data source exports the following attributes in addition to the arguments a
 ### encryption_at_rest
 
 * `catalog_encryption_mode` - The encryption-at-rest mode for encrypting Data Catalog data.
+* `catalog_encryption_service_role` - The ARN of the AWS IAM role used for accessing encrypted Data Catalog data.
 * `sse_aws_kms_key_id` - ARN of the AWS KMS key to use for encryption at rest.

--- a/website/docs/r/glue_data_catalog_encryption_settings.html.markdown
+++ b/website/docs/r/glue_data_catalog_encryption_settings.html.markdown
@@ -21,8 +21,9 @@ resource "aws_glue_data_catalog_encryption_settings" "example" {
     }
 
     encryption_at_rest {
-      catalog_encryption_mode = "SSE-KMS"
-      sse_aws_kms_key_id      = aws_kms_key.test.arn
+      catalog_encryption_mode         = "SSE-KMS"
+      catalog_encryption_service_role = aws_iam.role.test.arn
+      sse_aws_kms_key_id              = aws_kms_key.test.arn
     }
   }
 }
@@ -48,6 +49,7 @@ This resource supports the following arguments:
 ### encryption_at_rest
 
 * `catalog_encryption_mode` - (Required) The encryption-at-rest mode for encrypting Data Catalog data. Valid values are `DISABLED` and `SSE-KMS`.
+* `catalog_encryption_service_role` - (Optional) The ARN of the AWS IAM role used for accessing encrypted Data Catalog data.
 * `sse_aws_kms_key_id` - (Optional) The ARN of the AWS KMS key to use for encryption at rest.
 
 ## Attribute Reference


### PR DESCRIPTION
### Description
Add `catalog_encryption_service_role` property to `aws_glue_data_catalog_encryption_settings` (resource and data).

### Relations
Closes #35978

### References
https://aws.amazon.com/about-aws/whats-new/2024/02/aws-glue-data-catalog-delegating-kms-key-permissions-iam-role/
https://docs.aws.amazon.com/glue/latest/dg/encrypt-glue-data-catalog.html
https://docs.aws.amazon.com/glue/latest/webapi/API_PutDataCatalogEncryptionSettings.html


### Output from Acceptance Testing

```console
% make testacc TESTS='TestAccGlue_serial' PKG=glue
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/glue/... -v -count 1 -parallel 20 -run='TestAccGlue_serial'  -timeout 360m
=== RUN   TestAccGlue_serial
=== PAUSE TestAccGlue_serial
=== CONT  TestAccGlue_serial
=== RUN   TestAccGlue_serial/ResourcePolicy
=== RUN   TestAccGlue_serial/ResourcePolicy/disappears
=== RUN   TestAccGlue_serial/ResourcePolicy/equivalent
=== RUN   TestAccGlue_serial/ResourcePolicy/basic
=== RUN   TestAccGlue_serial/ResourcePolicy/update
=== RUN   TestAccGlue_serial/ResourcePolicy/hybrid
=== RUN   TestAccGlue_serial/DataCatalogEncryptionSettings
=== RUN   TestAccGlue_serial/DataCatalogEncryptionSettings/basic
    data_catalog_encryption_settings_test.go:22: Skipping aws_glue_data_catalog_encryption_settings tests due to potential KMS key corruption
=== RUN   TestAccGlue_serial/DataCatalogEncryptionSettings/dataSource
    data_catalog_encryption_settings_data_source_test.go:15: Skipping aws_glue_data_catalog_encryption_settings tests due to potential KMS key corruption
--- PASS: TestAccGlue_serial (138.44s)
    --- PASS: TestAccGlue_serial/ResourcePolicy (138.44s)
        --- PASS: TestAccGlue_serial/ResourcePolicy/disappears (18.74s)
        --- PASS: TestAccGlue_serial/ResourcePolicy/equivalent (21.95s)
        --- PASS: TestAccGlue_serial/ResourcePolicy/basic (20.33s)
        --- PASS: TestAccGlue_serial/ResourcePolicy/update (32.60s)
        --- PASS: TestAccGlue_serial/ResourcePolicy/hybrid (44.82s)
    --- PASS: TestAccGlue_serial/DataCatalogEncryptionSettings (0.00s)
        --- SKIP: TestAccGlue_serial/DataCatalogEncryptionSettings/basic (0.00s)
        --- SKIP: TestAccGlue_serial/DataCatalogEncryptionSettings/dataSource (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/glue	138.552s
```

Please note, that the most relevant tests are skipped due to KMS corruption.