### PR TITLE
f-aws_vpc_ipam_pool support for cascade

### DIFF
--- a/.changelog/36898.txt
+++ b/.changelog/36898.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_vpc_ipam_pool: Add `cascade` argument
+```

--- a/internal/service/ec2/ipam_pool.go
+++ b/internal/service/ec2/ipam_pool.go
@@ -81,6 +81,10 @@ func ResourceIPAMPool() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.StringInSlice(ec2.IpamPoolAwsService_Values(), false),
 			},
+			"cascade": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -315,10 +319,16 @@ func resourceIPAMPoolDelete(ctx context.Context, d *schema.ResourceData, meta in
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn(ctx)
 
-	log.Printf("[DEBUG] Deleting IPAM Pool: %s", d.Id())
-	_, err := conn.DeleteIpamPoolWithContext(ctx, &ec2.DeleteIpamPoolInput{
+	input := &ec2.DeleteIpamPoolInput{
 		IpamPoolId: aws.String(d.Id()),
-	})
+	}
+
+	if v, ok := d.GetOk("cascade"); ok {
+		input.Cascade = aws.Bool(v.(bool))
+	}
+
+	log.Printf("[DEBUG] Deleting IPAM Pool: %s", d.Id())
+	_, err := conn.DeleteIpamPoolWithContext(ctx, input)
 
 	if tfawserr.ErrCodeEquals(err, errCodeInvalidIPAMPoolIdNotFound) {
 		return diags

--- a/internal/service/ec2/ipam_pool_test.go
+++ b/internal/service/ec2/ipam_pool_test.go
@@ -175,7 +175,7 @@ func TestAccIPAMPool_cascade(t *testing.T) {
 				Config: testAccIPAMPoolConfig_cascade,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIPAMPoolExists(ctx, resourceName, &pool),
-					testAccCheckIPAMPoolCidrCreate(ctx, &pool),
+					testAccCheckIPAMPoolCIDRCreate(ctx, &pool),
 				),
 			},
 			{
@@ -344,7 +344,7 @@ resource "aws_vpc_ipam_pool" "test" {
 }
 `)
 
-func testAccCheckIPAMPoolCidrCreate(ctx context.Context, ipampool *ec2.IpamPool) resource.TestCheckFunc {
+func testAccCheckIPAMPoolCIDRCreate(ctx context.Context, ipampool *ec2.IpamPool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Conn(ctx)
 

--- a/internal/service/ec2/ipam_pool_test.go
+++ b/internal/service/ec2/ipam_pool_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -159,6 +160,34 @@ func TestAccIPAMPool_ipv6Contiguous(t *testing.T) {
 	})
 }
 
+func TestAccIPAMPool_cascade(t *testing.T) {
+	ctx := acctest.Context(t)
+	var pool ec2.IpamPool
+	resourceName := "aws_vpc_ipam_pool.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckIPAMPoolDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIPAMPoolConfig_cascade,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIPAMPoolExists(ctx, resourceName, &pool),
+					testAccCheckIPAMPoolCidrCreate(ctx, &pool),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"cascade"},
+			},
+		},
+	})
+}
+
 func TestAccIPAMPool_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var pool ec2.IpamPool
@@ -272,6 +301,14 @@ resource "aws_vpc_ipam_pool" "test" {
 }
 `)
 
+var testAccIPAMPoolConfig_cascade = acctest.ConfigCompose(testAccIPAMPoolConfig_base, `
+resource "aws_vpc_ipam_pool" "test" {
+  address_family = "ipv4"
+  ipam_scope_id  = aws_vpc_ipam.test.private_default_scope_id
+  cascade = true
+}
+`)
+
 var testAccIPAMPoolConfig_updated = acctest.ConfigCompose(testAccIPAMPoolConfig_base, `
 resource "aws_vpc_ipam_pool" "test" {
   address_family                    = "ipv4"
@@ -306,6 +343,19 @@ resource "aws_vpc_ipam_pool" "test" {
   publicly_advertisable = false
 }
 `)
+
+func testAccCheckIPAMPoolCidrCreate(ctx context.Context, ipampool *ec2.IpamPool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Conn(ctx)
+
+		_, err := conn.ProvisionIpamPoolCidrWithContext(ctx, &ec2.ProvisionIpamPoolCidrInput{
+			IpamPoolId: aws.String(*ipampool.IpamPoolId),
+			Cidr:       aws.String("10.0.0.0/16"),
+		})
+
+		return err
+	}
+}
 
 func testAccIPAMPoolConfig_tags(tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(testAccIPAMPoolConfig_base, fmt.Sprintf(`

--- a/internal/service/ec2/ipam_pool_test.go
+++ b/internal/service/ec2/ipam_pool_test.go
@@ -305,7 +305,7 @@ var testAccIPAMPoolConfig_cascade = acctest.ConfigCompose(testAccIPAMPoolConfig_
 resource "aws_vpc_ipam_pool" "test" {
   address_family = "ipv4"
   ipam_scope_id  = aws_vpc_ipam.test.private_default_scope_id
-  cascade = true
+  cascade        = true
 }
 `)
 

--- a/website/docs/r/vpc_ipam_pool.html.markdown
+++ b/website/docs/r/vpc_ipam_pool.html.markdown
@@ -77,6 +77,7 @@ This resource supports the following arguments:
 * `auto_import` - (Optional) If you include this argument, IPAM automatically imports any VPCs you have in your scope that fall
 within the CIDR range in the pool.
 * `aws_service` - (Optional) Limits which AWS service the pool can be used in. Only useable on public scopes. Valid Values: `ec2`.
+* `cascade` - (Optional) Enables you to quickly delete an IPAM pool and all resources within that pool, including provisioned CIDRs, allocations, and other pools.
 * `description` - (Optional) A description for the IPAM pool.
 * `ipam_scope_id` - (Required) The ID of the scope in which you would like to create the IPAM pool.
 * `locale` - (Optional) The locale in which you would like to create the IPAM pool. Locale is the Region where you want to make an IPAM pool available for allocations. You can only create pools with locales that match the operating Regions of the IPAM. You can only create VPCs from a pool whose locale matches the VPC's Region. Possible values: Any AWS region, such as `us-east-1`.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #36245

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccIPAM_cascade PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccIPAM_cascade'  -timeout 360m
=== RUN   TestAccIPAM_cascade
=== PAUSE TestAccIPAM_cascade
=== CONT  TestAccIPAM_cascade
--- PASS: TestAccIPAM_cascade (73.75s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	92.230s

...
```
