### PR TITLE
F-aws_dx_lag: support for request_macsec

### DIFF
--- a/.changelog/36872.txt
+++ b/.changelog/36872.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_dx_lag: Add `request_macsec`
+```

--- a/internal/service/directconnect/lag.go
+++ b/internal/service/directconnect/lag.go
@@ -173,7 +173,7 @@ func resourceLagRead(ctx context.Context, d *schema.ResourceData, meta interface
 	d.Set("name", lag.LagName)
 	d.Set("owner_account_id", lag.OwnerAccount)
 	d.Set("provider_name", lag.ProviderName)
-	d.Set("request_macsec", lag.RequestMACSec)
+	d.Set("request_macsec", lag.MacSecCapable)
 
 	return diags
 }

--- a/internal/service/directconnect/lag.go
+++ b/internal/service/directconnect/lag.go
@@ -82,6 +82,10 @@ func ResourceLag() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
+			"request_macsec": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
@@ -113,6 +117,10 @@ func resourceLagCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 
 	if v, ok := d.GetOk("provider_name"); ok {
 		input.ProviderName = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOkExists("request_macsec"); ok {
+		input.RequestMACSec = aws.Bool(v.(bool))
 	}
 
 	log.Printf("[DEBUG] Creating Direct Connect LAG: %s", input)
@@ -165,6 +173,7 @@ func resourceLagRead(ctx context.Context, d *schema.ResourceData, meta interface
 	d.Set("name", lag.LagName)
 	d.Set("owner_account_id", lag.OwnerAccount)
 	d.Set("provider_name", lag.ProviderName)
+	d.Set("request_macsec", lag.RequestMACSec)
 
 	return diags
 }

--- a/website/docs/r/dx_lag.html.markdown
+++ b/website/docs/r/dx_lag.html.markdown
@@ -33,6 +33,7 @@ This resource supports the following arguments:
 * `connection_id` - (Optional) The ID of an existing dedicated connection to migrate to the LAG.
 * `force_destroy` - (Optional, Default:false) A boolean that indicates all connections associated with the LAG should be deleted so that the LAG can be destroyed without error. These objects are *not* recoverable.
 * `provider_name` - (Optional) The name of the service provider associated with the LAG.
+* `request_macsec` - (Optional) Indicates whether the connection will support MAC Security (MACsec).
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attribute Reference


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #36693

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
