### PR TITLE
r/aws_devopsguru_notification_channel: fix filters persistent diff

### DIFF
--- a/.changelog/36804.txt
+++ b/.changelog/36804.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_devopsguru_notification_channel: Fix persistent diff when `filters.message_types` or `filters.severities` contains multiple elements
+```

--- a/internal/service/devopsguru/notification_channel.go
+++ b/internal/service/devopsguru/notification_channel.go
@@ -11,11 +11,12 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/devopsguru"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/devopsguru/types"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -60,28 +61,28 @@ func (r *resourceNotificationChannel) Schema(ctx context.Context, req resource.S
 				},
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
-						"message_types": schema.ListAttribute{
+						"message_types": schema.SetAttribute{
 							Optional:    true,
-							CustomType:  fwtypes.ListOfStringType,
+							CustomType:  fwtypes.SetOfStringType,
 							ElementType: types.StringType,
-							PlanModifiers: []planmodifier.List{
-								listplanmodifier.RequiresReplace(),
+							PlanModifiers: []planmodifier.Set{
+								setplanmodifier.RequiresReplace(),
 							},
-							Validators: []validator.List{
-								listvalidator.ValueStringsAre(
+							Validators: []validator.Set{
+								setvalidator.ValueStringsAre(
 									enum.FrameworkValidate[awstypes.NotificationMessageType](),
 								),
 							},
 						},
-						"severities": schema.ListAttribute{
+						"severities": schema.SetAttribute{
 							Optional:    true,
-							CustomType:  fwtypes.ListOfStringType,
+							CustomType:  fwtypes.SetOfStringType,
 							ElementType: types.StringType,
-							PlanModifiers: []planmodifier.List{
-								listplanmodifier.RequiresReplace(),
+							PlanModifiers: []planmodifier.Set{
+								setplanmodifier.RequiresReplace(),
 							},
-							Validators: []validator.List{
-								listvalidator.ValueStringsAre(
+							Validators: []validator.Set{
+								setvalidator.ValueStringsAre(
 									enum.FrameworkValidate[awstypes.InsightSeverity](),
 								),
 							},
@@ -241,8 +242,8 @@ type resourceNotificationChannelData struct {
 }
 
 type filtersData struct {
-	MessageTypes fwtypes.ListValueOf[types.String] `tfsdk:"message_types"`
-	Severities   fwtypes.ListValueOf[types.String] `tfsdk:"severities"`
+	MessageTypes fwtypes.SetValueOf[types.String] `tfsdk:"message_types"`
+	Severities   fwtypes.SetValueOf[types.String] `tfsdk:"severities"`
 }
 
 type snsData struct {

--- a/internal/service/devopsguru/notification_channel_test.go
+++ b/internal/service/devopsguru/notification_channel_test.go
@@ -91,7 +91,6 @@ func testAccNotificationChannel_filters(t *testing.T) {
 	resourceName := "aws_devopsguru_notification_channel.test"
 	snsTopicResourceName := "aws_sns_topic.test"
 	messageType := string(types.NotificationMessageTypeNewInsight)
-	severity := string(types.InsightSeverityHigh)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -104,7 +103,7 @@ func testAccNotificationChannel_filters(t *testing.T) {
 		CheckDestroy:             testAccCheckNotificationChannelDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNotificationChannelConfig_filters(rName, messageType, severity),
+				Config: testAccNotificationChannelConfig_filters(rName, messageType),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotificationChannelExists(ctx, resourceName, &channel),
 					resource.TestCheckResourceAttr(resourceName, "sns.#", "1"),
@@ -112,8 +111,7 @@ func testAccNotificationChannel_filters(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "filters.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "filters.0.message_types.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "filters.0.message_types.0", messageType),
-					resource.TestCheckResourceAttr(resourceName, "filters.0.severities.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "filters.0.severities.0", severity),
+					resource.TestCheckResourceAttr(resourceName, "filters.0.severities.#", "3"),
 				),
 			},
 			{
@@ -187,7 +185,7 @@ resource "aws_devopsguru_notification_channel" "test" {
 `, rName)
 }
 
-func testAccNotificationChannelConfig_filters(rName, messageType, severity string) string {
+func testAccNotificationChannelConfig_filters(rName, messageType string) string {
 	return fmt.Sprintf(`
 resource "aws_sns_topic" "test" {
   name = %[1]q
@@ -200,8 +198,8 @@ resource "aws_devopsguru_notification_channel" "test" {
 
   filters {
     message_types = [%[2]q]
-    severities    = [%[3]q]
+    severities    = ["LOW", "MEDIUM", "HIGH"]
   }
 }
-`, rName, messageType, severity)
+`, rName, messageType)
 }


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This changes the type of the `filters.message_types` and `filters.severities` arguments to `TypeSet`, preventing persistent differences when the AWS API returns elements in a different order than they were sent.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->
Depends on #36789 
Closes #36731


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->


```console
% make testacc PKG=devopsguru TESTS=TestAccDevOpsGuru_serial/NotificationChannel/
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/devopsguru/... -v -count 1 -parallel 20 -run='TestAccDevOpsGuru_serial/NotificationChannel/'  -timeout 360m

--- PASS: TestAccDevOpsGuru_serial (48.85s)
    --- PASS: TestAccDevOpsGuru_serial/NotificationChannel (37.73s)
        --- PASS: TestAccDevOpsGuru_serial/NotificationChannel/disappears (12.13s)
        --- PASS: TestAccDevOpsGuru_serial/NotificationChannel/filters (12.83s)
        --- PASS: TestAccDevOpsGuru_serial/NotificationChannel/basic (12.77s)
    --- PASS: TestAccDevOpsGuru_serial/NotificationChannelDataSource (11.12s)
        --- PASS: TestAccDevOpsGuru_serial/NotificationChannelDataSource/basic (11.12s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/devopsguru 54.578s
```
