### PR TITLE
Added the data source for a Slack Workspace

### DIFF
--- a/.changelog/37218.txt
+++ b/.changelog/37218.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_chatbot_slack_workspace
+```

--- a/.changelog/37218.txt
+++ b/.changelog/37218.txt
@@ -1,3 +1,3 @@
-```release-note:new-resource
+```release-note:new-data-source
 aws_chatbot_slack_workspace
 ```

--- a/internal/service/chatbot/service_package_gen.go
+++ b/internal/service/chatbot/service_package_gen.go
@@ -13,7 +13,12 @@ import (
 type servicePackage struct{}
 
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.ServicePackageFrameworkDataSource {
-	return []*types.ServicePackageFrameworkDataSource{}
+	return []*types.ServicePackageFrameworkDataSource{
+		{
+			Factory: newDataSourceSlackWorkspace,
+			Name:    "Slack Workspace",
+		},
+	}
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.ServicePackageFrameworkResource {

--- a/internal/service/chatbot/slack_workspace_data_source.go
+++ b/internal/service/chatbot/slack_workspace_data_source.go
@@ -49,7 +49,6 @@ func (d *dataSourceSlackWorkspace) Schema(ctx context.Context, req datasource.Sc
 }
 
 func (d *dataSourceSlackWorkspace) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-
 	conn := d.Meta().ChatbotClient(ctx)
 
 	var data dataSourceSlackWorkspaceData
@@ -85,7 +84,7 @@ func findSlackWorkspaceByName(ctx context.Context, conn *chatbot.Client, slack_t
 		}
 
 		for _, workspace := range output.SlackWorkspaces {
-			if *workspace.SlackTeamName == slack_team_name {
+			if aws.ToString(workspace.SlackTeamName) == slack_team_name {
 				return &workspace, nil
 			}
 		}
@@ -97,7 +96,6 @@ func findSlackWorkspaceByName(ctx context.Context, conn *chatbot.Client, slack_t
 	}
 	// If we are here, then we need to return an error that the data source was not found.
 	return nil, create.Error(names.Chatbot, "missing", DSNameSlackWorkspace, slack_team_name, nil)
-
 }
 
 type dataSourceSlackWorkspaceData struct {

--- a/internal/service/chatbot/slack_workspace_data_source.go
+++ b/internal/service/chatbot/slack_workspace_data_source.go
@@ -1,0 +1,106 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package chatbot
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/chatbot"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/chatbot/types"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource(name="Slack Workspace")
+func newDataSourceSlackWorkspace(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &dataSourceSlackWorkspace{}, nil
+}
+
+const (
+	DSNameSlackWorkspace = "Slack Workspace Data Source"
+)
+
+type dataSourceSlackWorkspace struct {
+	framework.DataSourceWithConfigure
+}
+
+func (d *dataSourceSlackWorkspace) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) { // nosemgrep:ci.meta-in-func-name
+	resp.TypeName = "aws_chatbot_slack_workspace"
+}
+
+func (d *dataSourceSlackWorkspace) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"slack_team_id": schema.StringAttribute{
+				Computed: true,
+			},
+			"slack_team_name": schema.StringAttribute{
+				Required: true,
+			},
+		},
+	}
+}
+
+func (d *dataSourceSlackWorkspace) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+
+	conn := d.Meta().ChatbotClient(ctx)
+
+	var data dataSourceSlackWorkspaceData
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := findSlackWorkspaceByName(ctx, conn, data.SlackTeamName.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.Chatbot, create.ErrActionReading, DSNameSlackWorkspace, data.SlackTeamName.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	data.SlackTeamID = flex.StringToFramework(ctx, out.SlackTeamId)
+	data.SlackTeamName = flex.StringToFramework(ctx, out.SlackTeamName)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func findSlackWorkspaceByName(ctx context.Context, conn *chatbot.Client, slack_team_name string) (*awstypes.SlackWorkspace, error) {
+	input := &chatbot.DescribeSlackWorkspacesInput{
+		MaxResults: aws.Int32(10),
+	}
+
+	for {
+		output, err := conn.DescribeSlackWorkspaces(ctx, input)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, workspace := range output.SlackWorkspaces {
+			if *workspace.SlackTeamName == slack_team_name {
+				return &workspace, nil
+			}
+		}
+
+		if output.NextToken == nil {
+			break
+		}
+		input.NextToken = output.NextToken
+	}
+	// If we are here, then we need to return an error that the data source was not found.
+	return nil, create.Error(names.Chatbot, "missing", DSNameSlackWorkspace, slack_team_name, nil)
+
+}
+
+type dataSourceSlackWorkspaceData struct {
+	SlackTeamName types.String `tfsdk:"slack_team_name"`
+	SlackTeamID   types.String `tfsdk:"slack_team_id"`
+}

--- a/internal/service/chatbot/slack_workspace_data_source_test.go
+++ b/internal/service/chatbot/slack_workspace_data_source_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package chatbot_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccChatbotSlackWorkspaceDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	// TIP: This is a long-running test guard for tests that run longer than
+	// 300s (5 min) generally.
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	// The slack workspace must be created via the AWS Console. It cannot be created via APIs or Terraform.
+	// Once it is created, export the name of the workspace in the env variable  for this test
+	key := "CHATBOT_SLACK_WORKSPACE_NAME"
+	workspace_name := os.Getenv(key)
+	if workspace_name == "" {
+		t.Skipf("Environment variable %s is not set", key)
+	}
+
+	dataSourceName := "data.aws_chatbot_slack_workspace.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ChatbotServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSlackWorkspaceDataSourceConfig_basic(workspace_name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "slack_team_name", workspace_name),
+					resource.TestCheckResourceAttrSet(dataSourceName, "slack_team_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccSlackWorkspaceDataSourceConfig_basic(workspace_name string) string {
+	return fmt.Sprintf(`
+data "aws_chatbot_slack_workspace" "test" {
+  slack_team_name = "%[1]s"
+}
+`, workspace_name)
+}

--- a/internal/service/chatbot/slack_workspace_data_source_test.go
+++ b/internal/service/chatbot/slack_workspace_data_source_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 

--- a/website/docs/d/chatbot_slack_workspace.html.markdown
+++ b/website/docs/d/chatbot_slack_workspace.html.markdown
@@ -1,0 +1,33 @@
+---
+subcategory: "Chatbot"
+layout: "aws"
+page_title: "AWS: aws_chatbot_slack_workspace"
+description: |-
+  Terraform data source for managing an AWS Chatbot Slack Workspace.
+---
+
+# Data Source: aws_chatbot_slack_workspace
+
+Terraform data source for managing an AWS Chatbot Slack Workspace.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_chatbot_slack_workspace" "example" {
+  team_slack_name = "abc"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `slack_team_name` - (Required) The Slack workspace name configured with AWS Chabot
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `slack_team_id` - The ID of the Slack Workspace assigned by AWS Chatbot.

--- a/website/docs/d/chatbot_slack_workspace.html.markdown
+++ b/website/docs/d/chatbot_slack_workspace.html.markdown
@@ -24,10 +24,10 @@ data "aws_chatbot_slack_workspace" "example" {
 
 The following arguments are required:
 
-* `slack_team_name` - (Required) The Slack workspace name configured with AWS Chabot
+* `slack_team_name` - (Required) Slack workspace name configured with AWS Chabot.
 
 ## Attribute Reference
 
 This data source exports the following attributes in addition to the arguments above:
 
-* `slack_team_id` - The ID of the Slack Workspace assigned by AWS Chatbot.
+* `slack_team_id` - ID of the Slack Workspace assigned by AWS Chatbot.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Added a new data source Slack Workspace for the service AWS Chatbot

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Relates #12304
or 
Closes #37123

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


https://awscli.amazonaws.com/v2/documentation/api/latest/reference/chatbot/delete-slack-workspace-authorization.html
https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/chatbot#Client.DescribeSlackWorkspaces

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc PKG=chatbot TESTS=TestAccChatbotSlackWorkspace*
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/chatbot/... -v -count 1 -parallel 20 -run='TestAccChatbotSlackWorkspace*'  -timeout 360m
=== RUN   TestAccChatbotSlackWorkspaceDataSource_basic
=== PAUSE TestAccChatbotSlackWorkspaceDataSource_basic
=== CONT  TestAccChatbotSlackWorkspaceDataSource_basic
--- PASS: TestAccChatbotSlackWorkspaceDataSource_basic (34.01s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/chatbot    47.826s
```
