### PR TITLE
WIP DMS: Pass timeout through function calls

### DIFF
--- a/internal/service/dms/replication_instance_test.go
+++ b/internal/service/dms/replication_instance_test.go
@@ -48,7 +48,7 @@ func TestAccDMSReplicationInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "replication_instance_class", replicationInstanceClass),
 					resource.TestCheckResourceAttr(resourceName, "replication_instance_id", rName),
 					resource.TestCheckResourceAttr(resourceName, "replication_instance_private_ips.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "replication_instance_public_ips.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "replication_instance_public_ips.#", "0"),
 					resource.TestCheckResourceAttrSet(resourceName, "replication_subnet_group_id"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "vpc_security_group_ids.#", "1"),

--- a/internal/service/dms/replication_task.go
+++ b/internal/service/dms/replication_task.go
@@ -129,11 +129,15 @@ func ResourceReplicationTask() *schema.Resource {
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
+
+		Timeouts: &schema.ResourceTimeout{},
 	}
 }
 
 func resourceReplicationTaskCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
+	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutCreate))
+	defer cancel()
 	conn := meta.(*conns.AWSClient).DMSConn(ctx)
 
 	taskID := d.Get("replication_task_id").(string)
@@ -176,7 +180,7 @@ func resourceReplicationTaskCreate(ctx context.Context, d *schema.ResourceData, 
 
 	d.SetId(taskID)
 
-	if _, err := waitReplicationTaskReady(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
+	if _, err := waitReplicationTaskReady(ctx, conn, d.Id()); err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for DMS Replication Task (%s) create: %s", d.Id(), err)
 	}
 
@@ -221,6 +225,8 @@ func resourceReplicationTaskRead(ctx context.Context, d *schema.ResourceData, me
 
 func resourceReplicationTaskUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
+	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutUpdate))
+	defer cancel()
 	conn := meta.(*conns.AWSClient).DMSConn(ctx)
 
 	if d.HasChangesExcept("tags", "tags_all", "replication_instance_arn", "start_replication_task") {
@@ -265,7 +271,7 @@ func resourceReplicationTaskUpdate(ctx context.Context, d *schema.ResourceData, 
 			return sdkdiag.AppendErrorf(diags, "modifying DMS Replication Task (%s): %s", d.Id(), err)
 		}
 
-		if _, err := waitReplicationTaskModified(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
+		if _, err := waitReplicationTaskModified(ctx, conn, d.Id()); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for DMS Replication Task (%s) update: %s", d.Id(), err)
 		}
 
@@ -292,7 +298,7 @@ func resourceReplicationTaskUpdate(ctx context.Context, d *schema.ResourceData, 
 			return sdkdiag.AppendErrorf(diags, "moving DMS Replication Task (%s): %s", d.Id(), err)
 		}
 
-		if _, err := waitReplicationTaskMoved(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
+		if _, err := waitReplicationTaskMoved(ctx, conn, d.Id()); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for DMS Replication Task (%s) update: %s", d.Id(), err)
 		}
 
@@ -320,6 +326,8 @@ func resourceReplicationTaskUpdate(ctx context.Context, d *schema.ResourceData, 
 
 func resourceReplicationTaskDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
+	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutDelete))
+	defer cancel()
 	conn := meta.(*conns.AWSClient).DMSConn(ctx)
 
 	if err := stopReplicationTask(ctx, conn, d.Id()); err != nil {
@@ -339,7 +347,7 @@ func resourceReplicationTaskDelete(ctx context.Context, d *schema.ResourceData, 
 		return sdkdiag.AppendErrorf(diags, "deleting DMS Replication Task (%s): %s", d.Id(), err)
 	}
 
-	if _, err := waitReplicationTaskDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
+	if _, err := waitReplicationTaskDeleted(ctx, conn, d.Id()); err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for DMS Replication Task (%s) delete: %s", d.Id(), err)
 	}
 
@@ -429,12 +437,13 @@ func setLastReplicationTaskError(err error, replication *dms.ReplicationTask) {
 	tfresource.SetLastError(err, errors.Join(errs...))
 }
 
