### PR TITLE
r/aws_bedrockagent_knowledge_base: Aurora Cluster is publicly accessible in acceptance tests

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"net"
 	"os"
+	"os/exec"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -2612,6 +2613,18 @@ func SkipIfEnvVarNotSet(t *testing.T, key string) string {
 	v := os.Getenv(key)
 	if v == "" {
 		t.Skipf("Environment variable %s is not set, skipping test", key)
+	}
+	return v
+}
+
+// SkipIfExeNotOnPath skips the current test if the specified executable is not found in the directories named by the PATH environment variable.
+// The absolute path to the executable is returned.
+func SkipIfExeNotOnPath(t *testing.T, file string) string {
+	t.Helper()
+
+	v, err := exec.LookPath(file)
+	if err != nil {
+		t.Skipf("File %s not found on PATH, skipping test: %s", v, err)
 	}
 	return v
 }

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -2418,6 +2418,34 @@ resource "aws_subnet" "test" {
 	)
 }
 
+func ConfigVPCWithSubnetsEnableDNSHostnames(rName string, subnetCount int) string {
+	return ConfigCompose(
+		ConfigAvailableAZsNoOptInDefaultExclude(),
+		fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test" {
+  count = %[2]d
+
+  vpc_id            = aws_vpc.test.id
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName, subnetCount),
+	)
+}
+
 func ConfigVPCWithSubnetsIPv6(rName string, subnetCount int) string {
 	return ConfigCompose(
 		ConfigAvailableAZsNoOptInDefaultExclude(),

--- a/internal/framework/flex/list.go
+++ b/internal/framework/flex/list.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 )
 
 func ExpandFrameworkStringList(ctx context.Context, v basetypes.ListValuable) []*string {
@@ -70,6 +71,10 @@ func FlattenFrameworkStringValueList[T ~string](ctx context.Context, v []T) type
 	must(Flatten(ctx, v, &output))
 
 	return output
+}
+
+func FlattenFrameworkStringValueListOfString(ctx context.Context, vs []string) fwtypes.ListValueOf[basetypes.StringValue] {
+	return fwtypes.ListValueOf[basetypes.StringValue]{ListValue: FlattenFrameworkStringValueList(ctx, vs)}
 }
 
 // FlattenFrameworkStringValueListLegacy is the Plugin Framework variant of FlattenStringValueList.

--- a/internal/service/bedrockagent/agent.go
+++ b/internal/service/bedrockagent/agent.go
@@ -353,14 +353,14 @@ func (r *agentResource) Delete(ctx context.Context, request resource.DeleteReque
 		return
 	}
 
-	if _, err := waitAgentDeleted(ctx, conn, agentID, r.DeleteTimeout(ctx, data.Timeouts)); err != nil {
-		response.Diagnostics.AddError(fmt.Sprintf("waiting for Bedrock Agent (%s) delete", agentID), err.Error())
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("deleting Bedrock Agent (%s)", agentID), err.Error())
 
 		return
 	}
 
-	if err != nil {
-		response.Diagnostics.AddError(fmt.Sprintf("deleting Bedrock Agent (%s)", data.ID.ValueString()), err.Error())
+	if _, err := waitAgentDeleted(ctx, conn, agentID, r.DeleteTimeout(ctx, data.Timeouts)); err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("waiting for Bedrock Agent (%s) delete", agentID), err.Error())
 
 		return
 	}

