### PR TITLE
New VPCLattice datasource aws_vpclattice_target_group

### DIFF
--- a/internal/service/vpclattice/service_package_gen.go
+++ b/internal/service/vpclattice/service_package_gen.go
@@ -49,6 +49,16 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 			TypeName: "aws_vpclattice_service_network",
 			Tags:     &types.ServicePackageResourceTags{},
 		},
+		{
+			Factory:  DataSourceTargetGroup,
+			TypeName: "aws_vpclattice_target_group",
+			Name:     "Target Group",
+		},
+		{
+			Factory:  DataSourceTargetGroups,
+			TypeName: "aws_vpclattice_target_groups",
+			Name:     "Target Groups",
+		},
 	}
 }
 

--- a/internal/service/vpclattice/service_package_gen.go
+++ b/internal/service/vpclattice/service_package_gen.go
@@ -54,11 +54,6 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 			TypeName: "aws_vpclattice_target_group",
 			Name:     "Target Group",
 		},
-		{
-			Factory:  DataSourceTargetGroups,
-			TypeName: "aws_vpclattice_target_groups",
-			Name:     "Target Groups",
-		},
 	}
 }
 

--- a/internal/service/vpclattice/target_group_data_source.go
+++ b/internal/service/vpclattice/target_group_data_source.go
@@ -1,0 +1,228 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package vpclattice
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
+	"github.com/aws/aws-sdk-go-v2/service/vpclattice/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// Function annotations are used for datasource registration to the Provider. DO NOT EDIT.
+// @SDKDataSource("aws_vpclattice_target_group", name="Target Group")
+func DataSourceTargetGroup() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceTargetGroupRead,
+
+		Schema: map[string]*schema.Schema{
+			names.AttrARN: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"config": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"health_check": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"health_check_interval_seconds": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"health_check_timeout_seconds": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"healthy_threshold_count": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"matcher": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"value": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"path": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"port": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"protocol": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"protocol_version": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"unhealthy_threshold_count": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"ip_address_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"lambda_event_structure_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"port": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"protocol": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"protocol_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vpc_identifier": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"last_updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Computed:     true,
+				Optional:     true,
+				ExactlyOneOf: []string{"name", "target_group_identifier"},
+			},
+			"service_arns": {
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": tftags.TagsSchemaComputed(),
+			"target_group_identifier": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: []string{"name", "target_group_identifier"},
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+const (
+	DSNameTargetGroup = "Target Group Data Source"
+)
+
+func dataSourceTargetGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
+
+	var out *vpclattice.GetTargetGroupOutput
+	if v, ok := d.GetOk("target_group_identifier"); ok {
+		targetGroupID := v.(string)
+		targetGroup, err := FindTargetGroupByID(ctx, conn, targetGroupID)
+
+		if err != nil {
+			return sdkdiag.AppendFromErr(diags, err)
+		}
+
+		out = targetGroup
+	} else if v, ok := d.GetOk("name"); ok {
+		filter := func(x types.TargetGroupSummary) bool {
+			return aws.ToString(x.Name) == v.(string)
+		}
+		output, err := findTargetGroup(ctx, conn, filter)
+
+		if err != nil {
+			return sdkdiag.AppendFromErr(diags, err)
+		}
+
+		targetGroup, err := FindTargetGroupByID(ctx, conn, aws.ToString(output.Id))
+
+		if err != nil {
+			return sdkdiag.AppendFromErr(diags, err)
+		}
+
+		out = targetGroup
+	}
+
+	// Set simple arguments
+	d.SetId(aws.ToString(out.Id))
+	targetGroupARN := aws.ToString(out.Arn)
+	d.Set("arn", targetGroupARN)
+	d.Set("created_at", aws.ToTime(out.CreatedAt).String())
+	d.Set("last_updated_at", aws.ToTime(out.LastUpdatedAt).String())
+	d.Set("name", out.Name)
+	d.Set("service_arns", out.ServiceArns)
+	d.Set("status", string(out.Status))
+	d.Set("target_group_identifier", out.Id)
+	d.Set("type", out.Type)
+
+	// Flatten complex config attribute - uses flatteners from target_group.go
+	if err := d.Set("config", []interface{}{
+		flattenTargetGroupConfig(out.Config),
+	}); err != nil {
+		return diag.Errorf("setting config: %s", err)
+	}
+
+	// Set tags
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+	tags, err := listTags(ctx, conn, aws.ToString(out.Arn))
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "listing tags for VPC Lattice Target Group (%s): %s", targetGroupARN, err)
+	}
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting tags for VPC Lattice Target Group (%s): %s", targetGroupARN, err)
+	}
+
+	return nil
+}

--- a/internal/service/vpclattice/target_group_data_source.go
+++ b/internal/service/vpclattice/target_group_data_source.go
@@ -200,7 +200,7 @@ func dataSourceTargetGroupRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set("last_updated_at", aws.ToTime(out.LastUpdatedAt).String())
 	d.Set("name", out.Name)
 	d.Set("service_arns", out.ServiceArns)
-	d.Set("status", string(out.Status))
+	d.Set("status", out.Status)
 	d.Set("target_group_identifier", out.Id)
 	d.Set("type", out.Type)
 

