### PR TITLE
Tech debt: Move `verify/ResourceDiffer` to `sdkv2` package

### DIFF
--- a/.teamcity/scripts/provider_tests/acceptance_tests.sh
+++ b/.teamcity/scripts/provider_tests/acceptance_tests.sh
@@ -51,6 +51,7 @@ TF_ACC=1 go test \
     ./internal/provider/... \
     ./internal/retry/... \
     ./internal/sdkv2/... \
+    ./internal/semver/... \
     ./internal/slices/... \
     ./internal/sweep/... \
     ./internal/tags/... \

--- a/.teamcity/scripts/provider_tests/unit_tests.sh
+++ b/.teamcity/scripts/provider_tests/unit_tests.sh
@@ -23,6 +23,7 @@ go test \
     ./internal/provider/... \
     ./internal/retry/... \
     ./internal/sdkv2/... \
+    ./internal/semver/... \
     ./internal/slices/... \
     ./internal/sweep/... \
     ./internal/tags/... \

--- a/internal/sdkv2/resource_differ.go
+++ b/internal/sdkv2/resource_differ.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-package verify
+package sdkv2
 
 // ResourceDiffer exposes the interface for accessing changes in a resource
 // Implementations:

--- a/internal/semver/semver.go
+++ b/internal/semver/semver.go
@@ -1,15 +1,15 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-package verify
+package semver
 
 import (
 	gversion "github.com/hashicorp/go-version"
 )
 
-// SemVerLessThan returns whether or not the first version string is less than the second
+// LessThan returns whether or not the first version string is less than the second
 // according to Semantic Versioning rules (https://semver.org/).