--- a/internal/service/bedrockagent/bedrockagent_test.go
+++ b/internal/service/bedrockagent/bedrockagent_test.go
@@ -14,11 +14,11 @@ func TestAccBedrockAgent_serial(t *testing.T) {
 
 	testCases := map[string]map[string]func(t *testing.T){
 		"KnowledgeBase": {
-			"basic":      testAccKnowledgeBase_basic,
-			"disappears": testAccKnowledgeBase_disappears,
-			"rds":        testAccKnowledgeBase_rds,
-			"update":     testAccKnowledgeBase_update,
-			"tags":       testAccKnowledgeBase_tags,
+			"basicRDS":         testAccKnowledgeBase_basicRDS,
+			"disappears":       testAccKnowledgeBase_disappears,
+			"tags":             testAccKnowledgeBase_tags,
+			"basicOpenSearch":  testAccKnowledgeBase_basicOpenSearch,
+			"updateOpenSearch": testAccKnowledgeBase_updateOpenSearch,
 		},
 	}
 

--- a/internal/service/bedrockagent/knowledge_base.go
+++ b/internal/service/bedrockagent/knowledge_base.go
@@ -5,6 +5,8 @@ package bedrockagent
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -13,21 +15,21 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
-	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -44,10 +46,6 @@ func newKnowledgeBaseResource(context.Context) (resource.ResourceWithConfigure, 
 
 	return r, nil
 }
-
-const (
-	ResNameKnowledgeBase = "Knowledge Base"
-)
 
 type knowledgeBaseResource struct {
 	framework.ResourceWithConfigure
@@ -77,9 +75,6 @@ func (r *knowledgeBaseResource) Schema(ctx context.Context, request resource.Sch
 				CustomType:  fwtypes.ListOfStringType,
 				ElementType: types.StringType,
 				Computed:    true,
-				PlanModifiers: []planmodifier.List{
-					listplanmodifier.UseStateForUnknown(),
-				},
 			},
 			names.AttrID: framework.IDAttribute(),
 			"name": schema.StringAttribute{
@@ -325,13 +320,13 @@ func (r *knowledgeBaseResource) Schema(ctx context.Context, request resource.Sch
 }
 
 func (r *knowledgeBaseResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
-	conn := r.Meta().BedrockAgentClient(ctx)
-
 	var data knowledgeBaseResourceModel
 	response.Diagnostics.Append(request.Plan.Get(ctx, &data)...)
 	if response.Diagnostics.HasError() {
 		return
 	}
+
+	conn := r.Meta().BedrockAgentClient(ctx)
 
 	input := &bedrockagent.CreateKnowledgeBaseInput{}
 	response.Diagnostics.Append(fwflex.Expand(ctx, data, input)...)
@@ -340,6 +335,7 @@ func (r *knowledgeBaseResource) Create(ctx context.Context, request resource.Cre
 	}
 
 	// Additional fields.
+	input.ClientToken = aws.String(id.UniqueId())
 	input.Tags = getTagsIn(ctx)
 
 	outputRaw, err := tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout, func() (interface{}, error) {
@@ -347,77 +343,64 @@ func (r *knowledgeBaseResource) Create(ctx context.Context, request resource.Cre
 	}, errCodeValidationException, "cannot assume role")
 
 	if err != nil {
-		response.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.BedrockAgent, create.ErrActionCreating, ResNameKnowledgeBase, data.Name.String(), err),
-			err.Error(),
-		)
+		response.Diagnostics.AddError("creating Bedrock Agent Knowledge Base", err.Error())
+
 		return
 	}
 
-	knowledgebase := outputRaw.(*bedrockagent.CreateKnowledgeBaseOutput).KnowledgeBase
-	data.KnowledgeBaseARN = fwflex.StringToFramework(ctx, knowledgebase.KnowledgeBaseArn)
-	data.KnowledgeBaseID = fwflex.StringToFramework(ctx, knowledgebase.KnowledgeBaseId)
+	kb := outputRaw.(*bedrockagent.CreateKnowledgeBaseOutput).KnowledgeBase
+	data.KnowledgeBaseARN = fwflex.StringToFramework(ctx, kb.KnowledgeBaseArn)
+	data.KnowledgeBaseID = fwflex.StringToFramework(ctx, kb.KnowledgeBaseId)
 
-	createTimeout := r.CreateTimeout(ctx, data.Timeouts)
-	knowledgebase, err = waitKnowledgeBaseCreated(ctx, conn, data.KnowledgeBaseID.ValueString(), createTimeout)
+	kb, err = waitKnowledgeBaseCreated(ctx, conn, data.KnowledgeBaseID.ValueString(), r.CreateTimeout(ctx, data.Timeouts))
+
 	if err != nil {
-		response.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.BedrockAgent, create.ErrActionWaitingForCreation, ResNameKnowledgeBase, data.Name.String(), err),
-			err.Error(),
-		)
-		return
-	}
+		response.Diagnostics.AddError(fmt.Sprintf("waiting for Bedrock Agent Knowledge Base (%s) create", data.KnowledgeBaseID.ValueString()), err.Error())
 
