### PR TITLE
Update documentation for `@FrameworkResource` annotation

### DIFF
--- a/docs/add-a-new-resource.md
+++ b/docs/add-a-new-resource.md
@@ -49,7 +49,7 @@ Resources use a self-registration process that adds them to the provider using t
         "github.com/hashicorp/terraform-provider-aws/internal/framework"
     )
 
-    // @FrameworkResource(name="Example")
+    // @FrameworkResource("aws_something_example", name="Example")
     func newResourceExample(_ context.Context) (resource.ResourceWithConfigure, error) {
     	return &resourceExample{}, nil
     }

--- a/docs/resource-tagging.md
+++ b/docs/resource-tagging.md
@@ -201,7 +201,7 @@ Most services can use a facility we call _transparent_ (or _implicit_) _tagging_
 
 === "Terraform Plugin Framework (Preferred)"
     ```go
-    // @FrameworkResource(name="Example")
+    // @FrameworkResource("aws_service_example", name="Example")
     // @Tags(identifierAttribute="arn")
     func newResourceExample(_ context.Context) (resource.ResourceWithConfigure, error) {
         return &resourceExample{}, nil

--- a/docs/terraform-plugin-migrations.md
+++ b/docs/terraform-plugin-migrations.md
@@ -88,7 +88,7 @@ func (r *resourceExampleResource) ModifyPlan(ctx context.Context, request resour
 Transparent Tagging that is used in SDKv2 also applies to the Framework by using the `@Tags` decorator when defining the resource.
 
 ```go
-// @FrameworkResource(name="Example Resource")
+// @FrameworkResource("aws_service_example", name="Example Resource")
 // @Tags(identifierAttribute="arn")
 func newResourceExampleResrouce(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := resourceExampleResource{}

--- a/skaff/resource/resourcefw.tmpl
+++ b/skaff/resource/resourcefw.tmpl
@@ -87,7 +87,7 @@ import (
 {{- end }}
 
 // Function annotations are used for resource registration to the Provider. DO NOT EDIT.
-// @FrameworkResource(name="{{ .HumanResourceName }}")
+// @FrameworkResource("aws_{{ .ServicePackage }}_{{ .ResourceSnake }}", name="{{ .HumanResourceName }}")
 {{- if .IncludeTags }}
 // @Tags(identifierAttribute="arn")
 {{- end }}

--- a/tools/tfsdk2fw/resource.tmpl
+++ b/tools/tfsdk2fw/resource.tmpl
@@ -28,7 +28,7 @@ import (
 	{{- end}}
 )
 
-// @FrameworkResource
+// @FrameworkResource("{{ .TFTypeName }}")
 func newResource{{ .Name }}(context.Context) (resource.ResourceWithConfigure, error) {
 	r := &resource{{ .Name }}{}
 	r.SetMigratedFromPluginSDK(true)


### PR DESCRIPTION
### Description

When tag test generation is implemented for a service, the resource type name is required in the `@FrameworkResource` annotation. Updates documentation and the `skaff` and `tfsdk2fw` tools.

Existing code will be updated as generation is rolled out.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #36875
