### PR TITLE
r/aws_vpc_dhcp_options: fix not found error handling on delete

### DIFF
--- a/.changelog/36933.txt
+++ b/.changelog/36933.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_vpc_dhcp_options: Fix `NotFound` error handling on delete
+```

--- a/internal/service/ec2/errors.go
+++ b/internal/service/ec2/errors.go
@@ -41,6 +41,7 @@ const (
 	errCodeInvalidConversionTaskIdMalformed                  = "InvalidConversionTaskId.Malformed"
 	errCodeInvalidCustomerGatewayIDNotFound                  = "InvalidCustomerGatewayID.NotFound"
 	errCodeInvalidDHCPOptionIDNotFound                       = "InvalidDhcpOptionID.NotFound"
+	errCodeInvalidDHCPOptionsIDNotFound                      = "InvalidDhcpOptionsID.NotFound"
 	errCodeInvalidFleetIdNotFound                            = "InvalidFleetId.NotFound"
 	errCodeInvalidFlowLogIdNotFound                          = "InvalidFlowLogId.NotFound"
 	errCodeInvalidGatewayIDNotFound                          = "InvalidGatewayID.NotFound"

--- a/internal/service/ec2/vpc_dhcp_options.go
+++ b/internal/service/ec2/vpc_dhcp_options.go
@@ -214,7 +214,7 @@ func resourceVPCDHCPOptionsDelete(ctx context.Context, d *schema.ResourceData, m
 		return conn.DeleteDhcpOptionsWithContext(ctx, input)
 	}, errCodeDependencyViolation)
 
-	if tfawserr.ErrCodeEquals(err, errCodeInvalidDHCPOptionIDNotFound) {
+	if tfawserr.ErrCodeEquals(err, errCodeInvalidDHCPOptionsIDNotFound) {
 		return diags
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The `DeleteDhcpOptions` API can return a slightly different error code than the associated read operation. This change introduces a new error code constant, preventing the delete operation from failing if the DHCP options have been deleted out-of-band.

Before: 

```console
% make testacc PKG=ec2 TESTS="TestAccVPCDHCPOptions_disappears|TestAccVPCDHCPOptionsAssociation_Disappears_dhcp"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCDHCPOptions_disappears|TestAccVPCDHCPOptionsAssociation_Disappears_dhcp'  -timeout 360m
=== RUN   TestAccVPCDHCPOptionsAssociation_Disappears_dhcp
=== PAUSE TestAccVPCDHCPOptionsAssociation_Disappears_dhcp
=== RUN   TestAccVPCDHCPOptions_disappears
=== PAUSE TestAccVPCDHCPOptions_disappears
=== CONT  TestAccVPCDHCPOptionsAssociation_Disappears_dhcp
=== CONT  TestAccVPCDHCPOptions_disappears
    vpc_dhcp_options_test.go:148: Error running post-test destroy, there may be dangling resources: exit status 1

        Error: deleting EC2 DHCP Options Set (dopt-0afbf75b2cde4f980): InvalidDhcpOptionsID.NotFound: The dhcpOptions ID 'dopt-0afbf75b2cde4f980' does not exist
                status code: 400, request id: fdf420ca-2934-44cd-8d0a-47d4eaceb401

--- FAIL: TestAccVPCDHCPOptions_disappears (10.52s)
=== NAME  TestAccVPCDHCPOptionsAssociation_Disappears_dhcp
    vpc_dhcp_options_association_test.go:76: Error running post-test destroy, there may be dangling resources: exit status 1

        Error: deleting EC2 DHCP Options Set (dopt-0a28e081bb7a4528e): InvalidDhcpOptionsID.NotFound: The dhcpOptions ID 'dopt-0a28e081bb7a4528e' does not exist
                status code: 400, request id: 35937877-857c-4309-b53f-48c8c2ec6dd3

--- FAIL: TestAccVPCDHCPOptionsAssociation_Disappears_dhcp (14.02s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/ec2        19.930s
```

After:


```console
% make testacc PKG=ec2 TESTS="TestAccVPCDHCPOptions_disappears|TestAccVPCDHCPOptionsAssociation_Disappears_dhcp"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCDHCPOptions_disappears|TestAccVPCDHCPOptionsAssociation_Disappears_dhcp'  -timeout 360m

--- PASS: TestAccVPCDHCPOptions_disappears (10.68s)
--- PASS: TestAccVPCDHCPOptionsAssociation_Disappears_dhcp (14.40s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        20.149s
```

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html#api-error-codes-table-client

Relates https://github.com/hashicorp/terraform-provider-aws/issues/35747.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=ec2 TESTS="TestAccVPCDHCPOptions_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCDHCPOptions_'  -timeout 360m

--- PASS: TestAccVPCDHCPOptions_disappears (11.88s)
--- PASS: TestAccVPCDHCPOptions_full (13.92s)
--- PASS: TestAccVPCDHCPOptions_basic (13.93s)
--- PASS: TestAccVPCDHCPOptions_tags (27.68s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        33.611s
```