### PR TITLE
d/wafv2_web_acl: Update default action docs

### DIFF
--- a/website/docs/r/wafv2_web_acl.html.markdown
+++ b/website/docs/r/wafv2_web_acl.html.markdown
@@ -452,7 +452,7 @@ Each `custom_response_body` block supports the following arguments:
 
 The `default_action` block supports the following arguments:
 
-~> **Note** One of `allow` or `block`, expressed as an empty configuration block `{}`, is required when specifying a `default_action`
+~> **Note** One of `allow` or `block` is required when specifying a `default_action`
 
 * `allow` - (Optional) Specifies that AWS WAF should allow requests by default. See [`allow`](#allow-block) below for details.
 * `block` - (Optional) Specifies that AWS WAF should block requests by default. See [`block`](#block-block) below for details.


### PR DESCRIPTION
### Description
In https://github.com/hashicorp/terraform-provider-aws/pull/19415 was added possibility to define [`custom_request_handling`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl#custom_request_handling) or [`custom_response`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl#custom_response) blocks for [`default_action`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl#default_action-block) in [`aws_wafv2_web_acl`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl) and for [`action`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_rule_group#action) in [`aws_wafv2_rule_group`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_rule_group) resource. 

Documentation note pointing that block/allow block should be empty was deleted for aws_wafv2_rule_group, but not for aws_wafv2_web_acl. This PR fixes docs


### Relations

Relates #19415