-	response.Diagnostics.Append(fwflex.Flatten(ctx, knowledgebase, &data)...)
-	if response.Diagnostics.HasError() {
 		return
 	}
 
 	// Set values for unknowns after creation is complete.
-	data.CreatedAt = fwflex.TimeToFramework(ctx, knowledgebase.CreatedAt)
-	data.UpdatedAt = fwflex.TimeToFramework(ctx, knowledgebase.UpdatedAt)
+	data.CreatedAt = fwflex.TimeToFramework(ctx, kb.CreatedAt)
+	data.FailureReasons = fwflex.FlattenFrameworkStringValueListOfString(ctx, kb.FailureReasons)
+	data.UpdatedAt = fwflex.TimeToFramework(ctx, kb.UpdatedAt)
 
 	response.Diagnostics.Append(response.State.Set(ctx, data)...)
 }
 
 func (r *knowledgeBaseResource) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
-	conn := r.Meta().BedrockAgentClient(ctx)
-
 	var data knowledgeBaseResourceModel
 	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
 	if response.Diagnostics.HasError() {
 		return
 	}
 
-	knowledgebase, err := findKnowledgeBaseByID(ctx, conn, data.KnowledgeBaseID.ValueString())
+	conn := r.Meta().BedrockAgentClient(ctx)
+
+	kb, err := findKnowledgeBaseByID(ctx, conn, data.KnowledgeBaseID.ValueString())
 
 	if tfresource.NotFound(err) {
+		response.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
 		response.State.RemoveResource(ctx)
-		return
-	}
-	if err != nil {
-		response.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.BedrockAgent, create.ErrActionSetting, ResNameKnowledgeBase, data.KnowledgeBaseID.String(), err),
-			err.Error(),
-		)
+
 		return
 	}
 
-	response.Diagnostics.Append(fwflex.Flatten(ctx, knowledgebase, &data)...)
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("reading Bedrock Agent Knowledge Base (%s)", data.KnowledgeBaseID.ValueString()), err.Error())
+
+		return
+	}
+
+	response.Diagnostics.Append(fwflex.Flatten(ctx, kb, &data)...)
 	if response.Diagnostics.HasError() {
 		return
 	}
-
-	// Set values for unknowns after creation is complete.
-	data.CreatedAt = fwflex.TimeToFramework(ctx, knowledgebase.CreatedAt)
-	data.UpdatedAt = fwflex.TimeToFramework(ctx, knowledgebase.UpdatedAt)
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
 
 func (r *knowledgeBaseResource) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
-	conn := r.Meta().BedrockAgentClient(ctx)
-
 	var old, new knowledgeBaseResourceModel
 	response.Diagnostics.Append(request.Plan.Get(ctx, &new)...)
 	if response.Diagnostics.HasError() {
@@ -428,9 +411,11 @@ func (r *knowledgeBaseResource) Update(ctx context.Context, request resource.Upd
 		return
 	}
 
-	if !new.Name.Equal(old.Name) ||
-		!new.Description.Equal(old.Description) ||
+	conn := r.Meta().BedrockAgentClient(ctx)
+
+	if !new.Description.Equal(old.Description) ||
 		!new.KnowledgeBaseConfiguration.Equal(old.KnowledgeBaseConfiguration) ||
+		!new.Name.Equal(old.Name) ||
 		!new.StorageConfiguration.Equal(old.StorageConfiguration) {
 		input := &bedrockagent.UpdateKnowledgeBaseInput{}
 		response.Diagnostics.Append(fwflex.Expand(ctx, new, input)...)
@@ -443,75 +428,59 @@ func (r *knowledgeBaseResource) Update(ctx context.Context, request resource.Upd
 		}, errCodeValidationException, "cannot assume role")
 
 		if err != nil {
-			response.Diagnostics.AddError(
-				create.ProblemStandardMessage(names.BedrockAgent, create.ErrActionUpdating, ResNameKnowledgeBase, new.KnowledgeBaseID.String(), err),
-				err.Error(),
-			)
+			response.Diagnostics.AddError(fmt.Sprintf("updating Bedrock Agent Knowledge Base (%s)", new.KnowledgeBaseID.ValueString()), err.Error())
+
 			return
 		}
-	}
 
