### PR TITLE
fix: add enabled_standard_arns if service_enabled is true in aws_securityhub_configuration_policy

### DIFF
--- a/.changelog/36740.txt
+++ b/.changelog/36740.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_securityhub_configuration_policy: Allow to configure empty `enabled_standard_arns`.
+resource/aws_securityhub_configuration_policy: Mark `configuration_policy.enabled_standard_arns` as Optional, fixing `InvalidInputException: Invalid semantics: Enabled standards and security control configurations must be configured when Security Hub is enabled` errors
 ```

--- a/.changelog/36740.txt
+++ b/.changelog/36740.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_securityhub_configuration_policy: Allow to configure empty `enabled_standard_arns`.
+```

--- a/internal/service/securityhub/configuration_policy.go
+++ b/internal/service/securityhub/configuration_policy.go
@@ -432,7 +432,7 @@ func expandPolicyMemberSecurityHub(tfMap map[string]interface{}) *types.PolicyMe
 		SecurityControlsConfiguration: expandSecurityControlsConfiguration(tfMap["security_controls_configuration"]),
 	}
 
-	if v, ok := tfMap["enabled_standard_arns"].(*schema.Set); ok && v.Len() > 0 {
+	if v, ok := tfMap["enabled_standard_arns"].(*schema.Set); ok {
 		apiObject.EnabledStandardIdentifiers = flex.ExpandStringValueSet(v)
 	}
 

--- a/internal/service/securityhub/configuration_policy.go
+++ b/internal/service/securityhub/configuration_policy.go
@@ -184,7 +184,7 @@ func resourceConfigurationPolicy() *schema.Resource {
 						Schema: map[string]*schema.Schema{
 							"enabled_standard_arns": {
 								Type:     schema.TypeSet,
-								Required: true,
+								Optional: true,
 								Elem: &schema.Schema{
 									Type:         schema.TypeString,
 									ValidateFunc: verify.ValidARN,
@@ -432,12 +432,14 @@ func expandPolicyMemberSecurityHub(tfMap map[string]interface{}) *types.PolicyMe
 		SecurityControlsConfiguration: expandSecurityControlsConfiguration(tfMap["security_controls_configuration"]),
 	}
 
-	if v, ok := tfMap["enabled_standard_arns"].(*schema.Set); ok {
-		apiObject.EnabledStandardIdentifiers = flex.ExpandStringValueSet(v)
-	}
-
 	if v, ok := tfMap["service_enabled"].(bool); ok {
 		apiObject.ServiceEnabled = aws.Bool(v)
+
+		if v {
+			if v, ok := tfMap["enabled_standard_arns"].(*schema.Set); ok {
+				apiObject.EnabledStandardIdentifiers = flex.ExpandStringValueSet(v)
+			}
+		}
 	}
 
 	return &types.PolicyMemberSecurityHub{

--- a/internal/service/securityhub/configuration_policy_test.go
+++ b/internal/service/securityhub/configuration_policy_test.go
@@ -369,8 +369,7 @@ resource "aws_securityhub_configuration_policy" "test" {
   description = %[2]q
 
   configuration_policy {
-    service_enabled       = false
-    enabled_standard_arns = []
+    service_enabled = false
   }
 
   depends_on = [aws_securityhub_organization_configuration.test]

--- a/website/docs/r/securityhub_configuration_policy.html.markdown
+++ b/website/docs/r/securityhub_configuration_policy.html.markdown
@@ -59,7 +59,6 @@ resource "aws_securityhub_configuration_policy" "disabled" {
 
   configuration_policy {
     service_enabled       = false
-    enabled_standard_arns = []
   }
 
   depends_on = [aws_securityhub_organization_configuration.example]
@@ -130,7 +129,7 @@ This resource supports the following arguments:
 
 The `configuration_policy` block supports the following:
 
-* `enabled_standard_arns` - (Required) A list that defines which security standards are enabled in the configuration policy.
+* `enabled_standard_arns` - (Optional) A list that defines which security standards are enabled in the configuration policy. It must be defined if `service_enabled` is set to true.
 * `security_controls_configuration` - (Optional) Defines which security controls are enabled in the configuration policy and any customizations to parameters affecting them. See [below](#security_controls_configuration).
 * `service_enabled` - (Required) Indicates whether Security Hub is enabled in the policy.
 

--- a/website/docs/r/securityhub_configuration_policy.html.markdown
+++ b/website/docs/r/securityhub_configuration_policy.html.markdown
@@ -58,7 +58,7 @@ resource "aws_securityhub_configuration_policy" "disabled" {
   description = "This is an example of disabled configuration policy"
 
   configuration_policy {
-    service_enabled       = false
+    service_enabled = false
   }
 
   depends_on = [aws_securityhub_organization_configuration.example]


### PR DESCRIPTION
### Description

If `enabled_standard_arns` is used, and `service_enabled` is set to `false`, it will be included in the AWS API call. Now it's only added if it is not empty.
This will fix the issue when trying to create a SecurityHub configuration policy without enabling any standards.

Current version ConfigurationPolicy:
```
2024-04-05T09:11:42.103+1030 [DEBUG] provider.terraform-provider-aws_v5.43.0_x5: HTTP Request Sent: ...
  http.request.body=
  | {"ConfigurationPolicy":{"SecurityHub":{"SecurityControlsConfiguration":{"DisabledSecurityControlIdentifiers":[]},"ServiceEnabled":true}},"Description":"ExampleDescription","Name":"Example"}
```

With the proposed fix:
```
2024-04-05T08:59:08.187+1030 [DEBUG] provider.terraform-provider-aws: HTTP Request Sent: http.request.header.x_amz_security_token="*****" rpc.method=CreateConfigurationPolicy
 http.request.body=
  | {"ConfigurationPolicy":{"SecurityHub":{"EnabledStandardIdentifiers":[],"SecurityControlsConfiguration":{"DisabledSecurityControlIdentifiers":[]},"ServiceEnabled":true}},"Description":"Enable SecurityHub in the organization","Name":"EnableSecurityHubOrganization"}
```

`enabled_standard_arns` must be included only if `service_enabled` is true.


### Relations

Closes #36739


### References

https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_SecurityHubPolicy.html
https://awscli.amazonaws.com/v2/documentation/api/latest/reference/securityhub/create-configuration-policy.html


### Output from Acceptance Testing

```console
% make testacc TESTARGS='-run=TestAccSecurityHub_serial/^ConfigurationPolicy$$/basic' PKG=securityhub
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go  test ./internal/service/securityhub/... -v -count 1 -parallel 20  -run=TestAccSecurityHub_serial/^ConfigurationPolicy$/basic -timeout 360m
=== RUN   TestAccSecurityHub_serial
=== PAUSE TestAccSecurityHub_serial
=== CONT  TestAccSecurityHub_serial
=== RUN   TestAccSecurityHub_serial/ConfigurationPolicy
=== RUN   TestAccSecurityHub_serial/ConfigurationPolicy/basic
--- PASS: TestAccSecurityHub_serial (84.46s)
    --- PASS: TestAccSecurityHub_serial/ConfigurationPolicy (84.46s)
        --- PASS: TestAccSecurityHub_serial/ConfigurationPolicy/basic (84.46s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/securityhub	89.319s
```
```console
% make testacc TESTARGS='-run=TestAccSecurityHub_serial/^ConfigurationPolicy$$/disappears' PKG=securityhub
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go  test ./internal/service/securityhub/... -v -count 1 -parallel 20  -run=TestAccSecurityHub_serial/^ConfigurationPolicy$/disappears -timeout 360m
=== RUN   TestAccSecurityHub_serial
=== PAUSE TestAccSecurityHub_serial
=== CONT  TestAccSecurityHub_serial
=== RUN   TestAccSecurityHub_serial/ConfigurationPolicy
=== RUN   TestAccSecurityHub_serial/ConfigurationPolicy/disappears
--- PASS: TestAccSecurityHub_serial (60.87s)
    --- PASS: TestAccSecurityHub_serial/ConfigurationPolicy (60.87s)
        --- PASS: TestAccSecurityHub_serial/ConfigurationPolicy/disappears (60.87s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/securityhub	65.561s
```
```console
% make testacc TESTARGS='-run=TestAccSecurityHub_serial/^ConfigurationPolicy$$/^C' PKG=securityhub
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go  test ./internal/service/securityhub/... -v -count 1 -parallel 20  -run=TestAccSecurityHub_serial/^ConfigurationPolicy$/^C -timeout 360m
=== RUN   TestAccSecurityHub_serial
=== PAUSE TestAccSecurityHub_serial
=== CONT  TestAccSecurityHub_serial
=== RUN   TestAccSecurityHub_serial/ConfigurationPolicy
=== RUN   TestAccSecurityHub_serial/ConfigurationPolicy/CustomParameters
=== RUN   TestAccSecurityHub_serial/ConfigurationPolicy/ControlIdentifiers
--- PASS: TestAccSecurityHub_serial (252.20s)
    --- PASS: TestAccSecurityHub_serial/ConfigurationPolicy (252.20s)
        --- PASS: TestAccSecurityHub_serial/ConfigurationPolicy/CustomParameters (168.85s)
        --- PASS: TestAccSecurityHub_serial/ConfigurationPolicy/ControlIdentifiers (83.34s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/securityhub	256.842s
```
