### PR TITLE
Updated docs for aws_apigatewayv2_route_response

### DIFF
--- a/website/docs/r/apigatewayv2_route_response.html.markdown
+++ b/website/docs/r/apigatewayv2_route_response.html.markdown
@@ -55,3 +55,8 @@ Using `terraform import`, import `aws_apigatewayv2_route_response` using the API
 ```console
 % terraform import aws_apigatewayv2_route_response.example aabbccddee/1122334/998877
 ```
+
+## Enable Two-Way Communication
+For websocket routes that require two-way communication enabled, a `aws_apigatewayv2_route_response` needs to be added to the route with `route_response_key = "$default"`. More information available  is available in [Amazon API Gateway Developer Guide](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api.html).
+
+>You can only define the $default route response for WebSocket APIs. You can use an integration response to manipulate the response from a backend service. For more information, see (Overview of integration responses)[https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-integration-responses.html#apigateway-websocket-api-integration-response-overview].

--- a/website/docs/r/apigatewayv2_route_response.html.markdown
+++ b/website/docs/r/apigatewayv2_route_response.html.markdown
@@ -57,6 +57,7 @@ Using `terraform import`, import `aws_apigatewayv2_route_response` using the API
 ```
 
 ## Enable Two-Way Communication
+
 For websocket routes that require two-way communication enabled, a `aws_apigatewayv2_route_response` needs to be added to the route with `route_response_key = "$default"`. More information available  is available in [Amazon API Gateway Developer Guide](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api.html).
 
 >You can only define the $default route response for WebSocket APIs. You can use an integration response to manipulate the response from a backend service. For more information, see (Overview of integration responses)[https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-integration-responses.html#apigateway-websocket-api-integration-response-overview].

--- a/website/docs/r/apigatewayv2_route_response.html.markdown
+++ b/website/docs/r/apigatewayv2_route_response.html.markdown
@@ -23,6 +23,12 @@ resource "aws_apigatewayv2_route_response" "example" {
 }
 ```
 
+## Enabling Two-Way Communication
+
+For websocket routes that require two-way communication enabled, an `aws_apigatewayv2_route_response` needs to be added to the route with `route_response_key = "$default"`. More information available  is available in [Amazon API Gateway Developer Guide](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api.html).
+
+You can only define the $default route response for WebSocket APIs. You can use an integration response to manipulate the response from a backend service. For more information, see [Overview of integration responses](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-integration-responses.html#apigateway-websocket-api-integration-response-overview).
+
 ## Argument Reference
 
 This resource supports the following arguments:
@@ -55,9 +61,3 @@ Using `terraform import`, import `aws_apigatewayv2_route_response` using the API
 ```console
 % terraform import aws_apigatewayv2_route_response.example aabbccddee/1122334/998877
 ```
-
-## Enable Two-Way Communication
-
-For websocket routes that require two-way communication enabled, a `aws_apigatewayv2_route_response` needs to be added to the route with `route_response_key = "$default"`. More information available  is available in [Amazon API Gateway Developer Guide](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api.html).
-
->You can only define the $default route response for WebSocket APIs. You can use an integration response to manipulate the response from a backend service. For more information, see (Overview of integration responses)[https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-integration-responses.html#apigateway-websocket-api-integration-response-overview].


### PR DESCRIPTION
### Description
Including information in docs for enabling two-way communication. Current AWS implementation requires specific inputs that aren't clear from terraform arguments.

### Relations
Closes #36711


### References
(Overview of integration responses)[https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-integration-responses.html#apigateway-websocket-api-integration-response-overview]