### PR TITLE
fsx/windows_file_system: Allow updates to disable audit logs

### DIFF
--- a/.changelog/36928.txt
+++ b/.changelog/36928.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_fsx_windows_file_system: Fix error `BadRequest: AuditLogDestination must not be provided when auditing is disabled` when updating `audit_log_configuration.0.file_access_audit_log_level` and `audit_log_configuration.0.file_share_access_audit_log_level` to `"DISABLED"`
+```

--- a/internal/service/fsx/windows_file_system.go
+++ b/internal/service/fsx/windows_file_system.go
@@ -721,6 +721,11 @@ func expandWindowsAuditLogCreateConfiguration(l []interface{}) *fsx.WindowsAudit
 		FileShareAccessAuditLogLevel: aws.String(data["file_share_access_audit_log_level"].(string)),
 	}
 
+	// audit_log_destination cannot be included in the request if the log levels are disabled
+	if data["file_access_audit_log_level"].(string) == fsx.WindowsAccessAuditLogLevelDisabled && data["file_share_access_audit_log_level"].(string) == fsx.WindowsAccessAuditLogLevelDisabled {
+		return req
+	}
+
 	if v, ok := data["audit_log_destination"].(string); ok && v != "" {
 		req.AuditLogDestination = aws.String(windowsAuditLogStateFunc(v))
 	}

--- a/internal/service/fsx/windows_file_system.go
+++ b/internal/service/fsx/windows_file_system.go
@@ -716,13 +716,20 @@ func expandWindowsAuditLogCreateConfiguration(l []interface{}) *fsx.WindowsAudit
 	}
 
 	data := l[0].(map[string]interface{})
+	fileAccessAuditLogLevel, ok1 := data["file_access_audit_log_level"].(string)
+	fileShareAccessAuditLogLevel, ok2 := data["file_share_access_audit_log_level"].(string)
+
+	if !ok1 || !ok2 {
+		return nil
+	}
+
 	req := &fsx.WindowsAuditLogCreateConfiguration{
-		FileAccessAuditLogLevel:      aws.String(data["file_access_audit_log_level"].(string)),
-		FileShareAccessAuditLogLevel: aws.String(data["file_share_access_audit_log_level"].(string)),
+		FileAccessAuditLogLevel:      aws.String(fileAccessAuditLogLevel),
+		FileShareAccessAuditLogLevel: aws.String(fileShareAccessAuditLogLevel),
 	}
 
 	// audit_log_destination cannot be included in the request if the log levels are disabled
-	if data["file_access_audit_log_level"].(string) == fsx.WindowsAccessAuditLogLevelDisabled && data["file_share_access_audit_log_level"].(string) == fsx.WindowsAccessAuditLogLevelDisabled {
+	if fileAccessAuditLogLevel == fsx.WindowsAccessAuditLogLevelDisabled && fileShareAccessAuditLogLevel == fsx.WindowsAccessAuditLogLevelDisabled {
 		return req
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #36927

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccFSxWindowsFileSystem_audit K=fsx
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/fsx/... -v -count 1 -parallel 20 -run='TestAccFSxWindowsFileSystem_audit'  -timeout 360m
=== RUN   TestAccFSxWindowsFileSystem_audit
=== PAUSE TestAccFSxWindowsFileSystem_audit
=== CONT  TestAccFSxWindowsFileSystem_audit
--- PASS: TestAccFSxWindowsFileSystem_audit (3343.73s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/fsx	3348.663s
```
