### PR TITLE
bcmdataexports/export: Add test for bad column

### DIFF
--- a/.changelog/37189.txt
+++ b/.changelog/37189.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/aws_bcmdataexports_export: Including `line_item_resource_id` in the SQL query in `export.0.data_query.0.query_statement` results in an error, `ValidationException: The columns in the query provided are not a subset of the table COST_AND_USAGE_REPORT`; please contact AWS Support to inquiry further
+```

--- a/.changelog/37189.txt
+++ b/.changelog/37189.txt
@@ -1,3 +1,3 @@
 ```release-note:note
-resource/aws_bcmdataexports_export: Including `line_item_resource_id` in the SQL query in `export.0.data_query.0.query_statement` results in an error, `ValidationException: The columns in the query provided are not a subset of the table COST_AND_USAGE_REPORT`; please contact AWS Support to inquiry further
+resource/aws_bcmdataexports_export: Including `line_item_resource_id` in the SQL query in `export.0.data_query.0.query_statement` results in an error, `ValidationException: The columns in the query provided are not a subset of the table COST_AND_USAGE_REPORT`; please contact AWS Support to inquire further
 ```

--- a/internal/service/bcmdataexports/export.go
+++ b/internal/service/bcmdataexports/export.go
@@ -226,7 +226,7 @@ func (r *resourceExport) Create(ctx context.Context, req resource.CreateRequest,
 
 	plan.Export = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, export)
 
-	log.Printf("[WARN] export arn: %s", export.ExportArn)
+	log.Printf("[INFO] export arn: %s", export.ExportArn)
 
 	createTimeout := r.CreateTimeout(ctx, plan.Timeouts)
 	_, err = waitExportCreated(ctx, conn, plan.ID.ValueString(), createTimeout)

--- a/internal/service/bcmdataexports/export_test.go
+++ b/internal/service/bcmdataexports/export_test.go
@@ -607,7 +607,7 @@ resource "aws_bcmdataexports_export" "test" {
   export {
     name = %[1]q
     data_query {
-	  query_statement = %[2]q
+      query_statement = %[2]q
       table_configurations = {
         "COST_AND_USAGE_REPORT" = {
           "TIME_GRANULARITY"                      = "HOURLY",

--- a/internal/service/bcmdataexports/export_test.go
+++ b/internal/service/bcmdataexports/export_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/bcmdataexports"
@@ -61,6 +62,166 @@ func TestAccBCMDataExportsExport_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// TestAccBCMDataExportsExport_curSubset should work without "line_item_resource_id" being commented
+// out. However, there is a problem.
+// https://github.com/hashicorp/terraform-provider-aws/issues/37126
+func TestAccBCMDataExportsExport_curSubset(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var export bcmdataexports.GetExportOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_bcmdataexports_export.test"
+
+	columns := []string{
+		"bill_bill_type",
+		"bill_billing_entity",
+		"bill_billing_period_end_date",
+		"bill_billing_period_start_date",
+		"bill_invoice_id",
+		"bill_invoicing_entity",
+		"bill_payer_account_id",
+		"bill_payer_account_name",
+		"cost_category",
+		"discount",
+		"discount_bundled_discount",
+		"discount_total_discount",
+		"identity_line_item_id",
+		"identity_time_interval",
+		"line_item_availability_zone",
+		"line_item_blended_cost",
+		"line_item_blended_rate",
+		"line_item_currency_code",
+		"line_item_legal_entity",
+		"line_item_line_item_description",
+		"line_item_line_item_type",
+		"line_item_net_unblended_cost",
+		"line_item_net_unblended_rate",
+		"line_item_normalization_factor",
+		"line_item_normalized_usage_amount",
+		"line_item_operation",
+		"line_item_product_code",
+		//"line_item_resource_id", // ATM this column causes "ValidationException: The columns in the query provided are not a subset of the table COST_AND_USAGE_REPORT"
+		"line_item_tax_type",
+		"line_item_unblended_cost",
+		"line_item_unblended_rate",
+		"line_item_usage_account_id",
+		"line_item_usage_account_name",
+		"line_item_usage_amount",
+		"line_item_usage_end_date",
+		"line_item_usage_start_date",
+		"line_item_usage_type",
+		"pricing_currency",
+		"pricing_lease_contract_length",
+		"pricing_offering_class",
+		"pricing_public_on_demand_cost",
+		"pricing_public_on_demand_rate",
+		"pricing_purchase_option",
+		"pricing_rate_code",
+		"pricing_rate_id",
+		"pricing_term",
+		"pricing_unit",
+		"product",
+		"product_comment",
+		"product_fee_code",
+		"product_fee_description",
+		"product_from_location",
+		"product_from_location_type",
+		"product_from_region_code",
+		"product_instance_family",
+		"product_instance_type",
+		"product_instancesku",
+		"product_location",
+		"product_location_type",
+		"product_operation",
+		"product_pricing_unit",
+		"product_product_family",
+		"product_region_code",
+		"product_servicecode",
+		"product_sku",
+		"product_to_location",
+		"product_to_location_type",
+		"product_to_region_code",
+		"product_usagetype",
+		"reservation_amortized_upfront_cost_for_usage",
+		"reservation_amortized_upfront_fee_for_billing_period",
+		"reservation_availability_zone",
+		"reservation_effective_cost",
+		"reservation_end_time",
+		"reservation_modification_status",
+		"reservation_net_amortized_upfront_cost_for_usage",
+		"reservation_net_amortized_upfront_fee_for_billing_period",
+		"reservation_net_effective_cost",
+		"reservation_net_recurring_fee_for_usage",
+		"reservation_net_unused_amortized_upfront_fee_for_billing_period",
+		"reservation_net_unused_recurring_fee",
+		"reservation_net_upfront_value",
+		"reservation_normalized_units_per_reservation",
+		"reservation_number_of_reservations",
+		"reservation_recurring_fee_for_usage",
+		"reservation_reservation_a_r_n",
+		"reservation_start_time",
+		"reservation_subscription_id",
+		"reservation_total_reserved_normalized_units",
+		"reservation_total_reserved_units",
+		"reservation_units_per_reservation",
+		"reservation_unused_amortized_upfront_fee_for_billing_period",
+		"reservation_unused_normalized_unit_quantity",
+		"reservation_unused_quantity",
+		"reservation_unused_recurring_fee",
+		"reservation_upfront_value",
+		"resource_tags",
+		"savings_plan_amortized_upfront_commitment_for_billing_period",
+		"savings_plan_end_time",
+		"savings_plan_instance_type_family",
+		"savings_plan_net_amortized_upfront_commitment_for_billing_period",
+		"savings_plan_net_recurring_commitment_for_billing_period",
+		"savings_plan_net_savings_plan_effective_cost",
+		"savings_plan_offering_type",
+		"savings_plan_payment_option",
+		"savings_plan_purchase_term",
+		"savings_plan_recurring_commitment_for_billing_period",
+		"savings_plan_region",
+		"savings_plan_savings_plan_a_r_n",
+		"savings_plan_savings_plan_effective_cost",
+		"savings_plan_savings_plan_rate",
+		"savings_plan_start_time",
+		"savings_plan_total_commitment_to_date",
+		"savings_plan_used_commitment",
+	}
+	query := fmt.Sprintf("SELECT %s FROM COST_AND_USAGE_REPORT", strings.Join(columns, ", "))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionNot(t, names.USGovCloudPartitionID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckExportDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccExportConfig_curSubset(rName, query),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExportExists(ctx, resourceName, &export),
+					resource.TestCheckResourceAttr(resourceName, "export.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.name", rName),
+					resource.TestCheckResourceAttr(resourceName, "export.0.data_query.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "export.0.data_query.0.query_statement"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.data_query.0.table_configurations.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.destination_configurations.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.destination_configurations.0.s3_destination.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.refresh_cadence.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.refresh_cadence.0.frequency", "SYNCHRONOUS"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.data_query.0.table_configurations.COST_AND_USAGE_REPORT.TIME_GRANULARITY", "HOURLY"),
+				),
 			},
 		},
 	})
@@ -436,4 +597,45 @@ resource "aws_bcmdataexports_export" "test" {
   }
 }
 `, rName, queryStatement))
