### PR TITLE
changed aws_guardduty_feature additional_configuration from list to set

### DIFF
--- a/internal/service/guardduty/detector_feature.go
+++ b/internal/service/guardduty/detector_feature.go
@@ -31,14 +31,12 @@ func ResourceDetectorFeature() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"additional_configuration": {
 				Optional: true,
-				ForceNew: true,
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ForceNew:     true,
 							ValidateFunc: validation.StringInSlice(guardduty.FeatureAdditionalConfiguration_Values(), false),
 						},
 						"status": {
@@ -79,8 +77,8 @@ func resourceDetectorFeaturePut(ctx context.Context, d *schema.ResourceData, met
 		Status: aws.String(d.Get("status").(string)),
 	}
 
-	if v, ok := d.GetOk("additional_configuration"); ok && len(v.([]interface{})) > 0 {
-		feature.AdditionalConfiguration = expandDetectorAdditionalConfigurations(v.([]interface{}))
+	if v, ok := d.GetOk("additional_configuration"); ok && v.(*schema.Set).Len() > 0 {
+		feature.AdditionalConfiguration = expandDetectorAdditionalConfigurations(v.(*schema.Set).List())
 	}
 
 	input := &guardduty.UpdateDetectorInput{

--- a/internal/service/guardduty/guardduty_test.go
+++ b/internal/service/guardduty/guardduty_test.go
@@ -29,9 +29,10 @@ func TestAccGuardDuty_serial(t *testing.T) {
 			"datasource_id":                     testAccDetectorDataSource_ID,
 		},
 		"DetectorFeature": {
-			"basic":                    testAccDetectorFeature_basic,
-			"additional_configuration": testAccDetectorFeature_additionalConfiguration,
-			"multiple":                 testAccDetectorFeature_multiple,
+			"basic":                          testAccDetectorFeature_basic,
+			"additional_configuration":       testAccDetectorFeature_additionalConfiguration,
+			"additional_configuration_order": testAccDetectorFeature_additionalConfigurationOrder,
+			"multiple":                       testAccDetectorFeature_multiple,
 		},
 		"Filter": {
 			"basic":      testAccFilter_basic,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This changes the `aws_guardduty_feature` `additional_configuration` type from a list to a set.  This is so that the order of the additional configurations does not matter.  Before pushing this fix, if you didn't provide the additional_configurations in the order the AWS API returns them, there would be a force replace on every terraform apply.

I added an additional acceptance test to confirm that the ordering of the additional_configurations doesn't matter and that an empty plan is returned no matter the order.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #36400

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
%  AWS_PROFILE=sandbox make testacc TESTS=TestAccGuard
Duty_serial/DetectorFeature PKG=guardduty 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/guardduty/... -v -count 1 -parallel 20 -run='TestAccGuardDuty_serial/Detect
orFeature'  -timeout 360m
=== RUN   TestAccGuardDuty_serial
=== PAUSE TestAccGuardDuty_serial
=== CONT  TestAccGuardDuty_serial
=== RUN   TestAccGuardDuty_serial/DetectorFeature
=== RUN   TestAccGuardDuty_serial/DetectorFeature/basic
=== RUN   TestAccGuardDuty_serial/DetectorFeature/additional_configuration
=== RUN   TestAccGuardDuty_serial/DetectorFeature/additional_configuration_order
=== RUN   TestAccGuardDuty_serial/DetectorFeature/multiple
--- PASS: TestAccGuardDuty_serial (120.23s)
    --- PASS: TestAccGuardDuty_serial/DetectorFeature (120.23s)
        --- PASS: TestAccGuardDuty_serial/DetectorFeature/basic (15.78s)
        --- PASS: TestAccGuardDuty_serial/DetectorFeature/additional_configuration (45.32s)
        --- PASS: TestAccGuardDuty_serial/DetectorFeature/additional_configuration_order (22.66s)
        --- PASS: TestAccGuardDuty_serial/DetectorFeature/multiple (36.47s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/guardduty  124.516s
...
```
