### PR TITLE
New resource/data source - CodeBuild fleet

### DIFF
--- a/.changelog/36790.txt
+++ b/.changelog/36790.txt
@@ -1,0 +1,11 @@
+```release-note:new-resource
+aws_codebuild_fleet
+```
+
+```release-note:new-data-source
+aws_codebuild_fleet
+```
+
+```release-note:enhancement
+resource/aws_codebuild_project: Add `fleet` attribute in `environment` configuration block
+```

--- a/internal/service/codebuild/exports_test.go
+++ b/internal/service/codebuild/exports_test.go
@@ -11,6 +11,7 @@ var (
 	ResourceSourceCredential = resourceSourceCredential
 	ResourceWebhook          = resourceWebhook
 
+	FindFleetByARNOrNames      = findFleetByARNOrNames
 	FindProjectByNameOrARN     = findProjectByNameOrARN
 	FindReportGroupByARN       = findReportGroupByARN
 	FindResourcePolicyByARN    = findResourcePolicyByARN

--- a/internal/service/codebuild/fleet.go
+++ b/internal/service/codebuild/fleet.go
@@ -1,0 +1,577 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package codebuild
+
+import (
+	"context"
+	"errors"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/codebuild"
+	"github.com/aws/aws-sdk-go-v2/service/codebuild/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKResource("aws_codebuild_fleet", name="Fleet")
+// @Tags(identifierAttribute="arn")
+func ResourceFleet() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceFleetCreate,
+		ReadWithoutTimeout:   resourceFleetRead,
+		UpdateWithoutTimeout: resourceFleetUpdate,
+		DeleteWithoutTimeout: resourceFleetDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"base_capacity": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ValidateFunc: validation.IntAtLeast(1),
+			},
+			"compute_type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(computeTypeValues(types.ComputeType("").Values()), false),
+			},
+			"created": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"environment_type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(environmentTypeValues(types.EnvironmentType("").Values()), false),
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"last_modified": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(2, 128),
+			},
+			"overflow_behavior": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice(fleetOverflowBehaviorValues(types.FleetOverflowBehavior("").Values()), false),
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if new == "" {
+						return true
+					}
+					return old == new
+				},
+			},
+			"scaling_configuration": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"desired_capacity": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"max_capacity": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntAtLeast(1),
+						},
+						"scaling_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"target_tracking_scaling_configs": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"metric_type": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringInSlice(fleetScalingMetricTypeValues(types.FleetScalingMetricType("").Values()), false),
+									},
+									"target_value": {
+										Type:         schema.TypeFloat,
+										Optional:     true,
+										ValidateFunc: validation.FloatAtLeast(0),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"status": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"context": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"message": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status_code": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+		},
+		CustomizeDiff: verify.SetTagsDiff,
+	}
+}
+
+const (
+	ResNameFleet = "Fleet"
+)
+
+func resourceFleetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	conn := meta.(*conns.AWSClient).CodeBuildClient(ctx)
+
+	input := &codebuild.CreateFleetInput{
+		BaseCapacity:    aws.Int32(int32(d.Get("base_capacity").(int))),
+		ComputeType:     types.ComputeType(d.Get("compute_type").(string)),
+		EnvironmentType: types.EnvironmentType(d.Get("environment_type").(string)),
+		Name:            aws.String(d.Get("name").(string)),
+		Tags:            getTagsIn(ctx),
+	}
+
+	if v, ok := d.GetOk("overflow_behavior"); ok {
+		input.OverflowBehavior = types.FleetOverflowBehavior(v.(string))
+	}
+
+	if v, ok := d.GetOk("scaling_configuration"); ok {
+		if len(v.([]interface{})) == 0 || v.([]interface{})[0] == nil {
+			return create.AppendDiagError(diags, names.CodeBuild, create.ErrActionCreating, ResNameFleet, d.Get("name").(string), errors.New("scaling_configuration cannot be empty"))
+		} else {
+			input.ScalingConfiguration = expandScalingConfiguration(v.([]interface{})[0].(map[string]interface{}))
+		}
+	}
+
+	out, err := conn.CreateFleet(ctx, input)
+	if err != nil {
+		return create.AppendDiagError(diags, names.CodeBuild, create.ErrActionCreating, ResNameFleet, d.Get("name").(string), err)
+	}
+
+	if out == nil || out.Fleet == nil {
+		return create.AppendDiagError(diags, names.CodeBuild, create.ErrActionCreating, ResNameFleet, d.Get("name").(string), errors.New("empty output"))
+	}
+
+	d.SetId(aws.ToString(out.Fleet.Arn))
+
+	if err := waitFleetActive(ctx, conn, d.Id()); err != nil {
+		return create.AppendDiagError(diags, names.CodeBuild, create.ErrActionWaitingForCreation, ResNameFleet, d.Id(), err)
+	}
+
+	return append(diags, resourceFleetRead(ctx, d, meta)...)
+}
+
+func resourceFleetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	conn := meta.(*conns.AWSClient).CodeBuildClient(ctx)
+
+	out, err := findFleetByARNOrNames(ctx, conn, d.Id())
+
+	if out == nil || len(out.Fleets) == 0 {
+		log.Printf("[WARN] CodeBuild Fleet (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return diags
+	}
+
+	if err != nil {
+		return create.AppendDiagError(diags, names.CodeBuild, create.ErrActionReading, ResNameFleet, d.Id(), err)
+	}
+
+	d.Set("arn", out.Fleets[0].Arn)
+	d.Set("base_capacity", out.Fleets[0].BaseCapacity)
+	d.Set("compute_type", out.Fleets[0].ComputeType)
+	d.Set("created", out.Fleets[0].Created.String())
+	d.Set("environment_type", out.Fleets[0].EnvironmentType)
+	d.Set("id", out.Fleets[0].Id)
+	d.Set("last_modified", out.Fleets[0].LastModified.String())
+	d.Set("name", out.Fleets[0].Name)
+	d.Set("overflow_behavior", out.Fleets[0].OverflowBehavior)
+	if len(out.Fleets) > 0 && out.Fleets[0].ScalingConfiguration != nil {
+		empty_scaling_configuration := out.Fleets[0].ScalingConfiguration.DesiredCapacity == nil &&
+			out.Fleets[0].ScalingConfiguration.MaxCapacity == nil &&
+			out.Fleets[0].ScalingConfiguration.ScalingType == "" &&
+			out.Fleets[0].ScalingConfiguration.TargetTrackingScalingConfigs == nil
+
+		if !empty_scaling_configuration {
+			if err := d.Set("scaling_configuration", []interface{}{flattenScalingConfiguration(out.Fleets[0].ScalingConfiguration)}); err != nil {
+				return sdkdiag.AppendErrorf(diags, "setting overflow behavior: %s", err)
+			}
+		} else {
+			d.Set("scaling_configuration", nil)
+		}
+	} else {
+		d.Set("scaling_configuration", nil)
+	}
+	if out.Fleets[0].Status != nil {
+		if err := d.Set("status", []interface{}{flattenStatus(out.Fleets[0].Status)}); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting status: %s", err)
+		}
+	} else {
+		d.Set("status", nil)
+	}
+	setTagsOut(ctx, out.Fleets[0].Tags)
+	return diags
+}
+
+func resourceFleetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).CodeBuildClient(ctx)
+
+	input := &codebuild.UpdateFleetInput{
+		Arn: aws.String(d.Id()),
+	}
+
+	if d.HasChange("base_capacity") {
+		input.BaseCapacity = aws.Int32(int32(d.Get("base_capacity").(int)))
+	}
+
+	if d.HasChange("compute_type") {
+		input.ComputeType = types.ComputeType(d.Get("compute_type").(string))
+	}
+
+	if d.HasChange("environment_type") {
+		input.EnvironmentType = types.EnvironmentType(d.Get("environment_type").(string))
+	}
+
+	// Make sure that overflow_behavior is set (if defined) on update - api ommit it on updates
+	if v, ok := d.GetOk("overflow_behavior"); ok {
+		input.OverflowBehavior = types.FleetOverflowBehavior(v.(string))
+	}
+
+	if d.HasChange("scaling_configuration") {
+		if v, ok := d.GetOk("scaling_configuration"); ok {
+			if len(v.([]interface{})) == 0 || v.([]interface{})[0] == nil {
+				return create.AppendDiagError(diags, names.CodeBuild, create.ErrActionCreating, ResNameFleet, d.Get("name").(string), errors.New("scaling_configuration cannot be empty"))
+			} else {
+				input.ScalingConfiguration = expandScalingConfiguration(v.([]interface{})[0].(map[string]interface{}))
+			}
+		} else {
+			input.ScalingConfiguration = &types.ScalingConfigurationInput{}
+		}
+	}
+
+	input.Tags = getTagsIn(ctx)
+
+	log.Printf("[DEBUG] Updating CodeBuild Fleet (%s): %#v", d.Id(), input)
+	_, err := conn.UpdateFleet(ctx, input)
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "updating CodeBuild Fleet (%s): %s", d.Id(), err)
+	}
+
+	if err := waitFleetActive(ctx, conn, d.Id()); err != nil {
+		return sdkdiag.AppendErrorf(diags, "updating CodeBuild Fleet (%s): %s", d.Id(), err)
+	}
+
+	return append(diags, resourceFleetRead(ctx, d, meta)...)
+}
+
+func resourceFleetDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).CodeBuildClient(ctx)
+
+	log.Printf("[INFO] Deleting CodeBuild Fleet %s", d.Id())
+
+	_, err := conn.DeleteFleet(ctx, &codebuild.DeleteFleetInput{
+		Arn: aws.String(d.Id()),
+	})
+
+	if errs.IsA[*types.ResourceNotFoundException](err) {
+		return diags
+	}
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "deleting CodeBuild Fleet (%s): %s", d.Id(), err)
+	}
+
+	if err := waitFleetDeleted(ctx, conn, d.Id()); err != nil {
+		return sdkdiag.AppendErrorf(diags, "deleting CodeBuild Fleet (%s): %s", d.Id(), err)
+	}
+
+	return diags
+}
+
+func waitFleetActive(ctx context.Context, conn *codebuild.Client, id string) error {
+	stateConf := &retry.StateChangeConf{
+		Pending:                   enum.Slice(types.FleetStatusCodeCreating, types.FleetStatusCodeUpdating, types.FleetStatusCodeDeleting, types.FleetStatusCodeRotating),
+		Target:                    enum.Slice(types.FleetStatusCodeActive),
+		Refresh:                   statusFleet(ctx, conn, id, false),
+		Timeout:                   20 * time.Minute,
+		MinTimeout:                15 * time.Second,
+		Delay:                     15 * time.Second,
+		NotFoundChecks:            20,
+		ContinuousTargetOccurence: 2,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+
+	return err
+}
+
+func waitFleetDeleted(ctx context.Context, conn *codebuild.Client, id string) error {
+	stateConf := &retry.StateChangeConf{
+		Pending:    enum.Slice(types.FleetStatusCodeDeleting, "PENDING_DELETION"),
+		Target:     []string{},
+		Refresh:    statusFleet(ctx, conn, id, true),
+		Timeout:    90 * time.Minute,
+		MinTimeout: 15 * time.Second,
+		Delay:      15 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+
+	return err
+}
+
+func statusFleet(ctx context.Context, conn *codebuild.Client, id string, delete bool) retry.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		out, err := findFleetByARNOrNames(ctx, conn, id)
+		if tfresource.NotFound(err) && delete {
+			return nil, "", nil
+		}
+		if err != nil {
+			return nil, "", err
+		}
+
+		return out, aws.ToString((*string)(&out.Fleets[0].Status.StatusCode)), nil
+	}
+}
+
+func findFleetByARNOrNames(ctx context.Context, conn *codebuild.Client, arn string) (*codebuild.BatchGetFleetsOutput, error) {
+	input := &codebuild.BatchGetFleetsInput{
+		Names: []string{arn},
+	}
+	output, err := conn.BatchGetFleets(ctx, input)
+
+	if output == nil || len(output.Fleets) == 0 || len(output.FleetsNotFound) > 0 {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return output, nil
+}
+
+func expandScalingConfiguration(tfMap map[string]interface{}) *types.ScalingConfigurationInput {
+	if len(tfMap) == 0 {
+		return nil
+	}
+
+	apiObject := &types.ScalingConfigurationInput{}
+	if v, ok := tfMap["max_capacity"].(int); ok {
+		int32Value := int32(v)
+		apiObject.MaxCapacity = &int32Value
+	}
+
+	if v, ok := tfMap["scaling_type"].(string); ok && v != "" {
+		apiObject.ScalingType = types.FleetScalingType(v)
+	}
+
+	if v, ok := tfMap["target_tracking_scaling_configs"].([]interface{}); ok && len(v) > 0 {
+		apiObject.TargetTrackingScalingConfigs = expandTargetTrackingScalingConfigs(v)
+	}
+
+	return apiObject
+}
+
+func expandTargetTrackingScalingConfigs(tfList []interface{}) []types.TargetTrackingScalingConfiguration {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	var apiObjects []types.TargetTrackingScalingConfiguration
+
+	for _, tfMapRaw := range tfList {
+		tfMap, ok := tfMapRaw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		apiObject := expandTargetTrackingScalingConfig(tfMap)
+		if apiObject == nil {
+			continue
+		}
+
+		apiObjects = append(apiObjects, *apiObject)
+	}
+	return apiObjects
+}
+
+func expandTargetTrackingScalingConfig(tfMap map[string]interface{}) *types.TargetTrackingScalingConfiguration {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &types.TargetTrackingScalingConfiguration{}
+
+	if v, ok := tfMap["metric_type"].(string); ok {
+		apiObject.MetricType = types.FleetScalingMetricType(v)
+	}
+
+	if v, ok := tfMap["target_value"].(float64); ok {
+		apiObject.TargetValue = &v
+	}
+
+	return apiObject
+}
+
+func flattenScalingConfiguration(apiObject *types.ScalingConfigurationOutput) map[string]interface{} {
+	tfMap := map[string]interface{}{}
+
+	if apiObject != nil {
+		if v := apiObject.DesiredCapacity; v != nil {
+			tfMap["desired_capacity"] = aws.ToInt32(v)
+		}
+
+		if v := apiObject.MaxCapacity; v != nil {
+			tfMap["max_capacity"] = aws.ToInt32(v)
+		}
+
+		if v := apiObject.ScalingType; v != "" {
+			tfMap["scaling_type"] = v
+		}
+
+		if v := apiObject.TargetTrackingScalingConfigs; v != nil {
+			tfMap["target_tracking_scaling_configs"] = flattenTargetTrackingScalingConfigs(v)
+		}
+	}
+
+	return tfMap
+}
+
+func flattenTargetTrackingScalingConfigs(apiObjects []types.TargetTrackingScalingConfiguration) []interface{} {
+	if len(apiObjects) == 0 {
+		return nil
+	}
+
+	var tfMaps []interface{}
+
+	for _, apiObject := range apiObjects {
+		tfMaps = append(tfMaps, flattenTargetTrackingScalingConfig(apiObject))
+	}
+
+	return tfMaps
+}
+
+func flattenTargetTrackingScalingConfig(apiObject types.TargetTrackingScalingConfiguration) map[string]interface{} {
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.MetricType; v != "" {
+		tfMap["metric_type"] = v
+	}
+
+	if v := apiObject.TargetValue; v != nil {
+		tfMap["target_value"] = aws.ToFloat64(v)
+	}
+
+	return tfMap
+}
+
+func flattenStatus(apiObject *types.FleetStatus) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.Context; v != "" {
+		tfMap["context"] = v
+	}
+
+	if v := apiObject.Message; v != nil {
+		tfMap["message"] = aws.ToString(v)
+	}
+
+	if v := apiObject.StatusCode; v != "" {
+		tfMap["status_code"] = v
+	}
+
+	return tfMap
+}
+
+func fleetOverflowBehaviorValues(in []types.FleetOverflowBehavior) []string {
+	var out []string
+
+	for _, v := range in {
+		out = append(out, string(v))
+	}
+
+	return out
+}
+
+func computeTypeValues(in []types.ComputeType) []string {
+	var out []string
+
+	for _, v := range in {
+		out = append(out, string(v))
+	}
+
+	return out
+}
+
+func environmentTypeValues(in []types.EnvironmentType) []string {
+	var out []string
+
+	for _, v := range in {
+		out = append(out, string(v))
+	}
+
+	return out
+}
+
+func fleetScalingMetricTypeValues(in []types.FleetScalingMetricType) []string {
+	var out []string
+
+	for _, v := range in {
+		out = append(out, string(v))
+	}
+
+	return out
+}

