### PR TITLE
aws_wafv2_web_acl_association Data Source Get by Resource ARN

### DIFF
--- a/internal/service/wafv2/web_acl_data_source.go
+++ b/internal/service/wafv2/web_acl_data_source.go
@@ -32,12 +32,18 @@ func DataSourceWebACL() *schema.Resource {
 				},
 				"name": {
 					Type:     schema.TypeString,
-					Required: true,
+					Computed: true,
+					Optional: true,
+				},
+				"resource_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+					Optional: true,
 				},
 				"scope": {
-					Type:         schema.TypeString,
-					Required:     true,
-					ValidateFunc: validation.StringInSlice(wafv2.Scope_Values(), false),
+					Type:     schema.TypeString,
+					Computed: true,
+					Optional: true,
 				},
 			}
 		},
@@ -47,6 +53,15 @@ func DataSourceWebACL() *schema.Resource {
 func dataSourceWebACLRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFV2Conn(ctx)
+	diags = validateDataSourceInput(d)
+	if diags.HasError() {
+		return diags
+	}
+
+	if v, ok := d.GetOk("resource_arn"); ok {
+		return getWebAclDataSourceByArn(ctx, conn, v.(string), d, diags)
+	}
+
 	name := d.Get("name").(string)
 
 	var foundWebACL *wafv2.WebACLSummary
@@ -87,4 +102,45 @@ func dataSourceWebACLRead(ctx context.Context, d *schema.ResourceData, meta inte
 	d.Set("description", foundWebACL.Description)
 
 	return diags
+}
+
+func getWebAclDataSourceByArn(ctx context.Context, conn *wafv2.WAFV2, arn string, d *schema.ResourceData, diags diag.Diagnostics) diag.Diagnostics {
+	input := &wafv2.GetWebACLForResourceInput{
+		ResourceArn: aws.String(arn),
+	}
+
+	output, err := conn.GetWebACLForResourceWithContext(ctx, input)
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading WAFv2 WebACLs: %s", err)
+	}
+
+	if output == nil || output.WebACL == nil {
+		return sdkdiag.AppendErrorf(diags, "WAFv2 WebACL not found for source: %s", arn)
+	}
+
+	d.SetId(*output.WebACL.Id)
+	d.Set("arn", *output.WebACL.ARN)
+	d.Set("name", *output.WebACL.Name)
+	d.Set("description", *output.WebACL.Description)
+	return diags
+}
+
+func validateDataSourceInput(d *schema.ResourceData) diag.Diagnostics {
+	if _, ok := d.GetOk("resource_arn"); ok {
+		return nil
+	}
+
+	if _, ok := d.GetOk("name"); !ok {
+		return diag.Errorf("name is required")
+	}
+
+	if v, ok := d.GetOk("scope"); !ok {
+		return diag.Errorf("scope is required")
+	} else {
+		_, err := validation.StringInSlice(wafv2.Scope_Values(), false)(v, "scope")
+		if len(err) == 0 {
+			return nil
+		}
+		return diag.FromErr(err[0])
+	}
 }

