### PR TITLE
feat: Add aws_db_activity_stream resource

### DIFF
--- a/.changelog/36775.txt
+++ b/.changelog/36775.txt
@@ -1,0 +1,6 @@
+```release-note:new-resource
+aws_db_activity_stream
+```
+```release-note:enhancement
+resource/aws_rds_cluster_activity_stream: Improve `resource_arn` argument validation
+```

--- a/internal/service/rds/activty_stream_test.go
+++ b/internal/service/rds/activty_stream_test.go
@@ -1,0 +1,185 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package rds_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/rds/types"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfrds "github.com/hashicorp/terraform-provider-aws/internal/service/rds"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccRDSActivityStream_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	var dbInstance types.DBInstance
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_db_activity_stream.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartition(t, names.StandardPartitionID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckActivityStreamDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccActivityStreamConfig_basic(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckActivityStreamExists(ctx, resourceName, &dbInstance),
+					resource.TestCheckResourceAttr(resourceName, "engine_native_audit_fields_included", acctest.CtFalse),
+					resource.TestCheckResourceAttrSet(resourceName, "kinesis_stream_name"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccActivityStreamConfig_basic(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckActivityStreamExists(ctx, resourceName, &dbInstance),
+					resource.TestCheckResourceAttr(resourceName, "engine_native_audit_fields_included", acctest.CtTrue),
+					resource.TestCheckResourceAttrSet(resourceName, "kinesis_stream_name"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccRDSActivityStream_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	var dbInstance types.DBInstance
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_db_activity_stream.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartition(t, names.StandardPartitionID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckActivityStreamDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccActivityStreamConfig_basic(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckActivityStreamExists(ctx, resourceName, &dbInstance),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfrds.ResourceActivityStream(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckActivityStreamDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).RDSClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_db_activity_stream" {
+				continue
+			}
+
+			_, err := tfrds.FindDBInstanceWithActivityStream(ctx, conn, rs.Primary.ID)
+
+			if tfresource.NotFound(err) {
+				continue
+			}
+
+			if err != nil {
+				return err
+			}
+
+			return fmt.Errorf("DB Activity Stream %s still exists", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckActivityStreamExists(ctx context.Context, n string, v *types.DBInstance) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).RDSClient(ctx)
+
+		output, err := tfrds.FindDBInstanceWithActivityStream(ctx, conn, rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		*v = *output
+
+		return nil
+	}
+}
+
+func testAccActivityStreamConfig_baseVPC(rName string) string {
+	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 2), fmt.Sprintf(`
+resource "aws_db_subnet_group" "test" {
+  name       = %[1]q
+  subnet_ids = aws_subnet.test[*].id
+}
+`, rName))
+}
+
+func testAccActivityStreamConfig_DBInstanceMSQQLBase(rName string) string {
+	return acctest.ConfigCompose(
+		testAccActivityStreamConfig_baseVPC(rName),
+		fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  description             = %[1]q
+  deletion_window_in_days = 7
+}
+resource "aws_db_instance" "test" {
+  allocated_storage       = 20
+  backup_retention_period = 0
+  db_subnet_group_name    = aws_db_subnet_group.test.name
+  engine                  = "sqlserver-se"
+  engine_version          = "15.00"
+  identifier              = %[1]q
+  instance_class          = "db.m6i.large"
+  license_model           = "license-included"
+  password                = "avoid-plaintext-passwords"
+  skip_final_snapshot     = true
+  storage_encrypted       = true
+  username                = "tfacctest"
+}
+`, rName))
+}
+
+func testAccActivityStreamConfig_basic(rName string, engineNativeAuditFieldsIncluded bool) string {
+	return acctest.ConfigCompose(testAccActivityStreamConfig_DBInstanceMSQQLBase(rName),
+		fmt.Sprintf(`
+resource "aws_db_activity_stream" "test" {
+  resource_arn                        = aws_db_instance.test.arn
+  kms_key_id                          = aws_kms_key.test.key_id
+  mode                                = "async"
+  engine_native_audit_fields_included = %[1]t
+}
+`, engineNativeAuditFieldsIncluded))
+}

--- a/internal/service/rds/exports_test.go
+++ b/internal/service/rds/exports_test.go
@@ -5,6 +5,7 @@ package rds
 
 // Exports for use in tests only.
 var (
+	ResourceActivityStream                      = resourceActivityStream
 	ResourceCertificate                         = resourceCertificate
 	ResourceCluster                             = resourceCluster
 	ResourceClusterActivityStream               = resourceClusterActivityStream
@@ -42,6 +43,7 @@ var (
 	FindDBInstanceAutomatedBackupByARN         = findDBInstanceAutomatedBackupByARN
 	FindDBInstanceByID                         = findDBInstanceByID
 	FindDBInstanceRoleByTwoPartKey             = findDBInstanceRoleByTwoPartKey
+	FindDBInstanceWithActivityStream           = findDBInstanceWithActivityStream
 	FindDBParameterGroupByName                 = findDBParameterGroupByName
 	FindDBProxyByName                          = findDBProxyByName
 	FindDBProxyEndpointByTwoPartKey            = findDBProxyEndpointByTwoPartKey

--- a/internal/service/rds/service_package_gen.go
+++ b/internal/service/rds/service_package_gen.go
@@ -120,6 +120,11 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePackageSDKResource {
 	return []*types.ServicePackageSDKResource{
 		{
+			Factory:  resourceActivityStream,
+			TypeName: "aws_db_activity_stream",
+			Name:     "Activity Stream",
+		},
+		{
 			Factory:  resourceClusterSnapshot,
 			TypeName: "aws_db_cluster_snapshot",
 			Name:     "DB Cluster Snapshot",

--- a/internal/service/rds/validate.go
+++ b/internal/service/rds/validate.go
@@ -8,7 +8,24 @@ import (
 	"strings"
 
 	"github.com/YakDriver/regexache"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 )
+
+func validDBClusterARN(v any, k string, arn arn.ARN) (ws []string, errors []error) {
+	if !(arn.Service == "rds" && strings.HasPrefix(arn.Resource, "cluster:")) {
+		errors = append(errors, fmt.Errorf(
+			"%q must be a valid DB cluster ARN: %q", k, v))
+	}
+	return
+}
+
+func validDBInstanceARN(v any, k string, arn arn.ARN) (ws []string, errors []error) {
+	if !(arn.Service == "rds" && strings.HasPrefix(arn.Resource, "db:")) {
+		errors = append(errors, fmt.Errorf(
+			"%q must be a valid DB instance ARN: %q", k, v))
+	}
+	return
+}
 
 func validEventSubscriptionName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
@@ -46,6 +63,44 @@ func validEventSubscriptionNamePrefix(v interface{}, k string) (ws []string, err
 	if len(value) > 229 {
 		errors = append(errors, fmt.Errorf(
 			"%q cannot be longer than 229 characters", k))
+	}
+	return
+}
+
+func validIdentifier(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexache.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only lowercase alphanumeric characters and hyphens allowed in %q", k))
+	}
+	if !regexache.MustCompile(`^[a-z]`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"first character of %q must be a letter", k))
+	}
+	if regexache.MustCompile(`--`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot contain two consecutive hyphens", k))
+	}
+	if regexache.MustCompile(`-$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot end with a hyphen", k))
+	}
+	return
+}
+
+func validIdentifierPrefix(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexache.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only lowercase alphanumeric characters and hyphens allowed in %q", k))
+	}
+	if !regexache.MustCompile(`^[a-z]`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"first character of %q must be a letter", k))
+	}
+	if regexache.MustCompile(`--`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot contain two consecutive hyphens", k))
 	}
 	return
 }
