### PR TITLE
AutoFlEx: Avoid loss of equivalence when flattening `float32`

### DIFF
--- a/internal/framework/flex/auto_flatten_test.go
+++ b/internal/framework/flex/auto_flatten_test.go
@@ -161,15 +161,14 @@ func TestFlatten(t *testing.T) {
 			},
 			Target: &TestFlexTF03{},
 			WantTarget: &TestFlexTF03{
-				Field1: types.StringValue("field1"),
-				Field2: types.StringValue("field2"),
-				Field3: types.Int64Value(3),
-				Field4: types.Int64Value(-4),
-				Field5: types.Int64Value(5),
-				Field6: types.Int64Value(-6),
-				// float32 -> float64 precision problems.
-				Field7:  types.Float64Value(float64(float32(7.7))),
-				Field8:  types.Float64Value(float64(float32(-8.8))),
+				Field1:  types.StringValue("field1"),
+				Field2:  types.StringValue("field2"),
+				Field3:  types.Int64Value(3),
+				Field4:  types.Int64Value(-4),
+				Field5:  types.Int64Value(5),
+				Field6:  types.Int64Value(-6),
+				Field7:  types.Float64Value(7.7),
+				Field8:  types.Float64Value(-8.8),
 				Field9:  types.Float64Value(9.99),
 				Field10: types.Float64Value(-10.101),
 				Field11: types.BoolValue(true),
@@ -954,6 +953,62 @@ func TestFlattenComplexNestedBlockWithFloat32(t *testing.T) {
 		{
 			TestName:   "single nested valid value",
 			Source:     &aws01{Field1: 1, Field2: &aws02{Field1: 1.11, Field2: aws.Float32(-2.22)}},
+			Target:     &tf02{},
+			WantTarget: &tf02{Field1: types.Int64Value(1), Field2: fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &tf01{Field1: types.Float64Value(1.11), Field2: types.Float64Value(-2.22)})},
+		},
+	}
+	runAutoFlattenTestCases(ctx, t, testCases)
+}
+
+func TestFlattenSimpleNestedBlockWithFloat64(t *testing.T) {
+	t.Parallel()
+
+	type tf01 struct {
+		Field1 types.Int64   `tfsdk:"field1"`
+		Field2 types.Float64 `tfsdk:"field2"`
+	}
+	type aws01 struct {
+		Field1 int64
+		Field2 *float64
+	}
+
+	ctx := context.Background()
+	testCases := autoFlexTestCases{
+		{
+			TestName:   "single nested valid value",
+			Source:     &aws01{Field1: 1, Field2: aws.Float64(0.01)},
+			Target:     &tf01{},
+			WantTarget: &tf01{Field1: types.Int64Value(1), Field2: types.Float64Value(0.01)},
+		},
+	}
+	runAutoFlattenTestCases(ctx, t, testCases)
+}
+
+func TestFlattenComplexNestedBlockWithFloat64(t *testing.T) {
+	t.Parallel()
+
+	type tf01 struct {
+		Field1 types.Float64 `tfsdk:"field1"`
+		Field2 types.Float64 `tfsdk:"field2"`
+	}
+	type tf02 struct {
+		Field1 types.Int64                           `tfsdk:"field1"`
+		Field2 fwtypes.ListNestedObjectValueOf[tf01] `tfsdk:"field2"`
+	}
+	type aws02 struct {
+		Field1 float64
+		Field2 *float64
+	}
+	type aws01 struct {
+		Field1 int64
+		Field2 *aws02
+	}
+
+	ctx := context.Background()
+	testCases := autoFlexTestCases{
+		{
+			TestName:   "single nested valid value",
+			Source:     &aws01{Field1: 1, Field2: &aws02{Field1: 1.11, Field2: aws.Float64(-2.22)}},
 			Target:     &tf02{},
 			WantTarget: &tf02{Field1: types.Int64Value(1), Field2: fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &tf01{Field1: types.Float64Value(1.11), Field2: types.Float64Value(-2.22)})},
 		},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Avoids loss of equivalence when flattening `float32`s by using [`InexactFloat64`](https://pkg.go.dev/github.com/shopspring/decimal#Decimal.InexactFloat64).

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/37103.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

#### Before

```console
% go test ./internal/framework/flex 
--- FAIL: TestFlattenSimpleNestedBlockWithFloat32 (0.00s)
    --- FAIL: TestFlattenSimpleNestedBlockWithFloat32/single_nested_valid_value (0.00s)
        auto_flatten_test.go:991: unexpected diff (+wanted, -got):   &flex.tf01{
              	Field1: s"1",
            - 	Field2: basetypes.Float64Value{
            - 		state: 2,
            - 		value: &big.Float{prec: 53, form: 1, mant: big.nat{11805915943291322368}, exp: -6},
            - 	},
            + 	Field2: basetypes.Float64Value{
            + 		state: 2,
            + 		value: &big.Float{prec: 53, form: 1, mant: big.nat{11805916207174113280}, exp: -6},
            + 	},
              }
--- FAIL: TestFlattenComplexNestedBlockWithFloat32 (0.00s)
    --- FAIL: TestFlattenComplexNestedBlockWithFloat32/single_nested_valid_value (0.00s)
        auto_flatten_test.go:991: unexpected diff (+wanted, -got):   &flex.tf02{
              	Field1: s"1",
            - 	Field2: types.ListNestedObjectValueOf[github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tf01·39]{
            - 		ListValue: basetypes.ListValue{
            - 			elements: []attr.Value{
            - 				types.ObjectValueOf[github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tf01·39]{
            - 					ObjectValue: basetypes.ObjectValue{
            - 						attributes: map[string]attr.Value{
            - 							"field1": basetypes.Float64Value{
            - 								state: 2,
            - 								value: &big.Float{prec: 53, form: 1, mant: big.nat{10237943092850196480}, exp: 1},
            - 							},
            - 							"field2": basetypes.Float64Value{
            - 								state: 2,
            - 								value: &big.Float{prec: 53, form: 1, neg: true, mant: big.nat{10237943092850196480}, exp: 2},
            - 							},
            - 						},
            - 						attributeTypes: map[string]attr.Type{"field1": basetypes.Float64Type{}, "field2": basetypes.Float64Type{}},
            - 						state:          2,
            - 					},
            - 				},
            - 			},
            - 			elementType: types.objectTypeOf[github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tf01·39]{
            - 				ObjectType: basetypes.ObjectType{
            - 					AttrTypes: map[string]attr.Type{"field1": basetypes.Float64Type{}, "field2": basetypes.Float64Type{}},
            - 				},
            - 			},
            - 			state: 2,
            - 		},
            - 	},
            + 	Field2: types.ListNestedObjectValueOf[github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tf01·39]{
            + 		ListValue: basetypes.ListValue{
            + 			elements: []attr.Value{
            + 				types.ObjectValueOf[github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tf01·39]{
            + 					ObjectValue: basetypes.ObjectValue{
            + 						attributes: map[string]attr.Value{
            + 							"field1": basetypes.Float64Value{
            + 								state: 2,
            + 								value: &big.Float{prec: 53, form: 1, mant: big.nat{10237942960908802048}, exp: 1},
            + 							},
            + 							"field2": basetypes.Float64Value{
            + 								state: 2,
            + 								value: &big.Float{prec: 53, form: 1, neg: true, mant: big.nat{10237942960908802048}, exp: 2},
            + 							},
            + 						},
            + 						attributeTypes: map[string]attr.Type{"field1": basetypes.Float64Type{}, "field2": basetypes.Float64Type{}},
            + 						state:          2,
            + 					},
            + 				},
            + 			},
            + 			elementType: types.objectTypeOf[github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tf01·39]{
            + 				ObjectType: basetypes.ObjectType{
            + 					AttrTypes: map[string]attr.Type{"field1": basetypes.Float64Type{}, "field2": basetypes.Float64Type{}},
            + 				},
            + 			},
            + 			state: 2,
            + 		},
            + 	},
              }
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/framework/flex	0.686s
FAIL
```

#### After

```console
% go test ./internal/framework/flex               
ok  	github.com/hashicorp/terraform-provider-aws/internal/framework/flex	0.670s
```