### PR TITLE
`r/kms_key`: add support for `rotation_period_in_days`

### DIFF
--- a/.changelog/37140.txt
+++ b/.changelog/37140.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_kms_key: Add rotation_period_in_days argument
+```

--- a/.changelog/37140.txt
+++ b/.changelog/37140.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_kms_key: Add rotation_period_in_days argument
+resource/aws_kms_key: Add `rotation_period_in_days` argument
 ```

--- a/internal/service/kms/key.go
+++ b/internal/service/kms/key.go
@@ -88,6 +88,13 @@ func resourceKey() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"rotation_period_in_days": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntBetween(90, 2560),
+				RequiredWith: []string{"enable_key_rotation"},
+			},
 			"is_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -189,8 +196,8 @@ func resourceKeyCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 
 	ctx = tflog.SetField(ctx, logging.KeyResourceId, d.Id())
 
-	if enableKeyRotation := d.Get("enable_key_rotation").(bool); enableKeyRotation {
-		if err := updateKeyRotationEnabled(ctx, conn, "KMS Key", d.Id(), enableKeyRotation); err != nil {
+	if enableKeyRotation, rotationPeriod := d.Get("enable_key_rotation").(bool), d.Get("rotation_period_in_days").(int); enableKeyRotation {
+		if err := updateKeyRotationEnabled(ctx, conn, "KMS Key", d.Id(), enableKeyRotation, rotationPeriod); err != nil {
 			return sdkdiag.AppendFromErr(diags, err)
 		}
 	}
@@ -244,6 +251,7 @@ func resourceKeyRead(ctx context.Context, d *schema.ResourceData, meta interface
 	d.Set("customer_master_key_spec", key.metadata.CustomerMasterKeySpec)
 	d.Set("description", key.metadata.Description)
 	d.Set("enable_key_rotation", key.rotation)
+	d.Set("rotation_period_in_days", key.rotation_period_in_days)
 	d.Set("is_enabled", key.metadata.Enabled)
 	d.Set("key_id", key.metadata.KeyId)
 	d.Set("key_usage", key.metadata.KeyUsage)
@@ -279,8 +287,10 @@ func resourceKeyUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 		}
 	}
 
-	if hasChange, enable := d.HasChange("enable_key_rotation"), d.Get("enable_key_rotation").(bool); hasChange {
-		if err := updateKeyRotationEnabled(ctx, conn, "KMS Key", d.Id(), enable); err != nil {
+	if hasChange, hasChangedRotationPeriod,
+		enable, rotationPeriod := d.HasChange("enable_key_rotation"), d.HasChange("rotation_period_in_days"),
+		d.Get("enable_key_rotation").(bool), d.Get("rotation_period_in_days").(int); hasChange || (enable && hasChangedRotationPeriod) {
+		if err := updateKeyRotationEnabled(ctx, conn, "KMS Key", d.Id(), enable, rotationPeriod); err != nil {
 			return sdkdiag.AppendFromErr(diags, err)
 		}
 	}
@@ -344,10 +354,11 @@ func resourceKeyDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 }
 
 type kmsKeyInfo struct {
-	metadata *awstypes.KeyMetadata
-	policy   string
-	rotation *bool
-	tags     []awstypes.Tag
+	metadata                *awstypes.KeyMetadata
+	policy                  string
+	rotation                *bool
+	rotation_period_in_days *int32
+	tags                    []awstypes.Tag
 }
 
 func findKeyInfo(ctx context.Context, conn *kms.Client, keyID string, isNewResource bool) (*kmsKeyInfo, error) {
@@ -375,7 +386,7 @@ func findKeyInfo(ctx context.Context, conn *kms.Client, keyID string, isNewResou
 		}
 
 		if key.metadata.Origin == awstypes.OriginTypeAwsKms {
-			key.rotation, err = findKeyRotationEnabledByKeyID(ctx, conn, keyID)
+			key.rotation, key.rotation_period_in_days, err = findKeyRotationEnabledByKeyID(ctx, conn, keyID)
 
 			if err != nil {
 				return nil, fmt.Errorf("reading KMS Key (%s) rotation enabled: %w", keyID, err)
@@ -486,7 +497,7 @@ func findKeyPolicyByTwoPartKey(ctx context.Context, conn *kms.Client, keyID, pol
 	return output.Policy, nil
 }
 
-func findKeyRotationEnabledByKeyID(ctx context.Context, conn *kms.Client, keyID string) (*bool, error) {
+func findKeyRotationEnabledByKeyID(ctx context.Context, conn *kms.Client, keyID string) (*bool, *int32, error) {
 	input := &kms.GetKeyRotationStatusInput{
 		KeyId: aws.String(keyID),
 	}
@@ -494,21 +505,21 @@ func findKeyRotationEnabledByKeyID(ctx context.Context, conn *kms.Client, keyID 
 	output, err := conn.GetKeyRotationStatus(ctx, input)
 
 	if errs.IsA[*awstypes.NotFoundException](err) {
-		return nil, &retry.NotFoundError{
+		return nil, nil, &retry.NotFoundError{
 			LastError:   err,
 			LastRequest: input,
 		}
 	}
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	if output == nil {
-		return nil, tfresource.NewEmptyResultError(input)
+		return nil, nil, tfresource.NewEmptyResultError(input)
 	}
 
-	return aws.Bool(output.KeyRotationEnabled), nil
+	return aws.Bool(output.KeyRotationEnabled), output.RotationPeriodInDays, nil
 }
 
 func updateKeyDescription(ctx context.Context, conn *kms.Client, resourceTypeName, keyID, description string) error {
@@ -597,7 +608,7 @@ func updateKeyPolicy(ctx context.Context, conn *kms.Client, resourceTypeName, ke
 	return nil
 }
 
-func updateKeyRotationEnabled(ctx context.Context, conn *kms.Client, resourceTypeName, keyID string, enabled bool) error {
+func updateKeyRotationEnabled(ctx context.Context, conn *kms.Client, resourceTypeName, keyID string, enabled bool, rotationPeriod int) error {
 	var action string
 
 	updateFunc := func() (interface{}, error) {
@@ -605,9 +616,13 @@ func updateKeyRotationEnabled(ctx context.Context, conn *kms.Client, resourceTyp
 
 		if enabled {
 			action = "enabling"
-			_, err = conn.EnableKeyRotation(ctx, &kms.EnableKeyRotationInput{
+			input := kms.EnableKeyRotationInput{
 				KeyId: aws.String(keyID),
-			})
+			}
+			if rotationPeriod > 0 {
+				input.RotationPeriodInDays = aws.Int32(int32(rotationPeriod))
+			}
+			_, err = conn.EnableKeyRotation(ctx, &input)
 		} else {
 			action = "disabling"
 			_, err = conn.DisableKeyRotation(ctx, &kms.DisableKeyRotationInput{
@@ -623,7 +638,7 @@ func updateKeyRotationEnabled(ctx context.Context, conn *kms.Client, resourceTyp
 	}
 
 	// Wait for propagation since KMS is eventually consistent.
-	if err := waitKeyRotationEnabledPropagated(ctx, conn, keyID, enabled); err != nil {
+	if err := waitKeyRotationEnabledPropagated(ctx, conn, keyID, enabled, int32(rotationPeriod)); err != nil {
 		return fmt.Errorf("waiting for %s (%s) rotation update: %w", resourceTypeName, keyID, err)
 	}
 
@@ -722,9 +737,9 @@ func waitKeyPolicyPropagated(ctx context.Context, conn *kms.Client, keyID, polic
 	return tfresource.WaitUntil(ctx, timeout, checkFunc, opts)
 }
 
-func waitKeyRotationEnabledPropagated(ctx context.Context, conn *kms.Client, keyID string, enabled bool) error {
+func waitKeyRotationEnabledPropagated(ctx context.Context, conn *kms.Client, keyID string, enabled bool, rotationPeriod int32) error {
 	checkFunc := func() (bool, error) {
-		output, err := findKeyRotationEnabledByKeyID(ctx, conn, keyID)
+		rotation, rotationPeriodConsolidated, err := findKeyRotationEnabledByKeyID(ctx, conn, keyID)
 
 		if tfresource.NotFound(err) {
 			return false, nil
@@ -734,7 +749,11 @@ func waitKeyRotationEnabledPropagated(ctx context.Context, conn *kms.Client, key
 			return false, err
 		}
 
-		return aws.ToBool(output) == enabled, nil
+		if rotationPeriod != 0 && rotationPeriodConsolidated != nil {
+			return aws.ToBool(rotation) == enabled && aws.ToInt32(rotationPeriodConsolidated) == rotationPeriod, nil
+		}
+
+		return aws.ToBool(rotation) == enabled, nil
 	}
 	opts := tfresource.WaitOpts{
 		ContinuousTargetOccurence: 5,

--- a/website/docs/r/kms_key.html.markdown
+++ b/website/docs/r/kms_key.html.markdown
@@ -45,7 +45,8 @@ The default value is `false`.
 If you specify a value, it must be between `7` and `30`, inclusive. If you do not specify a value, it defaults to `30`.
 If the KMS key is a multi-Region primary key with replicas, the waiting period begins when the last of its replica keys is deleted. Otherwise, the waiting period begins immediately.
 * `is_enabled` - (Optional) Specifies whether the key is enabled. Defaults to `true`.
-* `enable_key_rotation` - (Optional) Specifies whether [key rotation](http://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html) is enabled. Defaults to `false`.
+* `enable_key_rotation` - (Optional, required to be enabled if `rotation_period_in_days` is specified) Specifies whether [key rotation](http://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html) is enabled. Defaults to `false`.
+* `rotation_period_in_days` - (Optional) Custom period of time between each rotation date. Must be a number between 90 and 2560 (inclusive).
 * `multi_region` - (Optional) Indicates whether the KMS key is a multi-Region (`true`) or regional (`false`) key. Defaults to `false`.
 * `tags` - (Optional) A map of tags to assign to the object. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `xks_key_id` - (Optional) Identifies the external key that serves as key material for the KMS key in an external key store.


### PR DESCRIPTION
### Description
`rotation_period_in_days` enables a custom rotation period when you enable key rotation.

I've included it as an argument instead of using a separate resource, as enablement of key rotation was already included in the `aws_kms_key` resource.

**Edit:** I've rebased on `main` as #37092 is now merged

### Relations
Closes #36948

### References
[RotationPeriodInDays AWS docs](https://docs.aws.amazon.com/kms/latest/APIReference/API_EnableKeyRotation.html#API_EnableKeyRotation_RequestSyntax)


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccKMSKey_rotation PKG=kms 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/kms/... -v -count 1 -parallel 20 -run='TestAccKMSKey_rotation'  -timeout 360m
=== RUN   TestAccKMSKey_rotation
=== PAUSE TestAccKMSKey_rotation
=== CONT  TestAccKMSKey_rotation
--- PASS: TestAccKMSKey_rotation (44.54s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kms        48.404s
```
