### PR TITLE
fixed forced destroy of securitylake when meta_store_role_arn changes

### DIFF
--- a/internal/service/securitylake/data_lake.go
+++ b/internal/service/securitylake/data_lake.go
@@ -67,7 +67,7 @@ func (r *dataLakeResource) Schema(ctx context.Context, request resource.SchemaRe
 				CustomType: fwtypes.ARNType,
 				Required:   true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"s3_bucket_arn":   framework.ARNAttributeComputedOnly(),
@@ -287,7 +287,7 @@ func (r *dataLakeResource) Update(ctx context.Context, request resource.UpdateRe
 
 	conn := r.Meta().SecurityLakeClient(ctx)
 
-	if !new.Configurations.Equal(old.Configurations) {
+	if !new.Configurations.Equal(old.Configurations) || !new.MetaStoreManagerRoleARN.Equal(old.MetaStoreManagerRoleARN) {
 		input := &securitylake.UpdateDataLakeInput{}
 		response.Diagnostics.Append(fwflex.Expand(ctx, new, input)...)
 		if response.Diagnostics.HasError() {

--- a/internal/service/securitylake/data_lake_test.go
+++ b/internal/service/securitylake/data_lake_test.go
@@ -246,6 +246,52 @@ func testAccDataLake_lifeCycleUpdate(t *testing.T) {
 	})
 }
 
+func testAccDataLake_metaStoreUpdate(t *testing.T) {
+	ctx := acctest.Context(t)
+	var datalake types.DataLakeResource
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_securitylake_data_lake.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.SecurityLake)
+			acctest.PreCheckOrganizationsAccount(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SecurityLakeServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDataLakeDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataLakeConfig_metaStore(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataLakeExists(ctx, resourceName, &datalake),
+					resource.TestCheckResourceAttrPair(resourceName, "meta_store_manager_role_arn", "aws_iam_role.meta_store_manager", "arn"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"meta_store_manager_role_arn"},
+			},
+			{
+				Config: testAccDataLakeConfig_metaStoreUpdate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataLakeExists(ctx, resourceName, &datalake),
+					resource.TestCheckResourceAttrPair(resourceName, "meta_store_manager_role_arn", "aws_iam_role.meta_store_manager_v1", "arn"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"meta_store_manager_role_arn"},
+			},
+		},
+	})
+}
+
 func testAccDataLake_replication(t *testing.T) {
 	ctx := acctest.Context(t)
 	var datalake types.DataLakeResource
@@ -343,6 +389,31 @@ func testAccCheckDataLakeExists(ctx context.Context, n string, v *types.DataLake
 const testAccDataLakeConfigConfig_base = `
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
+
+resource "aws_iam_role" "meta_store_manager_v1" {
+  name               = "AmazonSecurityLakeMetaStoreManagerV1"
+  path               = "/service-role/"
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Sid": "AllowLambda",
+    "Effect": "Allow",
+    "Principal": {
+      "Service": [
+        "lambda.amazonaws.com"
+      ]
+    },
+    "Action": "sts:AssumeRole"
+  }]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "datalake_v1" {
+  role       = aws_iam_role.meta_store_manager_v1.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonSecurityLakeMetastoreManager"
+}
 
 resource "aws_iam_role" "meta_store_manager" {
   name               = "AmazonSecurityLakeMetaStoreManagerV2"
@@ -577,6 +648,43 @@ resource "aws_securitylake_data_lake" "test" {
   }
 
   depends_on = [aws_iam_role.meta_store_manager]
+}
+`, rName, acctest.Region()))
+}
+
+func testAccDataLakeConfig_metaStore(rName string) string {
+	return acctest.ConfigCompose(testAccDataLakeConfigConfig_base, fmt.Sprintf(`
+resource "aws_securitylake_data_lake" "test" {
+  meta_store_manager_role_arn = aws_iam_role.meta_store_manager.arn
+
+  configuration {
+    region = %[2]q
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+
+  depends_on = [aws_iam_role.meta_store_manager]
+}
+`, rName, acctest.Region()))
+}
+
+func testAccDataLakeConfig_metaStoreUpdate(rName string) string {
+	return acctest.ConfigCompose(testAccDataLakeConfigConfig_base,
+		fmt.Sprintf(`
+resource "aws_securitylake_data_lake" "test" {
+  meta_store_manager_role_arn = aws_iam_role.meta_store_manager_v1.arn
+
+  configuration {
+    region = %[2]q
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+
+  depends_on = [aws_iam_role.meta_store_manager_v1]
 }
 `, rName, acctest.Region()))
 }

