### PR TITLE
internal/framework/flex: support set of enum expansion

### DIFF
--- a/internal/framework/flex/auto_expand.go
+++ b/internal/framework/flex/auto_expand.go
@@ -539,7 +539,13 @@ func (expander autoExpander) setOfString(ctx context.Context, vFrom basetypes.Se
 				return diags
 			}
 
-			vTo.Set(reflect.ValueOf(to))
+			// Copy elements individually to enable expansion of lists of
+			// custom string types (AWS enums)
+			vals := reflect.MakeSlice(vTo.Type(), len(to), len(to))
+			for i := 0; i < len(to); i++ {
+				vals.Index(i).SetString(to[i])
+			}
+			vTo.Set(vals)
 			return diags
 
 		case reflect.Ptr:

--- a/internal/framework/flex/auto_expand_test.go
+++ b/internal/framework/flex/auto_expand_test.go
@@ -731,6 +731,80 @@ func TestExpandStringEnum(t *testing.T) {
 	runAutoExpandTestCases(ctx, t, testCases)
 }
 
+func TestExpandListOfStringEnum(t *testing.T) {
+	t.Parallel()
+
+	type testEnum string
+	var testEnumFoo testEnum = "foo"
+	var testEnumBar testEnum = "bar"
+
+	var testEnums []testEnum
+	testEnumsWant := []testEnum{testEnumFoo, testEnumBar}
+
+	ctx := context.Background()
+	testCases := autoFlexTestCases{
+		{
+			TestName: "valid value",
+			Source: types.ListValueMust(types.StringType, []attr.Value{
+				types.StringValue(string(testEnumFoo)),
+				types.StringValue(string(testEnumBar)),
+			}),
+			Target:     &testEnums,
+			WantTarget: &testEnumsWant,
+		},
+		{
+			TestName:   "empty value",
+			Source:     types.ListValueMust(types.StringType, []attr.Value{}),
+			Target:     &testEnums,
+			WantTarget: &testEnums,
+		},
+		{
+			TestName:   "null value",
+			Source:     types.ListNull(types.StringType),
+			Target:     &testEnums,
+			WantTarget: &testEnums,
+		},
+	}
+	runAutoExpandTestCases(ctx, t, testCases)
+}
+
+func TestExpandSetOfStringEnum(t *testing.T) {
+	t.Parallel()
+
+	type testEnum string
+	var testEnumFoo testEnum = "foo"
+	var testEnumBar testEnum = "bar"
+
+	var testEnums []testEnum
+	testEnumsWant := []testEnum{testEnumFoo, testEnumBar}
+
+	ctx := context.Background()
+	testCases := autoFlexTestCases{
+		{
+			TestName: "valid value",
+			Source: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue(string(testEnumFoo)),
+				types.StringValue(string(testEnumBar)),
+			}),
+			Target:     &testEnums,
+			WantTarget: &testEnumsWant,
+		},
+		{
+			TestName:   "empty value",
+			Source:     types.SetValueMust(types.StringType, []attr.Value{}),
+			Target:     &testEnums,
+			WantTarget: &testEnums,
+		},
+		{
+			TestName:   "null value",
+			Source:     types.SetNull(types.StringType),
+			Target:     &testEnums,
+			WantTarget: &testEnums,
+		},
+	}
+	runAutoExpandTestCases(ctx, t, testCases)
+}
+
 func TestExpandSimpleNestedBlockWithStringEnum(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This change enables expansion of sets of string enum types with AutoFlex.

```console
% go test ./internal/framework/flex/... -run=TestExpandSetOfStringEnum
--- FAIL: TestExpandSetOfStringEnum (0.00s)
    --- FAIL: TestExpandSetOfStringEnum/empty_value (0.00s)
panic: reflect.Set: value of type []string is not assignable to type []flex.testEnum [recovered]
        panic: reflect.Set: value of type []string is not assignable to type []flex.testEnum

goroutine 6 [running]:
testing.tRunner.func1.2({0x1014e13a0, 0x140006ba040})
        /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1631 +0x1c4
testing.tRunner.func1()
        /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1634 +0x33c
panic({0x1014e13a0?, 0x140006ba040?})
        /opt/homebrew/Cellar/go/1.22.2/libexec/src/runtime/panic.go:770 +0x124
reflect.Value.assignTo({0x1014dca40?, 0x140006c20a8?, 0x18?}, {0x100ffa971, 0xb}, 0x1014daf40, 0x0)
        /opt/homebrew/Cellar/go/1.22.2/libexec/src/reflect/value.go:3356 +0x20c
reflect.Value.Set({0x1014daf40?, 0x1400000ee58?, 0x0?}, {0x1014dca40?, 0x140006c20a8?, 0x2?})
        /opt/homebrew/Cellar/go/1.22.2/libexec/src/reflect/value.go:2325 +0xcc
github.com/hashicorp/terraform-provider-aws/internal/framework/flex.autoExpander.setOfString({}, {0x101587de0, 0x101a3f100}, {{0x101a3f100, 0x0, 0x0}, {0x101589b78, 0x101a3f100}, 0x
2}, {0x1014daf40?, ...})
        /Users/jaredbaker/development/terraform-provider-aws/internal/framework/flex/auto_expand.go:550 +0x4fc
github.com/hashicorp/terraform-provider-aws/internal/framework/flex.autoExpander.set({}, {0x101587de0, 0x101a3f100}, {0x10158be50, 0x14000498b40}, {0x1014daf40?, 0x1400000ee58?, 0x8
ef00?})
        /Users/jaredbaker/development/terraform-provider-aws/internal/framework/flex/auto_expand.go:507 +0x344
github.com/hashicorp/terraform-provider-aws/internal/framework/flex.autoExpander.convert({}, {0x101587de0, 0x101a3f100}, {0x101566840?, 0x14000498b40?, 0x140006b6d08?}, {0x1014daf40
?, 0x1400000ee58?, 0x140006b6e10?})
        /Users/jaredbaker/development/terraform-provider-aws/internal/framework/flex/auto_expand.go:93 +0x49c
github.com/hashicorp/terraform-provider-aws/internal/framework/flex.autoFlexConvert({0x101587de0, 0x101a3f100}, {0x101566840, 0x14000498b40}, {0x1014daf80, 0x1400000ee58}, {0x101583
f88, 0x101a3f100})
        /Users/jaredbaker/development/terraform-provider-aws/internal/framework/flex/autoflex.go:54 +0x214
github.com/hashicorp/terraform-provider-aws/internal/framework/flex.Expand({0x101587de0, 0x101a3f100}, {0x101566840, 0x14000498b40}, {0x1014daf80, 0x1400000ee58}, {0x0, 0x0, 0x14000
05df18?})
        /Users/jaredbaker/development/terraform-provider-aws/internal/framework/flex/auto_expand.go:35 +0xb0
github.com/hashicorp/terraform-provider-aws/internal/framework/flex.runAutoExpandTestCases.func1(0x140000a96c0)
        /Users/jaredbaker/development/terraform-provider-aws/internal/framework/flex/auto_expand_test.go:898 +0x8c
testing.tRunner(0x140000a96c0, 0x140004b52d0)
        /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1689 +0xec
created by testing.(*T).Run in goroutine 4
        /opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1742 +0x318
FAIL    github.com/hashicorp/terraform-provider-aws/internal/framework/flex     0.303s
FAIL
```

After:

```console
% go test ./internal/framework/flex/... -run=TestExpandSetOfStringEnum
ok      github.com/hashicorp/terraform-provider-aws/internal/framework/flex     0.480s
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #36557 (Added a similar enhancement for lists, but without tests 🙈 )
Relates #36731 (Fix depends on this)

