### PR TITLE
[Docs]: modified aws_quicksight_data_set.physical_table_map from required to optional 

### DIFF
--- a/website/docs/cdktf/python/r/quicksight_data_set.html.markdown
+++ b/website/docs/cdktf/python/r/quicksight_data_set.html.markdown
@@ -228,7 +228,7 @@ The following arguments are required:
 * `data_set_id` - (Required, Forces new resource) Identifier for the data set.
 * `import_mode` - (Required) Indicates whether you want to import the data into SPICE. Valid values are `SPICE` and `DIRECT_QUERY`.
 * `name` - (Required) Display name for the dataset.
-* `physical_table_map` - (Required) Declares the physical tables that are available in the underlying data sources. See [physical_table_map](#physical_table_map).
+* `physical_table_map` - (Optional) Declares the physical tables that are available in the underlying data sources. See [physical_table_map](#physical_table_map).
 
 The following arguments are optional:
 

--- a/website/docs/cdktf/typescript/r/quicksight_data_set.html.markdown
+++ b/website/docs/cdktf/typescript/r/quicksight_data_set.html.markdown
@@ -262,7 +262,7 @@ The following arguments are required:
 * `dataSetId` - (Required, Forces new resource) Identifier for the data set.
 * `importMode` - (Required) Indicates whether you want to import the data into SPICE. Valid values are `SPICE` and `DIRECT_QUERY`.
 * `name` - (Required) Display name for the dataset.
-* `physicalTableMap` - (Required) Declares the physical tables that are available in the underlying data sources. See [physical_table_map](#physical_table_map).
+* `physicalTableMap` - (Optional) Declares the physical tables that are available in the underlying data sources. See [physical_table_map](#physical_table_map).
 
 The following arguments are optional:
 

--- a/website/docs/r/quicksight_data_set.html.markdown
+++ b/website/docs/r/quicksight_data_set.html.markdown
@@ -167,7 +167,7 @@ The following arguments are required:
 * `data_set_id` - (Required, Forces new resource) Identifier for the data set.
 * `import_mode` - (Required) Indicates whether you want to import the data into SPICE. Valid values are `SPICE` and `DIRECT_QUERY`.
 * `name` - (Required) Display name for the dataset.
-* `physical_table_map` - (Required) Declares the physical tables that are available in the underlying data sources. See [physical_table_map](#physical_table_map).
+* `physical_table_map` - (Optional) Declares the physical tables that are available in the underlying data sources. See [physical_table_map](#physical_table_map).
 
 The following arguments are optional:
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
"Resource: aws_quicksight_data_set physical_table_map" is (Required) in the documentation, but should have been changed to Optional as of the link Pull Request.

### Relations

Closes #36744 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