--- a/internal/service/wafv2/web_acl_data_source_test.go
+++ b/internal/service/wafv2/web_acl_data_source_test.go
@@ -44,6 +44,31 @@ func TestAccWAFV2WebACLDataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccWAFV2WebACLDataSource_arn(t *testing.T) {
+	ctx := acctest.Context(t)
+	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_wafv2_web_acl.test"
+	datasourceName := "data.aws_wafv2_web_acl.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckScopeRegional(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.WAFV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWebACLDataSourceConfig_arn(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
+					acctest.MatchResourceAttrRegionalARN(datasourceName, "arn", "wafv2", regexache.MustCompile(fmt.Sprintf("regional/webacl/%v/.+$", name))),
+					resource.TestCheckResourceAttrPair(datasourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(datasourceName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+				),
+			},
+		},
+	})
+}
+
 func testAccWebACLDataSourceConfig_name(name string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_web_acl" "test" {
@@ -88,6 +113,71 @@ resource "aws_wafv2_web_acl" "test" {
 data "aws_wafv2_web_acl" "test" {
   name  = "tf-acc-test-does-not-exist"
   scope = "REGIONAL"
+}
+`, name)
+}
+
+func testAccWebACLDataSourceConfig_arn(name string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_web_acl" "test" {
+  name  = "%s"
+  scope = "REGIONAL"
+
+  default_action {
+    block {}
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-rule-metric-name"
+    sampled_requests_enabled   = false
+  }
+}
+
+resource "aws_api_gateway_rest_api" "test" {
+  name = "test"
+  body = jsonencode({
+    openapi = "3.0.1"
+    info = {
+      title   = "example"
+      version = "1.0"
+    }
+    paths = {
+      "/path1" = {
+        get = {
+          x-amazon-apigateway-integration = {
+            httpMethod           = "GET"
+            payloadFormatVersion = "1.0"
+            type                 = "HTTP_PROXY"
+            uri                  = "https://ip-ranges.amazonaws.com/ip-ranges.json"
+          }
+        }
+      }
+    }
+  })
+}
+
+resource "aws_api_gateway_deployment" "test" {
+  rest_api_id = aws_api_gateway_rest_api.test.id
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_api_gateway_stage" "test" {
+  deployment_id = aws_api_gateway_deployment.test.id
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  stage_name    = "test"
+}
+
+resource "aws_wafv2_web_acl_association" "test" {
+  resource_arn = aws_api_gateway_stage.test.arn
+  web_acl_arn  = aws_wafv2_web_acl.test.arn
+}
+
+data "aws_wafv2_web_acl" "test" {
+  resource_arn = aws_wafv2_web_acl_association.test.resource_arn
 }
 `, name)
 }

--- a/website/docs/d/wafv2_web_acl.html.markdown
+++ b/website/docs/d/wafv2_web_acl.html.markdown
@@ -23,8 +23,9 @@ data "aws_wafv2_web_acl" "example" {
 
 This data source supports the following arguments:
 
-* `name` - (Required) Name of the WAFv2 Web ACL.
-* `scope` - (Required) Specifies whether this is for an AWS CloudFront distribution or for a regional application. Valid values are `CLOUDFRONT` or `REGIONAL`. To work with CloudFront, you must also specify the region `us-east-1` (N. Virginia) on the AWS provider.
+* `name` - (Required) Name of the WAFv2 Web ACL. Optional if `resource_arn` is provided.
+* `resource_arn` - (Optional) Name of a resource associated with a WAF. 
+* `scope` - (Required) Specifies whether this is for an AWS CloudFront distribution or for a regional application. Valid values are `CLOUDFRONT` or `REGIONAL`. To work with CloudFront, you must also specify the region `us-east-1` (N. Virginia) on the AWS provider. Optional if `resource_arn` is provided.
 
 ## Attribute Reference
 


### PR DESCRIPTION
### Description
Added `resource_arn` to the `aws_wafv2_web_acl_association` data source.

### Relations
Closes #36998

### Output from Acceptance Testing

```console
$ make testacc TESTS=TestAccWAFV2WebACLDataSource PKG=wafv2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/wafv2/... -v -count 1 -parallel 20 -run='TestAccWAFV2WebACLDataSource'  -timeout 360m
=== RUN   TestAccWAFV2WebACLDataSource_basic
=== PAUSE TestAccWAFV2WebACLDataSource_basic
=== RUN   TestAccWAFV2WebACLDataSource_arn
=== PAUSE TestAccWAFV2WebACLDataSource_arn
=== CONT  TestAccWAFV2WebACLDataSource_basic
=== CONT  TestAccWAFV2WebACLDataSource_arn
--- PASS: TestAccWAFV2WebACLDataSource_basic (20.21s)
--- PASS: TestAccWAFV2WebACLDataSource_arn (54.76s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/wafv2      54.961s

```
