### PR TITLE
r/aws_dms_endpoint: fix `database_name` is ignored when `secrets_manager_arn` is set

### DIFF
--- a/internal/service/dms/endpoint.go
+++ b/internal/service/dms/endpoint.go
@@ -810,6 +810,7 @@ func resourceEndpointCreate(ctx context.Context, d *schema.ResourceData, meta in
 			input.MySQLSettings = &dms.MySQLSettings{
 				SecretsManagerAccessRoleArn: aws.String(d.Get("secrets_manager_access_role_arn").(string)),
 				SecretsManagerSecretId:      aws.String(d.Get("secrets_manager_arn").(string)),
+				DatabaseName:                aws.String(d.Get("database_name").(string)),
 			}
 		} else {
 			input.MySQLSettings = &dms.MySQLSettings{
@@ -1110,6 +1111,7 @@ func resourceEndpointUpdate(ctx context.Context, d *schema.ResourceData, meta in
 						input.MySQLSettings = &dms.MySQLSettings{
 							SecretsManagerAccessRoleArn: aws.String(d.Get("secrets_manager_access_role_arn").(string)),
 							SecretsManagerSecretId:      aws.String(d.Get("secrets_manager_arn").(string)),
+							DatabaseName:                aws.String(d.Get("database_name").(string)),
 						}
 					} else {
 						input.MySQLSettings = &dms.MySQLSettings{

--- a/internal/service/dms/endpoint_test.go
+++ b/internal/service/dms/endpoint_test.go
@@ -116,6 +116,40 @@ func TestAccDMSEndpoint_Aurora_secretID(t *testing.T) {
 	})
 }
 
+func TestAccDMSEndpoint_Aurora_updateSecretID(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_dms_endpoint.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEndpointDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEndpointConfig_auroraSecretID(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEndpointExists(ctx, resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "endpoint_arn"),
+				),
+			},
+			{
+				Config: testAccEndpointConfig_auroraUpdateSecretID(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEndpointExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "database_name", "tftest-new-database_name"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccDMSEndpoint_Aurora_update(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_endpoint.test"
@@ -1018,6 +1052,40 @@ func TestAccDMSEndpoint_MariaDB_secretID(t *testing.T) {
 	})
 }
 
+func TestAccDMSEndpoint_MariaDB_updateSecretID(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_dms_endpoint.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEndpointDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEndpointConfig_mariaDBSecretID(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEndpointExists(ctx, resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "endpoint_arn"),
+				),
+			},
+			{
+				Config: testAccEndpointConfig_mariaDBUpdateSecretID(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEndpointExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "database_name", "tftest-new-database_name"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccDMSEndpoint_MariaDB_update(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_endpoint.test"
@@ -1103,6 +1171,40 @@ func TestAccDMSEndpoint_MySQL_secretID(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointExists(ctx, resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "endpoint_arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccDMSEndpoint_MySQL_updateSecretID(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_dms_endpoint.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEndpointDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEndpointConfig_mySQLSecretID(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEndpointExists(ctx, resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "endpoint_arn"),
+				),
+			},
+			{
+				Config: testAccEndpointConfig_mySQLUpdateSecretID(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEndpointExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "database_name", "tftest-new-database_name"),
 				),
 			},
 			{
@@ -2424,11 +2526,31 @@ resource "aws_dms_endpoint" "test" {
   engine_name                     = "aurora"
   secrets_manager_access_role_arn = aws_iam_role.test.arn
   secrets_manager_arn             = aws_secretsmanager_secret.test.id
+  database_name                   = "tftest"
 
   tags = {
     Name   = %[1]q
     Update = "to-update"
     Remove = "to-remove"
+  }
+}
+`, rName))
+}
+
+func testAccEndpointConfig_auroraUpdateSecretID(rName string) string {
+	return acctest.ConfigCompose(testAccEndpointConfig_secretBase(rName), fmt.Sprintf(`
+resource "aws_dms_endpoint" "test" {
+  endpoint_id                     = %[1]q
+  endpoint_type                   = "source"
+  engine_name                     = "aurora"
+  secrets_manager_access_role_arn = aws_iam_role.test.arn
+  secrets_manager_arn             = aws_secretsmanager_secret.test.id
+  database_name                   = "tftest-new-database_name"
+
+  tags = {
+    Name   = %[1]q
+    Update = "updated"
+    Add    = "added"
   }
 }
 `, rName))
@@ -3679,11 +3801,31 @@ resource "aws_dms_endpoint" "test" {
   engine_name                     = "mariadb"
   secrets_manager_access_role_arn = aws_iam_role.test.arn
   secrets_manager_arn             = aws_secretsmanager_secret.test.id
+  database_name                   = "tftest"
 
   tags = {
     Name   = %[1]q
     Update = "to-update"
     Remove = "to-remove"
+  }
+}
+`, rName))
+}
+
+func testAccEndpointConfig_mariaDBUpdateSecretID(rName string) string {
+	return acctest.ConfigCompose(testAccEndpointConfig_secretBase(rName), fmt.Sprintf(`
+resource "aws_dms_endpoint" "test" {
+  endpoint_id                     = %[1]q
+  endpoint_type                   = "source"
+  engine_name                     = "mariadb"
+  secrets_manager_access_role_arn = aws_iam_role.test.arn
+  secrets_manager_arn             = aws_secretsmanager_secret.test.id
+  database_name                   = "tftest-new-database_name"
+
+  tags = {
+    Name   = %[1]q
+    Update = "updated"
+    Add    = "added"
   }
 }
 `, rName))
@@ -3743,11 +3885,31 @@ resource "aws_dms_endpoint" "test" {
   engine_name                     = "mysql"
   secrets_manager_access_role_arn = aws_iam_role.test.arn
   secrets_manager_arn             = aws_secretsmanager_secret.test.id
+  database_name                   = "tftest"
 
   tags = {
     Name   = %[1]q
     Update = "to-update"
     Remove = "to-remove"
+  }
+}
+`, rName))
+}
+
+func testAccEndpointConfig_mySQLUpdateSecretID(rName string) string {
+	return acctest.ConfigCompose(testAccEndpointConfig_secretBase(rName), fmt.Sprintf(`
+resource "aws_dms_endpoint" "test" {
+  endpoint_id                     = %[1]q
+  endpoint_type                   = "source"
+  engine_name                     = "mysql"
+  secrets_manager_access_role_arn = aws_iam_role.test.arn
+  secrets_manager_arn             = aws_secretsmanager_secret.test.id
+  database_name                   = "tftest-new-database_name"
+
+  tags = {
+    Name   = %[1]q
+    Update = "updated"
+    Add    = "added"
   }
 }
 `, rName))


### PR DESCRIPTION
### Description

The `database_name` is ignored when `engine_name` is `aurora`, `mariadb` or `mysql` and `secrets_manager_arn` is set.

This PR modifies to include `DatabaseName` parameter and adds tests for update `database_name` when `secrets_manager_arn` is set.

### Relations

Closes https://github.com/hashicorp/terraform-provider-aws/issues/36866

### References


### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccDMSEndpoint_\(Aurora\|MariaDB\|MySQL\)_\(updateS\|s\)ecretID PKG=dms

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/dms/... -v -count 1 -parallel 20 -run='TestAccDMSEndpoint_(Aurora|MariaDB|MySQL)_(updateS|s)ecretID'  -timeout 360m
=== RUN   TestAccDMSEndpoint_Aurora_secretID
=== PAUSE TestAccDMSEndpoint_Aurora_secretID
=== RUN   TestAccDMSEndpoint_Aurora_updateSecretID
=== PAUSE TestAccDMSEndpoint_Aurora_updateSecretID
=== RUN   TestAccDMSEndpoint_MariaDB_secretID
=== PAUSE TestAccDMSEndpoint_MariaDB_secretID
=== RUN   TestAccDMSEndpoint_MariaDB_updateSecretID
=== PAUSE TestAccDMSEndpoint_MariaDB_updateSecretID
=== RUN   TestAccDMSEndpoint_MySQL_secretID
=== PAUSE TestAccDMSEndpoint_MySQL_secretID
=== RUN   TestAccDMSEndpoint_MySQL_updateSecretID
=== PAUSE TestAccDMSEndpoint_MySQL_updateSecretID
=== CONT  TestAccDMSEndpoint_Aurora_secretID
=== CONT  TestAccDMSEndpoint_MariaDB_updateSecretID
=== CONT  TestAccDMSEndpoint_MySQL_updateSecretID
=== CONT  TestAccDMSEndpoint_MariaDB_secretID
=== CONT  TestAccDMSEndpoint_Aurora_updateSecretID
=== CONT  TestAccDMSEndpoint_MySQL_secretID
--- PASS: TestAccDMSEndpoint_MariaDB_secretID (124.68s)
--- PASS: TestAccDMSEndpoint_MySQL_secretID (124.92s)
--- PASS: TestAccDMSEndpoint_Aurora_secretID (125.12s)
--- PASS: TestAccDMSEndpoint_Aurora_updateSecretID (134.83s)
--- PASS: TestAccDMSEndpoint_MariaDB_updateSecretID (134.83s)
--- PASS: TestAccDMSEndpoint_MySQL_updateSecretID (134.83s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dms        139.747s
```
