### PR TITLE
autoflex/ expand json interface type

### DIFF
--- a/internal/framework/flex/auto_expand.go
+++ b/internal/framework/flex/auto_expand.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	smithyjson "github.com/hashicorp/terraform-provider-aws/internal/json"
 )
 
 // Expand  = TF -->  AWS
@@ -253,6 +254,18 @@ func (expander autoExpander) string(ctx context.Context, vFrom basetypes.StringV
 		//
 		if t, ok := vFrom.(timetypes.RFC3339); ok {
 			v, d := t.ValueRFC3339Time()
+			diags.Append(d...)
+			if diags.HasError() {
+				return diags
+			}
+
+			vTo.Set(reflect.ValueOf(v))
+			return diags
+		}
+
+	case reflect.Interface:
+		if s, ok := vFrom.(fwtypes.SmithyJSON[smithyjson.JSONStringer]); ok {
+			v, d := s.ValueInterface()
 			diags.Append(d...)
 			if diags.HasError() {
 				return diags

--- a/internal/framework/flex/auto_expand_test.go
+++ b/internal/framework/flex/auto_expand_test.go
@@ -289,6 +289,18 @@ func TestExpand(t *testing.T) {
 				CreationDateTime: testTimeTime,
 			},
 		},
+		{
+			TestName: "string Source to interface Target",
+			Source:   &TestFlexTF20{Field1: fwtypes.SmithyJSONValue(`{"field1": "a"}`, newTestJSONDocument)},
+			Target:   &TestFlexAWS19{},
+			WantTarget: &TestFlexAWS19{
+				Field1: &testJSONDocument{
+					Value: map[string]any{
+						"field1": "a",
+					},
+				},
+			},
+		},
 	}
 
 	runAutoExpandTestCases(ctx, t, testCases)

--- a/internal/framework/flex/auto_flatten_test.go
+++ b/internal/framework/flex/auto_flatten_test.go
@@ -60,7 +60,7 @@ func TestFlatten(t *testing.T) {
 			TestName: "json interface Source string Target",
 			Source: &TestFlexAWS19{
 				Field1: &testJSONDocument{
-					value: &struct {
+					Value: &struct {
 						Test string `json:"test"`
 					}{
 						Test: "a",

--- a/internal/framework/flex/autoflex_test.go
+++ b/internal/framework/flex/autoflex_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"time"
 
+	smithydocument "github.com/aws/smithy-go/document"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -315,13 +316,18 @@ type TestFlexMapBlockKeyTF05 struct {
 }
 
 var _ smithyjson.JSONStringer = (*testJSONDocument)(nil)
+var _ smithydocument.Marshaler = (*testJSONDocument)(nil)
 
 type testJSONDocument struct {
-	value any
+	Value any
+}
+
+func newTestJSONDocument(v any) smithyjson.JSONStringer {
+	return &testJSONDocument{Value: v}
 }
 
 func (m *testJSONDocument) UnmarshalSmithyDocument(v interface{}) error {
-	data, err := json.Marshal(m.value)
+	data, err := json.Marshal(m.Value)
 	if err != nil {
 		return err
 	}
@@ -329,7 +335,7 @@ func (m *testJSONDocument) UnmarshalSmithyDocument(v interface{}) error {
 }
 
 func (m *testJSONDocument) MarshalSmithyDocument() ([]byte, error) {
-	return json.Marshal(m.value)
+	return json.Marshal(m.Value)
 }
 
 type TestFlexAWS19 struct {
@@ -338,4 +344,8 @@ type TestFlexAWS19 struct {
 
 type TestFlexTF19 struct {
 	Field1 types.String `tfsdk:"field1"`
+}
+
+type TestFlexTF20 struct {
+	Field1 fwtypes.SmithyJSON[smithyjson.JSONStringer] `tfsdk:"field1"`
 }

--- a/internal/framework/types/smithy_json.go
+++ b/internal/framework/types/smithy_json.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package types
 
 import (

--- a/internal/framework/types/smithy_json.go
+++ b/internal/framework/types/smithy_json.go
@@ -1,0 +1,169 @@
+package types
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/attr/xattr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	smithyjson "github.com/hashicorp/terraform-provider-aws/internal/json"
+)
+
+var (
+	_ basetypes.StringTypable = (*SmithyJSONType[smithyjson.JSONStringer])(nil)
+)
+
+type SmithyJSONType[T smithyjson.JSONStringer] struct {
+	basetypes.StringType
+	f func(any) T
+}
+
+func NewSmithyJSONType[T smithyjson.JSONStringer](_ context.Context, f func(any) T) SmithyJSONType[T] {
+	return SmithyJSONType[T]{
+		f: f,
+	}
+}
+
+// String returns a human readable string of the type name.
+func (t SmithyJSONType[T]) String() string {
+	return "fwtypes.SmithyJSONType"
+}
+
+// ValueType returns the Value type.
+func (t SmithyJSONType[T]) ValueType(context.Context) attr.Value {
+	return SmithyJSON[T]{}
+}
+
+// Equal returns true if the given type is equivalent.
+func (t SmithyJSONType[T]) Equal(o attr.Type) bool {
+	other, ok := o.(SmithyJSONType[T])
+
+	if !ok {
+		return false
+	}
+
+	return t.StringType.Equal(other.StringType)
+}
+
+func (t SmithyJSONType[T]) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := t.StringType.ValueFromTerraform(ctx, in)
+
+	if err != nil {
+		return nil, err
+	}
+
+	stringValue, ok := attrValue.(basetypes.StringValue)
+
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", attrValue)
+	}
+
+	stringValuable, diags := t.ValueFromString(ctx, stringValue)
+
+	if diags.HasError() {
+		return nil, fmt.Errorf("unexpected error converting StringValue to StringValuable: %v", diags)
+	}
+
+	return stringValuable, nil
+}
+
+func (t SmithyJSONType[T]) ValueFromString(ctx context.Context, in basetypes.StringValue) (basetypes.StringValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return SmithyJSONNull[T](), diags
+	}
+
+	if in.IsUnknown() {
+		return SmithyJSONUnknown[T](), diags
+	}
+
+	return SmithyJSONValue[T](in.ValueString(), t.f), diags
+}
+
+var (
+	_ basetypes.StringValuable = (*SmithyJSON[smithyjson.JSONStringer])(nil)
+)
+
+type SmithyJSON[T smithyjson.JSONStringer] struct {
+	basetypes.StringValue
+	validate func(context.Context, tftypes.Value, path.Path) diag.Diagnostics
+	f        func(any) T
+}
+
+func (v SmithyJSON[T]) Equal(o attr.Value) bool {
+	other, ok := o.(SmithyJSON[T])
+
+	if !ok {
+		return false
+	}
+
+	return v.StringValue.Equal(other.StringValue)
+}
+
+func (v SmithyJSON[T]) ValueInterface() (T, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	var data map[string]any
+	err := json.Unmarshal([]byte(v.ValueString()), &data)
+
+	if err != nil {
+		var zero T
+		diags.AddError(
+			"JSON Unmarshal Error",
+			"An unexpected error occurred while unmarshalling a JSON string. "+
+				"Please report this to the provider developers.\n\n"+
+				"Error: "+err.Error(),
+		)
+		return zero, diags
+
+	}
+
+	return v.f(data), diags
+}
+
+func (v SmithyJSON[T]) Type(context.Context) attr.Type {
+	return SmithyJSONType[T]{}
+}
+
+func (v SmithyJSON[T]) ValidateAttribute(ctx context.Context, req xattr.ValidateAttributeRequest, resp *xattr.ValidateAttributeResponse) {
+	if v.IsNull() || v.IsUnknown() {
+		return
+	}
+
+	jt, err := jsontypes.NewNormalizedValue(v.ValueString()).ToTerraformValue(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"JSON Normalized Type Validation Error",
+			"An unexpected error was encountered trying to validate an attribute value. This is always an error in the provider. "+
+				"Please report the following to the provider developer:\n\n"+err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(v.validate(ctx, jt, req.Path)...)
+}
+
+func SmithyJSONValue[T smithyjson.JSONStringer](value string, f func(any) T) SmithyJSON[T] {
+	return SmithyJSON[T]{
+		StringValue: basetypes.NewStringValue(value),
+		validate:    jsontypes.NormalizedType{}.Validate,
+		f:           f,
+	}
+}
+func SmithyJSONNull[T smithyjson.JSONStringer]() SmithyJSON[T] {
+	return SmithyJSON[T]{
+		StringValue: basetypes.NewStringNull(),
+	}
+}
+
+func SmithyJSONUnknown[T smithyjson.JSONStringer]() SmithyJSON[T] {
+	return SmithyJSON[T]{
+		StringValue: basetypes.NewStringUnknown(),
+	}
+}

--- a/internal/framework/types/smithy_json.go
+++ b/internal/framework/types/smithy_json.go
@@ -87,6 +87,11 @@ func (t SmithyJSONType[T]) ValueFromString(ctx context.Context, in basetypes.Str
 		return SmithyJSONUnknown[T](), diags
 	}
 
+	var data map[string]any
+	if err := json.Unmarshal([]byte(in.ValueString()), &data); err != nil {
+		return SmithyJSONUnknown[T](), diags
+	}
+
 	return SmithyJSONValue[T](in.ValueString(), t.f), diags
 }
 
@@ -114,11 +119,16 @@ func (v SmithyJSON[T]) Equal(o attr.Value) bool {
 
 func (v SmithyJSON[T]) ValueInterface() (T, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	var zero T
+	if v.IsNull() || v.IsUnknown() {
+		return zero, diags
+	}
+
 	var data map[string]any
 	err := json.Unmarshal([]byte(v.ValueString()), &data)
 
 	if err != nil {
-		var zero T
 		diags.AddError(
 			"JSON Unmarshal Error",
 			"An unexpected error occurred while unmarshalling a JSON string. "+

--- a/internal/framework/types/smithy_json.go
+++ b/internal/framework/types/smithy_json.go
@@ -124,7 +124,6 @@ func (v SmithyJSON[T]) ValueInterface() (T, diag.Diagnostics) {
 				"Error: "+err.Error(),
 		)
 		return zero, diags
-
 	}
 
 	return v.f(data), diags

--- a/internal/framework/types/smithy_json_test.go
+++ b/internal/framework/types/smithy_json_test.go
@@ -76,7 +76,7 @@ func TestSmithyJSONValidateAttribute(t *testing.T) {
 		"valid SmithyJSON": { // lintignore:AWSAT003,AWSAT005
 			val: fwtypes.SmithyJSONValue[smithyjson.JSONStringer](`{"test": "value"}`, nil), // lintignore:AWSAT003,AWSAT005
 		},
-		"invalid ARN": {
+		"invalid SmithyJSON": {
 			val:         fwtypes.SmithyJSONValue[smithyjson.JSONStringer]("not ok", nil),
 			expectError: true,
 		},

--- a/internal/framework/types/smithy_json_test.go
+++ b/internal/framework/types/smithy_json_test.go
@@ -35,7 +35,7 @@ func TestSmithyJSONTypeValueFromTerraform(t *testing.T) {
 			val:      tftypes.NewValue(tftypes.String, `{"test": "value"}`),                      // lintignore:AWSAT003,AWSAT005
 			expected: fwtypes.SmithyJSONValue[smithyjson.JSONStringer](`{"test": "value"}`, nil), // lintignore:AWSAT003,AWSAT005
 		},
-		"invalid ARN": {
+		"invalid SmithyJSON": {
 			val:      tftypes.NewValue(tftypes.String, "not ok"),
 			expected: fwtypes.SmithyJSONUnknown[smithyjson.JSONStringer](),
 		},

--- a/internal/framework/types/smithy_json_test.go
+++ b/internal/framework/types/smithy_json_test.go
@@ -1,0 +1,172 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package types_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/attr/xattr"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	smithyjson "github.com/hashicorp/terraform-provider-aws/internal/json"
+)
+
+func TestSmithyJSONTypeValueFromTerraform(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		val      tftypes.Value
+		expected attr.Value
+	}{
+		"null value": {
+			val:      tftypes.NewValue(tftypes.String, nil),
+			expected: fwtypes.SmithyJSONNull[smithyjson.JSONStringer](),
+		},
+		"unknown value": {
+			val:      tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+			expected: fwtypes.SmithyJSONUnknown[smithyjson.JSONStringer](),
+		},
+		"valid SmithyJSON": {
+			val:      tftypes.NewValue(tftypes.String, `{"test": "value"}`),                      // lintignore:AWSAT003,AWSAT005
+			expected: fwtypes.SmithyJSONValue[smithyjson.JSONStringer](`{"test": "value"}`, nil), // lintignore:AWSAT003,AWSAT005
+		},
+		"invalid ARN": {
+			val:      tftypes.NewValue(tftypes.String, "not ok"),
+			expected: fwtypes.SmithyJSONUnknown[smithyjson.JSONStringer](),
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			val, err := fwtypes.SmithyJSONType[smithyjson.JSONStringer]{}.ValueFromTerraform(ctx, test.val)
+
+			if err != nil {
+				t.Fatalf("got unexpected error: %s", err)
+			}
+
+			if diff := cmp.Diff(val, test.expected); diff != "" {
+				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}
+
+func TestSmithyJSONValidateAttribute(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		val         fwtypes.SmithyJSON[smithyjson.JSONStringer]
+		expectError bool
+	}{
+		"null value": {
+			val: fwtypes.SmithyJSONNull[smithyjson.JSONStringer](),
+		},
+		"unknown value": {
+			val: fwtypes.SmithyJSONUnknown[smithyjson.JSONStringer](),
+		},
+		"valid SmithyJSON": { // lintignore:AWSAT003,AWSAT005
+			val: fwtypes.SmithyJSONValue[smithyjson.JSONStringer](`{"test": "value"}`, nil), // lintignore:AWSAT003,AWSAT005
+		},
+		"invalid ARN": {
+			val:         fwtypes.SmithyJSONValue[smithyjson.JSONStringer]("not ok", nil),
+			expectError: true,
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			req := xattr.ValidateAttributeRequest{}
+			resp := xattr.ValidateAttributeResponse{}
+
+			test.val.ValidateAttribute(ctx, req, &resp)
+			if resp.Diagnostics.HasError() != test.expectError {
+				t.Errorf("resp.Diagnostics.HasError() = %t, want = %t", resp.Diagnostics.HasError(), test.expectError)
+			}
+		})
+	}
+}
+
+type testJSONDocument struct {
+	Value any
+}
+
+func newTestJSONDocument(v any) smithyjson.JSONStringer {
+	return &testJSONDocument{Value: v}
+}
+
+func (m *testJSONDocument) UnmarshalSmithyDocument(v interface{}) error {
+	data, err := json.Marshal(m.Value)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, v)
+}
+
+func (m *testJSONDocument) MarshalSmithyDocument() ([]byte, error) {
+	return json.Marshal(m.Value)
+}
+
+func TestSmithyJSONValueInterface(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		val         fwtypes.SmithyJSON[smithyjson.JSONStringer]
+		expected    smithyjson.JSONStringer
+		expectError bool
+	}{
+		"null value": {
+			val: fwtypes.SmithyJSONNull[smithyjson.JSONStringer](),
+		},
+		"unknown value": {
+			val: fwtypes.SmithyJSONUnknown[smithyjson.JSONStringer](),
+		},
+		"valid SmithyJSON": { // lintignore:AWSAT003,AWSAT005
+			val: fwtypes.SmithyJSONValue[smithyjson.JSONStringer](`{"test": "value"}`, newTestJSONDocument), // lintignore:AWSAT003,AWSAT005
+			expected: &testJSONDocument{
+				Value: map[string]any{
+					"test": "value",
+				},
+			},
+		},
+		"invalid SmithyJSON": {
+			val:         fwtypes.SmithyJSONValue[smithyjson.JSONStringer]("not ok", newTestJSONDocument), // lintignore:AWSAT003,AWSAT005
+			expectError: true,
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			s, err := test.val.ValueInterface()
+			gotErr := err.HasError()
+
+			if gotErr != test.expectError {
+				t.Errorf("gotErr = %v, wantErr = %v", gotErr, test.expectError)
+			}
+
+			if gotErr {
+				if !test.expectError {
+					t.Errorf("err = %q", err)
+				}
+			} else if diff := cmp.Diff(s, test.expected); diff != "" {
+				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}

--- a/internal/framework/types/smithy_json_test.go
+++ b/internal/framework/types/smithy_json_test.go
@@ -32,7 +32,7 @@ func TestSmithyJSONTypeValueFromTerraform(t *testing.T) {
 			expected: fwtypes.SmithyJSONUnknown[smithyjson.JSONStringer](),
 		},
 		"valid SmithyJSON": {
-			val:      tftypes.NewValue(tftypes.String, `{"test": "value"}`),                      // lintignore:AWSAT003,AWSAT005
+			val:      tftypes.NewValue(tftypes.String, `{"test": "value"}`),
 			expected: fwtypes.SmithyJSONValue[smithyjson.JSONStringer](`{"test": "value"}`, nil), // lintignore:AWSAT003,AWSAT005
 		},
 		"invalid SmithyJSON": {

--- a/internal/service/opensearchserverless/lifecycle_policy.go
+++ b/internal/service/opensearchserverless/lifecycle_policy.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/opensearchserverless"
+	"github.com/aws/aws-sdk-go-v2/service/opensearchserverless/document"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/opensearchserverless/types"
-	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -48,7 +48,7 @@ func (r *resourceLifecyclePolicy) Metadata(_ context.Context, _ resource.Metadat
 	resp.TypeName = "aws_opensearchserverless_lifecycle_policy"
 }
 
-func (r *resourceLifecyclePolicy) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (r *resourceLifecyclePolicy) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"description": schema.StringAttribute{
@@ -68,7 +68,7 @@ func (r *resourceLifecyclePolicy) Schema(_ context.Context, _ resource.SchemaReq
 				},
 			},
 			"policy": schema.StringAttribute{
-				CustomType: jsontypes.NormalizedType{},
+				CustomType: fwtypes.NewSmithyJSONType(ctx, document.NewLazyDocument),
 				Required:   true,
 				Validators: []validator.String{
 					stringvalidator.LengthBetween(1, 20480),
@@ -268,7 +268,7 @@ type resourceLifecyclePolicyData struct {
 	Description   types.String                                     `tfsdk:"description"`
 	ID            types.String                                     `tfsdk:"id"`
 	Name          types.String                                     `tfsdk:"name"`
-	Policy        jsontypes.Normalized                             `tfsdk:"policy"`
+	Policy        fwtypes.SmithyJSON[document.Interface]           `tfsdk:"policy"`
 	PolicyVersion types.String                                     `tfsdk:"policy_version"`
 	Type          fwtypes.StringEnum[awstypes.LifecyclePolicyType] `tfsdk:"type"`
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

First pass at expanding JSON strings into Smithy objects

Uses `jsontypes.Normalized` as the standard for validating the document

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% go test -count=1 ./internal/framework/flex/... -run=TestFlatten\|TestExpand -v

--- PASS: TestFlattenFrameworkStringValueMapLegacy (0.00s)
    --- PASS: TestFlattenFrameworkStringValueMapLegacy/two_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringValueMapLegacy/zero_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringValueMapLegacy/nil_map (0.00s)
--- PASS: TestExpandFrameworkStringSet (0.00s)
    --- PASS: TestExpandFrameworkStringSet/null (0.00s)
    --- PASS: TestExpandFrameworkStringSet/zero_elements (0.00s)
    --- PASS: TestExpandFrameworkStringSet/unknown (0.00s)
    --- PASS: TestExpandFrameworkStringSet/two_elements (0.00s)
    --- PASS: TestExpandFrameworkStringSet/invalid_element_type (0.00s)
--- PASS: TestFlattenFrameworkStringValueMap (0.00s)
    --- PASS: TestFlattenFrameworkStringValueMap/two_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringValueMap/zero_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringValueMap/nil_map (0.00s)
--- PASS: TestFlattenSimpleSingleNestedBlock (0.00s)
    --- PASS: TestFlattenSimpleSingleNestedBlock/single_nested_block_pointer (0.00s)
    --- PASS: TestFlattenSimpleSingleNestedBlock/single_nested_block_nil (0.00s)
    --- PASS: TestFlattenSimpleSingleNestedBlock/single_nested_block_value (0.00s)
--- PASS: TestFlattenFrameworkStringMap (0.00s)
    --- PASS: TestFlattenFrameworkStringMap/nil_map (0.00s)
    --- PASS: TestFlattenFrameworkStringMap/two_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringMap/zero_elements (0.00s)
--- PASS: TestFlattenFrameworkStringValueSetLegacy (0.00s)
    --- PASS: TestFlattenFrameworkStringValueSetLegacy/two_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringValueSetLegacy/nil_array (0.00s)
    --- PASS: TestFlattenFrameworkStringValueSetLegacy/zero_elements (0.00s)
--- PASS: TestFlattenFrameworkStringValueList (0.00s)
    --- PASS: TestFlattenFrameworkStringValueList/nil_array (0.00s)
    --- PASS: TestFlattenFrameworkStringValueList/zero_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringValueList/two_elements (0.00s)
--- PASS: TestFlattenSimpleNestedBlockWithStringEnum (0.00s)
    --- PASS: TestFlattenSimpleNestedBlockWithStringEnum/single_nested_valid_value (0.00s)
    --- PASS: TestFlattenSimpleNestedBlockWithStringEnum/single_nested_empty_value (0.00s)
--- PASS: TestExpandFrameworkStringValueSet (0.00s)
    --- PASS: TestExpandFrameworkStringValueSet/null (0.00s)
    --- PASS: TestExpandFrameworkStringValueSet/zero_elements (0.00s)
    --- PASS: TestExpandFrameworkStringValueSet/invalid_element_type (0.00s)
    --- PASS: TestExpandFrameworkStringValueSet/two_elements (0.00s)
    --- PASS: TestExpandFrameworkStringValueSet/unknown (0.00s)
--- PASS: TestFlattenFrameworkStringValueListLegacy (0.00s)
    --- PASS: TestFlattenFrameworkStringValueListLegacy/two_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringValueListLegacy/nil_array (0.00s)
    --- PASS: TestFlattenFrameworkStringValueListLegacy/zero_elements (0.00s)
--- PASS: TestExpandFrameworkStringList (0.00s)
    --- PASS: TestExpandFrameworkStringList/null (0.00s)
    --- PASS: TestExpandFrameworkStringList/invalid_element_type (0.00s)
    --- PASS: TestExpandFrameworkStringList/zero_elements (0.00s)
    --- PASS: TestExpandFrameworkStringList/two_elements (0.00s)
    --- PASS: TestExpandFrameworkStringList/unknown (0.00s)
--- PASS: TestExpandFrameworkStringValueMap (0.00s)
    --- PASS: TestExpandFrameworkStringValueMap/null (0.00s)
    --- PASS: TestExpandFrameworkStringValueMap/zero_elements (0.00s)
    --- PASS: TestExpandFrameworkStringValueMap/two_elements (0.00s)
    --- PASS: TestExpandFrameworkStringValueMap/unknown (0.00s)
    --- PASS: TestExpandFrameworkStringValueMap/invalid_element_type (0.00s)
--- PASS: TestFlattenComplexNestedBlockWithStringEnum (0.00s)
    --- PASS: TestFlattenComplexNestedBlockWithStringEnum/single_nested_zero_value (0.00s)
    --- PASS: TestFlattenComplexNestedBlockWithStringEnum/single_nested_empty_value (0.00s)
    --- PASS: TestFlattenComplexNestedBlockWithStringEnum/single_nested_valid_value (0.00s)
--- PASS: TestFlattenFrameworkStringList (0.00s)
    --- PASS: TestFlattenFrameworkStringList/two_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringList/zero_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringList/nil_array (0.00s)
--- PASS: TestFlattenComplexSingleNestedBlock (0.00s)
    --- PASS: TestFlattenComplexSingleNestedBlock/single_nested_block_pointer (0.00s)
--- PASS: TestExpandListOfStringEnum (0.00s)
    --- PASS: TestExpandListOfStringEnum/valid_value (0.00s)
    --- PASS: TestExpandListOfStringEnum/null_value (0.00s)
    --- PASS: TestExpandListOfStringEnum/empty_value (0.00s)
--- PASS: TestExpandStringEnum (0.00s)
    --- PASS: TestExpandStringEnum/empty_value (0.00s)
    --- PASS: TestExpandStringEnum/valid_value (0.00s)
--- PASS: TestExpandComplexSingleNestedBlock (0.00s)
    --- PASS: TestExpandComplexSingleNestedBlock/single_nested_block_pointer (0.00s)
--- PASS: TestExpandSimpleNestedBlockWithStringEnum (0.00s)
    --- PASS: TestExpandSimpleNestedBlockWithStringEnum/single_nested_valid_value (0.00s)
    --- PASS: TestExpandSimpleNestedBlockWithStringEnum/single_nested_empty_value (0.00s)
--- PASS: TestExpandFrameworkStringMap (0.00s)
    --- PASS: TestExpandFrameworkStringMap/null (0.00s)
    --- PASS: TestExpandFrameworkStringMap/invalid_element_type (0.00s)
    --- PASS: TestExpandFrameworkStringMap/null_element (0.00s)
    --- PASS: TestExpandFrameworkStringMap/two_elements (0.00s)
    --- PASS: TestExpandFrameworkStringMap/zero_elements (0.00s)
    --- PASS: TestExpandFrameworkStringMap/unknown (0.00s)
--- PASS: TestFlattenFrameworkStringValueSet (0.00s)
    --- PASS: TestFlattenFrameworkStringValueSet/zero_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringValueSet/two_elements (0.00s)
    --- PASS: TestFlattenFrameworkStringValueSet/nil_array (0.00s)
--- PASS: TestExpandComplexNestedBlockWithStringEnum (0.00s)
    --- PASS: TestExpandComplexNestedBlockWithStringEnum/single_nested_valid_value (0.00s)
    --- PASS: TestExpandComplexNestedBlockWithStringEnum/single_nested_empty_value (0.00s)
--- PASS: TestExpandFrameworkStringValueList (0.01s)
    --- PASS: TestExpandFrameworkStringValueList/null (0.00s)
    --- PASS: TestExpandFrameworkStringValueList/zero_elements (0.00s)
    --- PASS: TestExpandFrameworkStringValueList/two_elements (0.00s)
    --- PASS: TestExpandFrameworkStringValueList/invalid_element_type (0.00s)
    --- PASS: TestExpandFrameworkStringValueList/unknown (0.00s)
--- PASS: TestExpandSetOfStringEnum (0.00s)
    --- PASS: TestExpandSetOfStringEnum/valid_value (0.00s)
    --- PASS: TestExpandSetOfStringEnum/null_value (0.00s)
    --- PASS: TestExpandSetOfStringEnum/empty_value (0.00s)
--- PASS: TestFlattenFrameworkStringListLegacy (0.00s)
    --- PASS: TestFlattenFrameworkStringListLegacy/nil_array (0.00s)
    --- PASS: TestFlattenFrameworkStringListLegacy/zero_elements (0.01s)
    --- PASS: TestFlattenFrameworkStringListLegacy/two_elements (0.00s)
--- PASS: TestExpandSimpleSingleNestedBlock (0.00s)
    --- PASS: TestExpandSimpleSingleNestedBlock/single_nested_block_nil (0.00s)
    --- PASS: TestExpandSimpleSingleNestedBlock/single_nested_block_pointer (0.00s)
    --- PASS: TestExpandSimpleSingleNestedBlock/single_nested_block_value (0.00s)
--- PASS: TestFlattenGeneric (0.00s)
    --- PASS: TestFlattenGeneric/map_block_key_ptr_both (0.00s)
    --- PASS: TestFlattenGeneric/map_block_key_ptr_source (0.00s)
    --- PASS: TestFlattenGeneric/map_block_enum_key (0.00s)
    --- PASS: TestFlattenGeneric/map_block_key_set (0.00s)
    --- PASS: TestFlattenGeneric/nested_string_map (0.00s)
    --- PASS: TestFlattenGeneric/map_string (0.00s)
    --- PASS: TestFlattenGeneric/complex_Source_and_complex_Target (0.00s)
    --- PASS: TestFlattenGeneric/empty_[]*struct_and_empty_list_Target (0.00s)
    --- PASS: TestFlattenGeneric/nil_[]*struct_and_null_set_Target (0.00s)
    --- PASS: TestFlattenGeneric/empty_[]*struct_and_empty_set_Target (0.00s)
    --- PASS: TestFlattenGeneric/nil_[]*struct_and_null_list_Target (0.00s)
    --- PASS: TestFlattenGeneric/non-empty_[]struct_and_non-empty_set_Target (0.00s)
    --- PASS: TestFlattenGeneric/non-empty_[]struct_and_non-empty_list_Target (0.00s)
    --- PASS: TestFlattenGeneric/empty_[]struct_and_empty_struct_Target (0.00s)
    --- PASS: TestFlattenGeneric/empty_[]struct_and_empty_list_Target (0.00s)
    --- PASS: TestFlattenGeneric/nil_[]struct_and_null_set_Target (0.00s)
    --- PASS: TestFlattenGeneric/non-empty_[]*struct_and_non-empty_set_Target (0.00s)
    --- PASS: TestFlattenGeneric/nil_[]struct_and_null_list_Target (0.00s)
    --- PASS: TestFlattenGeneric/*struct_Source_and_single_set_Target (0.00s)
    --- PASS: TestFlattenGeneric/nil_*struct_Source_and_single_list_Target (0.00s)
    --- PASS: TestFlattenGeneric/*struct_Source_and_single_list_Target (0.00s)
    --- PASS: TestFlattenGeneric/non-empty_[]*struct_and_non-empty_list_Target (0.00s)
    --- PASS: TestFlattenGeneric/map_block_key_list (0.00s)
--- PASS: TestFlatten (0.01s)
    --- PASS: TestFlatten/timestamp_empty (0.00s)
    --- PASS: TestFlatten/timestamp_nil (0.00s)
    --- PASS: TestFlatten/timestamp (0.00s)
    --- PASS: TestFlatten/timestamp_pointer (0.00s)
    --- PASS: TestFlatten/nil_Source_and_Target (0.00s)
    --- PASS: TestFlatten/single_nil_*string_Source_and_single_ARN_Target (0.00s)
    --- PASS: TestFlatten/capitalization_field_names (0.00s)
    --- PASS: TestFlatten/resource_name_prefix (0.00s)
    --- PASS: TestFlatten/slice/map_of_string_types_Source_and_List/Set/Map_of_string_types_Target (0.00s)
    --- PASS: TestFlatten/zero_value_slice/map_of_string_type_Source_and_List/Set/Map_of_string_types_Target (0.00s)
    --- PASS: TestFlatten/slice/map_of_primtive_types_Source_and_List/Set/Map_of_primtive_types_Target (0.00s)
    --- PASS: TestFlatten/zero_value_slice/map_of_primtive_types_Source_and_List/Set/Map_of_primtive_types_Target (0.00s)
    --- PASS: TestFlatten/primtive_types_Source_and_primtive_types_Target (0.00s)
    --- PASS: TestFlatten/zero_value_primtive_types_Source_and_primtive_types_Target (0.00s)
    --- PASS: TestFlatten/single_string_Source_and_single_ARN_Target (0.00s)
    --- PASS: TestFlatten/single_string_Source_and_single_int64_Target (0.00s)
    --- PASS: TestFlatten/single_*string_Source_and_single_ARN_Target (0.00s)
    --- PASS: TestFlatten/single_string_Source_and_single_string_Target (0.00s)
    --- PASS: TestFlatten/single_empty_string_Source_and_single_string_Target (0.00s)
    --- PASS: TestFlatten/does_not_implement_attr.Value_Target (0.00s)
    --- PASS: TestFlatten/single_*string_Source_and_single_string_Target (0.00s)
    --- PASS: TestFlatten/empty_struct_pointer_Source_and_Target (0.00s)
    --- PASS: TestFlatten/single_string_struct_pointer_Source_and_empty_Target (0.00s)
    --- PASS: TestFlatten/json_interface_Source_string_Target (0.00s)
    --- PASS: TestFlatten/non-struct_Target (0.00s)
    --- PASS: TestFlatten/non-struct_Source (0.00s)
    --- PASS: TestFlatten/non-pointer_Target (0.00s)
    --- PASS: TestFlatten/empty_struct_Source_and_Target (0.00s)
    --- PASS: TestFlatten/strange_plurality (0.00s)
    --- PASS: TestFlatten/single_nil_*string_Source_and_single_string_Target (0.00s)
    --- PASS: TestFlatten/plural_ordinary_field_names (0.00s)
    --- PASS: TestFlatten/plural_field_names (0.00s)
--- PASS: TestExpandGeneric (0.01s)
    --- PASS: TestExpandGeneric/single_list_Source_and_*struct_Target (0.00s)
    --- PASS: TestExpandGeneric/map_block_key_set (0.00s)
    --- PASS: TestExpandGeneric/map_block_key_list (0.00s)
    --- PASS: TestExpandGeneric/map_string (0.00s)
    --- PASS: TestExpandGeneric/map_block_key_ptr_both (0.00s)
    --- PASS: TestExpandGeneric/complex_Source_and_complex_Target (0.00s)
    --- PASS: TestExpandGeneric/map_block_enum_key (0.00s)
    --- PASS: TestExpandGeneric/non-empty_list_Source_and_non-empty_[]struct_Target (0.00s)
    --- PASS: TestExpandGeneric/empty_list_Source_and_empty_[]struct_Target (0.00s)
    --- PASS: TestExpandGeneric/map_block_key_ptr_source (0.00s)
    --- PASS: TestExpandGeneric/empty_list_Source_and_empty_[]*struct_Target (0.00s)
    --- PASS: TestExpandGeneric/single_set_Source_and_*struct_Target (0.00s)
    --- PASS: TestExpandGeneric/non-empty_list_Source_and_non-empty_[]*struct_Target (0.00s)
    --- PASS: TestExpandGeneric/non-empty_set_Source_and_non-empty_[]*struct_Target (0.00s)
    --- PASS: TestExpandGeneric/empty_set_Source_and_empty_[]*struct_Target (0.00s)
    --- PASS: TestExpandGeneric/non-empty_list_Source_and_non-empty_[]struct_Target#01 (0.00s)
    --- PASS: TestExpandGeneric/empty_list_Source_and_empty_[]struct_Target#01 (0.00s)
    --- PASS: TestExpandGeneric/non-empty_set_Source_and_non-empty_[]struct_Target (0.00s)
    --- PASS: TestExpandGeneric/nested_string_map (0.00s)
--- PASS: TestExpand (0.02s)
    --- PASS: TestExpand/nil_Source_and_Target (0.00s)
    --- PASS: TestExpand/string_Source_to_interface_Target (0.00s)
    --- PASS: TestExpand/timestamp (0.00s)
    --- PASS: TestExpand/timestamp_pointer (0.00s)
    --- PASS: TestExpand/single_ARN_Source_and_single_*string_Target (0.00s)
    --- PASS: TestExpand/single_ARN_Source_and_single_string_Target (0.00s)
    --- PASS: TestExpand/resource_name_prefix (0.00s)
    --- PASS: TestExpand/capitalization_field_names (0.00s)
    --- PASS: TestExpand/single_string_struct_pointer_Source_and_empty_Target (0.00s)
    --- PASS: TestExpand/List/Set/Map_of_primitive_types_Source_and_slice/map_of_primtive_types_Target (0.00s)
    --- PASS: TestExpand/primtive_types_Source_and_primtive_types_Target (0.00s)
    --- PASS: TestExpand/single_string_Source_and_single_int64_Target (0.00s)
    --- PASS: TestExpand/single_string_Source_and_single_*string_Target (0.00s)
    --- PASS: TestExpand/single_string_Source_and_single_string_Target (0.00s)
    --- PASS: TestExpand/does_not_implement_attr.Value_Source (0.00s)
    --- PASS: TestExpand/types.String_to_string (0.00s)
    --- PASS: TestExpand/empty_struct_pointer_Source_and_Target (0.00s)
    --- PASS: TestExpand/empty_struct_Source_and_Target (0.00s)
    --- PASS: TestExpand/non-struct_Source (0.00s)
    --- PASS: TestExpand/non-struct_Target (0.00s)
    --- PASS: TestExpand/non-pointer_Target (0.00s)
    --- PASS: TestExpand/plural_field_names (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/framework/flex	0.480s
```
