### PR TITLE
f-aws_opensearchserverless_collection autoflex

### DIFF
--- a/internal/service/opensearchserverless/collection.go
+++ b/internal/service/opensearchserverless/collection.go
@@ -5,7 +5,6 @@ package opensearchserverless
 
 import (
 	"context"
-	// "errors"
 	"time"
 
 	"github.com/YakDriver/regexache"

--- a/internal/service/opensearchserverless/collection.go
+++ b/internal/service/opensearchserverless/collection.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
@@ -157,22 +158,28 @@ func (r *resourceCollection) Create(ctx context.Context, req resource.CreateRequ
 	conn := r.Meta().OpenSearchServerlessClient(ctx)
 
 	in := &opensearchserverless.CreateCollectionInput{
-		ClientToken: aws.String(id.UniqueId()),
-		Name:        aws.String(plan.Name.ValueString()),
-		Tags:        getTagsIn(ctx),
+		// ClientToken: aws.String(id.UniqueId()),
+		// Name:        aws.String(plan.Name.ValueString()),
+		// Tags:        getTagsIn(ctx),
+	}
+	resp.Diagnostics.Append(flex.Expand(ctx, plan, in)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	if !plan.Description.IsNull() {
-		in.Description = aws.String(plan.Description.ValueString())
-	}
+	in.Tags = getTagsIn(ctx)
 
-	if !plan.Type.IsNull() {
-		in.Type = awstypes.CollectionType(plan.Type.ValueString())
-	}
+	// if !plan.Description.IsNull() {
+	// 	in.Description = aws.String(plan.Description.ValueString())
+	// }
 
-	if !plan.StandbyReplicas.IsNull() {
-		in.StandbyReplicas = awstypes.StandbyReplicas(plan.StandbyReplicas.ValueString())
-	}
+	// if !plan.Type.IsNull() {
+	// 	in.Type = awstypes.CollectionType(plan.Type.ValueString())
+	// }
+
+	// if !plan.StandbyReplicas.IsNull() {
+	// 	in.StandbyReplicas = awstypes.StandbyReplicas(plan.StandbyReplicas.ValueString())
+	// }
 
 	out, err := conn.CreateCollection(ctx, in)
 	if err != nil {
@@ -187,7 +194,7 @@ func (r *resourceCollection) Create(ctx context.Context, req resource.CreateRequ
 	state.ID = flex.StringToFramework(ctx, out.CreateCollectionDetail.Id)
 
 	createTimeout := r.CreateTimeout(ctx, plan.Timeouts)
-	waitOut, err := waitCollectionCreated(ctx, conn, aws.ToString(out.CreateCollectionDetail.Id), createTimeout)
+	_, err := waitCollectionCreated(ctx, conn, aws.ToString(out.CreateCollectionDetail.Id), createTimeout)
 
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -197,14 +204,19 @@ func (r *resourceCollection) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	state.ARN = flex.StringToFramework(ctx, waitOut.Arn)
-	state.CollectionEndpoint = flex.StringToFramework(ctx, waitOut.CollectionEndpoint)
-	state.DashboardEndpoint = flex.StringToFramework(ctx, waitOut.DashboardEndpoint)
-	state.Description = flex.StringToFramework(ctx, waitOut.Description)
-	state.KmsKeyARN = flex.StringToFramework(ctx, waitOut.KmsKeyArn)
-	state.Name = flex.StringToFramework(ctx, waitOut.Name)
-	state.StandbyReplicas = flex.StringValueToFramework(ctx, waitOut.StandbyReplicas)
-	state.Type = flex.StringValueToFramework(ctx, waitOut.Type)
+	// state.ARN = flex.StringToFramework(ctx, waitOut.Arn)
+	// state.CollectionEndpoint = flex.StringToFramework(ctx, waitOut.CollectionEndpoint)
+	// state.DashboardEndpoint = flex.StringToFramework(ctx, waitOut.DashboardEndpoint)
+	// state.Description = flex.StringToFramework(ctx, waitOut.Description)
+	// state.KmsKeyARN = flex.StringToFramework(ctx, waitOut.KmsKeyArn)
+	// state.Name = flex.StringToFramework(ctx, waitOut.Name)
+	// state.StandbyReplicas = flex.StringValueToFramework(ctx, waitOut.StandbyReplicas)
+	// state.Type = flex.StringValueToFramework(ctx, waitOut.Type)
+	resp.Diagnostics.Append(flex.Flatten(ctx, out.CollectionDetail, &state)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -225,23 +237,29 @@ func (r *resourceCollection) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	if err != nil {
-		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionReading, ResNameCollection, state.ID.ValueString(), nil),
-			err.Error(),
-		)
+	// if err != nil {
+	// 	resp.Diagnostics.AddError(
+	// 		create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionReading, ResNameCollection, state.ID.ValueString(), nil),
+	// 		err.Error(),
+	// 	)
+	// 	return
+	// }
+
+	// state.ARN = flex.StringToFramework(ctx, out.Arn)
+	// state.CollectionEndpoint = flex.StringToFramework(ctx, out.CollectionEndpoint)
+	// state.DashboardEndpoint = flex.StringToFramework(ctx, out.DashboardEndpoint)
+	// state.Description = flex.StringToFramework(ctx, out.Description)
+	// state.ID = flex.StringToFramework(ctx, out.Id)
+	// state.KmsKeyARN = flex.StringToFramework(ctx, out.KmsKeyArn)
+	// state.Name = flex.StringToFramework(ctx, out.Name)
+	// state.StandbyReplicas = flex.StringValueToFramework(ctx, out.StandbyReplicas)
+	// state.Type = flex.StringValueToFramework(ctx, out.Type)
+
+	resp.Diagnostics.Append(flex.Flatten(ctx, out, &state)...)
+
+	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	state.ARN = flex.StringToFramework(ctx, out.Arn)
-	state.CollectionEndpoint = flex.StringToFramework(ctx, out.CollectionEndpoint)
-	state.DashboardEndpoint = flex.StringToFramework(ctx, out.DashboardEndpoint)
-	state.Description = flex.StringToFramework(ctx, out.Description)
-	state.ID = flex.StringToFramework(ctx, out.Id)
-	state.KmsKeyARN = flex.StringToFramework(ctx, out.KmsKeyArn)
-	state.Name = flex.StringToFramework(ctx, out.Name)
-	state.StandbyReplicas = flex.StringValueToFramework(ctx, out.StandbyReplicas)
-	state.Type = flex.StringValueToFramework(ctx, out.Type)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -258,10 +276,16 @@ func (r *resourceCollection) Update(ctx context.Context, req resource.UpdateRequ
 
 	if !plan.Description.Equal(state.Description) {
 		input := &opensearchserverless.UpdateCollectionInput{
-			ClientToken: aws.String(id.UniqueId()),
-			Id:          flex.StringFromFramework(ctx, plan.ID),
-			Description: flex.StringFromFramework(ctx, plan.Description),
+			// ClientToken: aws.String(id.UniqueId()),
+			// Id:          flex.StringFromFramework(ctx, plan.ID),
+			// Description: flex.StringFromFramework(ctx, plan.Description),
 		}
+		resp.Diagnostics.Append(flex.Expand(ctx, plan, input)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		input.ClientToken = aws.String(id.UniqueId())
 
 		out, err := conn.UpdateCollection(ctx, input)
 
@@ -273,11 +297,16 @@ func (r *resourceCollection) Update(ctx context.Context, req resource.UpdateRequ
 			return
 		}
 
-		plan.ARN = flex.StringToFramework(ctx, out.UpdateCollectionDetail.Arn)
-		plan.Description = flex.StringToFramework(ctx, out.UpdateCollectionDetail.Description)
-		plan.ID = flex.StringToFramework(ctx, out.UpdateCollectionDetail.Id)
-		plan.Name = flex.StringToFramework(ctx, out.UpdateCollectionDetail.Name)
-		plan.Type = flex.StringValueToFramework(ctx, out.UpdateCollectionDetail.Type)
+		resp.Diagnostics.Append(flex.Flatten(ctx, out.CollectionDetail, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		// plan.ARN = flex.StringToFramework(ctx, out.UpdateCollectionDetail.Arn)
+		// plan.Description = flex.StringToFramework(ctx, out.UpdateCollectionDetail.Description)
+		// plan.ID = flex.StringToFramework(ctx, out.UpdateCollectionDetail.Id)
+		// plan.Name = flex.StringToFramework(ctx, out.UpdateCollectionDetail.Name)
+		// plan.Type = flex.StringValueToFramework(ctx, out.UpdateCollectionDetail.Type)
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -297,11 +326,15 @@ func (r *resourceCollection) Delete(ctx context.Context, req resource.DeleteRequ
 		Id:          aws.String(state.ID.ValueString()),
 	})
 
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return
+	}
+
 	if err != nil {
-		var nfe *awstypes.ResourceNotFoundException
-		if errors.As(err, &nfe) {
-			return
-		}
+		// var nfe *awstypes.ResourceNotFoundException
+		// if errors.As(err, &nfe) {
+		// 	return
+		// }
 		resp.Diagnostics.AddError(
 			create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionDeleting, ResNameCollection, state.Name.ValueString(), nil),
 			err.Error(),

--- a/internal/service/opensearchserverless/collection.go
+++ b/internal/service/opensearchserverless/collection.go
@@ -182,7 +182,7 @@ func (r *resourceCollection) Create(ctx context.Context, req resource.CreateRequ
 	state.ID = flex.StringToFramework(ctx, out.CreateCollectionDetail.Id)
 
 	createTimeout := r.CreateTimeout(ctx, plan.Timeouts)
-	_, err = waitCollectionCreated(ctx, conn, aws.ToString(out.CreateCollectionDetail.Id), createTimeout)
+	collection, err := waitCollectionCreated(ctx, conn, aws.ToString(out.CreateCollectionDetail.Id), createTimeout)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionWaitingForCreation, ResNameCollection, plan.Name.ValueString(), err),
@@ -191,7 +191,7 @@ func (r *resourceCollection) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	resp.Diagnostics.Append(flex.Flatten(ctx, out, &state)...)
+	resp.Diagnostics.Append(flex.Flatten(ctx, collection, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/service/opensearchserverless/collection_data_source.go
+++ b/internal/service/opensearchserverless/collection_data_source.go
@@ -129,16 +129,6 @@ func (d *dataSourceCollection) Read(ctx context.Context, req datasource.ReadRequ
 		out = output
 	}
 
-	data.ARN = flex.StringToFramework(ctx, out.Arn)
-	data.CollectionEndpoint = flex.StringToFramework(ctx, out.CollectionEndpoint)
-	data.DashboardEndpoint = flex.StringToFramework(ctx, out.DashboardEndpoint)
-	data.Description = flex.StringToFramework(ctx, out.Description)
-	data.ID = flex.StringToFramework(ctx, out.Id)
-	data.KmsKeyARN = flex.StringToFramework(ctx, out.KmsKeyArn)
-	data.Name = flex.StringToFramework(ctx, out.Name)
-	data.StandbyReplicas = flex.StringValueToFramework(ctx, out.StandbyReplicas)
-	data.Type = flex.StringValueToFramework(ctx, out.Type)
-
 	createdDate := time.UnixMilli(aws.ToInt64(out.CreatedDate))
 	data.CreatedDate = flex.StringValueToFramework(ctx, createdDate.Format(time.RFC3339))
 
@@ -147,7 +137,6 @@ func (d *dataSourceCollection) Read(ctx context.Context, req datasource.ReadRequ
 
 	ignoreTagsConfig := d.Meta().IgnoreTagsConfig
 	tags, err := listTags(ctx, conn, aws.ToString(out.Arn))
-
 	if err != nil {
 		resp.Diagnostics.AddError(
 			create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionReading, DSNameCollection, data.ID.String(), err),
@@ -158,6 +147,11 @@ func (d *dataSourceCollection) Read(ctx context.Context, req datasource.ReadRequ
 
 	tags = tags.IgnoreConfig(ignoreTagsConfig)
 	data.Tags = flex.FlattenFrameworkStringValueMapLegacy(ctx, tags.Map())
+
+	resp.Diagnostics.Append(flex.Flatten(ctx, out, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Use autoflex in collection resource and datasource.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
> make testacc TESTARGS="-run=TestAccOpenSearchServerlessCollection_" PKG=opensearchserverless
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/opensearchserverless/... -v -count 1 -parallel 20  -run=TestAccOpenSearchServerlessCollection_ -timeout 360m
=== RUN   TestAccOpenSearchServerlessCollection_basic
=== PAUSE TestAccOpenSearchServerlessCollection_basic
=== RUN   TestAccOpenSearchServerlessCollection_standbyReplicas
=== PAUSE TestAccOpenSearchServerlessCollection_standbyReplicas
=== RUN   TestAccOpenSearchServerlessCollection_tags
=== PAUSE TestAccOpenSearchServerlessCollection_tags
=== RUN   TestAccOpenSearchServerlessCollection_update
=== PAUSE TestAccOpenSearchServerlessCollection_update
=== RUN   TestAccOpenSearchServerlessCollection_disappears
=== PAUSE TestAccOpenSearchServerlessCollection_disappears
=== CONT  TestAccOpenSearchServerlessCollection_basic
=== CONT  TestAccOpenSearchServerlessCollection_update
=== CONT  TestAccOpenSearchServerlessCollection_disappears
=== CONT  TestAccOpenSearchServerlessCollection_tags
=== CONT  TestAccOpenSearchServerlessCollection_standbyReplicas
--- PASS: TestAccOpenSearchServerlessCollection_basic (351.12s)
--- PASS: TestAccOpenSearchServerlessCollection_disappears (357.78s)
--- PASS: TestAccOpenSearchServerlessCollection_update (358.18s)
--- PASS: TestAccOpenSearchServerlessCollection_standbyReplicas (360.77s)
--- PASS: TestAccOpenSearchServerlessCollection_tags (366.50s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/opensearchserverless       371.772s

> make testacc TESTARGS="-run=TestAccOpenSearchServerlessCollectionDataSource_" PKG=opensearchserverless
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/opensearchserverless/... -v -count 1 -parallel 20  -run=TestAccOpenSearchServerlessCollectionDataSource_ -timeout 360m
=== RUN   TestAccOpenSearchServerlessCollectionDataSource_basic
=== PAUSE TestAccOpenSearchServerlessCollectionDataSource_basic
=== RUN   TestAccOpenSearchServerlessCollectionDataSource_name
=== PAUSE TestAccOpenSearchServerlessCollectionDataSource_name
=== CONT  TestAccOpenSearchServerlessCollectionDataSource_basic
=== CONT  TestAccOpenSearchServerlessCollectionDataSource_name
--- PASS: TestAccOpenSearchServerlessCollectionDataSource_basic (346.20s)
--- PASS: TestAccOpenSearchServerlessCollectionDataSource_name (346.32s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/opensearchserverless       351.569s

...
```
