### PR TITLE
docs: Fix aws_ce_tags data source doc heading + add config block links

### DIFF
--- a/website/docs/d/ce_tags.html.markdown
+++ b/website/docs/d/ce_tags.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CE (Cost Explorer)"
 layout: "aws"
 page_title: "AWS: aws_ce_tags"
 description: |-
-  Provides details about a specific CE Tags
+  Provides the available cost allocation tag keys and tag values for a specified period.
 ---
 
-# Resource: aws_ce_tags
+# Data source: aws_ce_tags
 
-Provides details about a specific CE Tags.
+Provides the available cost allocation tag keys and tag values for a specified period.
 
 ## Example Usage
 
@@ -25,48 +25,60 @@ data "aws_ce_tags" "test" {
 
 The following arguments are required:
 
-* `time_period` - (Required) Configuration block for the start and end dates for retrieving the dimension values.
+* `time_period` - (Required) Configuration block for the start and end dates for retrieving the dimension values. See [`time_period` block](#time_period-block) below for details.
 
 The following arguments are optional:
 
-* `filter` - (Optional) Configuration block for the `Expression` object used to categorize costs. See below.
+* `filter` - (Optional) Configuration block for the `Expression` object used to categorize costs. See [`filter` block](#filter-block) below for details.
 * `search_string` - (Optional) Value that you want to search for.
-* `sort_by` - (Optional) Configuration block for the value by which you want to sort the data. See below.
+* `sort_by` - (Optional) Configuration block for the value by which you want to sort the data. [`sort_by` block](#sort_by-block) below for details.
 * `tag_key` - (Optional) Key of the tag that you want to return values for.
 
-### `time_period`
+### `filter` block
 
-* `start` - (Required) End of the time period.
-* `end` - (Required) Beginning of the time period.
-
-### `filter`
+The `filter` configuration block supports the following arguments:
 
 * `and` - (Optional) Return results that match both `Dimension` objects.
-* `cost_category` - (Optional) Configuration block for the filter that's based on `CostCategory` values. See below.
-* `dimension` - (Optional) Configuration block for the specific `Dimension` to use for `Expression`. See below.
+* `cost_category` - (Optional) Configuration block for the filter that's based on `CostCategory` values. See [`cost_category` block](#cost_category-block) below for details.
+* `dimension` - (Optional) Configuration block for the specific `Dimension` to use for `Expression`. See [`dimension` block](#dimension-block) below for details.
 * `not` - (Optional) Return results that match both `Dimension` object.
 * `or` - (Optional) Return results that match both `Dimension` object.
-* `tag` - (Optional) Configuration block for the specific `Tag` to use for `Expression`. See below.
+* `tag` - (Optional) Configuration block for the specific `Tag` to use for `Expression`. See [`tag` block](#tag-block) below for details.
 
-### `cost_category`
+#### `cost_category` block
 
-* `key` - (Optional) Unique name of the Cost Category.
-* `match_options` - (Optional) Match options that you can use to filter your results. MatchOptions is only applicable for actions related to cost category. The default values for MatchOptions is `EQUALS` and `CASE_SENSITIVE`. Valid values are: `EQUALS`,  `ABSENT`, `STARTS_WITH`, `ENDS_WITH`, `CONTAINS`, `CASE_SENSITIVE`, `CASE_INSENSITIVE`.
-* `values` - (Optional) Specific value of the Cost Category.
-
-### `dimension`
+The `cost_category` configuration block supports the following arguments:
 
 * `key` - (Optional) Unique name of the Cost Category.
 * `match_options` - (Optional) Match options that you can use to filter your results. MatchOptions is only applicable for actions related to cost category. The default values for MatchOptions is `EQUALS` and `CASE_SENSITIVE`. Valid values are: `EQUALS`,  `ABSENT`, `STARTS_WITH`, `ENDS_WITH`, `CONTAINS`, `CASE_SENSITIVE`, `CASE_INSENSITIVE`.
 * `values` - (Optional) Specific value of the Cost Category.
 
-### `tag`
+#### `dimension` block
+
+The `dimension` configuration block supports the following arguments:
+
+* `key` - (Optional) Unique name of the Cost Category.
+* `match_options` - (Optional) Match options that you can use to filter your results. MatchOptions is only applicable for actions related to cost category. The default values for MatchOptions is `EQUALS` and `CASE_SENSITIVE`. Valid values are: `EQUALS`,  `ABSENT`, `STARTS_WITH`, `ENDS_WITH`, `CONTAINS`, `CASE_SENSITIVE`, `CASE_INSENSITIVE`.
+* `values` - (Optional) Specific value of the Cost Category.
+
+#### `tag` block
+
+The `tag` configuration block supports the following arguments:
 
 * `key` - (Optional) Key for the tag.
 * `match_options` - (Optional) Match options that you can use to filter your results. MatchOptions is only applicable for actions related to cost category. The default values for MatchOptions is `EQUALS` and `CASE_SENSITIVE`. Valid values are: `EQUALS`,  `ABSENT`, `STARTS_WITH`, `ENDS_WITH`, `CONTAINS`, `CASE_SENSITIVE`, `CASE_INSENSITIVE`.
 * `values` - (Optional) Specific value of the Cost Category.
 
-### `sort_by`
+### `time_period` block
+
+The `time_period` configuration block supports the following arguments:
+
+* `start` - (Required) End of the time period.
+* `end` - (Required) Beginning of the time period.
+
+### `sort_by` block
+
+The `sort_by` configuration block supports the following arguments:
 
 * `key` - (Required) key that's used to sort the data. Valid values are: `BlendedCost`,  `UnblendedCost`, `AmortizedCost`, `NetAmortizedCost`, `NetUnblendedCost`, `UsageQuantity`, `NormalizedUsageAmount`.
 * `sort_order` - (Optional) order that's used to sort the data. Valid values are: `ASCENDING`,  `DESCENDING`.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to fix the heading of the `aws_ce_tags` data source documentation. I also noticed that the configuration blocks are not linked in the argument descriptions, so I added those as well.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #36841

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [GetTags](https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_GetTags.html) for some wordings.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
n/a
