### PR TITLE
BugFix:  `aws_cloudfrontkeyvaluestore_key mutex

### DIFF
--- a/internal/service/cloudfrontkeyvaluestore/key.go
+++ b/internal/service/cloudfrontkeyvaluestore/key.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
@@ -82,10 +83,18 @@ func (r *keyResource) Create(ctx context.Context, request resource.CreateRequest
 
 	conn := r.Meta().CloudFrontKeyValueStoreClient(ctx)
 
-	etag, err := findETagByARN(ctx, conn, data.KvsARN.ValueString())
+	kvsARN := data.KvsARN.ValueString()
+
+	// Adding a key changes the etag of the key value store.
+	// Use a mutex serialize actions
+	mutexKey := kvsARN
+	conns.GlobalMutexKV.Lock(mutexKey)
+	defer conns.GlobalMutexKV.Unlock(mutexKey)
+
+	etag, err := findETagByARN(ctx, conn, kvsARN)
 
 	if err != nil {
-		response.Diagnostics.AddError(fmt.Sprintf("reading CloudFront KeyValueStore ETag (%s)", data.KvsARN.ValueString()), err.Error())
+		response.Diagnostics.AddError(fmt.Sprintf("reading CloudFront KeyValueStore ETag (%s)", kvsARN), err.Error())
 
 		return
 	}
@@ -102,7 +111,7 @@ func (r *keyResource) Create(ctx context.Context, request resource.CreateRequest
 	output, err := conn.PutKey(ctx, input)
 
 	if err != nil {
-		response.Diagnostics.AddError(fmt.Sprintf("creating CloudFront KeyValueStore (%s) Key (%s)", data.KvsARN.ValueString(), data.Key.ValueString()), err.Error())
+		response.Diagnostics.AddError(fmt.Sprintf("creating CloudFront KeyValueStore (%s) Key (%s)", kvsARN, data.Key.ValueString()), err.Error())
 
 		return
 	}
@@ -167,10 +176,18 @@ func (r *keyResource) Update(ctx context.Context, request resource.UpdateRequest
 	conn := r.Meta().CloudFrontKeyValueStoreClient(ctx)
 
 	if !new.Value.Equal(old.Value) {
-		etag, err := findETagByARN(ctx, conn, new.KvsARN.ValueString())
+		kvsARN := new.KvsARN.ValueString()
+
+		// Updating a key changes the etag of the key value store.
+		// Use a mutex serialize actions
+		mutexKey := kvsARN
+		conns.GlobalMutexKV.Lock(mutexKey)
+		defer conns.GlobalMutexKV.Unlock(mutexKey)
+
+		etag, err := findETagByARN(ctx, conn, kvsARN)
 
 		if err != nil {
-			response.Diagnostics.AddError(fmt.Sprintf("reading CloudFront KeyValueStore ETag (%s)", new.KvsARN.ValueString()), err.Error())
+			response.Diagnostics.AddError(fmt.Sprintf("reading CloudFront KeyValueStore ETag (%s)", kvsARN), err.Error())
 
 			return
 		}
@@ -187,7 +204,7 @@ func (r *keyResource) Update(ctx context.Context, request resource.UpdateRequest
 		output, err := conn.PutKey(ctx, input)
 
 		if err != nil {
-			response.Diagnostics.AddError(fmt.Sprintf("updating CloudFront KeyValueStore (%s) Key (%s)", new.KvsARN.ValueString(), new.Key.ValueString()), err.Error())
+			response.Diagnostics.AddError(fmt.Sprintf("updating CloudFront KeyValueStore (%s) Key (%s)", kvsARN, new.Key.ValueString()), err.Error())
 
 			return
 		}
@@ -208,10 +225,18 @@ func (r *keyResource) Delete(ctx context.Context, request resource.DeleteRequest
 
 	conn := r.Meta().CloudFrontKeyValueStoreClient(ctx)
 
-	etag, err := findETagByARN(ctx, conn, data.KvsARN.ValueString())
+	kvsARN := data.KvsARN.ValueString()
+
+	// Deleting a key changes the etag of the key value store.
+	// Use a mutex serialize actions
+	mutexKey := kvsARN
+	conns.GlobalMutexKV.Lock(mutexKey)
+	defer conns.GlobalMutexKV.Unlock(mutexKey)
+
+	etag, err := findETagByARN(ctx, conn, kvsARN)
 
 	if err != nil {
-		response.Diagnostics.AddError(fmt.Sprintf("reading CloudFront KeyValueStore ETag (%s)", data.KvsARN.ValueString()), err.Error())
+		response.Diagnostics.AddError(fmt.Sprintf("reading CloudFront KeyValueStore ETag (%s)", kvsARN), err.Error())
 
 		return
 	}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This change implements a mutex to make actions against cloudfront key value stores serialized. 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #36534

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
✗ make testacc TESTARGS='-run=TestAccCloudFrontKeyValueStore' PKG=cloudfront            
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/cloudfront/... -v -count 1 -parallel 20  -run=TestAccCloudFrontKeyValueStore -timeout 360m
=== RUN   TestAccCloudFrontKeyValueStore_basic
=== PAUSE TestAccCloudFrontKeyValueStore_basic
=== RUN   TestAccCloudFrontKeyValueStore_disappears
=== PAUSE TestAccCloudFrontKeyValueStore_disappears
=== RUN   TestAccCloudFrontKeyValueStore_comment
=== PAUSE TestAccCloudFrontKeyValueStore_comment
=== CONT  TestAccCloudFrontKeyValueStore_basic
=== CONT  TestAccCloudFrontKeyValueStore_comment
=== CONT  TestAccCloudFrontKeyValueStore_disappears
--- PASS: TestAccCloudFrontKeyValueStore_disappears (26.39s)
--- PASS: TestAccCloudFrontKeyValueStore_basic (28.42s)
--- PASS: TestAccCloudFrontKeyValueStore_comment (36.13s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront 42.219s
➜ terraform-provider-aws (b-aws_cloudfrontkeyvaluestore_key-mutex) ✗ make testacc TESTARGS='-run=TestAccCloudFrontKeyValueStoreKey' PKG=cloudfrontkeyvaluestore
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/cloudfrontkeyvaluestore/... -v -count 1 -parallel 20  -run=TestAccCloudFrontKeyValueStoreKey -timeout 360m
=== RUN   TestAccCloudFrontKeyValueStoreKey_basic
=== PAUSE TestAccCloudFrontKeyValueStoreKey_basic
=== RUN   TestAccCloudFrontKeyValueStoreKey_mutex
=== PAUSE TestAccCloudFrontKeyValueStoreKey_mutex
=== RUN   TestAccCloudFrontKeyValueStoreKey_value
=== PAUSE TestAccCloudFrontKeyValueStoreKey_value
=== RUN   TestAccCloudFrontKeyValueStoreKey_disappears
=== PAUSE TestAccCloudFrontKeyValueStoreKey_disappears
=== CONT  TestAccCloudFrontKeyValueStoreKey_basic
=== CONT  TestAccCloudFrontKeyValueStoreKey_value
=== CONT  TestAccCloudFrontKeyValueStoreKey_disappears
=== CONT  TestAccCloudFrontKeyValueStoreKey_mutex
--- PASS: TestAccCloudFrontKeyValueStoreKey_disappears (28.06s)
--- PASS: TestAccCloudFrontKeyValueStoreKey_mutex (28.39s)
--- PASS: TestAccCloudFrontKeyValueStoreKey_basic (29.11s)
--- PASS: TestAccCloudFrontKeyValueStoreKey_value (36.55s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudfrontkeyvaluestore    42.382s

...
```
