### PR TITLE
awssdkpatch: enum type validation

### DIFF
--- a/tools/awssdkpatch/main.go
+++ b/tools/awssdkpatch/main.go
@@ -35,6 +35,7 @@ type TemplateData struct {
 	InputOutputTypes   []string
 	ContextFunctions   []string
 	Exceptions         []string
+	EnumTypes          []string
 }
 
 func main() {
@@ -133,6 +134,10 @@ func getPackageData(sd data.ServiceRecord) (TemplateData, error) {
 
 			if o.Kind == ast.Typ && strings.HasSuffix(n, "Exception") {
 				td.Exceptions = append(td.Exceptions, strings.TrimPrefix(n, "ErrCode"))
+			}
+
+			if o.Kind == ast.Fun && strings.HasSuffix(n, "_Values") {
+				td.EnumTypes = append(td.EnumTypes, strings.TrimSuffix(n, "_Values"))
 			}
 		}
 	}

--- a/tools/awssdkpatch/patch.tmpl
+++ b/tools/awssdkpatch/patch.tmpl
@@ -117,10 +117,35 @@ var x identifier
 @@
 -tfawserr.ErrMessageContains(err, awstypes.ErrCode{{ $exceptionName }}, x)
 +errs.IsAErrorMessageContains[*awstypes.{{ $exceptionName }}](err, x)
-{{ end }}
+{{- end }}
 
 @@
 var x identifier
 @@
 +import "github.com/hashicorp/terraform-provider-aws/internal/errs"
 errs.x
+
+# Step 4: Migrate enum validation
+#
+# This will only be partially correct. The enum.Validate function implements
+# ValidateDiagFunc, while StringInSliace implements ValidateFunc. Due to
+# limitiations with how gopatch handles multiple matches within an elision, we
+# cannot replace all instances of ValidateFunc inside the schema defintion (just
+# the first one). Instead, we'll insert the proper validation function and
+# ValidateFunc can be changed to ValidateDiagFunc manually.
+#
+# Ref: https://github.com/uber-go/gopatch/issues/10
+{{- range $enum := .EnumTypes }}
+# Replace enum validation for {{ $enum }}. Assign this to ValidateDiagFunc (instead of ValidateFunc) once patched.
+@@
+@@
+-validation.StringInSlice(awstypes.{{ $enum }}_Values(), false)
++enum.Validate[awstypes.{{ $enum }}]()
+{{- end }}
+
+
+@@
+var x identifier
+@@
++import "github.com/hashicorp/terraform-provider-aws/internal/enum"
+enum.x


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This enhancement adds patches to migrate validation functions for enum types to the `enum.Validate` function.

Due to a `gopatch` limitation, the field which the validation function is assigned to (`ValidateFunc`) cannot be migrated to the proper field (`ValidateDiagFunc`). The generated patches include a comment indicating that this step will need to be done manually once the patch is applied, at least until the underlying `gopatch` limitation is addressed.

Related section in the AWS SDK migration guide:
- https://hashicorp.github.io/terraform-provider-aws/aws-go-sdk-migrations/#validation-functions
