### PR TITLE
f-aws_rds_cluster_instance: new data source

### DIFF
--- a/.changelog/36899.txt
+++ b/.changelog/36899.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_rds_cluster_instance
+```

--- a/internal/service/rds/cluster_instance_data_source.go
+++ b/internal/service/rds/cluster_instance_data_source.go
@@ -1,0 +1,224 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package rds
+
+import (
+	"context"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+)
+
+// @SDKDataSource("aws_rds_cluster_instance")
+func DataSourceClusterInstance() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceClusterInstanceRead,
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"auto_minor_version_upgrade": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"availability_zone": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ca_cert_identifier": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cluster_identifier": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"copy_tags_to_snapshot": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"custom_iam_instance_profile": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"db_parameter_group_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"db_subnet_group_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"dbi_resource_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"endpoint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"engine": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"engine_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"engine_version_actual": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"identifier": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"instance_class": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"kms_key_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"monitoring_interval": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"monitoring_role_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"network_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"performance_insights_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"performance_insights_kms_key_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"performance_insights_retention_period": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"port": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"preferred_backup_window": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"preferred_maintenance_window": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"promotion_tier": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"publicly_accessible": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"storage_encrypted": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"tags": tftags.TagsSchemaComputed(),
+			"writer": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceClusterInstanceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).RDSConn(ctx)
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	identifier := d.Get("identifier").(string)
+
+	db, err := findDBInstanceByIDSDKv1(ctx, conn, identifier)
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading RDS Cluster Instance (%s): %s", identifier, err)
+	}
+
+	dbClusterID := aws.StringValue(db.DBClusterIdentifier)
+
+	if dbClusterID == "" {
+		return sdkdiag.AppendErrorf(diags, "DBClusterIdentifier is missing from RDS Cluster Instance (%s). The aws_db_instance resource should be used for non-Aurora instances", d.Id())
+	}
+
+	dbc, err := FindDBClusterByID(ctx, conn, dbClusterID)
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading RDS Cluster (%s): %s", dbClusterID, err)
+	}
+
+	log.Printf("DB Cluster: %v", dbc)
+
+	for _, m := range dbc.DBClusterMembers {
+		if aws.StringValue(m.DBInstanceIdentifier) == identifier {
+			if aws.BoolValue(m.IsClusterWriter) {
+				d.Set("writer", true)
+			} else {
+				d.Set("writer", false)
+			}
+		}
+	}
+
+	if db.Endpoint != nil {
+		d.Set("endpoint", db.Endpoint.Address)
+		d.Set("port", db.Endpoint.Port)
+	}
+
+	d.SetId(identifier)
+	d.Set("arn", db.DBInstanceArn)
+	d.Set("auto_minor_version_upgrade", db.AutoMinorVersionUpgrade)
+	d.Set("availability_zone", db.AvailabilityZone)
+	d.Set("ca_cert_identifier", db.CACertificateIdentifier)
+	d.Set("cluster_identifier", db.DBClusterIdentifier)
+	d.Set("copy_tags_to_snapshot", db.CopyTagsToSnapshot)
+	d.Set("custom_iam_instance_profile", db.CustomIamInstanceProfile)
+	d.Set("db_parameter_group_name", db.DBParameterGroups[0].DBParameterGroupName)
+	d.Set("db_subnet_group_name", db.DBSubnetGroup.DBSubnetGroupName)
+	d.Set("dbi_resource_id", db.DbiResourceId)
+	d.Set("engine", db.Engine)
+	d.Set("engine_version", db.EngineVersion)
+	d.Set("engine_version_actual", db.EngineVersion)
+	d.Set("instance_class", db.DBInstanceClass)
+	d.Set("kms_key_id", db.KmsKeyId)
+	d.Set("monitoring_interval", db.MonitoringInterval)
+	d.Set("monitoring_role_arn", db.MonitoringRoleArn)
+	d.Set("network_type", db.NetworkType)
+	d.Set("performance_insights_enabled", db.PerformanceInsightsEnabled)
+	d.Set("performance_insights_kms_key_id", db.PerformanceInsightsKMSKeyId)
+	d.Set("performance_insights_retention_period", db.PerformanceInsightsRetentionPeriod)
+	d.Set("preferred_backup_window", db.PreferredBackupWindow)
+	d.Set("preferred_maintenance_window", db.PreferredMaintenanceWindow)
+	d.Set("promotion_tier", db.PromotionTier)
+	d.Set("publicly_accessible", db.PubliclyAccessible)
+	d.Set("storage_encrypted", db.StorageEncrypted)
+
+	tags := KeyValueTags(ctx, db.TagList)
+
+	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
+	}
+
+	return nil
+}

--- a/internal/service/rds/cluster_instance_data_source_test.go
+++ b/internal/service/rds/cluster_instance_data_source_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package rds_test
+
+import (
+	"fmt"
+	"testing"
+
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccDataSourceClusterInstance_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_rds_cluster_instance.test"
+	resourceName := "aws_rds_cluster_instance.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterInstanceDataSourceConfig_complete(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "auto_minor_version_upgrade", resourceName, "auto_minor_version_upgrade"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "availability_zone", resourceName, "availability_zone"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ca_cert_identifier", resourceName, "ca_cert_identifier"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "cluster_identifier", resourceName, "cluster_identifier"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "copy_tags_to_snapshot", resourceName, "copy_tags_to_snapshot"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "custom_iam_instance_profile", resourceName, "custom_iam_instance_profile"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "db_parameter_group_name", resourceName, "db_parameter_group_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "db_subnet_group_name", resourceName, "db_subnet_group_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "dbi_resource_id", resourceName, "dbi_resource_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "endpoint", resourceName, "endpoint"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "engine", resourceName, "engine"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "engine_version", resourceName, "engine_version"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "instance_class", resourceName, "instance_class"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "kms_key_id", resourceName, "kms_key_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "monitoring_interval", resourceName, "monitoring_interval"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "monitoring_role_arn", resourceName, "monitoring_role_arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "network_type", resourceName, "network_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "performance_insights_enabled", resourceName, "performance_insights_enabled"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "performance_insights_kms_key_id", resourceName, "performance_insights_kms_key_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "performance_insights_retention_period", resourceName, "performance_insights_retention_period"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "preferred_backup_window", resourceName, "preferred_backup_window"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "preferred_maintenance_window", resourceName, "preferred_maintenance_window"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "promotion_tier", resourceName, "promotion_tier"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "publicly_accessible", resourceName, "publicly_accessible"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "storage_encrypted", resourceName, "storage_encrypted"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags.%", resourceName, "tags.%"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags.Name", resourceName, "tags.Name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "writer", resourceName, "writer"),
+				),
+			},
+		},
+	})
+}
+
+func testAccClusterInstanceDataSourceConfig_complete(rName string) string {
+	return acctest.ConfigCompose(
+		testAccClusterInstanceConfig_basic(rName),
+		fmt.Sprintf(`
+data "aws_rds_cluster_instance" "test" {
+  identifier = aws_rds_cluster_instance.test.identifier
+}
+`))
+}

--- a/internal/service/rds/service_package_gen.go
+++ b/internal/service/rds/service_package_gen.go
@@ -80,6 +80,11 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 			TypeName: "aws_rds_cluster",
 		},
 		{
+			Factory:  DataSourceClusterInstance,
+			TypeName: "aws_rds_cluster_instance",
+			Name:     "Cluster Instance",
+		},
+		{
 			Factory:  DataSourceClusters,
 			TypeName: "aws_rds_clusters",
 		},

--- a/website/docs/d/rds_cluster_instance.html.markdown
+++ b/website/docs/d/rds_cluster_instance.html.markdown
@@ -1,0 +1,32 @@
+---
+subcategory: "RDS (Relational Database)"
+layout: "aws"
+page_title: "AWS: aws_rds_cluster_instance"
+description: |-
+  Provides an RDS cluster instance data source.
+---
+
+# Data Source: aws_rds_cluster_instance
+
+Provides information about an RDS cluster instance.
+
+## Example Usage
+
+```terraform
+data "aws_rds_cluster_instance" "clusterInstanceName" {
+  identifier = "clusterInstanceName"
+}
+```
+
+## Argument Reference
+
+This data source supports the following arguments:
+
+* `identifier` - (Required) The unique identifier of the RDS cluster instance.
+
+## Attribute Reference
+
+See the [RDS Cluster Instance Resource](/docs/providers/aws/r/rds_cluster_instance.html) for details on the
+returned attributes - they are identical for all attributes, except the `tags_all`. If you need to get the tags for this resource, use the attribute `tags` as described below.
+
+* `tags` - A map of tags assigned to the resource.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Here’s a suggested description for your pull request to add the new RDS cluster instance data source:

---

This data source provides Terraform users with the ability to manage and retrieve detailed information about an Amazon RDS cluster instance. This will aid in the configuration and management of RDS cluster instances, supporting use cases where users need to obtain data dynamically based on instance identifiers without managing the instance itself.

The addition of `aws_rds_cluster_instance` as a standalone data source aligns with best practices for modular and decoupled Terraform configurations, enabling users to reference RDS cluster instance details in other parts of their Terraform projects independently of instance management.

This data source includes comprehensive attribute support, mirroring that available in the `aws_rds_cluster_instance` resource, thus ensuring consistency across Terraform configurations and facilitating a smoother integration with existing modules that manage RDS cluster resources.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #9739

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

- https://github.com/hashicorp/terraform-provider-aws/issues/29568

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccDataSourceClusterInstance_basic PKG=rds
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccDataSourceClusterInstance_basic'  -timeout 360m
=== RUN   TestAccDataSourceClusterInstance_basic
=== PAUSE TestAccDataSourceClusterInstance_basic
=== CONT  TestAccDataSourceClusterInstance_basic
--- PASS: TestAccDataSourceClusterInstance_basic (1554.50s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        1560.592s
...
```
