### PR TITLE
r/aws_bcmdataexports_export: fix error on table configuration

### DIFF
--- a/.changelog/37189.txt
+++ b/.changelog/37189.txt
@@ -1,3 +1,0 @@
-```release-note:note
-resource/aws_bcmdataexports_export: Including `line_item_resource_id` in the SQL query in `export.0.data_query.0.query_statement` results in an error, `ValidationException: The columns in the query provided are not a subset of the table COST_AND_USAGE_REPORT`; please contact AWS Support to inquire further
-```

--- a/.changelog/37205.txt
+++ b/.changelog/37205.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_bcmdataexports_export: Fix `table_configurations` expand/flatten
+```

--- a/internal/framework/flex/auto_expand.go
+++ b/internal/framework/flex/auto_expand.go
@@ -446,6 +446,48 @@ func (expander autoExpander) map_(ctx context.Context, vFrom basetypes.MapValuab
 	case basetypes.StringTypable:
 		diags.Append(expander.mapOfString(ctx, v, vTo)...)
 		return diags
+
+	case basetypes.MapTypable:
+		data, d := v.ToMapValue(ctx)
+		diags.Append(d...)
+		if diags.HasError() {
+			return diags
+		}
+		switch tMapElem := vTo.Type().Elem(); tMapElem.Kind() {
+		case reflect.Map:
+			//
+			// types.Map(OfMap) -> map[string]map[string]string.
+			//
+			switch k := tMapElem.Elem().Kind(); k {
+			case reflect.String:
+				var out map[string]map[string]string
+				diags.Append(data.ElementsAs(ctx, &out, false)...)
+
+				if diags.HasError() {
+					return diags
+				}
+
+				vTo.Set(reflect.ValueOf(out))
+				return diags
+
+			case reflect.Ptr:
+				switch k := tMapElem.Elem().Elem().Kind(); k {
+				case reflect.String:
+					//
+					// types.Map(OfMap) -> map[string]map[string]*string.
+					//
+					var to map[string]map[string]*string
+					diags.Append(data.ElementsAs(ctx, &to, false)...)
+
+					if diags.HasError() {
+						return diags
+					}
+
+					vTo.Set(reflect.ValueOf(to))
+					return diags
+				}
+			}
+		}
 	}
 
 	tflog.Info(ctx, "AutoFlex Expand; incompatible types", map[string]interface{}{

--- a/internal/framework/flex/auto_expand_test.go
+++ b/internal/framework/flex/auto_expand_test.go
@@ -450,6 +450,42 @@ func TestExpandGeneric(t *testing.T) {
 			},
 		},
 		{
+			TestName: "map of map of string",
+			Source: &TestFlexTF21{
+				Field1: fwtypes.NewMapValueOfMust[fwtypes.MapValueOf[types.String]](ctx, map[string]attr.Value{
+					"x": fwtypes.NewMapValueOfMust[types.String](ctx, map[string]attr.Value{
+						"y": types.StringValue("z"),
+					}),
+				}),
+			},
+			Target: &TestFlexAWS21{},
+			WantTarget: &TestFlexAWS21{
+				Field1: map[string]map[string]string{
+					"x": {
+						"y": "z",
+					},
+				},
+			},
+		},
+		{
+			TestName: "map of map of string pointer",
+			Source: &TestFlexTF21{
+				Field1: fwtypes.NewMapValueOfMust[fwtypes.MapValueOf[types.String]](ctx, map[string]attr.Value{
+					"x": fwtypes.NewMapValueOfMust[types.String](ctx, map[string]attr.Value{
+						"y": types.StringValue("z"),
+					}),
+				}),
+			},
+			Target: &TestFlexAWS22{},
+			WantTarget: &TestFlexAWS22{
+				Field1: map[string]map[string]*string{
+					"x": {
+						"y": aws.String("z"),
+					},
+				},
+			},
+		},
+		{
 			TestName: "nested string map",
 			Source: &TestFlexTF14{
 				FieldOuter: fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &TestFlexTF11{

--- a/internal/framework/flex/auto_flatten_test.go
+++ b/internal/framework/flex/auto_flatten_test.go
@@ -624,6 +624,42 @@ func TestFlattenGeneric(t *testing.T) {
 			},
 		},
 		{
+			TestName: "map of map of string",
+			Source: &TestFlexAWS21{
+				Field1: map[string]map[string]string{
+					"x": {
+						"y": "z",
+					},
+				},
+			},
+			Target: &TestFlexTF21{},
+			WantTarget: &TestFlexTF21{
+				Field1: fwtypes.NewMapValueOfMust[fwtypes.MapValueOf[types.String]](ctx, map[string]attr.Value{
+					"x": fwtypes.NewMapValueOfMust[types.String](ctx, map[string]attr.Value{
+						"y": types.StringValue("z"),
+					}),
+				}),
+			},
+		},
+		{
+			TestName: "map of map of string",
+			Source: &TestFlexAWS22{
+				Field1: map[string]map[string]*string{
+					"x": {
+						"y": aws.String("z"),
+					},
+				},
+			},
+			Target: &TestFlexTF21{},
+			WantTarget: &TestFlexTF21{
+				Field1: fwtypes.NewMapValueOfMust[fwtypes.MapValueOf[types.String]](ctx, map[string]attr.Value{
+					"x": fwtypes.NewMapValueOfMust[types.String](ctx, map[string]attr.Value{
+						"y": types.StringValue("z"),
+					}),
+				}),
+			},
+		},
+		{
 			TestName: "map block key list",
 			Source: &TestFlexMapBlockKeyAWS01{
 				MapBlock: map[string]TestFlexMapBlockKeyAWS02{

--- a/internal/framework/flex/auto_flatten_test.go
+++ b/internal/framework/flex/auto_flatten_test.go
@@ -642,7 +642,7 @@ func TestFlattenGeneric(t *testing.T) {
 			},
 		},
 		{
-			TestName: "map of map of string",
+			TestName: "map of map of string pointer",
 			Source: &TestFlexAWS22{
 				Field1: map[string]map[string]*string{
 					"x": {

--- a/internal/framework/flex/autoflex_test.go
+++ b/internal/framework/flex/autoflex_test.go
@@ -349,3 +349,15 @@ type TestFlexTF19 struct {
 type TestFlexTF20 struct {
 	Field1 fwtypes.SmithyJSON[smithyjson.JSONStringer] `tfsdk:"field1"`
 }
+
+type TestFlexTF21 struct {
+	Field1 fwtypes.MapValueOf[fwtypes.MapValueOf[types.String]] `tfsdk:"field1"`
+}
+
+type TestFlexAWS21 struct {
+	Field1 map[string]map[string]string
+}
+
+type TestFlexAWS22 struct {
+	Field1 map[string]map[string]*string
+}

--- a/internal/service/bcmdataexports/export.go
+++ b/internal/service/bcmdataexports/export.go
@@ -6,7 +6,6 @@ package bcmdataexports
 import (
 	"context"
 	"errors"
-	"log"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -14,7 +13,6 @@ import (
 	awstypes "github.com/aws/aws-sdk-go-v2/service/bcmdataexports/types"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
@@ -34,7 +32,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @FrameworkResource(name="Export")
+// @FrameworkResource("aws_bcmdataexports_export",name="Export")
 // @Tags(identifierAttribute="id")
 func newResourceExport(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &resourceExport{}
@@ -52,6 +50,7 @@ const (
 type resourceExport struct {
 	framework.ResourceWithConfigure
 	framework.WithTimeouts
+	framework.WithImportByID
 }
 
 func (r *resourceExport) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -72,6 +71,7 @@ func (r *resourceExport) Schema(ctx context.Context, req resource.SchemaRequest,
 					Optional:   true,
 					PlanModifiers: []planmodifier.Map{
 						mapplanmodifier.UseStateForUnknown(),
+						mapplanmodifier.RequiresReplace(),
 					},
 				},
 			},
@@ -85,14 +85,23 @@ func (r *resourceExport) Schema(ctx context.Context, req resource.SchemaRequest,
 				"compression": schema.StringAttribute{
 					Required:   true,
 					CustomType: fwtypes.StringEnumType[awstypes.CompressionOption](),
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.RequiresReplace(),
+					},
 				},
 				"format": schema.StringAttribute{
 					Required:   true,
 					CustomType: fwtypes.StringEnumType[awstypes.FormatOption](),
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.RequiresReplace(),
+					},
 				},
 				"output_type": schema.StringAttribute{
 					Required:   true,
 					CustomType: fwtypes.StringEnumType[awstypes.S3OutputType](),
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.RequiresReplace(),
+					},
 				},
 				"overwrite": schema.StringAttribute{
 					Required:   true,
@@ -108,12 +117,21 @@ func (r *resourceExport) Schema(ctx context.Context, req resource.SchemaRequest,
 			Attributes: map[string]schema.Attribute{
 				"s3_bucket": schema.StringAttribute{
 					Required: true,
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.RequiresReplace(),
+					},
 				},
 				"s3_prefix": schema.StringAttribute{
 					Required: true,
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.RequiresReplace(),
+					},
 				},
 				"s3_region": schema.StringAttribute{
 					Required: true,
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.RequiresReplace(),
+					},
 				},
 			},
 			Blocks: map[string]schema.Block{
@@ -138,6 +156,9 @@ func (r *resourceExport) Schema(ctx context.Context, req resource.SchemaRequest,
 				"frequency": schema.StringAttribute{
 					Required:   true,
 					CustomType: fwtypes.StringEnumType[awstypes.FrequencyOption](),
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.RequiresReplace(),
+					},
 				},
 			},
 		},
@@ -159,9 +180,15 @@ func (r *resourceExport) Schema(ctx context.Context, req resource.SchemaRequest,
 					Attributes: map[string]schema.Attribute{
 						"name": schema.StringAttribute{
 							Required: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.RequiresReplace(),
+							},
 						},
 						"description": schema.StringAttribute{
 							Optional: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.RequiresReplace(),
+							},
 						},
 						"export_arn": schema.StringAttribute{
 							Computed: true,
@@ -180,7 +207,6 @@ func (r *resourceExport) Schema(ctx context.Context, req resource.SchemaRequest,
 			"timeouts": timeouts.Block(ctx, timeouts.Opts{
 				Create: true,
 				Update: true,
-				Delete: true,
 			}),
 		},
 	}
@@ -211,6 +237,7 @@ func (r *resourceExport) Create(ctx context.Context, req resource.CreateRequest,
 		)
 		return
 	}
+
 	if out == nil {
 		resp.Diagnostics.AddError(
 			create.ProblemStandardMessage(names.BCMDataExports, create.ErrActionCreating, ResNameExport, "", nil),
@@ -221,20 +248,19 @@ func (r *resourceExport) Create(ctx context.Context, req resource.CreateRequest,
 
 	plan.ID = flex.StringToFramework(ctx, out.ExportArn)
 
-	export, _ := plan.Export.ToPtr(ctx)
-	export.ExportArn = flex.StringToFramework(ctx, out.ExportArn)
-
-	plan.Export = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, export)
-
-	log.Printf("[INFO] export arn: %s", export.ExportArn)
-
 	createTimeout := r.CreateTimeout(ctx, plan.Timeouts)
-	_, err = waitExportCreated(ctx, conn, plan.ID.ValueString(), createTimeout)
+	outRaw, err := waitExportCreated(ctx, conn, plan.ID.ValueString(), createTimeout)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			create.ProblemStandardMessage(names.BCMDataExports, create.ErrActionWaitingForCreation, ResNameExport, plan.ID.String(), err),
 			err.Error(),
 		)
+		return
+	}
+
+	resp.Diagnostics.Append(flex.Flatten(ctx, outRaw, &plan)...)
+
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -266,6 +292,11 @@ func (r *resourceExport) Read(ctx context.Context, req resource.ReadRequest, res
 	state.ID = flex.StringToFramework(ctx, out.Export.ExportArn)
 
 	resp.Diagnostics.Append(flex.Flatten(ctx, out, &state)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -348,18 +379,9 @@ func (r *resourceExport) Delete(ctx context.Context, req resource.DeleteRequest,
 	}
 }
 
-func (r *resourceExport) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
-}
-
 func (r *resourceExport) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
 	r.SetTagsAll(ctx, req, resp)
 }
-
-const (
-	statusHealthy   = awstypes.ExportStatusCodeHealthy
-	statusUnhealthy = awstypes.ExportStatusCodeUnhealthy
-)
 
 func waitExportCreated(ctx context.Context, conn *bcmdataexports.Client, id string, timeout time.Duration) (*bcmdataexports.GetExportOutput, error) {
 	stateConf := &retry.StateChangeConf{
@@ -408,7 +430,7 @@ func statusExport(ctx context.Context, conn *bcmdataexports.Client, id string) r
 			return nil, "", err
 		}
 
-		return out, string(statusHealthy), nil
+		return out, string(out.ExportStatus.StatusCode), nil
 	}
 }
 

--- a/internal/service/bcmdataexports/export.go
+++ b/internal/service/bcmdataexports/export.go
@@ -249,7 +249,7 @@ func (r *resourceExport) Create(ctx context.Context, req resource.CreateRequest,
 	plan.ID = flex.StringToFramework(ctx, out.ExportArn)
 
 	createTimeout := r.CreateTimeout(ctx, plan.Timeouts)
-	outRaw, err := waitExportCreated(ctx, conn, plan.ID.ValueString(), createTimeout)
+	outputRaw, err := waitExportCreated(ctx, conn, plan.ID.ValueString(), createTimeout)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			create.ProblemStandardMessage(names.BCMDataExports, create.ErrActionWaitingForCreation, ResNameExport, plan.ID.String(), err),
@@ -258,7 +258,7 @@ func (r *resourceExport) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	resp.Diagnostics.Append(flex.Flatten(ctx, outRaw, &plan)...)
+	resp.Diagnostics.Append(flex.Flatten(ctx, outputRaw, &plan)...)
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/service/bcmdataexports/export_test.go
+++ b/internal/service/bcmdataexports/export_test.go
@@ -143,8 +143,6 @@ func TestAccBCMDataExportsExport_update(t *testing.T) {
 	})
 }
 
-// TestAccBCMDataExportsExport_curSubset should work without "line_item_resource_id" being commented
-// out. However, there is a problem.
 // https://github.com/hashicorp/terraform-provider-aws/issues/37126
 func TestAccBCMDataExportsExport_curSubset(t *testing.T) {
 	ctx := acctest.Context(t)

--- a/internal/service/bcmdataexports/export_test.go
+++ b/internal/service/bcmdataexports/export_test.go
@@ -53,15 +53,91 @@ func TestAccBCMDataExportsExport_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "export.0.data_query.0.table_configurations.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "export.0.destination_configurations.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "export.0.destination_configurations.0.s3_destination.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.destination_configurations.0.s3_destination.0.s3_output_configurations.0.overwrite", "OVERWRITE_REPORT"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.destination_configurations.0.s3_destination.0.s3_output_configurations.0.format", "TEXT_OR_CSV"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.destination_configurations.0.s3_destination.0.s3_output_configurations.0.compression", "GZIP"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.destination_configurations.0.s3_destination.0.s3_output_configurations.0.output_type", "CUSTOM"),
 					resource.TestCheckResourceAttr(resourceName, "export.0.refresh_cadence.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "export.0.refresh_cadence.0.frequency", "SYNCHRONOUS"),
 					resource.TestCheckResourceAttr(resourceName, "export.0.data_query.0.table_configurations.COST_AND_USAGE_REPORT.TIME_GRANULARITY", "HOURLY"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.data_query.0.table_configurations.COST_AND_USAGE_REPORT.INCLUDE_RESOURCES", "FALSE"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.data_query.0.table_configurations.COST_AND_USAGE_REPORT.INCLUDE_MANUAL_DISCOUNT_COMPATIBILITY", "FALSE"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.data_query.0.table_configurations.COST_AND_USAGE_REPORT.INCLUDE_SPLIT_COST_ALLOCATION_DATA", "FALSE"),
 				),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccBCMDataExportsExport_update(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var export bcmdataexports.GetExportOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_bcmdataexports_export.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionNot(t, names.USGovCloudPartitionID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckExportDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccExportConfig_update(rName, "OVERWRITE_REPORT"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExportExists(ctx, resourceName, &export),
+					resource.TestCheckResourceAttr(resourceName, "export.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.name", rName),
+					resource.TestCheckResourceAttr(resourceName, "export.0.data_query.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "export.0.data_query.0.query_statement"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.data_query.0.table_configurations.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.destination_configurations.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.destination_configurations.0.s3_destination.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.destination_configurations.0.s3_destination.0.s3_output_configurations.0.overwrite", "OVERWRITE_REPORT"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.destination_configurations.0.s3_destination.0.s3_output_configurations.0.format", "TEXT_OR_CSV"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.destination_configurations.0.s3_destination.0.s3_output_configurations.0.compression", "GZIP"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.destination_configurations.0.s3_destination.0.s3_output_configurations.0.output_type", "CUSTOM"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.refresh_cadence.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.refresh_cadence.0.frequency", "SYNCHRONOUS"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.data_query.0.table_configurations.COST_AND_USAGE_REPORT.TIME_GRANULARITY", "HOURLY"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.data_query.0.table_configurations.COST_AND_USAGE_REPORT.INCLUDE_RESOURCES", "FALSE"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.data_query.0.table_configurations.COST_AND_USAGE_REPORT.INCLUDE_MANUAL_DISCOUNT_COMPATIBILITY", "FALSE"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.data_query.0.table_configurations.COST_AND_USAGE_REPORT.INCLUDE_SPLIT_COST_ALLOCATION_DATA", "FALSE"),
+				),
+			},
+			{
+				Config: testAccExportConfig_update(rName, "CREATE_NEW_REPORT"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExportExists(ctx, resourceName, &export),
+					resource.TestCheckResourceAttr(resourceName, "export.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.name", rName),
+					resource.TestCheckResourceAttr(resourceName, "export.0.data_query.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "export.0.data_query.0.query_statement"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.data_query.0.table_configurations.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.destination_configurations.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.destination_configurations.0.s3_destination.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.destination_configurations.0.s3_destination.0.s3_output_configurations.0.overwrite", "CREATE_NEW_REPORT"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.destination_configurations.0.s3_destination.0.s3_output_configurations.0.format", "TEXT_OR_CSV"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.destination_configurations.0.s3_destination.0.s3_output_configurations.0.compression", "GZIP"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.destination_configurations.0.s3_destination.0.s3_output_configurations.0.output_type", "CUSTOM"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.refresh_cadence.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.refresh_cadence.0.frequency", "SYNCHRONOUS"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.data_query.0.table_configurations.COST_AND_USAGE_REPORT.TIME_GRANULARITY", "HOURLY"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.data_query.0.table_configurations.COST_AND_USAGE_REPORT.INCLUDE_RESOURCES", "FALSE"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.data_query.0.table_configurations.COST_AND_USAGE_REPORT.INCLUDE_MANUAL_DISCOUNT_COMPATIBILITY", "FALSE"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.data_query.0.table_configurations.COST_AND_USAGE_REPORT.INCLUDE_SPLIT_COST_ALLOCATION_DATA", "FALSE"),
+				),
 			},
 		},
 	})
@@ -108,7 +184,7 @@ func TestAccBCMDataExportsExport_curSubset(t *testing.T) {
 		"line_item_normalized_usage_amount",
 		"line_item_operation",
 		"line_item_product_code",
-		//"line_item_resource_id", // ATM this column causes "ValidationException: The columns in the query provided are not a subset of the table COST_AND_USAGE_REPORT"
+		"line_item_resource_id",
 		"line_item_tax_type",
 		"line_item_unblended_cost",
 		"line_item_unblended_rate",
@@ -474,6 +550,46 @@ resource "aws_bcmdataexports_export" "test" {
 `, rName))
 }
 
