### PR TITLE
docs: Improved desc for control_sets and controls blocks for aws_auditmanager_framework resource

### DIFF
--- a/website/docs/r/auditmanager_framework.html.markdown
+++ b/website/docs/r/auditmanager_framework.html.markdown
@@ -21,7 +21,10 @@ resource "aws_auditmanager_framework" "test" {
   control_sets {
     name = "example"
     controls {
-      id = aws_auditmanager_control.test.id
+      id = aws_auditmanager_control.test_1.id
+    }
+    controls {
+      id = aws_auditmanager_control.test_2.id
     }
   }
 }
@@ -32,7 +35,7 @@ resource "aws_auditmanager_framework" "test" {
 The following arguments are required:
 
 * `name` - (Required) Name of the framework.
-* `control_sets` - (Required) Control sets that are associated with the framework. See [`control_sets`](#control_sets) below.
+* `control_sets` - (Required) Configuration block(s) for the control sets that are associated with the framework. See [`control_sets` Block](#control_sets-block) below for details.
 
 The following arguments are optional:
 
@@ -40,12 +43,16 @@ The following arguments are optional:
 * `description` - (Optional) Description of the framework.
 * `tags` - (Optional) A map of tags to assign to the framework. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
-### control_sets
+### `control_sets` Block
+
+The `control_sets` configuration block supports the following arguments:
 
 * `name` - (Required) Name of the control set.
-* `controls` - (Required) List of controls within the control set. See [`controls`](#controls) below.
+* `controls` - (Required) Configuration block(s) for the controls within the control set. See [`controls` Block](#controls-block) below for details.
 
-### controls
+### `controls` Block
+
+The `controls` configuration block supports the following arguments:
 
 * `id` - (Required) Unique identifier of the control.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to improve the description of the `control_sets` and `controls` configuration block arguments for the `aws_auditmanager_framework` resource. Earlier description mentions the word "list" (copied from the AWS API reference) which leaves some room for confusion about the data type.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #37000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to documentation for EKS resources, e.g. [aws_eks_fargate_profile](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_fargate_profile) for patterns in describing config block arguments.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
n/a