### PR TITLE
skaff: add function subcommand

### DIFF
--- a/docs/skaff.md
+++ b/docs/skaff.md
@@ -1,32 +1,39 @@
 # Provider Scaffolding (skaff)
 
-`skaff` is a Terraform AWS Provider scaffolding command line tool. It generates resource/data source files and accompanying test files which adhere to the latest best practices. These files are heavily commented with instructions so serve as the best way to get started with provider development.
+`skaff` is a Terraform AWS Provider scaffolding command line tool.
+It generates resource, data source, or function source files, along with test files which adhere to the latest best practices.
+These files are heavily commented with instructions, serving as the best way to get started with provider development.
 
 ## Overview workflow steps
 
 1. Figure out what you're trying to do:
-    * Resource or data source?
-    * [Name it](naming.md)
+    * Resource, data source, or function?
+    * [Name it](naming.md).
     !!! tip
         Net-new resources should be implemented with AWS SDK Go V2 and the Terraform Plugin Framework (e.g. the default `skaff` settings).
         See [AWS Go SDK Versions](aws-go-sdk-versions.md), [Terraform Plugin Development Packages](terraform-plugin-development-packages.md), and [this issue](https://github.com/hashicorp/terraform-provider-aws/issues/32917) for additional information.
-1. Use `skaff` to generate provider code
-1. Go through the generated code completing code and customizing for the AWS Go SDK API
-1. Run, test, refine
-1. Remove "TIP" comments
-1. Submit code in the pull request
+1. Use `skaff` to generate provider code.
+1. Go through the generated code, customizing as necessary.
+1. Run, test, refine.
+1. Remove "TIP" comments.
+1. Submit a pull request.
 
 ## Running `skaff`
 
 1. Clone the [Terraform AWS Provider](https://github.com/hashicorp/terraform-provider-aws) repository.
-1. Install `skaff`
+1. Install `skaff`.
 
     ```sh
     make skaff
     ```
 
-1. Change directories to the service where your new resource will reside. _E.g._, `cd internal/service/mq`.
-1. Generate a resource. _E.g._, `skaff resource --name BrokerReboot` (or equivalently `skaff resource -n BrokerReboot`).
+1. Change into the appropriate directory.
+    - For resources and data sources, this is the service directory where the new entity will reside, e.g. `internal/service/mq`.
+    - For functions, this is `internal/functions`.
+1. Generate the resource, data source or function. For example,
+    - `skaff resource --name BrokerReboot`.
+    - `skaff datasource --name IAMRole`.
+    - `skaff function --name ARNParse`.
 
 To get help, enter `skaff` without arguments.
 
@@ -45,6 +52,7 @@ Usage:
 Available Commands:
   completion  Generate the autocompletion script for the specified shell
   datasource  Create scaffolding for a data source
+  function    Create scaffolding for a function
   help        Help about any command
   resource    Create scaffolding for a resource
 
@@ -99,6 +107,29 @@ Flags:
   -p, --plugin-sdkv2       generate for Terraform Plugin SDK V2
   -s, --snakename string   if skaff doesn't get it right, explicitly give name in snake case (e.g., db_vpc_instance)
   -o, --v1                 generate for AWS Go SDK v1 (some existing services)
+```
+
+### Function
+
+Create scaffolding for a function.
+
+```console
+skaff function --help
+```
+
+```
+Create scaffolding for a function
+
+Usage:
+  skaff function [flags]
+
+Flags:
+  -c, --clear-comments       do not include instructional comments in source
+  -d, --description string   description of the function
+  -f, --force                force creation, overwriting existing files
+  -h, --help                 help for function
+  -n, --name string          name of the function
+  -s, --snakename string     if skaff doesn't get it right, explicitly give name in snake case (e.g., arn_build)
 ```
 
 ### Resource

--- a/skaff/cmd/function.go
+++ b/skaff/cmd/function.go
@@ -1,0 +1,30 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cmd
+
+import (
+	"github.com/hashicorp/terraform-provider-aws/skaff/function"
+	"github.com/spf13/cobra"
+)
+
+var description string
+
+var functionCmd = &cobra.Command{
+	Use:   "function",
+	Short: "Create scaffolding for a function",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return function.Create(name, snakeName, description, !clearComments, force)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(functionCmd)
+	functionCmd.Flags().BoolVarP(&clearComments, "clear-comments", "c", false, "do not include instructional comments in source")
+	functionCmd.Flags().BoolVarP(&force, "force", "f", false, "force creation, overwriting existing files")
+	functionCmd.Flags().StringVarP(&name, "name", "n", "", "name of the function")
+	functionCmd.Flags().StringVarP(&snakeName, "snakename", "s", "", "if skaff doesn't get it right, explicitly give name in snake case (e.g., arn_build)")
+	functionCmd.Flags().StringVarP(&description, "description", "d", "", "description of the function")
+	functionCmd.MarkFlagRequired("name")
+	functionCmd.MarkFlagRequired("description")
+}

--- a/skaff/cmd/root.go
+++ b/skaff/cmd/root.go
@@ -10,7 +10,7 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "skaff [resource|datasource]",
+	Use:   "skaff [resource|datasource|function]",
 	Short: "Create scaffolding for the Terraform AWS Provider",
 }
 

--- a/skaff/convert/convert.go
+++ b/skaff/convert/convert.go
@@ -6,6 +6,7 @@ package convert
 import (
 	"fmt"
 	"strings"
+	"unicode"
 
 	"github.com/YakDriver/regexache"
 )
@@ -39,4 +40,30 @@ func ToHumanResName(upper string) string {
 // of a resource or data source
 func ToProviderResourceName(servicePackage, snakeName string) string {
 	return fmt.Sprintf("aws_%s_%s", servicePackage, snakeName)
+}
+
+// ToLowercasePrefix converts a string beginning with uppercase letters
+// to begin lowercased
+//
+// Specifically, this is used to take user-provided input beginning with uppercase
+// letters, and transform it so that it can be used to name a private struct. This
+// function assumes all characters are unicode.
+func ToLowercasePrefix(s string) string {
+	var hasLower bool
+	var splitIdx int
+	for i, char := range s {
+		if unicode.IsLower(char) {
+			hasLower = true
+			break
+		}
+		splitIdx = i
+	}
+
+	if !hasLower {
+		return strings.ToLower(s)
+	}
+	if splitIdx == 0 && len(s) > 0 {
+		splitIdx++
+	}
+	return strings.ToLower(s[:splitIdx]) + s[splitIdx:]
 }

--- a/skaff/convert/convert.go
+++ b/skaff/convert/convert.go
@@ -1,0 +1,42 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package convert
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/YakDriver/regexache"
+)
+
+// ToSnakeCase converts a camel cased string to snake case
+//
+// If the override argument is a non-empty string, its value is returned
+// unchanged.
+func ToSnakeCase(upper string, override string) string {
+	if override != "" {
+		return override
+	}
+
+	re := regexache.MustCompile(`([a-z])([A-Z]{2,})`)
+	upper = re.ReplaceAllString(upper, `${1}_${2}`)
+
+	re2 := regexache.MustCompile(`([A-Z][a-z])`)
+	return strings.TrimPrefix(strings.ToLower(re2.ReplaceAllString(upper, `_$1`)), "_")
+}
+
+// ToHumanResName converts a camel cased string to a human readable name
+func ToHumanResName(upper string) string {
+	re := regexache.MustCompile(`([a-z])([A-Z]{2,})`)
+	upper = re.ReplaceAllString(upper, `${1} ${2}`)
+
+	re2 := regexache.MustCompile(`([A-Z][a-z])`)
+	return strings.TrimPrefix(re2.ReplaceAllString(upper, ` $1`), " ")
+}
+
+// ToProviderResourceName adds the appropriate prefix to a snake cased name
+// of a resource or data source
+func ToProviderResourceName(servicePackage, snakeName string) string {
+	return fmt.Sprintf("aws_%s_%s", servicePackage, snakeName)
+}

--- a/skaff/convert/convert_test.go
+++ b/skaff/convert/convert_test.go
@@ -104,3 +104,24 @@ func TestToHumanResName(t *testing.T) {
 		})
 	}
 }
+
+func TestToLowercasePrefix(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		want string
+	}{
+		{"title", "HelloWorld", "helloWorld"},
+		{"multi-upper prefix", "ARNParse", "arnParse"},
+		{"all upper", "FOO", "foo"},
+		{"all lower", "bar", "bar"},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ToLowercasePrefix(tt.s); got != tt.want {
+				t.Errorf("ToLowercasePrefix() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/skaff/convert/convert_test.go
+++ b/skaff/convert/convert_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-package resource
+package convert
 
 import (
 	"testing"
@@ -56,7 +56,7 @@ func TestToSnakeName(t *testing.T) {
 	}
 }
 
-func TestHumanResName(t *testing.T) {
+func TestToHumanResName(t *testing.T) {
 	testCases := []struct {
 		TestName string
 		Input    string
@@ -96,7 +96,7 @@ func TestHumanResName(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.TestName, func(t *testing.T) {
-			got := HumanResName(testCase.Input)
+			got := ToHumanResName(testCase.Input)
 
 			if got != testCase.Expected {
 				t.Errorf("got %s, expected %s", got, testCase.Expected)

--- a/skaff/datasource/datasource.go
+++ b/skaff/datasource/datasource.go
@@ -15,7 +15,7 @@ import (
 	"text/template"
 
 	"github.com/hashicorp/terraform-provider-aws/names"
-	"github.com/hashicorp/terraform-provider-aws/skaff/resource"
+	"github.com/hashicorp/terraform-provider-aws/skaff/convert"
 )
 
 //go:embed datasource.tmpl
@@ -67,7 +67,7 @@ func Create(dsName, snakeName string, comments, force, v2, pluginFramework, tags
 		return fmt.Errorf("error checking: snake name should be all lower case with underscores, if needed (e.g., db_instance)")
 	}
 
-	snakeName = resource.ToSnakeCase(dsName, snakeName)
+	snakeName = convert.ToSnakeCase(dsName, snakeName)
 
 	s, err := names.ProviderNameUpper(servicePackage)
 	if err != nil {
@@ -97,8 +97,8 @@ func Create(dsName, snakeName string, comments, force, v2, pluginFramework, tags
 		AWSServiceName:       sn,
 		AWSGoSDKV2:           v2,
 		PluginFramework:      pluginFramework,
-		HumanDataSourceName:  resource.HumanResName(dsName),
-		ProviderResourceName: resource.ProviderResourceName(servicePackage, snakeName),
+		HumanDataSourceName:  convert.ToHumanResName(dsName),
+		ProviderResourceName: convert.ToProviderResourceName(servicePackage, snakeName),
 	}
 
 	tmpl := datasourceTmpl

--- a/skaff/datasource/datasource_test.go
+++ b/skaff/datasource/datasource_test.go
@@ -1,4 +1,0 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
-package datasource

--- a/skaff/function/function.go
+++ b/skaff/function/function.go
@@ -31,6 +31,7 @@ var snakeCaseRegex = regexache.MustCompile(`[a-z0-9_]*`)
 
 type TemplateData struct {
 	Function        string
+	FunctionLower   string
 	FunctionSnake   string
 	Description     string
 	IncludeComments bool
@@ -49,6 +50,7 @@ func Create(name, snakeName, description string, comments, force bool) error {
 
 	templateData := TemplateData{
 		Function:        name,
+		FunctionLower:   convert.ToLowercasePrefix(name),
 		FunctionSnake:   snakeName,
 		Description:     description,
 		IncludeComments: comments,

--- a/skaff/function/function.go
+++ b/skaff/function/function.go
@@ -1,0 +1,108 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package function
+
+import (
+	"bytes"
+	_ "embed"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"github.com/YakDriver/regexache"
+	"github.com/hashicorp/terraform-provider-aws/skaff/resource"
+)
+
+//go:embed function.tmpl
+var functionTmpl string
+
+//go:embed functiontest.tmpl
+var functionTestTmpl string
+
+//go:embed websitedoc.tmpl
+var websiteTmpl string
+
+var snakeCaseRegex = regexache.MustCompile(`[a-z0-9_]*`)
+
+type TemplateData struct {
+	Function        string
+	FunctionSnake   string
+	Description     string
+	IncludeComments bool
+}
+
+func Create(name, snakeName, description string, comments, force bool) error {
+	if name == strings.ToLower(name) {
+		return fmt.Errorf("name should be properly capitalized (e.g., ARNBuild)")
+	}
+
+	if snakeName != "" && snakeName != strings.ToLower(snakeName) {
+		return fmt.Errorf("snake name should be all lower case with underscores, if needed (e.g., arn_build)")
+	}
+
+	snakeName = resource.ToSnakeCase(name, snakeName)
+
+	templateData := TemplateData{
+		Function:        name,
+		FunctionSnake:   snakeName,
+		Description:     description,
+		IncludeComments: comments,
+	}
+
+	tmpl := functionTmpl
+	f := fmt.Sprintf("%s.go", snakeName)
+	if err := writeTemplate("function", f, tmpl, force, templateData); err != nil {
+		return fmt.Errorf("writing resource template: %w", err)
+	}
+
+	tf := fmt.Sprintf("%s_test.go", snakeName)
+	if err := writeTemplate("functiontest", tf, functionTestTmpl, force, templateData); err != nil {
+		return fmt.Errorf("writing resource test template: %w", err)
+	}
+
+	wf := fmt.Sprintf("%s.html.markdown", snakeName)
+	wf = filepath.Join("..", "..", "website", "docs", "functions", wf)
+	if err := writeTemplate("webdoc", wf, websiteTmpl, force, templateData); err != nil {
+		return fmt.Errorf("writing resource website doc template: %w", err)
+	}
+
+	return nil
+}
+
+func writeTemplate(templateName, filename, tmpl string, force bool, td TemplateData) error {
+	if _, err := os.Stat(filename); !errors.Is(err, fs.ErrNotExist) && !force {
+		return fmt.Errorf("file (%s) already exists and force is not set", filename)
+	}
+
+	f, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return fmt.Errorf("error opening file (%s): %s", filename, err)
+	}
+
+	tplate, err := template.New(templateName).Parse(tmpl)
+	if err != nil {
+		return fmt.Errorf("error parsing template: %s", err)
+	}
+
+	var buffer bytes.Buffer
+	err = tplate.Execute(&buffer, td)
+	if err != nil {
+		return fmt.Errorf("error executing template: %s", err)
+	}
+
+	if _, err := f.Write(buffer.Bytes()); err != nil {
+		f.Close() // ignore error; Write error takes precedence
+		return fmt.Errorf("error writing to file (%s): %s", filename, err)
+	}
+
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("error closing file (%s): %s", filename, err)
+	}
+
+	return nil
+}

--- a/skaff/function/function.go
+++ b/skaff/function/function.go
@@ -15,7 +15,7 @@ import (
 	"text/template"
 
 	"github.com/YakDriver/regexache"
-	"github.com/hashicorp/terraform-provider-aws/skaff/resource"
+	"github.com/hashicorp/terraform-provider-aws/skaff/convert"
 )
 
 //go:embed function.tmpl
@@ -45,7 +45,7 @@ func Create(name, snakeName, description string, comments, force bool) error {
 		return fmt.Errorf("snake name should be all lower case with underscores, if needed (e.g., arn_build)")
 	}
 
-	snakeName = resource.ToSnakeCase(name, snakeName)
+	snakeName = convert.ToSnakeCase(name, snakeName)
 
 	templateData := TemplateData{
 		Function:        name,

--- a/skaff/function/function.tmpl
+++ b/skaff/function/function.tmpl
@@ -45,7 +45,7 @@ import (
 // 4. Metadata, Definition, and Run methods (in that order)
 {{- end }}
 
-var _ function.Function = {{ .Function }}Function{}
+var _ function.Function = {{ .FunctionLower }}Function{}
 {{ if .IncludeComments }}
 // TIP: ==== INITIALIZATION FUNCTION ====
 // The New* function returns an instance of the provider function struct. Currently,
@@ -54,12 +54,12 @@ var _ function.Function = {{ .Function }}Function{}
 // to the providers `Functions` method in `internal/provider/fwprovider/provider.go`.
 {{- end }}
 func New{{ .Function }}Function() function.Function {
-	return &{{ .Function }}Function{}
+	return &{{ .FunctionLower }}Function{}
 }
 
-type {{ .Function }}Function struct{}
+type {{ .FunctionLower }}Function struct{}
 
-func (f {{ .Function }}Function) Metadata(ctx context.Context, req function.MetadataRequest, resp *function.MetadataResponse) {
+func (f {{ .FunctionLower }}Function) Metadata(ctx context.Context, req function.MetadataRequest, resp *function.MetadataResponse) {
 	resp.Name = "{{ .FunctionSnake }}"
 }
 {{ if .IncludeComments }}
@@ -68,7 +68,7 @@ func (f {{ .Function }}Function) Metadata(ctx context.Context, req function.Meta
 // return values. The types of argument and return values are explicitly
 // defined in this method.
 {{- end }}
-func (f {{ .Function }}Function) Definition(ctx context.Context, req function.DefinitionRequest, resp *function.DefinitionResponse) {
+func (f {{ .FunctionLower }}Function) Definition(ctx context.Context, req function.DefinitionRequest, resp *function.DefinitionResponse) {
 	resp.Definition = function.Definition{
 		Summary:             "{{ .FunctionSnake }} Function",
 		MarkdownDescription: "{{ .Description }}",
@@ -86,7 +86,7 @@ func (f {{ .Function }}Function) Definition(ctx context.Context, req function.De
 // This method contains the logic of the function, such as manipulating 
 // arguments or returning static values.
 {{- end }}
-func (f {{ .Function }}Function) Run(ctx context.Context, req function.RunRequest, resp *function.RunResponse) {
+func (f {{ .FunctionLower }}Function) Run(ctx context.Context, req function.RunRequest, resp *function.RunResponse) {
 	var arg string
 
 	resp.Error = function.ConcatFuncErrors(req.Arguments.Get(ctx, &arg))

--- a/skaff/function/function.tmpl
+++ b/skaff/function/function.tmpl
@@ -1,0 +1,116 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package function
+
+{{- if .IncludeComments }}
+// **PLEASE DELETE THIS AND ALL TIP COMMENTS BEFORE SUBMITTING A PR FOR REVIEW!**
+//
+// TIP: ==== INTRODUCTION ====
+// Thank you for trying the skaff tool!
+//
+// You have opted to include these helpful comments. They all include "TIP:"
+// to help you find and remove them when you're done with them.
+//
+// While some aspects of this file are customized to your input, the
+// scaffold tool does *not* produce any function logic.
+//
+// In other words, as generated, this is a rough outline of the work you will
+// need to do. If something doesn't make sense for your situation, get rid of
+// it.{{- end }}
+
+import (
+{{- if .IncludeComments }}
+	// TIP: ==== IMPORTS ====
+	// This is a common set of imports but not customized to your code since
+	// your code hasn't been written yet. Make sure you, your IDE, or
+	// goimports -w <file> fixes these imports.
+	//
+	// The provider linter wants your imports to be in two groups: first,
+	// standard library (i.e., "fmt" or "strings"), second, everything else.
+{{- end }}
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/function"
+)
+{{- if .IncludeComments }}
+// TIP: ==== FILE STRUCTURE ====
+// All functions should follow this basic outline. Improve this functions's
+// maintainability by sticking to it.
+//
+// 1. Package declaration
+// 2. Imports
+// 3. Function struct with New* initialization function
+// 4. Metadata, Definition, and Run methods (in that order)
+{{- end }}
+
+var _ function.Function = {{ .Function }}Function{}
+{{ if .IncludeComments }}
+// TIP: ==== INITIALIZATION FUNCTION ====
+// The New* function returns an instance of the provider function struct. Currently,
+// functions DO NOT follow the self-registration process used by resources
+// and data sources, so this registration function must be manually added
+// to the providers `Functions` method in `internal/provider/fwprovider/provider.go`.
+{{- end }}
+func New{{ .Function }}Function() function.Function {
+	return &{{ .Function }}Function{}
+}
+
+type {{ .Function }}Function struct{}
+
+func (f {{ .Function }}Function) Metadata(ctx context.Context, req function.MetadataRequest, resp *function.MetadataResponse) {
+	resp.Name = "{{ .FunctionSnake }}"
+}
+{{ if .IncludeComments }}
+// TIP: ==== DEFINITION METHOD ====
+// This method contains function details such as description, arguments, and 
+// return values. The types of argument and return values are explicitly
+// defined in this method.
+{{- end }}
+func (f {{ .Function }}Function) Definition(ctx context.Context, req function.DefinitionRequest, resp *function.DefinitionResponse) {
+	resp.Definition = function.Definition{
+		Summary:             "{{ .FunctionSnake }} Function",
+		MarkdownDescription: "{{ .Description }}",
+		Parameters: []function.Parameter{
+			function.StringParameter{
+				Name:                "arg",
+				MarkdownDescription: "Example argument description",
+			},
+		},
+		Return: function.StringReturn{},
+	}
+}
+{{ if .IncludeComments }}
+// TIP: ==== RUN METHOD ====
+// This method contains the logic of the function, such as manipulating 
+// arguments or returning static values.
+{{- end }}
+func (f {{ .Function }}Function) Run(ctx context.Context, req function.RunRequest, resp *function.RunResponse) {
+	var arg string
+
+	resp.Error = function.ConcatFuncErrors(req.Arguments.Get(ctx, &arg))
+	if resp.Error != nil {
+		return
+	}
+{{ if .IncludeComments }}
+	// TIP: ==== ERROR HANDLING ====
+	// Depending on the function logic being applied, there may be multiple
+	// points at which the function could error. 
+	//
+	// Whenever logic is executed that could return an error, `resp.Error` should 
+	// be set to the return of the `function.ConcatFuncErrors` helper.
+{{- end }}
+	if arg != "foo" {
+		resp.Error = function.ConcatFuncErrors(resp.Error, function.NewFuncError("argument isn't foo"))
+		return
+	}
+
+	result := fmt.Sprintf("%s-bar", arg)
+{{ if .IncludeComments }}
+        // TIP: ==== SETTING THE RESULT ====
+	// This should always be the last step of this method, and potential
+	// errors from setting the value should always be handled.
+{{- end }}
+	resp.Error = function.ConcatFuncErrors(resp.Result.Set(ctx, result))
+}

--- a/skaff/function/functiontest.tmpl
+++ b/skaff/function/functiontest.tmpl
@@ -1,0 +1,117 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package function_test
+
+{{- if .IncludeComments }}
+// **PLEASE DELETE THIS AND ALL TIP COMMENTS BEFORE SUBMITTING A PR FOR REVIEW!**
+//
+// TIP: ==== INTRODUCTION ====
+// Thank you for trying the skaff tool!
+//
+// You have opted to include these helpful comments. They all include "TIP:"
+// to help you find and remove them when you're done with them.
+//
+// While some aspects of this file are customized to your input, the
+// scaffold tool does *not* produce any function logic.
+//
+// In other words, as generated, this is a rough outline of the work you will
+// need to do. If something doesn't make sense for your situation, get rid of
+// it.{{- end }}
+
+import (
+{{- if .IncludeComments }}
+	// TIP: ==== IMPORTS ====
+	// This is a common set of imports but not customized to your code since
+	// your code hasn't been written yet. Make sure you, your IDE, or
+	// goimports -w <file> fixes these imports.
+	//
+	// The provider linter wants your imports to be in two groups: first,
+	// standard library (i.e., "fmt" or "strings"), second, everything else.
+{{- end }}
+	"fmt"
+	"testing"
+
+	"github.com/YakDriver/regexache"
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+{{ if .IncludeComments }}
+// TIP: File Structure. The basic outline for all test files should be as
+// follows. Improve this resource's maintainability by following this
+// outline.
+//
+// 1. Package declaration (add "_test" since this is a test file)
+// 2. Imports
+// 3. Unit tests
+// 4. Function that returns a Terraform configuration
+{{- end }}
+{{- if .IncludeComments }}
+
+// TIP: ==== UNIT TESTS ====
+// All provider function tests are unit tests (versus acceptance tests for
+// resources and data sources). Because functions do not recieve provider
+// configuation details, setup is limited and exeuction is fast (relative
+// to acceptance tests).
+{{- end }}
+func Test{{ .Function }}Function_valid(t *testing.T) {
+	t.Parallel()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+{{- if .IncludeComments }}
+		// TIP: ==== TERRAFORM VERSION CHECKS ====
+		// Provider defined functions were introduced in Terraform 1.8. To avoid
+		// errors processing the provider function syntax, a pre-check is
+		// always included to skip tests when a pre-1.8 version of Terraform
+		// is detected.
+{{- end }}
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.8.0"))),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: test{{ .Function }}FunctionConfig("foo"),
+				Check:  resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckOutput("test", "foo-updated"),
+				),
+			},
+		},
+	})
+}
+{{ if .IncludeComments }}
+// TIP: ==== TESTING ERROR CASES ====
+// Known error cases should include a corresponding test validating that
+// the expected error text is returned.
+{{- end }}
+func Test{{ .Function }}Function_invalid(t *testing.T) {
+	t.Parallel()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.8.0"))),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: test{{ .Function }}FunctionConfig("notfoo"),
+				ExpectError: regexache.MustCompile("argument isn't foo"),
+			},
+		},
+	})
+}
+{{ if .IncludeComments }}
+// TIP: ==== TERRAFORM FUNCTION CONFIGURATION ====
+// For provider function unit tests, this configuration is typically just
+// an output block where the function is called with the argument(s) provided
+// by the test cases.
+{{- end }}
+func test{{ .Function }}FunctionConfig(arg string) string {
+	return fmt.Sprintf(`
+output "test" {
+  value = provider::aws::{{ .FunctionSnake }}(%[1]q)
+}
+`, arg)
+}

--- a/skaff/function/websitedoc.tmpl
+++ b/skaff/function/websitedoc.tmpl
@@ -1,0 +1,42 @@
+---
+subcategory: ""
+layout: "aws"
+page_title: "AWS: {{ .FunctionSnake }}"
+description: |-
+  {{ .Description }}.
+---
+
+{{- if .IncludeComments }}
+<!---
+TIP: A few guiding principles for writing documentation:
+1. Use simple language while avoiding jargon and figures of speech.
+2. Focus on brevity and clarity to keep a reader's attention.
+3. Use active voice and present tense whenever you can.
+4. Document your feature as it exists now; do not mention the future or past if you can help it.
+5. Use accessible and inclusive language.
+--->`
+{{- end }}
+# Function: {{ .FunctionSnake }}
+
+~> Provider-defined function support is in technical preview and offered without compatibility promises until Terraform 1.8 is generally available.
+
+{{ .Description }}.
+
+## Example Usage
+
+```terraform
+# result: foo-bar
+output "example" {
+  value = provider::aws::{{ .FunctionSnake }}("foo")
+}
+```
+
+## Signature
+
+```text
+{{ .FunctionSnake }}(arg string) string
+```
+
+## Arguments
+
+1. `arg` (String) Example argument description.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This command will allow contributors to generate the scaffolding of a new provider defined function, similar to the functionality available for resources and data sources.

Also moves the helper functions shared across the various subcommand packages into their own, standalone package, `convert`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #36805 


### Output from Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% cd skaff/ && go test -count=1 ./... && cd ..
?       github.com/hashicorp/terraform-provider-aws/skaff       [no test files]
?       github.com/hashicorp/terraform-provider-aws/skaff/cmd   [no test files]
?       github.com/hashicorp/terraform-provider-aws/skaff/datasource    [no test files]
?       github.com/hashicorp/terraform-provider-aws/skaff/function      [no test files]
?       github.com/hashicorp/terraform-provider-aws/skaff/resource      [no test files]
ok      github.com/hashicorp/terraform-provider-aws/skaff/convert       0.147s
```
