### PR TITLE
fix: add af-south-1 registry id for sagemaker prebuilt ECR image data source

### DIFF
--- a/.changelog/36803.txt
+++ b/.changelog/36803.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_sagemaker_prebuilt_ecr_image: Add `registry_id` for `af-south-1` AWS Region
+```

--- a/internal/service/sagemaker/prebuilt_ecr_image_data_source.go
+++ b/internal/service/sagemaker/prebuilt_ecr_image_data_source.go
@@ -260,6 +260,7 @@ var PrebuiltECRImageIDByRegion_sparkML = map[string]string{
 // https://github.com/aws/sagemaker-tensorflow-serving-container
 
 var prebuiltECRImageIDByRegion_deepLearning = map[string]string{
+	endpoints.AfSouth1RegionID:     "626614931356",
 	endpoints.ApEast1RegionID:      "871362719292",
 	endpoints.ApNortheast1RegionID: "763104351884",
 	endpoints.ApNortheast2RegionID: "763104351884",


### PR DESCRIPTION
### Description
The `prebuiltECRImageIDByRegion_deepLearning` map is missing the account-id / registry-id for the `af-south-1` (South Africa) region. This PR adds that missing account-id to ensure we avoid below error on `af-south-1`:
```
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: no registry ID available for region (af-south-1) and repository (huggingface-pytorch-inference)
│ 
│   with data.aws_sagemaker_prebuilt_ecr_image.deploy_image[0],
│   on main.tf line 29, in data "aws_sagemaker_prebuilt_ecr_image" "deploy_image":
│   29: data "aws_sagemaker_prebuilt_ecr_image" "deploy_image" {
│ 
╵
exit status 1
```

### References
https://docs.aws.amazon.com/sagemaker/latest/dg-ecr-paths/ecr-af-south-1.html#huggingface-af-south-1.title
https://github.com/aws/deep-learning-containers/blob/master/available_images.md

### Output from Acceptance Testing
```console
% make testacc TESTS=TestAccSageMakerPrebuiltECRImageDataSource_basic PKG=sagemaker
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/sagemaker/... -v -count 1 -parallel 20 -run='TestAccSageMakerPrebuiltECRImageDataSource_basic'  -timeout 360m
=== RUN   TestAccSageMakerPrebuiltECRImageDataSource_basic
=== PAUSE TestAccSageMakerPrebuiltECRImageDataSource_basic
=== CONT  TestAccSageMakerPrebuiltECRImageDataSource_basic
--- PASS: TestAccSageMakerPrebuiltECRImageDataSource_basic (9.37s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker  13.078s
% make testacc TESTS=TestAccSageMakerPrebuiltECRImageDataSource_region PKG=sagemaker
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/sagemaker/... -v -count 1 -parallel 20 -run='TestAccSageMakerPrebuiltECRImageDataSource_region'  -timeout 360m
=== RUN   TestAccSageMakerPrebuiltECRImageDataSource_region
=== PAUSE TestAccSageMakerPrebuiltECRImageDataSource_region
=== CONT  TestAccSageMakerPrebuiltECRImageDataSource_region
--- PASS: TestAccSageMakerPrebuiltECRImageDataSource_region (9.11s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker  12.690s
```
