### PR TITLE
internal/function(test): change terraform version checks to 1.8.0

### DIFF
--- a/internal/function/arn_build_test.go
+++ b/internal/function/arn_build_test.go
@@ -18,7 +18,7 @@ func TestARNBuildFunction_known(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.8.0-beta1"))),
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.8.0"))),
 		},
 		Steps: []resource.TestStep{
 			{

--- a/internal/function/arn_parse_test.go
+++ b/internal/function/arn_parse_test.go
@@ -20,7 +20,7 @@ func TestARNParseFunction_known(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.8.0-beta1"))),
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.8.0"))),
 		},
 		Steps: []resource.TestStep{
 			{
@@ -40,7 +40,7 @@ func TestARNParseFunction_invalid(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.8.0-beta1"))),
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.8.0"))),
 		},
 		Steps: []resource.TestStep{
 			{

--- a/internal/function/trim_iam_role_path_test.go
+++ b/internal/function/trim_iam_role_path_test.go
@@ -32,7 +32,7 @@ func TestTrimIAMRolePathFunction_valid(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.8.0-beta1"))),
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.8.0"))),
 		},
 		Steps: []resource.TestStep{
 			{
@@ -53,7 +53,7 @@ func TestTrimIAMRolePathFunction_validWithPath(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.8.0-beta1"))),
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.8.0"))),
 		},
 		Steps: []resource.TestStep{
 			{
@@ -73,7 +73,7 @@ func TestTrimIAMRolePathFunction_invalidARN(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.8.0-beta1"))),
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.8.0"))),
 		},
 		Steps: []resource.TestStep{
 			{
@@ -91,7 +91,7 @@ func TestTrimIAMRolePathFunction_invalidService(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.8.0-beta1"))),
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.8.0"))),
 		},
 		Steps: []resource.TestStep{
 			{
@@ -109,7 +109,7 @@ func TestTrimIAMRolePathFunction_invalidRegion(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.8.0-beta1"))),
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.8.0"))),
 		},
 		Steps: []resource.TestStep{
 			{
@@ -127,7 +127,7 @@ func TestTrimIAMRolePathFunction_invalidResource(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.8.0-beta1"))),
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.8.0"))),
 		},
 		Steps: []resource.TestStep{
 			{


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Now that Terraform 1.8 is generally available, the `TerraformVersionChecks` pre-check can refer to a proper minimum version, rather than the beta.


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% terraform -version
Terraform v1.8.0
on darwin_arm64
```

```console
% go test ./internal/function/...
ok      github.com/hashicorp/terraform-provider-aws/internal/function   10.935s
```
