### PR TITLE
r/aws_redshift_logging: new resource 

### DIFF
--- a/.changelog/36862.txt
+++ b/.changelog/36862.txt
@@ -1,0 +1,6 @@
+```release-note:new-resource
+aws_redshift_logging
+```
+```release-note:note
+resource/aws_redshift_cluster: The `logging` argument is now deprecated. Use the `aws_redshift_logging` resource instead.
+```

--- a/internal/service/redshift/cluster.go
+++ b/internal/service/redshift/cluster.go
@@ -224,6 +224,7 @@ func ResourceCluster() *schema.Resource {
 				Type:             schema.TypeList,
 				MaxItems:         1,
 				Optional:         true,
+				Computed:         true,
 				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/internal/service/redshift/cluster.go
+++ b/internal/service/redshift/cluster.go
@@ -221,7 +221,9 @@ func ResourceCluster() *schema.Resource {
 				ValidateFunc: verify.ValidARN,
 			},
 			"logging": {
-				Type:             schema.TypeList,
+				Type: schema.TypeList,
+				Deprecated: "Use the aws_redshift_logging resource instead. " +
+					"This argument will be removed in a future major version.",
 				MaxItems:         1,
 				Optional:         true,
 				Computed:         true,

--- a/internal/service/redshift/exports_test.go
+++ b/internal/service/redshift/exports_test.go
@@ -7,9 +7,11 @@ package redshift
 var (
 	ResourceDataShareAuthorization       = newResourceDataShareAuthorization
 	ResourceDataShareConsumerAssociation = newResourceDataShareConsumerAssociation
+	ResourceLogging                      = newResourceLogging
 	ResourceSnapshotCopy                 = newResourceSnapshotCopy
 
 	FindDataShareAuthorizationByID       = findDataShareAuthorizationByID
 	FindDataShareConsumerAssociationByID = findDataShareConsumerAssociationByID
+	FindLoggingByID                      = findLoggingByID
 	FindSnapshotCopyByID                 = findSnapshotCopyByID
 )

--- a/internal/service/redshift/logging.go
+++ b/internal/service/redshift/logging.go
@@ -1,0 +1,298 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package redshift
+
+import (
+	"context"
+	"errors"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/redshift"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/redshift/types"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource(name="Logging")
+func newResourceLogging(_ context.Context) (resource.ResourceWithConfigure, error) {
+	return &resourceLogging{}, nil
+}
+
+const (
+	ResNameLogging = "Logging"
+)
+
+type resourceLogging struct {
+	framework.ResourceWithConfigure
+}
+
+func (r *resourceLogging) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "aws_redshift_logging"
+}
+
+func (r *resourceLogging) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"bucket_name": schema.StringAttribute{
+				Optional: true,
+			},
+			"cluster_identifier": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"id": framework.IDAttribute(),
+			"log_destination_type": schema.StringAttribute{
+				Optional:   true,
+				CustomType: fwtypes.StringEnumType[awstypes.LogDestinationType](),
+			},
+			"log_exports": schema.SetAttribute{
+				Optional:    true,
+				CustomType:  fwtypes.SetOfStringType,
+				ElementType: types.StringType,
+				Validators: []validator.Set{
+					setvalidator.ValueStringsAre(
+						enum.FrameworkValidate[LogExports](),
+					),
+				},
+			},
+			"s3_key_prefix": schema.StringAttribute{
+				Optional: true,
+			},
+		},
+	}
+}
+
+func (r *resourceLogging) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().RedshiftClient(ctx)
+
+	var plan resourceLoggingData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	plan.ID = types.StringValue(plan.ClusterIdentifier.ValueString())
+
+	in := &redshift.EnableLoggingInput{}
+	resp.Diagnostics.Append(flex.Expand(ctx, plan, in)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Retry InvalidClusterState faults, which can occur when logging is enabled
+	// immediately after being disabled (ie. resource replacement).
+	out, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidClusterStateFault](ctx, propagationTimeout,
+		func() (interface{}, error) {
+			return conn.EnableLogging(ctx, in)
+		},
+		"There is an operation running on the Cluster",
+	)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.Redshift, create.ErrActionCreating, ResNameLogging, plan.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+	if out == nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.Redshift, create.ErrActionCreating, ResNameLogging, plan.ID.String(), nil),
+			errors.New("empty output").Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *resourceLogging) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().RedshiftClient(ctx)
+
+	var state resourceLoggingData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := findLoggingByID(ctx, conn, state.ID.ValueString())
+	if tfresource.NotFound(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.Redshift, create.ErrActionSetting, ResNameLogging, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	// LogDestinationType is not returned correctly from the DescribeLoggingStatus API when
+	// the type is "s3". Set attributes individually (rather than with AutoFlex) and skip setting
+	// log_destination_type to avoid persistent differences.
+	state.BucketName = flex.StringToFramework(ctx, out.BucketName)
+	state.S3KeyPrefix = flex.StringToFramework(ctx, out.S3KeyPrefix)
+	resp.Diagnostics.Append(flex.Flatten(ctx, out.LogExports, &state.LogExports)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *resourceLogging) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	conn := r.Meta().RedshiftClient(ctx)
+
+	var plan, state resourceLoggingData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !plan.BucketName.Equal(state.BucketName) ||
+		!plan.LogDestinationType.Equal(state.LogDestinationType) ||
+		!plan.LogExports.Equal(state.LogExports) ||
+		!plan.S3KeyPrefix.Equal(state.S3KeyPrefix) {
+		in := &redshift.EnableLoggingInput{}
+		resp.Diagnostics.Append(flex.Expand(ctx, plan, in)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		// Retry InvalidClusterState faults, which can occur when logging is enabled
+		// immediately after being disabled (ie. resource replacement).
+		out, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidClusterStateFault](ctx, propagationTimeout,
+			func() (interface{}, error) {
+				return conn.EnableLogging(ctx, in)
+			},
+			"There is an operation running on the Cluster",
+		)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.Redshift, create.ErrActionUpdating, ResNameLogging, plan.ID.String(), err),
+				err.Error(),
+			)
+			return
+		}
+		if out == nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.Redshift, create.ErrActionUpdating, ResNameLogging, plan.ID.String(), nil),
+				errors.New("empty output").Error(),
+			)
+			return
+		}
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *resourceLogging) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	conn := r.Meta().RedshiftClient(ctx)
+
+	var state resourceLoggingData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := &redshift.DisableLoggingInput{
+		ClusterIdentifier: aws.String(state.ID.ValueString()),
+	}
+
+	// Retry InvalidClusterState faults, which can occur when logging is being enabled.
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidClusterStateFault](ctx, propagationTimeout,
+		func() (interface{}, error) {
+			return conn.DisableLogging(ctx, in)
+		},
+		"There is an operation running on the Cluster",
+	)
+	if err != nil {
+		if errs.IsA[*awstypes.ClusterNotFoundFault](err) {
+			return
+		}
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.Redshift, create.ErrActionDeleting, ResNameLogging, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+}
+
+func (r *resourceLogging) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("cluster_identifier"), req.ID)...)
+}
+
+func findLoggingByID(ctx context.Context, conn *redshift.Client, id string) (*redshift.DescribeLoggingStatusOutput, error) {
+	in := &redshift.DescribeLoggingStatusInput{
+		ClusterIdentifier: aws.String(id),
+	}
+
+	out, err := conn.DescribeLoggingStatus(ctx, in)
+	if err != nil {
+		if errs.IsA[*awstypes.ClusterNotFoundFault](err) {
+			return nil, &retry.NotFoundError{
+				LastError:   err,
+				LastRequest: in,
+			}
+		}
+
+		return nil, err
+	}
+
+	if out == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+	if !aws.ToBool(out.LoggingEnabled) {
+		return nil, &retry.NotFoundError{
+			LastError:   errors.New("logging not enabled"),
+			LastRequest: in,
+		}
+	}
+
+	return out, nil
+}
+
+type resourceLoggingData struct {
+	BucketName         types.String                                    `tfsdk:"bucket_name"`
+	ClusterIdentifier  types.String                                    `tfsdk:"cluster_identifier"`
+	ID                 types.String                                    `tfsdk:"id"`
+	LogDestinationType fwtypes.StringEnum[awstypes.LogDestinationType] `tfsdk:"log_destination_type"`
+	LogExports         fwtypes.SetValueOf[types.String]                `tfsdk:"log_exports"`
+	S3KeyPrefix        types.String                                    `tfsdk:"s3_key_prefix"`
+}
+
+// This enum should be defined in the AWS SDK, but is missing.
+//
+// See the Redshift documentation for valid values.
+// https://docs.aws.amazon.com/redshift/latest/APIReference/API_EnableLogging.html
+type LogExports string
+
+// Enum values for LogExports
+const (
+	LogExportsConnectionLog   LogExports = "connectionlog"
+	LogExportsUserActivityLog LogExports = "useractivitylog"
+	LogExportsUserLog         LogExports = "userlog"
+)
+
+func (LogExports) Values() []LogExports {
+	return []LogExports{
+		LogExportsConnectionLog,
+		LogExportsUserActivityLog,
+		LogExportsUserLog,
+	}
+}

