### PR TITLE
update transitgateway cross account peering example

### DIFF
--- a/examples/transit-gateway-cross-account-peering-attachment/main.tf
+++ b/examples/transit-gateway-cross-account-peering-attachment/main.tf
@@ -57,11 +57,21 @@ resource "aws_ec2_transit_gateway_peering_attachment" "example" {
   }
 }
 
+data "aws_ec2_transit_gateway_peering_attachment" "example" {
+  provider = aws.first
+  filter {
+    name   = "transit-gateway-id"
+    values = [aws_ec2_transit_gateway.first.id]
+  }
+
+  depends_on = [aws_ec2_transit_gateway_peering_attachment.example]
+}
+
 # ...and accept it in the first account.
 resource "aws_ec2_transit_gateway_peering_attachment_accepter" "example" {
   provider = aws.first
 
-  transit_gateway_attachment_id = aws_ec2_transit_gateway_peering_attachment.example.id
+  transit_gateway_attachment_id = data.aws_ec2_transit_gateway_peering_attachment.example.id
   tags = {
     Name = "terraform-example"
     Side = "Acceptor"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

When peering transit gateways across different accounts, the `attachment_id` needs to be retrieved from the peer account. This `id` can be retrieved by using the `aws_transit_gateway_peering_attachment` data source.

It should be noted that this data source is only necessary when trying to peer on different accounts.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #24677

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
