### PR TITLE
[WIP] tools: aws sdk migration semgrep rules

### DIFF
--- a/tools/.semgrep-awssdk-migration.yml
+++ b/tools/.semgrep-awssdk-migration.yml
@@ -1,0 +1,106 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+rules:
+  - id: fix-aws-package-import
+    pattern: |
+      import "github.com/aws/aws-sdk-go/aws"
+    fix-regex:
+      regex: "github.com/aws/aws-sdk-go/aws"
+      replacement: "github.com/aws/aws-sdk-go-v2/aws"
+    message: Use aws package from AWS SDK for Go V2
+    languages: [go]
+    severity: WARNING
+    paths:
+      exclude:
+        - "*_gen.go"
+
+  # TODO service package import with types subpackage
+  ####
+  # - id: fix-aws-service-package-import
+  #   patterns:
+  #     - pattern-regex: "github.com/aws/aws-sdk-go/service/[a-z0-9]*"
+  #   # fix not working
+  #   fix-regex:
+  #     regex: "github.com/aws/aws-sdk-go/service/service/[a-z0-9]*"
+  #     replacement: "github.com/aws/aws-sdk-go-v2/service"
+  #   message: Use service package from AWS SDK for Go V2
+  #   languages: [go]
+  #   severity: WARNING
+  #   paths:
+  #     exclude:
+  #       - "*_gen.go"
+  #
+  - id: fix-aws-to-bool-conversion
+    pattern: "aws.BoolValue"
+    fix: "aws.ToBool"
+    message: Use AWS SDK for Go V2 to bool conversion
+    languages: [go]
+    severity: WARNING
+
+  - id: fix-aws-to-int32-conversion
+    pattern: "aws.Int32Value"
+    fix: "aws.ToInt32"
+    message: Use AWS SDK for Go V2 to int32 conversion
+    languages: [go]
+    severity: WARNING
+
+  - id: fix-aws-to-int64-conversion
+    pattern: "aws.Int64Value"
+    fix: "aws.ToInt64"
+    message: Use AWS SDK for Go V2 to int64 conversion
+    languages: [go]
+    severity: WARNING
+
+  - id: fix-aws-to-float32-conversion
+    pattern: "aws.Float32Value"
+    fix: "aws.ToFloat32"
+    message: Use AWS SDK for Go V2 to float32 conversion
+    languages: [go]
+    severity: WARNING
+
+  - id: fix-aws-to-float64-conversion
+    pattern: "aws.Float64Value"
+    fix: "aws.ToFloat64"
+    message: Use AWS SDK for Go V2 to float64 conversion
+    languages: [go]
+    severity: WARNING
+
+  - id: fix-aws-to-string-conversion
+    pattern: "aws.StringValue"
+    fix: "aws.ToString"
+    message: Use AWS SDK for Go V2 to string conversion
+    languages: [go]
+    severity: WARNING
+
+  - id: fix-conn-initialization
+    patterns:
+      - pattern: "meta.(*conns.AWSClient).$CLIENT(ctx)"
+      - metavariable-regex:
+          metavariable: $CLIENT
+          regex: (.*)Conn
+    fix-regex:
+      regex: (.*)Conn
+      replacement: '\1Client'
+    message: Initialize AWS SDK for Go V2 client
+    languages: [go]
+    severity: WARNING
+
+  - id: fix-conn-arguments
+    patterns:
+      - pattern: |
+          func $F(..., conn $CLIENT, ...) {
+            ...
+          }
+      - focus-metavariable: $CLIENT
+      - metavariable-pattern:
+          metavariable: $CLIENT
+          patterns:
+            - pattern-regex: '(.*)\..*'
+    # TODO: replacement isn't functional, though match is found?
+    fix-regex:
+      regex: '(.*)\..*'
+      replacement: 'TODO'
+    message: Use AWS SDK for Go V2 client in function arguments
+    languages: [go]
+    severity: WARNING


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
These rules are intended to assist with AWS SDK for Go migrations by auto-fixing certain patterns. The resulting code will be incomplete and may not compile. This tool will not automate migrations, but can alleviate some of the repetitive tasks required to updgrade a service.

The command below executes a dry run. Replace the `<service>` placeholder with the service to be migrated.

```console
% semgrep --config tools/.semgrep-awssdk-migration.yml --dryrun internal/service/<service>
```

Once comfortable with the proposed changes, pass the `--autofix` flag to apply automated fixes.

```console
% semgrep --config tools/.semgrep-awssdk-migration.yml --autofix internal/service/<service>
```


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #32976

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://hashicorp.github.io/terraform-provider-aws/aws-go-sdk-migrations/