### PR TITLE
docs: Fix basic example in `aws_ce_anomaly_subscription` resource doc

### DIFF
--- a/website/docs/r/ce_anomaly_subscription.html.markdown
+++ b/website/docs/r/ce_anomaly_subscription.html.markdown
@@ -26,27 +26,7 @@ resource "aws_ce_anomaly_subscription" "test" {
   frequency = "DAILY"
 
   monitor_arn_list = [
-    aws_ce_anomaly_monitor.test.arn,
-  ]
-
-  subscriber {
-    type    = "EMAIL"
-    address = "abc@example.com"
-  }
-}
-```
-
-### Threshold Expression Example
-
-#### For a Specific Dimension
-
-```terraform
-resource "aws_ce_anomaly_subscription" "test" {
-  name      = "AWSServiceMonitor"
-  frequency = "DAILY"
-
-  monitor_arn_list = [
-    aws_ce_anomaly_monitor.test.arn,
+    aws_ce_anomaly_monitor.test.arn
   ]
 
   subscriber {
@@ -57,8 +37,36 @@ resource "aws_ce_anomaly_subscription" "test" {
   threshold_expression {
     dimension {
       key           = "ANOMALY_TOTAL_IMPACT_ABSOLUTE"
-      values        = ["100.0"]
       match_options = ["GREATER_THAN_OR_EQUAL"]
+      values        = ["100"]
+    }
+  }
+}
+```
+
+### Threshold Expression Example
+
+#### Using a Percentage Threshold
+
+```terraform
+resource "aws_ce_anomaly_subscription" "test" {
+  name      = "AWSServiceMonitor"
+  frequency = "DAILY"
+
+  monitor_arn_list = [
+    aws_ce_anomaly_monitor.test.arn
+  ]
+
+  subscriber {
+    type    = "EMAIL"
+    address = "abc@example.com"
+  }
+
+  threshold_expression {
+    dimension {
+      key           = "ANOMALY_TOTAL_IMPACT_PERCENTAGE"
+      match_options = ["GREATER_THAN_OR_EQUAL"]
+      values        = ["100"]
     }
   }
 }
@@ -72,7 +80,7 @@ resource "aws_ce_anomaly_subscription" "test" {
   frequency = "DAILY"
 
   monitor_arn_list = [
-    aws_ce_anomaly_monitor.test.arn,
+    aws_ce_anomaly_monitor.test.arn
   ]
 
   subscriber {
@@ -113,7 +121,7 @@ data "aws_iam_policy_document" "sns_topic_policy" {
     sid = "AWSAnomalyDetectionSNSPublishingPermissions"
 
     actions = [
-      "SNS:Publish",
+      "SNS:Publish"
     ]
 
     effect = "Allow"
@@ -124,7 +132,7 @@ data "aws_iam_policy_document" "sns_topic_policy" {
     }
 
     resources = [
-      aws_sns_topic.cost_anomaly_updates.arn,
+      aws_sns_topic.cost_anomaly_updates.arn
     ]
   }
 
@@ -140,7 +148,7 @@ data "aws_iam_policy_document" "sns_topic_policy" {
       "SNS:ListSubscriptionsByTopic",
       "SNS:GetTopicAttributes",
       "SNS:DeleteTopic",
-      "SNS:AddPermission",
+      "SNS:AddPermission"
     ]
 
     condition {
@@ -148,7 +156,7 @@ data "aws_iam_policy_document" "sns_topic_policy" {
       variable = "AWS:SourceOwner"
 
       values = [
-        var.account-id,
+        var.account_id
       ]
     }
 
@@ -160,7 +168,7 @@ data "aws_iam_policy_document" "sns_topic_policy" {
     }
 
     resources = [
-      aws_sns_topic.cost_anomaly_updates.arn,
+      aws_sns_topic.cost_anomaly_updates.arn
     ]
   }
 }
@@ -182,7 +190,7 @@ resource "aws_ce_anomaly_subscription" "realtime_subscription" {
   frequency = "IMMEDIATE"
 
   monitor_arn_list = [
-    aws_ce_anomaly_monitor.anomaly_monitor.arn,
+    aws_ce_anomaly_monitor.anomaly_monitor.arn
   ]
 
   subscriber {
@@ -191,7 +199,7 @@ resource "aws_ce_anomaly_subscription" "realtime_subscription" {
   }
 
   depends_on = [
-    aws_sns_topic_policy.default,
+    aws_sns_topic_policy.default
   ]
 }
 ```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to fix the basic example in the `aws_ce_anomaly_subscription` resource doc. Since `Threshold` is deprecated, `ThresholdExpression` must be included in the request. So for the basic example, I added an absolute threshold, and changed the 2nd example to use a percentage threshold for a bit more variation.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #36853

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Checked [AnomalySubscription](https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_AnomalySubscription.html) on why the exception occurred.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
n/a