-func waitReplicationTaskDeleted(ctx context.Context, conn *dms.DatabaseMigrationService, id string, timeout time.Duration) (*dms.ReplicationTask, error) {
+func waitReplicationTaskDeleted(ctx context.Context, conn *dms.DatabaseMigrationService, id string) (*dms.ReplicationTask, error) {
+	expiration, _ := ctx.Deadline()
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{replicationTaskStatusDeleting},
 		Target:     []string{},
 		Refresh:    statusReplicationTask(ctx, conn, id),
-		Timeout:    timeout,
+		Timeout:    time.Until(expiration),
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second,
 	}
@@ -449,12 +458,13 @@ func waitReplicationTaskDeleted(ctx context.Context, conn *dms.DatabaseMigration
 	return nil, err
 }
 
-func waitReplicationTaskModified(ctx context.Context, conn *dms.DatabaseMigrationService, id string, timeout time.Duration) (*dms.ReplicationTask, error) {
+func waitReplicationTaskModified(ctx context.Context, conn *dms.DatabaseMigrationService, id string) (*dms.ReplicationTask, error) {
+	expiration, _ := ctx.Deadline()
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{replicationTaskStatusModifying},
 		Target:     []string{replicationTaskStatusReady, replicationTaskStatusStopped, replicationTaskStatusFailed},
 		Refresh:    statusReplicationTask(ctx, conn, id),
-		Timeout:    timeout,
+		Timeout:    time.Until(expiration),
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second,
 	}
@@ -469,12 +479,13 @@ func waitReplicationTaskModified(ctx context.Context, conn *dms.DatabaseMigratio
 	return nil, err
 }
 
-func waitReplicationTaskMoved(ctx context.Context, conn *dms.DatabaseMigrationService, id string, timeout time.Duration) (*dms.ReplicationTask, error) {
+func waitReplicationTaskMoved(ctx context.Context, conn *dms.DatabaseMigrationService, id string) (*dms.ReplicationTask, error) {
+	expiration, _ := ctx.Deadline()
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{replicationTaskStatusModifying, replicationTaskStatusMoving},
 		Target:     []string{replicationTaskStatusReady, replicationTaskStatusStopped, replicationTaskStatusFailed},
 		Refresh:    statusReplicationTask(ctx, conn, id),
-		Timeout:    timeout,
+		Timeout:    time.Until(expiration),
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second,
 	}
@@ -489,12 +500,13 @@ func waitReplicationTaskMoved(ctx context.Context, conn *dms.DatabaseMigrationSe
 	return nil, err
 }
 
-func waitReplicationTaskReady(ctx context.Context, conn *dms.DatabaseMigrationService, id string, timeout time.Duration) (*dms.ReplicationTask, error) {
+func waitReplicationTaskReady(ctx context.Context, conn *dms.DatabaseMigrationService, id string) (*dms.ReplicationTask, error) {
+	expiration, _ := ctx.Deadline()
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{replicationTaskStatusCreating},
 		Target:     []string{replicationTaskStatusReady},
 		Refresh:    statusReplicationTask(ctx, conn, id),
-		Timeout:    timeout,
+		Timeout:    time.Until(expiration),
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second,
 	}
@@ -510,14 +522,12 @@ func waitReplicationTaskReady(ctx context.Context, conn *dms.DatabaseMigrationSe
 }
 
 func waitReplicationTaskRunning(ctx context.Context, conn *dms.DatabaseMigrationService, id string) (*dms.ReplicationTask, error) {
-	const (
-		timeout = 5 * time.Minute
-	)
+	expiration, _ := ctx.Deadline()
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{replicationTaskStatusStarting},
 		Target:     []string{replicationTaskStatusRunning},
 		Refresh:    statusReplicationTask(ctx, conn, id),
-		Timeout:    timeout,
+		Timeout:    time.Until(expiration),
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second,
 	}
@@ -533,14 +543,12 @@ func waitReplicationTaskRunning(ctx context.Context, conn *dms.DatabaseMigration
 }
 
 func waitReplicationTaskStopped(ctx context.Context, conn *dms.DatabaseMigrationService, id string) (*dms.ReplicationTask, error) {
-	const (
-		timeout = 5 * time.Minute
-	)
+	expiration, _ := ctx.Deadline()
 	stateConf := &retry.StateChangeConf{
 		Pending:                   []string{replicationTaskStatusStopping, replicationTaskStatusRunning},
 		Target:                    []string{replicationTaskStatusStopped},
 		Refresh:                   statusReplicationTask(ctx, conn, id),
-		Timeout:                   timeout,
+		Timeout:                   time.Until(expiration),
 		MinTimeout:                10 * time.Second,
 		Delay:                     60 * time.Second,
 		ContinuousTargetOccurence: 2,
@@ -557,14 +565,12 @@ func waitReplicationTaskStopped(ctx context.Context, conn *dms.DatabaseMigration
 }
 
 func waitReplicationTaskSteady(ctx context.Context, conn *dms.DatabaseMigrationService, id string) (*dms.ReplicationTask, error) {
-	const (
-		timeout = 5 * time.Minute
-	)
+	expiration, _ := ctx.Deadline()
 	stateConf := &retry.StateChangeConf{
 		Pending:                   []string{replicationTaskStatusCreating, replicationTaskStatusDeleting, replicationTaskStatusModifying, replicationTaskStatusStopping, replicationTaskStatusStarting},
 		Target:                    []string{replicationTaskStatusFailed, replicationTaskStatusReady, replicationTaskStatusStopped, replicationTaskStatusRunning},
 		Refresh:                   statusReplicationTask(ctx, conn, id),
-		Timeout:                   timeout,
+		Timeout:                   time.Until(expiration),
 		MinTimeout:                10 * time.Second,
 		Delay:                     60 * time.Second,
 		ContinuousTargetOccurence: 2,

--- a/internal/service/dms/replication_task_test.go
+++ b/internal/service/dms/replication_task_test.go
@@ -336,8 +336,8 @@ func TestAccDMSReplicationTask_settings_LogComponents(t *testing.T) {
 					acctest.CheckResourceAttrJMES(resourceName, "replication_task_settings", "Logging.EnableLogging", "true"),
 					acctest.CheckResourceAttrJMES(resourceName, "replication_task_settings", "Logging.EnableLogContext", "false"),
 					acctest.CheckResourceAttrJMES(resourceName, "replication_task_settings", "Logging.LogComponents[?Id=='DATA_STRUCTURE'].Severity | [0]", "LOGGER_SEVERITY_WARNING"),
-					acctest.CheckResourceAttrJMES(resourceName, "replication_task_settings", "type(Logging.CloudWatchLogGroup)", "null"),
-					acctest.CheckResourceAttrJMES(resourceName, "replication_task_settings", "type(Logging.CloudWatchLogStream)", "null"),
+					acctest.CheckResourceAttrJMES(resourceName, "replication_task_settings", "type(Logging.CloudWatchLogGroup)", "string"),
+					acctest.CheckResourceAttrJMES(resourceName, "replication_task_settings", "type(Logging.CloudWatchLogStream)", "string"),
 				),
 			},
 			{

--- a/internal/service/dms/s3_endpoint.go
+++ b/internal/service/dms/s3_endpoint.go
@@ -547,6 +547,8 @@ func resourceS3EndpointUpdate(ctx context.Context, d *schema.ResourceData, meta 
 
 func resourceS3EndpointDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
+	ctx, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutDelete))
+	defer cancel()
 	conn := meta.(*conns.AWSClient).DMSConn(ctx)
 
 	log.Printf("[DEBUG] Deleting DMS Endpoint: (%s)", d.Id())
@@ -562,7 +564,7 @@ func resourceS3EndpointDelete(ctx context.Context, d *schema.ResourceData, meta 
 		return create.AppendDiagError(diags, names.DMS, create.ErrActionDeleting, ResNameS3Endpoint, d.Id(), err)
 	}
 
-	if err = waitEndpointDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
+	if err = waitEndpointDeleted(ctx, conn, d.Id()); err != nil {
 		return create.AppendDiagError(diags, names.DMS, create.ErrActionWaitingForDeletion, ResNameS3Endpoint, d.Id(), err)
 	}
 


### PR DESCRIPTION
These hard coded timeouts in waiters are being exceeded and there's currently no way to configure them. This passes through remaining time

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
More configurable DMS task timeouts.


### Relations
Closes https://github.com/hashicorp/terraform-provider-aws/issues/37026

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```

TODO
~- Update DMS task resource so the `timeout {}` block works~
~- Switch to using ctx.WithTimeout instead of passing around time.Duration~
- Tests