--- a/internal/service/redshift/logging_test.go
+++ b/internal/service/redshift/logging_test.go
@@ -1,0 +1,298 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package redshift_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/redshift"
+	"github.com/aws/aws-sdk-go-v2/service/redshift/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	tfredshift "github.com/hashicorp/terraform-provider-aws/internal/service/redshift"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccRedshiftLogging_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var log redshift.DescribeLoggingStatusOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_redshift_logging.test"
+	clusterResourceName := "aws_redshift_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.RedshiftEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.RedshiftServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLoggingDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoggingConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLoggingExists(ctx, resourceName, &log),
+					resource.TestCheckResourceAttrPair(resourceName, "cluster_identifier", clusterResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "log_destination_type", string(types.LogDestinationTypeCloudwatch)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"log_destination_type",
+				},
+			},
+		},
+	})
+}
+
+func TestAccRedshiftLogging_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var log redshift.DescribeLoggingStatusOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_redshift_logging.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.RedshiftEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.RedshiftServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLoggingDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoggingConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLoggingExists(ctx, resourceName, &log),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfredshift.ResourceLogging, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccRedshiftLogging_disappears_Cluster(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var log redshift.DescribeLoggingStatusOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_redshift_logging.test"
+	clusterResourceName := "aws_redshift_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.RedshiftEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.RedshiftServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLoggingDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoggingConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLoggingExists(ctx, resourceName, &log),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfredshift.ResourceCluster(), clusterResourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccRedshiftLogging_s3(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var log redshift.DescribeLoggingStatusOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_redshift_logging.test"
+	clusterResourceName := "aws_redshift_cluster.test"
+	bucketResourceName := "aws_s3_bucket.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.RedshiftEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.RedshiftServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLoggingDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoggingConfig_s3(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLoggingExists(ctx, resourceName, &log),
+					resource.TestCheckResourceAttrPair(resourceName, "cluster_identifier", clusterResourceName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "bucket_name", bucketResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "log_destination_type", string(types.LogDestinationTypeS3)),
+					resource.TestCheckResourceAttr(resourceName, "s3_key_prefix", "testprefix/"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"log_destination_type",
+				},
+			},
+		},
+	})
+}
+
+func testAccCheckLoggingDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).RedshiftClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_redshift_logging" {
+				continue
+			}
+
+			_, err := tfredshift.FindLoggingByID(ctx, conn, rs.Primary.ID)
+			if errs.IsA[*retry.NotFoundError](err) {
+				return nil
+			}
+			if err != nil {
+				return create.Error(names.Redshift, create.ErrActionCheckingDestroyed, tfredshift.ResNameLogging, rs.Primary.ID, err)
+			}
+
+			return create.Error(names.Redshift, create.ErrActionCheckingDestroyed, tfredshift.ResNameLogging, rs.Primary.ID, errors.New("not destroyed"))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckLoggingExists(ctx context.Context, name string, log *redshift.DescribeLoggingStatusOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.Redshift, create.ErrActionCheckingExistence, tfredshift.ResNameLogging, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.Redshift, create.ErrActionCheckingExistence, tfredshift.ResNameLogging, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).RedshiftClient(ctx)
+		out, err := tfredshift.FindLoggingByID(ctx, conn, rs.Primary.ID)
+		if err != nil {
+			return create.Error(names.Redshift, create.ErrActionCheckingExistence, tfredshift.ResNameLogging, rs.Primary.ID, err)
+		}
+
+		*log = *out
+
+		return nil
+	}
+}
+
+func testAccLoggingConfigBase(rName string) string {
+	return acctest.ConfigCompose(
+		// "InvalidVPCNetworkStateFault: The requested AZ us-west-2a is not a valid AZ."
+		acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"),
+		fmt.Sprintf(`
+resource "aws_redshift_cluster" "test" {
+  cluster_identifier                  = %[1]q
+  availability_zone                   = data.aws_availability_zones.available.names[0]
+  database_name                       = "mydb"
+  master_username                     = "foo_test"
+  master_password                     = "Mustbe8characters"
+  multi_az                            = false
+  node_type                           = "dc2.large"
+  automated_snapshot_retention_period = 0
+  allow_version_upgrade               = false
+  skip_final_snapshot                 = true
+}
+`, rName))
+}
+
+func testAccLoggingConfig_basic(rName string) string {
+	return acctest.ConfigCompose(
+		testAccLoggingConfigBase(rName),
+		`
+resource "aws_redshift_logging" "test" {
+  cluster_identifier   = aws_redshift_cluster.test.id
+  log_destination_type = "cloudwatch"
+  log_exports          = ["connectionlog", "useractivitylog", "userlog"]
+}
+`)
+}
+
+func testAccLoggingConfig_s3(rName string) string {
+	return acctest.ConfigCompose(
+		testAccLoggingConfigBase(rName),
+		fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_s3_bucket" "test" {
+  bucket        = %[1]q
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_policy" "test" {
+  bucket = aws_s3_bucket.test.id
+  policy = <<EOF
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "redshift.${data.aws_partition.current.dns_suffix}"
+      },
+      "Action": "s3:PutObject",
+      "Resource": "arn:${data.aws_partition.current.partition}:s3:::${aws_s3_bucket.test.id}/*"
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "redshift.${data.aws_partition.current.dns_suffix}"
+      },
+      "Action": "s3:GetBucketAcl",
+      "Resource": "arn:${data.aws_partition.current.partition}:s3:::${aws_s3_bucket.test.id}"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_redshift_logging" "test" {
+  depends_on = [aws_s3_bucket_policy.test]
+
+  cluster_identifier   = aws_redshift_cluster.test.id
+  bucket_name          = aws_s3_bucket.test.id
+  s3_key_prefix        = "testprefix/"
+  log_destination_type = "s3"
+}
+`, rName))
+}

--- a/internal/service/redshift/logging_test.go
+++ b/internal/service/redshift/logging_test.go
@@ -49,6 +49,10 @@ func TestAccRedshiftLogging_basic(t *testing.T) {
 					testAccCheckLoggingExists(ctx, resourceName, &log),
 					resource.TestCheckResourceAttrPair(resourceName, "cluster_identifier", clusterResourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "log_destination_type", string(types.LogDestinationTypeCloudwatch)),
+					resource.TestCheckResourceAttr(resourceName, "log_exports.#", "3"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "log_exports.*", string(tfredshift.LogExportsConnectionLog)),
+					resource.TestCheckTypeSetElemAttr(resourceName, "log_exports.*", string(tfredshift.LogExportsUserActivityLog)),
+					resource.TestCheckTypeSetElemAttr(resourceName, "log_exports.*", string(tfredshift.LogExportsUserLog)),
 				),
 			},
 			{

--- a/internal/service/redshift/service_package_gen.go
+++ b/internal/service/redshift/service_package_gen.go
@@ -41,6 +41,10 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 			Name:    "Data Share Consumer Association",
 		},
 		{
+			Factory: newResourceLogging,
+			Name:    "Logging",
+		},
+		{
 			Factory: newResourceSnapshotCopy,
 			Name:    "Snapshot Copy",
 		},

--- a/website/docs/r/redshift_cluster.html.markdown
+++ b/website/docs/r/redshift_cluster.html.markdown
@@ -100,7 +100,7 @@ This resource supports the following arguments:
 * `snapshot_cluster_identifier` - (Optional) The name of the cluster the source snapshot was created from.
 * `owner_account` - (Optional) The AWS customer account used to create or copy the snapshot. Required if you are restoring a snapshot you do not own, optional if you own the snapshot.
 * `iam_roles` - (Optional) A list of IAM Role ARNs to associate with the cluster. A Maximum of 10 can be associated to the cluster at any time.
-* `logging` - (Optional) Logging, documented below.
+* `logging` - (Optional, **Deprecated**) Logging, documented below.
 * `maintenance_track_name` - (Optional) The name of the maintenance track for the restored cluster. When you take a snapshot, the snapshot inherits the MaintenanceTrack value from the cluster. The snapshot might be on a different track than the cluster that was the source for the snapshot. For example, suppose that you take a snapshot of  a cluster that is on the current track and then change the cluster to be on the trailing track. In this case, the snapshot and the source cluster are on different tracks. Default value is `current`.
 * `manual_snapshot_retention_period` - (Optional)  The default number of days to retain a manual snapshot. If the value is -1, the snapshot is retained indefinitely. This setting doesn't change the retention period of existing snapshots. Valid values are between `-1` and `3653`. Default value is `-1`.
 * `snapshot_copy` - (Optional, **Deprecated**) Configuration of automatic copy of snapshots from one region to another. Documented below.
@@ -109,6 +109,8 @@ This resource supports the following arguments:
 ### Nested Blocks
 
 #### `logging`
+
+~> The `logging` argument is deprecated. Use the [`aws_redshift_logging`](./redshift_logging.html.markdown) resource instead. This argument will be removed in a future major version.
 
 * `enable` - (Required) Enables logging information such as queries and connection attempts, for the specified Amazon Redshift cluster.
 * `bucket_name` - (Optional, required when `enable` is `true` and `log_destination_type` is `s3`) The name of an existing S3 bucket where the log files are to be stored. Must be in the same region as the cluster and the cluster must have read bucket and put object permissions.

--- a/website/docs/r/redshift_logging.html.markdown
+++ b/website/docs/r/redshift_logging.html.markdown
@@ -1,0 +1,69 @@
+---
+subcategory: "Redshift"
+layout: "aws"
+page_title: "AWS: aws_redshift_logging"
+description: |-
+  Terraform resource for managing an AWS Redshift Logging configuration.
+---
+# Resource: aws_redshift_logging
+
+Terraform resource for managing an AWS Redshift Logging configuration.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_redshift_logging" "example" {
+  cluster_identifier   = aws_redshift_cluster.example.id
+  log_destination_type = "cloudwatch"
+  log_exports          = ["connectionlog", "userlog"]
+}
+```
+
+### S3 Destination Type
+
+```terraform
+resource "aws_redshift_logging" "example" {
+  cluster_identifier   = aws_redshift_cluster.example.id
+  log_destination_type = "s3"
+  bucket_name          = aws_s3_bucket.example.id
+  s3_key_prefix        = "example-prefix/"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `cluster_identifier` - (Required) Identifier of the source cluster.
+
+The following arguments are optional:
+
+* `bucket_name` - (Optional) Name of an existing S3 bucket where the log files are to be stored. Required when `log_destination_type` is `s3`. Must be in the same region as the cluster and the cluster must have read bucket and put object permissions. For more information on the permissions required for the bucket, please read the AWS [documentation](http://docs.aws.amazon.com/redshift/latest/mgmt/db-auditing.html#db-auditing-enable-logging)
+* `log_destination_type` - (Optional) Log destination type. Valid values are `s3` and `cloudwatch`.
+* `log_exports` - (Optional) Collection of exported log types. Required when `log_destination_type` is `cloudwatch`. Valid values are `connectionlog`, `useractivitylog`, and `userlog`.
+* `s3_key_prefix` - (Optional) Prefix applied to the log file names.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `id` - Identifier of the source cluster.
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Redshift Logging using the `id`. For example:
+
+```terraform
+import {
+  to = aws_redshift_logging.example
+  id = "cluster-id-12345678"
+}
+```
+
+Using `terraform import`, import Redshift Logging using the `id`. For example:
+
+```console
+% terraform import aws_redshift_logging.example cluster-id-12345678
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This resource will allow practitioners to manage Amazon Redshift cluster logging configurations with Terraform. This standalone resource will replace the optional `logging` block within the `aws_redshift_cluster` resource, allowing logging configurations to be managed independent of the parent cluster.

The `logging` argument within the `aws_redshift_cluster` resource is now deprecated.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #36651

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/redshift/latest/APIReference/API_EnableLogging.html
- https://docs.aws.amazon.com/redshift/latest/APIReference/API_DisableLogging.html
- https://docs.aws.amazon.com/redshift/latest/APIReference/API_DescribeLoggingStatus.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=redshift TESTS=TestAccRedshiftLogging_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/redshift/... -v -count 1 -parallel 20 -run='TestAccRedshiftLogging_'  -timeout 360m

--- PASS: TestAccRedshiftLogging_disappears_Cluster (411.73s)
--- PASS: TestAccRedshiftLogging_basic (425.21s)
--- PASS: TestAccRedshiftLogging_disappears (437.79s)
--- PASS: TestAccRedshiftLogging_s3 (522.88s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/redshift   528.588s
```