--- a/internal/service/securitylake/securitylake_test.go
+++ b/internal/service/securitylake/securitylake_test.go
@@ -28,6 +28,7 @@ func TestAccSecurityLake_serial(t *testing.T) {
 			"tags":            testAccDataLake_tags,
 			"lifecycle":       testAccDataLake_lifeCycle,
 			"lifecycleUpdate": testAccDataLake_lifeCycleUpdate,
+			"metaStoreUpdate": testAccDataLake_metaStoreUpdate,
 			"replication":     testAccDataLake_replication,
 		},
 		"Subscriber": {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This change updates the aws_securitylake_data_lake logic so that when the attribute `meta_store_manager_role_arn` is changed it does not require a delete of the entire data lake.  The [UpdateDataLake](https://docs.aws.amazon.com/security-lake/latest/APIReference/API_UpdateDataLake.html) recently included a change where you can update the metaStoreManagerRoleArn with this API call.  The stringplanmodifier.RequiresReplace is no longer necessary.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #36831 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
N/A

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$  make testacc TESTS=TestAccSecurityLake_ PKG=securitylake
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/securitylake/... -v -count 1 -parallel 20 -run='TestAccSecurityLake_'  -timeout 360m
=== RUN   TestAccSecurityLake_serial
=== PAUSE TestAccSecurityLake_serial
=== CONT  TestAccSecurityLake_serial
=== RUN   TestAccSecurityLake_serial/DataLake
=== RUN   TestAccSecurityLake_serial/DataLake/metaStoreUpdate
=== RUN   TestAccSecurityLake_serial/DataLake/replication
=== RUN   TestAccSecurityLake_serial/DataLake/basic
=== RUN   TestAccSecurityLake_serial/DataLake/disappears
=== RUN   TestAccSecurityLake_serial/DataLake/tags
=== RUN   TestAccSecurityLake_serial/DataLake/lifecycle
=== RUN   TestAccSecurityLake_serial/DataLake/lifecycleUpdate
=== RUN   TestAccSecurityLake_serial/Subscriber
=== RUN   TestAccSecurityLake_serial/Subscriber/basic
=== RUN   TestAccSecurityLake_serial/Subscriber/customLogs
=== RUN   TestAccSecurityLake_serial/Subscriber/disappears
=== RUN   TestAccSecurityLake_serial/Subscriber/tags
=== RUN   TestAccSecurityLake_serial/Subscriber/updated
=== RUN   TestAccSecurityLake_serial/SubscriberNotification
=== RUN   TestAccSecurityLake_serial/SubscriberNotification/https
=== RUN   TestAccSecurityLake_serial/SubscriberNotification/disappears
=== RUN   TestAccSecurityLake_serial/SubscriberNotification/update
=== RUN   TestAccSecurityLake_serial/SubscriberNotification/basic
=== RUN   TestAccSecurityLake_serial/AWSLogSource
=== RUN   TestAccSecurityLake_serial/AWSLogSource/basic
=== RUN   TestAccSecurityLake_serial/AWSLogSource/disappears
=== RUN   TestAccSecurityLake_serial/AWSLogSource/multiRegion
=== RUN   TestAccSecurityLake_serial/CustomLogSource
=== RUN   TestAccSecurityLake_serial/CustomLogSource/basic
=== RUN   TestAccSecurityLake_serial/CustomLogSource/disappears
--- PASS: TestAccSecurityLake_serial (1141.58s)
    --- PASS: TestAccSecurityLake_serial/DataLake (365.31s)
        --- PASS: TestAccSecurityLake_serial/DataLake/metaStoreUpdate (55.85s)
        --- PASS: TestAccSecurityLake_serial/DataLake/replication (80.38s)
        --- PASS: TestAccSecurityLake_serial/DataLake/basic (35.53s)
        --- PASS: TestAccSecurityLake_serial/DataLake/disappears (34.71s)
        --- PASS: TestAccSecurityLake_serial/DataLake/tags (57.93s)
        --- PASS: TestAccSecurityLake_serial/DataLake/lifecycle (40.68s)
        --- PASS: TestAccSecurityLake_serial/DataLake/lifecycleUpdate (60.21s)
    --- PASS: TestAccSecurityLake_serial/Subscriber (265.16s)
        --- PASS: TestAccSecurityLake_serial/Subscriber/basic (43.56s)
        --- PASS: TestAccSecurityLake_serial/Subscriber/customLogs (44.93s)
        --- PASS: TestAccSecurityLake_serial/Subscriber/disappears (40.37s)
        --- PASS: TestAccSecurityLake_serial/Subscriber/tags (76.45s)
        --- PASS: TestAccSecurityLake_serial/Subscriber/updated (59.85s)
    --- PASS: TestAccSecurityLake_serial/SubscriberNotification (275.65s)
        --- PASS: TestAccSecurityLake_serial/SubscriberNotification/https (55.18s)
        --- PASS: TestAccSecurityLake_serial/SubscriberNotification/disappears (56.28s)
        --- PASS: TestAccSecurityLake_serial/SubscriberNotification/update (109.87s)
        --- PASS: TestAccSecurityLake_serial/SubscriberNotification/basic (54.31s)
    --- PASS: TestAccSecurityLake_serial/AWSLogSource (155.59s)
        --- PASS: TestAccSecurityLake_serial/AWSLogSource/basic (41.52s)
        --- PASS: TestAccSecurityLake_serial/AWSLogSource/disappears (39.81s)
        --- PASS: TestAccSecurityLake_serial/AWSLogSource/multiRegion (74.27s)
    --- PASS: TestAccSecurityLake_serial/CustomLogSource (79.87s)
        --- PASS: TestAccSecurityLake_serial/CustomLogSource/basic (39.63s)
        --- PASS: TestAccSecurityLake_serial/CustomLogSource/disappears (40.24s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/securitylake       1146.023s

...
```
