### PR TITLE
Restore `v5.44.0` GH Issue labeler generator

### DIFF
--- a/.github/labeler-issue-triage.yml
+++ b/.github/labeler-issue-triage.yml
@@ -14,30 +14,15 @@ bug:
   # Terraform Plugin SDK:
   #   doesn't support update
   #   Invalid address to set
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - "(\\[Bug\\]:|doesn't support update|failed to satisfy constraint: Member must not be null|Invalid address to set|panic:|produced an (invalid|unexpected) new value|Provider produced inconsistent (final plan|result after apply))"
+  - "(\\[Bug\\]:|doesn't support update|failed to satisfy constraint: Member must not be null|Invalid address to set|panic:|produced an (invalid|unexpected) new value|Provider produced inconsistent (final plan|result after apply))"
 crash:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - 'panic:'
-function:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - 'provider::aws::'
-skaff:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - 'skaff'
+  - 'panic:'
 sweeper:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - 'sweeper'
+  - 'sweeper'
+skaff:
+  - 'skaff'
+function:
+  - 'provider::aws::'
 #
 # AWS Per-Service Labeling
 #
@@ -45,1727 +30,692 @@ sweeper:
 # 1. List items (* or -) with aws_XXX resource prefix (with or without backticks)
 # 2. "data aws_XXX" or "resource aws_XXX"
 service/accessanalyzer:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_accessanalyzer_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_accessanalyzer_'
 service/account:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_account_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_account_'
 service/acm:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_acm_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_acm_'
 service/acmpca:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_acmpca_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_acmpca_'
 service/alexaforbusiness:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_alexaforbusiness_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_alexaforbusiness_'
 service/amp:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_prometheus_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_prometheus_'
 service/amplify:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_amplify_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_amplify_'
 service/amplifybackend:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_amplifybackend_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_amplifybackend_'
 service/amplifyuibuilder:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_amplifyuibuilder_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_amplifyuibuilder_'
 service/apigateway:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_api_gateway_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_api_gateway_'
 service/apigatewaymanagementapi:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_apigatewaymanagementapi_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_apigatewaymanagementapi_'
 service/apigatewayv2:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_apigatewayv2_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_apigatewayv2_'
 service/appautoscaling:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_appautoscaling_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_appautoscaling_'
 service/appconfig:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_appconfig_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_appconfig_'
 service/appconfigdata:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_appconfigdata_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_appconfigdata_'
 service/appfabric:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_appfabric_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_appfabric_'
 service/appflow:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_appflow_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_appflow_'
 service/appintegrations:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_appintegrations_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_appintegrations_'
 service/applicationcostprofiler:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_applicationcostprofiler_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_applicationcostprofiler_'
 service/applicationinsights:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_applicationinsights_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_applicationinsights_'
 service/appmesh:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_appmesh_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_appmesh_'
 service/apprunner:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_apprunner_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_apprunner_'
 service/appstream:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_appstream_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_appstream_'
 service/appsync:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_appsync_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_appsync_'
 service/athena:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_athena_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_athena_'
 service/auditmanager:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_auditmanager_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_auditmanager_'
 service/autoscaling:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_(autoscaling_|launch_configuration)'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_(autoscaling_|launch_configuration)'
 service/autoscalingplans:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_autoscalingplans_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_autoscalingplans_'
 service/backup:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_backup_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_backup_'
 service/backupgateway:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_backupgateway_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_backupgateway_'
 service/batch:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_batch_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_batch_'
 service/bcmdataexports:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_bcmdataexports_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_bcmdataexports_'
 service/bedrock:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_bedrock_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_bedrock_'
 service/bedrockagent:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_bedrockagent_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_bedrockagent_'
 service/billingconductor:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_billingconductor_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_billingconductor_'
 service/braket:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_braket_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_braket_'
 service/budgets:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_budgets_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_budgets_'
 service/ce:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ce_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ce_'
 service/chime:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_chime_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_chime_'
 service/chimesdkidentity:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_chimesdkidentity_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_chimesdkidentity_'
 service/chimesdkmediapipelines:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_chimesdkmediapipelines_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_chimesdkmediapipelines_'
 service/chimesdkmeetings:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_chimesdkmeetings_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_chimesdkmeetings_'
 service/chimesdkmessaging:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_chimesdkmessaging_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_chimesdkmessaging_'
 service/chimesdkvoice:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_chimesdkvoice_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_chimesdkvoice_'
 service/cleanrooms:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_cleanrooms_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_cleanrooms_'
 service/cloud9:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_cloud9_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_cloud9_'
 service/cloudcontrol:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_cloudcontrolapi_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_cloudcontrolapi_'
 service/clouddirectory:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_clouddirectory_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_clouddirectory_'
 service/cloudformation:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_cloudformation_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_cloudformation_'
 service/cloudfront:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_cloudfront_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_cloudfront_'
 service/cloudfrontkeyvaluestore:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_cloudfrontkeyvaluestore_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_cloudfrontkeyvaluestore_'
 service/cloudhsmv2:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_cloudhsm_v2_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_cloudhsm_v2_'
 service/cloudsearch:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_cloudsearch_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_cloudsearch_'
 service/cloudsearchdomain:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_cloudsearchdomain_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_cloudsearchdomain_'
 service/cloudtrail:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_cloudtrail'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_cloudtrail'
 service/cloudwatch:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_cloudwatch_(?!(event_|log_|query_))'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_cloudwatch_(?!(event_|log_|query_))'
 service/codeartifact:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_codeartifact_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_codeartifact_'
 service/codebuild:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_codebuild_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_codebuild_'
 service/codecatalyst:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_codecatalyst_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_codecatalyst_'
 service/codecommit:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_codecommit_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_codecommit_'
 service/codeguruprofiler:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_codeguruprofiler_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_codeguruprofiler_'
 service/codegurureviewer:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_codegurureviewer_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_codegurureviewer_'
 service/codepipeline:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_codepipeline'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_codepipeline'
 service/codestar:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_codestar_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_codestar_'
 service/codestarconnections:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_codestarconnections_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_codestarconnections_'
 service/codestarnotifications:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_codestarnotifications_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_codestarnotifications_'
 service/cognitoidentity:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_cognito_identity_(?!provider)'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_cognito_identity_(?!provider)'
 service/cognitoidp:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_cognito_(identity_provider|resource|user|risk)'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_cognito_(identity_provider|resource|user|risk)'
 service/cognitosync:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_cognitosync_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_cognitosync_'
 service/comprehend:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_comprehend_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_comprehend_'
 service/comprehendmedical:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_comprehendmedical_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_comprehendmedical_'
 service/computeoptimizer:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_computeoptimizer_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_computeoptimizer_'
 service/configservice:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_config_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_config_'
 service/connect:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_connect_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_connect_'
 service/connectcases:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_connectcases_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_connectcases_'
 service/connectcontactlens:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_connectcontactlens_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_connectcontactlens_'
 service/connectparticipant:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_connectparticipant_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_connectparticipant_'
 service/controltower:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_controltower_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_controltower_'
 service/costoptimizationhub:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_costoptimizationhub_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_costoptimizationhub_'
 service/cur:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_cur_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_cur_'
 service/customerprofiles:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_customerprofiles_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_customerprofiles_'
 service/databrew:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_databrew_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_databrew_'
 service/dataexchange:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_dataexchange_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_dataexchange_'
 service/datapipeline:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_datapipeline_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_datapipeline_'
 service/datasync:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_datasync_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_datasync_'
 service/datazone:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_datazone_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_datazone_'
 service/dax:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_dax_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_dax_'
 service/deploy:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_codedeploy_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_codedeploy_'
 service/detective:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_detective_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_detective_'
 service/devicefarm:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_devicefarm_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_devicefarm_'
 service/devopsguru:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_devopsguru_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_devopsguru_'
 service/directconnect:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_dx_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_dx_'
 service/discovery:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_discovery_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_discovery_'
 service/dlm:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_dlm_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_dlm_'
 service/dms:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_dms_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_dms_'
 service/docdb:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_docdb_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_docdb_'
 service/docdbelastic:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_docdbelastic_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_docdbelastic_'
 service/drs:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_drs_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_drs_'
 service/ds:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_directory_service_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_directory_service_'
 service/dynamodb:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_dynamodb_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_dynamodb_'
 service/dynamodbstreams:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_dynamodbstreams_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_dynamodbstreams_'
 service/ebs:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ebs_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ebs_'
 service/ec2:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_(ami|availability_zone|ec2_(availability|capacity|fleet|host|instance|public_ipv4_pool|serial|spot|tag)|eip|instance|key_pair|launch_template|placement_group|spot)'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_(ami|availability_zone|ec2_(availability|capacity|fleet|host|instance|public_ipv4_pool|serial|spot|tag)|eip|instance|key_pair|launch_template|placement_group|spot)'
 service/ec2ebs:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_(ebs_|volume_attach|snapshot_create)'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_(ebs_|volume_attach|snapshot_create)'
 service/ec2instanceconnect:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ec2instanceconnect_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ec2instanceconnect_'
 service/ec2outposts:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ec2_(coip_pool|local_gateway)'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ec2_(coip_pool|local_gateway)'
 service/ecr:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ecr_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ecr_'
 service/ecrpublic:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ecrpublic_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ecrpublic_'
 service/ecs:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ecs_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ecs_'
 service/efs:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_efs_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_efs_'
 service/eks:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_eks_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_eks_'
 service/elasticache:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_elasticache_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_elasticache_'
 service/elasticbeanstalk:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_elastic_beanstalk_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_elastic_beanstalk_'
 service/elasticinference:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_elasticinference_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_elasticinference_'
 service/elasticsearch:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_elasticsearch_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_elasticsearch_'
 service/elastictranscoder:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_elastictranscoder_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_elastictranscoder_'
 service/elb:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_(app_cookie_stickiness_policy|elb|lb_cookie_stickiness_policy|lb_ssl_negotiation_policy|load_balancer_|proxy_protocol_policy)'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_(app_cookie_stickiness_policy|elb|lb_cookie_stickiness_policy|lb_ssl_negotiation_policy|load_balancer_|proxy_protocol_policy)'
 service/elbv2:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_a?lb(\b|_listener|_target_group|s|_trust_store)'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_a?lb(\b|_listener|_target_group|s|_trust_store)'
 service/emr:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_emr_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_emr_'
 service/emrcontainers:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_emrcontainers_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_emrcontainers_'
 service/emrserverless:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_emrserverless_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_emrserverless_'
 service/events:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_cloudwatch_event_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_cloudwatch_event_'
 service/evidently:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_evidently_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_evidently_'
 service/finspace:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_finspace_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_finspace_'
 service/finspacedata:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_finspacedata_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_finspacedata_'
 service/firehose:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_kinesis_firehose_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_kinesis_firehose_'
 service/fis:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_fis_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_fis_'
 service/fms:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_fms_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_fms_'
 service/forecast:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_forecast_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_forecast_'
 service/forecastquery:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_forecastquery_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_forecastquery_'
 service/frauddetector:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_frauddetector_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_frauddetector_'
 service/fsx:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_fsx_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_fsx_'
 service/gamelift:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_gamelift_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_gamelift_'
 service/glacier:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_glacier_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_glacier_'
 service/globalaccelerator:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_globalaccelerator_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_globalaccelerator_'
 service/glue:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_glue_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_glue_'
 service/grafana:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_grafana_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_grafana_'
 service/greengrass:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_greengrass_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_greengrass_'
 service/greengrassv2:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_greengrassv2_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_greengrassv2_'
 service/groundstation:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_groundstation_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_groundstation_'
 service/guardduty:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_guardduty_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_guardduty_'
 service/health:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_health_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_health_'
 service/healthlake:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_healthlake_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_healthlake_'
 service/honeycode:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_honeycode_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_honeycode_'
 service/iam:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_iam_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_iam_'
 service/identitystore:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_identitystore_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_identitystore_'
 service/imagebuilder:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_imagebuilder_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_imagebuilder_'
 service/inspector:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_inspector_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_inspector_'
 service/inspector2:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_inspector2_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_inspector2_'
 service/internetmonitor:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_internetmonitor_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_internetmonitor_'
 service/iot:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_iot_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_iot_'
 service/iot1clickdevices:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_iot1clickdevices_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_iot1clickdevices_'
 service/iot1clickprojects:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_iot1clickprojects_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_iot1clickprojects_'
 service/iotanalytics:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_iotanalytics_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_iotanalytics_'
 service/iotdata:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_iotdata_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_iotdata_'
 service/iotdeviceadvisor:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_iotdeviceadvisor_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_iotdeviceadvisor_'
 service/iotevents:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_iotevents_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_iotevents_'
 service/ioteventsdata:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ioteventsdata_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ioteventsdata_'
 service/iotfleethub:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_iotfleethub_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_iotfleethub_'
 service/iotjobsdata:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_iotjobsdata_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_iotjobsdata_'
 service/iotsecuretunneling:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_iotsecuretunneling_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_iotsecuretunneling_'
 service/iotsitewise:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_iotsitewise_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_iotsitewise_'
 service/iotthingsgraph:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_iotthingsgraph_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_iotthingsgraph_'
 service/iottwinmaker:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_iottwinmaker_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_iottwinmaker_'
 service/iotwireless:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_iotwireless_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_iotwireless_'
 service/ipam:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_vpc_ipam'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_vpc_ipam'
 service/ivs:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ivs_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ivs_'
 service/ivschat:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ivschat_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ivschat_'
 service/kafka:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_msk_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_msk_'
 service/kafkaconnect:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_mskconnect_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_mskconnect_'
 service/kendra:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_kendra_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_kendra_'
 service/keyspaces:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_keyspaces_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_keyspaces_'
 service/kinesis:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_kinesis_stream'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_kinesis_stream'
 service/kinesisanalytics:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_kinesis_analytics_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_kinesis_analytics_'
 service/kinesisanalyticsv2:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_kinesisanalyticsv2_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_kinesisanalyticsv2_'
 service/kinesisvideo:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_kinesisvideo_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_kinesisvideo_'
 service/kinesisvideoarchivedmedia:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_kinesisvideoarchivedmedia_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_kinesisvideoarchivedmedia_'
 service/kinesisvideomedia:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_kinesisvideomedia_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_kinesisvideomedia_'
 service/kinesisvideosignaling:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_kinesisvideosignaling_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_kinesisvideosignaling_'
 service/kms:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_kms_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_kms_'
 service/lakeformation:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_lakeformation_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_lakeformation_'
 service/lambda:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_lambda_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_lambda_'
 service/launchwizard:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_launchwizard_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_launchwizard_'
 service/lexmodels:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_lex_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_lex_'
 service/lexruntime:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_lexruntime_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_lexruntime_'
 service/lexruntimev2:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_lexruntimev2_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_lexruntimev2_'
 service/lexv2models:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_lexv2models_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_lexv2models_'
 service/licensemanager:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_licensemanager_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_licensemanager_'
 service/lightsail:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_lightsail_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_lightsail_'
 service/location:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_location_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_location_'
 service/logs:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_cloudwatch_(log_|query_)'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_cloudwatch_(log_|query_)'
 service/lookoutequipment:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_lookoutequipment_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_lookoutequipment_'
 service/lookoutmetrics:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_lookoutmetrics_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_lookoutmetrics_'
 service/lookoutvision:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_lookoutvision_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_lookoutvision_'
 service/m2:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_m2_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_m2_'
 service/machinelearning:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_machinelearning_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_machinelearning_'
 service/macie:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_macie_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_macie_'
 service/macie2:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_macie2_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_macie2_'
 service/managedblockchain:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_managedblockchain_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_managedblockchain_'
 service/marketplacecatalog:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_marketplacecatalog_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_marketplacecatalog_'
 service/marketplacecommerceanalytics:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_marketplacecommerceanalytics_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_marketplacecommerceanalytics_'
 service/marketplaceentitlement:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_marketplaceentitlement_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_marketplaceentitlement_'
 service/marketplacemetering:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_marketplacemetering_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_marketplacemetering_'
 service/mediaconnect:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_mediaconnect_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_mediaconnect_'
 service/mediaconvert:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_media_convert_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_media_convert_'
 service/medialive:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_medialive_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_medialive_'
 service/mediapackage:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_media_package_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_media_package_'
 service/mediapackagev2:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_media_packagev2_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_media_packagev2_'
 service/mediapackagevod:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_mediapackagevod_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_mediapackagevod_'
 service/mediastore:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_media_store_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_media_store_'
 service/mediastoredata:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_mediastoredata_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_mediastoredata_'
 service/mediatailor:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_mediatailor_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_mediatailor_'
 service/memorydb:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_memorydb_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_memorydb_'
 service/meta:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_(arn|billing_service_account|default_tags|ip_ranges|partition|regions?|service)$'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_(arn|billing_service_account|default_tags|ip_ranges|partition|regions?|service)$'
 service/mgh:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_mgh_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_mgh_'
 service/mgn:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_mgn_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_mgn_'
 service/migrationhubconfig:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_migrationhubconfig_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_migrationhubconfig_'
 service/migrationhubrefactorspaces:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_migrationhubrefactorspaces_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_migrationhubrefactorspaces_'
 service/migrationhubstrategy:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_migrationhubstrategy_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_migrationhubstrategy_'
 service/mobile:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_mobile_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_mobile_'
 service/mq:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_mq_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_mq_'
 service/mturk:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_mturk_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_mturk_'
 service/mwaa:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_mwaa_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_mwaa_'
 service/neptune:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_neptune_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_neptune_'
 service/neptunegraph:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_neptunegraph_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_neptunegraph_'
 service/networkfirewall:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_networkfirewall_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_networkfirewall_'
 service/networkmanager:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_networkmanager_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_networkmanager_'
 service/nimble:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_nimble_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_nimble_'
 service/oam:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_oam_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_oam_'
 service/opensearch:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_opensearch_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_opensearch_'
 service/opensearchserverless:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_opensearchserverless_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_opensearchserverless_'
 service/opsworks:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_opsworks_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_opsworks_'
 service/opsworkscm:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_opsworkscm_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_opsworkscm_'
 service/organizations:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_organizations_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_organizations_'
 service/osis:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_osis_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_osis_'
 service/outposts:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_outposts_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_outposts_'
 service/panorama:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_panorama_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_panorama_'
 service/paymentcryptography:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_paymentcryptography_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_paymentcryptography_'
 service/pcaconnectorad:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_pcaconnectorad_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_pcaconnectorad_'
 service/personalize:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_personalize_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_personalize_'
 service/personalizeevents:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_personalizeevents_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_personalizeevents_'
 service/personalizeruntime:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_personalizeruntime_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_personalizeruntime_'
 service/pi:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_pi_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_pi_'
 service/pinpoint:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_pinpoint_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_pinpoint_'
 service/pinpointemail:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_pinpointemail_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_pinpointemail_'
 service/pinpointsmsvoice:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_pinpointsmsvoice_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_pinpointsmsvoice_'
 service/pipes:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_pipes_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_pipes_'
 service/polly:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_polly_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_polly_'
 service/pricing:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_pricing_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_pricing_'
 service/proton:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_proton_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_proton_'
 service/qbusiness:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_qbusiness_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_qbusiness_'
 service/qldb:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_qldb_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_qldb_'
 service/qldbsession:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_qldbsession_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_qldbsession_'
 service/quicksight:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_quicksight_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_quicksight_'
 service/ram:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ram_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ram_'
 service/rbin:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_rbin_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_rbin_'
 service/rds:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_(db_|rds_)'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_(db_|rds_)'
 service/rdsdata:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_rdsdata_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_rdsdata_'
 service/redshift:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_redshift_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_redshift_'
 service/redshiftdata:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_redshiftdata_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_redshiftdata_'
 service/redshiftserverless:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_redshiftserverless_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_redshiftserverless_'
 service/rekognition:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_rekognition_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_rekognition_'
 service/resiliencehub:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_resiliencehub_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_resiliencehub_'
 service/resourceexplorer2:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_resourceexplorer2_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_resourceexplorer2_'
 service/resourcegroups:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_resourcegroups_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_resourcegroups_'
 service/resourcegroupstaggingapi:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_resourcegroupstaggingapi_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_resourcegroupstaggingapi_'
 service/robomaker:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_robomaker_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_robomaker_'
 service/rolesanywhere:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_rolesanywhere_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_rolesanywhere_'
 service/route53:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_route53_(?!resolver_)'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_route53_(?!resolver_)'
 service/route53domains:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_route53domains_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_route53domains_'
 service/route53recoverycluster:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_route53recoverycluster_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_route53recoverycluster_'
 service/route53recoverycontrolconfig:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_route53recoverycontrolconfig_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_route53recoverycontrolconfig_'
 service/route53recoveryreadiness:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_route53recoveryreadiness_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_route53recoveryreadiness_'
 service/route53resolver:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_route53_resolver_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_route53_resolver_'
 service/rum:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_rum_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_rum_'
 service/s3:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_(canonical_user_id|s3_bucket|s3_object|s3_directory_bucket)'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_(canonical_user_id|s3_bucket|s3_object|s3_directory_bucket)'
 service/s3control:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_(s3_account_|s3control_|s3_access_)'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_(s3_account_|s3control_|s3_access_)'
 service/s3outposts:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_s3outposts_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_s3outposts_'
 service/sagemaker:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_sagemaker_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_sagemaker_'
 service/sagemakera2iruntime:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_sagemakera2iruntime_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_sagemakera2iruntime_'
 service/sagemakeredge:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_sagemakeredge_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_sagemakeredge_'
 service/sagemakerfeaturestoreruntime:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_sagemakerfeaturestoreruntime_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_sagemakerfeaturestoreruntime_'
 service/sagemakerruntime:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_sagemakerruntime_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_sagemakerruntime_'
 service/savingsplans:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_savingsplans_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_savingsplans_'
 service/scheduler:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_scheduler_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_scheduler_'
 service/schemas:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_schemas_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_schemas_'
 service/secretsmanager:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_secretsmanager_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_secretsmanager_'
 service/securityhub:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_securityhub_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_securityhub_'
 service/securitylake:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_securitylake_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_securitylake_'
 service/serverlessrepo:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_serverlessapplicationrepository_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_serverlessapplicationrepository_'
 service/servicecatalog:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_servicecatalog_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_servicecatalog_'
 service/servicecatalogappregistry:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_servicecatalogappregistry_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_servicecatalogappregistry_'
 service/servicediscovery:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_service_discovery_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_service_discovery_'
 service/servicequotas:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_servicequotas_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_servicequotas_'
 service/ses:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ses_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ses_'
 service/sesv2:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_sesv2_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_sesv2_'
 service/sfn:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_sfn_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_sfn_'
 service/shield:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_shield_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_shield_'
 service/signer:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_signer_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_signer_'
 service/simpledb:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_simpledb_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_simpledb_'
 service/sms:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_sms_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_sms_'
 service/snowball:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_snowball_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_snowball_'
 service/snowdevicemanagement:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_snowdevicemanagement_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_snowdevicemanagement_'
 service/sns:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_sns_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_sns_'
 service/sqs:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_sqs_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_sqs_'
 service/ssm:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ssm_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ssm_'
 service/ssmcontacts:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ssmcontacts_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ssmcontacts_'
 service/ssmincidents:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ssmincidents_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ssmincidents_'
 service/ssmsap:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ssmsap_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ssmsap_'
 service/sso:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_sso_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_sso_'
 service/ssoadmin:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ssoadmin_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ssoadmin_'
 service/ssooidc:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ssooidc_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ssooidc_'
 service/storagegateway:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_storagegateway_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_storagegateway_'
 service/sts:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_caller_identity'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_caller_identity'
 service/support:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_support_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_support_'
 service/swf:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_swf_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_swf_'
 service/synthetics:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_synthetics_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_synthetics_'
 service/textract:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_textract_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_textract_'
 service/timestreamquery:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_timestreamquery_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_timestreamquery_'
 service/timestreamwrite:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_timestreamwrite_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_timestreamwrite_'
 service/transcribe:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_transcribe_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_transcribe_'
 service/transcribestreaming:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_transcribestreaming_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_transcribestreaming_'
 service/transfer:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_transfer_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_transfer_'
 service/transitgateway:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ec2_transit_gateway'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ec2_transit_gateway'
 service/translate:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_translate_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_translate_'
 service/verifiedaccess:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_verifiedaccess'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_verifiedaccess'
 service/verifiedpermissions:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_verifiedpermissions_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_verifiedpermissions_'
 service/voiceid:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_voiceid_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_voiceid_'
 service/vpc:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_((default_)?(network_acl|route_table|security_group|subnet|vpc(?!_ipam))|ec2_(managed|network|subnet|traffic)|egress_only_internet|flow_log|internet_gateway|main_route_table_association|nat_gateway|network_interface|prefix_list|route\b)'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_((default_)?(network_acl|route_table|security_group|subnet|vpc(?!_ipam))|ec2_(managed|network|subnet|traffic)|egress_only_internet|flow_log|internet_gateway|main_route_table_association|nat_gateway|network_interface|prefix_list|route\b)'
 service/vpclattice:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_vpclattice_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_vpclattice_'
 service/vpnclient:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ec2_client_vpn'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ec2_client_vpn'
 service/vpnsite:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_(customer_gateway|vpn_)'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_(customer_gateway|vpn_)'
 service/waf:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_waf_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_waf_'
 service/wafregional:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_wafregional_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_wafregional_'
 service/wafv2:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_wafv2_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_wafv2_'
 service/wavelength:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ec2_carrier_gateway'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_ec2_carrier_gateway'
 service/wellarchitected:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_wellarchitected_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_wellarchitected_'
 service/wisdom:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_wisdom_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_wisdom_'
 service/workdocs:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_workdocs_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_workdocs_'
 service/worklink:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_worklink_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_worklink_'
 service/workmail:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_workmail_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_workmail_'
 service/workmailmessageflow:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_workmailmessageflow_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_workmailmessageflow_'
 service/workspaces:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_workspaces_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_workspaces_'
 service/workspacesweb:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_workspacesweb_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_workspacesweb_'
 service/xray:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '((\*|-)\s*`?|(data|resource)\s+"?)aws_xray_'
