### PR TITLE
docs: Add missing arg and attr descs for aws_ssm_document

### DIFF
--- a/website/docs/d/ssm_document.html.markdown
+++ b/website/docs/d/ssm_document.html.markdown
@@ -38,14 +38,14 @@ data "aws_ssm_document" "test" {
 
 This data source supports the following arguments:
 
-* `name` - (Required) Name of the Systems Manager document.
-* `document_format` - (Optional) Returns the document in the specified format. The document format can be either `JSON`, `YAML` and `TEXT`. JSON is the default format.
-* `document_version` - (Optional) Document version for which you want information.
+* `name` - (Required) The name of the document.
+* `document_format` - The format of the document. Valid values: `JSON`, `TEXT`, `YAML`.
+* `document_version` - The document version.
 
 ## Attribute Reference
 
 This data source exports the following attributes in addition to the arguments above:
 
 * `arn` - ARN of the document. If the document is an AWS managed document, this value will be set to the name of the document instead.
-* `content` - Contents of the document.
-* `document_type` - Type of the document.
+* `content` - The content for the SSM document in JSON or YAML format.
+* `document_type` - The type of the document.

--- a/website/docs/r/ssm_document.html.markdown
+++ b/website/docs/r/ssm_document.html.markdown
@@ -71,54 +71,63 @@ DOC
 This resource supports the following arguments:
 
 * `name` - (Required) The name of the document.
-* `attachments_source` - (Optional) One or more configuration blocks describing attachments sources to a version of a document. Defined below.
-* `content` - (Required) The JSON or YAML content of the document.
-* `document_format` - (Optional, defaults to JSON) The format of the document. Valid document types include: `JSON` and `YAML`
-* `document_type` - (Required) The type of the document. Valid document types include: `Automation`, `Command`, `Package`, `Policy`, and `Session`
-* `permissions` - (Optional) Additional Permissions to attach to the document. See [Permissions](#permissions) below for details.
-* `target_type` - (Optional) The target type which defines the kinds of resources the document can run on. For example, /AWS::EC2::Instance. For a list of valid resource types, see AWS Resource Types Reference (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html)
+* `attachments_source` - (Optional) One or more configuration blocks describing attachments sources to a version of a document. See [`attachments_source` block](#attachments_source-block) below for details.
+* `content` - (Required) The content for the SSM document in JSON or YAML format. The content of the document must not exceed 64KB. This quota also includes the content specified for input parameters at runtime. We recommend storing the contents for your new document in an external JSON or YAML file and referencing the file in a command.
+* `document_format` - (Optional, defaults to `JSON`) The format of the document. Valid values: `JSON`, `TEXT`, `YAML`.
+* `document_type` - (Required) The type of the document. For a list of valid values, see the [API Reference](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_CreateDocument.html#systemsmanager-CreateDocument-request-DocumentType).
+* `permissions` - (Optional) Additional permissions to attach to the document. See [Permissions](#permissions) below for details.
+* `target_type` - (Optional) The target type which defines the kinds of resources the document can run on. For example, `/AWS::EC2::Instance`. For a list of valid resource types, see [AWS resource and property types reference](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html).
 * `tags` - (Optional) A map of tags to assign to the object. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
-* `version_name` - (Optional) A field specifying the version of the artifact you are creating with the document. For example, "Release 12, Update 6". This value is unique across all versions of a document and cannot be changed for an existing document version.
+* `version_name` - (Optional) The version of the artifact associated with the document. For example, `12.6`. This value is unique across all versions of a document, and can't be changed.
 
-## attachments_source
+### `attachments_source` block
 
-The `attachments_source` block supports the following:
+The `attachments_source` configuration block supports the following arguments:
 
-* `key` - (Required) The key describing the location of an attachment to a document. Valid key types include: `SourceUrl` and `S3FileUrl`
-* `values` - (Required) The value describing the location of an attachment to a document
-* `name` - (Optional) The name of the document attachment file
+* `key` - (Required) The key of a key-value pair that identifies the location of an attachment to the document. Valid values: `SourceUrl`, `S3FileUrl`, `AttachmentReference`.
+* `values` - (Required) The value of a key-value pair that identifies the location of an attachment to the document. The argument format is a list of a single string that depends on the type of key you specify - see the [API Reference](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_AttachmentsSource.html) for details.
+* `name` - (Optional) The name of the document attachment file.
+
+### Permissions
+
+The `permissions` attribute specifies how you want to share the document. If you share a document privately, you must specify the AWS user account IDs for those people who can use the document. If you share a document publicly, you must specify All as the account ID.
+
+The `permissions` map supports the following:
+
+* `type` - The permission type for the document. The permission type can be `Share`.
+* `account_ids` - The AWS user accounts that should have access to the document. The account IDs can either be a group of account IDs or `All`.
 
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:
 
+* `arn` - The Amazon Resource Name (ARN) of the document.
 * `created_date` - The date the document was created.
-* `description` - The description of the document.
-* `schema_version` - The schema version of the document.
 * `default_version` - The default version of the document.
+* `description` - The description of the document.
 * `document_version` - The document version.
-* `hash` - The sha1 or sha256 of the document content
-* `hash_type` - "Sha1" "Sha256". The hashing algorithm used when hashing the content.
+* `hash_type` - The hash type of the document. Valid values: `Sha256`, `Sha1`.
+* `hash` - The Sha256 or Sha1 hash created by the system when the document was created.
+* `id` - The name of the document.
 * `latest_version` - The latest version of the document.
-* `owner` - The AWS user account of the person who created the document.
-* `status` - "Creating", "Active" or "Deleting". The current status of the document.
-* `parameter` - The parameters that are available to this document.
-* `platform_types` - A list of OS platforms compatible with this SSM document, either "Windows" or "Linux".
+* `owner` - The Amazon Web Services user that created the document.
+* `parameter` - One or more configuration blocks describing the parameters for the document. See [`parameter` block](#parameter-block) below for details.
+* `platform_types` - The list of operating system (OS) platforms compatible with this SSM document. Valid values: `Windows`, `Linux`, `MacOS`.
+* `schema_version` - The schema version of the document.
+* `status` - The status of the SSM document. Valid values: `Creating`, `Active`, `Updating`, `Deleting`, `Failed`.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 [1]: http://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-ssm-docs.html#document-schemas-features
 [2]: https://docs.aws.amazon.com/systems-manager/latest/userguide/document-schemas-features.html
 
-## Permissions
+### `parameter` block
 
-The permissions attribute specifies how you want to share the document. If you share a document privately,
-you must specify the AWS user account IDs for those people who can use the document. If you share a document
-publicly, you must specify All as the account ID.
+The `parameter` configuration block provides the following attributes:
 
-The permissions mapping supports the following:
-
-* `type` - The permission type for the document. The permission type can be `Share`.
-* `account_ids` - The AWS user accounts that should have access to the document. The account IDs can either be a group of account IDs or `All`.
+* `default_value` - If specified, the default values for the parameters. Parameters without a default value are required. Parameters with a default value are optional.
+* `description` - A description of what the parameter does, how to use it, the default value, and whether or not the parameter is optional.
+* `name` - The name of the parameter.
+* `type` - The type of parameter. Valid values: `String`, `StringList`.
 
 ## Import
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add the missing attributes `arn` and `id`. Some argument and attribute descriptions are also outdates, so I updated them in this PR as well. I've also aligned some updated descriptions in the data source reference for consistency.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #36838

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [CreateDocument](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_CreateDocument.html) and [create-document](https://docs.aws.amazon.com/cli/latest/reference/ssm/create-document.html) for wordings.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
n/a