--- a/internal/service/codebuild/fleet_data_source.go
+++ b/internal/service/codebuild/fleet_data_source.go
@@ -1,0 +1,165 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package codebuild
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKDataSource("aws_codebuild_fleet", name="Fleet")
+func DataSourceFleet() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceFleetRead,
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"base_capacity": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"compute_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"environment_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"last_modified": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(2, 128),
+			},
+			"overflow_behavior": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"scaling_configuration": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"desired_capacity": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"max_capacity": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"scaling_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"target_tracking_scaling_configs": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"metric_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"target_value": {
+										Type:     schema.TypeFloat,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"status": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"context": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"message": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status_code": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"tags": tftags.TagsSchemaComputed(),
+		},
+	}
+}
+
+const (
+	DSNameFleet = "Fleet Data Source"
+)
+
+func dataSourceFleetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	conn := meta.(*conns.AWSClient).CodeBuildClient(ctx)
+	name := d.Get("name").(string)
+
+	out, err := findFleetByARNOrNames(ctx, conn, name)
+	if err != nil {
+		return create.AppendDiagError(diags, names.CodeBuild, create.ErrActionReading, DSNameFleet, name, err)
+	}
+	d.SetId(aws.StringValue(out.Fleets[0].Arn))
+
+	d.Set("arn", out.Fleets[0].Arn)
+	d.Set("base_capacity", out.Fleets[0].BaseCapacity)
+	d.Set("compute_type", out.Fleets[0].ComputeType)
+	d.Set("created", out.Fleets[0].Created.String())
+	d.Set("environment_type", out.Fleets[0].EnvironmentType)
+	d.Set("last_modified", out.Fleets[0].LastModified.String())
+	d.Set("overflow_behavior", out.Fleets[0].OverflowBehavior)
+	d.Set("name", out.Fleets[0].Name)
+	if out.Fleets[0].ScalingConfiguration != nil {
+		if err := d.Set("scaling_configuration", []interface{}{flattenScalingConfiguration(out.Fleets[0].ScalingConfiguration)}); err != nil {
+			return create.AppendDiagError(diags, names.CodeBuild, create.ErrActionSetting, DSNameFleet, d.Id(), err)
+		}
+	}
+	if out.Fleets[0].Status != nil {
+		if err := d.Set("status", []interface{}{flattenStatus(out.Fleets[0].Status)}); err != nil {
+			return create.AppendDiagError(diags, names.CodeBuild, create.ErrActionSetting, DSNameFleet, d.Id(), err)
+		}
+	}
+
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+	//lintignore:AWSR002
+	if err := d.Set("tags", KeyValueTags(ctx, out.Fleets[0].Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return create.AppendDiagError(diags, names.CodeBuild, create.ErrActionSetting, DSNameFleet, d.Id(), err)
+	}
+
+	return diags
+}

