### PR TITLE
cloudformation/stack_set: Add retry on create

### DIFF
--- a/.changelog/36982.txt
+++ b/.changelog/36982.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cloudformation_stack_set: Add retry when creating to potentially help with eventual consistency problems
+```

--- a/internal/service/cloudformation/stack_set.go
+++ b/internal/service/cloudformation/stack_set.go
@@ -266,7 +266,57 @@ func resourceStackSetCreate(ctx context.Context, d *schema.ResourceData, meta in
 		input.TemplateURL = aws.String(v.(string))
 	}
 
-	_, err := conn.CreateStackSetWithContext(ctx, input)
+	_, err := tfresource.RetryWhen(ctx, propagationTimeout,
+		func() (interface{}, error) {
+			output, err := conn.CreateStackSetWithContext(ctx, input)
+			if err != nil {
+				return nil, err
+			}
+
+			operation, err := WaitStackSetCreated(ctx, conn, name, d.Get("call_as").(string), d.Timeout(schema.TimeoutCreate))
+			if err != nil {
+				return nil, fmt.Errorf("waiting for completion (%s): %w", aws.StringValue(output.StackSetId), err)
+			}
+			return operation, nil
+		},
+		func(err error) (bool, error) {
+			if err == nil {
+				return false, nil
+			}
+
+			message := err.Error()
+
+			// IAM eventual consistency
+			if strings.Contains(message, "AccountGate check failed") {
+				return true, err
+			}
+
+			// IAM eventual consistency
+			// User: XXX is not authorized to perform: cloudformation:CreateStack on resource: YYY
+			if strings.Contains(message, "is not authorized") {
+				return true, err
+			}
+
+			// IAM eventual consistency
+			// XXX role has insufficient YYY permissions
+			if strings.Contains(message, "role has insufficient") {
+				return true, err
+			}
+
+			// IAM eventual consistency
+			// Account XXX should have YYY role with trust relationship to Role ZZZ
+			if strings.Contains(message, "role with trust relationship") {
+				return true, err
+			}
+
+			// IAM eventual consistency
+			if strings.Contains(message, "The security token included in the request is invalid") {
+				return true, err
+			}
+
+			return false, err
+		},
+	)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating CloudFormation StackSet (%s): %s", name, err)

--- a/internal/service/cloudformation/status.go
+++ b/internal/service/cloudformation/status.go
@@ -28,6 +28,22 @@ func StatusChangeSet(ctx context.Context, conn *cloudformation.CloudFormation, s
 	}
 }
 
+func StatusStackSet(ctx context.Context, conn *cloudformation.CloudFormation, name, callAs string) retry.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := FindStackSetByName(ctx, conn, name, callAs)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, aws.StringValue(output.Status), nil
+	}
+}
+
 func StatusStackSetOperation(ctx context.Context, conn *cloudformation.CloudFormation, stackSetName, operationID, callAs string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		output, err := FindStackSetOperationByStackSetNameAndOperationID(ctx, conn, stackSetName, operationID, callAs)

--- a/internal/service/cloudformation/wait.go
+++ b/internal/service/cloudformation/wait.go
@@ -40,6 +40,28 @@ func WaitChangeSetCreated(ctx context.Context, conn *cloudformation.CloudFormati
 	return nil, err
 }
 
+func WaitStackSetCreated(ctx context.Context, conn *cloudformation.CloudFormation, name, callAs string, timeout time.Duration) (*cloudformation.StackSet, error) {
+	stateConf := retry.StateChangeConf{
+		Pending: []string{},
+		Target:  []string{cloudformation.StackSetStatusActive},
+		Timeout: ChangeSetCreatedTimeout,
+		Refresh: StatusStackSet(ctx, conn, name, callAs),
+		Delay:   15 * time.Second,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*cloudformation.StackSet); ok {
+		if status := aws.StringValue(output.Status); status == cloudformation.ChangeSetStatusFailed {
+			tfresource.SetLastError(err, fmt.Errorf("describing CloudFormation Stack Set (%s) results: %w", name, err))
+		}
+
+		return output, err
+	}
+
+	return nil, err
+}
+
 const (
 	stackSetOperationDelay = 5 * time.Second
 )


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates to #32536

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccCloudFormationStackSet_ K=cloudformation 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/cloudformation/... -v -count 1 -parallel 20 -run='TestAccCloudFormationStackSet_'  -timeout 360m
=== RUN   TestAccCloudFormationStackSet_basic
=== PAUSE TestAccCloudFormationStackSet_basic
=== RUN   TestAccCloudFormationStackSet_disappears
=== PAUSE TestAccCloudFormationStackSet_disappears
=== RUN   TestAccCloudFormationStackSet_administrationRoleARN
=== PAUSE TestAccCloudFormationStackSet_administrationRoleARN
=== RUN   TestAccCloudFormationStackSet_description
=== PAUSE TestAccCloudFormationStackSet_description
=== RUN   TestAccCloudFormationStackSet_executionRoleName
=== PAUSE TestAccCloudFormationStackSet_executionRoleName
=== RUN   TestAccCloudFormationStackSet_managedExecution
=== PAUSE TestAccCloudFormationStackSet_managedExecution
=== RUN   TestAccCloudFormationStackSet_name
=== PAUSE TestAccCloudFormationStackSet_name
=== RUN   TestAccCloudFormationStackSet_operationPreferences
=== PAUSE TestAccCloudFormationStackSet_operationPreferences
=== RUN   TestAccCloudFormationStackSet_parameters
=== PAUSE TestAccCloudFormationStackSet_parameters
=== RUN   TestAccCloudFormationStackSet_Parameters_default
    stack_set_test.go:477: this resource does not currently ignore unconfigured CloudFormation template parameters with the Default property
--- SKIP: TestAccCloudFormationStackSet_Parameters_default (0.00s)
=== RUN   TestAccCloudFormationStackSet_Parameters_noEcho
    stack_set_test.go:531: this resource does not currently ignore CloudFormation template parameters with the NoEcho property
--- SKIP: TestAccCloudFormationStackSet_Parameters_noEcho (0.00s)
=== RUN   TestAccCloudFormationStackSet_PermissionModel_serviceManaged
    stack_set_test.go:577: API does not support enabling Organizations access (in particular, creating the Stack Sets IAM Service-Linked Role)
--- SKIP: TestAccCloudFormationStackSet_PermissionModel_serviceManaged (0.00s)
=== RUN   TestAccCloudFormationStackSet_tags
=== PAUSE TestAccCloudFormationStackSet_tags
=== RUN   TestAccCloudFormationStackSet_templateBody
=== PAUSE TestAccCloudFormationStackSet_templateBody
=== RUN   TestAccCloudFormationStackSet_templateURL
=== PAUSE TestAccCloudFormationStackSet_templateURL
=== RUN   TestAccCloudFormationStackSet_autoDeploymentEnabled
=== PAUSE TestAccCloudFormationStackSet_autoDeploymentEnabled
=== RUN   TestAccCloudFormationStackSet_autoDeploymentDisabled
=== PAUSE TestAccCloudFormationStackSet_autoDeploymentDisabled
=== RUN   TestAccCloudFormationStackSet_delegatedAdministrator
=== PAUSE TestAccCloudFormationStackSet_delegatedAdministrator
=== CONT  TestAccCloudFormationStackSet_basic
=== CONT  TestAccCloudFormationStackSet_parameters
=== CONT  TestAccCloudFormationStackSet_executionRoleName
=== CONT  TestAccCloudFormationStackSet_name
=== CONT  TestAccCloudFormationStackSet_operationPreferences
=== CONT  TestAccCloudFormationStackSet_delegatedAdministrator
=== CONT  TestAccCloudFormationStackSet_autoDeploymentDisabled
=== CONT  TestAccCloudFormationStackSet_autoDeploymentEnabled
=== CONT  TestAccCloudFormationStackSet_templateURL
=== CONT  TestAccCloudFormationStackSet_templateBody
=== CONT  TestAccCloudFormationStackSet_managedExecution
=== CONT  TestAccCloudFormationStackSet_administrationRoleARN
=== CONT  TestAccCloudFormationStackSet_tags
=== CONT  TestAccCloudFormationStackSet_description
=== CONT  TestAccCloudFormationStackSet_disappears
=== NAME  TestAccCloudFormationStackSet_autoDeploymentEnabled
    stack_set_test.go:763: this AWS account must be the management account of an AWS Organization
--- SKIP: TestAccCloudFormationStackSet_autoDeploymentEnabled (1.20s)
=== NAME  TestAccCloudFormationStackSet_autoDeploymentDisabled
    stack_set_test.go:802: this AWS account must be the management account of an AWS Organization
--- SKIP: TestAccCloudFormationStackSet_autoDeploymentDisabled (1.30s)
=== NAME  TestAccCloudFormationStackSet_delegatedAdministrator
    stack_set_test.go:856: this AWS account must be the management account of an AWS Organization
--- SKIP: TestAccCloudFormationStackSet_delegatedAdministrator (26.60s)
--- PASS: TestAccCloudFormationStackSet_disappears (62.57s)
--- PASS: TestAccCloudFormationStackSet_managedExecution (72.40s)
--- PASS: TestAccCloudFormationStackSet_basic (79.01s)
--- PASS: TestAccCloudFormationStackSet_description (98.43s)
--- PASS: TestAccCloudFormationStackSet_templateBody (98.58s)
--- PASS: TestAccCloudFormationStackSet_administrationRoleARN (98.74s)
--- PASS: TestAccCloudFormationStackSet_executionRoleName (100.85s)
--- PASS: TestAccCloudFormationStackSet_name (108.05s)
--- PASS: TestAccCloudFormationStackSet_templateURL (114.07s)
--- PASS: TestAccCloudFormationStackSet_tags (124.42s)
--- PASS: TestAccCloudFormationStackSet_parameters (140.78s)
--- PASS: TestAccCloudFormationStackSet_operationPreferences (181.53s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudformation	184.360s
```
