### PR TITLE
f-aws_iam_role_policies: New datasource

### DIFF
--- a/.changelog/36957.txt
+++ b/.changelog/36957.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_iam_role_policies
+```

--- a/internal/service/iam/role_policies_data_source.go
+++ b/internal/service/iam/role_policies_data_source.go
@@ -1,0 +1,95 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package iam
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource(name="Role Policies")
+func newDataSourceRolePolicies(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &dataSourceRolePolicies{}, nil
+}
+
+const (
+	DSNameRolePolicies = "Role Policies Data Source"
+)
+
+type dataSourceRolePolicies struct {
+	framework.DataSourceWithConfigure
+}
+
+func (d *dataSourceRolePolicies) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) { // nosemgrep:ci.meta-in-func-name
+	resp.TypeName = "aws_iam_role_policies"
+}
+
+func (d *dataSourceRolePolicies) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"policy_names": schema.ListAttribute{
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+			"role_name": schema.StringAttribute{
+				Description: "Name of the role where we should get the inline policies.",
+				Required:    true,
+			},
+		},
+	}
+}
+
+func (d *dataSourceRolePolicies) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+
+	conn := d.Meta().IAMClient(ctx)
+
+	var data dataSourceRolePoliciesData
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var nextMarker *string
+	var policyNames []string
+	for {
+		input := &iam.ListRolePoliciesInput{RoleName: aws.String(data.RoleName.ValueString())}
+		if nextMarker != nil {
+			input.Marker = nextMarker
+		}
+
+		output, err := conn.ListRolePolicies(ctx, input)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.IAM, create.ErrActionReading, DSNameRolePolicies, data.RoleName.String(), err),
+				err.Error(),
+			)
+			return
+		}
+		policyNames = append(policyNames, output.PolicyNames...)
+
+		if !output.IsTruncated {
+			break
+		}
+		// Specify the next marker to retrieve the next page of results
+		nextMarker = output.Marker
+	}
+
+	data.PolicyNames = flex.FlattenFrameworkStringValueList(ctx, policyNames)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+type dataSourceRolePoliciesData struct {
+	PolicyNames types.List   `tfsdk:"policy_names"`
+	RoleName    types.String `tfsdk:"role_name"`
+}

--- a/internal/service/iam/role_policies_data_source_test.go
+++ b/internal/service/iam/role_policies_data_source_test.go
@@ -1,0 +1,105 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package iam_test
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccIAMRolePoliciesDataSource(t *testing.T) {
+	ctx := acctest.Context(t)
+	// Long-running test guard for tests that run longer than defined thrshhold
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	inline_policies_names := []string{}
+	for i := 1; i <= 101; i++ {
+		inline_policies_names = append(inline_policies_names, fmt.Sprintf("%d", i))
+	}
+	dataSourceName := "data.aws_iam_role_policies.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Testing Empty case handling
+			{
+				Config: testAccRolePoliciesDataSourceConfig_basic(rName, []string{}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "policy_names.#", "0"),
+				),
+			},
+			// Testing normal case handling
+			{
+				Config: testAccRolePoliciesDataSourceConfig_basic(rName, inline_policies_names[0:2]),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "policy_names.#", strconv.Itoa(len(inline_policies_names[0:2]))),
+					resource.TestCheckResourceAttr(dataSourceName, "policy_names.0", inline_policies_names[0]),
+					resource.TestCheckResourceAttr(dataSourceName, "policy_names.1", inline_policies_names[1]),
+				),
+			},
+			// Testing correct handling of pagination
+			{
+				Config: testAccRolePoliciesDataSourceConfig_basic(rName, inline_policies_names),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "policy_names.#", strconv.Itoa(len(inline_policies_names))),
+				),
+			},
+		},
+	})
+}
+
+func testAccRolePoliciesDataSourceConfig_basic(rName string, inline_policies_names []string) string {
+	var inline_policies string
+	for _, v := range inline_policies_names {
+		inline_policies = fmt.Sprintf(`
+			%[2]s
+			
+			inline_policy {
+				name = %[1]q
+			
+				policy = jsonencode({
+				Version = "2012-10-17"
+				Statement = [
+					{
+					Action   = "*"
+					Effect   = "Allow"
+					Resource = "*"
+					},
+				]
+				})
+			}`, v, inline_policies)
+	}
+	return fmt.Sprintf(`
+		data "aws_iam_policy_document" "test" {
+			statement {
+			actions = ["sts:AssumeRole"]
+			principals {
+				type        = "Service"
+				identifiers = ["ec2.amazonaws.com"]
+			}
+			}
+		}
+		resource "aws_iam_role" "test" {
+			name               = %[1]q
+			assume_role_policy = data.aws_iam_policy_document.test.json
+			%[2]s
+		}
+		
+		data "aws_iam_role_policies" "test" {
+			role_name = aws_iam_role.test.name
+		}
+	`, rName, inline_policies)
+}

--- a/internal/service/iam/service_package_gen.go
+++ b/internal/service/iam/service_package_gen.go
@@ -15,7 +15,12 @@ import (
 type servicePackage struct{}
 
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.ServicePackageFrameworkDataSource {
-	return []*types.ServicePackageFrameworkDataSource{}
+	return []*types.ServicePackageFrameworkDataSource{
+		{
+			Factory: newDataSourceRolePolicies,
+			Name:    "Role Policies",
+		},
+	}
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.ServicePackageFrameworkResource {

--- a/website/docs/d/iam_role_policies.html.markdown
+++ b/website/docs/d/iam_role_policies.html.markdown
@@ -1,0 +1,33 @@
+---
+subcategory: "IAM (Identity & Access Management)"
+layout: "aws"
+page_title: "AWS: aws_iam_role_policies"
+description: |-
+  Terraform data source for retreiving inline role policies.
+---
+
+# Data Source: aws_iam_role_policies
+
+Terraform data source for retreiving inline role policies.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_iam_role_policies" "example" {
+  role_name = "test_role"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `role_name` - (Required) Role name from which we want to retreive the inline policies.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `policy_names` - List containing names of all inline policies of the specified role.


### PR DESCRIPTION
### Description
Adds `aws_iam_role_policies` new data source. Returns all inline policy names of a given role.

After this PR a proper implementation of [get-role-policy](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/iam/get-role-policy.html) should be done in order to get the inline policies content
Moreover a proper implementation of [list-attached-role-policies](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/iam/list-attached-role-policies.html) should be done to have the possibility to retreive all role policies (managed and inline)

There was already a PR implementing this but it seems to have been unmantained for a while: Check https://github.com/hashicorp/terraform-provider-aws/pull/27899. We moved the implemention to the new format by using the skaff tool.

### Relations
Relates https://github.com/hashicorp/terraform-provider-aws/issues/26769 --> Partially implements

### References
Docs from AWS CLI: https://docs.aws.amazon.com/cli/latest/reference/iam/list-role-policies.html


### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccIAMRolePoliciesDataSource PKG=iam
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMRolePoliciesDataSource'  -timeout 360m
=== RUN   TestAccIAMRolePoliciesDataSource
=== PAUSE TestAccIAMRolePoliciesDataSource
=== CONT  TestAccIAMRolePoliciesDataSource
--- PASS: TestAccIAMRolePoliciesDataSource (109.11s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        113.042s
```