+func testAccExportConfig_update(rName, overwrite string) string {
+	return acctest.ConfigCompose(
+		testAccExportConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_bcmdataexports_export" "test" {
+  export {
+    name = %[1]q
+    data_query {
+      query_statement = "SELECT identity_line_item_id, identity_time_interval, line_item_product_code,line_item_unblended_cost FROM COST_AND_USAGE_REPORT"
+      table_configurations = {
+        "COST_AND_USAGE_REPORT" = {
+          "TIME_GRANULARITY"                      = "HOURLY",
+          "INCLUDE_RESOURCES"                     = "FALSE",
+          "INCLUDE_MANUAL_DISCOUNT_COMPATIBILITY" = "FALSE",
+          "INCLUDE_SPLIT_COST_ALLOCATION_DATA"    = "FALSE",
+        }
+      }
+    }
+    destination_configurations {
+      s3_destination {
+        s3_bucket = aws_s3_bucket.test.bucket
+        s3_prefix = aws_s3_bucket.test.bucket_prefix
+        s3_region = aws_s3_bucket.test.region
+        s3_output_configurations {
+          overwrite   = %[2]q
+          format      = "TEXT_OR_CSV"
+          compression = "GZIP"
+          output_type = "CUSTOM"
+        }
+      }
+    }
+
+    refresh_cadence {
+      frequency = "SYNCHRONOUS"
+    }
+  }
+}
+`, rName, overwrite))
+}
+
 func testAccExportConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(
 		testAccExportConfigBase(rName),
@@ -611,7 +727,7 @@ resource "aws_bcmdataexports_export" "test" {
       table_configurations = {
         "COST_AND_USAGE_REPORT" = {
           "TIME_GRANULARITY"                      = "HOURLY",
-          "INCLUDE_RESOURCES"                     = "FALSE",
+          "INCLUDE_RESOURCES"                     = "TRUE",
           "INCLUDE_MANUAL_DISCOUNT_COMPATIBILITY" = "FALSE",
           "INCLUDE_SPLIT_COST_ALLOCATION_DATA"    = "FALSE",
         }

--- a/website/docs/r/bcmdataexports_export.html.markdown
+++ b/website/docs/r/bcmdataexports_export.html.markdown
@@ -10,8 +10,6 @@ description: |-
 
 Terraform resource for managing an AWS BCM Data Exports Export.
 
-~> **NOTE:** Including `line_item_resource_id` in the SQL query in `export.0.data_query.0.query_statement` results in an error, `ValidationException: The columns in the query provided are not a subset of the table COST_AND_USAGE_REPORT`. Based on [AWS Documentation](https://docs.aws.amazon.com/cur/latest/userguide/data-dictionary.html), `line_item_resource_id` should be a valid column but is currently causing errors.
-
 ## Example Usage
 
 ### Basic Usage


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #37126

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS="-run=TestAccBCMDataExportsExport_" PKG=bcmdataexports

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/bcmdataexports/... -v -count 1 -parallel 20  -run=TestAccBCMDataExportsExport_ -timeout 360m
--- PASS: TestAccBCMDataExportsExport_curSubset (18.99s)
--- PASS: TestAccBCMDataExportsExport_disappears (19.11s)
--- PASS: TestAccBCMDataExportsExport_basic (21.43s)
--- PASS: TestAccBCMDataExportsExport_update (29.31s)
--- PASS: TestAccBCMDataExportsExport_updateTable (31.95s)
--- PASS: TestAccBCMDataExportsExport_tags (41.44s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/bcmdataexports	46.669s
```