--- a/internal/service/codebuild/fleet_data_source_test.go
+++ b/internal/service/codebuild/fleet_data_source_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package codebuild_test
+
+import (
+	"fmt"
+	"testing"
+
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccCodeBuildFleetDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_codebuild_fleet.test"
+	datasourceName := "data.aws_codebuild_fleet.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CodeBuildServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFleetDataSourceConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "base_capacity", resourceName, "base_capacity"),
+					resource.TestCheckResourceAttrPair(datasourceName, "compute_type", resourceName, "compute_type"),
+					resource.TestCheckResourceAttrPair(datasourceName, "created", resourceName, "created"),
+					resource.TestCheckResourceAttrPair(datasourceName, "environment_type", resourceName, "environment_type"),
+					resource.TestCheckResourceAttrPair(datasourceName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "last_modified", resourceName, "last_modified"),
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "overflow_behavior", resourceName, "overflow_behavior"),
+					resource.TestCheckResourceAttrPair(datasourceName, "scaling_configuration.0.max_capacity", resourceName, "scaling_configuration.0.max_capacity"),
+					resource.TestCheckResourceAttrPair(datasourceName, "scaling_configuration.0.scaling_type", resourceName, "scaling_configuration.0.scaling_type"),
+					resource.TestCheckResourceAttrPair(datasourceName, "scaling_configuration.0.target_tracking_scaling_configs.0.metric_type", resourceName, "scaling_configuration.0.target_tracking_scaling_configs.0.metric_type"),
+					resource.TestCheckResourceAttrPair(datasourceName, "scaling_configuration.0.target_tracking_scaling_configs.0.target_value", resourceName, "scaling_configuration.0.target_tracking_scaling_configs.0.target_value"),
+				),
+			},
+		},
+	})
+}
+
+func testAccFleetDataSourceConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_codebuild_fleet" "test" {
+  base_capacity     = 1
+  compute_type      = "BUILD_GENERAL1_SMALL"
+  environment_type  = "ARM_CONTAINER"
+  name              = %q
+  overflow_behavior = "QUEUE"
+  scaling_configuration {
+    max_capacity = 2
+    scaling_type = "TARGET_TRACKING_SCALING"
+    target_tracking_scaling_configs {
+      metric_type  = "FLEET_UTILIZATION_RATE"
+      target_value = 97.5
+    }
+  }
+}
+
+data "aws_codebuild_fleet" "test" {
+  name = aws_codebuild_fleet.test.name
+}
+`, rName)
+}

--- a/internal/service/codebuild/fleet_test.go
+++ b/internal/service/codebuild/fleet_test.go
@@ -1,0 +1,375 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package codebuild_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfcodebuild "github.com/hashicorp/terraform-provider-aws/internal/service/codebuild"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccCodeBuildFleet_basic(t *testing.T) {
+	ctx := context.Background()
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_codebuild_fleet.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CodeBuildServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFleetDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFleetConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFleetExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "base_capacity", "1"),
+					resource.TestCheckResourceAttr(resourceName, "compute_type", "BUILD_GENERAL1_SMALL"),
+					resource.TestCheckResourceAttr(resourceName, "environment_type", "LINUX_CONTAINER"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "overflow_behavior", "ON_DEMAND"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccCodeBuildFleet_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resourceName := "aws_codebuild_fleet.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CodeBuildServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFleetDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFleetConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFleetExists(ctx, resourceName),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfcodebuild.ResourceFleet(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccCodeBuildFleet_tags(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_codebuild_fleet.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CodeBuildServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFleetDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFleetConfig_tags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFleetExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				Config: testAccFleetConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFleetExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccFleetConfig_tags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFleetExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCodeBuildFleet_updateBasicParameters(t *testing.T) {
+	ctx := context.Background()
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_codebuild_fleet.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CodeBuildServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFleetDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFleetConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFleetExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "base_capacity", "1"),
+					resource.TestCheckResourceAttr(resourceName, "compute_type", "BUILD_GENERAL1_SMALL"),
+					resource.TestCheckResourceAttr(resourceName, "environment_type", "LINUX_CONTAINER"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "overflow_behavior", "ON_DEMAND"),
+				),
+			},
+			{
+				Config: testAccFleetConfig_updateBaseCapacity(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFleetExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "base_capacity", "2"),
+					resource.TestCheckResourceAttr(resourceName, "compute_type", "BUILD_GENERAL1_SMALL"),
+					resource.TestCheckResourceAttr(resourceName, "environment_type", "LINUX_CONTAINER"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "overflow_behavior", "ON_DEMAND"),
+				),
+			},
+			{
+				Config: testAccFleetConfig_updateComputeType(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFleetExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "base_capacity", "1"),
+					resource.TestCheckResourceAttr(resourceName, "compute_type", "BUILD_GENERAL1_LARGE"),
+					resource.TestCheckResourceAttr(resourceName, "environment_type", "LINUX_CONTAINER"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "overflow_behavior", "ON_DEMAND"),
+				),
+			},
+			{
+				Config: testAccFleetConfig_updateEnvironmentType(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFleetExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "base_capacity", "1"),
+					resource.TestCheckResourceAttr(resourceName, "compute_type", "BUILD_GENERAL1_LARGE"),
+					resource.TestCheckResourceAttr(resourceName, "environment_type", "ARM_CONTAINER"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "overflow_behavior", "ON_DEMAND"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCodeBuildFleet_updateScalingConfiguration(t *testing.T) {
+	ctx := context.Background()
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_codebuild_fleet.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CodeBuildServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFleetDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFleetConfig_scalingConfiguration(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFleetExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "base_capacity", "1"),
+					resource.TestCheckResourceAttr(resourceName, "compute_type", "BUILD_GENERAL1_SMALL"),
+					resource.TestCheckResourceAttr(resourceName, "environment_type", "ARM_CONTAINER"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "overflow_behavior", "QUEUE"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_configuration.0.max_capacity", "2"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_configuration.0.scaling_type", "TARGET_TRACKING_SCALING"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_configuration.0.target_tracking_scaling_configs.0.metric_type", "FLEET_UTILIZATION_RATE"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_configuration.0.target_tracking_scaling_configs.0.target_value", "97.5"),
+				),
+			},
+			{
+				Config: testAccFleetConfig_noScalingConfiguration(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFleetExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "base_capacity", "1"),
+					resource.TestCheckResourceAttr(resourceName, "compute_type", "BUILD_GENERAL1_SMALL"),
+					resource.TestCheckResourceAttr(resourceName, "environment_type", "ARM_CONTAINER"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "overflow_behavior", "ON_DEMAND"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckFleetDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).CodeBuildClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_codebuild_fleet" {
+				continue
+			}
+
+			_, err := tfcodebuild.FindFleetByARNOrNames(ctx, conn, rs.Primary.ID)
+
+			if tfresource.NotFound(err) {
+				continue
+			}
+
+			if err != nil {
+				return err
+			}
+
+			return fmt.Errorf("CodeBuild Fleet %s still exists", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckFleetExists(ctx context.Context, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).CodeBuildClient(ctx)
+
+		fleet, err := tfcodebuild.FindFleetByARNOrNames(ctx, conn, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if len(fleet.Fleets) == 0 {
+			return fmt.Errorf("Fleet not found: %s", rs.Primary.ID)
+		}
+
+		expectedName := rs.Primary.Attributes["name"]
+		if *fleet.Fleets[0].Name != expectedName {
+			return fmt.Errorf("Fleet name mismatch, expected: %s, got: %s", expectedName, *fleet.Fleets[0].Name)
+		}
+
+		return nil
+	}
+}
+
+func testAccFleetConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_codebuild_fleet" "test" {
+  base_capacity     = 1
+  compute_type      = "BUILD_GENERAL1_SMALL"
+  environment_type  = "LINUX_CONTAINER"
+  name              = %q
+  overflow_behavior = "ON_DEMAND"
+}
+`, rName)
+}
+
+func testAccFleetConfig_updateBaseCapacity(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_codebuild_fleet" "test" {
+  base_capacity     = 2
+  compute_type      = "BUILD_GENERAL1_SMALL"
+  environment_type  = "LINUX_CONTAINER"
+  name              = %q
+  overflow_behavior = "ON_DEMAND"
+}
+`, rName)
+}
+
+func testAccFleetConfig_updateComputeType(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_codebuild_fleet" "test" {
+  base_capacity     = 1
+  compute_type      = "BUILD_GENERAL1_LARGE"
+  environment_type  = "LINUX_CONTAINER"
+  name              = %q
+  overflow_behavior = "ON_DEMAND"
+}
+`, rName)
+}
+
+func testAccFleetConfig_updateEnvironmentType(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_codebuild_fleet" "test" {
+  base_capacity     = 1
+  compute_type      = "BUILD_GENERAL1_LARGE"
+  environment_type  = "ARM_CONTAINER"
+  name              = %q
+  overflow_behavior = "ON_DEMAND"
+}
+`, rName)
+}
+
+func testAccFleetConfig_scalingConfiguration(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_codebuild_fleet" "test" {
+  base_capacity     = 1
+  compute_type      = "BUILD_GENERAL1_SMALL"
+  environment_type  = "ARM_CONTAINER"
+  name              = %q
+  overflow_behavior = "QUEUE"
+  scaling_configuration {
+    max_capacity = 2
+    scaling_type = "TARGET_TRACKING_SCALING"
+    target_tracking_scaling_configs {
+      metric_type  = "FLEET_UTILIZATION_RATE"
+      target_value = 97.5
+    }
+  }
+}
+`, rName)
+}
+
+func testAccFleetConfig_noScalingConfiguration(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_codebuild_fleet" "test" {
+  base_capacity     = 1
+  compute_type      = "BUILD_GENERAL1_SMALL"
+  environment_type  = "ARM_CONTAINER"
+  name              = %q
+  overflow_behavior = "ON_DEMAND"
+}
+`, rName)
+}
+
+func testAccFleetConfig_tags1(rName string, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_codebuild_fleet" "test" {
+  base_capacity     = 1
+  compute_type      = "BUILD_GENERAL1_SMALL"
+  environment_type  = "LINUX_CONTAINER"
+  name              = %q
+  overflow_behavior = "ON_DEMAND"
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccFleetConfig_tags2(rName string, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_codebuild_fleet" "test" {
+  base_capacity     = 1
+  compute_type      = "BUILD_GENERAL1_SMALL"
+  environment_type  = "LINUX_CONTAINER"
+  name              = %q
+  overflow_behavior = "ON_DEMAND"
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}

--- a/internal/service/codebuild/project_test.go
+++ b/internal/service/codebuild/project_test.go
@@ -2844,6 +2844,40 @@ func TestAccCodeBuildProject_concurrentBuildLimit(t *testing.T) {
 	})
 }
 
+func TestAccCodeBuildProject_fleet(t *testing.T) {
+	ctx := acctest.Context(t)
+	var project types.Project
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resourceName := "aws_codebuild_project.test"
+	roleResourceName := "aws_iam_role.test"
+	fleetResourceName := "aws_codebuild_fleet.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+			testAccPreCheckSourceCredentialsForServerType(ctx, t, types.ServerTypeGithub)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.CodeBuildServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckProjectDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProjectConfig_fleet(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckProjectExists(ctx, resourceName, &project),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "codebuild", fmt.Sprintf("project/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "environment.0.compute_type", string(types.ComputeTypeBuildGeneral1Small)),
+					resource.TestCheckResourceAttr(resourceName, "environment.0.fleet.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "environment.0.fleet.0.fleet_arn", fleetResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "service_role", roleResourceName, "arn"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckProjectExists(ctx context.Context, n string, v *types.Project) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -5541,4 +5575,39 @@ resource "aws_codebuild_project" "test" {
   }
 }
 `, concurrentBuildLimit, rName))
