### PR TITLE
awssdkpatch: add PreCheckPartitionHasService patch 

### DIFF
--- a/docs/aws-go-sdk-migrations.md
+++ b/docs/aws-go-sdk-migrations.md
@@ -247,31 +247,31 @@ ValidateFunc: validation.StringInSlice(<service>.Thing_Values(), false),
 ValidateDiagFunc: enum.Validate[awstypes.Thing](),
 ```
 
-## Acceptance Testing `ErrorCheck`
+## Acceptance Testing `PreCheckPartitionHasService`
 
 With V1, this check relies on the endpoint ID constant included in the SDK.
-These are not included in the V2 SDK, but can be replaced with a generated constant from the `names` package.
+These are not included in the V2 SDK, but can be replaced with a constant from the `names` package.
 
 ```go
 // Remove
-ErrorCheck: acctest.ErrorCheck(t, <service>.EndpointsID),
+acctest.PreCheckPartitionHasService(t, <service>.EndpointsID),
 ```
 
 ```go
 // Add
-ErrorCheck: acctest.ErrorCheck(t, names.<service>ServiceID),
+acctest.PreCheckPartitionHasService(t, names.<Service>EndpointID),
 ```
 
 For example,
 
 ```
-ErrorCheck: acctest.ErrorCheck(t, ssoadmin.EndpointsID),
+acctest.PreCheckPartitionHasService(t, ssoadmin.EndpointsID),
 ```
 
 becomes:
 
 ```go
-ErrorCheck: acctest.ErrorCheck(t, names.SSOAdminServiceID),
+acctest.PreCheckPartitionHasService(t, names.SSOAdminEndpointID),
 ```
 
 ## Pagination

--- a/tools/awssdkpatch/patch.tmpl
+++ b/tools/awssdkpatch/patch.tmpl
@@ -45,6 +45,12 @@ var x identifier
 -aws.StringValueMap(x)
 +x
 
+# Replace endpoint constants which are not included in the V2 SDK
+@@
+@@
+-acctest.PreCheckPartitionHasService(t, {{ .GoV1Package }}.EndpointsID)
++acctest.PreCheckPartitionHasService(t, names.{{ .GoV1ClientTypeName }}EndpointID)
+
 # Step 2: Convert AWS SDK v1 (service) to v2
 @@
 var x identifier


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Replaces references to the `EndpointsID` constant in a given service package with a constant from the internal `names` package.

Also updates the AWS SDK migration guide to reflect that the `PreCheckPartitionHasService` function needs to be migrated, not `acctest.ErrorCheck`.