### PR TITLE
autoflex: json interface

### DIFF
--- a/internal/framework/flex/auto_flatten.go
+++ b/internal/framework/flex/auto_flatten.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	smithyjson "github.com/hashicorp/terraform-provider-aws/internal/json"
 )
 
 // Flatten = AWS --> TF
@@ -313,8 +314,8 @@ func (flattener autoFlattener) interface_(ctx context.Context, vFrom reflect.Val
 			//
 			// JSONStringer -> types.String-ish.
 			//
-			if vFrom.Type().Implements(reflect.TypeOf((*JSONStringer)(nil)).Elem()) {
-				doc := vFrom.Interface().(JSONStringer)
+			if vFrom.Type().Implements(reflect.TypeOf((*smithyjson.JSONStringer)(nil)).Elem()) {
+				doc := vFrom.Interface().(smithyjson.JSONStringer)
 				b, err := doc.MarshalSmithyDocument()
 				if err != nil {
 					diags.AddError("AutoFlEx", err.Error())

--- a/internal/framework/flex/auto_flatten.go
+++ b/internal/framework/flex/auto_flatten.go
@@ -92,7 +92,6 @@ func (flattener autoFlattener) convert(ctx context.Context, vFrom, vTo reflect.V
 		return diags
 
 	case reflect.Interface:
-		// Smithy union type handling not yet implemented. Silently skip.
 		diags.Append(flattener.interface_(ctx, vFrom, false, tTo, vTo)...)
 		return diags
 	}

--- a/internal/framework/flex/auto_flatten.go
+++ b/internal/framework/flex/auto_flatten.go
@@ -92,6 +92,7 @@ func (flattener autoFlattener) convert(ctx context.Context, vFrom, vTo reflect.V
 
 	case reflect.Interface:
 		// Smithy union type handling not yet implemented. Silently skip.
+		diags.Append(flattener.interface_(ctx, vFrom, false, tTo, vTo)...)
 		return diags
 	}
 
@@ -291,6 +292,44 @@ func (flattener autoFlattener) ptr(ctx context.Context, vFrom reflect.Value, tTo
 
 	case reflect.Struct:
 		diags.Append(flattener.struct_(ctx, vElem, isNilFrom, tTo, vTo)...)
+		return diags
+	}
+
+	tflog.Info(ctx, "AutoFlex Flatten; incompatible types", map[string]interface{}{
+		"from": vFrom.Kind(),
+		"to":   tTo,
+	})
+
+	return diags
+}
+
+func (flattener autoFlattener) interface_(ctx context.Context, vFrom reflect.Value, isNullFrom bool, tTo attr.Type, vTo reflect.Value) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	switch tTo := tTo.(type) {
+	case basetypes.StringTypable:
+		stringValue := types.StringNull()
+		if !isNullFrom {
+			//
+			// JSONStringer -> types.String-ish.
+			//
+			if vFrom.Type().Implements(reflect.TypeOf((*JSONStringer)(nil)).Elem()) {
+				doc := vFrom.Interface().(JSONStringer)
+				b, err := doc.MarshalSmithyDocument()
+				if err != nil {
+					diags.AddError("AutoFlEx", err.Error())
+					return diags
+				}
+				stringValue = types.StringValue(string(b))
+			}
+		}
+		v, d := tTo.ValueFromString(ctx, stringValue)
+		diags.Append(d...)
+		if diags.HasError() {
+			return diags
+		}
+
+		vTo.Set(reflect.ValueOf(v))
 		return diags
 	}
 

--- a/internal/framework/flex/auto_flatten_test.go
+++ b/internal/framework/flex/auto_flatten_test.go
@@ -57,6 +57,20 @@ func TestFlatten(t *testing.T) {
 			WantErr:  true,
 		},
 		{
+			TestName: "json interface Source string Target",
+			Source: &TestFlexAWS19{
+				Field1: &testJSONDocument{
+					value: &struct {
+						Test string `json:"test"`
+					}{
+						Test: "a",
+					},
+				},
+			},
+			Target:     &TestFlexTF19{},
+			WantTarget: &TestFlexTF19{Field1: types.StringValue(`{"test":"a"}`)},
+		},
+		{
 			TestName:   "empty struct Source and Target",
 			Source:     TestFlex00{},
 			Target:     &TestFlex00{},

--- a/internal/framework/flex/autoflex_test.go
+++ b/internal/framework/flex/autoflex_test.go
@@ -4,6 +4,7 @@
 package flex
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
@@ -310,4 +311,30 @@ type TestFlexMapBlockKeyTF05 struct {
 	MapBlockKey fwtypes.StringEnum[TestEnum] `tfsdk:"map_block_key"`
 	Attr1       types.String                 `tfsdk:"attr1"`
 	Attr2       types.String                 `tfsdk:"attr2"`
+}
+
+var _ JSONStringer = (*testJSONDocument)(nil)
+
+type testJSONDocument struct {
+	value any
+}
+
+func (m *testJSONDocument) UnmarshalSmithyDocument(v interface{}) error {
+	data, err := json.Marshal(m.value)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, v)
+}
+
+func (m *testJSONDocument) MarshalSmithyDocument() ([]byte, error) {
+	return json.Marshal(m.value)
+}
+
+type TestFlexAWS19 struct {
+	Field1 JSONStringer `json:"field1"`
+}
+
+type TestFlexTF19 struct {
+	Field1 types.String `tfsdk:"field1"`
 }

--- a/internal/framework/flex/autoflex_test.go
+++ b/internal/framework/flex/autoflex_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	smithyjson "github.com/hashicorp/terraform-provider-aws/internal/json"
 )
 
 type TestFlex00 struct{}
@@ -313,7 +314,7 @@ type TestFlexMapBlockKeyTF05 struct {
 	Attr2       types.String                 `tfsdk:"attr2"`
 }
 
-var _ JSONStringer = (*testJSONDocument)(nil)
+var _ smithyjson.JSONStringer = (*testJSONDocument)(nil)
 
 type testJSONDocument struct {
 	value any
@@ -332,7 +333,7 @@ func (m *testJSONDocument) MarshalSmithyDocument() ([]byte, error) {
 }
 
 type TestFlexAWS19 struct {
-	Field1 JSONStringer `json:"field1"`
+	Field1 smithyjson.JSONStringer `json:"field1"`
 }
 
 type TestFlexTF19 struct {

--- a/internal/framework/flex/string.go
+++ b/internal/framework/flex/string.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	smithydocument "github.com/aws/smithy-go/document"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
@@ -103,4 +104,10 @@ func EmptyStringAsNull(v types.String) types.String {
 	}
 
 	return v
+}
+
+// JSONStringer interface is used to marshal and unmarshal JSON interface objects.
+type JSONStringer interface {
+	smithydocument.Marshaler
+	smithydocument.Unmarshaler
 }

--- a/internal/framework/flex/string.go
+++ b/internal/framework/flex/string.go
@@ -7,7 +7,6 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	smithydocument "github.com/aws/smithy-go/document"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
@@ -104,10 +103,4 @@ func EmptyStringAsNull(v types.String) types.String {
 	}
 
 	return v
-}
-
-// JSONStringer interface is used to marshal and unmarshal JSON interface objects.
-type JSONStringer interface {
-	smithydocument.Marshaler
-	smithydocument.Unmarshaler
 }

--- a/internal/json/smithy.go
+++ b/internal/json/smithy.go
@@ -37,3 +37,9 @@ func SmithyDocumentToString(document smithydocument.Unmarshaler) (string, error)
 
 	return string(bytes), nil
 }
+
+// JSONStringer interface is used to marshal and unmarshal JSON interface objects.
+type JSONStringer interface {
+	smithydocument.Marshaler
+	smithydocument.Unmarshaler
+}

--- a/internal/service/opensearchserverless/access_policy.go
+++ b/internal/service/opensearchserverless/access_policy.go
@@ -5,15 +5,14 @@ package opensearchserverless
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/opensearchserverless"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/opensearchserverless/types"
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -22,10 +21,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
-	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -36,12 +36,12 @@ func newResourceAccessPolicy(_ context.Context) (resource.ResourceWithConfigure,
 }
 
 type resourceAccessPolicyData struct {
-	Description   types.String `tfsdk:"description"`
-	ID            types.String `tfsdk:"id"`
-	Name          types.String `tfsdk:"name"`
-	Policy        types.String `tfsdk:"policy"`
-	PolicyVersion types.String `tfsdk:"policy_version"`
-	Type          types.String `tfsdk:"type"`
+	Description   types.String                                  `tfsdk:"description"`
+	ID            types.String                                  `tfsdk:"id"`
+	Name          types.String                                  `tfsdk:"name"`
+	Policy        jsontypes.Normalized                          `tfsdk:"policy"`
+	PolicyVersion types.String                                  `tfsdk:"policy_version"`
+	Type          fwtypes.StringEnum[awstypes.AccessPolicyType] `tfsdk:"type"`
 }
 
 const (
@@ -76,19 +76,21 @@ func (r *resourceAccessPolicy) Schema(ctx context.Context, req resource.SchemaRe
 				},
 			},
 			"policy": schema.StringAttribute{
-				Required: true,
+				CustomType: jsontypes.NormalizedType{},
+				Required:   true,
 				Validators: []validator.String{
 					stringvalidator.LengthBetween(1, 20480),
 				},
 			},
 			"policy_version": schema.StringAttribute{
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"type": schema.StringAttribute{
-				Required: true,
-				Validators: []validator.String{
-					enum.FrameworkValidate[awstypes.AccessPolicyType](),
-				},
+				CustomType: fwtypes.StringEnumType[awstypes.AccessPolicyType](),
+				Required:   true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
@@ -108,16 +110,15 @@ func (r *resourceAccessPolicy) Create(ctx context.Context, req resource.CreateRe
 
 	conn := r.Meta().OpenSearchServerlessClient(ctx)
 
-	in := &opensearchserverless.CreateAccessPolicyInput{
-		ClientToken: aws.String(id.UniqueId()),
-		Name:        aws.String(plan.Name.ValueString()),
-		Policy:      aws.String(plan.Policy.ValueString()),
-		Type:        awstypes.AccessPolicyType(plan.Type.ValueString()),
+	in := &opensearchserverless.CreateAccessPolicyInput{}
+
+	resp.Diagnostics.Append(flex.Expand(ctx, plan, in)...)
+
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	if !plan.Description.IsNull() {
-		in.Description = aws.String(plan.Description.ValueString())
-	}
+	in.ClientToken = aws.String(id.UniqueId())
 
 	out, err := conn.CreateAccessPolicy(ctx, in)
 	if err != nil {
@@ -129,7 +130,14 @@ func (r *resourceAccessPolicy) Create(ctx context.Context, req resource.CreateRe
 	}
 
 	state := plan
-	resp.Diagnostics.Append(state.refreshFromOutput(ctx, out.AccessPolicyDetail)...)
+	resp.Diagnostics.Append(flex.Flatten(ctx, out.AccessPolicyDetail, &state)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	state.ID = flex.StringToFramework(ctx, out.AccessPolicyDetail.Name)
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -149,7 +157,12 @@ func (r *resourceAccessPolicy) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 
-	resp.Diagnostics.Append(state.refreshFromOutput(ctx, out)...)
+	resp.Diagnostics.Append(flex.Flatten(ctx, out, &state)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -165,20 +178,16 @@ func (r *resourceAccessPolicy) Update(ctx context.Context, req resource.UpdateRe
 
 	if !plan.Description.Equal(state.Description) ||
 		!plan.Policy.Equal(state.Policy) {
-		input := &opensearchserverless.UpdateAccessPolicyInput{
-			ClientToken:   aws.String(id.UniqueId()),
-			Name:          flex.StringFromFramework(ctx, plan.Name),
-			PolicyVersion: flex.StringFromFramework(ctx, state.PolicyVersion),
-			Type:          awstypes.AccessPolicyType(plan.Type.ValueString()),
+
+		input := &opensearchserverless.UpdateAccessPolicyInput{}
+
+		resp.Diagnostics.Append(flex.Expand(ctx, plan, input)...)
+
+		if resp.Diagnostics.HasError() {
+			return
 		}
 
-		if !plan.Description.Equal(state.Description) {
-			input.Description = aws.String(plan.Description.ValueString())
-		}
-
-		if !plan.Policy.Equal(state.Policy) {
-			input.Policy = aws.String(plan.Policy.ValueString())
-		}
+		input.ClientToken = aws.String(id.UniqueId())
 
 		out, err := conn.UpdateAccessPolicy(ctx, input)
 
@@ -186,7 +195,11 @@ func (r *resourceAccessPolicy) Update(ctx context.Context, req resource.UpdateRe
 			resp.Diagnostics.AddError(fmt.Sprintf("updating Security Policy (%s)", plan.Name.ValueString()), err.Error())
 			return
 		}
-		resp.Diagnostics.Append(state.refreshFromOutput(ctx, out.AccessPolicyDetail)...)
+		resp.Diagnostics.Append(flex.Flatten(ctx, out.AccessPolicyDetail, &state)...)
+
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -206,15 +219,17 @@ func (r *resourceAccessPolicy) Delete(ctx context.Context, req resource.DeleteRe
 		Name:        aws.String(state.Name.ValueString()),
 		Type:        awstypes.AccessPolicyType(state.Type.ValueString()),
 	})
+
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return
+	}
+
 	if err != nil {
-		var nfe *awstypes.ResourceNotFoundException
-		if errors.As(err, &nfe) {
-			return
-		}
 		resp.Diagnostics.AddError(
 			create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionDeleting, ResNameAccessPolicy, state.Name.String(), nil),
 			err.Error(),
 		)
+		return
 	}
 }
 
@@ -229,7 +244,7 @@ func (r *resourceAccessPolicy) ImportState(ctx context.Context, req resource.Imp
 	state := resourceAccessPolicyData{
 		ID:   types.StringValue(parts[0]),
 		Name: types.StringValue(parts[0]),
-		Type: types.StringValue(parts[1]),
+		Type: fwtypes.StringEnumValue(awstypes.AccessPolicyType(parts[1])),
 	}
 
 	diags := resp.State.Set(ctx, &state)
@@ -237,31 +252,4 @@ func (r *resourceAccessPolicy) ImportState(ctx context.Context, req resource.Imp
 	if resp.Diagnostics.HasError() {
 		return
 	}
-}
-
-// refreshFromOutput writes state data from an AWS response object
-func (rd *resourceAccessPolicyData) refreshFromOutput(ctx context.Context, out *awstypes.AccessPolicyDetail) diag.Diagnostics {
-	var diags diag.Diagnostics
-
-	if out == nil {
-		return diags
-	}
-
-	rd.ID = flex.StringToFramework(ctx, out.Name)
-	rd.Description = flex.StringToFramework(ctx, out.Description)
-	rd.Name = flex.StringToFramework(ctx, out.Name)
-	rd.Type = flex.StringValueToFramework(ctx, out.Type)
-	rd.PolicyVersion = flex.StringToFramework(ctx, out.PolicyVersion)
-
-	policyBytes, err := out.Policy.MarshalSmithyDocument()
-	if err != nil {
-		diags.AddError(fmt.Sprintf("refreshing state for Security Policy (%s)", rd.Name), err.Error())
-		return diags
-	}
-
-	p := string(policyBytes)
-
-	rd.Policy = flex.StringToFramework(ctx, &p)
-
-	return diags
 }

--- a/internal/service/opensearchserverless/access_policy.go
+++ b/internal/service/opensearchserverless/access_policy.go
@@ -178,7 +178,6 @@ func (r *resourceAccessPolicy) Update(ctx context.Context, req resource.UpdateRe
 
 	if !plan.Description.Equal(state.Description) ||
 		!plan.Policy.Equal(state.Policy) {
-
 		input := &opensearchserverless.UpdateAccessPolicyInput{}
 
 		resp.Diagnostics.Append(flex.Expand(ctx, plan, input)...)

--- a/internal/service/opensearchserverless/access_policy_data_source.go
+++ b/internal/service/opensearchserverless/access_policy_data_source.go
@@ -82,23 +82,12 @@ func (d *dataSourceAccessPolicy) Read(ctx context.Context, req datasource.ReadRe
 		return
 	}
 
-	data.ID = flex.StringToFramework(ctx, out.Name)
-	data.Description = flex.StringToFramework(ctx, out.Description)
-	data.Name = flex.StringToFramework(ctx, out.Name)
-	data.Type = flex.StringValueToFramework(ctx, out.Type)
-	data.PolicyVersion = flex.StringToFramework(ctx, out.PolicyVersion)
-
-	policyBytes, err := out.Policy.MarshalSmithyDocument()
-
-	if err != nil {
-		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionReading, DSNameAccessPolicy, data.Name.String(), err),
-			err.Error(),
-		)
+	resp.Diagnostics.Append(flex.Flatten(ctx, out, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	pb := string(policyBytes)
-	data.Policy = flex.StringToFramework(ctx, &pb)
+	data.ID = flex.StringToFramework(ctx, out.Name)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/service/opensearchserverless/lifecycle_policy.go
+++ b/internal/service/opensearchserverless/lifecycle_policy.go
@@ -12,8 +12,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/opensearchserverless"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/opensearchserverless/types"
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -22,10 +22,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
-	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -67,7 +68,8 @@ func (r *resourceLifecyclePolicy) Schema(_ context.Context, _ resource.SchemaReq
 				},
 			},
 			"policy": schema.StringAttribute{
-				Required: true,
+				CustomType: jsontypes.NormalizedType{},
+				Required:   true,
 				Validators: []validator.String{
 					stringvalidator.LengthBetween(1, 20480),
 				},
@@ -79,10 +81,8 @@ func (r *resourceLifecyclePolicy) Schema(_ context.Context, _ resource.SchemaReq
 				},
 			},
 			"type": schema.StringAttribute{
-				Required: true,
-				Validators: []validator.String{
-					enum.FrameworkValidate[awstypes.LifecyclePolicyType](),
-				},
+				CustomType: fwtypes.StringEnumType[awstypes.LifecyclePolicyType](),
+				Required:   true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
@@ -100,16 +100,26 @@ func (r *resourceLifecyclePolicy) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
-	in := &opensearchserverless.CreateLifecyclePolicyInput{
-		ClientToken: aws.String(id.UniqueId()),
-		Name:        flex.StringFromFramework(ctx, plan.Name),
-		Policy:      flex.StringFromFramework(ctx, plan.Policy),
-		Type:        awstypes.LifecyclePolicyType(plan.Type.ValueString()),
+	//in := &opensearchserverless.CreateLifecyclePolicyInput{
+	//	ClientToken: aws.String(id.UniqueId()),
+	//	Name:        flex.StringFromFramework(ctx, plan.Name),
+	//	Policy:      flex.StringFromFramework(ctx, plan.Policy),
+	//	Type:        awstypes.LifecyclePolicyType(plan.Type.ValueString()),
+	//}
+	//
+	//if !plan.Description.IsNull() {
+	//	in.Description = flex.StringFromFramework(ctx, plan.Description)
+	//}
+
+	in := &opensearchserverless.CreateLifecyclePolicyInput{}
+
+	resp.Diagnostics.Append(flex.Expand(ctx, plan, in)...)
+
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	if !plan.Description.IsNull() {
-		in.Description = flex.StringFromFramework(ctx, plan.Description)
-	}
+	in.ClientToken = aws.String(id.UniqueId())
 
 	out, err := conn.CreateLifecyclePolicy(ctx, in)
 	if err != nil {
@@ -128,7 +138,11 @@ func (r *resourceLifecyclePolicy) Create(ctx context.Context, req resource.Creat
 	}
 
 	state := plan
-	resp.Diagnostics.Append(state.refreshFromOutput(ctx, out.LifecyclePolicyDetail)...)
+
+	resp.Diagnostics.Append(flex.Flatten(ctx, out.LifecyclePolicyDetail, &state)...)
+
+	state.ID = flex.StringToFramework(ctx, out.LifecyclePolicyDetail.Name)
+	// resp.Diagnostics.Append(state.refreshFromOutput(ctx, out.LifecyclePolicyDetail)...)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -157,7 +171,9 @@ func (r *resourceLifecyclePolicy) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
-	resp.Diagnostics.Append(state.refreshFromOutput(ctx, out)...)
+	resp.Diagnostics.Append(flex.Flatten(ctx, out, &state)...)
+
+	//resp.Diagnostics.Append(state.refreshFromOutput(ctx, out)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -172,20 +188,31 @@ func (r *resourceLifecyclePolicy) Update(ctx context.Context, req resource.Updat
 	}
 
 	if !plan.Description.Equal(state.Description) || !plan.Policy.Equal(state.Policy) {
-		in := &opensearchserverless.UpdateLifecyclePolicyInput{
-			ClientToken:   aws.String(id.UniqueId()),
-			Name:          flex.StringFromFramework(ctx, plan.Name),
-			PolicyVersion: flex.StringFromFramework(ctx, state.PolicyVersion),
-			Type:          awstypes.LifecyclePolicyType(plan.Type.ValueString()),
+		//in := &opensearchserverless.UpdateLifecyclePolicyInput{
+		//	ClientToken:   aws.String(id.UniqueId()),
+		//	Name:          flex.StringFromFramework(ctx, plan.Name),
+		//	PolicyVersion: flex.StringFromFramework(ctx, state.PolicyVersion),
+		//	Type:          awstypes.LifecyclePolicyType(plan.Type.ValueString()),
+		//}
+		//
+		//if !plan.Policy.Equal(state.Policy) {
+		//	in.Policy = flex.StringFromFramework(ctx, plan.Policy)
+		//}
+		//
+		//if !plan.Description.Equal(state.Description) {
+		//	in.Description = flex.StringFromFramework(ctx, plan.Description)
+		//}
+
+		in := &opensearchserverless.UpdateLifecyclePolicyInput{}
+
+		resp.Diagnostics.Append(flex.Expand(ctx, plan, in)...)
+
+		if resp.Diagnostics.HasError() {
+			return
 		}
 
-		if !plan.Policy.Equal(state.Policy) {
-			in.Policy = flex.StringFromFramework(ctx, plan.Policy)
-		}
-
-		if !plan.Description.Equal(state.Description) {
-			in.Description = flex.StringFromFramework(ctx, plan.Description)
-		}
+		in.ClientToken = aws.String(id.UniqueId())
+		in.PolicyVersion = flex.StringFromFramework(ctx, state.PolicyVersion)
 
 		out, err := conn.UpdateLifecyclePolicy(ctx, in)
 		if err != nil {
@@ -203,7 +230,8 @@ func (r *resourceLifecyclePolicy) Update(ctx context.Context, req resource.Updat
 			return
 		}
 
-		resp.Diagnostics.Append(state.refreshFromOutput(ctx, out.LifecyclePolicyDetail)...)
+		resp.Diagnostics.Append(flex.Flatten(ctx, out.LifecyclePolicyDetail, &state)...)
+		//resp.Diagnostics.Append(state.refreshFromOutput(ctx, out.LifecyclePolicyDetail)...)
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -226,11 +254,11 @@ func (r *resourceLifecyclePolicy) Delete(ctx context.Context, req resource.Delet
 
 	_, err := conn.DeleteLifecyclePolicy(ctx, in)
 
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return
+	}
+
 	if err != nil {
-		var nfe *awstypes.ResourceNotFoundException
-		if errors.As(err, &nfe) {
-			return
-		}
 		resp.Diagnostics.AddError(
 			create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionDeleting, ResNameLifecyclePolicy, state.ID.String(), err),
 			err.Error(),
@@ -250,7 +278,7 @@ func (r *resourceLifecyclePolicy) ImportState(ctx context.Context, req resource.
 	state := resourceLifecyclePolicyData{
 		ID:   types.StringValue(parts[0]),
 		Name: types.StringValue(parts[0]),
-		Type: types.StringValue(parts[1]),
+		Type: fwtypes.StringEnumValue(awstypes.LifecyclePolicyType(parts[1])),
 	}
 
 	diags := resp.State.Set(ctx, &state)
@@ -260,38 +288,38 @@ func (r *resourceLifecyclePolicy) ImportState(ctx context.Context, req resource.
 	}
 }
 
-// refreshFromOutput writes state data from an AWS response object
-func (rd *resourceLifecyclePolicyData) refreshFromOutput(ctx context.Context, out *awstypes.LifecyclePolicyDetail) diag.Diagnostics {
-	var diags diag.Diagnostics
-
-	if out == nil {
-		return diags
-	}
-
-	rd.ID = flex.StringToFramework(ctx, out.Name)
-	rd.Description = flex.StringToFramework(ctx, out.Description)
-	rd.Name = flex.StringToFramework(ctx, out.Name)
-	rd.Type = flex.StringValueToFramework(ctx, out.Type)
-	rd.PolicyVersion = flex.StringToFramework(ctx, out.PolicyVersion)
-
-	policyBytes, err := out.Policy.MarshalSmithyDocument()
-	if err != nil {
-		diags.AddError(fmt.Sprintf("refreshing state for %s (%s)", ResNameLifecyclePolicy, rd.Name), err.Error())
-		return diags
-	}
-
-	p := string(policyBytes)
-
-	rd.Policy = flex.StringToFramework(ctx, &p)
-
-	return diags
-}
+//// refreshFromOutput writes state data from an AWS response object
+//func (rd *resourceLifecyclePolicyData) refreshFromOutput(ctx context.Context, out *awstypes.LifecyclePolicyDetail) diag.Diagnostics {
+//	var diags diag.Diagnostics
+//
+//	if out == nil {
+//		return diags
+//	}
+//
+//	rd.ID = flex.StringToFramework(ctx, out.Name)
+//	rd.Description = flex.StringToFramework(ctx, out.Description)
+//	rd.Name = flex.StringToFramework(ctx, out.Name)
+//	rd.Type = flex.StringValueToFramework(ctx, out.Type)
+//	rd.PolicyVersion = flex.StringToFramework(ctx, out.PolicyVersion)
+//
+//	policyBytes, err := out.Policy.MarshalSmithyDocument()
+//	if err != nil {
+//		diags.AddError(fmt.Sprintf("refreshing state for %s (%s)", ResNameLifecyclePolicy, rd.Name), err.Error())
+//		return diags
+//	}
+//
+//	p := string(policyBytes)
+//
+//	rd.Policy = flex.StringToFramework(ctx, &p)
+//
+//	return diags
+//}
 
 type resourceLifecyclePolicyData struct {
-	Description   types.String `tfsdk:"description"`
-	ID            types.String `tfsdk:"id"`
-	Name          types.String `tfsdk:"name"`
-	Policy        types.String `tfsdk:"policy"`
-	PolicyVersion types.String `tfsdk:"policy_version"`
-	Type          types.String `tfsdk:"type"`
+	Description   types.String                                     `tfsdk:"description"`
+	ID            types.String                                     `tfsdk:"id"`
+	Name          types.String                                     `tfsdk:"name"`
+	Policy        jsontypes.Normalized                             `tfsdk:"policy"`
+	PolicyVersion types.String                                     `tfsdk:"policy_version"`
+	Type          fwtypes.StringEnum[awstypes.LifecyclePolicyType] `tfsdk:"type"`
 }

--- a/internal/service/opensearchserverless/lifecycle_policy.go
+++ b/internal/service/opensearchserverless/lifecycle_policy.go
@@ -100,17 +100,6 @@ func (r *resourceLifecyclePolicy) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
-	//in := &opensearchserverless.CreateLifecyclePolicyInput{
-	//	ClientToken: aws.String(id.UniqueId()),
-	//	Name:        flex.StringFromFramework(ctx, plan.Name),
-	//	Policy:      flex.StringFromFramework(ctx, plan.Policy),
-	//	Type:        awstypes.LifecyclePolicyType(plan.Type.ValueString()),
-	//}
-	//
-	//if !plan.Description.IsNull() {
-	//	in.Description = flex.StringFromFramework(ctx, plan.Description)
-	//}
-
 	in := &opensearchserverless.CreateLifecyclePolicyInput{}
 
 	resp.Diagnostics.Append(flex.Expand(ctx, plan, in)...)
@@ -172,8 +161,10 @@ func (r *resourceLifecyclePolicy) Read(ctx context.Context, req resource.ReadReq
 	}
 
 	resp.Diagnostics.Append(flex.Flatten(ctx, out, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-	//resp.Diagnostics.Append(state.refreshFromOutput(ctx, out)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -188,21 +179,6 @@ func (r *resourceLifecyclePolicy) Update(ctx context.Context, req resource.Updat
 	}
 
 	if !plan.Description.Equal(state.Description) || !plan.Policy.Equal(state.Policy) {
-		//in := &opensearchserverless.UpdateLifecyclePolicyInput{
-		//	ClientToken:   aws.String(id.UniqueId()),
-		//	Name:          flex.StringFromFramework(ctx, plan.Name),
-		//	PolicyVersion: flex.StringFromFramework(ctx, state.PolicyVersion),
-		//	Type:          awstypes.LifecyclePolicyType(plan.Type.ValueString()),
-		//}
-		//
-		//if !plan.Policy.Equal(state.Policy) {
-		//	in.Policy = flex.StringFromFramework(ctx, plan.Policy)
-		//}
-		//
-		//if !plan.Description.Equal(state.Description) {
-		//	in.Description = flex.StringFromFramework(ctx, plan.Description)
-		//}
-
 		in := &opensearchserverless.UpdateLifecyclePolicyInput{}
 
 		resp.Diagnostics.Append(flex.Expand(ctx, plan, in)...)
@@ -212,7 +188,6 @@ func (r *resourceLifecyclePolicy) Update(ctx context.Context, req resource.Updat
 		}
 
 		in.ClientToken = aws.String(id.UniqueId())
-		in.PolicyVersion = flex.StringFromFramework(ctx, state.PolicyVersion)
 
 		out, err := conn.UpdateLifecyclePolicy(ctx, in)
 		if err != nil {
@@ -231,7 +206,9 @@ func (r *resourceLifecyclePolicy) Update(ctx context.Context, req resource.Updat
 		}
 
 		resp.Diagnostics.Append(flex.Flatten(ctx, out.LifecyclePolicyDetail, &state)...)
-		//resp.Diagnostics.Append(state.refreshFromOutput(ctx, out.LifecyclePolicyDetail)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -287,33 +264,6 @@ func (r *resourceLifecyclePolicy) ImportState(ctx context.Context, req resource.
 		return
 	}
 }
-
-//// refreshFromOutput writes state data from an AWS response object
-//func (rd *resourceLifecyclePolicyData) refreshFromOutput(ctx context.Context, out *awstypes.LifecyclePolicyDetail) diag.Diagnostics {
-//	var diags diag.Diagnostics
-//
-//	if out == nil {
-//		return diags
-//	}
-//
-//	rd.ID = flex.StringToFramework(ctx, out.Name)
-//	rd.Description = flex.StringToFramework(ctx, out.Description)
-//	rd.Name = flex.StringToFramework(ctx, out.Name)
-//	rd.Type = flex.StringValueToFramework(ctx, out.Type)
-//	rd.PolicyVersion = flex.StringToFramework(ctx, out.PolicyVersion)
-//
-//	policyBytes, err := out.Policy.MarshalSmithyDocument()
-//	if err != nil {
-//		diags.AddError(fmt.Sprintf("refreshing state for %s (%s)", ResNameLifecyclePolicy, rd.Name), err.Error())
-//		return diags
-//	}
-//
-//	p := string(policyBytes)
-//
-//	rd.Policy = flex.StringToFramework(ctx, &p)
-//
-//	return diags
-//}
 
 type resourceLifecyclePolicyData struct {
 	Description   types.String                                     `tfsdk:"description"`

--- a/internal/service/opensearchserverless/lifecycle_policy.go
+++ b/internal/service/opensearchserverless/lifecycle_policy.go
@@ -131,7 +131,6 @@ func (r *resourceLifecyclePolicy) Create(ctx context.Context, req resource.Creat
 	resp.Diagnostics.Append(flex.Flatten(ctx, out.LifecyclePolicyDetail, &state)...)
 
 	state.ID = flex.StringToFramework(ctx, out.LifecyclePolicyDetail.Name)
-	// resp.Diagnostics.Append(state.refreshFromOutput(ctx, out.LifecyclePolicyDetail)...)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }

--- a/internal/service/opensearchserverless/lifecycle_policy_data_source.go
+++ b/internal/service/opensearchserverless/lifecycle_policy_data_source.go
@@ -96,6 +96,7 @@ func (d *dataSourceLifecyclePolicy) Read(ctx context.Context, req datasource.Rea
 		return
 	}
 
+	data.ID = flex.StringToFramework(ctx, out.Name)
 	createdDate := time.UnixMilli(aws.ToInt64(out.CreatedDate))
 	data.CreatedDate = flex.StringValueToFramework(ctx, createdDate.Format(time.RFC3339))
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Auto flex understands AWS interface types that convert JSON

`document.Interface` contains the following:
- MarshalSmithyDocument()
- UnmarshalSmithyDocument()


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Relates #36508

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccOpenSearchServerlessLifecyclePolicy_\|TestAccOpenSearchServerlessLifecyclePolicyDataSource_\|TestAccOpenSearchServerlessAccessPolicy_\|TestAccOpenSearchServerlessAccessPolicyDataSource_' PKG=opensearchserverless

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/opensearchserverless/... -v -count 1 -parallel 20  -run=TestAccOpenSearchServerlessLifecyclePolicy_\|TestAccOpenSearchServerlessLifecyclePolicyDataSource_\|TestAccOpenSearchServerlessAccessPolicy_\|TestAccOpenSearchServerlessAccessPolicyDataSource_ -timeout 360m
--- PASS: TestAccOpenSearchServerlessLifecyclePolicy_disappears (14.07s)
--- PASS: TestAccOpenSearchServerlessAccessPolicyDataSource_basic (14.14s)
--- PASS: TestAccOpenSearchServerlessLifecyclePolicyDataSource_basic (14.16s)
--- PASS: TestAccOpenSearchServerlessAccessPolicy_disappears (14.66s)
--- PASS: TestAccOpenSearchServerlessLifecyclePolicy_basic (15.78s)
--- PASS: TestAccOpenSearchServerlessAccessPolicy_basic (16.23s)
--- PASS: TestAccOpenSearchServerlessLifecyclePolicy_update (20.04s)
--- PASS: TestAccOpenSearchServerlessAccessPolicy_update (20.51s)
PASS
ok  	[github.com/hashicorp/terraform-provider-aws/internal/service/opensearchserverless](http://github.com/hashicorp/terraform-provider-aws/internal/service/opensearchserverless)	25.936s
```