-	updateTimeout := r.UpdateTimeout(ctx, new.Timeouts)
-	knowledgebase, err := waitKnowledgeBaseUpdated(ctx, conn, new.KnowledgeBaseID.ValueString(), updateTimeout)
-	if err != nil {
-		response.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.BedrockAgent, create.ErrActionWaitingForUpdate, ResNameKnowledgeBase, new.KnowledgeBaseID.String(), err),
-			err.Error(),
-		)
-		return
-	}
+		kb, err := waitKnowledgeBaseUpdated(ctx, conn, new.KnowledgeBaseID.ValueString(), r.UpdateTimeout(ctx, new.Timeouts))
 
-	response.Diagnostics.Append(fwflex.Flatten(ctx, knowledgebase, &new)...)
-	if response.Diagnostics.HasError() {
-		return
-	}
+		if err != nil {
+			response.Diagnostics.AddError(fmt.Sprintf("waiting for Bedrock Agent Knowledge Base (%s) create", new.KnowledgeBaseID.ValueString()), err.Error())
 
-	// Set values for unknowns after update is complete.
-	new.CreatedAt = fwflex.TimeToFramework(ctx, knowledgebase.CreatedAt)
-	new.UpdatedAt = fwflex.TimeToFramework(ctx, knowledgebase.UpdatedAt)
+			return
+		}
+
+		new.FailureReasons = fwflex.FlattenFrameworkStringValueListOfString(ctx, kb.FailureReasons)
+		new.UpdatedAt = fwflex.TimeToFramework(ctx, kb.UpdatedAt)
+	} else {
+		new.FailureReasons = old.FailureReasons
+		new.UpdatedAt = old.UpdatedAt
+	}
 
 	response.Diagnostics.Append(response.State.Set(ctx, &new)...)
 }
 
 func (r *knowledgeBaseResource) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {
-	conn := r.Meta().BedrockAgentClient(ctx)
-
 	var data knowledgeBaseResourceModel
 	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
 	if response.Diagnostics.HasError() {
 		return
 	}
 
-	in := &bedrockagent.DeleteKnowledgeBaseInput{
+	conn := r.Meta().BedrockAgentClient(ctx)
+
+	_, err := conn.DeleteKnowledgeBase(ctx, &bedrockagent.DeleteKnowledgeBaseInput{
 		KnowledgeBaseId: aws.String(data.KnowledgeBaseID.ValueString()),
-	}
+	})
 
-	_, err := conn.DeleteKnowledgeBase(ctx, in)
-
-	if err != nil {
-		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
-			return
-		}
-		response.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.BedrockAgent, create.ErrActionDeleting, ResNameKnowledgeBase, data.KnowledgeBaseID.String(), err),
-			err.Error(),
-		)
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return
 	}
 
-	deleteTimeout := r.DeleteTimeout(ctx, data.Timeouts)
-	_, err = waitKnowledgeBaseDeleted(ctx, conn, data.KnowledgeBaseID.ValueString(), deleteTimeout)
 	if err != nil {
-		response.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.BedrockAgent, create.ErrActionWaitingForDeletion, ResNameKnowledgeBase, data.KnowledgeBaseID.String(), err),
-			err.Error(),
-		)
+		response.Diagnostics.AddError(fmt.Sprintf("deleting Bedrock Agent Knowledge Base (%s)", data.KnowledgeBaseID.ValueString()), err.Error())
+
 		return
 	}
