### PR TITLE
rds/cluster: Add test for serverlessv2 with HTTP endpoint enabled

### DIFF
--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -1296,7 +1296,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		"iam_roles",
 		"replication_source_identifier",
 		"skip_final_snapshot",
-		"tags", "tags_all") {
+		names.AttrTags, names.AttrTagsAll) {
 		input := &rds.ModifyDBClusterInput{
 			ApplyImmediately:    aws.Bool(d.Get("apply_immediately").(bool)),
 			DBClusterIdentifier: aws.String(d.Id()),

--- a/internal/service/rds/cluster_test.go
+++ b/internal/service/rds/cluster_test.go
@@ -2467,6 +2467,34 @@ func TestAccRDSCluster_enableHTTPEndpoint(t *testing.T) {
 	})
 }
 
+func TestAccRDSCluster_enableHTTPEndpointProvisioned(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var dbCluster rds.DBCluster
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_rds_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfig_enableHTTPEndpointProvisioned(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(ctx, resourceName, &dbCluster),
+					resource.TestCheckResourceAttr(resourceName, "enable_http_endpoint", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccRDSCluster_password(t *testing.T) {
 	ctx := acctest.Context(t)
 	var dbCluster rds.DBCluster
@@ -4999,6 +5027,25 @@ resource "aws_rds_cluster" "test" {
   }
 }
 `, rName, tfrds.ClusterEngineAuroraMySQL, enableHttpEndpoint)
+}
+
+func testAccClusterConfig_enableHTTPEndpointProvisioned(rName string, enableHttpEndpoint bool) string {
+	return fmt.Sprintf(`
+resource "aws_rds_cluster" "test" {
+  cluster_identifier   = %[1]q
+  engine               = %[2]q
+  engine_mode          = "provisioned"
+  master_password      = "barbarbarbar"
+  master_username      = "foo"
+  skip_final_snapshot  = true
+  enable_http_endpoint = %[3]t
+
+  serverlessv2_scaling_configuration {
+    max_capacity = 1.0
+    min_capacity = 0.5
+  }
+}
+`, rName, tfrds.ClusterEngineAuroraPostgreSQL, enableHttpEndpoint)
 }
 
 func testAccClusterConfig_password(rName, password string) string {

--- a/internal/service/rds/cluster_test.go
+++ b/internal/service/rds/cluster_test.go
@@ -2469,9 +2469,6 @@ func TestAccRDSCluster_enableHTTPEndpoint(t *testing.T) {
 
 func TestAccRDSCluster_enableHTTPEndpointProvisioned(t *testing.T) {
 	ctx := acctest.Context(t)
-	if testing.Short() {
-		t.Skip("skipping long-running test in short mode")
-	}
 
 	var dbCluster rds.DBCluster
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccRDSCluster_enableHTTPEndpointProvisioned K=rds
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSCluster_enableHTTPEndpointProvisioned'  -timeout 360m
=== RUN   TestAccRDSCluster_enableHTTPEndpointProvisioned
=== PAUSE TestAccRDSCluster_enableHTTPEndpointProvisioned
=== CONT  TestAccRDSCluster_enableHTTPEndpointProvisioned
--- PASS: TestAccRDSCluster_enableHTTPEndpointProvisioned (147.24s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	149.615s
```