+}
+
+func testAccExportConfig_curSubset(rName, query string) string {
+	return acctest.ConfigCompose(
+		testAccExportConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_bcmdataexports_export" "test" {
+  export {
+    name = %[1]q
+    data_query {
+	  query_statement = %[2]q
+      table_configurations = {
+        "COST_AND_USAGE_REPORT" = {
+          "TIME_GRANULARITY"                      = "HOURLY",
+          "INCLUDE_RESOURCES"                     = "FALSE",
+          "INCLUDE_MANUAL_DISCOUNT_COMPATIBILITY" = "FALSE",
+          "INCLUDE_SPLIT_COST_ALLOCATION_DATA"    = "FALSE",
+        }
+      }
+    }
+
+    destination_configurations {
+      s3_destination {
+        s3_bucket = aws_s3_bucket.test.bucket
+        s3_prefix = aws_s3_bucket.test.bucket_prefix
+        s3_region = aws_s3_bucket.test.region
+        s3_output_configurations {
+          compression = "PARQUET"
+          format      = "PARQUET"
+          output_type = "CUSTOM"
+          overwrite   = "OVERWRITE_REPORT"
+        }
+      }
+    }
+
+    refresh_cadence {
+      frequency = "SYNCHRONOUS"
+    }
+  }
+}
+`, rName, query))
 }

--- a/website/docs/r/bcmdataexports_export.html.markdown
+++ b/website/docs/r/bcmdataexports_export.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Terraform resource for managing an AWS BCM Data Exports Export.
 
+~> **NOTE:** Including `line_item_resource_id` in the SQL query in `export.0.data_query.0.query_statement` results in an error, `ValidationException: The columns in the query provided are not a subset of the table COST_AND_USAGE_REPORT`. Based on [AWS Documentation](https://docs.aws.amazon.com/cur/latest/userguide/data-dictionary.html), `line_item_resource_id` should be a valid column but is currently causing errors.
+
 ## Example Usage
 
 ### Basic Usage


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR does not fix the issue but highlights it in a new test. The test `TestAccBCMDataExportsExport_curSubset` selects all the columns except `line_item_resource_id` and returns no error. 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #37126

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccBCMDataExportsExport_curSubset K=bcmdataexports
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/bcmdataexports/... -v -count 1 -parallel 20 -run='TestAccBCMDataExportsExport_curSubset'  -timeout 360m
=== RUN   TestAccBCMDataExportsExport_curSubset
=== PAUSE TestAccBCMDataExportsExport_curSubset
=== CONT  TestAccBCMDataExportsExport_curSubset
--- PASS: TestAccBCMDataExportsExport_curSubset (21.20s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/bcmdataexports	23.638s
```
