### PR TITLE
[docs] Typo fix in website docs

### DIFF
--- a/website/docs/r/codecommit_repository.html.markdown
+++ b/website/docs/r/codecommit_repository.html.markdown
@@ -41,7 +41,7 @@ This resource supports the following arguments:
 * `repository_name` - (Required) The name for the repository. This needs to be less than 100 characters.
 * `description` - (Optional) The description of the repository. This needs to be less than 1000 characters
 * `default_branch` - (Optional) The default branch of the repository. The branch specified here needs to exist.
-* `kms_key_id` - (Optional) The ARN of the encryption key. If no key is specified, the default `aws/codecommit`` Amazon Web Services managed key is used.
+* `kms_key_id` - (Optional) The ARN of the encryption key. If no key is specified, the default `aws/codecommit` Amazon Web Services managed key is used.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attribute Reference


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

Fix a typo in the documentation for `r/aws_codecommit_repository`

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
When the `aws_codecommit_repository` resource was enhanced to add the `kms_key_id` parameter in https://github.com/hashicorp/terraform-provider-aws/pull/35095, the documentation added for the new parameter had a typo in it, and closed the name of the fallback AWS-managed key with a double backtick ` `` ` instead of a single `. 

This results in [the name not rendering properly on the terraform provider registry website](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codecommit_repository#kms_key_id), and for some strange reason I haven't pinned down yet, only sometimes breaks a tool I use that parses the terraform provider documentation. I'll take care of fixing the tool, but I thought I'd open the PR to clean up the website. 

The same typo is present in the cdktf docs, but it looks like the normal practice is for those to be updated by codegen scripts, not by humans. If I'm wrong about that I prepared 3a3dfd1c1975cb02c8f2ba7b5ea0dbb33b2789be as well, but didn't open a PR.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

I didn't run acceptance testing because it's only a documentation change. 