-func SemVerLessThan(s1, s2 string) bool {
+func LessThan(s1, s2 string) bool {
 	v1, v2, err := parseVersions(s1, s2)
 
 	if err != nil {
@@ -19,9 +19,9 @@ func SemVerLessThan(s1, s2 string) bool {
 	return v1.LessThan(v2)
 }
 
-// SemVerGreaterThanOrEqual returns whether or not the first version string is greater than or equal
+// GreaterThanOrEqual returns whether or not the first version string is greater than or equal
 // to the second according to Semantic Versioning rules (https://semver.org/).
-func SemVerGreaterThanOrEqual(s1, s2 string) bool {
+func GreaterThanOrEqual(s1, s2 string) bool {
 	v1, v2, err := parseVersions(s1, s2)
 
 	if err != nil {
@@ -43,5 +43,6 @@ func parseVersions(s1, s2 string) (*gversion.Version, *gversion.Version, error) 
 	if err != nil {
 		return nil, nil, err
 	}
+
 	return v1, v2, nil
 }

--- a/internal/semver/semver_test.go
+++ b/internal/semver/semver_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-package verify
+package semver
 
 import (
 	"testing"
@@ -21,7 +21,7 @@ func TestSemVerLessThan(t *testing.T) {
 		{"2", "10", true},
 		{"abc", "xyz", false},
 	} {
-		lt := SemVerLessThan(tc.s1, tc.s2)
+		lt := LessThan(tc.s1, tc.s2)
 		if tc.lt != lt {
 			t.Fatalf("SemVerLessThan(%q, %q) should be: %t", tc.s1, tc.s2, tc.lt)
 		}
@@ -42,7 +42,7 @@ func TestSemVerGreaterThanOrEqual(t *testing.T) {
 		{"2", "10", false},
 		{"abc", "xyz", false},
 	} {
-		lt := SemVerGreaterThanOrEqual(tc.s1, tc.s2)
+		lt := GreaterThanOrEqual(tc.s1, tc.s2)
 		if tc.lt != lt {
 			t.Fatalf("SemVerGreaterThanOrEqual(%q, %q) should be: %t", tc.s1, tc.s2, tc.lt)
 		}

--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2/types/nullable"
+	"github.com/hashicorp/terraform-provider-aws/internal/semver"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -391,7 +392,7 @@ func ResourceReplicationGroup() *schema.Resource {
 			customdiff.ForceNewIf("transit_encryption_enabled", func(_ context.Context, d *schema.ResourceDiff, meta interface{}) bool {
 				// For Redis engine versions < 7.0.5, transit_encryption_enabled can only
 				// be configured during creation of the cluster.
-				return verify.SemVerLessThan(d.Get("engine_version_actual").(string), "7.0.5")
+				return semver.LessThan(d.Get("engine_version_actual").(string), "7.0.5")
 			}),
 			verify.SetTagsDiff,
 		),

--- a/internal/service/elasticsearch/domain.go
+++ b/internal/service/elasticsearch/domain.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/semver"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -891,7 +892,7 @@ func resourceDomainUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 					input.ElasticsearchClusterConfig = expandClusterConfig(m)
 
 					// Work around "ValidationException: Your domain's Elasticsearch version does not support cold storage options. Upgrade to Elasticsearch 7.9 or later.".
-					if verify.SemVerLessThan(d.Get("elasticsearch_version").(string), "7.9") {
+					if semver.LessThan(d.Get("elasticsearch_version").(string), "7.9") {
 						input.ElasticsearchClusterConfig.ColdStorageOptions = nil
 					}
 				}
@@ -1028,7 +1029,7 @@ func resourceDomainImport(ctx context.Context, d *schema.ResourceData, meta inte
 // inPlaceEncryptionEnableVersion returns true if, based on version, encryption
 // can be enabled in place (without ForceNew)
 func inPlaceEncryptionEnableVersion(version string) bool {
-	return verify.SemVerGreaterThanOrEqual(version, "6.7")
+	return semver.GreaterThanOrEqual(version, "6.7")
 }
 
 func suppressEquivalentKMSKeyIDs(k, old, new string, d *schema.ResourceData) bool {

--- a/internal/service/kafka/cluster.go
+++ b/internal/service/kafka/cluster.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/semver"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -51,7 +52,7 @@ func resourceCluster() *schema.Resource {
 
 		CustomizeDiff: customdiff.Sequence(
 			customdiff.ForceNewIfChange("kafka_version", func(_ context.Context, old, new, meta interface{}) bool {
-				return verify.SemVerLessThan(new.(string), old.(string))
+				return semver.LessThan(new.(string), old.(string))
 			}),
 			verify.SetTagsDiff,
 		),

--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -1283,7 +1284,7 @@ func updateComputedAttributesOnPublish(_ context.Context, d *schema.ResourceDiff
 	return nil
 }
 
-func needsFunctionCodeUpdate(d verify.ResourceDiffer) bool {
+func needsFunctionCodeUpdate(d sdkv2.ResourceDiffer) bool {
 	return d.HasChange("filename") ||
 		d.HasChange("source_code_hash") ||
 		d.HasChange("s3_bucket") ||
@@ -1293,7 +1294,7 @@ func needsFunctionCodeUpdate(d verify.ResourceDiffer) bool {
 		d.HasChange("architectures")
 }
 
-func needsFunctionConfigUpdate(d verify.ResourceDiffer) bool {
+func needsFunctionConfigUpdate(d sdkv2.ResourceDiffer) bool {
 	return d.HasChange("description") ||
 		d.HasChange("handler") ||
 		d.HasChange("file_system_config") ||

--- a/internal/service/lambda/layer_version_permission.go
+++ b/internal/service/lambda/layer_version_permission.go
@@ -155,7 +155,7 @@ func resourceLayerVersionPermissionRead(ctx context.Context, d *schema.ResourceD
 	d.Set("policy", layerVersionPolicyOutput.Policy)
 	d.Set("revision_id", layerVersionPolicyOutput.RevisionId)
 
-	if policyDoc != nil && len(policyDoc.Statements) > 0 {
+	if len(policyDoc.Statements) > 0 {
 		d.Set("statement_id", policyDoc.Statements[0].Sid)
 
 		if actions := policyDoc.Statements[0].Actions; actions != nil {

--- a/internal/service/lexmodels/bot.go
+++ b/internal/service/lexmodels/bot.go
@@ -19,8 +19,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
-	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 // @SDKResource("aws_lex_bot")
@@ -189,7 +189,7 @@ func updateComputedAttributesOnBotCreateVersion(_ context.Context, d *schema.Res
 	return nil
 }
 
-func hasBotConfigChanges(d verify.ResourceDiffer) bool {
+func hasBotConfigChanges(d sdkv2.ResourceDiffer) bool {
 	for _, key := range []string{
 		"description",
 		"child_directed",

--- a/internal/service/lexmodels/intent.go
+++ b/internal/service/lexmodels/intent.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
@@ -267,7 +268,7 @@ func updateComputedAttributesOnIntentCreateVersion(_ context.Context, d *schema.
 	return nil
 }
 
-func hasIntentConfigChanges(d verify.ResourceDiffer) bool {
+func hasIntentConfigChanges(d sdkv2.ResourceDiffer) bool {
 	for _, key := range []string{
 		"description",
 		"conclusion_statement",

--- a/internal/service/lexmodels/slot_type.go
+++ b/internal/service/lexmodels/slot_type.go
@@ -18,8 +18,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
-	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 const (
@@ -125,7 +125,7 @@ func updateComputedAttributesOnSlotTypeCreateVersion(_ context.Context, d *schem
 	return nil
 }
 
-func hasSlotTypeConfigChanges(d verify.ResourceDiffer) bool {
+func hasSlotTypeConfigChanges(d sdkv2.ResourceDiffer) bool {
 	for _, key := range []string{
 		"description",
 		"enumeration_value",

--- a/internal/service/opensearch/domain.go
+++ b/internal/service/opensearch/domain.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/semver"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -998,7 +999,7 @@ func resourceDomainUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 					if engineType, version, err := ParseEngineVersion(d.Get("engine_version").(string)); err == nil {
 						switch engineType {
 						case opensearchservice.EngineTypeElasticsearch:
-							if verify.SemVerLessThan(version, "7.9") {
+							if semver.LessThan(version, "7.9") {
 								input.ClusterConfig.ColdStorageOptions = nil
 							}
 						case opensearchservice.EngineTypeOpenSearch:
@@ -1155,7 +1156,7 @@ func inPlaceEncryptionEnableVersion(version string) bool {
 	if engineType, version, err := ParseEngineVersion(version); err == nil {
 		switch engineType {
 		case opensearchservice.EngineTypeElasticsearch:
-			if verify.SemVerGreaterThanOrEqual(version, "6.7") {
+			if semver.GreaterThanOrEqual(version, "6.7") {
 				return true
 			}
 		case opensearchservice.EngineTypeOpenSearch:

--- a/internal/service/s3/bucket_object.go
+++ b/internal/service/s3/bucket_object.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/kms"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -535,7 +536,7 @@ func resourceBucketObjectCustomizeDiff(_ context.Context, d *schema.ResourceDiff
 	return nil
 }
 
-func hasBucketObjectContentChanges(d verify.ResourceDiffer) bool {
+func hasBucketObjectContentChanges(d sdkv2.ResourceDiffer) bool {
 	for _, key := range []string{
 		"bucket_key_enabled",
 		"cache_control",

--- a/internal/service/s3/object.go
+++ b/internal/service/s3/object.go
@@ -30,6 +30,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/kms"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -641,7 +642,7 @@ func resourceObjectCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta
 	return nil
 }
 
-func hasObjectContentChanges(d verify.ResourceDiffer) bool {
+func hasObjectContentChanges(d sdkv2.ResourceDiffer) bool {
 	for _, key := range []string{
 		"bucket_key_enabled",
 		"cache_control",
@@ -735,7 +736,7 @@ func sdkv1CompatibleCleanKey(key string) string {
 	return key
 }
 
-func ignoreProviderDefaultTags(ctx context.Context, d verify.ResourceDiffer) bool {
+func ignoreProviderDefaultTags(ctx context.Context, d sdkv2.ResourceDiffer) bool {
 	if v, ok := d.GetOk("override_provider"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 		if data := expandOverrideProviderModel(ctx, v.([]interface{})[0].(map[string]interface{})); data != nil && data.DefaultTagsConfig != nil {
 			return len(data.DefaultTagsConfig.Tags) == 0

--- a/internal/service/sns/topic.go
+++ b/internal/service/sns/topic.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2"
 	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -470,7 +471,7 @@ func putTopicAttribute(ctx context.Context, conn *sns.Client, arn string, name, 
 	return nil
 }
 
-func topicName(d verify.ResourceDiffer) string {
+func topicName(d sdkv2.ResourceDiffer) string {
 	optFns := []create.NameGeneratorOptionsFunc{create.WithConfiguredName(d.Get("name").(string)), create.WithConfiguredPrefix(d.Get("name_prefix").(string))}
 	if d.Get("fifo_topic").(bool) {
 		optFns = append(optFns, create.WithSuffix(fifoTopicNameSuffix))

--- a/internal/service/sqs/queue.go
+++ b/internal/service/sqs/queue.go
@@ -31,6 +31,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tfmaps "github.com/hashicorp/terraform-provider-aws/internal/maps"
+	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -385,7 +386,7 @@ func resourceQueueCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, me
 	return nil
 }
 
-func queueName(d verify.ResourceDiffer) string {
+func queueName(d sdkv2.ResourceDiffer) string {
 	optFns := []create.NameGeneratorOptionsFunc{create.WithConfiguredName(d.Get("name").(string)), create.WithConfiguredPrefix(d.Get("name_prefix").(string))}
 	if d.Get("fifo_queue").(bool) {
 		optFns = append(optFns, create.WithSuffix(fifoQueueNameSuffix))

--- a/internal/service/ssm/patch_baseline.go
+++ b/internal/service/ssm/patch_baseline.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -602,7 +603,7 @@ func resourceObjectCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta
 	return nil
 }
 
-func hasObjectContentChanges(d verify.ResourceDiffer) bool {
+func hasObjectContentChanges(d sdkv2.ResourceDiffer) bool {
 	for _, key := range []string{
 		"description",
 		"global_filter",


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Moves the `internal/verify/ResourceDiffer` type to the `internal/sdkv2` package.
