### PR TITLE
feat: Add GitLab support to report_build_status and build_status_config for aws_codebuild_project

### DIFF
--- a/.changelog/36942.txt
+++ b/.changelog/36942.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_codebuild_project: Add GitLab and GitLab Self Managed support to the `report_build_status` and `build_status_config` arguments
+```

--- a/internal/service/codebuild/project.go
+++ b/internal/service/codebuild/project.go
@@ -1563,14 +1563,14 @@ func expandProjectSource(tfMap map[string]interface{}) *types.ProjectSource {
 		apiObject.SourceIdentifier = aws.String(v)
 	}
 
-	// Only valid for BITBUCKET, GITHUB, and GITHUB_ENTERPRISE source types, e.g.
-	// InvalidInputException: Source type NO_SOURCE does not support ReportBuildStatus
-	if sourceType == types.SourceTypeBitbucket || sourceType == types.SourceTypeGithub || sourceType == types.SourceTypeGithubEnterprise {
+	// Only valid for BITBUCKET, GITHUB, GITHUB_ENTERPRISE, GITLAB, and GITLAB_SELF_MANAGED source types
+	// e.g., InvalidInputException: Source type NO_SOURCE does not support ReportBuildStatus
+	if sourceType == types.SourceTypeBitbucket || sourceType == types.SourceTypeGithub || sourceType == types.SourceTypeGithubEnterprise || sourceType == types.SourceTypeGitlab || sourceType == types.SourceTypeGitlabSelfManaged {
 		apiObject.ReportBuildStatus = aws.Bool(tfMap["report_build_status"].(bool))
 	}
 
-	// Only valid for CODECOMMIT, GITHUB, GITHUB_ENTERPRISE, BITBUCKET source types.
-	if sourceType == types.SourceTypeCodecommit || sourceType == types.SourceTypeGithub || sourceType == types.SourceTypeGithubEnterprise || sourceType == types.SourceTypeBitbucket {
+	// Only valid for BITBUCKET, CODECOMMIT, GITHUB, and GITHUB_ENTERPRISE source types
+	if sourceType == types.SourceTypeBitbucket || sourceType == types.SourceTypeCodecommit || sourceType == types.SourceTypeGithub || sourceType == types.SourceTypeGithubEnterprise {
 		if v, ok := tfMap["git_submodules_config"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 			tfMap := v[0].(map[string]interface{})
 
@@ -1584,8 +1584,8 @@ func expandProjectSource(tfMap map[string]interface{}) *types.ProjectSource {
 		}
 	}
 
-	// Only valid for BITBUCKET, GITHUB, GITHUB_ENTERPRISE source types.
-	if sourceType == types.SourceTypeBitbucket || sourceType == types.SourceTypeGithub || sourceType == types.SourceTypeGithubEnterprise {
+	// Only valid for BITBUCKET, GITHUB, GITHUB_ENTERPRISE, GITLAB, and GITLAB_SELF_MANAGED source types
+	if sourceType == types.SourceTypeBitbucket || sourceType == types.SourceTypeGithub || sourceType == types.SourceTypeGithubEnterprise || sourceType == types.SourceTypeGitlab || sourceType == types.SourceTypeGitlabSelfManaged {
 		if v, ok := tfMap["build_status_config"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 			tfMap := v[0].(map[string]interface{})
 

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -357,14 +357,14 @@ See [ProjectFileSystemLocation](https://docs.aws.amazon.com/codebuild/latest/API
 * `git_submodules_config` - (Optional) Configuration block. Detailed below.
 * `insecure_ssl` - (Optional) Ignore SSL warnings when connecting to source control.
 * `location` - (Optional) Location of the source code from git or s3.
-* `report_build_status` - (Optional) Whether to report the status of a build's start and finish to your source provider. This option is only valid when your source provider is `GITHUB`, `BITBUCKET`, or `GITHUB_ENTERPRISE`.
-* `build_status_config` - (Optional) Configuration block that contains information that defines how the build project reports the build status to the source provider. This option is only used when the source provider is `GITHUB`, `GITHUB_ENTERPRISE`, or `BITBUCKET`. `build_status_config` blocks are documented below.
+* `report_build_status` - (Optional) Whether to report the status of a build's start and finish to your source provider. This option is valid only when your source provider is GitHub, GitHub Enterprise, GitLab, GitLab Self Managed, or Bitbucket.
+* `build_status_config` - (Optional) Configuration block that contains information that defines how the build project reports the build status to the source provider. This option is only used when the source provider is GitHub, GitHub Enterprise, GitLab, GitLab Self Managed, or Bitbucket. `build_status_config` blocks are documented below.
 * `source_identifier` - (Required) An identifier for this project source. The identifier can only contain alphanumeric characters and underscores, and must be less than 128 characters in length.
-* `type` - (Required) Type of repository that contains the source code to be built. Valid values: `CODECOMMIT`, `CODEPIPELINE`, `GITHUB`, `GITHUB_ENTERPRISE`, `BITBUCKET` or `S3`.
+* `type` - (Required) Type of repository that contains the source code to be built. Valid values: `BITBUCKET`, `CODECOMMIT`, `CODEPIPELINE`, `GITHUB`, `GITHUB_ENTERPRISE`, `GITLAB`, `GITLAB_SELF_MANAGED`, `NO_SOURCE`, `S3`.
 
 #### secondary_sources: git_submodules_config
 
-This block is only valid when the `type` is `CODECOMMIT`, `GITHUB` or `GITHUB_ENTERPRISE`.
+This block is only valid when the `type` is `CODECOMMIT`, `GITHUB`, `GITHUB_ENTERPRISE`, `GITLAB`, or `GITLAB_SELF_MANAGED`.
 
 * `fetch_submodules` - (Required) Whether to fetch Git submodules for the AWS CodeBuild build project.
 
@@ -385,13 +385,13 @@ This block is only valid when the `type` is `CODECOMMIT`, `GITHUB` or `GITHUB_EN
 * `git_submodules_config` - (Optional) Configuration block. Detailed below.
 * `insecure_ssl` - (Optional) Ignore SSL warnings when connecting to source control.
 * `location` - (Optional) Location of the source code from git or s3.