-}
 
-func (r *knowledgeBaseResource) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), request, response)
+	_, err = waitKnowledgeBaseDeleted(ctx, conn, data.KnowledgeBaseID.ValueString(), r.DeleteTimeout(ctx, data.Timeouts))
+
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("waiting for Bedrock Agent Knowledge Base (%s) delete", data.KnowledgeBaseID.ValueString()), err.Error())
+
+		return
+	}
 }
 
 func (r *knowledgeBaseResource) ModifyPlan(ctx context.Context, request resource.ModifyPlanRequest, response *resource.ModifyPlanResponse) {
@@ -520,17 +489,18 @@ func (r *knowledgeBaseResource) ModifyPlan(ctx context.Context, request resource
 
 func waitKnowledgeBaseCreated(ctx context.Context, conn *bedrockagent.Client, id string, timeout time.Duration) (*awstypes.KnowledgeBase, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending:                   enum.Slice(awstypes.KnowledgeBaseStatusCreating),
-		Target:                    enum.Slice(awstypes.KnowledgeBaseStatusActive),
-		Refresh:                   statusKnowledgeBase(ctx, conn, id),
-		Timeout:                   timeout,
-		NotFoundChecks:            20,
-		ContinuousTargetOccurence: 2,
+		Pending: enum.Slice(awstypes.KnowledgeBaseStatusCreating),
+		Target:  enum.Slice(awstypes.KnowledgeBaseStatusActive),
+		Refresh: statusKnowledgeBase(ctx, conn, id),
+		Timeout: timeout,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
-	if out, ok := outputRaw.(*awstypes.KnowledgeBase); ok {
-		return out, err
+
+	if output, ok := outputRaw.(*awstypes.KnowledgeBase); ok {
+		tfresource.SetLastError(err, errors.Join(tfslices.ApplyToAll(output.FailureReasons, errors.New)...))
+
+		return output, err
 	}
 
 	return nil, err
@@ -538,17 +508,18 @@ func waitKnowledgeBaseCreated(ctx context.Context, conn *bedrockagent.Client, id
 
 func waitKnowledgeBaseUpdated(ctx context.Context, conn *bedrockagent.Client, id string, timeout time.Duration) (*awstypes.KnowledgeBase, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending:                   enum.Slice(awstypes.KnowledgeBaseStatusUpdating),
-		Target:                    enum.Slice(awstypes.KnowledgeBaseStatusActive),
-		Refresh:                   statusKnowledgeBase(ctx, conn, id),
-		Timeout:                   timeout,
-		NotFoundChecks:            20,
-		ContinuousTargetOccurence: 2,
+		Pending: enum.Slice(awstypes.KnowledgeBaseStatusUpdating),
+		Target:  enum.Slice(awstypes.KnowledgeBaseStatusActive),
+		Refresh: statusKnowledgeBase(ctx, conn, id),
+		Timeout: timeout,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
-	if out, ok := outputRaw.(*awstypes.KnowledgeBase); ok {
-		return out, err
+
+	if output, ok := outputRaw.(*awstypes.KnowledgeBase); ok {
+		tfresource.SetLastError(err, errors.Join(tfslices.ApplyToAll(output.FailureReasons, errors.New)...))
+
+		return output, err
 	}
 
 	return nil, err
@@ -563,8 +534,11 @@ func waitKnowledgeBaseDeleted(ctx context.Context, conn *bedrockagent.Client, id
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
-	if out, ok := outputRaw.(*awstypes.KnowledgeBase); ok {
-		return out, err
+
+	if output, ok := outputRaw.(*awstypes.KnowledgeBase); ok {
+		tfresource.SetLastError(err, errors.Join(tfslices.ApplyToAll(output.FailureReasons, errors.New)...))
+
+		return output, err
 	}
 
 	return nil, err
@@ -573,6 +547,7 @@ func waitKnowledgeBaseDeleted(ctx context.Context, conn *bedrockagent.Client, id
 func statusKnowledgeBase(ctx context.Context, conn *bedrockagent.Client, id string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		output, err := findKnowledgeBaseByID(ctx, conn, id)
+
 		if tfresource.NotFound(err) {
 			return nil, "", nil
 		}
@@ -586,27 +561,28 @@ func statusKnowledgeBase(ctx context.Context, conn *bedrockagent.Client, id stri
 }
 
 func findKnowledgeBaseByID(ctx context.Context, conn *bedrockagent.Client, id string) (*awstypes.KnowledgeBase, error) {
-	in := &bedrockagent.GetKnowledgeBaseInput{
+	input := &bedrockagent.GetKnowledgeBaseInput{
 		KnowledgeBaseId: aws.String(id),
 	}
 
-	out, err := conn.GetKnowledgeBase(ctx, in)
-	if err != nil {
-		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
-			return nil, &retry.NotFoundError{
-				LastError:   err,
-				LastRequest: in,
-			}
-		}
+	output, err := conn.GetKnowledgeBase(ctx, input)
 
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
 		return nil, err
 	}
 
-	if out == nil || out.KnowledgeBase == nil {
-		return nil, tfresource.NewEmptyResultError(in)
+	if output == nil || output.KnowledgeBase == nil {
+		return nil, tfresource.NewEmptyResultError(input)
 	}
 
-	return out.KnowledgeBase, nil
+	return output.KnowledgeBase, nil
 }
 
 type knowledgeBaseResourceModel struct {

--- a/internal/service/bedrockagent/knowledge_base_test.go
+++ b/internal/service/bedrockagent/knowledge_base_test.go
@@ -448,8 +448,8 @@ resource "aws_default_route_table" "test" {
 }
 
 resource "aws_security_group" "test" {
-  name    = %[1]q
-  vpc_id  = aws_vpc.test.id
+  name   = %[1]q
+  vpc_id = aws_vpc.test.id
 
   ingress {
     from_port   = 5432

--- a/internal/service/bedrockagent/knowledge_base_test.go
+++ b/internal/service/bedrockagent/knowledge_base_test.go
@@ -98,7 +98,7 @@ func testAccKnowledgeBase_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckKnowledgeBaseDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKnowledgeBaseConfig_basicOpenSearch(rName, foundationModel),
+				Config: testAccKnowledgeBaseConfig_basicRDS(rName, foundationModel),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKnowledgeBaseExists(ctx, resourceName, &knowledgebase),
 					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfbedrockagent.ResourceKnowledgeBase, resourceName),

--- a/internal/service/bedrockagent/knowledge_base_test.go
+++ b/internal/service/bedrockagent/knowledge_base_test.go
@@ -22,7 +22,7 @@ import (
 // Prerequisites:
 // * psql run via null_resource/provisioner "local-exec"
 func testAccKnowledgeBase_basicRDS(t *testing.T) {
-	acctest.Skip(t, "Bedrock Agent Knowledge Base requires external configuration of a vector index")
+	acctest.SkipIfExeNotOnPath(t, "psql")
 
 	ctx := acctest.Context(t)
 	var knowledgebase types.KnowledgeBase
@@ -75,7 +75,7 @@ func testAccKnowledgeBase_basicRDS(t *testing.T) {
 // Prerequisites:
 // * psql run via null_resource/provisioner "local-exec"
 func testAccKnowledgeBase_disappears(t *testing.T) {
-	acctest.Skip(t, "Bedrock Agent Knowledge Base requires external configuration of a vector index")
+	acctest.SkipIfExeNotOnPath(t, "psql")
 
 	ctx := acctest.Context(t)
 	var knowledgebase types.KnowledgeBase
@@ -112,7 +112,7 @@ func testAccKnowledgeBase_disappears(t *testing.T) {
 // Prerequisites:
 // * psql run via null_resource/provisioner "local-exec"
 func testAccKnowledgeBase_tags(t *testing.T) {
-	acctest.Skip(t, "Bedrock Agent Knowledge Base requires external configuration of a vector index")
+	acctest.SkipIfExeNotOnPath(t, "psql")
 
 	ctx := acctest.Context(t)
 	var knowledgebase types.KnowledgeBase

--- a/internal/service/rds/cluster_instance_test.go
+++ b/internal/service/rds/cluster_instance_test.go
@@ -1360,29 +1360,7 @@ resource "aws_db_parameter_group" "test" {
 
 func testAccClusterInstanceConfig_publiclyAccessible(rName string, publiclyAccessible bool) string {
 	return acctest.ConfigCompose(
-		acctest.ConfigAvailableAZsNoOptInDefaultExclude(),
-		fmt.Sprintf(`
-resource "aws_vpc" "test" {
-  cidr_block           = "10.0.0.0/16"
-  enable_dns_hostnames = true
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_subnet" "test" {
-  count = %[2]d
-
-  vpc_id            = aws_vpc.test.id
-  availability_zone = data.aws_availability_zones.available.names[count.index]
-  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)
-
-  tags = {
-    Name = %[1]q
-  }
-}
-`, rName, 2),
+		acctest.ConfigVPCWithSubnetsEnableDNSHostnames(rName, 2),
 		testAccClusterInstanceConfig_orderableEngineBase("aurora-mysql", false),
 		fmt.Sprintf(`
 resource "aws_rds_cluster_instance" "test" {

--- a/internal/service/rds/cluster_instance_test.go
+++ b/internal/service/rds/cluster_instance_test.go
@@ -1365,6 +1365,10 @@ func testAccClusterInstanceConfig_publiclyAccessible(rName string, publiclyAcces
 resource "aws_vpc" "test" {
   cidr_block           = "10.0.0.0/16"
   enable_dns_hostnames = true
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 resource "aws_subnet" "test" {
@@ -1373,6 +1377,10 @@ resource "aws_subnet" "test" {
   vpc_id            = aws_vpc.test.id
   availability_zone = data.aws_availability_zones.available.names[count.index]
   cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)
+
+  tags = {
+    Name = %[1]q
+  }
 }
 `, rName, 2),
 		testAccClusterInstanceConfig_orderableEngineBase("aurora-mysql", false),
@@ -1390,6 +1398,10 @@ resource "aws_rds_cluster_instance" "test" {
 
 resource "aws_internet_gateway" "test" {
   vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 resource "aws_rds_cluster" "test" {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Makes the Aurora Cluster used in `aws_bedrockagent_knowledge_base` acceptance tests publicly accessible so that tests can be run from a laptop.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/36783.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccBedrockAgent_serial/KnowledgeBase/basicRDS\|TestAccBedrockAgent_serial/KnowledgeBase/disappears\|TestAccBedrockAgent_serial/KnowledgeBase/tags' PKG=bedrockagent ACCTEST_PARALLELISM=1
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/bedrockagent/... -v -count 1 -parallel 1  -run=TestAccBedrockAgent_serial/KnowledgeBase/basicRDS\|TestAccBedrockAgent_serial/KnowledgeBase/disappears\|TestAccBedrockAgent_serial/KnowledgeBase/tags -timeout 360m
=== RUN   TestAccBedrockAgent_serial
=== PAUSE TestAccBedrockAgent_serial
=== CONT  TestAccBedrockAgent_serial
=== RUN   TestAccBedrockAgent_serial/KnowledgeBase
=== RUN   TestAccBedrockAgent_serial/KnowledgeBase/basicRDS
=== RUN   TestAccBedrockAgent_serial/KnowledgeBase/disappears
=== RUN   TestAccBedrockAgent_serial/KnowledgeBase/tags
--- PASS: TestAccBedrockAgent_serial (4183.96s)
    --- PASS: TestAccBedrockAgent_serial/KnowledgeBase (4183.96s)
        --- PASS: TestAccBedrockAgent_serial/KnowledgeBase/basicRDS (1722.32s)
        --- PASS: TestAccBedrockAgent_serial/KnowledgeBase/disappears (1619.73s)
        --- PASS: TestAccBedrockAgent_serial/KnowledgeBase/tags (1983.44s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagent	4195.500s
```
