### PR TITLE
elbv2/lb: Add client keep alive

### DIFF
--- a/.changelog/36969.txt
+++ b/.changelog/36969.txt
@@ -1,0 +1,15 @@
+```release-note:enhancement
+resource/aws_lb: Add `client_keep_alive` argument
+```
+
+```release-note:enhancement
+resource/aws_alb: Add `client_keep_alive` argument
+```
+
+```release-note:enhancement
+data-source/aws_lb: Add `client_keep_alive` argument
+```
+
+```release-note:enhancement
+data-source/aws_alb: Add `client_keep_alive` argument
+```

--- a/internal/service/elbv2/const.go
+++ b/internal/service/elbv2/const.go
@@ -33,6 +33,7 @@ const (
 
 	// The following attributes are supported by only Application Load Balancers:
 	loadBalancerAttributeIdleTimeoutTimeoutSeconds                       = "idle_timeout.timeout_seconds"
+	loadBalancerAttributeClientKeepAliveSeconds                          = "client_keep_alive.seconds"
 	loadBalancerAttributeConnectionLogsS3Enabled                         = "connection_logs.s3.enabled"
 	loadBalancerAttributeConnectionLogsS3Bucket                          = "connection_logs.s3.bucket"
 	loadBalancerAttributeConnectionLogsS3Prefix                          = "connection_logs.s3.prefix"

--- a/internal/service/elbv2/exports_test.go
+++ b/internal/service/elbv2/exports_test.go
@@ -22,4 +22,6 @@ const (
 	AlpnPolicyHTTP2Optional  = alpnPolicyHTTP2Optional
 	AlpnPolicyHTTP2Preferred = alpnPolicyHTTP2Preferred
 	AlpnPolicyNone           = alpnPolicyNone
+
+	LoadBalancerAttributeClientKeepAliveSeconds = loadBalancerAttributeClientKeepAliveSeconds
 )

--- a/internal/service/elbv2/load_balancer.go
+++ b/internal/service/elbv2/load_balancer.go
@@ -101,6 +101,12 @@ func ResourceLoadBalancer() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"client_keep_alive": {
+				Type:             schema.TypeInt,
+				Optional:         true,
+				Default:          3600,
+				DiffSuppressFunc: suppressIfLBTypeNot(elbv2.LoadBalancerTypeEnumApplication),
+			},
 			"connection_logs": {
 				Type:             schema.TypeList,
 				Optional:         true,
@@ -702,6 +708,11 @@ type loadBalancerAttributeInfo struct {
 type loadBalancerAttributeMap map[string]loadBalancerAttributeInfo
 
 var loadBalancerAttributes = loadBalancerAttributeMap(map[string]loadBalancerAttributeInfo{
+	"client_keep_alive": {
+		apiAttributeKey:            loadBalancerAttributeClientKeepAliveSeconds,
+		tfType:                     schema.TypeInt,
+		loadBalancerTypesSupported: []string{elbv2.LoadBalancerTypeEnumApplication},
+	},
 	"desync_mitigation_mode": {
 		apiAttributeKey:            loadBalancerAttributeRoutingHTTPDesyncMitigationMode,
 		tfType:                     schema.TypeString,

--- a/internal/service/elbv2/load_balancer_data_source.go
+++ b/internal/service/elbv2/load_balancer_data_source.go
@@ -61,6 +61,10 @@ func DataSourceLoadBalancer() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"client_keep_alive": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 			"connection_logs": {
 				Type:     schema.TypeList,
 				Computed: true,

--- a/internal/service/iam/access_key_test.go
+++ b/internal/service/iam/access_key_test.go
@@ -164,7 +164,7 @@ func testAccCheckAccessKeyDestroy(ctx context.Context) resource.TestCheckFunc {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
-			if rs.Type != "aws_access_key" {
+			if rs.Type != "aws_iam_access_key" {
 				continue
 			}
 

--- a/website/docs/r/lb.html.markdown
+++ b/website/docs/r/lb.html.markdown
@@ -101,64 +101,63 @@ resource "aws_lb" "example" {
 
 This resource supports the following arguments:
 
-* `access_logs` - (Optional) An Access Logs block. Access Logs documented below.
-* `connection_logs` - (Optional) A Connection Logs block. Connection Logs documented below. Only valid for Load Balancers of type `application`.
-* `customer_owned_ipv4_pool` - (Optional) The ID of the customer owned ipv4 pool to use for this load balancer.
-* `desync_mitigation_mode` - (Optional) Determines how the load balancer handles requests that might pose a security risk to an application due to HTTP desync. Valid values are `monitor`, `defensive` (default), `strictest`.
-* `dns_record_client_routing_policy` - (Optional) Indicates how traffic is distributed among the load balancer Availability Zones. Possible values are `any_availability_zone` (default), `availability_zone_affinity`, or `partial_availability_zone_affinity`. See   [Availability Zone DNS affinity](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#zonal-dns-affinity) for additional details. Only valid for `network` type load balancers.
-* `drop_invalid_header_fields` - (Optional) Indicates whether HTTP headers with header fields that are not valid are removed by the load balancer (true) or routed to targets (false). The default is false. Elastic Load Balancing requires that message header names contain only alphanumeric characters and hyphens. Only valid for Load Balancers of type `application`.
+* `access_logs` - (Optional) Access Logs block. See below.
+* `connection_logs` - (Optional) Connection Logs block. See below. Only valid for Load Balancers of type `application`.
+* `client_keep_alive` - (Optional) Client keep alive value in seconds. The valid range is 60-604800 seconds. The default is 3600 seconds.
+* `customer_owned_ipv4_pool` - (Optional) ID of the customer owned ipv4 pool to use for this load balancer.
+* `desync_mitigation_mode` - (Optional) How the load balancer handles requests that might pose a security risk to an application due to HTTP desync. Valid values are `monitor`, `defensive` (default), `strictest`.
+* `dns_record_client_routing_policy` - (Optional) How traffic is distributed among the load balancer Availability Zones. Possible values are `any_availability_zone` (default), `availability_zone_affinity`, or `partial_availability_zone_affinity`. See   [Availability Zone DNS affinity](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#zonal-dns-affinity) for additional details. Only valid for `network` type load balancers.
+* `drop_invalid_header_fields` - (Optional) Whether HTTP headers with header fields that are not valid are removed by the load balancer (true) or routed to targets (false). The default is false. Elastic Load Balancing requires that message header names contain only alphanumeric characters and hyphens. Only valid for Load Balancers of type `application`.
 * `enable_cross_zone_load_balancing` - (Optional) If true, cross-zone load balancing of the load balancer will be enabled. For `network` and `gateway` type load balancers, this feature is disabled by default (`false`). For `application` load balancer this feature is always enabled (`true`) and cannot be disabled. Defaults to `false`.
 * `enable_deletion_protection` - (Optional) If true, deletion of the load balancer will be disabled via the AWS API. This will prevent Terraform from deleting the load balancer. Defaults to `false`.
-* `enable_http2` - (Optional) Indicates whether HTTP/2 is enabled in `application` load balancers. Defaults to `true`.
-* `enable_tls_version_and_cipher_suite_headers` - (Optional) Indicates whether the two headers (`x-amzn-tls-version` and `x-amzn-tls-cipher-suite`), which contain information about the negotiated TLS version and cipher suite, are added to the client request before sending it to the target. Only valid for Load Balancers of type `application`. Defaults to `false`
-* `enable_xff_client_port` - (Optional) Indicates whether the X-Forwarded-For header should preserve the source port that the client used to connect to the load balancer in `application` load balancers. Defaults to `false`.
-* `enable_waf_fail_open` - (Optional) Indicates whether to allow a WAF-enabled load balancer to route requests to targets if it is unable to forward the request to AWS WAF. Defaults to `false`.
-* `enforce_security_group_inbound_rules_on_private_link_traffic` - (Optional) Indicates whether inbound security group rules are enforced for traffic originating from a PrivateLink. Only valid for Load Balancers of type `network`. The possible values are `on` and `off`.
-* `idle_timeout` - (Optional) The time in seconds that the connection is allowed to be idle. Only valid for Load Balancers of type `application`. Default: 60.
+* `enable_http2` - (Optional) Whether HTTP/2 is enabled in `application` load balancers. Defaults to `true`.
+* `enable_tls_version_and_cipher_suite_headers` - (Optional) Whether the two headers (`x-amzn-tls-version` and `x-amzn-tls-cipher-suite`), which contain information about the negotiated TLS version and cipher suite, are added to the client request before sending it to the target. Only valid for Load Balancers of type `application`. Defaults to `false`
+* `enable_xff_client_port` - (Optional) Whether the X-Forwarded-For header should preserve the source port that the client used to connect to the load balancer in `application` load balancers. Defaults to `false`.
+* `enable_waf_fail_open` - (Optional) Whether to allow a WAF-enabled load balancer to route requests to targets if it is unable to forward the request to AWS WAF. Defaults to `false`.
+* `enforce_security_group_inbound_rules_on_private_link_traffic` - (Optional) Whether inbound security group rules are enforced for traffic originating from a PrivateLink. Only valid for Load Balancers of type `network`. The possible values are `on` and `off`.
+* `idle_timeout` - (Optional) Time in seconds that the connection is allowed to be idle. Only valid for Load Balancers of type `application`. Default: 60.
 * `internal` - (Optional) If true, the LB will be internal. Defaults to `false`.
-* `ip_address_type` - (Optional) The type of IP addresses used by the subnets for your load balancer. The possible values are `ipv4` and `dualstack`.
-* `load_balancer_type` - (Optional) The type of load balancer to create. Possible values are `application`, `gateway`, or `network`. The default value is `application`.
-* `name` - (Optional) The name of the LB. This name must be unique within your AWS account, can have a maximum of 32 characters,
-must contain only alphanumeric characters or hyphens, and must not begin or end with a hyphen. If not specified,
-Terraform will autogenerate a name beginning with `tf-lb`.
+* `ip_address_type` - (Optional) Type of IP addresses used by the subnets for your load balancer. The possible values are `ipv4` and `dualstack`.
+* `load_balancer_type` - (Optional) Type of load balancer to create. Possible values are `application`, `gateway`, or `network`. The default value is `application`.
+* `name` - (Optional) Name of the LB. This name must be unique within your AWS account, can have a maximum of 32 characters, must contain only alphanumeric characters or hyphens, and must not begin or end with a hyphen. If not specified, Terraform will autogenerate a name beginning with `tf-lb`.
 * `name_prefix` - (Optional) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
-* `security_groups` - (Optional) A list of security group IDs to assign to the LB. Only valid for Load Balancers of type `application` or `network`. For load balancers of type `network` security groups cannot be added if none are currently present, and cannot all be removed once added. If either of these conditions are met, this will force a recreation of the resource.
-* `preserve_host_header` - (Optional) Indicates whether the Application Load Balancer should preserve the Host header in the HTTP request and send it to the target without any change. Defaults to `false`.
-* `subnet_mapping` - (Optional) A subnet mapping block as documented below. For Load Balancers of type `network` subnet mappings can only be added.
-* `subnets` - (Optional) A list of subnet IDs to attach to the LB. For Load Balancers of type `network` subnets can only be added (see [Availability Zones](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#availability-zones)), deleting a subnet for load balancers of type `network` will force a recreation of the resource.
-* `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `security_groups` - (Optional) List of security group IDs to assign to the LB. Only valid for Load Balancers of type `application` or `network`. For load balancers of type `network` security groups cannot be added if none are currently present, and cannot all be removed once added. If either of these conditions are met, this will force a recreation of the resource.
+* `preserve_host_header` - (Optional) Whether the Application Load Balancer should preserve the Host header in the HTTP request and send it to the target without any change. Defaults to `false`.
+* `subnet_mapping` - (Optional) Subnet mapping block. See below. For Load Balancers of type `network` subnet mappings can only be added.
+* `subnets` - (Optional) List of subnet IDs to attach to the LB. For Load Balancers of type `network` subnets can only be added (see [Availability Zones](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#availability-zones)), deleting a subnet for load balancers of type `network` will force a recreation of the resource.
+* `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `xff_header_processing_mode` - (Optional) Determines how the load balancer modifies the `X-Forwarded-For` header in the HTTP request before sending the request to the target. The possible values are `append`, `preserve`, and `remove`. Only valid for Load Balancers of type `application`. The default is `append`.
 
 ### access_logs
 
-* `bucket` - (Required) The S3 bucket name to store the logs in.
+* `bucket` - (Required) S3 bucket name to store the logs in.
 * `enabled` - (Optional) Boolean to enable / disable `access_logs`. Defaults to `false`, even when `bucket` is specified.
-* `prefix` - (Optional) The S3 bucket prefix. Logs are stored in the root if not configured.
+* `prefix` - (Optional) S3 bucket prefix. Logs are stored in the root if not configured.
 
 ### connection_logs
 
-* `bucket` - (Required) The S3 bucket name to store the logs in.
+* `bucket` - (Required) S3 bucket name to store the logs in.
 * `enabled` - (Optional) Boolean to enable / disable `connection_logs`. Defaults to `false`, even when `bucket` is specified.
-* `prefix` - (Optional) The S3 bucket prefix. Logs are stored in the root if not configured.
+* `prefix` - (Optional) S3 bucket prefix. Logs are stored in the root if not configured.
 
 ### subnet_mapping
 
 * `subnet_id` - (Required) ID of the subnet of which to attach to the load balancer. You can specify only one subnet per Availability Zone.
-* `allocation_id` - (Optional) The allocation ID of the Elastic IP address for an internet-facing load balancer.
-* `ipv6_address` - (Optional) The IPv6 address. You associate IPv6 CIDR blocks with your VPC and choose the subnets where you launch both internet-facing and internal Application Load Balancers or Network Load Balancers.
-* `private_ipv4_address` - (Optional) The private IPv4 address for an internal load balancer.
+* `allocation_id` - (Optional) Allocation ID of the Elastic IP address for an internet-facing load balancer.
+* `ipv6_address` - (Optional) IPv6 address. You associate IPv6 CIDR blocks with your VPC and choose the subnets where you launch both internet-facing and internal Application Load Balancers or Network Load Balancers.
+* `private_ipv4_address` - (Optional) Private IPv4 address for an internal load balancer.
 
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `arn` - The ARN of the load balancer (matches `id`).
-* `arn_suffix` - The ARN suffix for use with CloudWatch Metrics.
-* `dns_name` - The DNS name of the load balancer.
-* `id` - The ARN of the load balancer (matches `arn`).
+* `arn` - ARN of the load balancer (matches `id`).
+* `arn_suffix` - ARN suffix for use with CloudWatch Metrics.
+* `dns_name` - DNS name of the load balancer.
+* `id` - ARN of the load balancer (matches `arn`).
 * `subnet_mapping.*.outpost_id` - ID of the Outpost containing the load balancer.
-* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
-* `zone_id` - The canonical hosted zone ID of the load balancer (to be used in a Route 53 Alias record).
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
+* `zone_id` - Canonical hosted zone ID of the load balancer (to be used in a Route 53 Alias record).
 
 ## Timeouts
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #36402

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T='TestAccELBV2LoadBalancersDataSource_|TestAccELBV2LoadBalancer_' K=elbv2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2LoadBalancersDataSource_|TestAccELBV2LoadBalancer_'  -timeout 360m
=== RUN   TestAccELBV2LoadBalancer_ALB_basic
=== PAUSE TestAccELBV2LoadBalancer_ALB_basic
=== RUN   TestAccELBV2LoadBalancer_NLB_basic
=== PAUSE TestAccELBV2LoadBalancer_NLB_basic
=== RUN   TestAccELBV2LoadBalancer_LoadBalancerType_gateway
=== PAUSE TestAccELBV2LoadBalancer_LoadBalancerType_gateway
=== RUN   TestAccELBV2LoadBalancer_disappears
=== PAUSE TestAccELBV2LoadBalancer_disappears
=== RUN   TestAccELBV2LoadBalancer_nameGenerated
=== PAUSE TestAccELBV2LoadBalancer_nameGenerated
=== RUN   TestAccELBV2LoadBalancer_nameGeneratedForZeroValue
=== PAUSE TestAccELBV2LoadBalancer_nameGeneratedForZeroValue
=== RUN   TestAccELBV2LoadBalancer_namePrefix
=== PAUSE TestAccELBV2LoadBalancer_namePrefix
=== RUN   TestAccELBV2LoadBalancer_duplicateName
=== PAUSE TestAccELBV2LoadBalancer_duplicateName
=== RUN   TestAccELBV2LoadBalancer_tags
=== PAUSE TestAccELBV2LoadBalancer_tags
=== RUN   TestAccELBV2LoadBalancer_Tags_EmptyTag_OnCreate
=== PAUSE TestAccELBV2LoadBalancer_Tags_EmptyTag_OnCreate
=== RUN   TestAccELBV2LoadBalancer_Tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccELBV2LoadBalancer_Tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccELBV2LoadBalancer_Tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccELBV2LoadBalancer_Tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccELBV2LoadBalancer_ipv6SubnetMapping
=== PAUSE TestAccELBV2LoadBalancer_ipv6SubnetMapping
=== RUN   TestAccELBV2LoadBalancer_LoadBalancerTypeGateway_enableCrossZoneLoadBalancing
=== PAUSE TestAccELBV2LoadBalancer_LoadBalancerTypeGateway_enableCrossZoneLoadBalancing
=== RUN   TestAccELBV2LoadBalancer_ALB_outpost
=== PAUSE TestAccELBV2LoadBalancer_ALB_outpost
=== RUN   TestAccELBV2LoadBalancer_networkLoadBalancerEIP
=== PAUSE TestAccELBV2LoadBalancer_networkLoadBalancerEIP
=== RUN   TestAccELBV2LoadBalancer_NLB_privateIPv4Address
=== PAUSE TestAccELBV2LoadBalancer_NLB_privateIPv4Address
=== RUN   TestAccELBV2LoadBalancer_backwardsCompatibility
=== PAUSE TestAccELBV2LoadBalancer_backwardsCompatibility
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateCrossZone
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateCrossZone
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateHTTP2
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateHTTP2
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_clientKeepAlive
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_clientKeepAlive
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDropInvalidHeaderFields
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDropInvalidHeaderFields
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatePreserveHostHeader
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatePreserveHostHeader
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDeletionProtection
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDeletionProtection
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateWAFFailOpen
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateWAFFailOpen
=== RUN   TestAccELBV2LoadBalancer_updateIPAddressType
=== PAUSE TestAccELBV2LoadBalancer_updateIPAddressType
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatedSecurityGroups
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatedSecurityGroups
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_addSubnet
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_addSubnet
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_deleteSubnet
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_deleteSubnet
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_addSubnetMapping
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_addSubnetMapping
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_deleteSubnetMapping
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_deleteSubnetMapping
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_noSecurityGroup
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_noSecurityGroup
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_accessLogs
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_accessLogs
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_accessLogsPrefix
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_accessLogsPrefix
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_connectionLogs
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_connectionLogs
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_connectionLogsPrefix
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_connectionLogsPrefix
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_accessLogs
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_accessLogs
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_accessLogsPrefix
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_accessLogsPrefix
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateDNSRecordClientRoutingPolicy
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateDNSRecordClientRoutingPolicy
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateSecurityGroups
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateSecurityGroups
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_enforcePrivateLink
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_enforcePrivateLink
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_addSubnet
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_addSubnet
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_deleteSubnet
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_deleteSubnet
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_addSubnetMapping
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_addSubnetMapping
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_deleteSubnetMapping
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_deleteSubnetMapping
=== RUN   TestAccELBV2LoadBalancer_updateDesyncMitigationMode
=== PAUSE TestAccELBV2LoadBalancer_updateDesyncMitigationMode
=== RUN   TestAccELBV2LoadBalancer_ALB_updateTLSVersionAndCipherSuite
=== PAUSE TestAccELBV2LoadBalancer_ALB_updateTLSVersionAndCipherSuite
=== RUN   TestAccELBV2LoadBalancer_ALB_updateXffHeaderProcessingMode
=== PAUSE TestAccELBV2LoadBalancer_ALB_updateXffHeaderProcessingMode
=== RUN   TestAccELBV2LoadBalancer_ALB_updateXffClientPort
=== PAUSE TestAccELBV2LoadBalancer_ALB_updateXffClientPort
=== RUN   TestAccELBV2LoadBalancersDataSource_basic
=== PAUSE TestAccELBV2LoadBalancersDataSource_basic
=== CONT  TestAccELBV2LoadBalancer_ALB_basic
=== CONT  TestAccELBV2LoadBalancer_updateIPAddressType
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateDNSRecordClientRoutingPolicy
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_deleteSubnetMapping
=== CONT  TestAccELBV2LoadBalancer_backwardsCompatibility
=== CONT  TestAccELBV2LoadBalancer_Tags_EmptyTag_OnUpdate_Replace
=== CONT  TestAccELBV2LoadBalancer_Tags_EmptyTag_OnCreate
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_accessLogsPrefix
=== CONT  TestAccELBV2LoadBalancer_duplicateName
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateWAFFailOpen
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDeletionProtection
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatePreserveHostHeader
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDropInvalidHeaderFields
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_clientKeepAlive
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateHTTP2
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateCrossZone
=== CONT  TestAccELBV2LoadBalancer_ipv6SubnetMapping
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_accessLogs
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_connectionLogsPrefix
=== CONT  TestAccELBV2LoadBalancer_LoadBalancerTypeGateway_enableCrossZoneLoadBalancing
--- PASS: TestAccELBV2LoadBalancer_ALB_basic (232.16s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_connectionLogs
--- PASS: TestAccELBV2LoadBalancer_backwardsCompatibility (233.86s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_accessLogsPrefix
--- PASS: TestAccELBV2LoadBalancer_duplicateName (235.20s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_accessLogs
--- PASS: TestAccELBV2LoadBalancer_LoadBalancerTypeGateway_enableCrossZoneLoadBalancing (243.29s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_noSecurityGroup
--- PASS: TestAccELBV2LoadBalancer_Tags_EmptyTag_OnCreate (247.38s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_deleteSubnetMapping
--- PASS: TestAccELBV2LoadBalancer_Tags_EmptyTag_OnUpdate_Replace (283.21s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_addSubnetMapping
--- PASS: TestAccELBV2LoadBalancer_ipv6SubnetMapping (320.45s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_deleteSubnet
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateDNSRecordClientRoutingPolicy (321.07s)
=== CONT  TestAccELBV2LoadBalancer_nameGenerated
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatePreserveHostHeader (321.86s)
=== CONT  TestAccELBV2LoadBalancer_namePrefix
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_clientKeepAlive (326.16s)
=== CONT  TestAccELBV2LoadBalancer_nameGeneratedForZeroValue
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDeletionProtection (330.17s)
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_addSubnet
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateHTTP2 (330.48s)
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_addSubnetMapping
--- PASS: TestAccELBV2LoadBalancer_updateIPAddressType (338.36s)
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_deleteSubnet
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_connectionLogsPrefix (343.27s)
=== CONT  TestAccELBV2LoadBalancer_LoadBalancerType_gateway
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDropInvalidHeaderFields (343.55s)
=== CONT  TestAccELBV2LoadBalancer_disappears
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateWAFFailOpen (351.48s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_addSubnet
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateCrossZone (360.45s)
=== CONT  TestAccELBV2LoadBalancer_tags
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancer_accessLogsPrefix (361.39s)
=== CONT  TestAccELBV2LoadBalancer_Tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancer_accessLogs (408.06s)
=== CONT  TestAccELBV2LoadBalancer_ALB_updateXffHeaderProcessingMode
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_noSecurityGroup (216.51s)
=== CONT  TestAccELBV2LoadBalancersDataSource_basic
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancer_deleteSubnetMapping (495.44s)
=== CONT  TestAccELBV2LoadBalancer_ALB_updateXffClientPort
--- PASS: TestAccELBV2LoadBalancer_nameGeneratedForZeroValue (221.48s)
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_enforcePrivateLink
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_addSubnetMapping (273.27s)
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateSecurityGroups
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_accessLogsPrefix (331.84s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatedSecurityGroups
--- PASS: TestAccELBV2LoadBalancer_LoadBalancerType_gateway (223.04s)
=== CONT  TestAccELBV2LoadBalancer_networkLoadBalancerEIP
--- PASS: TestAccELBV2LoadBalancer_disappears (223.08s)
=== CONT  TestAccELBV2LoadBalancer_NLB_privateIPv4Address
--- PASS: TestAccELBV2LoadBalancer_nameGenerated (253.60s)
=== CONT  TestAccELBV2LoadBalancer_ALB_updateTLSVersionAndCipherSuite
--- PASS: TestAccELBV2LoadBalancer_namePrefix (253.60s)
=== CONT  TestAccELBV2LoadBalancer_NLB_basic
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_deleteSubnet (283.12s)
=== CONT  TestAccELBV2LoadBalancer_updateDesyncMitigationMode
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_connectionLogs (372.17s)
=== CONT  TestAccELBV2LoadBalancer_ALB_outpost
    load_balancer_test.go:572: skipping since no Outposts found
--- SKIP: TestAccELBV2LoadBalancer_ALB_outpost (0.44s)
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_accessLogs (380.13s)
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_addSubnet (279.52s)
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancer_addSubnet (306.62s)
--- PASS: TestAccELBV2LoadBalancer_Tags_EmptyTag_OnUpdate_Add (279.07s)
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancer_addSubnetMapping (323.80s)
--- PASS: TestAccELBV2LoadBalancer_tags (312.79s)
--- PASS: TestAccELBV2LoadBalancersDataSource_basic (232.74s)
--- PASS: TestAccELBV2LoadBalancer_ALB_updateXffHeaderProcessingMode (303.09s)
--- PASS: TestAccELBV2LoadBalancer_NLB_basic (191.54s)
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancer_deleteSubnet (433.48s)
--- PASS: TestAccELBV2LoadBalancer_networkLoadBalancerEIP (223.85s)
--- PASS: TestAccELBV2LoadBalancer_ALB_updateXffClientPort (307.07s)
--- PASS: TestAccELBV2LoadBalancer_NLB_privateIPv4Address (248.59s)
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatedSecurityGroups (268.85s)
--- PASS: TestAccELBV2LoadBalancer_ALB_updateTLSVersionAndCipherSuite (317.71s)
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancer_enforcePrivateLink (355.43s)
--- PASS: TestAccELBV2LoadBalancer_updateDesyncMitigationMode (301.17s)
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateSecurityGroups (724.55s)
% make t T=TestAccIAMAccessKey_ K=iam      
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMAccessKey_'  -timeout 360m
=== RUN   TestAccIAMAccessKey_basic
=== PAUSE TestAccIAMAccessKey_basic
=== RUN   TestAccIAMAccessKey_disappears
=== PAUSE TestAccIAMAccessKey_disappears
=== RUN   TestAccIAMAccessKey_encrypted
=== PAUSE TestAccIAMAccessKey_encrypted
=== RUN   TestAccIAMAccessKey_status
=== PAUSE TestAccIAMAccessKey_status
=== CONT  TestAccIAMAccessKey_basic
=== CONT  TestAccIAMAccessKey_encrypted
=== CONT  TestAccIAMAccessKey_status
=== CONT  TestAccIAMAccessKey_disappears
--- PASS: TestAccIAMAccessKey_disappears (27.46s)
--- PASS: TestAccIAMAccessKey_basic (33.27s)
--- PASS: TestAccIAMAccessKey_encrypted (33.76s)
--- PASS: TestAccIAMAccessKey_status (60.43s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	63.164s
```