### PR TITLE
perf(lambda): fail fast on kms access denied error

### DIFF
--- a/internal/service/lambda/permission_test.go
+++ b/internal/service/lambda/permission_test.go
@@ -636,6 +636,23 @@ func TestAccLambdaPermission_iamRole(t *testing.T) {
 	})
 }
 
+func TestAccLambdaPermission_kms(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccPermissionConfig_kms(rName),
+				ExpectError: regexache.MustCompile(`KMSAccessDeniedException`),
+			},
+		},
+	})
+}
+
 func TestAccLambdaPermission_FunctionURLs_iam(t *testing.T) {
 	ctx := acctest.Context(t)
 	var statement tflambda.PolicyStatement
@@ -941,6 +958,94 @@ resource "aws_lambda_permission" "third" {
   principal     = "events.amazonaws.com"
 }
 `, funcName, roleName)
+}
+
+func testAccPermissionConfig_kms(rName string) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+data "aws_partition" "current" {}
+
+resource "aws_kms_key" "test" {
+  description             = %[1]q
+  deletion_window_in_days = 7
+
+  policy = jsonencode({
+    Id = %[1]q
+    Statement = [
+      {
+        Action = "kms:*"
+        Effect = "Allow"
+        Principal = {
+          AWS = data.aws_caller_identity.current.arn
+        }
+
+        Resource = "*"
+        Sid      = "Enable IAM User Permissions"
+      },
+	  {
+		  "Sid": "DenyAllExceptRoot",
+		  "Effect": "Deny",
+		  "Principal": "*",
+		  "Action": "kms:Decrypt",
+		  "Resource": "*"
+	  }
+    ]
+    Version = "2012-10-17"
+  })
+}
+
+resource "aws_lambda_function" "test" {
+  filename      = "test-fixtures/lambdatest.zip"
+  function_name = %[1]q
+  role          = aws_iam_role.test.arn
+  kms_key_arn   = aws_kms_key.test.arn
+  handler       = "exports.handler"
+  runtime       = "nodejs16.x"
+  environment {
+    variables = {
+      foo = "bar"
+    }
+  }
+}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "execution_policy" {
+  role       = aws_iam_role.test.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+data "aws_lambda_invocation" "test" {
+  function_name = aws_lambda_function.test.function_name
+
+  input = <<JSON
+{}
+JSON
+}
+
+output "result_entry" {
+  value = jsondecode(data.aws_lambda_invocation.test.result)
+}
+	`, rName)
 }
 
 func testAccPermissionConfig_s3(rName string) string {

--- a/internal/service/lambda/service_package_extra.go
+++ b/internal/service/lambda/service_package_extra.go
@@ -1,0 +1,25 @@
+package lambda
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws/request"
+	lambda_sdkv1 "github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+)
+
+// Customize lambda retries.
+//
+// References:
+//
+// https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/retries-and-waiters.md
+func (p *servicePackage) CustomizeConn(ctx context.Context, conn *lambda_sdkv1.Lambda) (*lambda_sdkv1.Lambda, error) {
+	conn.Handlers.Retry.PushBack(func(r *request.Request) {
+		if tfawserr.ErrMessageContains(r.Error, lambda_sdkv1.ErrCodeKMSAccessDeniedException,
+			"Lambda was unable to decrypt the environment variables because KMS access was denied.") {
+			// Do not retry this condition at all.
+			r.RetryCount = r.MaxRetries() + 1
+		}
+	})
+	return conn, nil
+}


### PR DESCRIPTION
This is related to #6352 which was closed by a documentation update. When this error is encountered (e.g. with a `aws_lambda_invocation` data source) it can take a long time for the apply operation to fail since it will continue to retry the operation until the default retries are exhausted.

This PR introduces a custom retry handler where we will not retry the `KMS access denied` error message.

As an example, I ran the acceptance test without the custom retry logic and the test took `3885` seconds (64 minutes) to run.

```console
% make testacc TESTS=TestAccLambdaPermission_kms PKG=lambda
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaPermission_kms'  -timeout 360m
=== RUN   TestAccLambdaPermission_kms
=== PAUSE TestAccLambdaPermission_kms
=== CONT  TestAccLambdaPermission_kms
--- PASS: TestAccLambdaPermission_kms (3885.93s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     3889.612s
```

With the custom retry logic it took `16` seconds to run.

```console
% make testacc TESTS=TestAccLambdaPermission_kms PKG=lambda
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaPermission_kms'  -timeout 360m
=== RUN   TestAccLambdaPermission_kms
=== PAUSE TestAccLambdaPermission_kms
=== CONT  TestAccLambdaPermission_kms
--- PASS: TestAccLambdaPermission_kms (16.51s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     20.039s
```

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #6352.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/29847.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccLambdaPermission_kms PKG=lambda
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaPermission_kms'  -timeout 360m
=== RUN   TestAccLambdaPermission_kms
=== PAUSE TestAccLambdaPermission_kms
=== CONT  TestAccLambdaPermission_kms
--- PASS: TestAccLambdaPermission_kms (16.51s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     20.039s
```
