### PR TITLE
f-aws_mskconnect_worker_configuration: Add resource deletion support

### DIFF
--- a/.changelog/37010.txt
+++ b/.changelog/37010.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_mskconnect_worker_configuration: Add resource deletion support
+```

--- a/internal/service/kafkaconnect/worker_configuration.go
+++ b/internal/service/kafkaconnect/worker_configuration.go
@@ -23,7 +23,7 @@ func ResourceWorkerConfiguration() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceWorkerConfigurationCreate,
 		ReadWithoutTimeout:   resourceWorkerConfigurationRead,
-		DeleteWithoutTimeout: schema.NoopContext,
+		DeleteWithoutTimeout: resourceWorkerConfigurationDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -119,6 +119,22 @@ func resourceWorkerConfigurationRead(ctx context.Context, d *schema.ResourceData
 	} else {
 		d.Set("latest_revision", nil)
 		d.Set("properties_file_content", nil)
+	}
+
+	return diags
+}
+
+func resourceWorkerConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	conn := meta.(*conns.AWSClient).KafkaConnectConn(ctx)
+
+	_, err := conn.DeleteWorkerConfigurationWithContext(ctx, &kafkaconnect.DeleteWorkerConfigurationInput{
+		WorkerConfigurationArn: aws.String(d.Id()),
+	})
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "deleting MSK Connect Worker Configuration (%s): %s", d.Id(), err)
 	}
 
 	return diags


### PR DESCRIPTION
### Description

Adds deletion support to the `aws_mskconnect_worker_configuration` resource.

### Relations

Closes #36672

### References

[sdk-for-go KafkaConnect.DeleteWorkerConfigurationWithContext](https://docs.aws.amazon.com/sdk-for-go/api/service/kafkaconnect/#KafkaConnect.DeleteWorkerConfigurationWithContext)

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccKafkaConnectWorkerConfiguration PKG=kafkaconnect
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/kafkaconnect/... -v -count 1 -parallel 20 -run='TestAccKafkaConnectWorkerConfiguration'  -timeout 360m
=== RUN   TestAccKafkaConnectWorkerConfigurationDataSource_basic
=== PAUSE TestAccKafkaConnectWorkerConfigurationDataSource_basic
=== RUN   TestAccKafkaConnectWorkerConfiguration_basic
=== PAUSE TestAccKafkaConnectWorkerConfiguration_basic
=== RUN   TestAccKafkaConnectWorkerConfiguration_description
=== PAUSE TestAccKafkaConnectWorkerConfiguration_description
=== CONT  TestAccKafkaConnectWorkerConfigurationDataSource_basic
=== CONT  TestAccKafkaConnectWorkerConfiguration_description
=== CONT  TestAccKafkaConnectWorkerConfiguration_basic
--- PASS: TestAccKafkaConnectWorkerConfigurationDataSource_basic (15.77s)
--- PASS: TestAccKafkaConnectWorkerConfiguration_description (16.38s)
--- PASS: TestAccKafkaConnectWorkerConfiguration_basic (23.21s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kafkaconnect	26.931s
```
