### PR TITLE
[WIP] fix: Add validation to prevent use of CODEPIPELINE type in secondary_artifacts and secondary_sources in aws_codebuild_project

### DIFF
--- a/.changelog/37072.txt
+++ b/.changelog/37072.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_codebuild_project: Add plan-time validation to prevent use of `CODEPIPELINE` for `type` in the `secondary_artifacts` and `secondary_sources` blocks
+```

--- a/internal/service/codebuild/project.go
+++ b/internal/service/codebuild/project.go
@@ -497,7 +497,7 @@ func resourceProject() *schema.Resource {
 						"type": {
 							Type:             schema.TypeString,
 							Required:         true,
-							ValidateDiagFunc: enum.Validate[types.ArtifactsType](),
+							ValidateDiagFunc: validation.ToDiagFunc(validateSecondaryArtifactsType),
 						},
 					},
 				},
@@ -566,7 +566,7 @@ func resourceProject() *schema.Resource {
 						"type": {
 							Type:             schema.TypeString,
 							Required:         true,
-							ValidateDiagFunc: enum.Validate[types.SourceType](),
+							ValidateDiagFunc: validation.ToDiagFunc(validateSecondarySourcesType),
 						},
 					},
 				},
@@ -2004,6 +2004,34 @@ func validProjectS3LogsLocation(v interface{}, k string) (ws []string, errors []
 		errors = append(errors, fmt.Errorf(
 			"%q does not match pattern (%q): %q",
 			k, simplePattern, value))
+	}
+
+	return
+}
+
+func validateSecondaryArtifactsType(v interface{}, k string) (warnings []string, errors []error) {
+	ws, es := validation.StringInSlice(enum.Values[types.ArtifactsType](), false)(v, k)
+	warnings = append(warnings, ws...)
+	errors = append(errors, es...)
+
+	value := v.(string)
+	if value == string(types.ArtifactsTypeCodepipeline) {
+		errors = append(errors, fmt.Errorf(
+			"the %q type is not supported for secondary artifacts", value))
+	}
+
+	return
+}
+
+func validateSecondarySourcesType(v interface{}, k string) (warnings []string, errors []error) {
+	ws, es := validation.StringInSlice(enum.Values[types.SourceType](), false)(v, k)
+	warnings = append(warnings, ws...)
+	errors = append(errors, es...)
+
+	value := v.(string)
+	if value == string(types.SourceTypeCodepipeline) {
+		errors = append(errors, fmt.Errorf(
+			"the %q type is not supported for secondary sources", value))
 	}
 
 	return

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -350,6 +350,8 @@ See [ProjectFileSystemLocation](https://docs.aws.amazon.com/codebuild/latest/API
 * `path` - (Optional) Along with `namespace_type` and `name`, the pattern that AWS CodeBuild uses to name and store the output artifact. If `type` is set to `CODEPIPELINE` or `NO_ARTIFACTS`, this value is ignored if specified. If `type` is set to `S3`, this is the path to the output artifact.
 * `type` - (Required) Build output artifact's type. Valid values `CODEPIPELINE`, `NO_ARTIFACTS`, and `S3`.
 
+  **Note:** The `CODEPIPELINE` type is not supported for `secondary_artifacts`.
+
 ### secondary_sources
 
 * `buildspec` - (Optional) The build spec declaration to use for this build project's related builds. This must be set when `type` is `NO_SOURCE`. It can either be a path to a file residing in the repository to be built or a local file path leveraging the `file()` built-in.
@@ -361,6 +363,8 @@ See [ProjectFileSystemLocation](https://docs.aws.amazon.com/codebuild/latest/API
 * `build_status_config` - (Optional) Configuration block that contains information that defines how the build project reports the build status to the source provider. This option is only used when the source provider is GitHub, GitHub Enterprise, GitLab, GitLab Self Managed, or Bitbucket. `build_status_config` blocks are documented below.
 * `source_identifier` - (Required) An identifier for this project source. The identifier can only contain alphanumeric characters and underscores, and must be less than 128 characters in length.
 * `type` - (Required) Type of repository that contains the source code to be built. Valid values: `BITBUCKET`, `CODECOMMIT`, `CODEPIPELINE`, `GITHUB`, `GITHUB_ENTERPRISE`, `GITLAB`, `GITLAB_SELF_MANAGED`, `NO_SOURCE`, `S3`.
+
+  **Note:** The `CODEPIPELINE` type is not supported for `secondary_sources`.
 
 #### secondary_sources: git_submodules_config
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add plan-time validation to prevent `CODEPIPELINE` from being used for `type` argument in the `secondary_artifacts` and `secondary_sources` configuration blocks in the `aws_codebuild_project` resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #36987

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [CreateProject](https://docs.aws.amazon.com/codebuild/latest/APIReference/API_CreateProject.html) for specs and wordings for documentation.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

TBD - blocked by acceptance test failures as reported in #37051 and #37052

```console
TBD
```