### PR TITLE
Update Go devcontainer image to version 1.22

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,5 +3,5 @@
 {
 	"name": "Go",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/go:1.21"
+	"image": "mcr.microsoft.com/devcontainers/go:1.22"
 }


### PR DESCRIPTION
### Description
Go version has been updated to version 1.22.
Upgrade .devcontainer.json to match this new version. This should be added to the to upgrade list when upgrading to the next Go versions :)

### Relations
Closes  #37022

