### PR TITLE
r/ecs_sevice doc: removes duplicate references

### DIFF
--- a/.changelog/36983.txt
+++ b/.changelog/36983.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ecs_service: Removes duplicate argument references to `name`, `cluster`, and `iam_role` in docs.
+```

--- a/.changelog/36983.txt
+++ b/.changelog/36983.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-resource/aws_ecs_service: Removes duplicate argument references to `name`, `cluster`, and `iam_role` in docs.
-```

--- a/website/docs/r/ecs_service.html.markdown
+++ b/website/docs/r/ecs_service.html.markdown
@@ -299,11 +299,7 @@ For more information, see [Task Networking](https://docs.aws.amazon.com/AmazonEC
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `cluster` - Amazon Resource Name (ARN) of cluster which the service runs on.
-* `desired_count` - Number of instances of the task definition.
-* `iam_role` - ARN of IAM role used for ELB.
 * `id` - ARN that identifies the service.
-* `name` - Name of the service.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Timeouts


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
`name`, `Iam_role`, `desired_count` are all attribute arguments to `ecs_service` but the docs listed them both as attribute-arguments and as additional attributes. My brain tripped over this when it came to `iam_role` because I thought to myself "wait, I thought the IAM role was an argument on this resource". 

This isn't a big change and maybe it too much of a nit pick vs perhaps it's useful to keep this thing in multiple places, but I know I tripped over it and figured I cast a PR out there to see if this is thing kind of thing that's worth a quick clean up for the next me/ person like me. 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
