### PR TITLE
td/fix various EBS test failures

### DIFF
--- a/internal/service/ec2/ebs_default_kms_key_data_source_test.go
+++ b/internal/service/ec2/ebs_default_kms_key_data_source_test.go
@@ -29,5 +29,11 @@ func TestAccEC2EBSDefaultKMSKeyDataSource_basic(t *testing.T) {
 }
 
 const testAccEBSDefaultKMSKeyDataSourceConfig_basic = `
+resource "aws_kms_key" "test" {}
+
+resource "aws_ebs_default_kms_key" "test" {
+  key_arn = aws_kms_key.test.arn
+}
+
 data "aws_ebs_default_kms_key" "current" {}
 `

--- a/internal/service/ec2/ebs_volume_attachment.go
+++ b/internal/service/ec2/ebs_volume_attachment.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -177,6 +178,10 @@ func resourceVolumeAttachmentDelete(ctx context.Context, d *schema.ResourceData,
 
 	log.Printf("[DEBUG] Deleting EBS Volume Attachment: %s", d.Id())
 	_, err := conn.DetachVolumeWithContext(ctx, input)
+
+	if tfawserr.ErrMessageContains(err, "IncorrectState", "available") {
+		return diags
+	}
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "deleting EBS Volume (%s) Attachment (%s): %s", volumeID, instanceID, err)

--- a/internal/service/ec2/ebs_volume_attachment.go
+++ b/internal/service/ec2/ebs_volume_attachment.go
@@ -179,7 +179,7 @@ func resourceVolumeAttachmentDelete(ctx context.Context, d *schema.ResourceData,
 	log.Printf("[DEBUG] Deleting EBS Volume Attachment: %s", d.Id())
 	_, err := conn.DetachVolumeWithContext(ctx, input)
 
-	if tfawserr.ErrMessageContains(err, "IncorrectState", "available") {
+	if tfawserr.ErrMessageContains(err, errCodeIncorrectState, "available") {
 		return diags
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

```console
=== CONT  TestAccEC2EBSVolumeAttachment_disappears
    ebs_volume_attachment_test.go:185: Error running post-test destroy, there may be dangling resources: exit status 1
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS="-run=TestAccEC2EBSDefaultKMSKeyDataSource_basic\|TestAccEC2EBSVolumeAttachment_disappears" PKG=ec2

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccEC2EBSDefaultKMSKeyDataSource_basic\|TestAccEC2EBSVolumeAttachment_disappears -timeout 360m
--- PASS: TestAccEC2EBSDefaultKMSKeyDataSource_basic (11.18s)
--- PASS: TestAccEC2EBSVolumeAttachment_disappears (108.27s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	114.023s
```
