### PR TITLE
Add status output for organizations_account resource

### DIFF
--- a/website/docs/r/organizations_account.html.markdown
+++ b/website/docs/r/organizations_account.html.markdown
@@ -46,6 +46,7 @@ This resource exports the following attributes in addition to the arguments abov
 * `arn` - The ARN for this account.
 * `govcloud_id` - ID for a GovCloud account created with the account.
 * `id` - The AWS account id
+* `status` - The status of the account in the organization.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Import


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

`aws_organizations_account` resource has `status` output. But, there is not defined in the docs.

```
  " {
    "arn" = "arn:aws:organizations:xxxxx:account/o-zzzzzz/111111"
    "email" = "test@example.com"
    "id" = "xxxxx"
    .....
    "status" = "ACTIVE"
  }

```