+}
+
+func testAccProjectConfig_fleet(rName string) string {
+	return acctest.ConfigCompose(testAccProjectConfig_baseServiceRole(rName), fmt.Sprintf(`
+resource "aws_codebuild_fleet" "test" {
+  base_capacity     = 1
+  compute_type      = "BUILD_GENERAL1_SMALL"
+  environment_type  = "LINUX_CONTAINER"
+  name              = %[1]q
+  overflow_behavior = "ON_DEMAND"
+}
+
+resource "aws_codebuild_project" "test" {
+  name         = %[1]q
+  service_role = aws_iam_role.test.arn
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type = "BUILD_GENERAL1_SMALL"
+    image        = "2"
+    type         = "LINUX_CONTAINER"
+    fleet {
+      fleet_arn = aws_codebuild_fleet.test.arn
+    }
+  }
+
+  source {
+    location = %[2]q
+    type     = "GITHUB"
+  }
+}
+`, rName, testAccGitHubSourceLocationFromEnv()))
 }

--- a/internal/service/codebuild/service_package_gen.go
+++ b/internal/service/codebuild/service_package_gen.go
@@ -23,11 +23,25 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 }
 
 func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePackageSDKDataSource {
-	return []*types.ServicePackageSDKDataSource{}
+	return []*types.ServicePackageSDKDataSource{
+		{
+			Factory:  DataSourceFleet,
+			TypeName: "aws_codebuild_fleet",
+			Name:     "Fleet",
+		},
+	}
 }
 
 func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePackageSDKResource {
 	return []*types.ServicePackageSDKResource{
+		{
+			Factory:  ResourceFleet,
+			TypeName: "aws_codebuild_fleet",
+			Name:     "Fleet",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
+		},
 		{
 			Factory:  resourceProject,
 			TypeName: "aws_codebuild_project",

--- a/website/docs/d/codebuild_fleet.html.markdown
+++ b/website/docs/d/codebuild_fleet.html.markdown
@@ -1,0 +1,74 @@
+---
+subcategory: "CodeBuild"
+layout: "aws"
+page_title: "AWS: aws_codebuild_fleet"
+description: |-
+  Retrieve information about an CodeBuild Fleet
+---
+
+# Data Source: aws_codebuild_fleet
+
+Retrieve information about an CodeBuild Fleet.
+
+## Example Usage
+
+```terraform
+data "aws_codebuild_fleet" "test" {
+  name = aws_codebuild_fleet.test.name
+}
+
+resource "aws_codebuild_fleet" "test" {
+  base_capacity     = 2
+  compute_type      = "BUILD_GENERAL1_SMALL"
+  environment_type  = "LINUX_CONTAINER"
+  name              = "full-example-codebuild-fleet"
+  overflow_behavior = "QUEUE"
+  scaling_configuration {
+    max_capacity = 5
+    scaling_type = "TARGET_TRACKING_SCALING"
+    target_tracking_scaling_configs {
+      metric_type  = "FLEET_UTILIZATION_RATE"
+      target_value = 97.5
+    }
+  }
+}
+```
+
+### Basic Usage
+
+```terraform
+data "aws_codebuild_fleet" "example" {
+  name = "my-codebuild-fleet-name"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `name` - (Required) Fleet name.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `arn` - ARN of the Fleet.
+* `base_capacity` - Number of machines allocated to the ﬂeet.
+* `compute_type` - Compute resources the compute fleet uses.
+* `created` - Creation time of the fleet.
+* `environment_type` - Environment type of the compute fleet.
+* `id` - ARN of the Fleet.
+* `last_modified` - Last modification time of the fleet.
+* `overflow_behavior` - Overflow behavior for compute fleet.
+* `scaling_configuration` -  Nested attribute containing information about the scaling configuration.
+    * `desired_capacity` - The desired number of instances in the ﬂeet when auto-scaling.
+    * `max_capacity` - The maximum number of instances in the ﬂeet when auto-scaling.
+    * `scaling_type` - The scaling type for a compute fleet.
+    * `target_tracking_scaling_configs` - Nested attribute containing information about thresholds when new instance is auto-scaled into the compute fleet.
+        * `metric_type` - The metric type to determine auto-scaling.
+        * `target_value` - The value of metric_type when to start scaling.
+* `status` - Nested attribute containing information about the current status of the fleet.
+    * `context` - Additional information about a compute fleet.
+    * `message` - Message associated with the status of a compute fleet.
+    * `status_code` - Status code of the compute fleet.
+* `tags` - Mapping of Key-Value tags for the resource.

--- a/website/docs/r/codebuild_fleet.html.markdown
+++ b/website/docs/r/codebuild_fleet.html.markdown
@@ -1,0 +1,95 @@
+---
+subcategory: "CodeBuild"
+layout: "aws"
+page_title: "AWS: aws_codebuild_fleet"
+description: |-
+  Provides a CodeBuild Fleet Resource.
+---
+
+# Resource: aws_codebuild_fleet
+
+Provides a CodeBuild Fleet Resource.
+
+## Example Usage
+
+```terraform
+resource "aws_codebuild_fleet" "test" {
+  base_capacity     = 2
+  compute_type      = "BUILD_GENERAL1_SMALL"
+  environment_type  = "LINUX_CONTAINER"
+  name              = "full-example-codebuild-fleet"
+  overflow_behavior = "QUEUE"
+  scaling_configuration {
+    max_capacity = 5
+    scaling_type = "TARGET_TRACKING_SCALING"
+    target_tracking_scaling_configs {
+      metric_type  = "FLEET_UTILIZATION_RATE"
+      target_value = 97.5
+    }
+  }
+}
+```
+
+### Basic Usage
+
+```terraform
+resource "aws_codebuild_fleet" "example" {
+  name = "example-codebuild-fleet"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `name` - (Required) Fleet name.
+
+The following arguments are optional:
+
+* `base_capacity` - (Optional) Number of machines allocated to the ﬂeet.
+* `compute_type` - (Optional) Compute resources the compute fleet uses. See [compute types](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-compute-types.html#environment.types) for more information and valid values.
+* `environment_type` - (Optional) Environment type of the compute fleet. See [environment types](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-compute-types.html#environment.types) for more information and valid values.
+* `overflow_behavior` - (Optional) Overflow behavior for compute fleet. Valid values: `ON_DEMAND`, `QUEUE`.
+* `scaling_configuration` - (Optional) Configuration block. Detailed below. This option is only valid when your overflow behavior is `QUEUE`.
+* `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### scaling_configuration
+
+* `max_capacity` - (Optional) Maximum number of instances in the ﬂeet when auto-scaling.
+* `scaling_type` - (Optional) Scaling type for a compute fleet. Valid value: `TARGET_TRACKING_SCALING`.
+* `target_tracking_scaling_configs` - (Optional) Configuration block. Detailed below.
+
+#### scaling_configuration:target_tracking_scaling_configs
+
+* `metric_type` - (Optional) Metric type to determine auto-scaling. Valid value: `FLEET_UTILIZATION_RATE`.
+* `target_value` - (Optional) Value of metricType when to start scaling.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `arn` - ARN of the Fleet.
+* `created` - Creation time of the fleet.
+* `id` - ARN of the Fleet.
+* `last_modified` - Last modification time of the fleet.
+* `status` - Nested attribute containing information about the current status of the fleet.
+    * `context` - Additional information about a compute fleet.
+    * `message` - Message associated with the status of a compute fleet.
+    * `status_code` - Status code of the compute fleet.
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import CodeBuild Fleet using the `name` or the `arn`. For example:
+
+```terraform
+import {
+  to = aws_codebuild_fleet.name
+  id = "fleet-name"
+}
+```
+
+Using `terraform import`, import CodeBuild Fleet using the `name`. For example:
+
+```console
+% terraform import aws_codebuild_fleet.name fleet-name
+```

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -289,12 +289,17 @@ The following arguments are optional:
 
 * `certificate` - (Optional) ARN of the S3 bucket, path prefix and object key that contains the PEM-encoded certificate.
 * `compute_type` - (Required) Information about the compute resources the build project will use. Valid values: `BUILD_GENERAL1_SMALL`, `BUILD_GENERAL1_MEDIUM`, `BUILD_GENERAL1_LARGE`, `BUILD_GENERAL1_2XLARGE`, `BUILD_LAMBDA_1GB`, `BUILD_LAMBDA_2GB`, `BUILD_LAMBDA_4GB`, `BUILD_LAMBDA_8GB`, `BUILD_LAMBDA_10GB`. `BUILD_GENERAL1_SMALL` is only valid if `type` is set to `LINUX_CONTAINER`. When `type` is set to `LINUX_GPU_CONTAINER`, `compute_type` must be `BUILD_GENERAL1_LARGE`. When `type` is set to `LINUX_LAMBDA_CONTAINER` or `ARM_LAMBDA_CONTAINER`, `compute_type` must be `BUILD_LAMBDA_XGB`.`
+* `fleet` - (Optional) Configuration block. Detailed below.
 * `environment_variable` - (Optional) Configuration block. Detailed below.
 * `image_pull_credentials_type` - (Optional) Type of credentials AWS CodeBuild uses to pull images in your build. Valid values: `CODEBUILD`, `SERVICE_ROLE`. When you use a cross-account or private registry image, you must use SERVICE_ROLE credentials. When you use an AWS CodeBuild curated image, you must use CodeBuild credentials. Defaults to `CODEBUILD`.
 * `image` - (Required) Docker image to use for this build project. Valid values include [Docker images provided by CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-available.html) (e.g `aws/codebuild/amazonlinux2-x86_64-standard:4.0`), [Docker Hub images](https://hub.docker.com/) (e.g., `hashicorp/terraform:latest`), and full Docker repository URIs such as those for ECR (e.g., `137112412989.dkr.ecr.us-west-2.amazonaws.com/amazonlinux:latest`).
 * `privileged_mode` - (Optional) Whether to enable running the Docker daemon inside a Docker container. Defaults to `false`.
 * `registry_credential` - (Optional) Configuration block. Detailed below.
 * `type` - (Required) Type of build environment to use for related builds. Valid values: `LINUX_CONTAINER`, `LINUX_GPU_CONTAINER`, `WINDOWS_CONTAINER` (deprecated), `WINDOWS_SERVER_2019_CONTAINER`, `ARM_CONTAINER`, `LINUX_LAMBDA_CONTAINER`, `ARM_LAMBDA_CONTAINER`. For additional information, see the [CodeBuild User Guide](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-compute-types.html).
+
+#### environment: fleet
+
+* `fleet_arn` - (Optional) Compute fleet ARN for the build project.
 
 #### environment: environment_variable
 


### PR DESCRIPTION
### Description
* Adds `aws_codebuild_fleet` resource
* Adds `aws_codebuild_fleet` data source

### Relations

Closes #36010

### References
https://docs.aws.amazon.com/codebuild/latest/userguide/fleets.html
https://docs.aws.amazon.com/codebuild/latest/APIReference/API_Fleet.html


### Output from Acceptance Testing
`Resource tests:`

```console
% make testacc TESTS=TestAccCodeBuildFleet_ PKG=codebuild
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/codebuild/... -v -count 1 -parallel 20 -run='TestAccCodeBuildFleet_'  -timeout 360m
=== RUN   TestAccCodeBuildFleet_basic
=== PAUSE TestAccCodeBuildFleet_basic
=== RUN   TestAccCodeBuildFleet_disappears
=== PAUSE TestAccCodeBuildFleet_disappears
=== RUN   TestAccCodeBuildFleet_tags
=== PAUSE TestAccCodeBuildFleet_tags
=== RUN   TestAccCodeBuildFleet_updateBasicParameters
=== PAUSE TestAccCodeBuildFleet_updateBasicParameters
=== RUN   TestAccCodeBuildFleet_updateScalingConfiguration
=== PAUSE TestAccCodeBuildFleet_updateScalingConfiguration
=== CONT  TestAccCodeBuildFleet_basic
=== CONT  TestAccCodeBuildFleet_updateBasicParameters
=== CONT  TestAccCodeBuildFleet_tags
=== CONT  TestAccCodeBuildFleet_updateScalingConfiguration
=== CONT  TestAccCodeBuildFleet_disappears
--- PASS: TestAccCodeBuildFleet_updateBasicParameters (189.50s)
--- PASS: TestAccCodeBuildFleet_basic (3723.52s)
--- PASS: TestAccCodeBuildFleet_updateScalingConfiguration (3780.94s)
--- PASS: TestAccCodeBuildFleet_tags (3786.34s)
--- PASS: TestAccCodeBuildFleet_disappears (3807.02s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codebuild  3812.976s
```

`Data source tests:`

```console
% make testacc TESTS=TestAccCodeBuildFleetDataSource_basic PKG=codebuild
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/codebuild/... -v -count 1 -parallel 20 -run='TestAccCodeBuildFleetDataSource_basic'  -timeout 360m
=== RUN   TestAccCodeBuildFleetDataSource_basic
=== PAUSE TestAccCodeBuildFleetDataSource_basic
=== CONT  TestAccCodeBuildFleetDataSource_basic
--- PASS: TestAccCodeBuildFleetDataSource_basic (3740.92s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codebuild  3746.811s
```

`Integration with CodeBuild project tests:`

```console
%make testacc TESTS=TestAccCodeBuildProject_fleet PKG=codebuild
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/codebuild/... -v -count 1 -parallel 20 -run='TestAccCodeBuildProject_fleet'  -timeout 360m
=== RUN   TestAccCodeBuildProject_fleet
=== PAUSE TestAccCodeBuildProject_fleet
=== CONT  TestAccCodeBuildProject_fleet
--- PASS: TestAccCodeBuildProject_fleet (3772.54s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codebuild  3778.661s
```

