### PR TITLE
f-aws_ecs_service: support for EBS

### DIFF
--- a/.changelog/37019.txt
+++ b/.changelog/37019.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_ecs_service: Add `volume_configuration` argument
+```

--- a/.changelog/37019.txt
+++ b/.changelog/37019.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
 resource/aws_ecs_service: Add `volume_configuration` argument
 ```
+
+```release-note:enhancement
+resource/aws_ecs_task_definition: Add `configure_at_launch` parameter in `volume` argument
+```

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -503,6 +503,7 @@ semgrep-code-quality: semgrep-validate ## [CI] Semgrep Checks / Code Quality Sca
 semgrep-constants: semgrep-validate ## Fix constants with Semgrep --autofix
 	@echo "make: Fix constants with Semgrep --autofix"
 	@semgrep $(SEMGREP_ARGS) --autofix \
+		$(if $(filter-out $(origin PKG), undefined),--include $(PKG_NAME),) \
 		--config .ci/.semgrep-constants.yml \
 		--config .ci/.semgrep-test-constants.yml
 

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -525,7 +525,7 @@ func ResourceService() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
-							Type:     schema.TypeBool,
+							Type:     schema.TypeString,
 							Required: true,
 						},
 						"managed_ebs_volume": {

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -524,7 +524,7 @@ func ResourceService() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"name": {
+						names.AttrName: {
 							Type:     schema.TypeString,
 							Required: true,
 						},
@@ -534,12 +534,12 @@ func ResourceService() *schema.Resource {
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"role_arn": {
+									names.AttrRoleARN: {
 										Type:         schema.TypeString,
 										Required:     true,
 										ValidateFunc: verify.ValidARN,
 									},
-									"encrypted": {
+									names.AttrEncrypted: {
 										Type:     schema.TypeBool,
 										Optional: true,
 										Default:  true,
@@ -550,11 +550,11 @@ func ResourceService() *schema.Resource {
 										Default:      ecs.TaskFilesystemTypeXfs,
 										ValidateFunc: validation.StringInSlice(ecs.TaskFilesystemType_Values(), false),
 									},
-									"iops": {
+									names.AttrIOPS: {
 										Type:     schema.TypeInt,
 										Optional: true,
 									},
-									"kms_key_id": {
+									names.AttrKMSKeyID: {
 										Type:     schema.TypeString,
 										Optional: true,
 									},
@@ -562,7 +562,7 @@ func ResourceService() *schema.Resource {
 										Type:     schema.TypeInt,
 										Optional: true,
 									},
-									"snapshot_id": {
+									names.AttrSnapshotID: {
 										Type:     schema.TypeString,
 										Optional: true,
 									},
@@ -571,7 +571,7 @@ func ResourceService() *schema.Resource {
 										Optional:     true,
 										ValidateFunc: validation.IntBetween(0, 1000),
 									},
-									"volume_type": {
+									names.AttrVolumeType: {
 										Type:     schema.TypeString,
 										Optional: true,
 									},
@@ -1548,7 +1548,7 @@ func expandVolumeConfigurations(vc []interface{}) []*ecs.ServiceVolumeConfigurat
 		p := raw.(map[string]interface{})
 
 		config := &ecs.ServiceVolumeConfiguration{
-			Name: aws.String(p["name"].(string)),
+			Name: aws.String(p[names.AttrName].(string)),
 		}
 
 		if v, ok := p["managed_ebs_volume"].([]interface{}); ok && len(v) > 0 {
@@ -1567,31 +1567,31 @@ func expandManagedEBSVolume(ebs []interface{}) *ecs.ServiceManagedEBSVolumeConfi
 	raw := ebs[0].(map[string]interface{})
 
 	config := &ecs.ServiceManagedEBSVolumeConfiguration{}
-	if v, ok := raw["role_arn"].(string); ok && v != "" {
+	if v, ok := raw[names.AttrRoleARN].(string); ok && v != "" {
 		config.RoleArn = aws.String(v)
 	}
-	if v, ok := raw["encrypted"].(bool); ok {
+	if v, ok := raw[names.AttrEncrypted].(bool); ok {
 		config.Encrypted = aws.Bool(v)
 	}
 	if v, ok := raw["file_system_type"].(string); ok && v != "" {
 		config.FilesystemType = aws.String(v)
 	}
-	if v, ok := raw["iops"].(int); ok && v != 0 {
+	if v, ok := raw[names.AttrIOPS].(int); ok && v != 0 {
 		config.Iops = aws.Int64(int64(v))
 	}
-	if v, ok := raw["kms_key_id"].(string); ok && v != "" {
+	if v, ok := raw[names.AttrKMSKeyID].(string); ok && v != "" {
 		config.KmsKeyId = aws.String(v)
 	}
 	if v, ok := raw["size_in_gb"].(int); ok && v != 0 {
 		config.SizeInGiB = aws.Int64(int64(v))
 	}
-	if v, ok := raw["snapshot_id"].(string); ok && v != "" {
+	if v, ok := raw[names.AttrSnapshotID].(string); ok && v != "" {
 		config.SnapshotId = aws.String(v)
 	}
 	if v, ok := raw["throughput"].(int); ok && v != 0 {
 		config.Throughput = aws.Int64(int64(v))
 	}
-	if v, ok := raw["volume_type"].(string); ok && v != "" {
+	if v, ok := raw[names.AttrVolumeType].(string); ok && v != "" {
 		config.VolumeType = aws.String(v)
 	}
 

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -518,6 +518,68 @@ func ResourceService() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"volume_configuration": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeBool,
+							Required: true,
+						},
+						"managed_ebs_volume": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"role_arn": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: verify.ValidARN,
+									},
+									"encrypted": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"file_system_type": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										Default:      ecs.TaskFilesystemTypeXfs,
+										ValidateFunc: validation.StringInSlice(ecs.TaskFilesystemType_Values(), false),
+									},
+									"iops": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
+									"kms_key_id": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"size_in_gb": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
+									"snapshot_id": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"throughput": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(0, 1000),
+									},
+									"volume_type": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 
 		CustomizeDiff: customdiff.Sequence(
@@ -623,6 +685,10 @@ func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 	if v, ok := d.GetOk("service_connect_configuration"); ok && len(v.([]interface{})) > 0 {
 		input.ServiceConnectConfiguration = expandServiceConnectConfiguration(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("volume_configuration"); ok && len(v.([]interface{})) > 0 {
+		input.VolumeConfigurations = expandVolumeConfigurations(v.([]interface{}))
 	}
 
 	serviceRegistries := d.Get("service_registries").([]interface{})
@@ -954,6 +1020,10 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 		if d.HasChange("service_connect_configuration") {
 			input.ServiceConnectConfiguration = expandServiceConnectConfiguration(d.Get("service_connect_configuration").([]interface{}))
+		}
+
+		if d.HasChange("volume_configuration") {
+			input.VolumeConfigurations = expandVolumeConfigurations(d.Get("volume_configuration").([]interface{}))
 		}
 
 		if d.HasChange("service_registries") {
@@ -1464,6 +1534,62 @@ func expandSecretOptions(sop []interface{}) []*ecs.Secret {
 	}
 
 	return out
+}
+
+func expandVolumeConfigurations(vc []interface{}) *ecs.ServiceVolumeConfiguration {
+	if len(vc) == 0 {
+		return nil
+	}
+	raw := vc[0].(map[string]interface{})
+
+	config := &ecs.ServiceVolumeConfiguration{}
+	if v, ok := raw["name"].(bool); ok {
+		config.Enabled = aws.Bool(v)
+	}
+
+	if v, ok := raw["managed_ebs_volume"].([]interface{}); ok && len(v) > 0 {
+		config.ManagedEBSVolume = expandManagedEBSVolume(v)
+	}
+
+	return config
+}
+
+func expandManagedEBSVolume(ebs []interface{}) *ecs.ServiceManagedEBSVolumeConfiguration {
+	if len(ebs) == 0 {
+		return &ecs.ServiceManagedEBSVolumeConfiguration{}
+	}
+	raw := ebs[0].(map[string]interface{})
+
+	config := &ecs.ServiceManagedEBSVolumeConfiguration{}
+	if v, ok := raw["role_arn"].(string); ok && v != "" {
+		config.RoleArn = aws.String(v)
+	}
+	if v, ok := raw["encrypted"].(bool); ok && v != "" {
+		config.Encrypted = aws.Bool(v)
+	}
+	if v, ok := raw["file_system_type"].(string); ok && v != "" {
+		config.FilesystemType = aws.String(v)
+	}
+	if v, ok := raw["iops"].(int); ok && v != "" {
+		config.Iops = aws.Int32(int32(v))
+	}
+	if v, ok := raw["kms_key_id"].(string); ok && v != "" {
+		config.KmsKeyId = aws.String(v)
+	}
+	if v, ok := raw["size_in_gb"].(int); ok && v != "" {
+		config.SizeInGiB = aws.Int32(int32(v))
+	}
+	if v, ok := raw["snapshot_id"].(string); ok && v != "" {
+		config.SnapshotId = aws.String(v)
+	}
+	if v, ok := raw["throughput"].(int); ok && v != "" {
+		config.Throughput = aws.Int32(int32(v))
+	}
+	if v, ok := raw["volume_type"].(string); ok && v != "" {
+		config.VolumeType = aws.String(v)
+	}
+
+	return config
 }
 
 func expandServices(srv []interface{}) []*ecs.ServiceConnectService {

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -542,6 +542,7 @@ func ResourceService() *schema.Resource {
 									"encrypted": {
 										Type:     schema.TypeBool,
 										Optional: true,
+										Default: true,
 									},
 									"file_system_type": {
 										Type:         schema.TypeString,

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -530,7 +530,7 @@ func ResourceService() *schema.Resource {
 						},
 						"managed_ebs_volume": {
 							Type:     schema.TypeList,
-							Optional: true,
+							Required: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -542,7 +542,7 @@ func ResourceService() *schema.Resource {
 									"encrypted": {
 										Type:     schema.TypeBool,
 										Optional: true,
-										Default: true,
+										Default:  true,
 									},
 									"file_system_type": {
 										Type:         schema.TypeString,

--- a/internal/service/ecs/service_test.go
+++ b/internal/service/ecs/service_test.go
@@ -2250,8 +2250,8 @@ resource "aws_ecs_service" "test" {
   volume_configuration {
     name = "vol1"
     managed_ebs_volume {
-        role_arn = aws_iam_role.test.arn
-        size_in_gb = %[3]d
+        role_arn    = aws_iam_role.test.arn
+        size_in_gb  = %[3]d
         volume_type = %[2]q
     }
   }

--- a/internal/service/ecs/service_test.go
+++ b/internal/service/ecs/service_test.go
@@ -2184,8 +2184,8 @@ resource "aws_ecs_service" "test" {
   volume_configuration {
     name = "vol1"
     managed_ebs_volume {
-      role_arn    = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS"
-      size_in_gb  = "8"
+      role_arn   = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS"
+      size_in_gb = "8"
     }
   }
 }

--- a/internal/service/ecs/service_test.go
+++ b/internal/service/ecs/service_test.go
@@ -2185,6 +2185,7 @@ resource "aws_ecs_service" "test" {
     name = "vol1"
     managed_ebs_volume {
       role_arn    = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS"
+      size_in_gb  = "8"
     }
   }
 }

--- a/internal/service/ecs/service_test.go
+++ b/internal/service/ecs/service_test.go
@@ -2147,6 +2147,7 @@ resource "aws_ecs_service" "test" {
 func testAccServiceConfig_volumeConfigurations_basic(rName string) string {
 	return fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
 
 resource "aws_ecs_cluster" "test" {
   name = %[1]q
@@ -2184,7 +2185,7 @@ resource "aws_ecs_service" "test" {
   volume_configuration {
     name = "vol1"
     managed_ebs_volume {
-      role_arn   = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS"
+      role_arn   = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS"
       size_in_gb = "8"
     }
   }
@@ -2195,6 +2196,7 @@ resource "aws_ecs_service" "test" {
 func testAccServiceConfig_volumeConfigurations_update(rName, volumeType string, size int) string {
 	return fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
 
 resource "aws_ecs_cluster" "test" {
   name = %[1]q
@@ -2232,7 +2234,7 @@ resource "aws_ecs_service" "test" {
   volume_configuration {
     name = "vol1"
     managed_ebs_volume {
-      role_arn    = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS"
+      role_arn    = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS"
       size_in_gb  = %[3]d
       volume_type = %[2]q
     }

--- a/internal/service/ecs/task_definition.go
+++ b/internal/service/ecs/task_definition.go
@@ -438,6 +438,7 @@ func ResourceTaskDefinition() *schema.Resource {
 						"configure_at_launch": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							Computed: true,
 							ForceNew: true,
 						},
 					},

--- a/internal/service/ecs/task_definition.go
+++ b/internal/service/ecs/task_definition.go
@@ -435,6 +435,11 @@ func ResourceTaskDefinition() *schema.Resource {
 							Required: true,
 							ForceNew: true,
 						},
+						"configure_at_launch": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+						},
 					},
 				},
 				Set: resourceTaskDefinitionVolumeHash,
@@ -924,6 +929,10 @@ func expandVolumes(configured []interface{}) []*ecs.Volume {
 			}
 		}
 
+		if v, ok := data["configure_at_launch"].(bool); ok {
+			l.ConfiguredAtLaunch = aws.Bool(v)
+		}
+
 		if v, ok := data["docker_volume_configuration"].([]interface{}); ok && len(v) > 0 {
 			l.DockerVolumeConfiguration = expandVolumesDockerVolume(v)
 		}
@@ -1054,6 +1063,10 @@ func flattenVolumes(list []*ecs.Volume) []map[string]interface{} {
 
 		if volume.Host != nil && volume.Host.SourcePath != nil {
 			l["host_path"] = aws.StringValue(volume.Host.SourcePath)
+		}
+
+		if volume.ConfiguredAtLaunch != nil {
+			l["configure_at_launch"] = aws.BoolValue(volume.ConfiguredAtLaunch)
 		}
 
 		if volume.DockerVolumeConfiguration != nil {

--- a/internal/service/ecs/task_definition.go
+++ b/internal/service/ecs/task_definition.go
@@ -438,7 +438,7 @@ func ResourceTaskDefinition() *schema.Resource {
 						"configure_at_launch": {
 							Type:     schema.TypeBool,
 							Optional: true,
-							Computed: true,
+							ForceNew: true,
 						},
 					},
 				},

--- a/internal/service/ecs/task_definition_test.go
+++ b/internal/service/ecs/task_definition_test.go
@@ -153,7 +153,8 @@ func TestAccECSTaskDefinition_configuredAtLaunch(t *testing.T) {
 				Config: testAccTaskDefinitionConfig_configuredAtLaunch(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(ctx, resourceName, &def),
-					resource.TestCheckResourceAttr(resourceName, "configure_at_launch", "true"),
+					resource.TestCheckResourceAttr(resourceName, "volume.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "volume.0.configure_at_launch", "true"),
 				),
 			},
 			{
@@ -1836,7 +1837,10 @@ resource "aws_ecs_task_definition" "test" {
     "cpu": 10,
     "command": ["sleep","360"],
     "memory": 10,
-    "essential": true
+    "essential": true,
+    "mountPoints": [
+      {"sourceVolume": %[1]q, "containerPath": "/"}
+    ]
   }
 ]
 TASK_DEFINITION

--- a/internal/service/ecs/task_definition_test.go
+++ b/internal/service/ecs/task_definition_test.go
@@ -153,7 +153,7 @@ func TestAccECSTaskDefinition_configuredAtLaunch(t *testing.T) {
 				Config: testAccTaskDefinitionConfig_configuredAtLaunch(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(ctx, resourceName, &def),
-					resource.TestCheckResourceAttr(resourceName, "volume.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "volume.#", acctest.Ct1),
 					resource.TestCheckResourceAttr(resourceName, "volume.0.configure_at_launch", "true"),
 				),
 			},
@@ -162,7 +162,7 @@ func TestAccECSTaskDefinition_configuredAtLaunch(t *testing.T) {
 				ImportState:             true,
 				ImportStateIdFunc:       testAccTaskDefinitionImportStateIdFunc(resourceName),
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"skip_destroy", "track_latest"},
+				ImportStateVerifyIgnore: []string{names.AttrSkipDestroy, "track_latest"},
 			},
 		},
 	})

--- a/internal/service/ecs/task_definition_test.go
+++ b/internal/service/ecs/task_definition_test.go
@@ -137,6 +137,36 @@ func TestAccECSTaskDefinition_scratchVolume(t *testing.T) {
 	})
 }
 
+func TestAccECSTaskDefinition_configuredAtLaunch(t *testing.T) {
+	ctx := acctest.Context(t)
+	var def ecs.TaskDefinition
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_ecs_task_definition.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTaskDefinitionDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: TestAccECSTaskDefinition_configuredAtLaunch(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTaskDefinitionExists(ctx, resourceName, &def),
+					resource.TestCheckResourceAttr(resourceName, "configure_at_launch", "true"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateIdFunc:       testAccTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy", "track_latest"},
+			},
+		},
+	})
+}
+
 func TestAccECSTaskDefinition_DockerVolume_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var def ecs.TaskDefinition
@@ -1788,6 +1818,32 @@ TASK_DEFINITION
 
   volume {
     name = %[1]q
+  }
+}
+`, rName)
+}
+
+func TestAccECSTaskDefinition_configuredAtLaunch(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ecs_task_definition" "test" {
+  family = %[1]q
+
+  container_definitions = <<TASK_DEFINITION
+[
+  {
+    "name": "sleep",
+    "image": "busybox",
+    "cpu": 10,
+    "command": ["sleep","360"],
+    "memory": 10,
+    "essential": true
+  }
+]
+TASK_DEFINITION
+
+  volume {
+    name                = %[1]q
+    configure_at_launch = true
   }
 }
 `, rName)

--- a/internal/service/ecs/task_definition_test.go
+++ b/internal/service/ecs/task_definition_test.go
@@ -150,7 +150,7 @@ func TestAccECSTaskDefinition_configuredAtLaunch(t *testing.T) {
 		CheckDestroy:             testAccCheckTaskDefinitionDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: TestAccECSTaskDefinition_configuredAtLaunch(rName),
+				Config: testAccTaskDefinitionConfig_configuredAtLaunch(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(ctx, resourceName, &def),
 					resource.TestCheckResourceAttr(resourceName, "configure_at_launch", "true"),
@@ -1823,7 +1823,7 @@ TASK_DEFINITION
 `, rName)
 }
 
-func TestAccECSTaskDefinition_configuredAtLaunch(rName string) string {
+func testAccTaskDefinitionConfig_configuredAtLaunch(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_task_definition" "test" {
   family = %[1]q

--- a/website/docs/r/ecs_service.html.markdown
+++ b/website/docs/r/ecs_service.html.markdown
@@ -152,6 +152,7 @@ The following arguments are optional:
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `task_definition` - (Optional) Family and revision (`family:revision`) or full ARN of the task definition that you want to run in your service. Required unless using the `EXTERNAL` deployment controller. If a revision is not specified, the latest `ACTIVE` revision is used.
 * `triggers` - (Optional) Map of arbitrary keys and values that, when changed, will trigger an in-place update (redeployment). Useful with `plantimestamp()`. See example above.
+* `volume_configuration` - (Optional) The configuration for a volume specified in the task definition as a volume that is configured at launch time. Currently, the only supported volume type is an Amazon EBS volume. [See below](#volume_configuration).
 * `wait_for_steady_state` - (Optional) If `true`, Terraform will wait for the service to reach a steady state (like [`aws ecs wait services-stable`](https://docs.aws.amazon.com/cli/latest/reference/ecs/wait/services-stable.html)) before continuing. Default `false`.
 
 ### alarms
@@ -161,6 +162,27 @@ The `alarms` configuration block supports the following:
 * `alarm_names` - (Required) One or more CloudWatch alarm names.
 * `enable` - (Required) Determines whether to use the CloudWatch alarm option in the service deployment process.
 * `rollback` - (Required) Determines whether to configure Amazon ECS to roll back the service if a service deployment fails. If rollback is used, when a service deployment fails, the service is rolled back to the last deployment that completed successfully.
+
+### volume_configuration
+
+The `volume_configuration` configuration block supports the following:
+
+* `name` - (Required) Name of the volume.
+* `managed_ebs_volume` - (Required) Configuration for the Amazon EBS volume that Amazon ECS creates and manages on your behalf. [See below](#managed_ebs_volume).
+
+### managed_ebs_volume
+
+The `managed_ebs_volume` configuration block supports the following:
+
+* `role_arn` - (Required) Amazon ECS infrastructure IAM role that is used to manage your Amazon Web Services infrastructure. Recommended using the Amazon ECS-managed `AmazonECSInfrastructureRolePolicyForVolumes` IAM policy with this role.
+* `encrypted` - (Optional) Whether the volume should be encrypted. Default value is `true`.
+* `file_system_type` - (Optional)Linux filesystem type for the volume. For volumes created from a snapshot, same filesystem type must be specified that the volume was using when the snapshot was created. Valid values are `ext3`, `ext4`, `xfs`. Default value is `xfs`.
+* `iops` - (Optional) Number of I/O operations per second (IOPS).
+* `kms_key_id` - (Optional) Amazon Resource Name (ARN) identifier of the Amazon Web Services Key Management Service key to use for Amazon EBS encryption.
+* `size_in_gb` - (Optional) The size of the volume in GiB. You must specify either a `size_in_gb` or a `snapshot_id`. You can optionally specify a volume size greater than or equal to the snapshot size.
+* `snapshot_id` - (Optional) The snapshot that Amazon ECS uses to create the volume. You must specify either a `size_in_gb` or a `snapshot_id`.
+* `throughput` - (Optional) The throughput to provision for a volume, in MiB/s, with a maximum of 1,000 MiB/s.
+* `volume_type` - (Optional) The volume type.
 
 ### capacity_provider_strategy
 

--- a/website/docs/r/ecs_service.html.markdown
+++ b/website/docs/r/ecs_service.html.markdown
@@ -134,8 +134,8 @@ The following arguments are optional:
 * `deployment_maximum_percent` - (Optional) Upper limit (as a percentage of the service's desiredCount) of the number of running tasks that can be running in a service during a deployment. Not valid when using the `DAEMON` scheduling strategy.
 * `deployment_minimum_healthy_percent` - (Optional) Lower limit (as a percentage of the service's desiredCount) of the number of running tasks that must remain running and healthy in a service during a deployment.
 * `desired_count` - (Optional) Number of instances of the task definition to place and keep running. Defaults to 0. Do not specify if using the `DAEMON` scheduling strategy.
-* `enable_ecs_managed_tags` - (Optional) Specifies whether to enable Amazon ECS managed tags for the tasks within the service.
-* `enable_execute_command` - (Optional) Specifies whether to enable Amazon ECS Exec for the tasks within the service.
+* `enable_ecs_managed_tags` - (Optional) Whether to enable Amazon ECS managed tags for the tasks within the service.
+* `enable_execute_command` - (Optional) Whether to enable Amazon ECS Exec for the tasks within the service.
 * `force_new_deployment` - (Optional) Enable to force a new task deployment of the service. This can be used to update tasks to use a newer Docker image with same image/tag combination (e.g., `myimage:latest`), roll Fargate tasks onto a newer platform version, or immediately deploy `ordered_placement_strategy` and `placement_constraints` updates.
 * `health_check_grace_period_seconds` - (Optional) Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 2147483647. Only valid for services configured to use load balancers.
 * `iam_role` - (Optional) ARN of the IAM role that allows Amazon ECS to make calls to your load balancer on your behalf. This parameter is required if you are using a load balancer with your service, but only if your task definition does not use the `awsvpc` network mode. If using `awsvpc` network mode, do not specify this role. If your account has already created the Amazon ECS service-linked role, that role is used by default for your service unless you specify a role here.
@@ -145,14 +145,14 @@ The following arguments are optional:
 * `ordered_placement_strategy` - (Optional) Service level strategy rules that are taken into consideration during task placement. List from top to bottom in order of precedence. Updates to this configuration will take effect next task deployment unless `force_new_deployment` is enabled. The maximum number of `ordered_placement_strategy` blocks is `5`. See below.
 * `placement_constraints` - (Optional) Rules that are taken into consideration during task placement. Updates to this configuration will take effect next task deployment unless `force_new_deployment` is enabled. Maximum number of `placement_constraints` is `10`. See below.
 * `platform_version` - (Optional) Platform version on which to run your service. Only applicable for `launch_type` set to `FARGATE`. Defaults to `LATEST`. More information about Fargate platform versions can be found in the [AWS ECS User Guide](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html).
-* `propagate_tags` - (Optional) Specifies whether to propagate the tags from the task definition or the service to the tasks. The valid values are `SERVICE` and `TASK_DEFINITION`.
+* `propagate_tags` - (Optional) Whether to propagate the tags from the task definition or the service to the tasks. The valid values are `SERVICE` and `TASK_DEFINITION`.
 * `scheduling_strategy` - (Optional) Scheduling strategy to use for the service. The valid values are `REPLICA` and `DAEMON`. Defaults to `REPLICA`. Note that [*Tasks using the Fargate launch type or the `CODE_DEPLOY` or `EXTERNAL` deployment controller types don't support the `DAEMON` scheduling strategy*](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_CreateService.html).
-* `service_connect_configuration` - (Optional) The ECS Service Connect configuration for this service to discover and connect to services, and be discovered by, and connected from, other services within a namespace. See below.
+* `service_connect_configuration` - (Optional) ECS Service Connect configuration for this service to discover and connect to services, and be discovered by, and connected from, other services within a namespace. See below.
 * `service_registries` - (Optional) Service discovery registries for the service. The maximum number of `service_registries` blocks is `1`. See below.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `task_definition` - (Optional) Family and revision (`family:revision`) or full ARN of the task definition that you want to run in your service. Required unless using the `EXTERNAL` deployment controller. If a revision is not specified, the latest `ACTIVE` revision is used.
 * `triggers` - (Optional) Map of arbitrary keys and values that, when changed, will trigger an in-place update (redeployment). Useful with `plantimestamp()`. See example above.
-* `volume_configuration` - (Optional) The configuration for a volume specified in the task definition as a volume that is configured at launch time. Currently, the only supported volume type is an Amazon EBS volume. [See below](#volume_configuration).
+* `volume_configuration` - (Optional) Configuration for a volume specified in the task definition as a volume that is configured at launch time. Currently, the only supported volume type is an Amazon EBS volume. [See below](#volume_configuration).
 * `wait_for_steady_state` - (Optional) If `true`, Terraform will wait for the service to reach a steady state (like [`aws ecs wait services-stable`](https://docs.aws.amazon.com/cli/latest/reference/ecs/wait/services-stable.html)) before continuing. Default `false`.
 
 ### alarms
@@ -160,8 +160,8 @@ The following arguments are optional:
 The `alarms` configuration block supports the following:
 
 * `alarm_names` - (Required) One or more CloudWatch alarm names.
-* `enable` - (Required) Determines whether to use the CloudWatch alarm option in the service deployment process.
-* `rollback` - (Required) Determines whether to configure Amazon ECS to roll back the service if a service deployment fails. If rollback is used, when a service deployment fails, the service is rolled back to the last deployment that completed successfully.
+* `enable` - (Required) Whether to use the CloudWatch alarm option in the service deployment process.
+* `rollback` - (Required) Whether to configure Amazon ECS to roll back the service if a service deployment fails. If rollback is used, when a service deployment fails, the service is rolled back to the last deployment that completed successfully.
 
 ### volume_configuration
 
@@ -176,13 +176,13 @@ The `managed_ebs_volume` configuration block supports the following:
 
 * `role_arn` - (Required) Amazon ECS infrastructure IAM role that is used to manage your Amazon Web Services infrastructure. Recommended using the Amazon ECS-managed `AmazonECSInfrastructureRolePolicyForVolumes` IAM policy with this role.
 * `encrypted` - (Optional) Whether the volume should be encrypted. Default value is `true`.
-* `file_system_type` - (Optional)Linux filesystem type for the volume. For volumes created from a snapshot, same filesystem type must be specified that the volume was using when the snapshot was created. Valid values are `ext3`, `ext4`, `xfs`. Default value is `xfs`.
+* `file_system_type` - (Optional) Linux filesystem type for the volume. For volumes created from a snapshot, same filesystem type must be specified that the volume was using when the snapshot was created. Valid values are `ext3`, `ext4`, `xfs`. Default value is `xfs`.
 * `iops` - (Optional) Number of I/O operations per second (IOPS).
 * `kms_key_id` - (Optional) Amazon Resource Name (ARN) identifier of the Amazon Web Services Key Management Service key to use for Amazon EBS encryption.
-* `size_in_gb` - (Optional) The size of the volume in GiB. You must specify either a `size_in_gb` or a `snapshot_id`. You can optionally specify a volume size greater than or equal to the snapshot size.
-* `snapshot_id` - (Optional) The snapshot that Amazon ECS uses to create the volume. You must specify either a `size_in_gb` or a `snapshot_id`.
-* `throughput` - (Optional) The throughput to provision for a volume, in MiB/s, with a maximum of 1,000 MiB/s.
-* `volume_type` - (Optional) The volume type.
+* `size_in_gb` - (Optional) Size of the volume in GiB. You must specify either a `size_in_gb` or a `snapshot_id`. You can optionally specify a volume size greater than or equal to the snapshot size.
+* `snapshot_id` - (Optional) Snapshot that Amazon ECS uses to create the volume. You must specify either a `size_in_gb` or a `snapshot_id`.
+* `throughput` - (Optional) Throughput to provision for a volume, in MiB/s, with a maximum of 1,000 MiB/s.
+* `volume_type` - (Optional) Volume type.
 
 ### capacity_provider_strategy
 
@@ -258,64 +258,64 @@ For more information, see [Task Networking](https://docs.aws.amazon.com/AmazonEC
 
 `service_connect_configuration` supports the following:
 
-* `enabled` - (Required) Specifies whether to use Service Connect with this service.
-* `log_configuration` - (Optional) The log configuration for the container. See below.
-* `namespace` - (Optional) The namespace name or ARN of the [`aws_service_discovery_http_namespace`](/docs/providers/aws/r/service_discovery_http_namespace.html) for use with Service Connect.
-* `service` - (Optional) The list of Service Connect service objects. See below.
+* `enabled` - (Required) Whether to use Service Connect with this service.
+* `log_configuration` - (Optional) Log configuration for the container. See below.
+* `namespace` - (Optional) Namespace name or ARN of the [`aws_service_discovery_http_namespace`](/docs/providers/aws/r/service_discovery_http_namespace.html) for use with Service Connect.
+* `service` - (Optional) List of Service Connect service objects. See below.
 
 ### log_configuration
 
 `log_configuration` supports the following:
 
-* `log_driver` - (Required) The log driver to use for the container.
-* `options` - (Optional) The configuration options to send to the log driver.
-* `secret_option` - (Optional) The secrets to pass to the log configuration. See below.
+* `log_driver` - (Required) Log driver to use for the container.
+* `options` - (Optional) Configuration options to send to the log driver.
+* `secret_option` - (Optional) Secrets to pass to the log configuration. See below.
 
 ### secret_option
 
 `secret_option` supports the following:
 
-* `name` - (Required) The name of the secret.
-* `value_from` - (Required) The secret to expose to the container. The supported values are either the full ARN of the AWS Secrets Manager secret or the full ARN of the parameter in the SSM Parameter Store.
+* `name` - (Required) Name of the secret.
+* `value_from` - (Required) Secret to expose to the container. The supported values are either the full ARN of the AWS Secrets Manager secret or the full ARN of the parameter in the SSM Parameter Store.
 
 ### service
 
 `service` supports the following:
 
-* `client_alias` - (Optional) The list of client aliases for this Service Connect service. You use these to assign names that can be used by client applications. The maximum number of client aliases that you can have in this list is 1. See below.
-* `discovery_name` - (Optional) The name of the new AWS Cloud Map service that Amazon ECS creates for this Amazon ECS service.
-* `ingress_port_override` - (Optional) The port number for the Service Connect proxy to listen on.
-* `port_name` - (Required) The name of one of the `portMappings` from all the containers in the task definition of this Amazon ECS service.
+* `client_alias` - (Optional) List of client aliases for this Service Connect service. You use these to assign names that can be used by client applications. The maximum number of client aliases that you can have in this list is 1. See below.
+* `discovery_name` - (Optional) Name of the new AWS Cloud Map service that Amazon ECS creates for this Amazon ECS service.
+* `ingress_port_override` - (Optional) Port number for the Service Connect proxy to listen on.
+* `port_name` - (Required) Name of one of the `portMappings` from all the containers in the task definition of this Amazon ECS service.
 * `timeout` - (Optional) Configuration timeouts for Service Connect
-* `tls` - (Optional) The configuration for enabling Transport Layer Security (TLS)
+* `tls` - (Optional) Configuration for enabling Transport Layer Security (TLS)
 
 ### timeout
 
 `timeout` supports the following:
 
-* `idle_timeout_seconds` - (Optional) The amount of time in seconds a connection will stay active while idle. A value of 0 can be set to disable idleTimeout.
-* `per_request_timeout_seconds` - (Optional) The amount of time in seconds for the upstream to respond with a complete response per request. A value of 0 can be set to disable perRequestTimeout. Can only be set when appProtocol isn't TCP.
+* `idle_timeout_seconds` - (Optional) Amount of time in seconds a connection will stay active while idle. A value of 0 can be set to disable idleTimeout.
+* `per_request_timeout_seconds` - (Optional) Amount of time in seconds for the upstream to respond with a complete response per request. A value of 0 can be set to disable perRequestTimeout. Can only be set when appProtocol isn't TCP.
 
 ### tls
 
 `tls` supports the following:
 
-* `issuer_cert_authority` - (Required) The details of the certificate authority which will issue the certificate.
-* `kms_key` - (Optional) The KMS key used to encrypt the private key in Secrets Manager.
-* `role_arn` - (Optional) The ARN of the IAM Role that's associated with the Service Connect TLS.
+* `issuer_cert_authority` - (Required) Details of the certificate authority which will issue the certificate.
+* `kms_key` - (Optional) KMS key used to encrypt the private key in Secrets Manager.
+* `role_arn` - (Optional) ARN of the IAM Role that's associated with the Service Connect TLS.
 
 ### issuer_cert_authority
 
 `issuer_cert_authority` supports the following:
 
-* `aws_pca_authority_arn` - (Optional) The ARN of the [`aws_acmpca_certificate_authority`](/docs/providers/aws/r/acmpca_certificate_authority.html) used to create the TLS Certificates.
+* `aws_pca_authority_arn` - (Optional) ARN of the [`aws_acmpca_certificate_authority`](/docs/providers/aws/r/acmpca_certificate_authority.html) used to create the TLS Certificates.
 
 ### client_alias
 
 `client_alias` supports the following:
 
-* `dns_name` - (Optional) The name that you use in the applications of client tasks to connect to this service.
-* `port` - (Required) The listening port number for the Service Connect proxy. This port is available inside of all of the tasks within the same namespace.
+* `dns_name` - (Optional) Name that you use in the applications of client tasks to connect to this service.
+* `port` - (Required) Listening port number for the Service Connect proxy. This port is available inside of all of the tasks within the same namespace.
 
 ## Attribute Reference
 

--- a/website/docs/r/ecs_task_definition.html.markdown
+++ b/website/docs/r/ecs_task_definition.html.markdown
@@ -260,6 +260,7 @@ The following arguments are optional:
 * `efs_volume_configuration` - (Optional) Configuration block for an [EFS volume](#efs_volume_configuration). Detailed below.
 * `fsx_windows_file_server_volume_configuration` - (Optional) Configuration block for an [FSX Windows File Server volume](#fsx_windows_file_server_volume_configuration). Detailed below.
 * `host_path` - (Optional) Path on the host container instance that is presented to the container. If not set, ECS will create a nonpersistent data volume that starts empty and is deleted after the task has finished.
+* `configure_at_launch` - (Optional) Whether the volume should be configured at launch time. This is used to create Amazon EBS volumes for standalone tasks or tasks created as part of a service. Each task definition revision may only have one volume configured at launch in the volume configuration.
 * `name` - (Required) Name of the volume. This name is referenced in the `sourceVolume`
 parameter of container definition in the `mountPoints` section.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #35279

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccECSTaskDefinition_configuredAtLaunch PKG=ecs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSTaskDefinition_configuredAtLaunch'  -timeout 360m
=== RUN   TestAccECSTaskDefinition_configuredAtLaunch
=== PAUSE TestAccECSTaskDefinition_configuredAtLaunch
=== CONT  TestAccECSTaskDefinition_configuredAtLaunch
--- PASS: TestAccECSTaskDefinition_configuredAtLaunch (54.53s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	126.627s
% make testacc TESTS=TestAccECSTaskDefinition_ PKG=ecs                    
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSTaskDefinition_'  -timeout 360m
=== RUN   TestAccECSTaskDefinition_basic
=== PAUSE TestAccECSTaskDefinition_basic
=== RUN   TestAccECSTaskDefinition_scratchVolume
=== PAUSE TestAccECSTaskDefinition_scratchVolume
=== RUN   TestAccECSTaskDefinition_configuredAtLaunch
=== PAUSE TestAccECSTaskDefinition_configuredAtLaunch
=== RUN   TestAccECSTaskDefinition_DockerVolume_basic
=== PAUSE TestAccECSTaskDefinition_DockerVolume_basic
=== RUN   TestAccECSTaskDefinition_DockerVolume_minimal
=== PAUSE TestAccECSTaskDefinition_DockerVolume_minimal
=== RUN   TestAccECSTaskDefinition_runtimePlatform
=== PAUSE TestAccECSTaskDefinition_runtimePlatform
=== RUN   TestAccECSTaskDefinition_Fargate_runtimePlatform
=== PAUSE TestAccECSTaskDefinition_Fargate_runtimePlatform
=== RUN   TestAccECSTaskDefinition_Fargate_runtimePlatformWithoutArch
=== PAUSE TestAccECSTaskDefinition_Fargate_runtimePlatformWithoutArch
=== RUN   TestAccECSTaskDefinition_EFSVolume_minimal
=== PAUSE TestAccECSTaskDefinition_EFSVolume_minimal
=== RUN   TestAccECSTaskDefinition_EFSVolume_basic
=== PAUSE TestAccECSTaskDefinition_EFSVolume_basic
=== RUN   TestAccECSTaskDefinition_EFSVolume_transitEncryptionMinimal
=== PAUSE TestAccECSTaskDefinition_EFSVolume_transitEncryptionMinimal
=== RUN   TestAccECSTaskDefinition_EFSVolume_transitEncryption
=== PAUSE TestAccECSTaskDefinition_EFSVolume_transitEncryption
=== RUN   TestAccECSTaskDefinition_EFSVolume_transitEncryptionDisabled
=== PAUSE TestAccECSTaskDefinition_EFSVolume_transitEncryptionDisabled
=== RUN   TestAccECSTaskDefinition_EFSVolume_accessPoint
=== PAUSE TestAccECSTaskDefinition_EFSVolume_accessPoint
=== RUN   TestAccECSTaskDefinition_fsxWinFileSystem
=== PAUSE TestAccECSTaskDefinition_fsxWinFileSystem
=== RUN   TestAccECSTaskDefinition_DockerVolume_taskScoped
=== PAUSE TestAccECSTaskDefinition_DockerVolume_taskScoped
=== RUN   TestAccECSTaskDefinition_service
=== PAUSE TestAccECSTaskDefinition_service
=== RUN   TestAccECSTaskDefinition_taskRoleARN
=== PAUSE TestAccECSTaskDefinition_taskRoleARN
=== RUN   TestAccECSTaskDefinition_networkMode
=== PAUSE TestAccECSTaskDefinition_networkMode
=== RUN   TestAccECSTaskDefinition_ipcMode
=== PAUSE TestAccECSTaskDefinition_ipcMode
=== RUN   TestAccECSTaskDefinition_pidMode
=== PAUSE TestAccECSTaskDefinition_pidMode
=== RUN   TestAccECSTaskDefinition_constraint
=== PAUSE TestAccECSTaskDefinition_constraint
=== RUN   TestAccECSTaskDefinition_changeVolumesForcesNewResource
=== PAUSE TestAccECSTaskDefinition_changeVolumesForcesNewResource
=== RUN   TestAccECSTaskDefinition_arrays
=== PAUSE TestAccECSTaskDefinition_arrays
=== RUN   TestAccECSTaskDefinition_Fargate_basic
=== PAUSE TestAccECSTaskDefinition_Fargate_basic
=== RUN   TestAccECSTaskDefinition_Fargate_ephemeralStorage
=== PAUSE TestAccECSTaskDefinition_Fargate_ephemeralStorage
=== RUN   TestAccECSTaskDefinition_executionRole
=== PAUSE TestAccECSTaskDefinition_executionRole
=== RUN   TestAccECSTaskDefinition_disappears
=== PAUSE TestAccECSTaskDefinition_disappears
=== RUN   TestAccECSTaskDefinition_tags
=== PAUSE TestAccECSTaskDefinition_tags
=== RUN   TestAccECSTaskDefinition_proxy
=== PAUSE TestAccECSTaskDefinition_proxy
=== RUN   TestAccECSTaskDefinition_inferenceAccelerator
=== PAUSE TestAccECSTaskDefinition_inferenceAccelerator
=== RUN   TestAccECSTaskDefinition_invalidContainerDefinition
=== PAUSE TestAccECSTaskDefinition_invalidContainerDefinition
=== RUN   TestAccECSTaskDefinition_trackLatest
=== PAUSE TestAccECSTaskDefinition_trackLatest
=== CONT  TestAccECSTaskDefinition_basic
=== CONT  TestAccECSTaskDefinition_taskRoleARN
=== CONT  TestAccECSTaskDefinition_Fargate_ephemeralStorage
=== CONT  TestAccECSTaskDefinition_proxy
=== CONT  TestAccECSTaskDefinition_tags
=== CONT  TestAccECSTaskDefinition_trackLatest
=== CONT  TestAccECSTaskDefinition_disappears
=== CONT  TestAccECSTaskDefinition_invalidContainerDefinition
=== CONT  TestAccECSTaskDefinition_executionRole
=== CONT  TestAccECSTaskDefinition_runtimePlatform
=== CONT  TestAccECSTaskDefinition_Fargate_basic
=== CONT  TestAccECSTaskDefinition_EFSVolume_minimal
=== CONT  TestAccECSTaskDefinition_Fargate_runtimePlatformWithoutArch
=== CONT  TestAccECSTaskDefinition_EFSVolume_basic
=== CONT  TestAccECSTaskDefinition_service
=== CONT  TestAccECSTaskDefinition_DockerVolume_taskScoped
=== CONT  TestAccECSTaskDefinition_fsxWinFileSystem
=== CONT  TestAccECSTaskDefinition_EFSVolume_accessPoint
=== CONT  TestAccECSTaskDefinition_Fargate_runtimePlatform
=== CONT  TestAccECSTaskDefinition_inferenceAccelerator
--- PASS: TestAccECSTaskDefinition_invalidContainerDefinition (40.18s)
=== CONT  TestAccECSTaskDefinition_EFSVolume_transitEncryptionDisabled
--- PASS: TestAccECSTaskDefinition_DockerVolume_taskScoped (266.12s)
=== CONT  TestAccECSTaskDefinition_EFSVolume_transitEncryption
--- PASS: TestAccECSTaskDefinition_inferenceAccelerator (322.31s)
=== CONT  TestAccECSTaskDefinition_EFSVolume_transitEncryptionMinimal
--- PASS: TestAccECSTaskDefinition_trackLatest (322.34s)
=== CONT  TestAccECSTaskDefinition_constraint
--- PASS: TestAccECSTaskDefinition_taskRoleARN (322.60s)
=== CONT  TestAccECSTaskDefinition_arrays
--- PASS: TestAccECSTaskDefinition_proxy (322.62s)
=== CONT  TestAccECSTaskDefinition_changeVolumesForcesNewResource
--- PASS: TestAccECSTaskDefinition_Fargate_runtimePlatform (322.85s)
=== CONT  TestAccECSTaskDefinition_ipcMode
--- PASS: TestAccECSTaskDefinition_runtimePlatform (322.91s)
=== CONT  TestAccECSTaskDefinition_pidMode
--- PASS: TestAccECSTaskDefinition_Fargate_runtimePlatformWithoutArch (322.96s)
=== CONT  TestAccECSTaskDefinition_networkMode
--- PASS: TestAccECSTaskDefinition_Fargate_ephemeralStorage (323.09s)
=== CONT  TestAccECSTaskDefinition_DockerVolume_basic
--- PASS: TestAccECSTaskDefinition_executionRole (323.28s)
=== CONT  TestAccECSTaskDefinition_configuredAtLaunch
--- PASS: TestAccECSTaskDefinition_EFSVolume_basic (325.74s)
=== CONT  TestAccECSTaskDefinition_scratchVolume
--- PASS: TestAccECSTaskDefinition_EFSVolume_minimal (325.88s)
=== CONT  TestAccECSTaskDefinition_DockerVolume_minimal
--- PASS: TestAccECSTaskDefinition_EFSVolume_accessPoint (330.20s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_transitEncryptionDisabled (304.26s)
--- PASS: TestAccECSTaskDefinition_Fargate_basic (424.24s)
--- PASS: TestAccECSTaskDefinition_disappears (475.37s)
--- PASS: TestAccECSTaskDefinition_basic (516.57s)
--- PASS: TestAccECSTaskDefinition_service (555.15s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_transitEncryption (296.36s)
--- PASS: TestAccECSTaskDefinition_DockerVolume_basic (274.79s)
--- PASS: TestAccECSTaskDefinition_configuredAtLaunch (274.69s)
--- PASS: TestAccECSTaskDefinition_arrays (275.37s)
--- PASS: TestAccECSTaskDefinition_constraint (275.73s)
--- PASS: TestAccECSTaskDefinition_scratchVolume (272.33s)
--- PASS: TestAccECSTaskDefinition_DockerVolume_minimal (272.16s)
--- PASS: TestAccECSTaskDefinition_networkMode (275.15s)
--- PASS: TestAccECSTaskDefinition_ipcMode (275.30s)
--- PASS: TestAccECSTaskDefinition_pidMode (275.38s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_transitEncryptionMinimal (278.14s)
--- PASS: TestAccECSTaskDefinition_tags (603.07s)
--- PASS: TestAccECSTaskDefinition_changeVolumesForcesNewResource (292.14s)
--- PASS: TestAccECSTaskDefinition_fsxWinFileSystem (3773.78s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	3790.964s
--- PASS: TestAccECSService_Tags_basic (771.31s)
--- PASS: TestAccECSService_deploymentCircuitBreaker (238.53s)
--- PASS: TestAccECSService_DeploymentControllerType_external (243.35s)
--- PASS: TestAccECSService_DeploymentValues_basic (247.90s)
--- PASS: TestAccECSService_clusterName (245.17s)
--- PASS: TestAccECSService_PlacementStrategy_basic (839.21s)
--- PASS: TestAccECSService_PlacementConstraints_basic (428.55s)
--- PASS: TestAccECSService_alarmsAdd (356.84s)
--- PASS: TestAccECSService_LaunchTypeFargate_basic (544.55s)
--- PASS: TestAccECSService_DeploymentValues_minZeroMaxOneHundred (190.27s)
--- PASS: TestAccECSService_LaunchTypeFargate_platformVersion (563.30s)
--- PASS: TestAccECSService_alarmsUpdate (352.59s)
--- PASS: TestAccECSService_PlacementStrategy_unnormalized (166.33s)
--- PASS: TestAccECSService_CapacityProviderStrategy_basic (314.26s)
--- PASS: TestAccECSService_CapacityProviderStrategy_forceNewDeployment (182.11s)
--- PASS: TestAccECSService_ServiceConnect_remove (381.43s)
--- PASS: TestAccECSService_disappears (265.32s)
--- PASS: TestAccECSService_alb (429.33s)
--- PASS: TestAccECSService_CapacityProviderStrategy_update (331.87s)
--- PASS: TestAccECSService_basicImport (277.42s)
--- PASS: TestAccECSService_ServiceConnect_tls_with_empty_timeout (393.58s)
--- PASS: TestAccECSService_ServiceConnect_full (423.89s)
--- PASS: TestAccECSService_PlacementConstraints_emptyExpression (305.40s)
--- PASS: TestAccECSService_ServiceConnect_basic (435.95s)
--- PASS: TestAccECSService_Tags_propagate (713.88s)
--- PASS: TestAccECSService_iamRole (311.74s)
--- PASS: TestAccECSService_Tags_managed (332.92s)
--- PASS: TestAccECSService_ServiceRegistries_container (411.25s)
--- PASS: TestAccECSService_DaemonSchedulingStrategy_basic (327.54s)
--- PASS: TestAccECSService_DaemonSchedulingStrategy_setDeploymentMinimum (329.12s)
--- PASS: TestAccECSService_PlacementStrategy_missing (28.58s)
--- PASS: TestAccECSService_replicaSchedulingStrategy (364.99s)
--- PASS: TestAccECSService_familyAndRevision (563.38s)
--- PASS: TestAccECSService_multipleTargetGroups (568.18s)
--- PASS: TestAccECSService_basic (570.75s)
--- PASS: TestAccECSService_executeCommand (572.83s)
--- PASS: TestAccECSService_forceNewDeployment (573.30s)
--- PASS: TestAccECSService_forceNewDeploymentTriggers (573.51s)
--- PASS: TestAccECSService_DeploymentControllerType_codeDeploy (620.25s)
...
```
