### PR TITLE
Add parameters to aws_controltower_control

### DIFF
--- a/.changelog/37079.txt
+++ b/.changelog/37079.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_controltower_control: Add parameter argument
+```

--- a/internal/service/controltower/control.go
+++ b/internal/service/controltower/control.go
@@ -34,6 +34,7 @@ func resourceControl() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceControlCreate,
 		ReadWithoutTimeout:   resourceControlRead,
+		UpdateWithoutTimeout: resourceControlUpdate,
 		DeleteWithoutTimeout: resourceControlDelete,
 
 		Importer: &schema.ResourceImporter{
@@ -42,6 +43,7 @@ func resourceControl() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(60 * time.Minute),
+			Update: schema.DefaultTimeout(60 * time.Minute),
 			Delete: schema.DefaultTimeout(60 * time.Minute),
 		},
 
@@ -61,7 +63,7 @@ func resourceControl() *schema.Resource {
 			"parameters": {
 				Type:     schema.TypeList,
 				Optional: true,
-				ForceNew: true,
+				ForceNew: false,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"key": {
@@ -95,7 +97,7 @@ func resourceControlCreate(ctx context.Context, d *schema.ResourceData, meta int
 	targetIdentifier := d.Get("target_identifier").(string)
 	parameters := d.Get("parameters").([]interface{})
 
-	new_params := make([]types.EnabledControlParameter, len(parameters))
+	newParams := make([]types.EnabledControlParameter, len(parameters))
 	for i, param := range parameters {
 		param := param.(map[string]interface{})
 		var value interface{}
@@ -103,7 +105,7 @@ func resourceControlCreate(ctx context.Context, d *schema.ResourceData, meta int
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		new_params[i] = types.EnabledControlParameter{
+		newParams[i] = types.EnabledControlParameter{
 			Key:   aws.String(param["key"].(string)),
 			Value: document.NewLazyDocument(value),
 		}
@@ -113,7 +115,7 @@ func resourceControlCreate(ctx context.Context, d *schema.ResourceData, meta int
 	input := &controltower.EnableControlInput{
 		ControlIdentifier: aws.String(controlIdentifier),
 		TargetIdentifier:  aws.String(targetIdentifier),
-		Parameters:        new_params,
+		Parameters:        newParams,
 	}
 
 	output, err := conn.EnableControl(ctx, input)
@@ -158,6 +160,58 @@ func resourceControlRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set("target_identifier", targetIdentifier)
 
 	return diags
+}
+
+func resourceControlUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	conn := meta.(*conns.AWSClient).ControlTowerClient(ctx)
+
+	controlIdentifier := d.Get("control_identifier").(string)
+	targetIdentifier := d.Get("target_identifier").(string)
+	parameters := d.Get("parameters").([]interface{})
+
+	newParams := make([]types.EnabledControlParameter, len(parameters))
+	for i, param := range parameters {
+		param := param.(map[string]interface{})
+		var value interface{}
+		err := json.Unmarshal([]byte(param["value"].(string)), &value)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		newParams[i] = types.EnabledControlParameter{
+			Key:   aws.String(param["key"].(string)),
+			Value: document.NewLazyDocument(value),
+		}
+	}
+
+	controlOutput, err := findEnabledControlByTwoPartKey(ctx, conn, targetIdentifier, controlIdentifier)
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] ControlTower Control %s not found, removing from state", d.Id())
+		d.SetId("")
+		return diags
+	}
+
+	id := errs.Must(flex.FlattenResourceId([]string{targetIdentifier, controlIdentifier}, controlResourceIDPartCount, false))
+	input := &controltower.UpdateEnabledControlInput{
+		EnabledControlIdentifier: controlOutput.Arn,
+		Parameters:               newParams,
+	}
+
+	output, err := conn.UpdateEnabledControl(ctx, input)
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "updating ControlTower Control (%s): %s", id, err)
+	}
+
+	d.SetId(id)
+
+	if _, err := waitOperationSucceeded(ctx, conn, aws.ToString(output.OperationIdentifier), d.Timeout(schema.TimeoutUpdate)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "waiting for ControlTower Control (%s) updating: %s", d.Id(), err)
+	}
+
+	return append(diags, resourceControlRead(ctx, d, meta)...)
 }
 
 func resourceControlDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Add the ability to set parameters on aws_controltower_control

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
make fmt && make testacc TESTS=TestAccControlTowerControl PKG=controltower
make: fixing source code with gofmt...
gofmt -s -w ./internal ./names ./.ci/providerlint/helper ./.ci/providerlint/main.go ./.ci/providerlint/passes
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/controltower/... -v -count 1 -parallel 20 -run='TestAccControlTowerControl'  -timeout 360m
=== RUN   TestAccControlTowerControl_serial
=== PAUSE TestAccControlTowerControl_serial
=== RUN   TestAccControlTowerControlsDataSource_basic
=== PAUSE TestAccControlTowerControlsDataSource_basic
=== CONT  TestAccControlTowerControl_serial
=== RUN   TestAccControlTowerControl_serial/Control
=== CONT  TestAccControlTowerControlsDataSource_basic
=== RUN   TestAccControlTowerControl_serial/Control/parameters
--- PASS: TestAccControlTowerControlsDataSource_basic (13.71s)
=== RUN   TestAccControlTowerControl_serial/Control/disappears
    control_test.go:123: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: deleting ControlTower Control (arn:aws:organizations::253298000021:ou/o-spazz6vij9/ou-el3d-g2qlq3yx,arn:aws:controltower:eu-central-1::control/AWS-GR_EC2_VOLUME_INUSE_CHECK): operation error ControlTower: DisableControl, https response error StatusCode: 404, RequestID: 484eb95a-4fcb-4b76-9771-c895cff75f76, ResourceNotFoundException: The control AWS-GR_EC2_VOLUME_INUSE_CHECK is not enabled on organizational unit ou-el3d-g2qlq3yx.
        
=== RUN   TestAccControlTowerControl_serial/Control/basic
--- FAIL: TestAccControlTowerControl_serial (282.09s)
    --- FAIL: TestAccControlTowerControl_serial/Control (282.09s)
        --- PASS: TestAccControlTowerControl_serial/Control/parameters (140.56s)
        --- FAIL: TestAccControlTowerControl_serial/Control/disappears (71.46s)
        --- PASS: TestAccControlTowerControl_serial/Control/basic (70.07s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/controltower       282.207s
FAIL
make: *** [GNUmakefile:418: testacc] Error 1
```
The failing test was already failing. The new test is `--- PASS: TestAccControlTowerControl_serial/Control/parameters`