### PR TITLE
tools/awssdkpatch: enum type input/output patch

### DIFF
--- a/tools/awssdkpatch/patch.tmpl
+++ b/tools/awssdkpatch/patch.tmpl
@@ -131,24 +131,38 @@ var x identifier
 +import "github.com/hashicorp/terraform-provider-aws/internal/errs"
 errs.x
 
-# Step 4: Migrate enum validation
+# Step 4: Migrate enum types
 #
-# This will only be partially correct. The enum.Validate function implements
-# ValidateDiagFunc, while StringInSlice implements ValidateFunc. Due to
-# limitations with how gopatch handles multiple matches within an elision, we
+# Note: The validation changes will only be partially correct. The enum.Validate
+# function implements ValidateDiagFunc, while StringInSlice implements ValidateFunc.
+# Due to limitations with how gopatch handles multiple matches within an elision, we
 # cannot replace all instances of ValidateFunc inside the schema defintion (just
 # the first one). Instead, we'll insert the proper validation function and
 # ValidateFunc can be changed to ValidateDiagFunc manually.
 #
 # Ref: https://github.com/uber-go/gopatch/issues/10
 {{- range $enum := .EnumTypes }}
+
 # Replace enum validation for {{ $enum }}. Assign this to ValidateDiagFunc (instead of ValidateFunc) once patched.
 @@
 @@
 -validation.StringInSlice(awstypes.{{ $enum }}_Values(), false)
 +enum.Validate[awstypes.{{ $enum }}]()
-{{- end }}
 
+# Replace enum {{ $enum }} assignment on input structs.
+@@
+var input identifier
+@@
+-input.{{ $enum }} = aws.String(...)
++input.{{ $enum }} = awstypes.{{ $enum }}(...)
+
+# Replace enum {{ $enum }} conversion on output structs.
+@@
+var output identifier
+@@
+-aws.ToString(output.{{ $enum }})
++string(output.{{ $enum }})
+{{- end }}
 
 @@
 var x identifier


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This change will covert the assignment and conversion of enum types when being passed into Input and read from Output structs, respectively.

See this related item in the AWS SDK migration guide:
- https://hashicorp.github.io/terraform-provider-aws/aws-go-sdk-migrations/#input-structs


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #32976 

