### PR TITLE
Update glue_connection.html.markdown smiley

### DIFF
--- a/website/docs/r/glue_connection.html.markdown
+++ b/website/docs/r/glue_connection.html.markdown
@@ -83,7 +83,7 @@ resource "aws_glue_connection" "example_connector" {
     CONNECTOR_CLASS_NAME = "net.snowflake.client.jdbc.SnowflakeDriver"
     CONNECTION_TYPE      = "Jdbc"
     CONNECTOR_URL        = "s3://example/snowflake-jdbc.jar" # S3 path to the snowflake jdbc jar
-    JDBC_CONNECTION_URL  = "[[\"default=jdbc:snowflake://example.com/?user=$${user}&password=$${password}\"],\",\"]"
+    JDBC_CONNECTION_URL  = "[[\"default=jdbc:snowflake//example.com/?user=$${user}&password=$${password}\"],\",\"]"
   }
 
   name = "example_connector"
@@ -100,7 +100,7 @@ resource "aws_glue_connection" "example_connection" {
     CONNECTOR_CLASS_NAME = "net.snowflake.client.jdbc.SnowflakeDriver"
     CONNECTION_TYPE      = "Jdbc"
     CONNECTOR_URL        = "s3://example/snowflake-jdbc.jar"
-    JDBC_CONNECTION_URL  = "jdbc:snowflake://example.com/?user=$${user}&password=$${password}"
+    JDBC_CONNECTION_URL  = "jdbc:snowflake//example.com/?user=$${user}&password=$${password}"
     SECRET_ID            = data.aws_secretmanager_secret.example.name
   }
   name           = "example"


### PR DESCRIPTION
### Description

There is a snowflake emoji in a code block.
It looks like:

JDBC_CONNECTION_URL  = "[[\"default=jdbc❄//example.com/?user=$${user}&password=$${password}\"],\",\"]"
  }
But it should be:

JDBC_CONNECTION_URL  = "[[\"default=jdbc:snowflake//example.com/?user=$${user}&password=$${password}\"],\",\"]"
  }

### Relations

Closes #36022.

### References

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/glue_connection.html#connection-using-a-custom-connector