### PR TITLE
internal/framework/flex(test): fix race condition

### DIFF
--- a/internal/framework/flex/auto_expand_test.go
+++ b/internal/framework/flex/auto_expand_test.go
@@ -738,9 +738,6 @@ func TestExpandListOfStringEnum(t *testing.T) {
 	var testEnumFoo testEnum = "foo"
 	var testEnumBar testEnum = "bar"
 
-	var testEnums []testEnum
-	testEnumsWant := []testEnum{testEnumFoo, testEnumBar}
-
 	ctx := context.Background()
 	testCases := autoFlexTestCases{
 		{
@@ -749,20 +746,20 @@ func TestExpandListOfStringEnum(t *testing.T) {
 				types.StringValue(string(testEnumFoo)),
 				types.StringValue(string(testEnumBar)),
 			}),
-			Target:     &testEnums,
-			WantTarget: &testEnumsWant,
+			Target:     &[]testEnum{},
+			WantTarget: &[]testEnum{testEnumFoo, testEnumBar},
 		},
 		{
 			TestName:   "empty value",
 			Source:     types.ListValueMust(types.StringType, []attr.Value{}),
-			Target:     &testEnums,
-			WantTarget: &testEnums,
+			Target:     &[]testEnum{},
+			WantTarget: &[]testEnum{},
 		},
 		{
 			TestName:   "null value",
 			Source:     types.ListNull(types.StringType),
-			Target:     &testEnums,
-			WantTarget: &testEnums,
+			Target:     &[]testEnum{},
+			WantTarget: &[]testEnum{},
 		},
 	}
 	runAutoExpandTestCases(ctx, t, testCases)
@@ -775,9 +772,6 @@ func TestExpandSetOfStringEnum(t *testing.T) {
 	var testEnumFoo testEnum = "foo"
 	var testEnumBar testEnum = "bar"
 
-	var testEnums []testEnum
-	testEnumsWant := []testEnum{testEnumFoo, testEnumBar}
-
 	ctx := context.Background()
 	testCases := autoFlexTestCases{
 		{
@@ -786,20 +780,20 @@ func TestExpandSetOfStringEnum(t *testing.T) {
 				types.StringValue(string(testEnumFoo)),
 				types.StringValue(string(testEnumBar)),
 			}),
-			Target:     &testEnums,
-			WantTarget: &testEnumsWant,
+			Target:     &[]testEnum{},
+			WantTarget: &[]testEnum{testEnumFoo, testEnumBar},
 		},
 		{
 			TestName:   "empty value",
 			Source:     types.SetValueMust(types.StringType, []attr.Value{}),
-			Target:     &testEnums,
-			WantTarget: &testEnums,
+			Target:     &[]testEnum{},
+			WantTarget: &[]testEnum{},
 		},
 		{
 			TestName:   "null value",
 			Source:     types.SetNull(types.StringType),
-			Target:     &testEnums,
-			WantTarget: &testEnums,
+			Target:     &[]testEnum{},
+			WantTarget: &[]testEnum{},
 		},
 	}
 	runAutoExpandTestCases(ctx, t, testCases)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The `TestExpandSetOfStringEnum` and `TestExpandListOfStringEnum` tests both contained a race condition caused by re-use of a slice across test cases. This change initializes new slices for each case instead.

```console
% go test -race ./internal/framework/flex/... -run=TestExpandSetOfStringEnum
ok      github.com/hashicorp/terraform-provider-aws/internal/framework/flex     1.632s
```

```console
% go test -race ./internal/framework/flex/... -run=TestExpandListOfStringEnum
ok      github.com/hashicorp/terraform-provider-aws/internal/framework/flex     1.483s
```


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Fixes #36832
Relates #36789 


