### PR TITLE
r/aws_vpc_endpoint: fix multiple services matched in DynamoDB gateway endpoint tests

### DIFF
--- a/.changelog/37180.txt
+++ b/.changelog/37180.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-r/aws_vpc_endpoint: fix multiple services matched in DynamoDB gateway endpoint tests
-```

--- a/.changelog/37180.txt
+++ b/.changelog/37180.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+r/aws_vpc_endpoint: fix multiple services matched in DynamoDB gateway endpoint tests
+```

--- a/internal/service/ec2/vpc_endpoint_test.go
+++ b/internal/service/ec2/vpc_endpoint_test.go
@@ -890,7 +890,7 @@ resource "aws_vpc_endpoint" "test" {
 func testAccVPCEndpointConfig_gatewayPolicy(rName, policy string) string {
 	return fmt.Sprintf(`
 data "aws_vpc_endpoint_service" "test" {
-  service = "dynamodb"
+  service      = "dynamodb"
   service_type = "Gateway"
 }
 
@@ -1171,7 +1171,7 @@ resource "aws_vpc_endpoint" "test" {
 func testAccVPCEndpointConfig_orderPolicy(rName string) string {
 	return fmt.Sprintf(`
 data "aws_vpc_endpoint_service" "test" {
-  service = "dynamodb"
+  service      = "dynamodb"
   service_type = "Gateway"
 }
 
@@ -1211,7 +1211,7 @@ resource "aws_vpc_endpoint" "test" {
 func testAccVPCEndpointConfig_newOrderPolicy(rName string) string {
 	return fmt.Sprintf(`
 data "aws_vpc_endpoint_service" "test" {
-  service = "dynamodb"
+  service      = "dynamodb"
   service_type = "Gateway"
 }
 

--- a/internal/service/ec2/vpc_endpoint_test.go
+++ b/internal/service/ec2/vpc_endpoint_test.go
@@ -891,6 +891,7 @@ func testAccVPCEndpointConfig_gatewayPolicy(rName, policy string) string {
 	return fmt.Sprintf(`
 data "aws_vpc_endpoint_service" "test" {
   service = "dynamodb"
+  service_type = "Gateway"
 }
 
 resource "aws_vpc" "test" {
@@ -1171,6 +1172,7 @@ func testAccVPCEndpointConfig_orderPolicy(rName string) string {
 	return fmt.Sprintf(`
 data "aws_vpc_endpoint_service" "test" {
   service = "dynamodb"
+  service_type = "Gateway"
 }
 
 resource "aws_vpc" "test" {
@@ -1210,6 +1212,7 @@ func testAccVPCEndpointConfig_newOrderPolicy(rName string) string {
 	return fmt.Sprintf(`
 data "aws_vpc_endpoint_service" "test" {
   service = "dynamodb"
+  service_type = "Gateway"
 }
 
 resource "aws_vpc" "test" {


### PR DESCRIPTION
### Description
Acceptance tests `TestAccVPCEndpoint_ignoreEquivalent` and `TestAccVPCEndpoint_gatewayPolicy` both use a data source to retrieve the service name for DynamoDB as part of testing gateway endpoints. AWS recently announced interface endpoint support for DynamoDB - previously DynamoDB supported a gateway endpoint only.  This changes updates the HCL in the acceptance tests to explicitly request a gateway type endpoint, preventing the tests from failing due to ambiguity about the requested endpoint type.

Before:
```
$ make testacc TESTS="TestAccVPCEndpoint_ignoreEquivalent|TestAccVPCEndpoint_gatewayPolicy" PKG=ec2                                
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCEndpoint_ignoreEquivalent|TestAccVPCEndpoint_gatewayPolicy'  -timeout 360m
=== RUN   TestAccVPCEndpoint_gatewayPolicy
=== PAUSE TestAccVPCEndpoint_gatewayPolicy
=== RUN   TestAccVPCEndpoint_ignoreEquivalent
=== PAUSE TestAccVPCEndpoint_ignoreEquivalent
=== CONT  TestAccVPCEndpoint_gatewayPolicy
=== CONT  TestAccVPCEndpoint_ignoreEquivalent
    vpc_endpoint_test.go:371: Step 1/2 error: Error running pre-apply plan: exit status 1
        
        Error: multiple EC2 VPC Endpoint Services matched; use additional constraints to reduce matches to a single EC2 VPC Endpoint Service
        
          with data.aws_vpc_endpoint_service.test,
          on terraform_plugin_test.tf line 12, in data "aws_vpc_endpoint_service" "test":
          12: data "aws_vpc_endpoint_service" "test" {
        
--- FAIL: TestAccVPCEndpoint_ignoreEquivalent (5.91s)
=== NAME  TestAccVPCEndpoint_gatewayPolicy
    vpc_endpoint_test.go:338: Step 1/3 error: Error running pre-apply plan: exit status 1
        
        Error: multiple EC2 VPC Endpoint Services matched; use additional constraints to reduce matches to a single EC2 VPC Endpoint Service
        
          with data.aws_vpc_endpoint_service.test,
          on terraform_plugin_test.tf line 12, in data "aws_vpc_endpoint_service" "test":
          12: data "aws_vpc_endpoint_service" "test" {
        
--- FAIL: TestAccVPCEndpoint_gatewayPolicy (6.01s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/ec2        13.457s
FAIL
make: *** [testacc] Error 1
```

After:
```
$ make testacc TESTS="TestAccVPCEndpoint_ignoreEquivalent|TestAccVPCEndpoint_gatewayPolicy" PKG=ec2                       
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCEndpoint_ignoreEquivalent|TestAccVPCEndpoint_gatewayPolicy'  -timeout 360m
=== RUN   TestAccVPCEndpoint_gatewayPolicy
=== PAUSE TestAccVPCEndpoint_gatewayPolicy
=== RUN   TestAccVPCEndpoint_ignoreEquivalent
=== PAUSE TestAccVPCEndpoint_ignoreEquivalent
=== CONT  TestAccVPCEndpoint_gatewayPolicy
=== CONT  TestAccVPCEndpoint_ignoreEquivalent
--- PASS: TestAccVPCEndpoint_ignoreEquivalent (45.25s)
--- PASS: TestAccVPCEndpoint_gatewayPolicy (62.37s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        68.961s
```

Note this does NOT address the failing acceptance test for `TestAccVPCEndpoint_interfaceWithSubnetAndSecurityGroup`, which appears to be unrelated (see #35747)

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #35747

### References
- https://aws.amazon.com/about-aws/whats-new/2024/03/amazon-dynamodb-aws-privatelink/


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS="TestAccVPCEndpoint_ignoreEquivalent|TestAccVPCEndpoint_gatewayPolicy" PKG=ec2                       
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCEndpoint_ignoreEquivalent|TestAccVPCEndpoint_gatewayPolicy'  -timeout 360m
=== RUN   TestAccVPCEndpoint_gatewayPolicy
=== PAUSE TestAccVPCEndpoint_gatewayPolicy
=== RUN   TestAccVPCEndpoint_ignoreEquivalent
=== PAUSE TestAccVPCEndpoint_ignoreEquivalent
=== CONT  TestAccVPCEndpoint_gatewayPolicy
=== CONT  TestAccVPCEndpoint_ignoreEquivalent
--- PASS: TestAccVPCEndpoint_ignoreEquivalent (45.25s)
--- PASS: TestAccVPCEndpoint_gatewayPolicy (62.37s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        68.961s
```
```