--- a/internal/service/vpclattice/target_group_data_source_test.go
+++ b/internal/service/vpclattice/target_group_data_source_test.go
@@ -1,0 +1,121 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package vpclattice_test
+
+import (
+	"fmt"
+	"testing"
+
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccVPCLatticeTargetGroupDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_vpclattice_target_group.test"
+	dataSourceName := "data.aws_vpclattice_target_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.VPCLatticeEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTargetGroupDataSourceConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "config.0.health_check.0.port", dataSourceName, "config.0.health_check.0.port"),
+					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "name"),
+					resource.TestCheckResourceAttr(dataSourceName, "status", "ACTIVE"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.%", dataSourceName, "tags.%"),
+					resource.TestCheckResourceAttrPair(resourceName, "type", dataSourceName, "type"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccVPCLatticeTargetGroupDataSource_byName(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_vpclattice_target_group.test"
+	dataSourceName := "data.aws_vpclattice_target_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.VPCLatticeEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTargetGroupDataSourceConfig_byName(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "config.0.health_check.0.port", dataSourceName, "config.0.health_check.0.port"),
+					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "name"),
+					resource.TestCheckResourceAttr(dataSourceName, "status", "ACTIVE"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.%", dataSourceName, "tags.%"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "target_group_identifier"),
+					resource.TestCheckResourceAttrPair(resourceName, "type", dataSourceName, "type"),
+				),
+			},
+		},
+	})
+}
+
+func testAccTargetGroupDataSourceConfig_basic(rName string) string {
+	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 0), fmt.Sprintf(`
+resource "aws_vpclattice_target_group" "test" {
+  name = %[1]q
+  type = "INSTANCE"
+
+  config {
+    port           = 80
+    protocol       = "HTTP"
+    vpc_identifier = aws_vpc.test.id
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+data "aws_vpclattice_target_group" "test" {
+  target_group_identifier = aws_vpclattice_target_group.test.id
+}
+`, rName))
+}
+
+func testAccTargetGroupDataSourceConfig_byName(rName string) string {
+	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 0), fmt.Sprintf(`
+resource "aws_vpclattice_target_group" "test" {
+  name = %[1]q
+  type = "INSTANCE"
+
+  config {
+    port           = 80
+    protocol       = "HTTP"
+    vpc_identifier = aws_vpc.test.id
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+data "aws_vpclattice_target_group" "test" {
+  name = aws_vpclattice_target_group.test.name
+}
+`, rName))
+}

--- a/website/docs/d/vpclattice_target_group.html.markdown
+++ b/website/docs/d/vpclattice_target_group.html.markdown
@@ -1,0 +1,44 @@
+---
+subcategory: "VPC Lattice"
+layout: "aws"
+page_title: "AWS: aws_vpclattice_target_group"
+description: |-
+  Terraform data source for managing an AWS VPC Lattice Target Group.
+---
+
+# Data Source: aws_vpclattice_target_group
+
+Terraform data source for managing an AWS VPC Lattice Target Group.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_vpclattice_target_group" "example" {
+  name = "example"
+}
+```
+
+## Argument Reference
+
+The arguments of this data source act as filters for querying the available VPC lattice target groups.
+The given filters must match exactly one VPC lattice target group whose data will be exported as attributes.
+
+* `name` - (Optional) Target group name.
+    Cannot be used with `target_group_identifier`.
+* `target_group_identifier` - (Optional) ID or Amazon Resource Name (ARN) of the target group.
+    Cannot be used with `name`.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `arn` - ARN of the target group.
+* `id` - Unique identifier for the target group.
+* `config` - Configuration of the target group.
+* `created_at` - Date and time that the target group was created.
+* `last_updated_at` - Date and time that the target group was last updated.
+* `service_arns` - List of VPC lattice service arns the target group is associated with.
+* `status` - Status of the target group.
+* `type` - Type of the target group. Either `IP`, `LAMBDA`, `INSTANCE` or `ALB`.

--- a/website/docs/d/vpclattice_target_group.html.markdown
+++ b/website/docs/d/vpclattice_target_group.html.markdown
@@ -40,5 +40,5 @@ This data source exports the following attributes in addition to the arguments a
 * `created_at` - Date and time that the target group was created.
 * `last_updated_at` - Date and time that the target group was last updated.
 * `service_arns` - List of VPC lattice service arns the target group is associated with.
-* `status` - Status of the target group.
+* `status` - Status of the target group. Either `CREATE_IN_PROGRESS`, `ACTIVE`, `DELETE_IN_PROGRESS`, `CREATE_FAILED` or `DELETE_FAILED`
 * `type` - Type of the target group. Either `IP`, `LAMBDA`, `INSTANCE` or `ALB`.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

Adds support for the VPC Lattice target group data source. 
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates [#30380](https://github.com/hashicorp/terraform-provider-aws/issues/30380)

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

- SDK:
  - https://docs.aws.amazon.com/sdk-for-go/api/service/vpclattice/#VPCLattice.GetTargetGroup
  - https://docs.aws.amazon.com/sdk-for-go/api/service/vpclattice/#VPCLattice.ListTargetGroups
- API:
  - https://docs.aws.amazon.com/vpc-lattice/latest/APIReference/API_GetTargetGroup.html
  - https://docs.aws.amazon.com/vpc-lattice/latest/APIReference/API_ListTargetGroups.html


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccVPCLatticeTargetGroupDataSource_ PKG=vpclattice
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/vpclattice/... -v -count 1 -parallel 20 -run='TestAccVPCLatticeTargetGroupDataSource_'  -timeout 360m
=== RUN   TestAccVPCLatticeTargetGroupDataSource_basic
=== PAUSE TestAccVPCLatticeTargetGroupDataSource_basic
=== RUN   TestAccVPCLatticeTargetGroupDataSource_byName
=== PAUSE TestAccVPCLatticeTargetGroupDataSource_byName
=== CONT  TestAccVPCLatticeTargetGroupDataSource_basic
=== CONT  TestAccVPCLatticeTargetGroupDataSource_byName
--- PASS: TestAccVPCLatticeTargetGroupDataSource_byName (71.13s)
--- PASS: TestAccVPCLatticeTargetGroupDataSource_basic (101.25s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/vpclattice 106.802s
```
