### PR TITLE
resource/aws_cloudformation_stack_set: Adds guidance about required permissions to error message

### DIFF
--- a/.changelog/37069.txt
+++ b/.changelog/37069.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cloudformation_stack_set: Adds guidance on permissions when using delegated administrator account
+```

--- a/internal/service/cloudformation/stack_set_test.go
+++ b/internal/service/cloudformation/stack_set_test.go
@@ -828,6 +828,11 @@ func TestAccCloudFormationStackSet_autoDeploymentDisabled(t *testing.T) {
 }
 
 // https://github.com/hashicorp/terraform-provider-aws/issues/32536.
+// Prerequisites:
+// * Organizations root account
+// * Organization member account
+// * Deleegated administrator not configured
+// Authenticate with member account as target account and root account as alternate.
 func TestAccCloudFormationStackSet_delegatedAdministrator(t *testing.T) {
 	ctx := acctest.Context(t)
 	providers := make(map[string]*schema.Provider)

--- a/internal/service/cloudformation/stack_set_test.go
+++ b/internal/service/cloudformation/stack_set_test.go
@@ -831,7 +831,7 @@ func TestAccCloudFormationStackSet_autoDeploymentDisabled(t *testing.T) {
 // Prerequisites:
 // * Organizations root account
 // * Organization member account
-// * Deleegated administrator not configured
+// * Delegated administrator not configured
 // Authenticate with member account as target account and root account as alternate.
 func TestAccCloudFormationStackSet_delegatedAdministrator(t *testing.T) {
 	ctx := acctest.Context(t)

--- a/website/docs/r/cloudformation_stack_set.html.markdown
+++ b/website/docs/r/cloudformation_stack_set.html.markdown
@@ -14,6 +14,8 @@ Manages a CloudFormation StackSet. StackSets allow CloudFormation templates to b
 
 ~> **NOTE:** All `NoEcho` template parameters must be ignored with the `lifecycle` configuration block `ignore_changes` argument.
 
+~> **NOTE:** When using a delegated administrator account, ensure that your IAM User or Role has the `organizations:ListDelegatedAdministrators` permission. Otherwise, you may get an error like `ValidationError: Account used is not a delegated administrator`.
+
 ## Example Usage
 
 ```terraform


### PR DESCRIPTION
### Description

When using a delegation administrator account with `aws_cloudformation_stack_set`, if the IAM User or Role does not have the `organizations:ListDelegatedAdministrators` permission, the AWS API returns the error

> ValidationError: Account used is not a delegated administrator

instead of indicating that there are not sufficient permissions.

Adds guidance to the error message to point to the IAM permissions.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #32536

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=cloudformation TESTS=TestAccCloudFormationStackSet_

--- SKIP: TestAccCloudFormationStackSet_delegatedAdministrator (1.05s)
--- SKIP: TestAccCloudFormationStackSet_autoDeploymentEnabled (1.50s)
--- SKIP: TestAccCloudFormationStackSet_autoDeploymentDisabled (1.54s)
--- PASS: TestAccCloudFormationStackSet_managedExecution (42.52s)
--- PASS: TestAccCloudFormationStackSet_disappears (50.47s)
--- PASS: TestAccCloudFormationStackSet_basic (63.02s)
--- PASS: TestAccCloudFormationStackSet_executionRoleName (65.70s)
--- PASS: TestAccCloudFormationStackSet_administrationRoleARN (67.11s)
--- PASS: TestAccCloudFormationStackSet_description (67.62s)
--- PASS: TestAccCloudFormationStackSet_templateBody (74.34s)
--- PASS: TestAccCloudFormationStackSet_templateURL (78.01s)
--- PASS: TestAccCloudFormationStackSet_name (87.33s)
--- PASS: TestAccCloudFormationStackSet_tags (88.76s)
--- PASS: TestAccCloudFormationStackSet_parameters (95.39s)
--- PASS: TestAccCloudFormationStackSet_operationPreferences (119.17s)
```
