### PR TITLE
Fix deprecation message for aws_batch_job_queue

### DIFF
--- a/internal/service/batch/job_queue.go
+++ b/internal/service/batch/job_queue.go
@@ -79,7 +79,7 @@ func (r *resourceJobQueue) Schema(ctx context.Context, request resource.SchemaRe
 			"compute_environments": schema.ListAttribute{
 				ElementType:        fwtypes.ARNType,
 				Optional:           true,
-				DeprecationMessage: "This parameter will be replaced by `compute_environments_order`.",
+				DeprecationMessage: "This parameter will be replaced by `compute_environment_order`.",
 			},
 			"id": framework.IDAttribute(),
 			"name": schema.StringAttribute{


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
`compute_environments` was replaced by `compute_environment_order` in https://github.com/hashicorp/terraform-provider-aws/pull/34750 — the deprecation message incorrectly pluralised `environment`, which is fixed in this PR.


### Relations

Relates #34750

### References

See docs for the resource [here](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/batch_job_queue). 

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
make testacc TESTS=TestAccBatchJobQueue_ PKG=batch                                                                       <aws:personal>
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/batch/... -v -count 1 -parallel 3 -run='TestAccBatchJobQueue_'  -timeout 360m
=== RUN   TestAccBatchJobQueue_tags
=== PAUSE TestAccBatchJobQueue_tags
=== RUN   TestAccBatchJobQueue_tags_null
    job_queue_tags_gen_test.go:84: Tags with null values are not correctly handled with the Plugin Framework
--- SKIP: TestAccBatchJobQueue_tags_null (0.00s)
=== RUN   TestAccBatchJobQueue_tags_AddOnUpdate
=== PAUSE TestAccBatchJobQueue_tags_AddOnUpdate
=== RUN   TestAccBatchJobQueue_tags_EmptyTag_OnCreate
=== PAUSE TestAccBatchJobQueue_tags_EmptyTag_OnCreate
=== RUN   TestAccBatchJobQueue_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccBatchJobQueue_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccBatchJobQueue_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccBatchJobQueue_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccBatchJobQueue_tags_DefaultTags_providerOnly
=== PAUSE TestAccBatchJobQueue_tags_DefaultTags_providerOnly
=== RUN   TestAccBatchJobQueue_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccBatchJobQueue_tags_DefaultTags_nonOverlapping
=== RUN   TestAccBatchJobQueue_tags_DefaultTags_overlapping
=== PAUSE TestAccBatchJobQueue_tags_DefaultTags_overlapping
=== RUN   TestAccBatchJobQueue_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccBatchJobQueue_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccBatchJobQueue_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccBatchJobQueue_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccBatchJobQueue_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccBatchJobQueue_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccBatchJobQueue_tags_DefaultTags_nullOverlappingResourceTag
    job_queue_tags_gen_test.go:632: Tags with null values are not correctly handled with the Plugin Framework
--- SKIP: TestAccBatchJobQueue_tags_DefaultTags_nullOverlappingResourceTag (0.00s)
=== RUN   TestAccBatchJobQueue_tags_DefaultTags_nullNonOverlappingResourceTag
    job_queue_tags_gen_test.go:667: Tags with null values are not correctly handled with the Plugin Framework
--- SKIP: TestAccBatchJobQueue_tags_DefaultTags_nullNonOverlappingResourceTag (0.00s)
=== RUN   TestAccBatchJobQueue_basic
=== PAUSE TestAccBatchJobQueue_basic
=== RUN   TestAccBatchJobQueue_basicCEO
=== PAUSE TestAccBatchJobQueue_basicCEO
=== RUN   TestAccBatchJobQueue_disappears
=== PAUSE TestAccBatchJobQueue_disappears
=== RUN   TestAccBatchJobQueue_disappearsCEO
=== PAUSE TestAccBatchJobQueue_disappearsCEO
=== RUN   TestAccBatchJobQueue_MigrateFromPluginSDK
=== PAUSE TestAccBatchJobQueue_MigrateFromPluginSDK
=== RUN   TestAccBatchJobQueue_ComputeEnvironments_multiple
=== PAUSE TestAccBatchJobQueue_ComputeEnvironments_multiple
=== RUN   TestAccBatchJobQueue_ComputeEnvironmentOrder_multiple
=== PAUSE TestAccBatchJobQueue_ComputeEnvironmentOrder_multiple
=== RUN   TestAccBatchJobQueue_ComputeEnvironments_externalOrderUpdate
=== PAUSE TestAccBatchJobQueue_ComputeEnvironments_externalOrderUpdate
=== RUN   TestAccBatchJobQueue_priority
=== PAUSE TestAccBatchJobQueue_priority
=== RUN   TestAccBatchJobQueue_schedulingPolicy
=== PAUSE TestAccBatchJobQueue_schedulingPolicy
=== RUN   TestAccBatchJobQueue_state
=== PAUSE TestAccBatchJobQueue_state
=== CONT  TestAccBatchJobQueue_tags
=== CONT  TestAccBatchJobQueue_basic
=== CONT  TestAccBatchJobQueue_ComputeEnvironmentOrder_multiple
--- PASS: TestAccBatchJobQueue_basic (153.01s)
=== CONT  TestAccBatchJobQueue_disappearsCEO
--- PASS: TestAccBatchJobQueue_ComputeEnvironmentOrder_multiple (179.52s)
=== CONT  TestAccBatchJobQueue_ComputeEnvironments_multiple
--- PASS: TestAccBatchJobQueue_tags (216.98s)
=== CONT  TestAccBatchJobQueue_MigrateFromPluginSDK
    job_queue_test.go:160: Error retrieving state, there may be dangling resources: exit status 1
        Failed to marshal state to json: schema version 0 for aws_batch_job_queue.test in state does not match version 1 from the provider
--- FAIL: TestAccBatchJobQueue_MigrateFromPluginSDK (62.95s)
=== CONT  TestAccBatchJobQueue_tags_DefaultTags_nonOverlapping
--- PASS: TestAccBatchJobQueue_disappearsCEO (137.85s)
=== CONT  TestAccBatchJobQueue_tags_DefaultTags_emptyResourceTag
--- PASS: TestAccBatchJobQueue_ComputeEnvironments_multiple (193.27s)
=== CONT  TestAccBatchJobQueue_tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccBatchJobQueue_tags_DefaultTags_emptyResourceTag (146.06s)
=== CONT  TestAccBatchJobQueue_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccBatchJobQueue_tags_DefaultTags_nonOverlapping (180.69s)
=== CONT  TestAccBatchJobQueue_tags_DefaultTags_overlapping
--- PASS: TestAccBatchJobQueue_tags_DefaultTags_updateToResourceOnly (151.72s)
=== CONT  TestAccBatchJobQueue_disappears
--- PASS: TestAccBatchJobQueue_tags_DefaultTags_updateToProviderOnly (148.54s)
=== CONT  TestAccBatchJobQueue_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccBatchJobQueue_tags_DefaultTags_overlapping (160.77s)
=== CONT  TestAccBatchJobQueue_tags_DefaultTags_providerOnly
    job_queue_tags_gen_test.go:289: Step 1/8 error: Error running apply: exit status 1
        
        Error: waiting for Batch Compute Environment (tf-acc-test-8758415913684899913) create: unexpected state 'INVALID', wanted target 'VALID'. last error: CLIENT_ERROR - User: arn:aws:sts::xxx:assumed-role/tf-acc-test-8758415913684899913/aws-batch is not authorized to perform: ecs:DescribeClusters on resource: arn:aws:ecs:us-west-2:xxx:cluster/tf-acc-test-8758415913684899913_Batch_c5cf35b2-9903-3078-905f-4bae3d9b5c27 because no identity-based policy allows the ecs:DescribeClusters action (Service: AmazonECS; Status Code: 400; Error Code: AccessDeniedException; Request ID: fd1356f5-0155-426f-bdbb-e9c2471037ad; Proxy: null)
        
          with aws_batch_compute_environment.test,
          on terraform_plugin_test.tf line 108, in resource "aws_batch_compute_environment" "test":
         108: resource "aws_batch_compute_environment" "test" {
        
--- FAIL: TestAccBatchJobQueue_tags_DefaultTags_providerOnly (21.32s)
=== CONT  TestAccBatchJobQueue_tags_EmptyTag_OnUpdate_Replace
--- PASS: TestAccBatchJobQueue_disappears (138.45s)
=== CONT  TestAccBatchJobQueue_schedulingPolicy
--- PASS: TestAccBatchJobQueue_tags_EmptyTag_OnUpdate_Add (160.83s)
=== CONT  TestAccBatchJobQueue_state
--- PASS: TestAccBatchJobQueue_tags_EmptyTag_OnUpdate_Replace (160.99s)
=== CONT  TestAccBatchJobQueue_tags_EmptyTag_OnCreate
--- PASS: TestAccBatchJobQueue_schedulingPolicy (209.50s)
=== CONT  TestAccBatchJobQueue_priority
--- PASS: TestAccBatchJobQueue_state (182.35s)
=== CONT  TestAccBatchJobQueue_basicCEO
--- PASS: TestAccBatchJobQueue_tags_EmptyTag_OnCreate (161.39s)
=== CONT  TestAccBatchJobQueue_tags_AddOnUpdate
--- PASS: TestAccBatchJobQueue_priority (189.07s)
=== CONT  TestAccBatchJobQueue_ComputeEnvironments_externalOrderUpdate
--- PASS: TestAccBatchJobQueue_basicCEO (160.25s)
--- PASS: TestAccBatchJobQueue_tags_AddOnUpdate (127.20s)
--- PASS: TestAccBatchJobQueue_ComputeEnvironments_externalOrderUpdate (150.88s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/batch	1217.629s
FAIL
make: *** [testacc] Error 1
...
```