### PR TITLE
:pencil: docs fix for role_arn argument

### DIFF
--- a/website/docs/r/sagemaker_pipeline.html.markdown
+++ b/website/docs/r/sagemaker_pipeline.html.markdown
@@ -42,7 +42,7 @@ The following arguments are supported:
 * `pipeline_display_name` - (Required) The display name of the pipeline.
 * `pipeline_definition` - (Optional) The [JSON pipeline definition](https://aws-sagemaker-mlops.github.io/sagemaker-model-building-pipeline-definition-JSON-schema/) of the pipeline.
 * `pipeline_definition_s3_location` - (Optional) The location of the pipeline definition stored in Amazon S3. If specified, SageMaker will retrieve the pipeline definition from this location. see [Pipeline Definition S3 Location](#pipeline-definition-s3-location) details below.
-* `role_arn` - (Required) The name of the Pipeline (must be unique).
+* `role_arn` - (Required) The ARN of the IAM role the pipeline will execute as.
 * `parallelism_configuration` - (Optional) This is the configuration that controls the parallelism of the pipeline. If specified, it applies to all runs of this pipeline by default. see [Parallelism Configuration](#parallelism-configuration) details below.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 


### PR DESCRIPTION
### Description
Minor documentation fix for resource [aws_sagemaker_pipeline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sagemaker_pipeline), had description for pipeline name in the argument `role_arn`

![image](https://github.com/hashicorp/terraform-provider-aws/assets/29043118/fcad6458-5aeb-4ad2-819b-db7b089e8a81)