-* `report_build_status` - (Optional) Whether to report the status of a build's start and finish to your source provider. This option is only valid when the `type` is `BITBUCKET` or `GITHUB`.
+* `report_build_status` - (Optional) Whether to report the status of a build's start and finish to your source provider. This option is valid only when your source provider is GitHub, GitHub Enterprise, GitLab, GitLab Self Managed, or Bitbucket.
 * `build_status_config` - (Optional) Configuration block that contains information that defines how the build project reports the build status to the source provider. This option is only used when the source provider is GitHub, GitHub Enterprise, GitLab, GitLab Self Managed, or Bitbucket. `build_status_config` blocks are documented below.
 * `type` - (Required) Type of repository that contains the source code to be built. Valid values: `BITBUCKET`, `CODECOMMIT`, `CODEPIPELINE`, `GITHUB`, `GITHUB_ENTERPRISE`, `GITLAB`, `GITLAB_SELF_MANAGED`, `NO_SOURCE`, `S3`.
 
 #### source: git_submodules_config
 
-This block is only valid when the `type` is `CODECOMMIT`, `GITHUB` or `GITHUB_ENTERPRISE`.
+This block is only valid when the `type` is `CODECOMMIT`, `GITHUB`, `GITHUB_ENTERPRISE`, `GITLAB`, or `GITLAB_SELF_MANAGED`.
 
 * `fetch_submodules` - (Required) Whether to fetch Git submodules for the AWS CodeBuild build project.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add GitLab and GitLab Self Managed support to the `report_build_status` and `build_status_config` arguments in the `aws_codebuild_project` resource. The expansion code apparently has code logic to detect the build type to determine whether these arguments/config blocks should be added. Personally I think it should be deferred to the API to determine that, but to fix the issue quickly I just follow suit for now.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #36937

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [ProjectSource](https://docs.aws.amazon.com/codebuild/latest/APIReference/API_ProjectSource.html) for specs and documentation wordings. Also cross-checked the availability of options in the AWS Management Console - note that `git_submodules_config` is grayed out (and thus not supported) for GitLab source types.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

**Note:** Unfortunately I don't really have the right setup to test GitHub and BitBucket source types, so I can't really test them. I also don't have GitLab so I can't write new tests for it either even when I wanted to. If any maintainer can facilitate adding a test cases for GitLab source types, that's be greatly appreciated.

```console
$ make testacc PKG=codebuild TESTS=TestAccCodeBuildProject_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/codebuild/... -v -count 1 -parallel 20 -run='TestAccCodeBuildProject_'  -timeout 360m
=== RUN   TestAccCodeBuildProject_basic
=== PAUSE TestAccCodeBuildProject_basic
=== RUN   TestAccCodeBuildProject_disappears
=== PAUSE TestAccCodeBuildProject_disappears
=== RUN   TestAccCodeBuildProject_tags
=== PAUSE TestAccCodeBuildProject_tags
=== RUN   TestAccCodeBuildProject_publicVisibility
=== PAUSE TestAccCodeBuildProject_publicVisibility
=== RUN   TestAccCodeBuildProject_badgeEnabled
=== PAUSE TestAccCodeBuildProject_badgeEnabled
=== RUN   TestAccCodeBuildProject_buildTimeout
=== PAUSE TestAccCodeBuildProject_buildTimeout
=== RUN   TestAccCodeBuildProject_queuedTimeout
=== PAUSE TestAccCodeBuildProject_queuedTimeout
=== RUN   TestAccCodeBuildProject_cache
=== PAUSE TestAccCodeBuildProject_cache
=== RUN   TestAccCodeBuildProject_description
=== PAUSE TestAccCodeBuildProject_description
=== RUN   TestAccCodeBuildProject_fileSystemLocations
=== PAUSE TestAccCodeBuildProject_fileSystemLocations
=== RUN   TestAccCodeBuildProject_sourceVersion
=== PAUSE TestAccCodeBuildProject_sourceVersion
=== RUN   TestAccCodeBuildProject_encryptionKey
=== PAUSE TestAccCodeBuildProject_encryptionKey
=== RUN   TestAccCodeBuildProject_Environment_environmentVariable
=== PAUSE TestAccCodeBuildProject_Environment_environmentVariable
=== RUN   TestAccCodeBuildProject_EnvironmentEnvironmentVariable_type
=== PAUSE TestAccCodeBuildProject_EnvironmentEnvironmentVariable_type
=== RUN   TestAccCodeBuildProject_EnvironmentEnvironmentVariable_value
=== PAUSE TestAccCodeBuildProject_EnvironmentEnvironmentVariable_value
=== RUN   TestAccCodeBuildProject_Environment_certificate
=== PAUSE TestAccCodeBuildProject_Environment_certificate
=== RUN   TestAccCodeBuildProject_Environment_registryCredential
=== PAUSE TestAccCodeBuildProject_Environment_registryCredential
=== RUN   TestAccCodeBuildProject_Logs_cloudWatchLogs
=== PAUSE TestAccCodeBuildProject_Logs_cloudWatchLogs
=== RUN   TestAccCodeBuildProject_Logs_s3Logs
=== PAUSE TestAccCodeBuildProject_Logs_s3Logs
=== RUN   TestAccCodeBuildProject_buildBatch
=== PAUSE TestAccCodeBuildProject_buildBatch
=== RUN   TestAccCodeBuildProject_buildBatchConfigDelete
=== PAUSE TestAccCodeBuildProject_buildBatchConfigDelete
=== RUN   TestAccCodeBuildProject_Source_gitCloneDepth
=== PAUSE TestAccCodeBuildProject_Source_gitCloneDepth
=== RUN   TestAccCodeBuildProject_SourceGitSubmodules_codeCommit
=== PAUSE TestAccCodeBuildProject_SourceGitSubmodules_codeCommit
=== RUN   TestAccCodeBuildProject_SourceGitSubmodules_gitHub
=== PAUSE TestAccCodeBuildProject_SourceGitSubmodules_gitHub
=== RUN   TestAccCodeBuildProject_SourceGitSubmodules_gitHubEnterprise
=== PAUSE TestAccCodeBuildProject_SourceGitSubmodules_gitHubEnterprise
=== RUN   TestAccCodeBuildProject_SecondarySourcesGitSubmodules_codeCommit
=== PAUSE TestAccCodeBuildProject_SecondarySourcesGitSubmodules_codeCommit
=== RUN   TestAccCodeBuildProject_SecondarySourcesGitSubmodules_gitHub
=== PAUSE TestAccCodeBuildProject_SecondarySourcesGitSubmodules_gitHub
=== RUN   TestAccCodeBuildProject_SecondarySourcesGitSubmodules_gitHubEnterprise
=== PAUSE TestAccCodeBuildProject_SecondarySourcesGitSubmodules_gitHubEnterprise
=== RUN   TestAccCodeBuildProject_SecondarySourcesVersions
=== PAUSE TestAccCodeBuildProject_SecondarySourcesVersions
=== RUN   TestAccCodeBuildProject_Source_insecureSSL
=== PAUSE TestAccCodeBuildProject_Source_insecureSSL
=== RUN   TestAccCodeBuildProject_SourceBuildStatus_gitHubEnterprise
=== PAUSE TestAccCodeBuildProject_SourceBuildStatus_gitHubEnterprise
=== RUN   TestAccCodeBuildProject_SourceReportBuildStatus_gitHubEnterprise
=== PAUSE TestAccCodeBuildProject_SourceReportBuildStatus_gitHubEnterprise
=== RUN   TestAccCodeBuildProject_SourceReportBuildStatus_bitbucket
=== PAUSE TestAccCodeBuildProject_SourceReportBuildStatus_bitbucket
=== RUN   TestAccCodeBuildProject_SourceReportBuildStatus_gitHub
=== PAUSE TestAccCodeBuildProject_SourceReportBuildStatus_gitHub
=== RUN   TestAccCodeBuildProject_SourceType_bitbucket
=== PAUSE TestAccCodeBuildProject_SourceType_bitbucket
=== RUN   TestAccCodeBuildProject_SourceType_codeCommit
=== PAUSE TestAccCodeBuildProject_SourceType_codeCommit
=== RUN   TestAccCodeBuildProject_SourceType_codePipeline
=== PAUSE TestAccCodeBuildProject_SourceType_codePipeline
=== RUN   TestAccCodeBuildProject_SourceType_gitHubEnterprise
=== PAUSE TestAccCodeBuildProject_SourceType_gitHubEnterprise
=== RUN   TestAccCodeBuildProject_SourceType_s3
=== PAUSE TestAccCodeBuildProject_SourceType_s3
=== RUN   TestAccCodeBuildProject_SourceType_noSource
=== PAUSE TestAccCodeBuildProject_SourceType_noSource
=== RUN   TestAccCodeBuildProject_SourceType_noSourceInvalid
=== PAUSE TestAccCodeBuildProject_SourceType_noSourceInvalid
=== RUN   TestAccCodeBuildProject_vpc
=== PAUSE TestAccCodeBuildProject_vpc
=== RUN   TestAccCodeBuildProject_windowsServer2019Container
=== PAUSE TestAccCodeBuildProject_windowsServer2019Container
=== RUN   TestAccCodeBuildProject_armContainer
=== PAUSE TestAccCodeBuildProject_armContainer
=== RUN   TestAccCodeBuildProject_linuxLambdaContainer
=== PAUSE TestAccCodeBuildProject_linuxLambdaContainer
=== RUN   TestAccCodeBuildProject_Artifacts_artifactIdentifier
=== PAUSE TestAccCodeBuildProject_Artifacts_artifactIdentifier
=== RUN   TestAccCodeBuildProject_Artifacts_encryptionDisabled
=== PAUSE TestAccCodeBuildProject_Artifacts_encryptionDisabled
=== RUN   TestAccCodeBuildProject_Artifacts_location
=== PAUSE TestAccCodeBuildProject_Artifacts_location
=== RUN   TestAccCodeBuildProject_Artifacts_name
=== PAUSE TestAccCodeBuildProject_Artifacts_name
=== RUN   TestAccCodeBuildProject_Artifacts_namespaceType
=== PAUSE TestAccCodeBuildProject_Artifacts_namespaceType
=== RUN   TestAccCodeBuildProject_Artifacts_overrideArtifactName
=== PAUSE TestAccCodeBuildProject_Artifacts_overrideArtifactName
=== RUN   TestAccCodeBuildProject_Artifacts_packaging
=== PAUSE TestAccCodeBuildProject_Artifacts_packaging
=== RUN   TestAccCodeBuildProject_Artifacts_path
=== PAUSE TestAccCodeBuildProject_Artifacts_path
=== RUN   TestAccCodeBuildProject_Artifacts_type
=== PAUSE TestAccCodeBuildProject_Artifacts_type
=== RUN   TestAccCodeBuildProject_Artifacts_bucketOwnerAccess
=== PAUSE TestAccCodeBuildProject_Artifacts_bucketOwnerAccess
=== RUN   TestAccCodeBuildProject_secondaryArtifacts
=== PAUSE TestAccCodeBuildProject_secondaryArtifacts
=== RUN   TestAccCodeBuildProject_SecondaryArtifacts_artifactIdentifier
=== PAUSE TestAccCodeBuildProject_SecondaryArtifacts_artifactIdentifier
=== RUN   TestAccCodeBuildProject_SecondaryArtifacts_overrideArtifactName
=== PAUSE TestAccCodeBuildProject_SecondaryArtifacts_overrideArtifactName
=== RUN   TestAccCodeBuildProject_SecondaryArtifacts_encryptionDisabled
=== PAUSE TestAccCodeBuildProject_SecondaryArtifacts_encryptionDisabled
=== RUN   TestAccCodeBuildProject_SecondaryArtifacts_location
=== PAUSE TestAccCodeBuildProject_SecondaryArtifacts_location
=== RUN   TestAccCodeBuildProject_SecondaryArtifacts_name
    project_test.go:2585: Currently no solution to allow updates on name attribute
--- SKIP: TestAccCodeBuildProject_SecondaryArtifacts_name (0.00s)
=== RUN   TestAccCodeBuildProject_SecondaryArtifacts_namespaceType
=== PAUSE TestAccCodeBuildProject_SecondaryArtifacts_namespaceType
=== RUN   TestAccCodeBuildProject_SecondaryArtifacts_path
=== PAUSE TestAccCodeBuildProject_SecondaryArtifacts_path
=== RUN   TestAccCodeBuildProject_SecondaryArtifacts_packaging
=== PAUSE TestAccCodeBuildProject_SecondaryArtifacts_packaging
=== RUN   TestAccCodeBuildProject_SecondaryArtifacts_type
=== PAUSE TestAccCodeBuildProject_SecondaryArtifacts_type
=== RUN   TestAccCodeBuildProject_SecondarySources_codeCommit
=== PAUSE TestAccCodeBuildProject_SecondarySources_codeCommit
=== RUN   TestAccCodeBuildProject_concurrentBuildLimit
=== PAUSE TestAccCodeBuildProject_concurrentBuildLimit
=== CONT  TestAccCodeBuildProject_basic
=== CONT  TestAccCodeBuildProject_SourceReportBuildStatus_gitHub
=== CONT  TestAccCodeBuildProject_Artifacts_overrideArtifactName
=== CONT  TestAccCodeBuildProject_windowsServer2019Container
=== CONT  TestAccCodeBuildProject_SecondaryArtifacts_encryptionDisabled
=== CONT  TestAccCodeBuildProject_SecondaryArtifacts_packaging
=== CONT  TestAccCodeBuildProject_concurrentBuildLimit
=== CONT  TestAccCodeBuildProject_SecondarySources_codeCommit
=== CONT  TestAccCodeBuildProject_SecondaryArtifacts_type
=== CONT  TestAccCodeBuildProject_Artifacts_bucketOwnerAccess
=== CONT  TestAccCodeBuildProject_SecondaryArtifacts_overrideArtifactName
=== CONT  TestAccCodeBuildProject_SecondaryArtifacts_artifactIdentifier
=== CONT  TestAccCodeBuildProject_Artifacts_encryptionDisabled
=== CONT  TestAccCodeBuildProject_secondaryArtifacts
=== CONT  TestAccCodeBuildProject_Artifacts_namespaceType
=== CONT  TestAccCodeBuildProject_linuxLambdaContainer
=== CONT  TestAccCodeBuildProject_Artifacts_name
=== CONT  TestAccCodeBuildProject_Artifacts_location
=== CONT  TestAccCodeBuildProject_Artifacts_artifactIdentifier
=== CONT  TestAccCodeBuildProject_armContainer
=== NAME  TestAccCodeBuildProject_SourceReportBuildStatus_gitHub
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_SourceReportBuildStatus_gitHub (1.02s)
=== NAME  TestAccCodeBuildProject_linuxLambdaContainer
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
=== CONT  TestAccCodeBuildProject_SecondaryArtifacts_namespaceType
--- SKIP: TestAccCodeBuildProject_linuxLambdaContainer (1.02s)
=== CONT  TestAccCodeBuildProject_SecondaryArtifacts_path
=== NAME  TestAccCodeBuildProject_SecondaryArtifacts_packaging
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_SecondaryArtifacts_packaging (1.02s)
=== CONT  TestAccCodeBuildProject_SecondaryArtifacts_location
=== NAME  TestAccCodeBuildProject_SecondaryArtifacts_artifactIdentifier
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_SecondaryArtifacts_artifactIdentifier (1.02s)
=== CONT  TestAccCodeBuildProject_Logs_cloudWatchLogs
=== NAME  TestAccCodeBuildProject_armContainer
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_armContainer (1.02s)
=== NAME  TestAccCodeBuildProject_secondaryArtifacts
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
=== CONT  TestAccCodeBuildProject_SourceReportBuildStatus_bitbucket
--- SKIP: TestAccCodeBuildProject_secondaryArtifacts (1.02s)
=== CONT  TestAccCodeBuildProject_SourceReportBuildStatus_gitHubEnterprise
=== NAME  TestAccCodeBuildProject_Artifacts_artifactIdentifier
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_Artifacts_artifactIdentifier (1.02s)
=== CONT  TestAccCodeBuildProject_SourceBuildStatus_gitHubEnterprise
=== NAME  TestAccCodeBuildProject_basic
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_basic (1.03s)
=== NAME  TestAccCodeBuildProject_SecondaryArtifacts_overrideArtifactName
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
=== CONT  TestAccCodeBuildProject_Source_insecureSSL
=== NAME  TestAccCodeBuildProject_Artifacts_name
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
=== NAME  TestAccCodeBuildProject_Artifacts_location
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
=== NAME  TestAccCodeBuildProject_windowsServer2019Container
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
=== CONT  TestAccCodeBuildProject_Environment_registryCredential
=== CONT  TestAccCodeBuildProject_Environment_certificate
=== CONT  TestAccCodeBuildProject_fileSystemLocations
=== CONT  TestAccCodeBuildProject_SecondarySourcesVersions
--- SKIP: TestAccCodeBuildProject_SecondaryArtifacts_overrideArtifactName (1.03s)
--- SKIP: TestAccCodeBuildProject_Artifacts_name (1.03s)
--- SKIP: TestAccCodeBuildProject_windowsServer2019Container (1.03s)
=== NAME  TestAccCodeBuildProject_Artifacts_namespaceType
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_Artifacts_location (1.03s)
--- SKIP: TestAccCodeBuildProject_Artifacts_namespaceType (1.03s)
=== CONT  TestAccCodeBuildProject_EnvironmentEnvironmentVariable_value
=== NAME  TestAccCodeBuildProject_Artifacts_encryptionDisabled
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_Artifacts_encryptionDisabled (1.04s)
=== CONT  TestAccCodeBuildProject_SecondarySourcesGitSubmodules_gitHubEnterprise
=== NAME  TestAccCodeBuildProject_SecondaryArtifacts_encryptionDisabled
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_SecondaryArtifacts_encryptionDisabled (1.04s)
=== CONT  TestAccCodeBuildProject_EnvironmentEnvironmentVariable_type
=== NAME  TestAccCodeBuildProject_concurrentBuildLimit
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_concurrentBuildLimit (1.04s)
=== CONT  TestAccCodeBuildProject_SecondarySourcesGitSubmodules_gitHub
=== NAME  TestAccCodeBuildProject_Artifacts_overrideArtifactName
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_Artifacts_overrideArtifactName (1.05s)
=== CONT  TestAccCodeBuildProject_sourceVersion
=== NAME  TestAccCodeBuildProject_SecondaryArtifacts_namespaceType
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_SecondaryArtifacts_namespaceType (0.21s)
=== NAME  TestAccCodeBuildProject_SecondaryArtifacts_path
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
=== CONT  TestAccCodeBuildProject_SecondarySourcesGitSubmodules_codeCommit
--- SKIP: TestAccCodeBuildProject_SecondaryArtifacts_path (0.21s)
=== CONT  TestAccCodeBuildProject_SourceGitSubmodules_gitHubEnterprise
=== NAME  TestAccCodeBuildProject_SourceReportBuildStatus_bitbucket
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (BITBUCKET) not found
--- SKIP: TestAccCodeBuildProject_SourceReportBuildStatus_bitbucket (0.21s)
=== CONT  TestAccCodeBuildProject_Source_gitCloneDepth
=== NAME  TestAccCodeBuildProject_Logs_cloudWatchLogs
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
=== NAME  TestAccCodeBuildProject_Environment_registryCredential
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_Logs_cloudWatchLogs (0.22s)
--- SKIP: TestAccCodeBuildProject_Environment_registryCredential (0.21s)
=== CONT  TestAccCodeBuildProject_buildBatchConfigDelete
=== CONT  TestAccCodeBuildProject_SourceGitSubmodules_gitHub
=== NAME  TestAccCodeBuildProject_SecondaryArtifacts_location
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_SecondaryArtifacts_location (0.23s)
=== CONT  TestAccCodeBuildProject_buildBatch
=== NAME  TestAccCodeBuildProject_SourceBuildStatus_gitHubEnterprise
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB_ENTERPRISE) not found
--- SKIP: TestAccCodeBuildProject_SourceBuildStatus_gitHubEnterprise (0.22s)
=== CONT  TestAccCodeBuildProject_SourceGitSubmodules_codeCommit
=== NAME  TestAccCodeBuildProject_EnvironmentEnvironmentVariable_value
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_EnvironmentEnvironmentVariable_value (0.22s)
=== CONT  TestAccCodeBuildProject_Logs_s3Logs
=== NAME  TestAccCodeBuildProject_fileSystemLocations
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_fileSystemLocations (0.38s)
=== CONT  TestAccCodeBuildProject_buildTimeout
=== NAME  TestAccCodeBuildProject_SourceGitSubmodules_gitHubEnterprise
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB_ENTERPRISE) not found
--- SKIP: TestAccCodeBuildProject_SourceGitSubmodules_gitHubEnterprise (0.21s)
=== CONT  TestAccCodeBuildProject_description
=== NAME  TestAccCodeBuildProject_Source_gitCloneDepth
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_Source_gitCloneDepth (0.22s)
=== CONT  TestAccCodeBuildProject_publicVisibility
=== NAME  TestAccCodeBuildProject_Logs_s3Logs
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_Logs_s3Logs (0.21s)
=== CONT  TestAccCodeBuildProject_cache
=== NAME  TestAccCodeBuildProject_Environment_certificate
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_Environment_certificate (9.30s)
=== CONT  TestAccCodeBuildProject_badgeEnabled
=== NAME  TestAccCodeBuildProject_SourceGitSubmodules_gitHub
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_SourceGitSubmodules_gitHub (10.74s)
=== CONT  TestAccCodeBuildProject_queuedTimeout
=== NAME  TestAccCodeBuildProject_badgeEnabled
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_badgeEnabled (1.70s)
=== CONT  TestAccCodeBuildProject_tags
=== NAME  TestAccCodeBuildProject_queuedTimeout
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_queuedTimeout (0.23s)
=== CONT  TestAccCodeBuildProject_Environment_environmentVariable
=== NAME  TestAccCodeBuildProject_Source_insecureSSL
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_Source_insecureSSL (11.27s)
=== CONT  TestAccCodeBuildProject_disappears
=== NAME  TestAccCodeBuildProject_Environment_environmentVariable
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_Environment_environmentVariable (0.20s)
=== CONT  TestAccCodeBuildProject_Artifacts_path
=== NAME  TestAccCodeBuildProject_disappears
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_disappears (0.21s)
=== CONT  TestAccCodeBuildProject_encryptionKey
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_encryptionKey (0.22s)
=== CONT  TestAccCodeBuildProject_Artifacts_type
=== NAME  TestAccCodeBuildProject_Artifacts_path
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_Artifacts_path (3.73s)
=== CONT  TestAccCodeBuildProject_Artifacts_packaging
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_Artifacts_packaging (0.37s)
=== CONT  TestAccCodeBuildProject_SourceType_codePipeline
=== NAME  TestAccCodeBuildProject_sourceVersion
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_sourceVersion (15.62s)
=== CONT  TestAccCodeBuildProject_SourceType_gitHubEnterprise
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB_ENTERPRISE) not found
--- SKIP: TestAccCodeBuildProject_SourceType_gitHubEnterprise (0.22s)
=== CONT  TestAccCodeBuildProject_SourceType_codeCommit
=== NAME  TestAccCodeBuildProject_tags
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_tags (7.07s)
=== CONT  TestAccCodeBuildProject_SourceType_noSourceInvalid
=== NAME  TestAccCodeBuildProject_buildBatchConfigDelete
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_buildBatchConfigDelete (21.97s)
=== CONT  TestAccCodeBuildProject_SourceType_bitbucket
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (BITBUCKET) not found
--- SKIP: TestAccCodeBuildProject_SourceType_bitbucket (0.21s)
=== CONT  TestAccCodeBuildProject_vpc
=== NAME  TestAccCodeBuildProject_EnvironmentEnvironmentVariable_type
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_EnvironmentEnvironmentVariable_type (22.70s)
=== CONT  TestAccCodeBuildProject_SourceType_noSource
=== NAME  TestAccCodeBuildProject_vpc
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_vpc (0.39s)
=== CONT  TestAccCodeBuildProject_SourceType_s3
=== NAME  TestAccCodeBuildProject_SourceReportBuildStatus_gitHubEnterprise
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB_ENTERPRISE) not found
--- SKIP: TestAccCodeBuildProject_SourceReportBuildStatus_gitHubEnterprise (24.74s)
--- PASS: TestAccCodeBuildProject_SecondaryArtifacts_type (28.15s)
=== NAME  TestAccCodeBuildProject_buildBatch
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_buildBatch (29.14s)
--- PASS: TestAccCodeBuildProject_SecondarySources_codeCommit (30.79s)
=== NAME  TestAccCodeBuildProject_description
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_description (29.58s)
=== NAME  TestAccCodeBuildProject_cache
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_cache (30.95s)
--- PASS: TestAccCodeBuildProject_SourceType_noSourceInvalid (14.85s)
=== NAME  TestAccCodeBuildProject_buildTimeout
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_buildTimeout (33.72s)
=== NAME  TestAccCodeBuildProject_SecondarySourcesGitSubmodules_gitHub
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_SecondarySourcesGitSubmodules_gitHub (43.64s)
=== NAME  TestAccCodeBuildProject_publicVisibility
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB) not found
--- SKIP: TestAccCodeBuildProject_publicVisibility (43.68s)
--- PASS: TestAccCodeBuildProject_SourceType_codePipeline (29.68s)
--- PASS: TestAccCodeBuildProject_Artifacts_bucketOwnerAccess (50.46s)
=== NAME  TestAccCodeBuildProject_SecondarySourcesGitSubmodules_gitHubEnterprise
    source_credential_test.go:144: skipping acceptance testing: Source Credentials (GITHUB_ENTERPRISE) not found

$
```