+  - '((\*|-)\s*`?|(data|resource)\s+"?)aws_xray_'

--- a/internal/generate/issuelabels/file.tmpl
+++ b/internal/generate/issuelabels/file.tmpl
@@ -14,30 +14,15 @@ bug:
   # Terraform Plugin SDK:
   #   doesn't support update
   #   Invalid address to set
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - "(\\[Bug\\]:|doesn't support update|failed to satisfy constraint: Member must not be null|Invalid address to set|panic:|produced an (invalid|unexpected) new value|Provider produced inconsistent (final plan|result after apply))"
+  - "(\\[Bug\\]:|doesn't support update|failed to satisfy constraint: Member must not be null|Invalid address to set|panic:|produced an (invalid|unexpected) new value|Provider produced inconsistent (final plan|result after apply))"
 crash:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - 'panic:'
-function:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - 'provider::aws::'
-skaff:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - 'skaff'
+  - 'panic:'
 sweeper:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - 'sweeper'
+  - 'sweeper'
+skaff:
+  - 'skaff'
+function:
+  - 'provider::aws::'
 #
 # AWS Per-Service Labeling
 #
@@ -46,8 +31,5 @@ sweeper:
 # 2. "data aws_XXX" or "resource aws_XXX"
 {{- range .Services }}
 service/{{ .ProviderPackage }}:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - '{{ .RegExp }}'
+  - '{{ .RegExp }}'
 {{- end }}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Only `actions/labeler`s configuration file syntax changed, not `github/issue-labeler`'s.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/36785.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/34853.

PR labeler is [working OK](https://github.com/hashicorp/terraform-provider-aws/actions/runs/8604615137/job/23579110421):

```
Run actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9
  with:
    configuration-path: .github/labeler-pr-triage.yml
    repo-token: ***
    sync-labels: false
    dot: true
The configuration file (path: .github/labeler-pr-triage.yml) was found locally, reading from the file
```