@@ -168,44 +223,6 @@ func validSubnetGroupNamePrefix(v interface{}, k string) (ws []string, errors []
 	if len(value) > 229 {
 		errors = append(errors, fmt.Errorf(
 			"%q cannot be longer than 229 characters", k))
-	}
-	return
-}
-
-func validIdentifier(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if !regexache.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"only lowercase alphanumeric characters and hyphens allowed in %q", k))
-	}
-	if !regexache.MustCompile(`^[a-z]`).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"first character of %q must be a letter", k))
-	}
-	if regexache.MustCompile(`--`).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"%q cannot contain two consecutive hyphens", k))
-	}
-	if regexache.MustCompile(`-$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"%q cannot end with a hyphen", k))
-	}
-	return
-}
-
-func validIdentifierPrefix(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if !regexache.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"only lowercase alphanumeric characters and hyphens allowed in %q", k))
-	}
-	if !regexache.MustCompile(`^[a-z]`).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"first character of %q must be a letter", k))
-	}
-	if regexache.MustCompile(`--`).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"%q cannot contain two consecutive hyphens", k))
 	}
 	return
 }

--- a/internal/service/rds/validate_test.go
+++ b/internal/service/rds/validate_test.go
@@ -7,9 +7,68 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
+
+func TestValidDBClusterARN(t *testing.T) {
+	t.Parallel()
+
+	validARNs := []string{
+		"arn:aws:rds:us-east-2:123456789012:cluster:my-aurora-cluster-1",
+	}
+	for _, v := range validARNs {
+		arn, _ := arn.Parse(v)
+		_, errors := validDBClusterARN(v, names.AttrResourceARN, arn)
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid RDS Cluster ARN: %q", v, errors)
+		}
+	}
+
+	invalidARNs := []string{
+		"arn:aws:rds:us-east-2:123456789012:db:my-mysql-instance-1",
+		"arn:aws:rds:us-east-2:123456789012:1cluster:my-aurora-cluster-1",
+		"arn:aws:rds:us-east-2:123456789012:cluster1:my-aurora-cluster-1",
+		"arn:aws:ec2:us-east-2:123456789012:cluster:my-aurora-cluster-1",
+	}
+	for _, v := range invalidARNs {
+		arn, _ := arn.Parse(v)
+		_, errors := validDBClusterARN(v, names.AttrResourceARN, arn)
+		if len(errors) == 0 {
+			t.Fatalf("%q should be an invalid RDS Cluster ARN", v)
+		}
+	}
+}
+
+func TestValidDBInstanceARN(t *testing.T) {
+	t.Parallel()
+
+	validARNs := []string{
+		"arn:aws:rds:us-east-2:123456789012:db:my-mysql-instance-1",
+	}
+	for _, v := range validARNs {
+		arn, _ := arn.Parse(v)
+		_, errors := validDBInstanceARN(v, names.AttrResourceARN, arn)
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid RDS Database ARN: %q", v, errors)
+		}
+	}
+
+	invalidARNs := []string{
+		"arn:aws:rds:us-east-2:123456789012:cluster:my-aurora-cluster-1",
+		"arn:aws:rds:us-east-2:123456789012:1db:my-mysql-instance-1",
+		"arn:aws:rds:us-east-2:123456789012:db1:my-mysql-instance-1",
+		"arn:aws:ec2:us-east-2:123456789012:db:my-mysql-instance-1",
+	}
+	for _, v := range invalidARNs {
+		arn, _ := arn.Parse(v)
+		_, errors := validDBInstanceARN(v, names.AttrResourceARN, arn)
+		if len(errors) == 0 {
+			t.Fatalf("%q should be an invalid RDS Database ARN", v)
+		}
+	}
+}
 
 func TestValidEventSubscriptionName(t *testing.T) {
 	t.Parallel()

--- a/website/docs/r/db_activity_stream.html.markdown
+++ b/website/docs/r/db_activity_stream.html.markdown
@@ -1,0 +1,82 @@
+---
+subcategory: "RDS (Relational Database)"
+layout: "aws"
+page_title: "AWS: aws_db_activity_stream"
+description: |-
+  Manages RDS Database Activity Streams
+---
+
+# Resource: aws_db_activity_stream
+
+Manages RDS Database Activity Streams.
+
+Database Activity Streams have some limits and requirements, refer to the [Monitoring Amazon RDS with Database Activity Streams][1] documentation and the [Supported Regions and DB engines for database activity streams in Amazon RDS][2] documentation for detailed limitations and requirements.
+
+~> **Note:** This resource always calls the RDS [`StartActivityStream`][3] API with the `ApplyImmediately` parameter set to `true`. This is because the Terraform needs the activity stream to be started in order for it to get the associated attributes.
+
+## Example Usage
+
+```terraform
+resource "aws_kms_key" "example" {
+  description = "AWS KMS Key to encrypt Database Activity Stream"
+}
+
+resource "aws_db_instance" "example" {
+  allocated_storage       = 20
+  backup_retention_period = 0
+  db_subnet_group_name    = local.db_subnet_group_name
+  engine                  = "sqlserver-se"
+  engine_version          = "15.00"
+  identifier              = "example-db-instance"
+  instance_class          = "db.m6i.large"
+  license_model           = "license-included"
+  password                = "avoid-plaintext-passwords"
+  skip_final_snapshot     = true
+  storage_encrypted       = true
+  username                = "example"
+}
+
+resource "aws_db_activity_stream" "example" {
+  resource_arn                        = aws_db_instance.example.arn
+  kms_key_id                          = aws_kms_key.example.key_id
+  mode                                = "async"
+  engine_native_audit_fields_included = true
+}
+```
+
+## Argument Reference
+
+This resource supports the following arguments:
+
+* `resource_arn` - (Required, Forces new resources) Amazon Resource Name (ARN) of the DB cluster.
+* `mode` - (Required, Forces new resources) Mode of the database activity stream. Database events such as a change or access generate an activity stream event. The database session can handle these events either synchronously or asynchronously. One of: `sync`, `async`.
+* `kms_key_id` - (Required, Forces new resources) AWS KMS key identifier for encrypting messages in the database activity stream. The AWS KMS key identifier is the key ARN, key ID, alias ARN, or alias name for the KMS key.
+* `engine_native_audit_fields_included` - (Optional, Forces new resources) Whether the database activity stream includes engine-native audit fields. This option applies to an Oracle or Microsoft SQL Server DB instance. By default, no engine-native audit fields are included. Defaults `false`.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `id` - Amazon Resource Name (ARN) of the DB cluster.
+* `kinesis_stream_name` - Name of the Amazon Kinesis data stream to be used for the database activity stream.
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import RDS Database Activity Streams using the `resource_arn`. For example:
+
+```terraform
+import {
+  to = aws_db_activity_stream.default
+  id = "arn:aws:rds:us-west-2:123456789012:db:my-mysql-instance-1"
+}
+```
+
+Using `terraform import`, import RDS Database Activity Streams using the `resource_arn`. For example:
+
+```console
+% terraform import aws_db_activity_stream.default arn:aws:rds:us-west-2:123456789012:db:my-mysql-instance-1
+```
+
+[1]: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/DBActivityStreams.html
+[2]: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RDS_Fea_Regions_DB-eng.Feature.DBActivityStreams.html
+[3]: https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_StartActivityStream.html

--- a/website/docs/r/rds_cluster_activity_stream.html.markdown
+++ b/website/docs/r/rds_cluster_activity_stream.html.markdown
@@ -10,65 +10,62 @@ description: |-
 
 Manages RDS Aurora Cluster Database Activity Streams.
 
-Database Activity Streams have some limits and requirements, refer to the [Monitoring Amazon Aurora using Database Activity Streams][1] documentation for detailed limitations and requirements.
+Database Activity Streams have some limits and requirements, refer to the [Monitoring Amazon Aurora using Database Activity Streams][1] documentation and the [Supported Regions and Aurora DB engines for database activity streams][2] documentation for detailed limitations and requirements.
 
-~> **Note:** This resource always calls the RDS [`StartActivityStream`][2] API with the `ApplyImmediately` parameter set to `true`. This is because the Terraform needs the activity stream to be started in order for it to get the associated attributes.
+~> **Note:** This resource always calls the RDS [`StartActivityStream`][3] API with the `ApplyImmediately` parameter set to `true`. This is because the Terraform needs the activity stream to be started in order for it to get the associated attributes.
 
 ~> **Note:** This resource depends on having at least one `aws_rds_cluster_instance` created. To avoid race conditions when all resources are being created together, add an explicit resource reference using the [resource `depends_on` meta-argument](https://www.terraform.io/docs/configuration/resources.html#depends_on-explicit-resource-dependencies).
-
-~> **Note:** This resource is available in all regions except the following: `cn-north-1`, `cn-northwest-1`, `us-gov-east-1`, `us-gov-west-1`
 
 ## Example Usage
 
 ```terraform
-resource "aws_rds_cluster" "default" {
-  cluster_identifier = "aurora-cluster-demo"
+resource "aws_rds_cluster" "example" {
+  cluster_identifier = "example-aurora-cluster"
   availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
-  database_name      = "mydb"
+  database_name      = "example"
   master_username    = "foo"
   master_password    = "mustbeeightcharaters"
   engine             = "aurora-postgresql"
   engine_version     = "13.4"
 }
 
-resource "aws_rds_cluster_instance" "default" {
-  identifier         = "aurora-instance-demo"
-  cluster_identifier = aws_rds_cluster.default.cluster_identifier
-  engine             = aws_rds_cluster.default.engine
+resource "aws_rds_cluster_instance" "example" {
+  identifier         = "example-aurora-instance"
+  cluster_identifier = aws_rds_cluster.example.cluster_identifier
+  engine             = aws_rds_cluster.example.engine
   instance_class     = "db.r6g.large"
 }
 
-resource "aws_kms_key" "default" {
+resource "aws_kms_key" "example" {
   description = "AWS KMS Key to encrypt Database Activity Stream"
 }
 
-resource "aws_rds_cluster_activity_stream" "default" {
-  resource_arn = aws_rds_cluster.default.arn
+resource "aws_rds_cluster_activity_stream" "example" {
+  resource_arn = aws_rds_cluster.example.arn
   mode         = "async"
-  kms_key_id   = aws_kms_key.default.key_id
+  kms_key_id   = aws_kms_key.example.key_id
 
-  depends_on = [aws_rds_cluster_instance.default]
+  depends_on = [aws_rds_cluster_instance.example]
 }
 ```
 
 ## Argument Reference
 
-For more detailed documentation about each argument, refer to
-the [AWS official documentation][3].
-
 This resource supports the following arguments:
 
-* `resource_arn` - (Required, Forces new resources) The Amazon Resource Name (ARN) of the DB cluster.
-* `mode` - (Required, Forces new resources) Specifies the mode of the database activity stream. Database events such as a change or access generate an activity stream event. The database session can handle these events either synchronously or asynchronously. One of: `sync`, `async`.
-* `kms_key_id` - (Required, Forces new resources) The AWS KMS key identifier for encrypting messages in the database activity stream. The AWS KMS key identifier is the key ARN, key ID, alias ARN, or alias name for the KMS key.
-* `engine_native_audit_fields_included` - (Optional, Forces new resources) Specifies whether the database activity stream includes engine-native audit fields. This option only applies to an Oracle DB instance. By default, no engine-native audit fields are included. Defaults `false`.
+* `resource_arn` - (Required, Forces new resources) Amazon Resource Name (ARN) of the DB cluster.
+* `mode` - (Required, Forces new resources) Mode of the database activity stream. Database events such as a change or access generate an activity stream event. The database session can handle these events either synchronously or asynchronously. One of: `sync`, `async`.
+* `kms_key_id` - (Required, Forces new resources) AWS KMS key identifier for encrypting messages in the database activity stream. The AWS KMS key identifier is the key ARN, key ID, alias ARN, or alias name for the KMS key.
+* `engine_native_audit_fields_included` - (Optional, Forces new resources) Whether the database activity stream includes engine-native audit fields. This option applies to an Oracle or Microsoft SQL Server DB instance. By default, no engine-native audit fields are included. Defaults `false`.
+
+  **Note:** Since this argument is not applicable to Aurora DB clusters, it should either not be set (which defaults to 'false') or be explicitly set to `false`.
 
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `id` - The Amazon Resource Name (ARN) of the DB cluster.
-* `kinesis_stream_name` - The name of the Amazon Kinesis data stream to be used for the database activity stream.
+* `id` - Amazon Resource Name (ARN) of the DB cluster.
+* `kinesis_stream_name` - Name of the Amazon Kinesis data stream to be used for the database activity stream.
 
 ## Import
 
@@ -88,5 +85,5 @@ Using `terraform import`, import RDS Aurora Cluster Database Activity Streams us
 ```
 
 [1]: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/DBActivityStreams.html
-[2]: https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_StartActivityStream.html
-[3]: https://docs.aws.amazon.com/cli/latest/reference/rds/start-activity-stream.html
+[2]: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Concepts.Aurora_Fea_Regions_DB-eng.Feature.DBActivityStreams.html
+[3]: https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_StartActivityStream.html


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add a new resource `aws_db_activity_stream` to implement Database Activity Streams for RDS for Oracle and RDS for SQL Server instances. The existing resource `aws_rds_cluster_activity_stream` will be used for Aurora clusters.

As part of this fix, resource ARN validation is added to ensure that the ARN refers to a DB instance or an Aurora Cluster respectively.

I also figured out why the "disappears" test case was failing for RDS. Apparently the error message uses uppercase statuses "STARTED" and "STOPPED", whereas for Aurora clusters the error message uses lowercase. It's strange that they are mixed considering that the same API is used to stop activity streams, but the error message is now the correct on in their respective test cases.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #36468

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to the following API reference pages for specs:

- [StartActivityStream](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_StartActivityStream.html)
- [StopActivityStream](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_StopActivityStream.html)
- [DBCluster](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DBCluster.html)
- [DBInstance](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DBInstance.html)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TESTS="TestAccRDSClusterActivityStream_|TestAccRDSActivityStream_" PKG=rds
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSClusterActivityStream_|TestAccRDSActivityStream_'  -timeout 360m
=== RUN   TestAccRDSActivityStream_basic
=== PAUSE TestAccRDSActivityStream_basic
=== RUN   TestAccRDSActivityStream_disappears
=== PAUSE TestAccRDSActivityStream_disappears
=== RUN   TestAccRDSClusterActivityStream_basic
=== PAUSE TestAccRDSClusterActivityStream_basic
=== RUN   TestAccRDSClusterActivityStream_disappears
=== PAUSE TestAccRDSClusterActivityStream_disappears
=== CONT  TestAccRDSActivityStream_basic
=== CONT  TestAccRDSClusterActivityStream_basic
=== CONT  TestAccRDSClusterActivityStream_disappears
=== CONT  TestAccRDSActivityStream_disappears
--- PASS: TestAccRDSActivityStream_disappears (1755.82s)
--- PASS: TestAccRDSClusterActivityStream_basic (1965.95s)
--- PASS: TestAccRDSClusterActivityStream_disappears (2156.34s)
--- PASS: TestAccRDSActivityStream_basic (2816.74s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        2816.971s

$
```

```console
$ make testacc TESTS="TestValidDBClusterARN|TestValidDBInstanceARN" PKG=rds
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestValidDBClusterARN|TestValidDBInstanceARN'  -timeout 360m
=== RUN   TestValidDBClusterARN
=== PAUSE TestValidDBClusterARN
=== RUN   TestValidDBInstanceARN
=== PAUSE TestValidDBInstanceARN
=== CONT  TestValidDBClusterARN
=== CONT  TestValidDBInstanceARN
--- PASS: TestValidDBClusterARN (0.00s)
--- PASS: TestValidDBInstanceARN (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        0.226s

$
```
